### PR TITLE
showPicker() method of date input doesn't work

### DIFF
--- a/LayoutTests/fast/forms/date/date-show-picker-expected.txt
+++ b/LayoutTests/fast/forms/date/date-show-picker-expected.txt
@@ -1,0 +1,4 @@
+
+Is showing date picker? true
+
+This test verifies that a date picker is presented when calling showPicker on a date input.

--- a/LayoutTests/fast/forms/date/date-show-picker.html
+++ b/LayoutTests/fast/forms/date/date-show-picker.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+
+body {
+    margin: 0;
+}
+</style>
+<head>
+<body onload="runTest()">
+<input id="input" type="date"/>
+<pre>Is showing date picker? <span id="before"></span></pre>
+<br>
+<div>This test verifies that a date picker is presented when calling showPicker on a date input.</div>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+async function runTest() {
+    await UIHelper.activateAt(0, 0);
+    input.showPicker();
+
+    before.textContent = await UIHelper.isShowingDateTimePicker();
+
+    testRunner.notifyDone();
+}
+</script>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker-expected.txt
@@ -1,0 +1,4 @@
+
+Is showing date picker? true
+
+This test verifies that a date picker is presented when calling showPicker on a datetime-local input.

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+
+body {
+    margin: 0;
+}
+</style>
+<head>
+<body onload="runTest()">
+<input id="input" type="datetime-local"/>
+<pre>Is showing date picker? <span id="before"></span></pre>
+<br>
+<div>This test verifies that a date picker is presented when calling showPicker on a datetime-local input.</div>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+async function runTest() {
+    await UIHelper.activateAt(0, 0);
+    input.showPicker();
+
+    before.textContent = await UIHelper.isShowingDateTimePicker();
+
+    testRunner.notifyDone();
+}
+</script>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -312,6 +312,8 @@ fast/history/page-cache-notification-suspendable.html
 # UI pickers are not implemented for date and time inputs.
 webkit.org/b/224924 fast/forms/date/date-show-hide-picker.html [ Skip ]
 webkit.org/b/224924 fast/forms/datetimelocal/datetimelocal-show-hide-picker.html [ Skip ]
+webkit.org/b/224924 fast/forms/date/date-show-picker.html [ Skip ]
+webkit.org/b/224924 fast/forms/datetimelocal/datetimelocal-show-picker.html [ Skip ]
 
 # Requires WebP support.
 webkit.org/b/98939 fast/canvas/canvas-toDataURL-webp.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3271,6 +3271,8 @@ fast/text/selection-is-prevent-defaulted.html [ Failure ]
 # FIXME: These tests require UIScriptControllerIOS additions to know when a date/time picker is presented
 fast/forms/date/date-show-hide-picker.html [ Skip ]
 fast/forms/datetimelocal/datetimelocal-show-hide-picker.html [ Skip ]
+fast/forms/date/date-show-picker.html [ Skip ]
+fast/forms/datetimelocal/datetimelocal-show-picker.html [ Skip ]
 
 # <rdar://problem/59636115> REGRESSION: [ iOS & macOS ] two imported/w3c/web-platform-tests/WebCryptoAPI are failing
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.worker.html [ Failure ]

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -302,6 +302,15 @@ void BaseDateAndTimeInputType::handleDOMActivateEvent(Event&)
 
     if (m_dateTimeChooser)
         return;
+
+    showPicker();
+}
+
+void BaseDateAndTimeInputType::showPicker()
+{
+    if (!element()->renderer())
+        return;
+
     if (!element()->document().page())
         return;
 
@@ -309,7 +318,7 @@ void BaseDateAndTimeInputType::handleDOMActivateEvent(Event&)
     if (!setupDateTimeChooserParameters(parameters))
         return;
 
-    if (auto chrome = this->chrome()) {
+    if (auto* chrome = this->chrome()) {
         m_dateTimeChooser = chrome->createDateTimeChooser(*this);
         if (m_dateTimeChooser)
             m_dateTimeChooser->showChooser(parameters);

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -146,6 +146,8 @@ private:
     bool setupDateTimeChooserParameters(DateTimeChooserParameters&);
     void closeDateTimeChooser();
 
+    void showPicker() override;
+
     std::unique_ptr<DateTimeChooser> m_dateTimeChooser;
     RefPtr<DateTimeEditElement> m_dateTimeEditElement;
 };

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -132,6 +132,10 @@ void MonthInputType::handleDOMActivateEvent(Event&)
 {
 }
 
+void MonthInputType::showPicker()
+{
+}
+
 bool MonthInputType::isValidFormat(OptionSet<DateTimeFormatValidationResults> results) const
 {
     return results.containsAll({ DateTimeFormatValidationResults::HasYear, DateTimeFormatValidationResults::HasMonth });

--- a/Source/WebCore/html/MonthInputType.h
+++ b/Source/WebCore/html/MonthInputType.h
@@ -59,6 +59,7 @@ private:
     std::optional<DateComponents> parseToDateComponents(StringView) const final;
     std::optional<DateComponents> setMillisecondToDateComponents(double) const final;
     void handleDOMActivateEvent(Event&) final;
+    void showPicker() final;
 
     bool isValidFormat(OptionSet<DateTimeFormatValidationResults>) const final;
     String formatDateTimeFieldsState(const DateTimeFieldsState&) const final;

--- a/Source/WebCore/html/TimeInputType.cpp
+++ b/Source/WebCore/html/TimeInputType.cpp
@@ -107,6 +107,10 @@ void TimeInputType::handleDOMActivateEvent(Event&)
 {
 }
 
+void TimeInputType::showPicker()
+{
+}
+
 bool TimeInputType::isValidFormat(OptionSet<DateTimeFormatValidationResults> results) const
 {
     return results.containsAll({ DateTimeFormatValidationResults::HasHour, DateTimeFormatValidationResults::HasMinute, DateTimeFormatValidationResults::HasMeridiem });

--- a/Source/WebCore/html/TimeInputType.h
+++ b/Source/WebCore/html/TimeInputType.h
@@ -53,6 +53,7 @@ private:
     std::optional<DateComponents> parseToDateComponents(StringView) const final;
     std::optional<DateComponents> setMillisecondToDateComponents(double) const final;
     void handleDOMActivateEvent(Event&) final;
+    void showPicker() final;
 
     bool isValidFormat(OptionSet<DateTimeFormatValidationResults>) const final;
     String formatDateTimeFieldsState(const DateTimeFieldsState&) const final;

--- a/Source/WebCore/html/WeekInputType.cpp
+++ b/Source/WebCore/html/WeekInputType.cpp
@@ -83,6 +83,10 @@ void WeekInputType::handleDOMActivateEvent(Event&)
 {
 }
 
+void WeekInputType::showPicker()
+{
+}
+
 bool WeekInputType::isValidFormat(OptionSet<DateTimeFormatValidationResults> results) const
 {
     return results.containsAll({ DateTimeFormatValidationResults::HasYear, DateTimeFormatValidationResults::HasWeek });

--- a/Source/WebCore/html/WeekInputType.h
+++ b/Source/WebCore/html/WeekInputType.h
@@ -55,6 +55,7 @@ private:
     std::optional<DateComponents> parseToDateComponents(StringView) const final;
     std::optional<DateComponents> setMillisecondToDateComponents(double) const final;
     void handleDOMActivateEvent(Event&) final;
+    void showPicker() final;
 
     bool isValidFormat(OptionSet<DateTimeFormatValidationResults>) const final;
     String formatDateTimeFieldsState(const DateTimeFieldsState&) const final;


### PR DESCRIPTION
#### 96b83e8d4b0e7d4e8f08fc92b7723dbfa07eac8f
<pre>
showPicker() method of date input doesn&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=257308">https://bugs.webkit.org/show_bug.cgi?id=257308</a>

Reviewed by Aditya Keerthi.

Implement showPicker for date and datetime-local inputs.

* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::handleDOMActivateEvent):
(WebCore::BaseDateAndTimeInputType::showPicker):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/MonthInputType.cpp:
(WebCore::MonthInputType::showPicker):
* Source/WebCore/html/MonthInputType.h:
* Source/WebCore/html/TimeInputType.cpp:
(WebCore::TimeInputType::showPicker):
* Source/WebCore/html/TimeInputType.h:
* Source/WebCore/html/WeekInputType.cpp:
(WebCore::WeekInputType::showPicker):
* Source/WebCore/html/WeekInputType.h:
* LayoutTests/fast/forms/date/date-show-picker-expected.txt: Added.
* LayoutTests/fast/forms/date/date-show-picker.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker-expected.txt: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269257@main">https://commits.webkit.org/269257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ad0d319dc08548b1a0c59cd9c25e56bdff71cb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22563 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21461 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24770 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26226 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24093 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17559 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19778 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5254 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->