### PR TITLE
AVVideoCaptureSource is beginning configuration of device even if reapplying the same configuration

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1176,7 +1176,7 @@ void RealtimeMediaSource::applyConstraints(const FlattenedConstraint& constraint
     if (constraints.isEmpty())
         return;
 
-    beginConfiguration();
+    startApplyingConstraints();
 
     auto videoFrameSizeConstraints = extractVideoFrameSizeConstraints(constraints);
 
@@ -1200,7 +1200,7 @@ void RealtimeMediaSource::applyConstraints(const FlattenedConstraint& constraint
         applyConstraint(variant);
     }
 
-    commitConfiguration();
+    endApplyingConstraints();
 }
 
 std::optional<RealtimeMediaSource::ApplyConstraintsError> RealtimeMediaSource::applyConstraints(const MediaConstraints& constraints)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -265,8 +265,8 @@ protected:
 
     void scheduleDeferredTask(Function<void()>&&);
 
-    virtual void beginConfiguration() { }
-    virtual void commitConfiguration() { }
+    virtual void startApplyingConstraints() { }
+    virtual void endApplyingConstraints() { }
 
     bool selectSettings(const MediaConstraints&, FlattenedConstraint&, String&);
     double fitnessDistance(const MediaConstraint&);

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -136,7 +136,7 @@ private:
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
     CaptureDevice::DeviceType deviceType() const { return m_capturer->deviceType(); }
-    void commitConfiguration() final { m_capturer->commitConfiguration(settings()); }
+    void endApplyingConstraints() final { commitConfiguration(); }
     IntSize computeResizedVideoFrameSize(IntSize desiredSize, IntSize actualSize) final;
     void setSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double>, std::optional<double>) final;
 
@@ -148,6 +148,7 @@ private:
     void capturerFailed() final { captureFailed(); }
     void capturerConfigurationChanged() final;
 
+    void commitConfiguration() { m_capturer->commitConfiguration(settings()); }
     void emitFrame();
 
     UniqueRef<Capturer> m_capturer;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -89,8 +89,8 @@ private:
     void stopProducingData() final;
     void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) final;
     void monitorOrientation(OrientationNotifier&) final;
-    void beginConfiguration() final;
-    void commitConfiguration() final;
+    void startApplyingConstraints() final;
+    void endApplyingConstraints() final;
     bool isCaptureSource() const final { return true; }
     CaptureDevice::DeviceType deviceType() const final { return CaptureDevice::DeviceType::Camera; }
     bool interrupted() const final;
@@ -120,6 +120,10 @@ private:
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "AVVideoCaptureSource"; }
 #endif
+
+    void beginConfiguration();
+    void commitConfiguration();
+    void beginConfigurationForConstraintsIfNeeded();
 
     void updateVerifyCapturingTimer();
     void verifyIsCapturing();
@@ -154,6 +158,7 @@ private:
     uint64_t m_beginConfigurationCount { 0 };
     bool m_interrupted { false };
     bool m_isRunning { false };
+    bool m_hasBegunConfigurationForConstraints { false };
 
     static constexpr Seconds verifyCaptureInterval = 30_s;
     static const uint64_t framesToDropWhenStarting = 4;


### PR DESCRIPTION
#### 55bd33553749d9b02da3898b427fdbcbb69ec198
<pre>
AVVideoCaptureSource is beginning configuration of device even if reapplying the same configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=261749">https://bugs.webkit.org/show_bug.cgi?id=261749</a>
rdar://113717799

Reviewed by Eric Carlson.

When the AVCaptureSession beginConfiguration is called, this triggers flashing of the camera and camera red pill.
We were doing so whenever applyConstraints is called.

To prevent this, we are now only calling beginConfiguration if we detect some parameters are changed.
These change checks happen in two places, setFrameRateAndZoomWithPreset and updateWhiteBalanceMode.

We are therefore renaming RealtimeMediaSource beginConfiguration/commitConfiguration to startApplyingConstraints and endApplyingConstraints.
We implement startApplyingConstraints and endApplyingConstraints in AVVideoCaptureSource by storing whether we are applying constraints.
In setFrameRateAndZoomWithPreset and updateWhiteBalanceMode, we then call beginConfiguration if some parameters changed and beginConfiguration has not been called already.
endApplyingConstraints will then call commitConfiguration if beginConfiguration was called previously.

Manually tested.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::applyConstraints):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::startApplyingConstraints):
(WebCore::AVVideoCaptureSource::endApplyingConstraints):
(WebCore::AVVideoCaptureSource::beginConfigurationForConstraintsIfNeeded):
(WebCore::AVVideoCaptureSource::commitConfiguration):
(WebCore::AVVideoCaptureSource::setFrameRateAndZoomWithPreset):
(WebCore::isSameFrameRateRange):
(WebCore::AVVideoCaptureSource::setSessionSizeFrameRateAndZoom):
(WebCore::AVVideoCaptureSource::updateWhiteBalanceMode):
(WebCore::AVVideoCaptureSource::setupSession):
(WebCore::AVVideoCaptureSource::setupCaptureSession):

Canonical link: <a href="https://commits.webkit.org/268439@main">https://commits.webkit.org/268439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ab50a664715aed9282c7aed3d3c0a4c713cba4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18827 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19423 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21578 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23595 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21505 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15208 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16993 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4710 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->