### PR TITLE
Move RenderSVGResourceContainer into legacy

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2739,6 +2739,7 @@ rendering/svg/legacy/LegacyRenderSVGImage.cpp
 rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
 rendering/svg/legacy/LegacyRenderSVGPath.cpp
 rendering/svg/legacy/LegacyRenderSVGRect.cpp
+rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
 rendering/svg/legacy/LegacyRenderSVGRoot.cpp
 rendering/svg/legacy/LegacyRenderSVGShape.cpp
 rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -2757,7 +2758,6 @@ rendering/svg/RenderSVGPath.cpp
 rendering/svg/RenderSVGRect.cpp
 rendering/svg/RenderSVGResource.cpp
 rendering/svg/RenderSVGResourceClipper.cpp
-rendering/svg/RenderSVGResourceContainer.cpp
 rendering/svg/RenderSVGResourceFilter.cpp
 rendering/svg/RenderSVGResourceFilterPrimitive.cpp
 rendering/svg/RenderSVGResourceGradient.cpp

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -583,7 +583,7 @@ struct SVGResourcesMap {
 
     MemoryCompactRobinHoodHashMap<AtomString, WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>> pendingResources;
     MemoryCompactRobinHoodHashMap<AtomString, WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>> pendingResourcesForRemoval;
-    MemoryCompactRobinHoodHashMap<AtomString, RenderSVGResourceContainer*> resources;
+    MemoryCompactRobinHoodHashMap<AtomString, LegacyRenderSVGResourceContainer*> resources;
 };
 
 SVGResourcesMap& TreeScope::svgResourcesMap() const
@@ -593,7 +593,7 @@ SVGResourcesMap& TreeScope::svgResourcesMap() const
     return *m_svgResourcesMap;
 }
 
-void TreeScope::addSVGResource(const AtomString& id, RenderSVGResourceContainer& resource)
+void TreeScope::addSVGResource(const AtomString& id, LegacyRenderSVGResourceContainer& resource)
 {
     if (id.isEmpty())
         return;
@@ -610,7 +610,7 @@ void TreeScope::removeSVGResource(const AtomString& id)
     svgResourcesMap().resources.remove(id);
 }
 
-RenderSVGResourceContainer* TreeScope::svgResourceById(const AtomString& id) const
+LegacyRenderSVGResourceContainer* TreeScope::svgResourceById(const AtomString& id) const
 {
     if (id.isEmpty())
         return nullptr;

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -51,10 +51,10 @@ class HTMLImageElement;
 class HTMLLabelElement;
 class HTMLMapElement;
 class LayoutPoint;
+class LegacyRenderSVGResourceContainer;
 class IdTargetObserverRegistry;
 class Node;
 class RadioButtonGroups;
-class RenderSVGResourceContainer;
 class SVGElement;
 class ShadowRoot;
 class WeakPtrImplWithEventTargetData;
@@ -130,9 +130,9 @@ public:
     std::span<const RefPtr<CSSStyleSheet>> adoptedStyleSheets() const;
     ExceptionOr<void> setAdoptedStyleSheets(Vector<RefPtr<CSSStyleSheet>>&&);
 
-    void addSVGResource(const AtomString& id, RenderSVGResourceContainer&);
+    void addSVGResource(const AtomString& id, LegacyRenderSVGResourceContainer&);
     void removeSVGResource(const AtomString& id);
-    RenderSVGResourceContainer* svgResourceById(const AtomString& id) const;
+    LegacyRenderSVGResourceContainer* svgResourceById(const AtomString& id) const;
 
     void addPendingSVGResource(const AtomString& id, SVGElement&);
     bool isIdOfPendingSVGResource(const AtomString& id) const;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -746,7 +746,7 @@ bool RenderElement::layerCreationAllowedForSubtree() const
     // simply omit the layer creation for any children of a <defs> element (or in general
     // any "hidden container"). For LBSE layers are needed for painting, even if a
     // RenderSVGHiddenContainer is in the render tree ancestor chain -- however they are
-    // never painted directly, only indirectly through the "RenderSVGResourceContainer
+    // never painted directly, only indirectly through the "LegacyRenderSVGResourceContainer
     // elements (such as RenderSVGResourceClipper, RenderSVGResourceMasker, etc.)
     if (document().settings().layerBasedSVGEngineEnabled())
         return true;

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -108,7 +108,7 @@ void RenderLayerFilters::removeReferenceFilterClients()
 
     for (auto& filterElement : m_internalSVGReferences) {
         if (auto* renderer = filterElement->renderer())
-            downcast<RenderSVGResourceContainer>(*renderer).removeClientRenderLayer(m_layer);
+            downcast<LegacyRenderSVGResourceContainer>(*renderer).removeClientRenderLayer(m_layer);
     }
     m_internalSVGReferences.clear();
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -68,7 +68,6 @@
 #include "RenderSVGBlock.h"
 #include "RenderSVGInline.h"
 #include "RenderSVGModelObject.h"
-#include "RenderSVGResourceContainer.h"
 #include "RenderScrollbarPart.h"
 #include "RenderTableRow.h"
 #include "RenderTheme.h"

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -38,6 +38,7 @@
 #include "InlineIteratorTextBox.h"
 #include "LegacyRenderSVGContainer.h"
 #include "LegacyRenderSVGImage.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "LegacyRenderSVGRoot.h"
 #include "LegacyRenderSVGShape.h"
 #include "LocalFrame.h"
@@ -67,7 +68,6 @@
 #include "RenderSVGContainer.h"
 #include "RenderSVGGradientStop.h"
 #include "RenderSVGInlineText.h"
-#include "RenderSVGResourceContainer.h"
 #include "RenderSVGRoot.h"
 #include "RenderSVGShapeInlines.h"
 #include "RenderSVGText.h"
@@ -596,8 +596,8 @@ void write(TextStream& ts, const RenderObject& o, OptionSet<RenderAsTextFlag> be
         writeSVGGradientStop(ts, downcast<RenderSVGGradientStop>(o), behavior);
         return;
     }
-    if (is<RenderSVGResourceContainer>(o)) {
-        writeSVGResourceContainer(ts, downcast<RenderSVGResourceContainer>(o), behavior);
+    if (is<LegacyRenderSVGResourceContainer>(o)) {
+        writeSVGResourceContainer(ts, downcast<LegacyRenderSVGResourceContainer>(o), behavior);
         return;
     }
     if (is<LegacyRenderSVGContainer>(o)) {

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -21,8 +21,8 @@
 #include "RenderSVGGradientStop.h"
 
 #include "ElementInlines.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "RenderSVGGradientStopInlines.h"
-#include "RenderSVGResourceContainer.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGGradientElement.h"
 #include "SVGNames.h"
@@ -60,7 +60,7 @@ void RenderSVGGradientStop::styleDidChange(StyleDifference diff, const RenderSty
     if (!renderer)
         return;
 
-    downcast<RenderSVGResourceContainer>(*renderer).removeAllClientsFromCache();
+    downcast<LegacyRenderSVGResourceContainer>(*renderer).removeAllClientsFromCache();
 }
 
 void RenderSVGGradientStop::layout()

--- a/Source/WebCore/rendering/svg/RenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResource.cpp
@@ -233,9 +233,9 @@ void RenderSVGResource::markForLayoutAndParentResourceInvalidation(RenderObject&
     while (current) {
         removeFromCacheAndInvalidateDependencies(*current, needsLayout);
 
-        if (is<RenderSVGResourceContainer>(*current)) {
+        if (is<LegacyRenderSVGResourceContainer>(*current)) {
             // This will process the rest of the ancestors.
-            downcast<RenderSVGResourceContainer>(*current).removeAllClientsFromCache();
+            downcast<LegacyRenderSVGResourceContainer>(*current).removeAllClientsFromCache();
             break;
         }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -51,7 +51,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceClipper);
 
 RenderSVGResourceClipper::RenderSVGResourceClipper(SVGClipPathElement& element, RenderStyle&& style)
-    : RenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "RenderSVGResourceContainer.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "SVGUnitTypes.h"
 
 #include <wtf/HashMap.h>
@@ -56,7 +56,7 @@ struct ClipperData {
     Inputs inputs;
 };
 
-class RenderSVGResourceClipper final : public RenderSVGResourceContainer {
+class RenderSVGResourceClipper final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceClipper);
 public:
     RenderSVGResourceClipper(SVGClipPathElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(FilterData);
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceFilter);
 
 RenderSVGResourceFilter::RenderSVGResourceFilter(SVGFilterElement& element, RenderStyle&& style)
-    : RenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -25,7 +25,7 @@
 
 #include "FilterResults.h"
 #include "FilterTargetSwitcher.h"
-#include "RenderSVGResourceContainer.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "SVGFilter.h"
 #include "SVGUnitTypes.h"
 #include <wtf/IsoMalloc.h>
@@ -53,7 +53,7 @@ public:
     FilterDataState state { PaintingSource };
 };
 
-class RenderSVGResourceFilter final : public RenderSVGResourceContainer {
+class RenderSVGResourceFilter final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceFilter);
 public:
     RenderSVGResourceFilter(SVGFilterElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 inline SVGFilterElement& RenderSVGResourceFilter::filterElement() const
 {
-    return downcast<SVGFilterElement>(RenderSVGResourceContainer::element());
+    return downcast<SVGFilterElement>(LegacyRenderSVGResourceContainer::element());
 }
 
 inline SVGUnitTypes::SVGUnitType RenderSVGResourceFilter::filterUnits() const

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceGradient);
 
 RenderSVGResourceGradient::RenderSVGResourceGradient(SVGGradientElement& node, RenderStyle&& style)
-    : RenderSVGResourceContainer(node, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(node, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include "ImageBuffer.h"
-#include "RenderSVGResourceContainer.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "SVGGradientElement.h"
 #include <memory>
 #include <wtf/HashMap.h>
@@ -56,10 +56,10 @@ struct GradientData {
     Inputs inputs;
 };
 
-class RenderSVGResourceGradient : public RenderSVGResourceContainer {
+class RenderSVGResourceGradient : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceGradient);
 public:
-    SVGGradientElement& gradientElement() const { return static_cast<SVGGradientElement&>(RenderSVGResourceContainer::element()); }
+    SVGGradientElement& gradientElement() const { return static_cast<SVGGradientElement&>(LegacyRenderSVGResourceContainer::element()); }
 
     void removeAllClientsFromCache(bool markForInvalidation = true) final;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) final;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceMarker);
 
 RenderSVGResourceMarker::RenderSVGResourceMarker(SVGMarkerElement& element, RenderStyle&& style)
-    : RenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "RenderSVGResourceContainer.h"
+#include "LegacyRenderSVGResourceContainer.h"
 
 namespace WebCore {
 
@@ -27,7 +27,7 @@ class AffineTransform;
 class RenderObject;
 class SVGMarkerElement;
 
-class RenderSVGResourceMarker final : public RenderSVGResourceContainer {
+class RenderSVGResourceMarker final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceMarker);
 public:
     RenderSVGResourceMarker(SVGMarkerElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 inline SVGMarkerElement& RenderSVGResourceMarker::markerElement() const
 {
-    return downcast<SVGMarkerElement>(RenderSVGResourceContainer::element());
+    return downcast<SVGMarkerElement>(LegacyRenderSVGResourceContainer::element());
 }
 
 inline SVGMarkerUnitsType RenderSVGResourceMarker::markerUnits() const

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceMasker);
 
 RenderSVGResourceMasker::RenderSVGResourceMasker(SVGMaskElement& element, RenderStyle&& style)
-    : RenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "ImageBuffer.h"
-#include "RenderSVGResourceContainer.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "SVGUnitTypes.h"
 
 #include <wtf/HashMap.h>
@@ -35,7 +35,7 @@ struct MaskerData {
     RefPtr<ImageBuffer> maskImage;
 };
 
-class RenderSVGResourceMasker final : public RenderSVGResourceContainer {
+class RenderSVGResourceMasker final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceMasker);
 public:
     RenderSVGResourceMasker(SVGMaskElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 inline SVGMaskElement& RenderSVGResourceMasker::maskElement() const
 {
-    return downcast<SVGMaskElement>(RenderSVGResourceContainer::element());
+    return downcast<SVGMaskElement>(LegacyRenderSVGResourceContainer::element());
 }
 
 SVGUnitTypes::SVGUnitType RenderSVGResourceMasker::maskUnits() const

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -39,13 +39,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourcePattern);
 
 RenderSVGResourcePattern::RenderSVGResourcePattern(SVGPatternElement& element, RenderStyle&& style)
-    : RenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
 {
 }
 
 SVGPatternElement& RenderSVGResourcePattern::patternElement() const
 {
-    return downcast<SVGPatternElement>(RenderSVGResourceContainer::element());
+    return downcast<SVGPatternElement>(LegacyRenderSVGResourceContainer::element());
 }
 
 void RenderSVGResourcePattern::removeAllClientsFromCache(bool markForInvalidation)

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
@@ -22,9 +22,9 @@
 #pragma once
 
 #include "ImageBuffer.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "Pattern.h"
 #include "PatternAttributes.h"
-#include "RenderSVGResourceContainer.h"
 #include "SVGPatternElement.h"
 #include <memory>
 #include <wtf/IsoMallocInlines.h>
@@ -39,7 +39,7 @@ public:
     AffineTransform transform;
 };
 
-class RenderSVGResourcePattern final : public RenderSVGResourceContainer {
+class RenderSVGResourcePattern final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourcePattern);
 public:
     RenderSVGResourcePattern(SVGPatternElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -30,6 +30,7 @@
 #include "GraphicsContext.h"
 #include "HitTestResult.h"
 #include "LayoutRepainter.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "LocalFrame.h"
 #include "Page.h"
 #include "RenderBoxInlines.h"
@@ -40,7 +41,6 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderLayoutState.h"
 #include "RenderSVGResource.h"
-#include "RenderSVGResourceContainer.h"
 #include "RenderSVGResourceFilter.h"
 #include "RenderSVGText.h"
 #include "RenderSVGViewportContainer.h"
@@ -513,7 +513,7 @@ bool RenderSVGRoot::hasRelativeDimensions() const
     return svgSVGElement().intrinsicHeight().isPercentOrCalculated() || svgSVGElement().intrinsicWidth().isPercentOrCalculated();
 }
 
-void RenderSVGRoot::addResourceForClientInvalidation(RenderSVGResourceContainer* resource)
+void RenderSVGRoot::addResourceForClientInvalidation(LegacyRenderSVGResourceContainer* resource)
 {
     UNUSED_PARAM(resource);
     /* FIXME: [LBSE] Rename findTreeRootObject -> findLegacyTreeRootObject, and re-add findTreeRootObject for RenderSVGRoot

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class RenderSVGResourceContainer;
+class LegacyRenderSVGResourceContainer;
 class RenderSVGViewportContainer;
 class SVGSVGElement;
 
@@ -60,7 +60,7 @@ public:
 
     // The flag is cleared at the beginning of each layout() pass. Elements then call this
     // method during layout when they are invalidated by a filter.
-    static void addResourceForClientInvalidation(RenderSVGResourceContainer*);
+    static void addResourceForClientInvalidation(LegacyRenderSVGResourceContainer*);
 
     bool shouldApplyViewportClip() const;
 
@@ -127,7 +127,7 @@ private:
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     FloatRect m_strokeBoundingBox;
-    WeakHashSet<RenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
+    WeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -169,8 +169,8 @@ static void writeSVGPaintingResource(TextStream& ts, const RenderSVGResource& re
     else if (resourceType == RadialGradientResourceType)
         ts << "[type=RADIAL-GRADIENT]";
 
-    // All other resources derive from RenderSVGResourceContainer
-    const auto& container = static_cast<const RenderSVGResourceContainer&>(resource);
+    // All other resources derive from LegacyRenderSVGResourceContainer
+    const auto& container = static_cast<const LegacyRenderSVGResourceContainer&>(resource);
     ts << " [id=\"" << container.element().getIdAttribute() << "\"]";
 }
 
@@ -455,7 +455,7 @@ static inline void writeCommonGradientProperties(TextStream& ts, SVGSpreadMethod
         ts << " [gradientTransform=" << gradientTransform << "]";
 }
 
-void writeSVGResourceContainer(TextStream& ts, const RenderSVGResourceContainer& resource, OptionSet<RenderAsTextFlag> behavior)
+void writeSVGResourceContainer(TextStream& ts, const LegacyRenderSVGResourceContainer& resource, OptionSet<RenderAsTextFlag> behavior)
 {
     writeStandardPrefix(ts, resource, behavior);
 

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.h
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.h
@@ -32,13 +32,13 @@ namespace WebCore {
 
 class LegacyRenderSVGContainer;
 class LegacyRenderSVGImage;
+class LegacyRenderSVGResourceContainer;
 class LegacyRenderSVGRoot;
 class LegacyRenderSVGShape;
 class RenderElement;
 class RenderObject;
 class RenderSVGGradientStop;
 class RenderSVGInlineText;
-class RenderSVGResourceContainer;
 class RenderSVGText;
 class SVGGraphicsElement;
 
@@ -46,7 +46,7 @@ class SVGGraphicsElement;
 void write(WTF::TextStream&, const LegacyRenderSVGRoot&, OptionSet<RenderAsTextFlag>);
 void write(WTF::TextStream&, const LegacyRenderSVGShape&, OptionSet<RenderAsTextFlag>);
 void writeSVGGradientStop(WTF::TextStream&, const RenderSVGGradientStop&, OptionSet<RenderAsTextFlag>);
-void writeSVGResourceContainer(WTF::TextStream&, const RenderSVGResourceContainer&, OptionSet<RenderAsTextFlag>);
+void writeSVGResourceContainer(WTF::TextStream&, const LegacyRenderSVGResourceContainer&, OptionSet<RenderAsTextFlag>);
 void writeSVGContainer(WTF::TextStream&, const LegacyRenderSVGContainer&, OptionSet<RenderAsTextFlag>);
 void writeSVGGraphicsElement(WTF::TextStream&, const SVGGraphicsElement&);
 void writeSVGImage(WTF::TextStream&, const LegacyRenderSVGImage&, OptionSet<RenderAsTextFlag>);

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -179,13 +179,13 @@ static inline bool isChainableResource(const SVGElement& element, const SVGEleme
     return false;
 }
 
-static inline RenderSVGResourceContainer* paintingResourceFromSVGPaint(TreeScope& treeScope, const SVGPaintType& paintType, const String& paintUri, AtomString& id, bool& hasPendingResource)
+static inline LegacyRenderSVGResourceContainer* paintingResourceFromSVGPaint(TreeScope& treeScope, const SVGPaintType& paintType, const String& paintUri, AtomString& id, bool& hasPendingResource)
 {
     if (paintType != SVGPaintType::URI && paintType != SVGPaintType::URIRGBColor && paintType != SVGPaintType::URICurrentColor)
         return nullptr;
 
     id = SVGURIReference::fragmentIdentifierFromIRIString(paintUri, treeScope.documentScope());
-    RenderSVGResourceContainer* container = getRenderSVGResourceContainerById(treeScope, id);
+    LegacyRenderSVGResourceContainer* container = getRenderSVGResourceContainerById(treeScope, id);
     if (!container) {
         hasPendingResource = true;
         return nullptr;
@@ -369,7 +369,7 @@ void SVGResources::removeClientFromCache(RenderElement& renderer, bool markForIn
     }
 }
 
-bool SVGResources::resourceDestroyed(RenderSVGResourceContainer& resource)
+bool SVGResources::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
 {
     if (isEmpty())
         return false;
@@ -453,7 +453,7 @@ bool SVGResources::resourceDestroyed(RenderSVGResourceContainer& resource)
     return foundResources;
 }
 
-void SVGResources::buildSetOfResources(WeakHashSet<RenderSVGResourceContainer>& set)
+void SVGResources::buildSetOfResources(WeakHashSet<LegacyRenderSVGResourceContainer>& set)
 {
     if (isEmpty())
         return;
@@ -618,7 +618,7 @@ void SVGResources::resetMasker()
     m_clipperFilterMaskerData->masker = nullptr;
 }
 
-bool SVGResources::setFill(RenderSVGResourceContainer* fill)
+bool SVGResources::setFill(LegacyRenderSVGResourceContainer* fill)
 {
     if (!fill)
         return false;
@@ -641,7 +641,7 @@ void SVGResources::resetFill()
     m_fillStrokeData->fill = nullptr;
 }
 
-bool SVGResources::setStroke(RenderSVGResourceContainer* stroke)
+bool SVGResources::setStroke(LegacyRenderSVGResourceContainer* stroke)
 {
     if (!stroke)
         return false;
@@ -664,7 +664,7 @@ void SVGResources::resetStroke()
     m_fillStrokeData->stroke = nullptr;
 }
 
-bool SVGResources::setLinkedResource(RenderSVGResourceContainer* linkedResource)
+bool SVGResources::setLinkedResource(LegacyRenderSVGResourceContainer* linkedResource)
 {
     if (!linkedResource)
         return false;

--- a/Source/WebCore/rendering/svg/SVGResources.h
+++ b/Source/WebCore/rendering/svg/SVGResources.h
@@ -31,10 +31,10 @@
 namespace WebCore {
 
 class Document;
+class LegacyRenderSVGResourceContainer;
 class RenderElement;
 class RenderObject;
 class RenderStyle;
-class RenderSVGResourceContainer;
 class LegacyRenderSVGRoot;
 class SVGRenderStyle;
 
@@ -57,18 +57,18 @@ public:
     RenderSVGResourceFilter* filter() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->filter.get() : nullptr; }
 
     // Paint servers
-    RenderSVGResourceContainer* fill() const { return m_fillStrokeData ? m_fillStrokeData->fill.get() : nullptr; }
-    RenderSVGResourceContainer* stroke() const { return m_fillStrokeData ? m_fillStrokeData->stroke.get() : nullptr; }
+    LegacyRenderSVGResourceContainer* fill() const { return m_fillStrokeData ? m_fillStrokeData->fill.get() : nullptr; }
+    LegacyRenderSVGResourceContainer* stroke() const { return m_fillStrokeData ? m_fillStrokeData->stroke.get() : nullptr; }
 
     // Chainable resources - linked through xlink:href
-    RenderSVGResourceContainer* linkedResource() const { return m_linkedResource.get(); }
+    LegacyRenderSVGResourceContainer* linkedResource() const { return m_linkedResource.get(); }
 
-    void buildSetOfResources(WeakHashSet<RenderSVGResourceContainer>&);
+    void buildSetOfResources(WeakHashSet<LegacyRenderSVGResourceContainer>&);
 
     // Methods operating on all cached resources
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) const;
     // Returns true if the resource-to-be-destroyed is one of our resources.
-    bool resourceDestroyed(RenderSVGResourceContainer&);
+    bool resourceDestroyed(LegacyRenderSVGResourceContainer&);
 
 #if ENABLE(TREE_DEBUGGING)
     void dump(const RenderObject*);
@@ -95,9 +95,9 @@ private:
     bool setMarkerMid(RenderSVGResourceMarker*);
     bool setMarkerEnd(RenderSVGResourceMarker*);
     bool setMasker(RenderSVGResourceMasker*);
-    bool setFill(RenderSVGResourceContainer*);
-    bool setStroke(RenderSVGResourceContainer*);
-    bool setLinkedResource(RenderSVGResourceContainer*);
+    bool setFill(LegacyRenderSVGResourceContainer*);
+    bool setStroke(LegacyRenderSVGResourceContainer*);
+    bool setLinkedResource(LegacyRenderSVGResourceContainer*);
     
     bool isEmpty() const { return !m_clipperFilterMaskerData && !m_markerData && !m_fillStrokeData && !m_linkedResource; }
 
@@ -134,14 +134,14 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         FillStrokeData() = default;
-        WeakPtr<RenderSVGResourceContainer> fill;
-        WeakPtr<RenderSVGResourceContainer> stroke;
+        WeakPtr<LegacyRenderSVGResourceContainer> fill;
+        WeakPtr<LegacyRenderSVGResourceContainer> stroke;
     };
 
     std::unique_ptr<ClipperFilterMaskerData> m_clipperFilterMaskerData;
     std::unique_ptr<MarkerData> m_markerData;
     std::unique_ptr<FillStrokeData> m_fillStrokeData;
-    WeakPtr<RenderSVGResourceContainer> m_linkedResource;
+    WeakPtr<LegacyRenderSVGResourceContainer> m_linkedResource;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -21,7 +21,7 @@
 #include "SVGResourcesCache.h"
 
 #include "ElementInlines.h"
-#include "RenderSVGResourceContainer.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "SVGRenderStyle.h"
 #include "SVGResources.h"
 #include "SVGResourcesCycleSolver.h"
@@ -48,7 +48,7 @@ void SVGResourcesCache::addResourcesFromRenderer(RenderElement& renderer, const 
     SVGResourcesCycleSolver::resolveCycles(renderer, resources);
 
     // Walk resources and register the render object at each resources.
-    WeakHashSet<RenderSVGResourceContainer> resourceSet;
+    WeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
     resources.buildSetOfResources(resourceSet);
 
     for (auto& resourceContainer : resourceSet)
@@ -62,7 +62,7 @@ void SVGResourcesCache::removeResourcesFromRenderer(RenderElement& renderer)
         return;
 
     // Walk resources and register the render object at each resources.
-    WeakHashSet<RenderSVGResourceContainer> resourceSet;
+    WeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
     resources->buildSetOfResources(resourceSet);
 
     for (auto& resourceContainer : resourceSet)
@@ -204,7 +204,7 @@ void SVGResourcesCache::clientDestroyed(RenderElement& renderer)
     resourcesCacheFromRenderer(renderer).removeResourcesFromRenderer(renderer);
 }
 
-void SVGResourcesCache::resourceDestroyed(RenderSVGResourceContainer& resource)
+void SVGResourcesCache::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
 {
     auto& cache = resourcesCacheFromRenderer(resource);
 

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.h
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.h
@@ -26,10 +26,10 @@
 
 namespace WebCore {
 
+class LegacyRenderSVGResourceContainer;
 class RenderElement;
 class RenderObject;
 class RenderStyle;
-class RenderSVGResourceContainer;
 class SVGResources;
 
 class SVGResourcesCache {
@@ -46,7 +46,7 @@ public:
     // Called from all SVG renderers removeChild() methods.
     static void clientWillBeRemovedFromTree(RenderObject&);
 
-    // Called from all SVG renderers destroy() methods - except for RenderSVGResourceContainer.
+    // Called from all SVG renderers destroy() methods - except for LegacyRenderSVGResourceContainer.
     static void clientDestroyed(RenderElement&);
 
     // Called from all SVG renderers layout() methods.
@@ -55,8 +55,8 @@ public:
     // Called from all SVG renderers styleDidChange() methods.
     static void clientStyleChanged(RenderElement&, StyleDifference, const RenderStyle* oldStyle, const RenderStyle& newStyle);
 
-    // Called from RenderSVGResourceContainer::willBeDestroyed().
-    static void resourceDestroyed(RenderSVGResourceContainer&);
+    // Called from LegacyRenderSVGResourceContainer::willBeDestroyed().
+    static void resourceDestroyed(LegacyRenderSVGResourceContainer&);
 
     class SetStyleForScope {
         WTF_MAKE_NONCOPYABLE(SetStyleForScope);

--- a/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
@@ -34,8 +34,8 @@
 
 namespace WebCore {
 
-bool SVGResourcesCycleSolver::resourceContainsCycles(RenderSVGResourceContainer& resource,
-    WeakHashSet<RenderSVGResourceContainer>& activeResources, WeakHashSet<RenderSVGResourceContainer>& acyclicResources)
+bool SVGResourcesCycleSolver::resourceContainsCycles(LegacyRenderSVGResourceContainer& resource,
+    WeakHashSet<LegacyRenderSVGResourceContainer>& activeResources, WeakHashSet<LegacyRenderSVGResourceContainer>& acyclicResources)
 {
     if (acyclicResources.contains(resource))
         return false;
@@ -53,7 +53,7 @@ bool SVGResourcesCycleSolver::resourceContainsCycles(RenderSVGResourceContainer&
         }
         if (is<RenderElement>(*node)) {
             if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(downcast<RenderElement>(*node))) {
-                WeakHashSet<RenderSVGResourceContainer> resourceSet;
+                WeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
                 resources->buildSetOfResources(resourceSet);
 
                 for (auto& resource : resourceSet) {
@@ -72,14 +72,14 @@ bool SVGResourcesCycleSolver::resourceContainsCycles(RenderSVGResourceContainer&
 
 void SVGResourcesCycleSolver::resolveCycles(RenderElement& renderer, SVGResources& resources)
 {
-    WeakHashSet<RenderSVGResourceContainer> localResources;
+    WeakHashSet<LegacyRenderSVGResourceContainer> localResources;
     resources.buildSetOfResources(localResources);
 
-    WeakHashSet<RenderSVGResourceContainer> activeResources;
-    WeakHashSet<RenderSVGResourceContainer> acyclicResources;
+    WeakHashSet<LegacyRenderSVGResourceContainer> activeResources;
+    WeakHashSet<LegacyRenderSVGResourceContainer> acyclicResources;
 
-    if (is<RenderSVGResourceContainer>(renderer))
-        activeResources.add(downcast<RenderSVGResourceContainer>(renderer));
+    if (is<LegacyRenderSVGResourceContainer>(renderer))
+        activeResources.add(downcast<LegacyRenderSVGResourceContainer>(renderer));
 
     // The job of this function is to determine wheter any of the 'resources' associated with the given 'renderer'
     // references us (or whether any of its kids references us) -> that's a cycle, we need to find and break it.
@@ -89,7 +89,7 @@ void SVGResourcesCycleSolver::resolveCycles(RenderElement& renderer, SVGResource
     }
 }
 
-void SVGResourcesCycleSolver::breakCycle(RenderSVGResourceContainer& resourceLeadingToCycle, SVGResources& resources)
+void SVGResourcesCycleSolver::breakCycle(LegacyRenderSVGResourceContainer& resourceLeadingToCycle, SVGResources& resources)
 {
     if (&resourceLeadingToCycle == resources.linkedResource()) {
         resources.resetLinkedResource();

--- a/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h
+++ b/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h
@@ -25,8 +25,8 @@
 
 namespace WebCore {
 
+class LegacyRenderSVGResourceContainer;
 class RenderElement;
-class RenderSVGResourceContainer;
 class SVGResources;
 
 class SVGResourcesCycleSolver {
@@ -37,8 +37,8 @@ public:
 private:
     SVGResourcesCycleSolver() { }
 
-    static bool resourceContainsCycles(RenderSVGResourceContainer&, WeakHashSet<RenderSVGResourceContainer>& activeResources, WeakHashSet<RenderSVGResourceContainer>& acyclicResources);
-    static void breakCycle(RenderSVGResourceContainer&, SVGResources&);
+    static bool resourceContainsCycles(LegacyRenderSVGResourceContainer&, WeakHashSet<LegacyRenderSVGResourceContainer>& activeResources, WeakHashSet<LegacyRenderSVGResourceContainer>& acyclicResources);
+    static void breakCycle(LegacyRenderSVGResourceContainer&, SVGResources&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "config.h"
-#include "RenderSVGResourceContainer.h"
+#include "LegacyRenderSVGResourceContainer.h"
 
 #include "LegacyRenderSVGRoot.h"
 #include "RenderLayer.h"
@@ -33,17 +33,17 @@
 
 namespace WebCore {
 
-WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceContainer);
+WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGResourceContainer);
 
-RenderSVGResourceContainer::RenderSVGResourceContainer(SVGElement& element, RenderStyle&& style)
+LegacyRenderSVGResourceContainer::LegacyRenderSVGResourceContainer(SVGElement& element, RenderStyle&& style)
     : LegacyRenderSVGHiddenContainer(element, WTFMove(style))
     , m_id(element.getIdAttribute())
 {
 }
 
-RenderSVGResourceContainer::~RenderSVGResourceContainer() = default;
+LegacyRenderSVGResourceContainer::~LegacyRenderSVGResourceContainer() = default;
 
-void RenderSVGResourceContainer::layout()
+void LegacyRenderSVGResourceContainer::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
     // Invalidate all resources if our layout changed.
@@ -53,7 +53,7 @@ void RenderSVGResourceContainer::layout()
     LegacyRenderSVGHiddenContainer::layout();
 }
 
-void RenderSVGResourceContainer::willBeDestroyed()
+void LegacyRenderSVGResourceContainer::willBeDestroyed()
 {
     SVGResourcesCache::resourceDestroyed(*this);
 
@@ -65,7 +65,7 @@ void RenderSVGResourceContainer::willBeDestroyed()
     LegacyRenderSVGHiddenContainer::willBeDestroyed();
 }
 
-void RenderSVGResourceContainer::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
+void LegacyRenderSVGResourceContainer::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     LegacyRenderSVGHiddenContainer::styleDidChange(diff, oldStyle);
 
@@ -75,7 +75,7 @@ void RenderSVGResourceContainer::styleDidChange(StyleDifference diff, const Rend
     }
 }
 
-void RenderSVGResourceContainer::idChanged()
+void LegacyRenderSVGResourceContainer::idChanged()
 {
     // Invalidate all our current clients.
     removeAllClientsFromCache();
@@ -87,12 +87,12 @@ void RenderSVGResourceContainer::idChanged()
     registerResource();
 }
 
-void RenderSVGResourceContainer::markAllClientsForRepaint()
+void LegacyRenderSVGResourceContainer::markAllClientsForRepaint()
 {
     markAllClientsForInvalidation(RepaintInvalidation);
 }
 
-void RenderSVGResourceContainer::markAllClientsForInvalidation(InvalidationMode mode)
+void LegacyRenderSVGResourceContainer::markAllClientsForInvalidation(InvalidationMode mode)
 {
     // FIXME: Style invalidation should either be a pre-layout task or this function
     // should never get called while in layout. See webkit.org/b/208903.
@@ -110,8 +110,8 @@ void RenderSVGResourceContainer::markAllClientsForInvalidation(InvalidationMode 
         if (root != SVGRenderSupport::findTreeRootObject(client))
             continue;
 
-        if (is<RenderSVGResourceContainer>(client)) {
-            downcast<RenderSVGResourceContainer>(client).removeAllClientsFromCache(markForInvalidation);
+        if (is<LegacyRenderSVGResourceContainer>(client)) {
+            downcast<LegacyRenderSVGResourceContainer>(client).removeAllClientsFromCache(markForInvalidation);
             continue;
         }
 
@@ -124,7 +124,7 @@ void RenderSVGResourceContainer::markAllClientsForInvalidation(InvalidationMode 
     markAllClientLayersForInvalidation();
 }
 
-void RenderSVGResourceContainer::markAllClientLayersForInvalidation()
+void LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation()
 {
     if (m_clientLayers.isEmptyIgnoringNullReferences())
         return;
@@ -147,7 +147,7 @@ void RenderSVGResourceContainer::markAllClientLayersForInvalidation()
     }
 }
 
-void RenderSVGResourceContainer::markClientForInvalidation(RenderObject& client, InvalidationMode mode)
+void LegacyRenderSVGResourceContainer::markClientForInvalidation(RenderObject& client, InvalidationMode mode)
 {
     ASSERT(!m_clients.isEmptyIgnoringNullReferences());
 
@@ -165,28 +165,28 @@ void RenderSVGResourceContainer::markClientForInvalidation(RenderObject& client,
     }
 }
 
-void RenderSVGResourceContainer::addClient(RenderElement& client)
+void LegacyRenderSVGResourceContainer::addClient(RenderElement& client)
 {
     m_clients.add(client);
 }
 
-void RenderSVGResourceContainer::removeClient(RenderElement& client)
+void LegacyRenderSVGResourceContainer::removeClient(RenderElement& client)
 {
     removeClientFromCache(client, false);
     m_clients.remove(client);
 }
 
-void RenderSVGResourceContainer::addClientRenderLayer(RenderLayer& client)
+void LegacyRenderSVGResourceContainer::addClientRenderLayer(RenderLayer& client)
 {
     m_clientLayers.add(client);
 }
 
-void RenderSVGResourceContainer::removeClientRenderLayer(RenderLayer& client)
+void LegacyRenderSVGResourceContainer::removeClientRenderLayer(RenderLayer& client)
 {
     m_clientLayers.remove(client);
 }
 
-void RenderSVGResourceContainer::registerResource()
+void LegacyRenderSVGResourceContainer::registerResource()
 {
     auto& treeScope = this->treeScopeForSVGReferences();
     if (!treeScope.isIdOfPendingSVGResource(m_id)) {
@@ -210,7 +210,7 @@ void RenderSVGResourceContainer::registerResource()
     }
 }
 
-float RenderSVGResourceContainer::computeTextPaintingScale(const RenderElement& renderer)
+float LegacyRenderSVGResourceContainer::computeTextPaintingScale(const RenderElement& renderer)
 {
 #if USE(CG)
     UNUSED_PARAM(renderer);
@@ -227,7 +227,7 @@ float RenderSVGResourceContainer::computeTextPaintingScale(const RenderElement& 
 }
 
 // FIXME: This does not belong here.
-AffineTransform RenderSVGResourceContainer::transformOnNonScalingStroke(RenderObject* object, const AffineTransform& resourceTransform)
+AffineTransform LegacyRenderSVGResourceContainer::transformOnNonScalingStroke(RenderObject* object, const AffineTransform& resourceTransform)
 {
     if (!object->isSVGShapeOrLegacySVGShape())
         return resourceTransform;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -28,11 +28,11 @@ namespace WebCore {
 
 class RenderLayer;
 
-class RenderSVGResourceContainer : public LegacyRenderSVGHiddenContainer,
-                                   public RenderSVGResource {
-    WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceContainer);
+class LegacyRenderSVGResourceContainer : public LegacyRenderSVGHiddenContainer,
+                                         public RenderSVGResource {
+    WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceContainer);
 public:
-    virtual ~RenderSVGResourceContainer();
+    virtual ~LegacyRenderSVGResourceContainer();
 
     void layout() override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
@@ -49,7 +49,7 @@ public:
     void markAllClientLayersForInvalidation();
 
 protected:
-    RenderSVGResourceContainer(SVGElement&, RenderStyle&&);
+    LegacyRenderSVGResourceContainer(SVGElement&, RenderStyle&&);
 
     enum InvalidationMode {
         LayoutAndBoundariesInvalidation,
@@ -79,12 +79,12 @@ private:
     bool m_isInvalidating { false };
 };
 
-inline RenderSVGResourceContainer* getRenderSVGResourceContainerById(TreeScope& treeScope, const AtomString& id)
+inline LegacyRenderSVGResourceContainer* getRenderSVGResourceContainerById(TreeScope& treeScope, const AtomString& id)
 {
     if (id.isEmpty())
         return nullptr;
 
-    if (RenderSVGResourceContainer* renderResource = treeScope.svgResourceById(id))
+    if (LegacyRenderSVGResourceContainer* renderResource = treeScope.svgResourceById(id))
         return renderResource;
 
     return nullptr;
@@ -94,7 +94,7 @@ template<typename Renderer>
 Renderer* getRenderSVGResourceById(TreeScope& treeScope, const AtomString& id)
 {
     // Using the RenderSVGResource type here avoids ambiguous casts for types that
-    // descend from both RenderObject and RenderSVGResourceContainer.
+    // descend from both RenderObject and LegacyRenderSVGResourceContainer.
     RenderSVGResource* container = getRenderSVGResourceContainerById(treeScope, id);
     if (is<Renderer>(container))
         return downcast<Renderer>(container);
@@ -104,4 +104,4 @@ Renderer* getRenderSVGResourceById(TreeScope& treeScope, const AtomString& id)
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceContainer, isSVGResourceContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGResourceContainer, isSVGResourceContainer())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -27,6 +27,7 @@
 #include "GraphicsContext.h"
 #include "HitTestResult.h"
 #include "LayoutRepainter.h"
+#include "LegacyRenderSVGResourceContainer.h"
 #include "LocalFrame.h"
 #include "Page.h"
 #include "RenderBoxInlines.h"
@@ -36,7 +37,6 @@
 #include "RenderLayer.h"
 #include "RenderLayoutState.h"
 #include "RenderSVGResource.h"
-#include "RenderSVGResourceContainer.h"
 #include "RenderSVGResourceFilter.h"
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
@@ -467,7 +467,7 @@ bool LegacyRenderSVGRoot::hasRelativeDimensions() const
     return svgSVGElement().intrinsicHeight().isPercentOrCalculated() || svgSVGElement().intrinsicWidth().isPercentOrCalculated();
 }
 
-void LegacyRenderSVGRoot::addResourceForClientInvalidation(RenderSVGResourceContainer* resource)
+void LegacyRenderSVGRoot::addResourceForClientInvalidation(LegacyRenderSVGResourceContainer* resource)
 {
     LegacyRenderSVGRoot* svgRoot = SVGRenderSupport::findTreeRootObject(*resource);
     if (!svgRoot)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 class AffineTransform;
-class RenderSVGResourceContainer;
+class LegacyRenderSVGResourceContainer;
 class SVGSVGElement;
 
 class LegacyRenderSVGRoot final : public RenderReplaced {
@@ -63,7 +63,7 @@ public:
 
     // The flag is cleared at the beginning of each layout() pass. Elements then call this
     // method during layout when they are invalidated by a filter.
-    static void addResourceForClientInvalidation(RenderSVGResourceContainer*);
+    static void addResourceForClientInvalidation(LegacyRenderSVGResourceContainer*);
 
 private:
     void element() const = delete;
@@ -116,7 +116,7 @@ private:
     FloatRect m_repaintBoundingBox;
     mutable AffineTransform m_localToParentTransform;
     AffineTransform m_localToBorderBoxTransform;
-    WeakHashSet<RenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
+    WeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
     bool m_isLayoutSizeChanged : 1;
     bool m_needsBoundariesOrTransformUpdate : 1;
     bool m_hasBoxDecorations : 1;

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -29,7 +29,6 @@ namespace WebCore {
 
 class Document;
 class Element;
-class RenderSVGResourceContainer;
 class SVGElement;
 class SVGFontFaceElement;
 class SVGResourcesCache;

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1019,8 +1019,8 @@ void SVGElement::svgAttributeChanged(const QualifiedName& attrName)
     if (attrName == HTMLNames::idAttr) {
         auto renderer = this->renderer();
         // Notify resources about id changes, this is important as we cache resources by id in SVGDocumentExtensions
-        if (is<RenderSVGResourceContainer>(renderer))
-            downcast<RenderSVGResourceContainer>(*renderer).idChanged();
+        if (is<LegacyRenderSVGResourceContainer>(renderer))
+            downcast<LegacyRenderSVGResourceContainer>(*renderer).idChanged();
         if (isConnected())
             buildPendingResourcesIfNeeded();
         invalidateInstances();
@@ -1066,7 +1066,7 @@ void SVGElement::buildPendingResourcesIfNeeded()
         if (clientElement->hasPendingResources()) {
             clientElement->buildPendingResource();
             if (auto renderer = clientElement->renderer()) {
-                for (auto& ancestor : ancestorsOfType<RenderSVGResourceContainer>(*renderer))
+                for (auto& ancestor : ancestorsOfType<LegacyRenderSVGResourceContainer>(*renderer))
                     ancestor.markAllClientsForRepaint();
             }
             treeScope.clearHasPendingSVGResourcesIfPossible(*clientElement);


### PR DESCRIPTION
#### 789a2cd2bfb74f69ba8b4669045ad853b9016ba7
<pre>
Move RenderSVGResourceContainer into legacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=261739">https://bugs.webkit.org/show_bug.cgi?id=261739</a>

Reviewed by Nikolas Zimmermann.

Move RenderSVGResourceContainer into legacy and rename it. A new RenderSVGResourceContainer
will be introduced soon for the new LBSE resource concept.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::addSVGResource):
(WebCore::TreeScope::svgResourceById const):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::layerCreationAllowedForSubtree const):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::removeReferenceFilterClients):
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::write):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGResource.cpp:
(WebCore::RenderSVGResource::markForLayoutAndParentResourceInvalidation):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::RenderSVGResourceClipper):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::RenderSVGResourceFilter):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h:
(WebCore::RenderSVGResourceFilter::filterElement const):
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
(WebCore::RenderSVGResourceGradient::RenderSVGResourceGradient):
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
(WebCore::RenderSVGResourceGradient::gradientElement const):
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
(WebCore::RenderSVGResourceMarker::RenderSVGResourceMarker):
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h:
(WebCore::RenderSVGResourceMarker::markerElement const):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::RenderSVGResourceMasker):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h:
(WebCore::RenderSVGResourceMasker::maskElement const):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::RenderSVGResourcePattern):
(WebCore::RenderSVGResourcePattern::patternElement const):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::addResourceForClientInvalidation):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGPaintingResource):
(WebCore::writeSVGResourceContainer):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.h:
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::paintingResourceFromSVGPaint):
(WebCore::SVGResources::resourceDestroyed):
(WebCore::SVGResources::buildSetOfResources):
(WebCore::SVGResources::setFill):
(WebCore::SVGResources::setStroke):
(WebCore::SVGResources::setLinkedResource):
* Source/WebCore/rendering/svg/SVGResources.h:
(WebCore::SVGResources::fill const):
(WebCore::SVGResources::stroke const):
(WebCore::SVGResources::linkedResource const):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::addResourcesFromRenderer):
(WebCore::SVGResourcesCache::removeResourcesFromRenderer):
(WebCore::SVGResourcesCache::resourceDestroyed):
* Source/WebCore/rendering/svg/SVGResourcesCache.h:
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp:
(WebCore::SVGResourcesCycleSolver::resourceContainsCycles):
(WebCore::SVGResourcesCycleSolver::resolveCycles):
(WebCore::SVGResourcesCycleSolver::breakCycle):
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp: Renamed from Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp.
(WebCore::LegacyRenderSVGResourceContainer::LegacyRenderSVGResourceContainer):
(WebCore::LegacyRenderSVGResourceContainer::layout):
(WebCore::LegacyRenderSVGResourceContainer::willBeDestroyed):
(WebCore::LegacyRenderSVGResourceContainer::styleDidChange):
(WebCore::LegacyRenderSVGResourceContainer::idChanged):
(WebCore::LegacyRenderSVGResourceContainer::markAllClientsForRepaint):
(WebCore::LegacyRenderSVGResourceContainer::markAllClientsForInvalidation):
(WebCore::LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation):
(WebCore::LegacyRenderSVGResourceContainer::markClientForInvalidation):
(WebCore::LegacyRenderSVGResourceContainer::addClient):
(WebCore::LegacyRenderSVGResourceContainer::removeClient):
(WebCore::LegacyRenderSVGResourceContainer::addClientRenderLayer):
(WebCore::LegacyRenderSVGResourceContainer::removeClientRenderLayer):
(WebCore::LegacyRenderSVGResourceContainer::registerResource):
(WebCore::LegacyRenderSVGResourceContainer::computeTextPaintingScale):
(WebCore::LegacyRenderSVGResourceContainer::transformOnNonScalingStroke):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h: Renamed from Source/WebCore/rendering/svg/RenderSVGResourceContainer.h.
(WebCore::LegacyRenderSVGResourceContainer::selfNeedsClientInvalidation const):
(WebCore::getRenderSVGResourceContainerById):
(WebCore::getRenderSVGResourceById):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::addResourceForClientInvalidation):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/svg/SVGDocumentExtensions.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::svgAttributeChanged):
(WebCore::SVGElement::buildPendingResourcesIfNeeded):

Canonical link: <a href="https://commits.webkit.org/268196@main">https://commits.webkit.org/268196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6781d83f9b9aaf2a6bb469527f9ffa968f187148

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18795 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20661 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/18988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19408 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21543 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23580 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21486 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17901 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15185 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16964 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4516 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->