### PR TITLE
Regression(267850@main) Flaky crash under PermissionStatus::virtualHasPendingActivity()

### DIFF
--- a/Source/WebCore/Modules/permissions/PermissionStatus.cpp
+++ b/Source/WebCore/Modules/permissions/PermissionStatus.cpp
@@ -115,9 +115,8 @@ bool PermissionStatus::virtualHasPendingActivity() const
     if (!m_hasChangeEventListener)
         return false;
 
-    RefPtr context = scriptExecutionContext();
-    if (is<Document>(context.get()))
-        return downcast<Document>(*context).hasBrowsingContext();
+    if (WeakPtr document = dynamicDowncast<Document>(scriptExecutionContext()))
+        return document->hasBrowsingContext();
 
     return true;
 }


### PR DESCRIPTION
#### 7f9259f2cf69171ea980ee8e98e1e101de63e8ec
<pre>
Regression(267850@main) Flaky crash under PermissionStatus::virtualHasPendingActivity()
<a href="https://bugs.webkit.org/show_bug.cgi?id=261763">https://bugs.webkit.org/show_bug.cgi?id=261763</a>

Reviewed by Brent Fulgham.

PermissionStatus::virtualHasPendingActivity() can get called on a GC-thread,
in which case we would try to ref the Document off the main thread, thus
hitting an assertion in Node::ref().

Switch to WeakPtr to avoid the issue.

* Source/WebCore/Modules/permissions/PermissionStatus.cpp:
(WebCore::PermissionStatus::virtualHasPendingActivity const):

Canonical link: <a href="https://commits.webkit.org/268145@main">https://commits.webkit.org/268145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51f30b7743c9ae9db097656cef27b52ef3e5cfa0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19332 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21606 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17188 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21533 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17014 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4473 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21381 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->