### PR TITLE
Use CheckedPtr more for Node types now that Node subclasses CanMakeCheckedPtr

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -232,7 +232,7 @@ private:
 
     bool isDescendantOfElementType(const HashSet<QualifiedName>&) const;
 
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_node;
+    CheckedPtr<Node> m_node;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -117,7 +117,7 @@ void DeclarativeAnimation::initialize(const RenderStyle* oldStyle, const RenderS
     ASSERT(m_owningElement);
 
     setEffect(KeyframeEffect::create(*m_owningElement, m_owningPseudoId));
-    setTimeline(&m_owningElement->document().timeline());
+    setTimeline(&m_owningElement.get()->document().timeline());
     downcast<KeyframeEffect>(effect())->computeDeclarativeAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
     syncPropertiesWithBackingAnimation();
     if (backingAnimation().playState() == AnimationPlayState::Playing)
@@ -264,7 +264,7 @@ auto DeclarativeAnimation::shouldFireDOMEvents() const -> ShouldFireEvents
     if (!m_owningElement)
         return ShouldFireEvents::No;
 
-    auto& document = m_owningElement->document();
+    auto& document = m_owningElement.get()->document();
     if (is<CSSAnimation>(*this)) {
         if (document.hasListenerType(Document::ListenerType::CSSAnimation))
             return ShouldFireEvents::YesForCSSAnimation;

--- a/Source/WebCore/animation/DeclarativeAnimation.h
+++ b/Source/WebCore/animation/DeclarativeAnimation.h
@@ -94,7 +94,7 @@ private:
     bool m_wasPending { false };
     AnimationEffectPhase m_previousPhase { AnimationEffectPhase::Idle };
 
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_owningElement;
+    CheckedPtr<Element> m_owningElement;
     PseudoId m_owningPseudoId;
     Ref<Animation> m_backingAnimation;
     double m_previousIteration;

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -142,7 +142,7 @@ void Attr::detachFromElementWithValue(const AtomString& value)
 void Attr::attachToElement(Element& element)
 {
     ASSERT(!m_element);
-    m_element = element;
+    m_element = &element;
     m_standaloneValue = nullAtom();
     setTreeScopeRecursively(element.treeScope());
 }

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -78,7 +78,7 @@ private:
 
     // Attr wraps either an element/name, or a name/value pair (when it's a standalone Node.)
     // Note that m_name is always set, but m_element/m_standaloneValue may be null.
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
+    CheckedPtr<Element> m_element;
     QualifiedName m_name;
     AtomString m_standaloneValue;
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8693,12 +8693,12 @@ std::optional<FrameIdentifier> Document::frameID() const
 
 void Document::registerArticleElement(Element& article)
 {
-    m_articleElements.add(article);
+    m_articleElements.add(&article);
 }
 
 void Document::unregisterArticleElement(Element& article)
 {
-    m_articleElements.remove(article);
+    m_articleElements.remove(&article);
     if (m_mainArticleElement == &article)
         m_mainArticleElement = nullptr;
 }
@@ -8718,7 +8718,7 @@ void Document::updateMainArticleElementAfterLayout()
 
     m_mainArticleElement = nullptr;
 
-    auto numberOfArticles = m_articleElements.computeSize();
+    auto numberOfArticles = m_articleElements.size();
     if (!numberOfArticles || numberOfArticles > maxNumberOfArticlesBeforeIgnoringMainContentArticle)
         return;
 
@@ -8728,19 +8728,19 @@ void Document::updateMainArticleElementAfterLayout()
     float secondTallestArticleHeight = 0;
 
     for (auto& article : m_articleElements) {
-        auto* box = article.renderBox();
+        auto* box = article.get()->renderBox();
         float height = box ? box->height().toFloat() : 0;
         if (height >= tallestArticleHeight) {
             secondTallestArticleHeight = tallestArticleHeight;
             tallestArticleHeight = height;
             tallestArticleWidth = box ? box->width().toFloat() : 0;
-            tallestArticle = &article;
+            tallestArticle = article.get();
         } else if (height >= secondTallestArticleHeight)
             secondTallestArticleHeight = height;
     }
 
     if (numberOfArticles == 1) {
-        m_mainArticleElement = tallestArticle;
+        m_mainArticleElement = tallestArticle.get();
         return;
     }
 
@@ -8754,7 +8754,7 @@ void Document::updateMainArticleElementAfterLayout()
     if (tallestArticleWidth * tallestArticleHeight < minimumViewportAreaFactor * (viewportSize.width() * viewportSize.height()).toFloat())
         return;
 
-    m_mainArticleElement = tallestArticle;
+    m_mainArticleElement = tallestArticle.get();
 }
 
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2009,7 +2009,7 @@ private:
 
     std::unique_ptr<Style::Update> m_pendingRenderTreeUpdate;
 
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_cssTarget;
+    CheckedPtr<Element> m_cssTarget;
 
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
 
@@ -2067,8 +2067,8 @@ private:
     WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElementShowingTextTrack;
 #endif
 
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_mainArticleElement;
-    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_articleElements;
+    CheckedPtr<Element> m_mainArticleElement;
+    HashSet<CheckedPtr<Element>> m_articleElements;
 
     WeakHashSet<VisibilityChangeClient> m_visibilityStateCallbackClients;
 

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(ShadowRoot);
 
 struct SameSizeAsShadowRoot : public DocumentFragment, public TreeScope {
     uint8_t flagsAndModes[3];
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> host;
+    CheckedPtr<Element> host;
     void* styleSheetList;
     void* styleScope;
     void* slotAssignment;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -83,7 +83,7 @@ public:
     void setIsDeclarativeShadowRoot(bool flag) { m_isDeclarativeShadowRoot = flag; }
 
     Element* host() const { return m_host.get(); }
-    void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTFMove(host); }
+    void setHost(CheckedPtr<Element>&& host) { m_host = WTFMove(host); }
 
     String innerHTML() const;
     ExceptionOr<void> setInnerHTML(const String&);
@@ -150,7 +150,7 @@ private:
     ShadowRootMode m_mode { ShadowRootMode::UserAgent };
     SlotAssignmentMode m_slotAssignmentMode { SlotAssignmentMode::Named };
 
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_host;
+    CheckedPtr<Element> m_host;
     RefPtr<StyleSheetList> m_styleSheetList;
 
     std::unique_ptr<Style::Scope> m_styleScope;

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -958,7 +958,6 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
 void TextManipulationController::removeNode(Node& node)
 {
     m_manipulatedNodes.remove(node);
-    m_textNodesWithNewRenderer.remove(node);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -101,8 +101,6 @@ private:
     std::optional<ManipulationFailure::Type> replace(const ManipulationItemData&, const Vector<TextManipulationToken>&, HashSet<Ref<Node>>& containersWithoutVisualOverflowBeforeReplacement);
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_elementsWithNewRenderer;
-    WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_textNodesWithNewRenderer;
     WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_manipulatedNodes;
     WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_manipulatedNodesWithNewContent;
     WeakHashSet<Node, WeakPtrImplWithEventTargetData> m_addedOrNewlyRenderedNodes;

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -45,7 +45,7 @@ public:
 
 private:
     LocalFrameView& m_frameView;
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_anchorElement;
+    CheckedPtr<Element> m_anchorElement;
     FloatPoint m_lastPositionForAnchorElement;
 };
 

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -106,7 +106,7 @@ private:
 
     void clearXSLStylesheetDocument();
 
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
+    CheckedPtr<Node> m_ownerNode;
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };


### PR DESCRIPTION
#### bfdea7f1b0cabdce68bc719edfabe473c6ff5edd
<pre>
Use CheckedPtr more for Node types now that Node subclasses CanMakeCheckedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=261796">https://bugs.webkit.org/show_bug.cgi?id=261796</a>

Reviewed by Darin Adler.

Use CheckedPtr more for Node types now that Node subclasses CanMakeCheckedPtr.
It is more efficient in the case where we don&apos;t need the pointer to get
automatically nulled out.

* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::initialize):
(WebCore::DeclarativeAnimation::shouldFireDOMEvents const):
* Source/WebCore/animation/DeclarativeAnimation.h:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::attachToElement):
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::registerArticleElement):
(WebCore::Document::unregisterArticleElement):
(WebCore::Document::updateMainArticleElementAfterLayout):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::elementIdentifiersMap):
(WebCore::Element::~Element):
(WebCore::Element::addShadowRoot):
(WebCore::Element::identifier const):
(WebCore::Element::fromIdentifier):
* Source/WebCore/dom/Node.cpp:
(WebCore::liveNodeSet):
(WebCore::Node::dumpStatistics):
(WebCore::Node::trackForDebugging):
(WebCore::Node::~Node):
* Source/WebCore/dom/ShadowRoot.cpp:
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::removeNode):
* Source/WebCore/editing/TextManipulationController.h:
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/xml/XSLStyleSheet.h:

Canonical link: <a href="https://commits.webkit.org/268215@main">https://commits.webkit.org/268215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a9515d10f1265bd4366d0c5166972dd092c5eb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19003 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17770 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19475 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21761 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19175 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23725 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16493 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21671 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18334 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18071 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22384 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/18836 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17153 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5437 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4532 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21515 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23632 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17904 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5298 "Passed tests") | 
<!--EWS-Status-Bubble-End-->