### PR TITLE
[WebGPU] Wrong default values for bytesPerRow and rowsPerImage in QueueImpl::writeTexture

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -99,8 +99,8 @@ void QueueImpl::writeTexture(
     WGPUTextureDataLayout backingDataLayout {
         nullptr,
         dataLayout.offset,
-        dataLayout.bytesPerRow.value_or(0),
-        dataLayout.rowsPerImage.value_or(1),
+        dataLayout.bytesPerRow.value_or(WGPU_COPY_STRIDE_UNDEFINED),
+        dataLayout.rowsPerImage.value_or(WGPU_COPY_STRIDE_UNDEFINED),
     };
 
     WGPUExtent3D backingSize = m_convertToBackingContext->convertToBacking(size);

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -320,8 +320,11 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, const void* da
         return;
 
     NSUInteger bytesPerRow = dataLayout.bytesPerRow;
+    if (bytesPerRow == WGPU_COPY_STRIDE_UNDEFINED)
+        bytesPerRow = size.height ? (dataSize / size.height) : dataSize;
 
-    NSUInteger bytesPerImage = dataLayout.bytesPerRow * dataLayout.rowsPerImage;
+    NSUInteger rowsPerImage = (dataLayout.rowsPerImage == WGPU_COPY_STRIDE_UNDEFINED) ? size.height : dataLayout.rowsPerImage;
+    NSUInteger bytesPerImage = bytesPerRow * rowsPerImage;
 
     MTLBlitOption options = MTLBlitOptionNone;
     switch (destination.aspect) {


### PR DESCRIPTION
#### 91c2da047ad0f1e57a8669c49d9f22ec57f2a0cf
<pre>
[WebGPU] Wrong default values for bytesPerRow and rowsPerImage in QueueImpl::writeTexture
<a href="https://bugs.webkit.org/show_bug.cgi?id=261776">https://bugs.webkit.org/show_bug.cgi?id=261776</a>
&lt;radar://115746284&gt;

Reviewed by Dan Glastonbury.

0 and 1 are incorrect here, we should use the default of WGPU_COPY_STRIDE_UNDEFINED
instead.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::writeTexture):

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):
Fall back to defaults when undefined constant is passed.

Canonical link: <a href="https://commits.webkit.org/268181@main">https://commits.webkit.org/268181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebadcf3cb218a63c9e948dd87c214cd0aaeae812

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20749 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19453 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21633 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23630 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21554 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15241 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17037 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4501 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->