### PR TITLE
[iOS] Refactor some `UIViewController`-related code to make testing easier

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -161,10 +161,6 @@ typedef NS_ENUM(NSInteger, _UIDataOwner) {
 
 @end
 
-@interface UIViewController ()
-+ (UIViewController *)viewControllerForView:(UIView *)view;
-@end
-
 @interface NSURL ()
 @property (nonatomic, copy, setter=_setTitle:) NSString *_title;
 @end

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -538,6 +538,7 @@ platform/ios/SystemMemoryIOS.cpp
 platform/ios/ThemeIOS.mm
 platform/ios/TileControllerMemoryHandlerIOS.cpp
 platform/ios/UIFoundationSoftLink.mm
+platform/ios/UIViewControllerUtilities.mm
 platform/ios/UserAgentIOS.mm
 platform/ios/ValidationBubbleIOS.mm
 platform/ios/VideoFullscreenInterfaceAVKit.mm @no-unify

--- a/Source/WebCore/platform/ios/UIViewControllerUtilities.h
+++ b/Source/WebCore/platform/ios/UIViewControllerUtilities.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+OBJC_CLASS UIView;
+OBJC_CLASS UIViewController;
+
+namespace WebCore {
+
+WEBCORE_EXPORT UIViewController *viewController(UIView *);
+
+}
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/ios/UIViewControllerUtilities.mm
+++ b/Source/WebCore/platform/ios/UIViewControllerUtilities.mm
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "UIViewControllerUtilities.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "RuntimeApplicationChecks.h"
+#import <pal/ios/UIKitSoftLink.h>
+
+@interface UIViewController (OnlyAllowedInUIViewControllerUtilities)
++ (UIViewController *)viewControllerForView:(UIView *)view;
+@end
+
+namespace WebCore {
+
+UIViewController *viewController(UIView *view)
+{
+    if (!IOSApplication::isMobileSafari())
+        return [PAL::getUIViewControllerClass() viewControllerForView:view];
+
+    auto responder = view.nextResponder;
+    if (![responder isKindOfClass:PAL::getUIViewControllerClass()])
+        return nil;
+
+    auto controller = static_cast<UIViewController *>(responder);
+    return controller.viewIfLoaded == view ? controller : nil;
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
+++ b/Source/WebCore/platform/ios/ValidationBubbleIOS.mm
@@ -29,6 +29,7 @@
 
 #import "ValidationBubble.h"
 
+#import "UIViewControllerUtilities.h"
 #import <UIKit/UIGeometry.h>
 #import <objc/message.h>
 #import <pal/ios/UIKitSoftLink.h>
@@ -205,9 +206,11 @@ void ValidationBubble::show()
 
 static UIViewController *fallbackViewController(UIView *view)
 {
+    // FIXME: This logic to find a fallback view controller should move out of WebCore,
+    // and into the client layer.
     for (UIView *currentView = view; currentView; currentView = currentView.superview) {
-        if (UIViewController *viewController = [PAL::getUIViewControllerClass() viewControllerForView:currentView])
-            return viewController;
+        if (auto controller = viewController(currentView))
+            return controller;
     }
     NSLog(@"Failed to find a view controller to show form validation popover");
     return nil;

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -32,6 +32,7 @@
 #import "PictureInPictureSupport.h"
 #import "RuntimeApplicationChecks.h"
 #import "TimeRanges.h"
+#import "UIViewControllerUtilities.h"
 #import "WebAVPlayerController.h"
 #import "WebAVPlayerLayer.h"
 #import "WebAVPlayerLayerView.h"
@@ -821,10 +822,12 @@ bool VideoFullscreenInterfaceAVKit::pictureInPictureWasStartedWhenEnteringBackgr
 #if PLATFORM(WATCHOS)
 static UIViewController *fallbackViewController(UIView *view)
 {
+    // FIXME: This logic to find a fallback view controller should move out of WebCore,
+    // and into the client layer.
     for (UIView *currentView = view; currentView; currentView = currentView.superview) {
-        if (UIViewController *viewController = [PAL::getUIViewControllerClass() viewControllerForView:currentView]) {
-            if (![viewController parentViewController])
-                return viewController;
+        if (auto controller = viewController(currentView)) {
+            if (!controller.parentViewController)
+                return controller;
         }
     }
 

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -576,8 +576,6 @@ typedef enum {
 @end
 
 @interface UIViewController ()
-+ (UIViewController *)_viewControllerForFullScreenPresentationFromView:(UIView *)view;
-+ (UIViewController *)viewControllerForView:(UIView *)view;
 - (BOOL)isPerformingModalTransition;
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -729,7 +729,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
 
 - (UIEdgeInsets)_contentInsetsFromSystemMinimumLayoutMargins
 {
-    if (auto controller = [UIViewController _viewControllerForFullScreenPresentationFromView:self]) {
+    if (auto controller = self._wk_viewControllerForFullScreenPresentation) {
         auto margins = controller.systemMinimumLayoutMargins;
         auto insets = UIEdgeInsetsMake(margins.top, margins.leading, margins.bottom, margins.trailing);
         if (_page && _page->userInterfaceLayoutDirection() == WebCore::UserInterfaceLayoutDirection::RTL)
@@ -3350,7 +3350,7 @@ static bool isLockdownModeWarningNeeded()
 
             [alert addAction:[UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"OK", "Lockdown Mode alert OK button") style:UIAlertActionStyleDefault handler:nil]];
 
-            UIViewController *presentationViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:protectedSelf.get()];
+            auto presentationViewController = [protectedSelf _wk_viewControllerForFullScreenPresentation];
             [presentationViewController presentViewController:alert.get() animated:YES completion:nil];
             [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WebKitLockdownModeAlertShownKey];
         });

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -33,6 +33,7 @@
 #import "ProcessAssertion.h"
 #import "SandboxUtilities.h"
 #import "UIKitSPI.h"
+#import <WebCore/UIViewControllerUtilities.h>
 #import <wtf/ObjCRuntimeExtras.h>
 #import <wtf/cocoa/Entitlements.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
@@ -139,7 +140,7 @@ ApplicationStateTracker::ApplicationStateTracker(UIView *view, SEL didEnterBackg
         UIViewController *serviceViewController = nil;
 
         for (UIView *view = m_view.get().get(); view; view = view.superview) {
-            UIViewController *viewController = [UIViewController viewControllerForView:view];
+            auto viewController = WebCore::viewController(view);
 
             if (viewController._hostProcessIdentifier) {
                 serviceViewController = viewController;

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -243,7 +243,7 @@ void alertForPermission(WebPageProxy& page, MediaPermissionReason reason, const 
     [alert addAction:doNotAllowAction];
     [alert addAction:allowAction];
 
-    [[UIViewController _viewControllerForFullScreenPresentationFromView:webView.get()] presentViewController:alert.get() animated:YES completion:nil];
+    [[webView _wk_viewControllerForFullScreenPresentation] presentViewController:alert.get() animated:YES completion:nil];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -40,6 +40,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #endif
 
 SOFT_LINK_FRAMEWORK(Contacts)
@@ -166,7 +167,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
     [_contactPickerViewController setDelegate:_contactPickerDelegate.get()];
     [_contactPickerViewController setPrompt:requestData.url];
 
-    UIViewController *presentationViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:_webView.get().get()];
+    auto presentationViewController = [_webView _wk_viewControllerForFullScreenPresentation];
     [presentationViewController presentViewController:_contactPickerViewController.get() animated:YES completion:[weakSelf = WeakObjCPtr<WKContactPicker>(self)] {
         auto strongSelf = weakSelf.get();
         if (!strongSelf)

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -44,6 +44,7 @@
 #if PLATFORM(IOS_FAMILY)
 #import "LinkPresentationSPI.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "WKContentViewInteraction.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #else
@@ -345,7 +346,7 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
     if ([_delegate respondsToSelector:@selector(shareSheet:willShowActivityItems:)])
         [_delegate shareSheet:self willShowActivityItems:sharingItems];
 
-    _presentationViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:webView];
+    _presentationViewController = webView._wk_viewControllerForFullScreenPresentation;
     [_presentationViewController presentViewController:_shareSheetViewController.get() animated:YES completion:nil];
 #endif
 }

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
@@ -107,7 +107,7 @@ void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSStrin
     [alert addAction:doNotAllowAction];
     [alert addAction:allowAction];
 
-    [[UIViewController _viewControllerForFullScreenPresentationFromView:webView] presentViewController:alert.get() animated:YES completion:nil];
+    [webView._wk_viewControllerForFullScreenPresentation presentViewController:alert.get() animated:YES completion:nil];
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -34,6 +34,10 @@
 @property (readonly, nonatomic) BOOL _wk_isInterruptingDeceleration;
 @end
 
+@interface UIView (WebKitInternal)
+@property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
+@end
+
 namespace WebKit {
 
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message);

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -39,6 +39,19 @@
 
 @end
 
+@implementation UIView (WebKitInternal)
+
+- (UIViewController *)_wk_viewControllerForFullScreenPresentation
+{
+    auto controller = self.window.rootViewController;
+    UIViewController *nextPresentedController = nil;
+    while ((nextPresentedController = controller.presentedViewController))
+        controller = nextPresentedController;
+    return controller.viewIfLoaded.window == self.window ? controller : nil;
+}
+
+@end
+
 namespace WebKit {
 
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message)

--- a/Source/WebKit/UIProcess/ios/WKActionSheet.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheet.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import <wtf/RetainPtr.h>
 
 @implementation WKActionSheet {
@@ -121,7 +122,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (_popoverPresentationControllerDelegateWhileRotating)
         presentationController.delegate = _popoverPresentationControllerDelegateWhileRotating.get();
 
-    _currentPresentingViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:view];
+    _currentPresentingViewController = view._wk_viewControllerForFullScreenPresentation;
     [_currentPresentingViewController presentViewController:presentedViewController animated:YES completion:nil];
 
     return YES;
@@ -163,7 +164,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!view)
         return;
 
-    UIViewController *presentingViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:view];
+    auto presentingViewController = view._wk_viewControllerForFullScreenPresentation;
 
     // topPresentedViewController is either self (cases (a) and (b) above) or an action's view controller
     // (case (c) above).

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -42,6 +42,7 @@
 #import <WebCore/FloatRect.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/PathUtilities.h>
+#import <WebCore/UIViewControllerUtilities.h>
 #import <pal/spi/ios/DataDetectorsUISoftLink.h>
 #import <wtf/CompletionHandler.h>
 #import <wtf/SoftLinking.h>
@@ -168,7 +169,7 @@ static LSAppLink *appLinkForURL(NSURL *url)
     UIViewController *controller = nil;
     UIView *currentView = view;
     while (currentView) {
-        UIViewController *aController = [UIViewController viewControllerForView:currentView];
+        auto aController = WebCore::viewController(currentView);
         if (aController)
             controller = aController;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1655,7 +1655,7 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
             // a view underneath this view controller; however, there doesn't seem to be any way of doing
             // so at the moment. In lieu of this, we can at least check that the web view itself isn't
             // inside the popover.
-            auto *controller = [UIViewController _viewControllerForFullScreenPresentationFromView:self];
+            auto controller = self._wk_viewControllerForFullScreenPresentation;
             return [self isDescendantOfView:controller.viewIfLoaded] || controller.modalPresentationStyle != UIModalPresentationPopover;
         }
 #endif // PLATFORM(MACCATALYST)
@@ -7616,7 +7616,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
     [self dismissAllInputViewControllers:NO];
 
     _shouldRestoreFirstResponderStatusAfterLosingFocus = self.isFirstResponder;
-    UIViewController *presentingViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:self];
+    auto presentingViewController = self._wk_viewControllerForFullScreenPresentation;
 
     ASSERT(!_presentedFullScreenInputViewController);
 
@@ -11042,7 +11042,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
     _visualSearchPreviewImageBounds = imageBounds;
 
-    UIViewController *currentPresentingViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:self];
+    auto currentPresentingViewController = self._wk_viewControllerForFullScreenPresentation;
     [currentPresentingViewController presentViewController:_visualSearchPreviewController.get() animated:YES completion:nil];
 }
 
@@ -11212,7 +11212,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 - (void)updateImageAnalysisForContextMenuPresentation:(CocoaImageAnalysis *)analysis
 {
 #if USE(UICONTEXTMENU) && ENABLE(IMAGE_ANALYSIS_FOR_MACHINE_READABLE_CODES)
-    analysis.presentingViewControllerForMrcAction = [UIViewController _viewControllerForFullScreenPresentationFromView:self];
+    analysis.presentingViewControllerForMrcAction = self._wk_viewControllerForFullScreenPresentation;
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -196,7 +196,7 @@ struct PermissionRequest {
         [alert addAction:denyAction];
         [alert addAction:allowAction];
 
-        [[UIViewController _viewControllerForFullScreenPresentationFromView:_activeChallenge->view.get()] presentViewController:alert.get() animated:YES completion:nil];
+        [[_activeChallenge->view _wk_viewControllerForFullScreenPresentation] presentViewController:alert.get() animated:YES completion:nil];
     }];
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(AIRPLAY_PICKER)
 
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import <WebCore/AudioSession.h>
 #import <pal/spi/ios/MediaPlayerSPI.h>
 #import <wtf/RetainPtr.h>
@@ -96,7 +97,7 @@ typedef NSInteger WKAirPlayRoutePickerRouteSharingPolicy;
         _actionSheet = nil;
     };
 
-    UIViewController *viewControllerForPresentation = [UIViewController _viewControllerForFullScreenPresentationFromView:view];
+    auto viewControllerForPresentation = view._wk_viewControllerForFullScreenPresentation;
     [viewControllerForPresentation presentViewController:_actionSheet.get() animated:YES completion:nil];
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import <WebCore/LocalizedStrings.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
@@ -166,7 +167,7 @@
 
 - (void)presentInView:(UIView *)view sourceRect:(CGRect)rect interactionBounds:(CGRect)interactionBounds completion:(void(^)())completion
 {
-    RetainPtr controller = [UIViewController _viewControllerForFullScreenPresentationFromView:view];
+    RetainPtr controller = [view _wk_viewControllerForFullScreenPresentation];
 
     while ([controller isBeingDismissed]) {
         // When tabbing between date pickers, it's possible for the view controller for fullscreen presentation

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -34,6 +34,7 @@
 #import "APIString.h"
 #import "PhotosUISPI.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "WKContentViewInteraction.h"
 #import "WKData.h"
 #import "WKStringCF.h"
@@ -544,7 +545,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // If there is any kind of view controller presented on this view, it will be removed.
 
     if (auto view = _view.get())
-        [[UIViewController _viewControllerForFullScreenPresentationFromView:view.get()] dismissViewControllerAnimated:NO completion:nil];
+        [[view _wk_viewControllerForFullScreenPresentation] dismissViewControllerAnimated:NO completion:nil];
 
     _presentationViewController = nil;
 
@@ -895,7 +896,7 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
 {
     [self _dismissDisplayAnimated:animated];
 
-    _presentationViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:_view.getAutoreleased()];
+    _presentationViewController = [_view _wk_viewControllerForFullScreenPresentation];
     [_presentationViewController presentViewController:viewController animated:animated completion:nil];
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -30,6 +30,7 @@
 
 #import "FocusedElementInformation.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "WKContentViewInteraction.h"
 #import "WebPageProxy.h"
 #import <WebCore/ColorCocoa.h>
@@ -118,7 +119,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self updateColorPickerState];
     [self configurePresentation];
 
-    UIViewController *presentingViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:_view];
+    auto presentingViewController = _view._wk_viewControllerForFullScreenPresentation;
     [presentingViewController presentViewController:_colorPickerViewController.get() animated:YES completion:nil];
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "UIKitUtilities.h"
 #import "WKContentView.h"
 #import "WKContentViewInteraction.h"
 #import "WKFormPopover.h"
@@ -1226,7 +1227,7 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
     [_view startRelinquishingFirstResponderToFocusedElement];
 
     [self configurePresentation];
-    UIViewController *presentingViewController = [UIViewController _viewControllerForFullScreenPresentationFromView:_view];
+    auto presentingViewController = _view._wk_viewControllerForFullScreenPresentation;
     [presentingViewController presentViewController:_navigationController.get() animated:YES completion:nil];
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -55,6 +55,7 @@
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #endif
 
 static bool didReceiveMessage;
@@ -412,7 +413,7 @@ constexpr auto WebKitLockdownModeAlertShownKey = @"WebKitCaptivePortalModeAlertS
 
 TEST(WebKit, LockdownModeDefaultFirstUseMessage)
 {
-    ClassMethodSwizzler swizzler(UIViewController.class, @selector(_viewControllerForFullScreenPresentationFromView:), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
+    InstanceMethodSwizzler swizzler(UIView.class, @selector(_wk_viewControllerForFullScreenPresentation), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
 
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
@@ -453,7 +454,7 @@ static bool showedNoFirstUseMessage;
 
 TEST(WebKit, LockdownModeNoFirstUseMessage)
 {
-    ClassMethodSwizzler swizzler(UIViewController.class, @selector(_viewControllerForFullScreenPresentationFromView:), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
+    InstanceMethodSwizzler swizzler(UIView.class, @selector(_wk_viewControllerForFullScreenPresentation), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
 
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);
@@ -507,7 +508,7 @@ static bool requestFutureFirstUseMessage;
 
 TEST(WebKit, LockdownModeAskAgainFirstUseMessage)
 {
-    ClassMethodSwizzler swizzler(UIViewController.class, @selector(_viewControllerForFullScreenPresentationFromView:), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
+    InstanceMethodSwizzler swizzler(UIView.class, @selector(_wk_viewControllerForFullScreenPresentation), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
 
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     EXPECT_FALSE(webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled);

--- a/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
@@ -27,13 +27,13 @@
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
 
-#import "ClassMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import "TestWKWebViewController.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "UserInterfaceSwizzler.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <MobileCoreServices/MobileCoreServices.h>
@@ -110,11 +110,11 @@ TEST(ActionSheetTests, DISABLED_DismissingActionSheetShouldNotDismissPresentingV
     [webView setNavigationDelegate:navigationDelegate.get()];
     [rootViewController presentViewController:webViewController.get() animated:NO completion:nil];
 
-    // Since TestWebKitAPI is not a UI application, +[UIViewController _viewControllerForFullScreenPresentationFromView:]
+    // Since TestWebKitAPI is not a UI application, -[UIView _wk_viewControllerForFullScreenPresentation]
     // returns nil. To ensure that we actually present the action sheet from the web view controller, we mock this for the
     // time being until https://webkit.org/b/175204 is fixed.
     setOverrideViewControllerForFullscreenPresentation(webViewController.get());
-    ClassMethodSwizzler swizzler([UIViewController class], @selector(_viewControllerForFullScreenPresentationFromView:), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
+    InstanceMethodSwizzler swizzler([UIView class], @selector(_wk_viewControllerForFullScreenPresentation), reinterpret_cast<IMP>(overrideViewControllerForFullscreenPresentation));
 
     [observer setPresentationHandler:^(_WKActivatedElementInfo *, NSArray *actions) {
         // Killing the web content process should dismiss the action sheet.

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -219,10 +219,6 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (void)removeTextPlaceholder:(UITextPlaceholder *)placeholder willInsertText:(BOOL)willInsertText completionHandler:(void (^)(void))completionHandler;
 @end
 
-@interface UIViewController ()
-+ (UIViewController *)_viewControllerForFullScreenPresentationFromView:(UIView *)view;
-@end
-
 IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 
 @interface UIWebBrowserView : UIView <UIKeyInput>


### PR DESCRIPTION
#### 943ff888b0fde28477028c8d533a69b0f1f2dd80
<pre>
[iOS] Refactor some `UIViewController`-related code to make testing easier
<a href="https://bugs.webkit.org/show_bug.cgi?id=261781">https://bugs.webkit.org/show_bug.cgi?id=261781</a>
rdar://115762143

Reviewed by Aditya Keerthi.

Refactor some logic to:

1.  Walk the presenting view controller chain in search for a `UIViewController` suitable for
    presenting popovers and other modal view controllers, and
2.  Find the corresponding `UIViewController` for a given `UIView`.

...by pulling these out into helper functions in `UIKitUtilities` and `UIViewControllerUtilities`,
respectively. Adopt them everywhere they&apos;re needed in WebCore and WebKit, in lieu of the existing
UIKit APIs.

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/ios/UIViewControllerUtilities.h: Copied from Source/WebKit/UIProcess/ios/UIKitUtilities.h.
* Source/WebCore/platform/ios/UIViewControllerUtilities.mm: Copied from Source/WebKit/UIProcess/ios/UIKitUtilities.h.
(WebCore::viewController):

Maintain compatibility with both Safari and system apps by preserving the existing call to
`+viewControllerForView:`.

* Source/WebCore/platform/ios/ValidationBubbleIOS.mm:
(WebCore::fallbackViewController):
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(fallbackViewController):
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _contentInsetsFromSystemMinimumLayoutMargins]):
(-[WKWebView _presentLockdownMode]):
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::ApplicationStateTracker::ApplicationStateTracker):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::alertForPermission):
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker presentWithRequestData:completionHandler:]):
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet presentWithShareDataArray:inRect:]):
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(WebKit::displayStorageAccessAlert):
* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_viewControllerForFullScreenPresentation]):
* Source/WebKit/UIProcess/ios/WKActionSheet.mm:
(-[WKActionSheet presentSheetFromRect:]):
(-[WKActionSheet willRotate]):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant superviewForSheet]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView endEditingAndUpdateFocusAppearanceWithReason:]):
(-[WKContentView presentViewControllerForCurrentFocusedElement]):
(-[WKContentView presentVisualSearchPreviewControllerForImage:imageURL:title:imageBounds:appearanceActions:]):
(-[WKContentView updateImageAnalysisForContextMenuPresentation:]):
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(-[WKWebGeolocationPolicyDecider _executeNextChallenge]):
* Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm:
(-[WKAirPlayRoutePicker showFromView:routeSharingPolicy:routingContextUID:hasVideo:]):
* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverController presentInView:sourceRect:interactionBounds:completion:]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadPanel dismiss]):
* Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm:
(-[WKColorPicker controlBeginEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectMultiplePicker controlBeginEditing]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
* Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/ios/UIKitSPI.h:

Canonical link: <a href="https://commits.webkit.org/268184@main">https://commits.webkit.org/268184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47fb5ff0e40e465207bb40fecee8a462525c9c37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20797 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19401 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19267 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16479 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21685 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17248 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17515 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21594 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18004 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17084 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4502 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->