### PR TITLE
Declarative Web Push - Expose window.navigator.pushManager

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -571,6 +571,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/pictureinpicture/PictureInPictureEvent.idl
     Modules/pictureinpicture/PictureInPictureWindow.idl
 
+    Modules/push-api/NavigatorPush.idl
     Modules/push-api/PushEncryptionKeyName.idl
     Modules/push-api/PushEvent.idl
     Modules/push-api/PushEventInit.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -786,6 +786,7 @@ $(PROJECT_DIR)/Modules/pictureinpicture/DocumentOrShadowRoot+PictureInPicture.id
 $(PROJECT_DIR)/Modules/pictureinpicture/HTMLVideoElement+PictureInPicture.idl
 $(PROJECT_DIR)/Modules/pictureinpicture/PictureInPictureEvent.idl
 $(PROJECT_DIR)/Modules/pictureinpicture/PictureInPictureWindow.idl
+$(PROJECT_DIR)/Modules/push-api/NavigatorPush.idl
 $(PROJECT_DIR)/Modules/push-api/PushEncryptionKeyName.idl
 $(PROJECT_DIR)/Modules/push-api/PushEvent.idl
 $(PROJECT_DIR)/Modules/push-api/PushEventInit.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1961,6 +1961,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorOnLine.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorOnLine.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorPlugins.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorPlugins.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorPush.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorPush.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorServiceWorker.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorServiceWorker.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorShare.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -560,6 +560,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/pictureinpicture/HTMLVideoElement+PictureInPicture.idl \
     $(WebCore)/Modules/pictureinpicture/PictureInPictureEvent.idl \
     $(WebCore)/Modules/pictureinpicture/PictureInPictureWindow.idl \
+    $(WebCore)/Modules/push-api/NavigatorPush.idl \
     $(WebCore)/Modules/push-api/PushEncryptionKeyName.idl \
     $(WebCore)/Modules/push-api/PushEvent.idl \
     $(WebCore)/Modules/push-api/PushEventInit.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -532,6 +532,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/push-api/PushDatabase.h
     Modules/push-api/PushMessageCrypto.h
     Modules/push-api/PushPermissionState.h
+    Modules/push-api/PushStrategy.h
     Modules/push-api/PushSubscriptionData.h
     Modules/push-api/PushSubscriptionIdentifier.h
 

--- a/Source/WebCore/Modules/push-api/NavigatorPush.idl
+++ b/Source/WebCore/Modules/push-api/NavigatorPush.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Experimental but standards tracked
+[
+    Conditional=DECLARATIVE_WEB_PUSH,
+    EnabledBySetting=DeclarativeWebPush,
+] interface mixin NavigatorPush {
+    readonly attribute PushManager pushManager;
+};

--- a/Source/WebCore/Modules/push-api/PushStrategy.h
+++ b/Source/WebCore/Modules/push-api/PushStrategy.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+
+#include "PushSubscriptionIdentifier.h"
+
+namespace WebCore {
+
+class WEBCORE_EXPORT PushStrategy {
+public:
+    virtual ~PushStrategy() = default;
+
+    using SubscribeToPushServiceCallback = CompletionHandler<void(ExceptionOr<PushSubscriptionData>&&)>;
+    virtual void navigatorSubscribeToPushService(const URL& scope, const Vector<uint8_t>& applicationServerKey, SubscribeToPushServiceCallback&&) = 0;
+
+    using UnsubscribeFromPushServiceCallback = CompletionHandler<void(ExceptionOr<bool>&&)>;
+    virtual void navigatorUnsubscribeFromPushService(const URL& scope, PushSubscriptionIdentifier, UnsubscribeFromPushServiceCallback&&) = 0;
+
+    using GetPushSubscriptionCallback = CompletionHandler<void(ExceptionOr<std::optional<PushSubscriptionData>>&&)>;
+    virtual void navigatorGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&&) = 0;
+
+    using GetPushPermissionStateCallback = CompletionHandler<void(ExceptionOr<PushPermissionState>&&)>;
+    virtual void navigatorGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) = 0;
+};
+
+} // namespace WebCore
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -36,6 +36,7 @@ Navigator includes NavigatorMaxTouchPoints;
 Navigator includes NavigatorOnLine;
 Navigator includes NavigatorCookies;
 Navigator includes NavigatorPlugins;
+Navigator includes NavigatorPush;
 Navigator includes NavigatorServiceWorker;
 Navigator includes NavigatorShare;
 Navigator includes NavigatorStorage;

--- a/Source/WebCore/platform/PlatformStrategies.h
+++ b/Source/WebCore/platform/PlatformStrategies.h
@@ -31,6 +31,9 @@ class BlobRegistry;
 class LoaderStrategy;
 class MediaStrategy;
 class PasteboardStrategy;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+class PushStrategy;
+#endif
 
 class PlatformStrategies {
 public:
@@ -62,6 +65,15 @@ public:
         return m_blobRegistry;
     }
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    PushStrategy* pushStrategy()
+    {
+        if (!m_pushStrategy)
+            m_pushStrategy = createPushStrategy();
+        return m_pushStrategy;
+    }
+#endif
+
 protected:
     PlatformStrategies() = default;
 
@@ -79,6 +91,11 @@ private:
     PasteboardStrategy* m_pasteboardStrategy { };
     MediaStrategy* m_mediaStrategy { };
     BlobRegistry* m_blobRegistry { };
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    virtual PushStrategy* createPushStrategy() = 0;
+    PushStrategy* m_pushStrategy { };
+#endif
 };
 
 bool hasPlatformStrategies();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -48,6 +48,7 @@
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
+#include <WebCore/PushSubscriptionIdentifier.h>
 #include <WebCore/RTCDataChannelIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/WebSocketIdentifier.h>
@@ -353,6 +354,13 @@ private:
     void cookiesAdded(const String& host, const Vector<WebCore::Cookie>&) final;
     void cookiesDeleted(const String& host, const Vector<WebCore::Cookie>&) final;
     void allCookiesDeleted() final;
+#endif
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    void navigatorSubscribeToPushService(URL&& scopeURL, Vector<uint8_t>&& applicationServerKey, CompletionHandler<void(Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&&)>&&);
+    void navigatorUnsubscribeFromPushService(URL&& scopeURL, const WebCore::PushSubscriptionIdentifier&, CompletionHandler<void(Expected<bool, WebCore::ExceptionData>&&)>&&);
+    void navigatorGetPushSubscription(URL&& scopeURL, CompletionHandler<void(Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&&)>&&);
+    void navigatorGetPushPermissionState(URL&& scopeURL, CompletionHandler<void(Expected<uint8_t, WebCore::ExceptionData>&&)>&&);
 #endif
 
     struct ResourceNetworkActivityTracker {

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -126,4 +126,11 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
 
     AddAllowedFirstPartyForCookies(WebCore::RegistrableDomain firstPartyDomain)
     UseRedirectionForCurrentNavigation(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier, WebCore::ResourceResponse response)
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    NavigatorSubscribeToPushService(URL scopeURL, Vector<uint8_t> applicationServerKey) -> (Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData> result)
+    NavigatorUnsubscribeFromPushService(URL scopeURL, WebCore::PushSubscriptionIdentifier pushSubscriptionIdentifier) -> (Expected<bool, WebCore::ExceptionData> result)
+    NavigatorGetPushSubscription(URL scopeURL) -> (Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData> result)
+    NavigatorGetPushPermissionState(URL scopeURL) -> (Expected<uint8_t, WebCore::ExceptionData> result)
+#endif
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp
@@ -72,4 +72,11 @@ BlobRegistry* NetworkProcessPlatformStrategies::createBlobRegistry()
     return &blobRegistry.get();
 }
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+PushStrategy* NetworkProcessPlatformStrategies::createPushStrategy()
+{
+    return nullptr;
+}
+#endif
+
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.h
@@ -40,6 +40,9 @@ private:
     WebCore::PasteboardStrategy* createPasteboardStrategy() override;
     WebCore::MediaStrategy* createMediaStrategy() override;
     WebCore::BlobRegistry* createBlobRegistry() override;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    WebCore::PushStrategy* createPushStrategy() override;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h
@@ -28,10 +28,17 @@
 #include <WebCore/LoaderStrategy.h>
 #include <WebCore/PasteboardStrategy.h>
 #include <WebCore/PlatformStrategies.h>
+#include <WebCore/PushStrategy.h>
 
 namespace WebKit {
 
-class WebPlatformStrategies : public WebCore::PlatformStrategies, private WebCore::PasteboardStrategy {
+class WebPlatformStrategies :
+    public WebCore::PlatformStrategies,
+    private WebCore::PasteboardStrategy
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    , public WebCore::PushStrategy
+#endif
+{
     friend NeverDestroyed<WebPlatformStrategies>;
 public:
     static void initialize();
@@ -44,6 +51,9 @@ private:
     WebCore::PasteboardStrategy* createPasteboardStrategy() override;
     WebCore::MediaStrategy* createMediaStrategy() override;
     WebCore::BlobRegistry* createBlobRegistry() override;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    WebCore::PushStrategy* createPushStrategy() override;
+#endif
 
     // WebCore::PasteboardStrategy
 #if PLATFORM(IOS_FAMILY)
@@ -98,6 +108,14 @@ private:
     Vector<String> typesSafeForDOMToReadAndWrite(const String& pasteboardName, const String& origin, const WebCore::PasteboardContext*) override;
     int64_t writeCustomData(const Vector<WebCore::PasteboardCustomData>&, const String&, const WebCore::PasteboardContext*) override;
     bool containsStringSafeForDOMToReadForType(const String&, const String& pasteboardName, const WebCore::PasteboardContext*) override;
+
+    // WebCore::PushStrategy
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    void navigatorSubscribeToPushService(const URL& scope, const Vector<uint8_t>& applicationServerKey, SubscribeToPushServiceCallback&&) override;
+    void navigatorUnsubscribeFromPushService(const URL& scope, WebCore::PushSubscriptionIdentifier, UnsubscribeFromPushServiceCallback&&) override;
+    void navigatorGetPushSubscription(const URL& scope, GetPushSubscriptionCallback&&) override;
+    void navigatorGetPushPermissionState(const URL& scope, GetPushPermissionStateCallback&&) override;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h
@@ -46,6 +46,10 @@ private:
     WebCore::MediaStrategy* createMediaStrategy() override;
     WebCore::BlobRegistry* createBlobRegistry() override;
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    WebCore::PushStrategy* createPushStrategy() override { return nullptr; }
+#endif
+
     // WebCore::PasteboardStrategy
 #if PLATFORM(IOS_FAMILY)
     void writeToPasteboard(const WebCore::PasteboardURL&, const String& pasteboardName, const WebCore::PasteboardContext*) override;


### PR DESCRIPTION
#### 1656d3b67f45abd302bda420d9c233f323cd7fbd
<pre>
Declarative Web Push - Expose window.navigator.pushManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=261751">https://bugs.webkit.org/show_bug.cgi?id=261751</a>
rdar://115730929

Reviewed by Tim Horton.

Since a goal of Declarative Web Push is to work without service workers, you must be able to (un)subscribe
from a window browsing context, no ServiceWorkerRegistration needed.

To that end, expose a PushManager on window.navigator.

The push subscriptions from a window whose scope matches a service worker can be seen from that service worker.
And vice versa.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/push-api/NavigatorPush.idl: Copied from Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.h.
* Source/WebCore/Modules/push-api/PushStrategy.h: Copied from Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.h.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::Navigator):
(WebCore::Navigator::pushManager):
(WebCore::toScope):
(WebCore::Navigator::subscribeToPushService):
(WebCore::Navigator::unsubscribeFromPushService):
(WebCore::Navigator::getPushSubscription):
(WebCore::Navigator::getPushPermissionState):
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/Navigator.idl:
* Source/WebCore/platform/PlatformStrategies.h:
(WebCore::PlatformStrategies::pushStrategy):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::navigatorSubscribeToPushService):
(WebKit::NetworkConnectionToWebProcess::navigatorUnsubscribeFromPushService):
(WebKit::NetworkConnectionToWebProcess::navigatorGetPushSubscription):
(WebKit::NetworkConnectionToWebProcess::navigatorGetPushPermissionState):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.cpp:
(WebKit::NetworkProcessPlatformStrategies::createPushStrategy):
* Source/WebKit/NetworkProcess/NetworkProcessPlatformStrategies.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::createPushStrategy):
(WebKit::WebPlatformStrategies::navigatorSubscribeToPushService):
(WebKit::WebPlatformStrategies::navigatorUnsubscribeFromPushService):
(WebKit::WebPlatformStrategies::navigatorGetPushSubscription):
(WebKit::WebPlatformStrategies::navigatorGetPushPermissionState):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::log):
(TestWebKitAPI::function):
(TestWebKitAPI::subscribe):
(TestWebKitAPI::unsubscribe):
(TestWebKitAPI::getPushSubscription):
(TestWebKitAPI::then): Deleted.
(TestWebKitAPI::catch): Deleted.
(TestWebKitAPI::disableShowNotifications): Deleted.

Canonical link: <a href="https://commits.webkit.org/268147@main">https://commits.webkit.org/268147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02d165018a57ed12a18a366fb13f8344c763044e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18843 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20712 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19323 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21594 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17179 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21524 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17942 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17007 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4479 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->