### PR TITLE
Enums in ApplyStyleCommand should be enum classes

### DIFF
--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -121,7 +121,7 @@ Ref<HTMLElement> createStyleSpanElement(Document& document)
     return createHTMLElement(document, spanTag);
 }
 
-ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* style, EditAction editingAction, EPropertyLevel propertyLevel)
+ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* style, EditAction editingAction, PropertyLevel propertyLevel)
     : CompositeEditCommand(document, editingAction)
     , m_style(style->copy())
     , m_propertyLevel(propertyLevel)
@@ -132,7 +132,7 @@ ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* sty
 {
 }
 
-ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* style, const Position& start, const Position& end, EditAction editingAction, EPropertyLevel propertyLevel)
+ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* style, const Position& start, const Position& end, EditAction editingAction, PropertyLevel propertyLevel)
     : CompositeEditCommand(document, editingAction)
     , m_style(style->copy())
     , m_propertyLevel(propertyLevel)
@@ -146,7 +146,6 @@ ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* sty
 ApplyStyleCommand::ApplyStyleCommand(Ref<Element>&& element, bool removeOnly, EditAction editingAction)
     : CompositeEditCommand(element->document(), editingAction)
     , m_style(EditingStyle::create())
-    , m_propertyLevel(PropertyDefault)
     , m_start(endingSelection().start().downstream())
     , m_end(endingSelection().end().upstream())
     , m_useEndingSelection(true)
@@ -158,7 +157,6 @@ ApplyStyleCommand::ApplyStyleCommand(Ref<Element>&& element, bool removeOnly, Ed
 ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* style, IsInlineElementToRemoveFunction isInlineElementToRemoveFunction, EditAction editingAction)
     : CompositeEditCommand(document, editingAction)
     , m_style(style->copy())
-    , m_propertyLevel(PropertyDefault)
     , m_start(endingSelection().start().downstream())
     , m_end(endingSelection().end().upstream())
     , m_useEndingSelection(true)
@@ -200,7 +198,7 @@ Position ApplyStyleCommand::endPosition()
 void ApplyStyleCommand::doApply()
 {
     switch (m_propertyLevel) {
-    case PropertyDefault: {
+    case PropertyLevel::Default: {
         // Apply the block-centric properties of the style.
         auto blockStyle = m_style->extractAndRemoveBlockProperties();
         if (!blockStyle->isEmpty())
@@ -212,7 +210,7 @@ void ApplyStyleCommand::doApply()
         }
         break;
     }
-    case ForceBlockProperties:
+    case PropertyLevel::ForceBlock:
         // Force all properties to be applied as block styles.
         applyBlockStyle(*m_style);
         break;
@@ -840,7 +838,7 @@ void ApplyStyleCommand::applyInlineStyleToNodeRange(EditingStyle& style, Node& s
         if (run.dummyElement)
             removeNode(*run.dummyElement);
         if (run.startAndEndAreStillInDocument())
-            applyInlineStyleChange(run.start.releaseNonNull(), run.end.releaseNonNull(), run.change, AddStyledElement);
+            applyInlineStyleChange(run.start.releaseNonNull(), run.end.releaseNonNull(), run.change, AddStyledElement::Yes);
     }
 }
 
@@ -883,7 +881,7 @@ void ApplyStyleCommand::removeConflictingInlineStyleFromRun(EditingStyle& style,
         RefPtr<Node> previousSibling = node->previousSibling();
         RefPtr<Node> nextSibling = node->nextSibling();
         RefPtr<ContainerNode> parent = node->parentNode();
-        removeInlineStyleFromElement(style, downcast<HTMLElement>(*node), RemoveAlways);
+        removeInlineStyleFromElement(style, downcast<HTMLElement>(*node), InlineStyleRemovalMode::Always);
         if (!node->isConnected()) {
             // FIXME: We might need to update the start and the end of current selection here but need a test.
             if (runStart == node)
@@ -900,7 +898,7 @@ bool ApplyStyleCommand::removeInlineStyleFromElement(EditingStyle& style, HTMLEl
         return false;
 
     if (isStyledInlineElementToRemove(&element)) {
-        if (mode == RemoveNone)
+        if (mode == InlineStyleRemovalMode::None)
             return true;
         if (extractedStyle)
             extractedStyle->mergeInlineStyleOfElement(element, EditingStyle::OverrideValues);
@@ -935,20 +933,20 @@ void ApplyStyleCommand::replaceWithSpanOrRemoveIfWithoutAttributes(HTMLElement& 
 
 bool ApplyStyleCommand::removeImplicitlyStyledElement(EditingStyle& style, HTMLElement& element, InlineStyleRemovalMode mode, EditingStyle* extractedStyle)
 {
-    if (mode == RemoveNone) {
+    if (mode == InlineStyleRemovalMode::None) {
         ASSERT(!extractedStyle);
         return style.conflictsWithImplicitStyleOfElement(element) || style.conflictsWithImplicitStyleOfAttributes(element);
     }
 
-    ASSERT(mode == RemoveIfNeeded || mode == RemoveAlways);
-    if (style.conflictsWithImplicitStyleOfElement(element, extractedStyle, mode == RemoveAlways ? EditingStyle::ExtractMatchingStyle : EditingStyle::DoNotExtractMatchingStyle)) {
+    ASSERT(mode == InlineStyleRemovalMode::IfNeeded || mode == InlineStyleRemovalMode::Always);
+    if (style.conflictsWithImplicitStyleOfElement(element, extractedStyle, mode == InlineStyleRemovalMode::Always ? EditingStyle::ExtractMatchingStyle : EditingStyle::DoNotExtractMatchingStyle)) {
         replaceWithSpanOrRemoveIfWithoutAttributes(element);
         return true;
     }
 
     // unicode-bidi and direction are pushed down separately so don't push down with other styles
     Vector<QualifiedName> attributes;
-    if (!style.extractConflictingImplicitStyleOfAttributes(element, extractedStyle ? EditingStyle::PreserveWritingDirection : EditingStyle::DoNotPreserveWritingDirection, extractedStyle, attributes, mode == RemoveAlways ? EditingStyle::ExtractMatchingStyle : EditingStyle::DoNotExtractMatchingStyle))
+    if (!style.extractConflictingImplicitStyleOfAttributes(element, extractedStyle ? EditingStyle::PreserveWritingDirection : EditingStyle::DoNotPreserveWritingDirection, extractedStyle, attributes, mode == InlineStyleRemovalMode::Always ? EditingStyle::ExtractMatchingStyle : EditingStyle::DoNotExtractMatchingStyle))
         return false;
 
     for (auto& attribute : attributes)
@@ -962,7 +960,7 @@ bool ApplyStyleCommand::removeImplicitlyStyledElement(EditingStyle& style, HTMLE
 
 bool ApplyStyleCommand::removeCSSStyle(EditingStyle& style, HTMLElement& element, InlineStyleRemovalMode mode, EditingStyle* extractedStyle)
 {
-    if (mode == RemoveNone)
+    if (mode == InlineStyleRemovalMode::None)
         return style.conflictsWithInlineStyleOfElement(element);
 
     RefPtr<MutableStyleProperties> newInlineStyle;
@@ -1032,7 +1030,7 @@ void ApplyStyleCommand::applyInlineStyleToPushDown(Node& node, EditingStyle* sty
     // We can't wrap node with the styled element here because new styled element will never be removed if we did.
     // If we modified the child pointer in pushDownInlineStyleAroundNode to point to new style element
     // then we fall into an infinite loop where we keep removing and adding styled element wrapping node.
-    addInlineStyleIfNeeded(newInlineStyle.get(), node, node, DoNotAddStyledElement);
+    addInlineStyleIfNeeded(newInlineStyle.get(), node, node, AddStyledElement::No);
 }
 
 void ApplyStyleCommand::pushDownInlineStyleAroundNode(EditingStyle& style, Node* targetNode)
@@ -1058,7 +1056,7 @@ void ApplyStyleCommand::pushDownInlineStyleAroundNode(EditingStyle& style, Node*
 
         auto styleToPushDown = EditingStyle::create();
         if (is<HTMLElement>(*current))
-            removeInlineStyleFromElement(style, downcast<HTMLElement>(*current), RemoveIfNeeded, styleToPushDown.ptr());
+            removeInlineStyleFromElement(style, downcast<HTMLElement>(*current), InlineStyleRemovalMode::IfNeeded, styleToPushDown.ptr());
 
         // The inner loop will go through children on each level
         // FIXME: we should aggregate inline child elements together so that we don't wrap each child separately.
@@ -1141,7 +1139,7 @@ void ApplyStyleCommand::removeInlineStyle(EditingStyle& style, const Position& s
                 childNode = element->firstChild();
             }
 
-            removeInlineStyleFromElement(style, element, RemoveIfNeeded, styleToPushDown.get());
+            removeInlineStyleFromElement(style, element, InlineStyleRemovalMode::IfNeeded, styleToPushDown.get());
             if (!element->isConnected()) {
                 if (s.deprecatedNode() == element.ptr()) {
                     // Since elem must have been fully selected, and it is at the start
@@ -1389,7 +1387,7 @@ void ApplyStyleCommand::addBlockStyle(const StyleChange& styleChange, HTMLElemen
     setNodeAttribute(block, styleAttr, joinWithSpace(styleChange.cssStyle()->asText(), block.getAttribute(styleAttr)));
 }
 
-void ApplyStyleCommand::addInlineStyleIfNeeded(EditingStyle* style, Node& start, Node& end, EAddStyledElement addStyledElement)
+void ApplyStyleCommand::addInlineStyleIfNeeded(EditingStyle* style, Node& start, Node& end, AddStyledElement addStyledElement)
 {
     if (!start.isConnected() || !end.isConnected())
         return;
@@ -1416,7 +1414,7 @@ Position ApplyStyleCommand::positionToComputeInlineStyleChange(Node& startNode, 
     return firstPositionInOrBeforeNode(&startNode);
 }
 
-void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEnd, StyleChange& styleChange, EAddStyledElement addStyledElement)
+void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEnd, StyleChange& styleChange, AddStyledElement addStyledElement)
 {
     RefPtr<Node> startNode = &passedStart;
     RefPtr<Node> endNode = &passedEnd;
@@ -1495,7 +1493,7 @@ void ApplyStyleCommand::applyInlineStyleChange(Node& passedStart, Node& passedEn
     else if (styleChange.applySuperscript())
         surroundNodeRangeWithElement(*startNode, *endNode, createHTMLElement(document, supTag));
 
-    if (m_styledInlineElement && addStyledElement == AddStyledElement)
+    if (m_styledInlineElement && addStyledElement == AddStyledElement::Yes)
         surroundNodeRangeWithElement(*startNode, *endNode, m_styledInlineElement->cloneElementWithoutChildren(document));
 }
 

--- a/Source/WebCore/editing/ApplyStyleCommand.h
+++ b/Source/WebCore/editing/ApplyStyleCommand.h
@@ -42,16 +42,16 @@ enum ShouldIncludeTypingStyle {
 
 class ApplyStyleCommand : public CompositeEditCommand {
 public:
-    enum EPropertyLevel { PropertyDefault, ForceBlockProperties };
-    enum InlineStyleRemovalMode { RemoveIfNeeded, RemoveAlways, RemoveNone };
-    enum EAddStyledElement { AddStyledElement, DoNotAddStyledElement };
+    enum class PropertyLevel : bool { Default, ForceBlock };
+    enum class InlineStyleRemovalMode : uint8_t { IfNeeded, Always, None };
+    enum class AddStyledElement : bool { No, Yes };
     typedef bool (*IsInlineElementToRemoveFunction)(const Element*);
 
-    static Ref<ApplyStyleCommand> create(Document& document, const EditingStyle* style, EditAction action = EditAction::ChangeAttributes, EPropertyLevel level = PropertyDefault)
+    static Ref<ApplyStyleCommand> create(Document& document, const EditingStyle* style, EditAction action = EditAction::ChangeAttributes, PropertyLevel level = PropertyLevel::Default)
     {
         return adoptRef(*new ApplyStyleCommand(document, style, action, level));
     }
-    static Ref<ApplyStyleCommand> create(Document& document, const EditingStyle* style, const Position& start, const Position& end, EditAction action = EditAction::ChangeAttributes, EPropertyLevel level = PropertyDefault)
+    static Ref<ApplyStyleCommand> create(Document& document, const EditingStyle* style, const Position& start, const Position& end, EditAction action = EditAction::ChangeAttributes, PropertyLevel level = PropertyLevel::Default)
     {
         return adoptRef(*new ApplyStyleCommand(document, style, start, end, action, level));
     }
@@ -65,8 +65,8 @@ public:
     }
 
 private:
-    ApplyStyleCommand(Document&, const EditingStyle*, EditAction, EPropertyLevel);
-    ApplyStyleCommand(Document&, const EditingStyle*, const Position& start, const Position& end, EditAction, EPropertyLevel);
+    ApplyStyleCommand(Document&, const EditingStyle*, EditAction, PropertyLevel);
+    ApplyStyleCommand(Document&, const EditingStyle*, const Position& start, const Position& end, EditAction, PropertyLevel);
     ApplyStyleCommand(Ref<Element>&&, bool removeOnly, EditAction);
     ApplyStyleCommand(Document&, const EditingStyle*, bool (*isInlineElementToRemove)(const Element*), EditAction);
 
@@ -77,11 +77,11 @@ private:
     bool isStyledInlineElementToRemove(Element*) const;
     bool shouldApplyInlineStyleToRun(EditingStyle&, Node* runStart, Node* pastEndNode);
     void removeConflictingInlineStyleFromRun(EditingStyle&, RefPtr<Node>& runStart, RefPtr<Node>& runEnd, Node* pastEndNode);
-    bool removeInlineStyleFromElement(EditingStyle&, HTMLElement&, InlineStyleRemovalMode = RemoveIfNeeded, EditingStyle* extractedStyle = nullptr);
-    inline bool shouldRemoveInlineStyleFromElement(EditingStyle& style, HTMLElement& element) {return removeInlineStyleFromElement(style, element, RemoveNone);}
+    bool removeInlineStyleFromElement(EditingStyle&, HTMLElement&, InlineStyleRemovalMode = InlineStyleRemovalMode::IfNeeded, EditingStyle* extractedStyle = nullptr);
+    inline bool shouldRemoveInlineStyleFromElement(EditingStyle& style, HTMLElement& element) { return removeInlineStyleFromElement(style, element, InlineStyleRemovalMode::None); }
     void replaceWithSpanOrRemoveIfWithoutAttributes(HTMLElement&);
     bool removeImplicitlyStyledElement(EditingStyle&, HTMLElement&, InlineStyleRemovalMode, EditingStyle* extractedStyle);
-    bool removeCSSStyle(EditingStyle&, HTMLElement&, InlineStyleRemovalMode = RemoveIfNeeded, EditingStyle* extractedStyle = nullptr);
+    bool removeCSSStyle(EditingStyle&, HTMLElement&, InlineStyleRemovalMode = InlineStyleRemovalMode::IfNeeded, EditingStyle* extractedStyle = nullptr);
     RefPtr<HTMLElement> highestAncestorWithConflictingInlineStyle(EditingStyle&, Node*);
     void applyInlineStyleToPushDown(Node&, EditingStyle*);
     void pushDownInlineStyleAroundNode(EditingStyle&, Node*);
@@ -96,9 +96,9 @@ private:
     void fixRangeAndApplyInlineStyle(EditingStyle&, const Position& start, const Position& end);
     void applyInlineStyleToNodeRange(EditingStyle&, Node& startNode, Node* pastEndNode);
     void addBlockStyle(const StyleChange&, HTMLElement&);
-    void addInlineStyleIfNeeded(EditingStyle*, Node& start, Node& end, EAddStyledElement = AddStyledElement);
+    void addInlineStyleIfNeeded(EditingStyle*, Node& start, Node& end, AddStyledElement = AddStyledElement::Yes);
     Position positionToComputeInlineStyleChange(Node&, RefPtr<Node>& dummyElement);
-    void applyInlineStyleChange(Node& startNode, Node& endNode, StyleChange&, EAddStyledElement);
+    void applyInlineStyleChange(Node& startNode, Node& endNode, StyleChange&, AddStyledElement);
     void splitTextAtStart(const Position& start, const Position& end);
     void splitTextAtEnd(const Position& start, const Position& end);
     void splitTextElementAtStart(const Position& start, const Position& end);
@@ -121,7 +121,7 @@ private:
     Position endPosition();
 
     RefPtr<EditingStyle> m_style;
-    EPropertyLevel m_propertyLevel;
+    PropertyLevel m_propertyLevel { PropertyLevel::Default };
     Position m_start;
     Position m_end;
     bool m_useEndingSelection;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1047,7 +1047,7 @@ void Editor::applyParagraphStyle(StyleProperties* style, EditAction editingActio
     if (m_document.selection().isNone())
         return;
 
-    ApplyStyleCommand::create(document(), EditingStyle::create(style).ptr(), editingAction, ApplyStyleCommand::ForceBlockProperties)->apply();
+    ApplyStyleCommand::create(document(), EditingStyle::create(style).ptr(), editingAction, ApplyStyleCommand::PropertyLevel::ForceBlock)->apply();
 
     if (client())
         client()->didApplyStyle();


### PR DESCRIPTION
#### c537ee925021abf80ed011c2111331e875ec13e6
<pre>
Enums in ApplyStyleCommand should be enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261774">https://bugs.webkit.org/show_bug.cgi?id=261774</a>
rdar://problem/115751437

Reviewed by Wenson Hsieh.

ApplyStyleCommand defines three enumerations, namely EPropertyLevel,
InlineStyleRemovalMode, and EAddStyledElement. This patch makes each of
these enums an enum class, narrows down the underlying type, and renames
the enum cases to address redundancy.

We also choose to default initialize the m_propertyLevel attribute of the
AppleStyleCommand class to PropertyLevel::Default through class member
initialization (rather than through explicit mem-init in _some_
constructor overloads). This is not a behavior change, but does make
construction cleaner.

* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::ApplyStyleCommand):
(WebCore::ApplyStyleCommand::doApply):
(WebCore::ApplyStyleCommand::applyInlineStyleToNodeRange):
(WebCore::ApplyStyleCommand::removeConflictingInlineStyleFromRun):
(WebCore::ApplyStyleCommand::removeInlineStyleFromElement):
(WebCore::ApplyStyleCommand::removeImplicitlyStyledElement):
(WebCore::ApplyStyleCommand::removeCSSStyle):
(WebCore::ApplyStyleCommand::applyInlineStyleToPushDown):
(WebCore::ApplyStyleCommand::pushDownInlineStyleAroundNode):
(WebCore::ApplyStyleCommand::removeInlineStyle):
(WebCore::ApplyStyleCommand::addInlineStyleIfNeeded):
(WebCore::ApplyStyleCommand::applyInlineStyleChange):
* Source/WebCore/editing/ApplyStyleCommand.h:
(WebCore::ApplyStyleCommand::create):
(WebCore::ApplyStyleCommand::shouldRemoveInlineStyleFromElement):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::applyParagraphStyle):

Canonical link: <a href="https://commits.webkit.org/268223@main">https://commits.webkit.org/268223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/004f012450b4488972ab5462cc002de2d1e9e6ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17685 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19473 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21663 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16467 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23655 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21591 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15257 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17064 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4541 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->