### PR TITLE
[iOS] Stop using `-[UIPopoverPresentationController _setCentersPopoverIfSourceViewNotSet:]`

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1025,10 +1025,6 @@ WTF_EXTERN_C_END
 @interface _UIVisualEffectLayerConfig : NSObject
 @end
 
-@interface UIPopoverPresentationController ()
-@property (assign, nonatomic, setter=_setCentersPopoverIfSourceViewNotSet:, getter=_centersPopoverIfSourceViewNotSet) BOOL _centersPopoverIfSourceViewNotSet;
-@end
-
 @interface UIWKDocumentContext : NSObject
 
 @property (nonatomic, copy) NSObject *contextBefore;

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -336,11 +336,10 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
 #endif // PLATFORM(VISION)
     {
         UIPopoverPresentationController *popoverController = [_shareSheetViewController popoverPresentationController];
-        if (rect) {
-            popoverController.sourceView = webView;
-            popoverController.sourceRect = *rect;
-        } else
-            popoverController._centersPopoverIfSourceViewNotSet = YES;
+        popoverController.sourceView = webView;
+        popoverController.sourceRect = rect.value_or(webView.bounds);
+        if (!rect)
+            popoverController.permittedArrowDirections = 0;
     }
 
     if ([_delegate respondsToSelector:@selector(shareSheet:willShowActivityItems:)])


### PR DESCRIPTION
#### b21e19bbf7995da57b77823019869c718eb65d15
<pre>
[iOS] Stop using `-[UIPopoverPresentationController _setCentersPopoverIfSourceViewNotSet:]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=261747">https://bugs.webkit.org/show_bug.cgi?id=261747</a>

Reviewed by Aditya Keerthi.

Replace the single use of `-_setCentersPopoverIfSourceViewNotSet:` in Web Share code (in the case
where no target rect is explicitly specified) with equivalent logic to present the popover with:

1. The `WKWebView` as the source view.
2. The target rect being the entire bounds of the web view.
3. No permitted arrow direction (which causes the popover to show up with no arrow).

This achieves the same final effect as setting the SPI flag to `YES`.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet presentWithShareDataArray:inRect:]):

Canonical link: <a href="https://commits.webkit.org/268133@main">https://commits.webkit.org/268133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55634652252b1767519216fc7ae509886ceba9d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17619 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19302 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16391 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16401 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23591 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21499 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17926 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16988 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4464 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->