### PR TITLE
All RemoteDOMWindow functions are inaccessible in WebKitTestRunner

### DIFF
--- a/LayoutTests/http/tests/site-isolation/post-message-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/post-message-expected.txt
@@ -1,0 +1,5 @@
+PASS postMessage received
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/post-message.html
+++ b/LayoutTests/http/tests/site-isolation/post-message.html
@@ -1,0 +1,14 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+addEventListener("message", () => {
+    testPassed("postMessage received");
+    testRunner.notifyDone();
+});
+</script>
+<iframe src="http://localhost:8000/site-isolation/resources/post-message-to-parent.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-to-parent.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-to-parent.html
@@ -1,0 +1,3 @@
+<script>
+window.parent.postMessage("message", "*");
+</script>

--- a/Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp
@@ -38,6 +38,10 @@ bool JSRemoteDOMWindow::getOwnPropertySlot(JSObject* object, JSGlobalObject* lex
     if (std::optional<unsigned> index = parseIndex(propertyName))
         return getOwnPropertySlotByIndex(object, lexicalGlobalObject, index.value(), slot);
 
+    // FIXME (rdar://115751655): This should be replaced with a same-origin check between the active and target document.
+    if (propertyName == "$vm"_s)
+        return true;
+
     auto* thisObject = jsCast<JSRemoteDOMWindow*>(object);
     return jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess<DOMWindowType::Remote>(thisObject, thisObject->wrapped(), *lexicalGlobalObject, propertyName, slot, String());
 }


### PR DESCRIPTION
#### 040fd20a08c9f51305ed7f0caa0a2eea6a20d713
<pre>
All RemoteDOMWindow functions are inaccessible in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=261783">https://bugs.webkit.org/show_bug.cgi?id=261783</a>
rdar://115753929

Reviewed by Alex Christensen.

When site isolation is enabled in layout tests, attempting to access any RemoteDOMWindow function will
throw a security error. This is because WebKitTestRunner will expose `$vm` to each web content process,
and the proper security checks are not in place in `JSRemoteDOMWindow::getOwnPropertySlot()` to allow
these symbol properties. When site isolation is disabled, we avoid throwing this security error by
checking if the active and target document are of the same origin. We don’t have a good way to do that
right now with site isolation, so let’s always allow `$vm` for now.

Added a test for postMessage to verify that RemoteDOMWindow functions now work.

* LayoutTests/http/tests/site-isolation/post-message-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/post-message.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-to-parent.html: Added.
* Source/WebCore/bindings/js/JSRemoteDOMWindowCustom.cpp:
(WebCore::JSRemoteDOMWindow::getOwnPropertySlot):

Canonical link: <a href="https://commits.webkit.org/268182@main">https://commits.webkit.org/268182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7432bbec22fe062e5bc1d63ca4f578606ad5419e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20776 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19379 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21661 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16461 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23648 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17496 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17401 "4 flakes 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17986 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17063 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4500 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->