### PR TITLE
[WGSL] Concretize variable initializers

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -134,4 +134,44 @@ const Type* satisfyOrPromote(const Type* type, Constraint constraint, const Type
     }
 }
 
+const Type* concretize(const Type* type, TypeStore& types)
+{
+    using namespace Types;
+
+    return WTF::switchOn(*type,
+        [&](const Primitive&) -> const Type* {
+            return satisfyOrPromote(type, Constraints::ConcreteScalar, types);
+        },
+        [&](const Vector& vector) -> const Type* {
+            return types.vectorType(concretize(vector.element, types), vector.size);
+        },
+        [&](const Matrix& matrix) -> const Type* {
+            return types.matrixType(concretize(matrix.element, types), matrix.columns, matrix.rows);
+        },
+        [&](const Array& array) -> const Type* {
+            return types.arrayType(concretize(array.element, types), array.size);
+        },
+        [&](const Struct&) -> const Type* {
+            return type;
+        },
+        [&](const Function&) -> const Type* {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Texture&) -> const Type* {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const TextureStorage&) -> const Type* {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Reference&) -> const Type* {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const TypeConstructor&) -> const Type* {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Bottom&) -> const Type* {
+            return type;
+        });
+}
+
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Constraints.h
+++ b/Source/WebGPU/WGSL/Constraints.h
@@ -66,5 +66,6 @@ constexpr Constraint Number = Float | Integer;
 
 bool satisfies(const Type*, Constraint);
 const Type* satisfyOrPromote(const Type*, Constraint, const TypeStore&);
+const Type* concretize(const Type*, TypeStore&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -269,9 +269,12 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
             variable.maybeInitializer()->m_inferredType = initializerType;
         }
 
-        if (!result)
-            result = initializerType;
-        else if (unify(result, initializerType))
+        if (!result) {
+            if (variable.flavor() == AST::VariableFlavor::Const)
+                result = initializerType;
+            else
+                result = concretize(initializerType, m_types);
+        } else if (unify(result, initializerType))
             variable.maybeInitializer()->m_inferredType = result;
         else
             typeError(InferBottom::No, variable.span(), "cannot initialize var of type '", *result, "' with value of type '", *initializerType, "'");

--- a/Source/WebGPU/WGSL/tests/invalid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/for.wgsl
@@ -1,7 +1,7 @@
 // RUN: %not %wgslc | %check
 
 fn testForStatement() {
-  // CHECK-L: for-loop condition must be bool, got ref<function, <AbstractInt>, read_write>
+  // CHECK-L: for-loop condition must be bool, got ref<function, i32, read_write>
   for (var i = 0; i; i++) {
   }
 }

--- a/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
@@ -5,6 +5,9 @@ fn testVariableInialization() {
   let x2: vec2<u32> = vec2(0, 0);
   let x3: f32 = 0;
   let x4: f32 = 0.0;
+
+  var v1 = vec2(0.0);
+  v1 = vec2f(0);
 }
 
 @vertex


### PR DESCRIPTION
#### ed7550022458b84e82cfd858d708d80d2160a5d5
<pre>
[WGSL] Concretize variable initializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=261759">https://bugs.webkit.org/show_bug.cgi?id=261759</a>
rdar://115735821

Reviewed by Mike Wyrzykowski.

When initializing any non-const declaration (i.e. let, override or var), if the
type of the declaration is inferred from the initial value, then the value must
be concretized (as defined in the spec[1]). The implementation is built on top
of the existing constraint function `satisfyOrPromote`, which is applied to
primitive types and components of composite types.

[1]: <a href="https://www.w3.org/TR/WGSL/#var-and-value">https://www.w3.org/TR/WGSL/#var-and-value</a>

* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::concretize):
* Source/WebGPU/WGSL/Constraints.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
* Source/WebGPU/WGSL/tests/invalid/for.wgsl:
* Source/WebGPU/WGSL/tests/valid/concretization.wgsl:

Canonical link: <a href="https://commits.webkit.org/268199@main">https://commits.webkit.org/268199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f49a8f3c719abc33eaf789ba00daa75de2d3d2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17637 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19430 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21621 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16420 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23629 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15218 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17006 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4517 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->