### PR TITLE
Support #else and conditional using statements in messages.in files

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -932,6 +932,9 @@ template<> bool isValidOptionSet<EnumNamespace2::OptionSetEnumType>(OptionSet<En
 #if ENABLE(OPTION_SET_SECOND_VALUE)
         | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValue)
 #endif
+#if !ENABLE(OPTION_SET_SECOND_VALUE)
+        | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValueElse)
+#endif
         | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue)
         | 0;
     return (value.toRaw() | allValidBitsValue) == allValidBitsValue;

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -257,6 +257,16 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         { "WebCore::UsingWithSemicolon"_s, {
             { "uint32_t"_s, "alias"_s }
         } },
+#if OS(WINDOWS)
+        { "WTF::ProcessID"_s, {
+            { "int"_s, "alias"_s }
+        } },
+#endif
+#if !OS(WINDOWS)
+        { "WTF::ProcessID"_s, {
+            { "pid_t"_s, "alias"_s }
+        } },
+#endif
     };
 }
 
@@ -285,6 +295,9 @@ Vector<SerializedEnumInfo> allSerializedEnums()
             static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetFirstValue),
 #if ENABLE(OPTION_SET_SECOND_VALUE)
             static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValue),
+#endif
+#if !ENABLE(OPTION_SET_SECOND_VALUE)
+            static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValueElse),
 #endif
             static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue),
         } },

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -76,6 +76,8 @@ enum class EnumNamespace::EnumType : uint16_t {
     OptionSetFirstValue,
 #if ENABLE(OPTION_SET_SECOND_VALUE)
     OptionSetSecondValue,
+#else
+    OptionSetSecondValueElse,
 #endif
     OptionSetThirdValue
 }
@@ -183,3 +185,9 @@ class WebKit::LayerProperties {
 #endif
     [OptionalTupleBit=WebKit::LayerChange::FeatureEnabledMember, BitField] bool bitFieldMember;
 };
+
+#if OS(WINDOWS)
+using WTF::ProcessID = int;
+#else
+using WTF::ProcessID = pid_t;
+#endif


### PR DESCRIPTION
#### d1b0dd2cdba0f0f9c9c4d3a0521067eb183fb96a
<pre>
Support #else and conditional using statements in messages.in files
<a href="https://bugs.webkit.org/show_bug.cgi?id=261779">https://bugs.webkit.org/show_bug.cgi?id=261779</a>
rdar://115749632

Reviewed by Brady Eidson.

This will be useful for the serialization of things like WTF::ProcessID.

* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedEnum.is_webkit_platform):
(EnumMember.__init__):
(ConditionalHeader.__hash__):
(UsingStatement):
(UsingStatement.__init__):
(generate_serialized_type_info):
(parse_serialized_types):
(main):
(generate_serialized_type_info.in): Deleted.
(main.in): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(WTF::isValidOptionSet&lt;EnumNamespace2::OptionSetEnumType&gt;):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
(WebKit::allSerializedEnums):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268177@main">https://commits.webkit.org/268177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7229df6e3756623ed3415dec920418909a255c34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20770 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17677 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19373 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21654 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19075 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16458 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23643 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21572 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17980 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17056 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21418 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2312 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->