### PR TITLE
GLContextX11.cpp:89:66: error: invalid cast from type 'long unsigned int' to type 'EGLNativePixmapType' {aka 'unsigned int'}

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContextX11.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextX11.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<GLContext> GLContext::createPixmapContext(PlatformDisplay& platf
     // swap buffers. So, we use a custom XError handler here that ignores BadDrawable errors and only warns about any other
     // errors without aborting in any case.
     XErrorTrapper trapper(x11Display, XErrorTrapper::Policy::Warn, { BadDrawable });
-    EGLSurface surface = eglCreatePixmapSurface(display, config, reinterpret_cast<EGLNativePixmapType>(pixmap.get()), 0);
+    EGLSurface surface = eglCreatePixmapSurface(display, config, (EGLNativePixmapType)pixmap.get(), 0);
     if (surface == EGL_NO_SURFACE) {
         eglDestroyContext(display, context);
         return nullptr;


### PR DESCRIPTION
#### 356c9d5d33e0e3883cdd5909a601fa5736495fff
<pre>
GLContextX11.cpp:89:66: error: invalid cast from type &apos;long unsigned int&apos; to type &apos;EGLNativePixmapType&apos; {aka &apos;unsigned int&apos;}
<a href="https://bugs.webkit.org/show_bug.cgi?id=261754">https://bugs.webkit.org/show_bug.cgi?id=261754</a>

Unreviewed build fix.

As usual, we need to use C-style casts with EGL types.

* Source/WebCore/platform/graphics/egl/GLContextX11.cpp:
(WebCore::GLContext::createPixmapContext):

Canonical link: <a href="https://commits.webkit.org/268137@main">https://commits.webkit.org/268137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92a2f37a0845d0872321c464e95486068c3f3c7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21580 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17157 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21507 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16995 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4463 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21362 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->