### PR TITLE
[JHBuild] Add fallback JHBuild git url

### DIFF
--- a/Tools/jhbuild/jhbuild-wrapper
+++ b/Tools/jhbuild/jhbuild-wrapper
@@ -24,7 +24,7 @@ import shlex
 import subprocess
 import sys
 
-jhbuild_revision = 'acb52b03594989cfb45173841b318fccf557fefb'
+jhbuild_revision = '048920f64d82779eef88158455bfd1d160a3be1a'
 
 def determine_platform():
     if '--gtk' in sys.argv:
@@ -76,16 +76,22 @@ def update_jhbuild():
 
 
 def clone_jhbuild():
+    JHBUILD_GIT_URLS = [
+        'https://gitlab.gnome.org/GNOME/jhbuild.git',
+        'https://github.com/GNOME/jhbuild.git',
+    ]
     if not os.path.exists(source_path):
         os.makedirs(source_path)
     if not os.path.exists(installation_prefix):
         os.makedirs(installation_prefix)
 
     # Use only 1 thread to workaround a QEMU bug - see http://webkit.org/b/143095 for details.
-    process = subprocess.Popen(['git', 'clone', '--config', 'pack.threads=1', 'https://git.gnome.org/browse/jhbuild'], cwd=source_path)
-    process.wait()
-    if process.returncode != 0:
-        raise Exception('jhbuild git clone failed with return code: %i' % process.returncode)
+    for url in JHBUILD_GIT_URLS:
+        process = subprocess.Popen(['git', 'clone', '--config', 'pack.threads=1', url], cwd=source_path)
+        process.wait()
+        if process.returncode == 0:
+            return
+    raise Exception('Could not clone jhbuild git repository')
 
 
 def install_jhbuild():


### PR DESCRIPTION
#### 928fbce3a5f2fa26006bcffe0181af52828c2e72
<pre>
[JHBuild] Add fallback JHBuild git url
<a href="https://bugs.webkit.org/show_bug.cgi?id=261797">https://bugs.webkit.org/show_bug.cgi?id=261797</a>

Reviewed by Michael Catanzaro.

Add GitHub&apos;s JHBuild repository URL as fallback, in case primary URL
cannot be reached.

Also, update JHBuild&apos;s revision.

* Tools/jhbuild/jhbuild-wrapper:
(clone_jhbuild):

Canonical link: <a href="https://commits.webkit.org/268225@main">https://commits.webkit.org/268225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f59f981c1d58e33d56b43a3d0d3a05728e1370df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20930 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21812 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17631 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17208 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4538 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21566 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->