### PR TITLE
Adopt new jit write toggle API

### DIFF
--- a/Source/JavaScriptCore/assembler/FastJITPermissions.h
+++ b/Source/JavaScriptCore/assembler/FastJITPermissions.h
@@ -34,7 +34,9 @@
 
 #include <wtf/Platform.h>
 
-#if USE(PTHREAD_JIT_PERMISSIONS_API)
+#if USE(INLINE_JIT_PERMISSIONS_API)
+#include <ServiceExtensions/SEMemory_Private.h>
+#elif USE(PTHREAD_JIT_PERMISSIONS_API)
 #include <pthread.h>
 #elif USE(APPLE_INTERNAL_SDK)
 #include <os/thread_self_restrict.h> 
@@ -44,7 +46,9 @@ static ALWAYS_INLINE void threadSelfRestrictRWXToRW()
 {
     ASSERT(g_jscConfig.useFastJITPermissions);
 
-#if USE(PTHREAD_JIT_PERMISSIONS_API) 
+#if USE(INLINE_JIT_PERMISSIONS_API)
+    se_memory_inline_jit_restrict_rwx_to_rw_with_witness();
+#elif USE(PTHREAD_JIT_PERMISSIONS_API)
     pthread_jit_write_protect_np(false);
 #elif USE(APPLE_INTERNAL_SDK)
     os_thread_self_restrict_rwx_to_rw();
@@ -59,7 +63,9 @@ static ALWAYS_INLINE void threadSelfRestrictRWXToRX()
 {
     ASSERT(g_jscConfig.useFastJITPermissions);
 
-#if USE(PTHREAD_JIT_PERMISSIONS_API) 
+#if USE(INLINE_JIT_PERMISSIONS_API)
+    se_memory_inline_jit_restrict_rwx_to_rx_with_witness();
+#elif USE(PTHREAD_JIT_PERMISSIONS_API)
     pthread_jit_write_protect_np(true);
 #elif USE(APPLE_INTERNAL_SDK)
     os_thread_self_restrict_rwx_to_rx();

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -415,7 +415,9 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
 
         bool fastJITPermissionsIsSupported = false;
 #if OS(DARWIN) && CPU(ARM64)
-#if USE(PTHREAD_JIT_PERMISSIONS_API) 
+#if USE(INLINE_JIT_PERMISSIONS_API)
+        fastJITPermissionsIsSupported = !!se_memory_inline_jit_restrict_with_witness_supported();
+#elif USE(PTHREAD_JIT_PERMISSIONS_API)
         fastJITPermissionsIsSupported = !!pthread_jit_write_protect_supported_np();
 #elif USE(APPLE_INTERNAL_SDK)
         fastJITPermissionsIsSupported = !!os_thread_self_restrict_rwx_is_supported();


### PR DESCRIPTION
#### 2f65efbad704d90dc41e45cb8581c99d70273943
<pre>
Adopt new jit write toggle API
<a href="https://bugs.webkit.org/show_bug.cgi?id=261792">https://bugs.webkit.org/show_bug.cgi?id=261792</a>
rdar://115758153

Reviewed by Mark Lam.

Adopt new jit write toggle API, which has been renamed to be more descriptive.

* Source/JavaScriptCore/assembler/FastJITPermissions.h:
(threadSelfRestrictRWXToRW):
(threadSelfRestrictRWXToRX):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):

Canonical link: <a href="https://commits.webkit.org/268429@main">https://commits.webkit.org/268429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6a50b0099176df94e39fde962a9918c94ab1b78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18406 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22432 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17917 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17125 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22185 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/19075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18687 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23082 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17836 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4700 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22190 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24335 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18512 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5400 "Passed tests") | 
<!--EWS-Status-Bubble-End-->