### PR TITLE
[GTK] Remove libsoup2 package

### DIFF
--- a/Tools/gtk/dependencies/apt
+++ b/Tools/gtk/dependencies/apt
@@ -23,7 +23,6 @@ PACKAGES+=(
     libpulse-dev
     librsvg2-dev
     libsecret-1-dev
-    libsoup2.4-dev
     libsrtp2-dev
     libtheora-dev
     libupower-glib-dev

--- a/Tools/gtk/dependencies/pacman
+++ b/Tools/gtk/dependencies/pacman
@@ -20,7 +20,7 @@ PACKAGES+=(
     libpulse
     librsvg
     libsecret
-    libsoup
+    libsoup3
     libsrtp
     libtheora
     libvorbis


### PR DESCRIPTION
#### 233870307cf8017656a397273927ee5c4ab7a455
<pre>
[GTK] Remove libsoup2 package
<a href="https://bugs.webkit.org/show_bug.cgi?id=261192">https://bugs.webkit.org/show_bug.cgi?id=261192</a>

Reviewed by Michael Catanzaro.

Now that JHBuild is shipping libsoup3 is not necessary to install
libsoup2-dev package.

* Tools/gtk/dependencies/apt: Remove libsoup2-dev package.
* Tools/gtk/dependencies/pacman: Change libsoup to libsoup3.

Canonical link: <a href="https://commits.webkit.org/268202@main">https://commits.webkit.org/268202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/222f8e0c25a41a2cb9b393c82970156bbcba5442

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19450 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19313 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21736 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17299 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23703 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17561 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21644 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18048 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17130 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4519 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->