### PR TITLE
Optionally return a StreamConnectionPair in StreamClientConnection::create

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -56,14 +56,14 @@ void StreamClientConnection::DedicatedConnectionClient::didReceiveInvalidMessage
     ASSERT_NOT_REACHED(); // The sender is expected to be trusted, so all invalid messages are programming errors.
 }
 
-StreamClientConnection::StreamConnectionPair StreamClientConnection::create(unsigned bufferSizeLog2)
+std::optional<StreamClientConnection::StreamConnectionPair> StreamClientConnection::create(unsigned bufferSizeLog2)
 {
     auto connectionIdentifiers = Connection::createConnectionIdentifierPair();
     if (!connectionIdentifiers)
-        return { };
+        return std::nullopt;
     auto buffer = StreamClientConnectionBuffer::create(bufferSizeLog2);
     if (!buffer)
-        return { };
+        return std::nullopt;
     // Create StreamClientConnection with "server" type Connection. The caller will send the "client" type connection identifier via
     // IPC to the other side, where StreamServerConnection will be created with "client" type Connection.
     // For Connection, "server" means the connection which was created first, the connection which is not sent through IPC to other party.
@@ -76,7 +76,7 @@ StreamClientConnection::StreamConnectionPair StreamClientConnection::create(unsi
         WTFMove(connectionIdentifiers->client),
         clientConnection->m_buffer.createHandle()
     };
-    return { WTFMove(clientConnection), WTFMove(serverHandle) };
+    return StreamClientConnection::StreamConnectionPair { WTFMove(clientConnection), WTFMove(serverHandle) };
 }
 
 StreamClientConnection::StreamClientConnection(Ref<Connection> connection, StreamClientConnectionBuffer&& buffer)

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -58,12 +58,12 @@ class StreamClientConnection final : public ThreadSafeRefCounted<StreamClientCon
     WTF_MAKE_NONCOPYABLE(StreamClientConnection);
 public:
     struct StreamConnectionPair {
-        RefPtr<StreamClientConnection> streamConnection;
+        Ref<StreamClientConnection> streamConnection;
         IPC::StreamServerConnection::Handle connectionHandle;
     };
 
     // The messages from the server are delivered to the caller through the passed IPC::MessageReceiver.
-    static StreamConnectionPair create(unsigned bufferSizeLog2);
+    static std::optional<StreamConnectionPair> create(unsigned bufferSizeLog2);
 
     ~StreamClientConnection();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -81,10 +81,11 @@ RefPtr<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::create(IPC::C
     unsigned connectionBufferSizeLog2 = defaultConnectionBufferSizeLog2;
     if (attributes.failContextCreationForTesting == WebCore::GraphicsContextGLAttributes::SimulatedCreationFailure::IPCBufferOOM)
         connectionBufferSizeLog2 = 50; // Expect this to fail.
-    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
-    if (!clientConnection)
+    auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
+    if (!connectionPair)
         return nullptr;
-    auto instance = platformCreate(connection, clientConnection.releaseNonNull(), attributes
+    auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
+    auto instance = platformCreate(connection, clientConnection, attributes
 #if ENABLE(VIDEO)
         , WTFMove(videoFrameObjectHeapProxy)
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -85,9 +85,10 @@ void RemoteRenderingBackendProxy::ensureGPUProcessConnection()
 {
     if (!m_streamConnection) {
         static constexpr auto connectionBufferSizeLog2 = 21;
-        auto [streamConnection, serverHandle] = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
-        if (!streamConnection)
+        auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
+        if (!connectionPair)
             CRASH();
+        auto [streamConnection, serverHandle] = WTFMove(*connectionPair);
         m_streamConnection = WTFMove(streamConnection);
         // RemoteRenderingBackendProxy behaves as the dispatcher for the connection to obtain isolated state for its
         // connection. This prevents waits on RemoteRenderingBackendProxy to process messages from other connections.

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -46,10 +46,11 @@ namespace WebKit {
 RefPtr<RemoteGPUProxy> RemoteGPUProxy::create(GPUProcessConnection& gpuProcessConnection, WebGPU::ConvertToBackingContext& convertToBackingContext, WebGPUIdentifier identifier, RenderingBackendIdentifier renderingBackend)
 {
     constexpr size_t connectionBufferSizeLog2 = 21;
-    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
-    if (!clientConnection)
+    auto connectionPair = IPC::StreamClientConnection::create(connectionBufferSizeLog2);
+    if (!connectionPair)
         return nullptr;
-    auto remoteGPUProxy = adoptRef(new RemoteGPUProxy(gpuProcessConnection, clientConnection.releaseNonNull(), convertToBackingContext, identifier));
+    auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
+    auto remoteGPUProxy = adoptRef(new RemoteGPUProxy(gpuProcessConnection, clientConnection, convertToBackingContext, identifier));
     remoteGPUProxy->initializeIPC(WTFMove(serverConnectionHandle), renderingBackend);
     return remoteGPUProxy;
 }

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -212,8 +212,9 @@ public:
 
 TEST_F(StreamConnectionTest, OpenConnections)
 {
-    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
-    ASSERT_TRUE(clientConnection);
+    auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
+    ASSERT_TRUE(!!connectionPair);
+    auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
     auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle)).releaseNonNull();
     auto cleanup = localReferenceBarrier();
     MockMessageReceiver mockClientReceiver;
@@ -229,8 +230,9 @@ TEST_F(StreamConnectionTest, OpenConnections)
 
 TEST_F(StreamConnectionTest, InvalidateUnopened)
 {
-    auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
-    ASSERT_TRUE(clientConnection);
+    auto connectionPair = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
+    ASSERT_TRUE(!!connectionPair);
+    auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
     auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle)).releaseNonNull();
     auto cleanup = localReferenceBarrier();
     serverQueue().dispatch([this, serverConnection] {
@@ -250,8 +252,9 @@ public:
     void SetUp() override
     {
         setupBase();
-        auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(bufferSizeLog2());
-        ASSERT(clientConnection);
+        auto connectionPair = IPC::StreamClientConnection::create(bufferSizeLog2());
+        ASSERT(!!connectionPair);
+        auto [clientConnection, serverConnectionHandle] = WTFMove(*connectionPair);
         auto serverConnection = IPC::StreamServerConnection::tryCreate(WTFMove(serverConnectionHandle)).releaseNonNull();
         m_clientConnection = WTFMove(clientConnection);
         m_clientConnection->setSemaphores(copyViaEncoder(serverQueue().wakeUpSemaphore()).value(), copyViaEncoder(serverConnection->clientWaitSemaphore()).value());


### PR DESCRIPTION
#### fd3a4d231104825ad39d97741e09928f391c32bb
<pre>
Optionally return a StreamConnectionPair in StreamClientConnection::create
<a href="https://bugs.webkit.org/show_bug.cgi?id=261782">https://bugs.webkit.org/show_bug.cgi?id=261782</a>

Reviewed by Kimmo Kinnunen.

Change function signature of `StreamClientConnection::create` to return
a `std::optional&lt;StreamConnectionPair&gt;`. Modify `StreamConnectionPair`
to use a `Ref&lt;StreamClientConnection&gt;` since the value will never be
`null`. Updated the call sites for `StreamClientConnection::create` to
handle the changes.

This is a step towards `SharedMemory::Handle` also always being valid.

* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::create):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::create):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::ensureGPUProcessConnection):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::create):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::createError):
(WebKit::IPCTestingAPI::JSIPC::createStreamClientConnection):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:

Canonical link: <a href="https://commits.webkit.org/268220@main">https://commits.webkit.org/268220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ab105e6c7f37568e03afcb72252eb2f8ce8a82a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19493 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19247 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19346 "4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21776 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17336 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21680 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18085 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17172 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4535 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->