### PR TITLE
Add UnifiedPDF

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6793,6 +6793,20 @@ UndoManagerAPIEnabled:
     WebCore:
       default: false
 
+UnifiedPDFEnabled:
+  type: bool
+  status: internal
+  category: security
+  humanReadableName: "Unified PDF Viewer"
+  humanReadableDescription: "Enable Unified PDF Viewer"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 UnprefixedFullscreenAPIEnabled:
   type: bool
   status: stable

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -663,6 +663,7 @@ WebProcess/Model/ios/ARKitInlinePreviewModelPlayerIOS.mm
 WebProcess/Model/mac/ARKitInlinePreviewModelPlayerMac.mm
 
 WebProcess/Plugins/PDF/PDFPlugin.mm
+WebProcess/Plugins/PDF/PDFPluginBase.mm
 WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginPasswordField.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2995,6 +2995,8 @@
 		0FF24A2B1879E4BC003ABF0D /* RemoteCaptureSampleManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteCaptureSampleManagerMessageReceiver.cpp; sourceTree = "<group>"; };
 		0FF24A2C1879E4BC003ABF0C /* RemoteLayerTreeDrawingAreaProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteLayerTreeDrawingAreaProxyMessages.h; sourceTree = "<group>"; };
 		0FF24A2F1879E4FE003ABF0C /* RemoteLayerTreeDrawingAreaProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteLayerTreeDrawingAreaProxy.messages.in; sourceTree = "<group>"; };
+		0FF655D22ABA5FDD00A58832 /* PDFPluginBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PDFPluginBase.h; path = PDF/PDFPluginBase.h; sourceTree = "<group>"; };
+		0FF655D32ABA5FDD00A58832 /* PDFPluginBase.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = PDFPluginBase.mm; path = PDF/PDFPluginBase.mm; sourceTree = "<group>"; };
 		0FF7CE882901FDA500EA62D6 /* RemoteScrollingTreeIOS.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteScrollingTreeIOS.cpp; sourceTree = "<group>"; };
 		0FF7CE892901FDA500EA62D6 /* RemoteScrollingTreeIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingTreeIOS.h; sourceTree = "<group>"; };
 		0FF7CE8A2901FDAC00EA62D6 /* RemoteScrollingTreeMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingTreeMac.h; sourceTree = "<group>"; };
@@ -13935,6 +13937,8 @@
 				2D0035231BC7414800DA8716 /* PDFPlugin.mm */,
 				2D2ADF021636243500197E47 /* PDFPluginAnnotation.h */,
 				2D2ADF031636243500197E47 /* PDFPluginAnnotation.mm */,
+				0FF655D22ABA5FDD00A58832 /* PDFPluginBase.h */,
+				0FF655D32ABA5FDD00A58832 /* PDFPluginBase.mm */,
 				2D2ADF0D16364D8200197E47 /* PDFPluginChoiceAnnotation.h */,
 				2D2ADF0E16364D8200197E47 /* PDFPluginChoiceAnnotation.mm */,
 				2D429BFA1721E2BA00EC681F /* PDFPluginPasswordField.h */,

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,28 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WebBadgeClient.h"
+#pragma once
 
-#include "WebPage.h"
-#include "WebProcess.h"
-#include "WebProcessProxyMessages.h"
+#if ENABLE(PDFKIT_PLUGIN) || ENABLE(UNIFIED_PDF)
 
-namespace WebKit {
-using namespace WebCore;
 
-void WebBadgeClient::setAppBadge(Page* page, const SecurityOriginData& origin, std::optional<uint64_t> badge)
-{
-    std::optional<WebPageProxyIdentifier> pageIdentifier;
-    if (page)
-        pageIdentifier = WebPage::fromCorePage(*page)->webPageProxyIdentifier();
 
-    WebProcess::singleton().setAppBadge(pageIdentifier, origin, badge);
-}
-
-void WebBadgeClient::setClientBadge(Page& page, const SecurityOriginData& origin, std::optional<uint64_t> badge)
-{
-    WebProcess::singleton().setClientBadge(WebPage::fromCorePage(page)->webPageProxyIdentifier(), origin, badge);
-}
-
-} // namespace WebKit
+#endif // ENABLE(PDFKIT_PLUGIN) || ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,28 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WebBadgeClient.h"
+#import "config.h"
+#import "PDFPluginBase.h"
 
-#include "WebPage.h"
-#include "WebProcess.h"
-#include "WebProcessProxyMessages.h"
+#if ENABLE(PDFKIT_PLUGIN) || ENABLE(UNIFIED_PDF)
 
-namespace WebKit {
-using namespace WebCore;
-
-void WebBadgeClient::setAppBadge(Page* page, const SecurityOriginData& origin, std::optional<uint64_t> badge)
-{
-    std::optional<WebPageProxyIdentifier> pageIdentifier;
-    if (page)
-        pageIdentifier = WebPage::fromCorePage(*page)->webPageProxyIdentifier();
-
-    WebProcess::singleton().setAppBadge(pageIdentifier, origin, badge);
-}
-
-void WebBadgeClient::setClientBadge(Page& page, const SecurityOriginData& origin, std::optional<uint64_t> badge)
-{
-    WebProcess::singleton().setClientBadge(WebPage::fromCorePage(page)->webPageProxyIdentifier(), origin, badge);
-}
-
-} // namespace WebKit
+#endif // ENABLE(PDFKIT_PLUGIN) || ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -28,6 +28,8 @@
 
 #if ENABLE(CONTEXT_MENUS)
 
+#import "MessageSenderInlines.h"
+#import "WebPageProxyMessages.h"
 #import "WebCoreArgumentCoders.h"
 #import "WebPage.h"
 #import "WebPageProxyMessages.h"

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -33,9 +33,11 @@
 #import "PluginView.h"
 #import "UserMediaCaptureManager.h"
 #import "WKAccessibilityWebPageObjectBase.h"
+#import "WebFrame.h"
 #import "WebPageProxyMessages.h"
 #import "WebPasteboardOverrides.h"
 #import "WebPaymentCoordinator.h"
+#import "WebProcess.h"
 #import "WebRemoteObjectRegistry.h"
 #import <WebCore/DeprecatedGlobalSettings.h>
 #import <WebCore/DictionaryLookup.h>
@@ -45,6 +47,7 @@
 #import <WebCore/EventHandler.h>
 #import <WebCore/EventNames.h>
 #import <WebCore/FocusController.h>
+#import <WebCore/FrameLoader.h>
 #import <WebCore/FrameView.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/HTMLBodyElement.h>
@@ -82,6 +85,8 @@
 #if PLATFORM(COCOA)
 
 namespace WebKit {
+
+using namespace WebCore;
 
 void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
 {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -52,7 +52,7 @@ public:
     void setScrollbarMinimumThumbLength(WebCore::ScrollbarOrientation, int) final;
     void setScrollbarVisibilityState(WebCore::ScrollbarOrientation, bool) final;
     bool shouldDrawIntoScrollbarLayer(WebCore::Scrollbar&) const final;
-    bool shouldRegisterScrollbars() const final { return scrollableArea().isListBox(); }
+    bool shouldRegisterScrollbars() const final;
     int minimumThumbLength(WebCore::ScrollbarOrientation) final;
     void updateScrollbarEnabledState(WebCore::Scrollbar&) final;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -94,6 +94,11 @@ bool RemoteScrollbarsController::shouldDrawIntoScrollbarLayer(WebCore::Scrollbar
     return scrollbar.isCustomScrollbar() || scrollbar.isMockScrollbar();
 }
 
+bool RemoteScrollbarsController::shouldRegisterScrollbars() const
+{
+    return scrollableArea().isListBox();
+}
+
 void RemoteScrollbarsController::setScrollbarMinimumThumbLength(WebCore::ScrollbarOrientation orientation, int minimumThumbLength)
 {
     if (orientation == WebCore::ScrollbarOrientation::Horizontal)

--- a/Source/WebKit/webpushd/MockPushServiceConnection.mm
+++ b/Source/WebKit/webpushd/MockPushServiceConnection.mm
@@ -28,9 +28,8 @@
 
 #import <wtf/text/Base64.h>
 
-using namespace WebCore::PushCrypto;
-
 namespace WebPushD {
+using namespace WebCore::PushCrypto;
 
 MockPushServiceConnection::MockPushServiceConnection()
 {

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -38,10 +38,9 @@
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/Base64.h>
 
+namespace WebPushD {
 using namespace WebKit;
 using namespace WebCore;
-
-namespace WebPushD {
 
 static void updateTopicLists(PushServiceConnection& connection, PushDatabase& database, CompletionHandler<void()> completionHandler)
 {

--- a/Source/WebKit/webpushd/PushServiceConnection.mm
+++ b/Source/WebKit/webpushd/PushServiceConnection.mm
@@ -28,9 +28,8 @@
 
 #import <wtf/WorkQueue.h>
 
-using namespace WebCore;
-
 namespace WebPushD {
+using namespace WebCore;
 
 PushCrypto::ClientKeys PushServiceConnection::generateClientKeys()
 {


### PR DESCRIPTION
#### 7ba7f1664729c24f8bb6f7a24bda5a64b71b2deb
<pre>
Add UnifiedPDF feature flag, PDFPluginBase.* and fix the unified sources fallout
<a href="https://bugs.webkit.org/show_bug.cgi?id=261788">https://bugs.webkit.org/show_bug.cgi?id=261788</a>
&lt;rdar://problem/115756126&gt;

Reviewed by NOBODY (OOPS!).

Add a feature flag for UnifiedPDF, which is a PDF plugin shared between platforms.

Add empty PDFPluginBase.h/mm files, and deal with the unified sources fallout.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h: Copied from Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm: Copied from Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp.
* Source/WebKit/WebProcess/WebCoreSupport/WebBadgeClient.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
(WebKit::RemoteScrollbarsController::shouldRegisterScrollbars const):
* Source/WebKit/webpushd/MockPushServiceConnection.mm:
* Source/WebKit/webpushd/PushService.mm:
* Source/WebKit/webpushd/PushServiceConnection.mm:
</pre>
----------------------------------------------------------------------
#### 892f8ed1e0ee01e7ae9481cb2ac875a08bb61ca9
<pre>
Add UnifiedPDFEnabled switch
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ba7f1664729c24f8bb6f7a24bda5a64b71b2deb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18912 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19859 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/20777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/22549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/19380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/20777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19137 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/22549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/22549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/21662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/16407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/22549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/18230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/17987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/19380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22290 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/17063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5421 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23537 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5280 "Passed tests") | 
<!--EWS-Status-Bubble-End-->