### PR TITLE
Have EventTarget subclass CanMakeCheckedPtr

### DIFF
--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -28,6 +28,7 @@
 #include "StyleSheet.h"
 #include <memory>
 #include <variant>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakHashSet.h>
@@ -182,7 +183,7 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_constructorDocument;
     WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
 
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
+    CheckedPtr<Node> m_ownerNode;
     WeakPtr<CSSImportRule> m_ownerRule;
 
     TextPosition m_startPosition;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -391,6 +391,10 @@ public:
 
     virtual ~Document();
 
+    // Resolve ambiguity for CanMakeCheckedPtr.
+    void incrementPtrCount() const { static_cast<const ContainerNode*>(this)->incrementPtrCount(); }
+    void decrementPtrCount() const { static_cast<const ContainerNode*>(this)->decrementPtrCount(); }
+
     // Nodes belonging to this document increase referencingNodeCount -
     // these are enough to keep the document from being destroyed, but
     // not enough to keep it from removing its children. This allows a

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -58,7 +58,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(EventTarget);
 
-struct SameSizeAsEventTarget : public ScriptWrappable, public CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData> {
+struct SameSizeAsEventTarget : ScriptWrappable, CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, CanMakeCheckedPtr {
     virtual ~SameSizeAsEventTarget() = default; // Allocate vtable pointer.
 };
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -37,6 +37,7 @@
 #include "ScriptWrappable.h"
 #include <memory>
 #include <variant>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -78,7 +79,7 @@ private:
     EventTargetData m_eventTargetData;
 };
 
-class EventTarget : public ScriptWrappable, public CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData> {
+class EventTarget : public ScriptWrappable, public CanMakeWeakPtr<EventTarget, WeakPtrFactoryInitialization::Lazy, WeakPtrImplWithEventTargetData>, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(EventTarget);
 public:
     static Ref<EventTarget> create(ScriptExecutionContext&);

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -116,7 +116,7 @@ struct SameSizeAsRenderObject : CanMakeWeakPtr<SameSizeAsRenderObject> {
 #if ASSERT_ENABLED
     WeakHashSet<void*> cachedResourceClientAssociatedResources;
 #endif
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> node;
+    CheckedRef<Node> node;
     void* pointers[3];
     CheckedPtr<Layout::Box> layoutBox;
 #if ASSERT_ENABLED

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -269,7 +269,7 @@ public:
     virtual bool isRenderScrollbarPart() const { return false; }
     virtual bool isRenderVTTCue() const { return false; }
 
-    bool isDocumentElementRenderer() const { return document().documentElement() == m_node; }
+    bool isDocumentElementRenderer() const { return document().documentElement() == m_node.ptr(); }
     bool isBody() const { return node() && node()->hasTagName(HTMLNames::bodyTag); }
     bool isHR() const { return node() && node()->hasTagName(HTMLNames::hrTag); }
     bool isLegend() const;
@@ -495,8 +495,7 @@ public:
     { 
         if (isAnonymous())
             return nullptr;
-        ASSERT(m_node);
-        return m_node.get(); 
+        return m_node.ptr();
     }
 
     Node* nonPseudoNode() const { return isPseudoElement() ? nullptr : node(); }
@@ -506,8 +505,8 @@ public:
     // pseudo elements for which their parent node is returned.
     Node* generatingNode() const { return isPseudoElement() ? generatingPseudoHostElement() : node(); }
 
-    Document& document() const { ASSERT(m_node); return m_node->document(); }
-    TreeScope& treeScopeForSVGReferences() const { ASSERT(m_node); return m_node->treeScopeForSVGReferences(); }
+    Document& document() const { return m_node.get().document(); }
+    TreeScope& treeScopeForSVGReferences() const { return m_node.get().treeScopeForSVGReferences(); }
     LocalFrame& frame() const;
     Page& page() const;
     Settings& settings() const { return page().settings(); }
@@ -813,7 +812,7 @@ protected:
     void setNextSibling(RenderObject* next) { m_next = next; }
     void setParent(RenderElement*);
     //////////////////////////////////////////
-    Node& nodeForNonAnonymous() const { ASSERT(!isAnonymous()); ASSERT(m_node); return *m_node; }
+    Node& nodeForNonAnonymous() const { ASSERT(!isAnonymous()); return m_node.get(); }
 
     void adjustRectForOutlineAndShadow(LayoutRect&) const;
 
@@ -864,7 +863,7 @@ private:
     void checkBlockPositionedObjectsNeedLayout();
 #endif
 
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_node;
+    CheckedRef<Node> m_node;
 
     RenderElement* m_parent;
     RenderObject* m_previous;


### PR DESCRIPTION
#### 621b09e126a65fbc16a33b9c510e4cbb8d438d78
<pre>
Have EventTarget subclass CanMakeCheckedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=261748">https://bugs.webkit.org/show_bug.cgi?id=261748</a>

Reviewed by Brent Fulgham.

Have EventTarget subclass CanMakeCheckedPtr and start using CheckedPtr in a few
places instead of WeakPtr.

CheckedPtr is more efficient and having EventTarget subclasses (such as Node)
support it will help our smart pointer effort.

This tested as perf-neutral on MotionMark and Membuster. This tested as a
0.4% progression (with 98% confidence) on Speedometer 3.

* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/dom/Document.h:
(WebCore::Document::incrementPtrCount const):
(WebCore::Document::decrementPtrCount const):
* Source/WebCore/dom/EventTarget.cpp:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isDocumentElementRenderer const):
(WebCore::RenderObject::node const):
(WebCore::RenderObject::document const):
(WebCore::RenderObject::treeScopeForSVGReferences const):
(WebCore::RenderObject::nodeForNonAnonymous const):

Canonical link: <a href="https://commits.webkit.org/268146@main">https://commits.webkit.org/268146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cfdfe9a993a3973a905fec110fc829a020a2fec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19319 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21589 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17173 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21522 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17938 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17003 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4475 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21370 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->