### PR TITLE
Address missed review feedback from PR 17874

### DIFF
--- a/Source/WebKit/Shared/WebPushMessage.cpp
+++ b/Source/WebKit/Shared/WebPushMessage.cpp
@@ -39,12 +39,10 @@ WebCore::NotificationData WebPushMessage::notificationPayloadToCoreData() const
     static NeverDestroyed<WebCore::ScriptExecutionContextIdentifier> sharedScriptIdentifier = WebCore::ScriptExecutionContextIdentifier::generate();
 
     String body, iconURL, tag, language;
-    WebCore::NotificationDirection direction = WebCore::NotificationDirection::Auto;
+    auto direction = WebCore::NotificationDirection::Auto;
     std::optional<bool> silent;
 
-    CString dataCString;
     Vector<uint8_t> dataJSON;
-
     if (notificationPayload->options) {
         body = notificationPayload->options->body;
         language = notificationPayload->options->lang;
@@ -53,17 +51,17 @@ WebCore::NotificationData WebPushMessage::notificationPayloadToCoreData() const
         direction = notificationPayload->options->dir;
         silent = notificationPayload->options->silent;
 
-        dataCString = notificationPayload->options->dataJSONString.utf8();
+        CString dataCString = notificationPayload->options->dataJSONString.utf8();
         dataJSON = { dataCString.dataAsUInt8Ptr(), dataCString.length() };
     }
 
     return {
         notificationPayload->defaultActionURL,
         notificationPayload->title,
-        body,
-        iconURL,
-        tag,
-        language,
+        WTFMove(body),
+        WTFMove(iconURL),
+        WTFMove(tag),
+        WTFMove(language),
         direction,
         WebCore::SecurityOriginData::fromURL(registrationURL).toString(),
         registrationURL,
@@ -72,7 +70,7 @@ WebCore::NotificationData WebPushMessage::notificationPayloadToCoreData() const
         PAL::SessionID::defaultSessionID(),
         MonotonicTime::now(),
         WTFMove(dataJSON),
-        silent
+        WTFMove(silent)
     };
 }
 


### PR DESCRIPTION
#### 9693d694a9fe16f7d47e537d226e246198ea6448
<pre>
Address missed review feedback from PR 17874
<a href="https://bugs.webkit.org/show_bug.cgi?id=261750">https://bugs.webkit.org/show_bug.cgi?id=261750</a>
rdar://115730529

Unreviewed. (Review feedback from Chris Dumez on original patch)

Githubs &quot;Hidden conversations&quot; UI made me miss these originally.

* Source/WebKit/Shared/WebPushMessage.cpp:
(WebKit::WebPushMessage::notificationPayloadToCoreData const):

Canonical link: <a href="https://commits.webkit.org/268134@main">https://commits.webkit.org/268134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a534a2f9037c16cc6e23b25add0bfca939f666b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17617 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19300 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21569 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16399 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21498 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17924 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16986 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4466 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->