### PR TITLE
EWordSide should be an enum class

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3247,13 +3247,13 @@ CharacterOffset AXObjectCache::previousCharacterOffset(const CharacterOffset& ch
     return characterOffsetForNodeAndOffset(*characterOffset.node, previousOffset, TraverseOptionIncludeStart);
 }
 
-CharacterOffset AXObjectCache::startCharacterOffsetOfWord(const CharacterOffset& characterOffset, EWordSide side)
+CharacterOffset AXObjectCache::startCharacterOffsetOfWord(const CharacterOffset& characterOffset, WordSide side)
 {
     if (characterOffset.isNull())
         return CharacterOffset();
     
     CharacterOffset c = characterOffset;
-    if (side == RightWordIfOnBoundary) {
+    if (side == WordSide::RightWordIfOnBoundary) {
         CharacterOffset endOfParagraph = endCharacterOffsetOfParagraph(c);
         if (c.isEqual(endOfParagraph))
             return c;
@@ -3269,13 +3269,13 @@ CharacterOffset AXObjectCache::startCharacterOffsetOfWord(const CharacterOffset&
     return previousBoundary(c, startWordBoundary);
 }
 
-CharacterOffset AXObjectCache::endCharacterOffsetOfWord(const CharacterOffset& characterOffset, EWordSide side)
+CharacterOffset AXObjectCache::endCharacterOffsetOfWord(const CharacterOffset& characterOffset, WordSide side)
 {
     if (characterOffset.isNull())
         return CharacterOffset();
     
     CharacterOffset c = characterOffset;
-    if (side == LeftWordIfOnBoundary) {
+    if (side == WordSide::LeftWordIfOnBoundary) {
         CharacterOffset startOfParagraph = startCharacterOffsetOfParagraph(c);
         if (c.isEqual(startOfParagraph))
             return c;
@@ -3301,7 +3301,7 @@ CharacterOffset AXObjectCache::previousWordStartCharacterOffset(const CharacterO
     if (previousOffset.isNull())
         return CharacterOffset();
     
-    return startCharacterOffsetOfWord(previousOffset, RightWordIfOnBoundary);
+    return startCharacterOffsetOfWord(previousOffset, WordSide::RightWordIfOnBoundary);
 }
 
 CharacterOffset AXObjectCache::nextWordEndCharacterOffset(const CharacterOffset& characterOffset)
@@ -3313,19 +3313,19 @@ CharacterOffset AXObjectCache::nextWordEndCharacterOffset(const CharacterOffset&
     if (nextOffset.isNull())
         return CharacterOffset();
     
-    return endCharacterOffsetOfWord(nextOffset, LeftWordIfOnBoundary);
+    return endCharacterOffsetOfWord(nextOffset, WordSide::LeftWordIfOnBoundary);
 }
 
 std::optional<SimpleRange> AXObjectCache::leftWordRange(const CharacterOffset& characterOffset)
 {
-    CharacterOffset start = startCharacterOffsetOfWord(characterOffset, LeftWordIfOnBoundary);
+    CharacterOffset start = startCharacterOffsetOfWord(characterOffset, WordSide::LeftWordIfOnBoundary);
     CharacterOffset end = endCharacterOffsetOfWord(start);
     return rangeForUnorderedCharacterOffsets(start, end);
 }
 
 std::optional<SimpleRange> AXObjectCache::rightWordRange(const CharacterOffset& characterOffset)
 {
-    CharacterOffset start = startCharacterOffsetOfWord(characterOffset, RightWordIfOnBoundary);
+    CharacterOffset start = startCharacterOffsetOfWord(characterOffset, WordSide::RightWordIfOnBoundary);
     CharacterOffset end = endCharacterOffsetOfWord(start);
     return rangeForUnorderedCharacterOffsets(start, end);
 }

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -531,8 +531,8 @@ protected:
     enum class NeedsContextAtParagraphStart : bool { No, Yes };
     CharacterOffset previousBoundary(const CharacterOffset&, BoundarySearchFunction, NeedsContextAtParagraphStart = NeedsContextAtParagraphStart::No);
     CharacterOffset nextBoundary(const CharacterOffset&, BoundarySearchFunction);
-    CharacterOffset startCharacterOffsetOfWord(const CharacterOffset&, EWordSide = RightWordIfOnBoundary);
-    CharacterOffset endCharacterOffsetOfWord(const CharacterOffset&, EWordSide = RightWordIfOnBoundary);
+    CharacterOffset startCharacterOffsetOfWord(const CharacterOffset&, WordSide = WordSide::RightWordIfOnBoundary);
+    CharacterOffset endCharacterOffsetOfWord(const CharacterOffset&, WordSide = WordSide::RightWordIfOnBoundary);
     CharacterOffset startCharacterOffsetOfParagraph(const CharacterOffset&, EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
     CharacterOffset endCharacterOffsetOfParagraph(const CharacterOffset&, EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
     CharacterOffset startCharacterOffsetOfSentence(const CharacterOffset&);

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1455,13 +1455,13 @@ VisiblePositionRange AccessibilityObject::visiblePositionRangeForUnorderedPositi
 
 VisiblePositionRange AccessibilityObject::positionOfLeftWord(const VisiblePosition& visiblePos) const
 {
-    auto start = startOfWord(visiblePos, LeftWordIfOnBoundary);
+    auto start = startOfWord(visiblePos, WordSide::LeftWordIfOnBoundary);
     return { start, endOfWord(start) };
 }
 
 VisiblePositionRange AccessibilityObject::positionOfRightWord(const VisiblePosition& visiblePos) const
 {
-    auto start = startOfWord(visiblePos, RightWordIfOnBoundary);
+    auto start = startOfWord(visiblePos, WordSide::RightWordIfOnBoundary);
     return { start, endOfWord(start) };
 }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -404,7 +404,7 @@ IntPoint AccessibilityObjectAtspi::boundaryOffset(unsigned utf16Offset, TextGran
         if (!utf16Offset && m_hasListMarkerAtStart)
             return { 0, 1 };
 
-        startPosition = isStartOfWord(offsetPosition) && deprecatedIsEditingWhitespace(offsetPosition.characterBefore()) ? offsetPosition : startOfWord(offsetPosition, LeftWordIfOnBoundary);
+        startPosition = isStartOfWord(offsetPosition) && deprecatedIsEditingWhitespace(offsetPosition.characterBefore()) ? offsetPosition : startOfWord(offsetPosition, WordSide::LeftWordIfOnBoundary);
         endPostion = nextWordPosition(startPosition);
         auto positionAfterSpacingAndFollowingWord = nextWordPosition(endPostion);
         if (positionAfterSpacingAndFollowingWord != endPostion) {

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -142,7 +142,7 @@ void AlternativeTextController::applyPendingCorrection(const VisibleSelection& s
     // Apply pending autocorrection before next round of spell checking.
     bool doApplyCorrection = true;
     VisiblePosition startOfSelection = selectionAfterTyping.visibleStart();
-    VisibleSelection currentWord = VisibleSelection(startOfWord(startOfSelection, LeftWordIfOnBoundary), endOfWord(startOfSelection, RightWordIfOnBoundary));
+    VisibleSelection currentWord = VisibleSelection(startOfWord(startOfSelection, WordSide::LeftWordIfOnBoundary), endOfWord(startOfSelection, WordSide::RightWordIfOnBoundary));
     if (currentWord.visibleEnd() == startOfSelection) {
         if (auto wordRange = currentWord.firstRange()) {
             String wordText = plainText(*wordRange);
@@ -253,7 +253,7 @@ void AlternativeTextController::timerFired()
     case AlternativeTextType::Correction: {
         VisibleSelection selection(m_document.selection().selection());
         VisiblePosition start(selection.start(), selection.affinity());
-        VisiblePosition p = startOfWord(start, LeftWordIfOnBoundary);
+        VisiblePosition p = startOfWord(start, WordSide::LeftWordIfOnBoundary);
         VisibleSelection adjacentWords = VisibleSelection(p, start);
         auto adjacentWordRange = adjacentWords.toNormalizedRange();
         m_document.editor().markAllMisspellingsAndBadGrammarInRanges({ TextCheckingType::Spelling, TextCheckingType::Replacement, TextCheckingType::ShowCorrectionPanel }, adjacentWordRange, adjacentWordRange, std::nullopt);
@@ -407,7 +407,7 @@ void AlternativeTextController::respondToChangedSelection(const VisibleSelection
     if (selectionPosition.isNull())
         return;
     
-    VisiblePosition endPositionOfWord = endOfWord(selectionPosition, LeftWordIfOnBoundary);
+    VisiblePosition endPositionOfWord = endOfWord(selectionPosition, WordSide::LeftWordIfOnBoundary);
     if (selectionPosition != endPositionOfWord)
         return;
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1175,8 +1175,8 @@ static inline bool didApplyAutocorrection(Document& document, AlternativeTextCon
     auto selection = document.selection().selection();
     auto startOfSelection = selection.start();
 
-    auto wordStart = startOfWord(startOfSelection, LeftWordIfOnBoundary);
-    auto wordEnd = endOfWord(startOfSelection, LeftWordIfOnBoundary);
+    auto wordStart = startOfWord(startOfSelection, WordSide::LeftWordIfOnBoundary);
+    auto wordEnd = endOfWord(startOfSelection, WordSide::LeftWordIfOnBoundary);
 
     if (auto range = makeSimpleRange(wordStart, wordEnd)) {
         if (document.markers().hasMarkers(*range, DocumentMarker::CorrectionIndicator))
@@ -2697,7 +2697,7 @@ void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart,
     if (!textCheckingOptions.contains(TextCheckingType::Spelling))
         return;
 
-    auto adjacentWords = VisibleSelection(startOfWord(wordStart, LeftWordIfOnBoundary), endOfWord(wordStart, RightWordIfOnBoundary));
+    auto adjacentWords = VisibleSelection(startOfWord(wordStart, WordSide::LeftWordIfOnBoundary), endOfWord(wordStart, WordSide::RightWordIfOnBoundary));
     auto adjacentWordRange = adjacentWords.toNormalizedRange();
 
 #if ENABLE(POST_EDITING_GRAMMAR_CHECKING)
@@ -2790,7 +2790,7 @@ void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart,
         if (!spellCheckingRange)
             return;
 
-        auto adjacentWordRange = intersection(VisibleSelection(startOfWord(wordStart, LeftWordIfOnBoundary), endOfWord(wordStart, RightWordIfOnBoundary)).toNormalizedRange(), fullSentenceRange);
+        auto adjacentWordRange = intersection(VisibleSelection(startOfWord(wordStart, WordSide::LeftWordIfOnBoundary), endOfWord(wordStart, WordSide::RightWordIfOnBoundary)).toNormalizedRange(), fullSentenceRange);
         if (!adjacentWordRange)
             return;
 
@@ -2808,7 +2808,7 @@ void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart,
         return;
 
     // Check spelling of one word
-    auto misspellingRange = markMisspellings(VisibleSelection(startOfWord(wordStart, LeftWordIfOnBoundary), endOfWord(wordStart, RightWordIfOnBoundary)));
+    auto misspellingRange = markMisspellings(VisibleSelection(startOfWord(wordStart, WordSide::LeftWordIfOnBoundary), endOfWord(wordStart, WordSide::RightWordIfOnBoundary)));
 
     // Autocorrect the misspelled word.
     if (!misspellingRange)
@@ -3245,20 +3245,20 @@ void Editor::updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionA
     if (startOfSelection.isNull())
         return;
     // First word is the word that ends after or on the start of selection.
-    VisiblePosition startOfFirstWord = startOfWord(startOfSelection, LeftWordIfOnBoundary);
-    VisiblePosition endOfFirstWord = endOfWord(startOfSelection, LeftWordIfOnBoundary);
+    VisiblePosition startOfFirstWord = startOfWord(startOfSelection, WordSide::LeftWordIfOnBoundary);
+    VisiblePosition endOfFirstWord = endOfWord(startOfSelection, WordSide::LeftWordIfOnBoundary);
     // Last word is the word that begins before or on the end of selection
-    VisiblePosition startOfLastWord = startOfWord(endOfSelection, RightWordIfOnBoundary);
-    VisiblePosition endOfLastWord = endOfWord(endOfSelection, RightWordIfOnBoundary);
+    VisiblePosition startOfLastWord = startOfWord(endOfSelection, WordSide::RightWordIfOnBoundary);
+    VisiblePosition endOfLastWord = endOfWord(endOfSelection, WordSide::RightWordIfOnBoundary);
 
     if (startOfFirstWord.isNull()) {
-        startOfFirstWord = startOfWord(startOfSelection, RightWordIfOnBoundary);
-        endOfFirstWord = endOfWord(startOfSelection, RightWordIfOnBoundary);
+        startOfFirstWord = startOfWord(startOfSelection, WordSide::RightWordIfOnBoundary);
+        endOfFirstWord = endOfWord(startOfSelection, WordSide::RightWordIfOnBoundary);
     }
     
     if (endOfLastWord.isNull()) {
-        startOfLastWord = startOfWord(endOfSelection, LeftWordIfOnBoundary);
-        endOfLastWord = endOfWord(endOfSelection, LeftWordIfOnBoundary);
+        startOfLastWord = startOfWord(endOfSelection, WordSide::LeftWordIfOnBoundary);
+        endOfLastWord = endOfWord(endOfSelection, WordSide::LeftWordIfOnBoundary);
     }
 
     auto originalEndOfFirstWord = endOfFirstWord;
@@ -3268,7 +3268,7 @@ void Editor::updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionA
     // we choose next word as the first word.
     if (doNotRemoveIfSelectionAtWordBoundary && endOfFirstWord == startOfSelection) {
         startOfFirstWord = nextWordPosition(startOfFirstWord);
-        endOfFirstWord = endOfWord(startOfFirstWord, RightWordIfOnBoundary);
+        endOfFirstWord = endOfWord(startOfFirstWord, WordSide::RightWordIfOnBoundary);
         if (startOfFirstWord == originalStartOfLastWord)
             return;
     }
@@ -3277,7 +3277,7 @@ void Editor::updateMarkersForWordsAffectedByEditing(bool doNotRemoveIfSelectionA
     // we choose previous word as the last word.
     if (doNotRemoveIfSelectionAtWordBoundary && startOfLastWord == endOfSelection) {
         startOfLastWord = previousWordPosition(startOfLastWord);
-        endOfLastWord = endOfWord(startOfLastWord, RightWordIfOnBoundary);
+        endOfLastWord = endOfWord(startOfLastWord, WordSide::RightWordIfOnBoundary);
         if (endOfLastWord == originalEndOfFirstWord)
             return;
     }
@@ -4008,18 +4008,18 @@ void Editor::editorUIUpdateTimerFired()
         if (document->selection().selection().isContentEditable() || caretBrowsing) {
             VisiblePosition newStart(document->selection().selection().visibleStart());
 #if !PLATFORM(IOS_FAMILY)
-            newAdjacentWords = VisibleSelection(startOfWord(newStart, LeftWordIfOnBoundary), endOfWord(newStart, RightWordIfOnBoundary));
+            newAdjacentWords = VisibleSelection(startOfWord(newStart, WordSide::LeftWordIfOnBoundary), endOfWord(newStart, WordSide::RightWordIfOnBoundary));
 #else
             // If this bug gets fixed, this PLATFORM(IOS_FAMILY) code could be removed:
             // <rdar://problem/7259611> Word boundary code on iPhone gives different results than desktop
-            EWordSide startWordSide = LeftWordIfOnBoundary;
+            WordSide startWordSide = WordSide::LeftWordIfOnBoundary;
             UChar32 c = newStart.characterBefore();
             // FIXME: VisiblePosition::characterAfter() and characterBefore() do not emit newlines the same
             // way as TextIterator, so we do an isStartOfParagraph check here.
             if (deprecatedIsSpaceOrNewline(c) || c == noBreakSpace || isStartOfParagraph(newStart)) {
-                startWordSide = RightWordIfOnBoundary;
+                startWordSide = WordSide::RightWordIfOnBoundary;
             }
-            newAdjacentWords = VisibleSelection(startOfWord(newStart, startWordSide), endOfWord(newStart, RightWordIfOnBoundary));
+            newAdjacentWords = VisibleSelection(startOfWord(newStart, startWordSide), endOfWord(newStart, WordSide::RightWordIfOnBoundary));
 #endif // !PLATFORM(IOS_FAMILY)
             if (isContinuousGrammarCheckingEnabled)
                 newSelectedSentence = VisibleSelection(startOfSentence(newStart), endOfSentence(newStart));
@@ -4030,7 +4030,7 @@ void Editor::editorUIUpdateTimerFired()
         // oldSelection may no longer be in the document.
         if (m_editorUIUpdateTimerShouldCheckSpellingAndGrammar && oldSelection.isContentEditable() && oldSelection.start().deprecatedNode() && oldSelection.start().anchorNode()->isConnected()) {
             VisiblePosition oldStart(oldSelection.visibleStart());
-            VisibleSelection oldAdjacentWords = VisibleSelection(startOfWord(oldStart, LeftWordIfOnBoundary), endOfWord(oldStart, RightWordIfOnBoundary));
+            VisibleSelection oldAdjacentWords = VisibleSelection(startOfWord(oldStart, WordSide::LeftWordIfOnBoundary), endOfWord(oldStart, WordSide::RightWordIfOnBoundary));
             if (oldAdjacentWords != newAdjacentWords) {
                 if (isContinuousGrammarCheckingEnabled) {
                     VisibleSelection oldSelectedSentence = VisibleSelection(startOfSentence(oldStart), endOfSentence(oldStart));

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -461,8 +461,8 @@ void TypingCommand::markMisspellingsAfterTyping(Type commandType)
     VisiblePosition previous = start.previous();
     if (previous.isNotNull()) {
 #if !PLATFORM(IOS_FAMILY)
-        VisiblePosition p1 = startOfWord(previous, LeftWordIfOnBoundary);
-        VisiblePosition p2 = startOfWord(start, LeftWordIfOnBoundary);
+        VisiblePosition p1 = startOfWord(previous, WordSide::LeftWordIfOnBoundary);
+        VisiblePosition p2 = startOfWord(start, WordSide::LeftWordIfOnBoundary);
         if (p1 != p2) {
             auto range = makeSimpleRange(p1, p2);
             String trimmedPreviousWord;
@@ -475,12 +475,12 @@ void TypingCommand::markMisspellingsAfterTyping(Type commandType)
         UNUSED_PARAM(commandType);
         // If this bug gets fixed, this PLATFORM(IOS_FAMILY) code could be removed:
         // <rdar://problem/7259611> Word boundary code on iPhone gives different results than desktop
-        EWordSide startWordSide = LeftWordIfOnBoundary;
+        WordSide startWordSide = WordSide::LeftWordIfOnBoundary;
         UChar32 c = previous.characterAfter();
         // FIXME: VisiblePosition::characterAfter() and characterBefore() do not emit newlines the same
         // way as TextIterator, so we do an isEndOfParagraph check here.
         if (deprecatedIsSpaceOrNewline(c) || c == noBreakSpace || isEndOfParagraph(previous)) {
-            startWordSide = RightWordIfOnBoundary;
+            startWordSide = WordSide::RightWordIfOnBoundary;
         }
         VisiblePosition p1 = startOfWord(previous, startWordSide);
         VisiblePosition p2 = startOfWord(start, startWordSide);

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -283,13 +283,13 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
             // last word to the line break (also RightWordIfOnBoundary);
             VisiblePosition start = VisiblePosition(m_start, m_affinity);
             VisiblePosition originalEnd(m_end, m_affinity);
-            EWordSide side = RightWordIfOnBoundary;
+            WordSide side = WordSide::RightWordIfOnBoundary;
             if (isEndOfEditableOrNonEditableContent(start) || (isEndOfLine(start) && !isStartOfLine(start) && !isEndOfParagraph(start)))
-                side = LeftWordIfOnBoundary;
+                side = WordSide::LeftWordIfOnBoundary;
             m_start = startOfWord(start, side).deepEquivalent();
-            side = RightWordIfOnBoundary;
+            side = WordSide::RightWordIfOnBoundary;
             if (isEndOfEditableOrNonEditableContent(originalEnd) || (isEndOfLine(originalEnd) && !isStartOfLine(originalEnd) && !isEndOfParagraph(originalEnd)))
-                side = LeftWordIfOnBoundary;
+                side = WordSide::LeftWordIfOnBoundary;
 
             VisiblePosition wordEnd(endOfWord(originalEnd, side));
             VisiblePosition end(wordEnd);

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -650,12 +650,12 @@ unsigned startWordBoundary(StringView text, unsigned offset, BoundarySearchConte
     return start;
 }
 
-VisiblePosition startOfWord(const VisiblePosition& c, EWordSide side)
+VisiblePosition startOfWord(const VisiblePosition& c, WordSide side)
 {
     // FIXME: This returns a null VP for c at the start of the document
     // and side == LeftWordIfOnBoundary
     VisiblePosition p = c;
-    if (side == RightWordIfOnBoundary) {
+    if (side == WordSide::RightWordIfOnBoundary) {
         // at paragraph end, the startofWord is the current position
         if (isEndOfParagraph(c))
             return c;
@@ -680,10 +680,10 @@ unsigned endWordBoundary(StringView text, unsigned offset, BoundarySearchContext
     return end;
 }
 
-VisiblePosition endOfWord(const VisiblePosition& c, EWordSide side)
+VisiblePosition endOfWord(const VisiblePosition& c, WordSide side)
 {
     VisiblePosition p = c;
-    if (side == LeftWordIfOnBoundary) {
+    if (side == WordSide::LeftWordIfOnBoundary) {
         if (isStartOfParagraph(c))
             return c;
             
@@ -728,7 +728,7 @@ VisiblePosition nextWordPosition(const VisiblePosition& position)
 
 bool isStartOfWord(const VisiblePosition& p)
 {
-    return p.isNotNull() && p == startOfWord(p, RightWordIfOnBoundary);
+    return p.isNotNull() && p == startOfWord(p, WordSide::RightWordIfOnBoundary);
 }
 
 // ---------
@@ -1503,7 +1503,7 @@ bool atBoundaryOfGranularity(const VisiblePosition& vp, TextGranularity granular
             return false;
 
         // Note that "Left" and "Right" in this context apparently mean "upstream/previous" and "downstream/next".
-        boundary = useDownstream ? endOfWord(vp, LeftWordIfOnBoundary) : startOfWord(vp, RightWordIfOnBoundary);
+        boundary = useDownstream ? endOfWord(vp, WordSide::LeftWordIfOnBoundary) : startOfWord(vp, WordSide::RightWordIfOnBoundary);
         break;
 
     case TextGranularity::SentenceGranularity: {
@@ -1553,11 +1553,11 @@ bool withinTextUnitOfGranularity(const VisiblePosition& vp, TextGranularity gran
     switch (granularity) {
     case TextGranularity::WordGranularity:
         // Note that "Left" and "Right" in this context apparently mean "upstream/previous" and "downstream/next".
-        prevBoundary = startOfWord(vp, (useDownstream ? RightWordIfOnBoundary : LeftWordIfOnBoundary));
-        nextBoundary = endOfWord(vp, (useDownstream ? RightWordIfOnBoundary : LeftWordIfOnBoundary));
-    
+        prevBoundary = startOfWord(vp, (useDownstream ? WordSide::RightWordIfOnBoundary : WordSide::LeftWordIfOnBoundary));
+        nextBoundary = endOfWord(vp, (useDownstream ? WordSide::RightWordIfOnBoundary : WordSide::LeftWordIfOnBoundary));
+
         // Workaround for <rdar://problem/7259611> Word boundary code on iPhone gives different results than desktop
-        if (endOfWord(prevBoundary, RightWordIfOnBoundary) != nextBoundary)
+        if (endOfWord(prevBoundary, WordSide::RightWordIfOnBoundary) != nextBoundary)
             return false;
 
         break;
@@ -1614,16 +1614,16 @@ static VisiblePosition nextWordBoundaryInDirection(const VisiblePosition& vp, Se
     
     if (useDownstream) {
         if (withinUnitOfGranularity)
-            result = endOfWord(vp, RightWordIfOnBoundary);
+            result = endOfWord(vp, WordSide::RightWordIfOnBoundary);
         else {
-            VisiblePosition start = startOfWord(vp, RightWordIfOnBoundary);
+            VisiblePosition start = startOfWord(vp, WordSide::RightWordIfOnBoundary);
             if (start > vp && start != endOfWord(start))
                 result = start;
             else {
                 // Do same thing as backwards traveling below.
                 start = vp;
                 while (true) {
-                    result = startOfWord(nextWordPosition(start), RightWordIfOnBoundary);
+                    result = startOfWord(nextWordPosition(start), WordSide::RightWordIfOnBoundary);
 
                     if (result == start)
                         break;
@@ -1646,18 +1646,18 @@ static VisiblePosition nextWordBoundaryInDirection(const VisiblePosition& vp, Se
         }
     } else {
         if (withinUnitOfGranularity)
-            result = startOfWord(vp, LeftWordIfOnBoundary);
+            result = startOfWord(vp, WordSide::LeftWordIfOnBoundary);
         else {
             // This is complicated because:
             //   When given "Blah blah.|", endOfWord is "Blah blah|.", and previousWordPosition is "Blah| blah."
             //   When given "Blah blah. |", endOfWord is "Blah blah.| ", and previousWordPosition is "Blah |blah. ".
-            VisiblePosition end = endOfWord(vp, LeftWordIfOnBoundary);
+            VisiblePosition end = endOfWord(vp, WordSide::LeftWordIfOnBoundary);
             if (end < vp && end != startOfWord(end))
                 result = end;
             else {
                 end = vp;
                 while (true) {
-                    result = endOfWord(previousWordPosition(end), RightWordIfOnBoundary);
+                    result = endOfWord(previousWordPosition(end), WordSide::RightWordIfOnBoundary);
 
                     if (result == end)
                         break;
@@ -1776,11 +1776,11 @@ std::optional<SimpleRange> enclosingTextUnitOfGranularity(const VisiblePosition&
         case TextGranularity::WordGranularity:
             // NB: "Left" and "Right" in this context apparently mean "upstream/previous" and "downstream/next".
             if (useDownstream) {
-                prevBoundary = startOfWord(vp, RightWordIfOnBoundary);
-                nextBoundary = endOfWord(vp, RightWordIfOnBoundary);
+                prevBoundary = startOfWord(vp, WordSide::RightWordIfOnBoundary);
+                nextBoundary = endOfWord(vp, WordSide::RightWordIfOnBoundary);
             } else {
-                prevBoundary = startOfWord(vp, LeftWordIfOnBoundary);
-                nextBoundary = endOfWord(vp, LeftWordIfOnBoundary);
+                prevBoundary = startOfWord(vp, WordSide::LeftWordIfOnBoundary);
+                nextBoundary = endOfWord(vp, WordSide::LeftWordIfOnBoundary);
             }
             break;
 

--- a/Source/WebCore/editing/VisibleUnits.h
+++ b/Source/WebCore/editing/VisibleUnits.h
@@ -36,11 +36,11 @@ class VisiblePosition;
 class SimplifiedBackwardsTextIterator;
 class TextIterator;
 
-enum EWordSide { RightWordIfOnBoundary = false, LeftWordIfOnBoundary = true };
+enum class WordSide : bool { RightWordIfOnBoundary, LeftWordIfOnBoundary };
 
 // words
-WEBCORE_EXPORT VisiblePosition startOfWord(const VisiblePosition&, EWordSide = RightWordIfOnBoundary);
-WEBCORE_EXPORT VisiblePosition endOfWord(const VisiblePosition&, EWordSide = RightWordIfOnBoundary);
+WEBCORE_EXPORT VisiblePosition startOfWord(const VisiblePosition&, WordSide = WordSide::RightWordIfOnBoundary);
+WEBCORE_EXPORT VisiblePosition endOfWord(const VisiblePosition&, WordSide = WordSide::RightWordIfOnBoundary);
 WEBCORE_EXPORT VisiblePosition previousWordPosition(const VisiblePosition&);
 WEBCORE_EXPORT VisiblePosition nextWordPosition(const VisiblePosition&);
 WEBCORE_EXPORT VisiblePosition rightWordPosition(const VisiblePosition&, bool skipsSpaceWhenMovingRight);


### PR DESCRIPTION
#### 456666ee4e2dc383d138624c83e922838341d510
<pre>
EWordSide should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=261770">https://bugs.webkit.org/show_bug.cgi?id=261770</a>
rdar://115743034

Reviewed by Michael Catanzaro.

This commit narrows down the underlying type of EWordSide and converts it
to an enum class for type safety.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::startCharacterOffsetOfWord):
(WebCore::AXObjectCache::endCharacterOffsetOfWord):
(WebCore::AXObjectCache::previousWordStartCharacterOffset):
(WebCore::AXObjectCache::nextWordEndCharacterOffset):
(WebCore::AXObjectCache::leftWordRange):
(WebCore::AXObjectCache::rightWordRange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::positionOfLeftWord const):
(WebCore::AccessibilityObject::positionOfRightWord const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::boundaryOffset const):
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::applyPendingCorrection):
(WebCore::AlternativeTextController::timerFired):
(WebCore::AlternativeTextController::respondToChangedSelection):
* Source/WebCore/editing/Editor.cpp:
(WebCore::didApplyAutocorrection):
(WebCore::Editor::markMisspellingsAfterTypingToWord):
(WebCore::Editor::updateMarkersForWordsAffectedByEditing):
(WebCore::Editor::editorUIUpdateTimerFired):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::markMisspellingsAfterTyping):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::adjustSelectionRespectingGranularity):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::startOfWord):
(WebCore::endOfWord):
(WebCore::isStartOfWord):
(WebCore::atBoundaryOfGranularity):
(WebCore::withinTextUnitOfGranularity):
(WebCore::nextWordBoundaryInDirection):
(WebCore::enclosingTextUnitOfGranularity):
* Source/WebCore/editing/VisibleUnits.h:

Canonical link: <a href="https://commits.webkit.org/268296@main">https://commits.webkit.org/268296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ac84b8b5b9cfd45f3624b38a7fa082316034d34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17966 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19646 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21959 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23841 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21795 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15454 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17370 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4604 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18082 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->