### PR TITLE
Add HashMap::getOptional

### DIFF
--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -133,6 +133,7 @@ public:
     const_iterator find(const KeyType&) const;
     bool contains(const KeyType&) const;
     MappedPeekType get(const KeyType&) const;
+    std::optional<MappedType> getOptional(const KeyType&) const;
 
     // Same as get(), but aggressively inlined.
     MappedPeekType inlineGet(const KeyType&) const;
@@ -468,6 +469,15 @@ template<typename T, typename U, typename V, typename W, typename X, typename Y>
 inline auto HashMap<T, U, V, W, X, Y>::get(const KeyType& key) const -> MappedPeekType
 {
     return get<IdentityTranslatorType>(key);
+}
+
+template<typename T, typename U, typename V, typename W, typename X, typename Y>
+inline auto HashMap<T, U, V, W, X, Y>::getOptional(const KeyType& key) const -> std::optional<MappedType>
+{
+    auto* entry = const_cast<HashTableType&>(m_impl).template lookup<IdentityTranslatorType>(key);
+    if (!entry)
+        return { };
+    return { entry->value };
 }
 
 template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -621,7 +621,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
         renderer.setLocation(Layout::BoxGeometry::borderBoxRect(logicalGeometry).topLeft() + logicalOffset);
     }
 
-    HashMap<CheckedRef<const Layout::Box>, std::optional<LayoutSize>> floatPaginationOffsetMap;
+    HashMap<CheckedRef<const Layout::Box>, LayoutSize> floatPaginationOffsetMap;
     if (!lineAdjustments.isEmpty()) {
         for (auto& floatItem : m_blockFormattingState.floatingState().floats()) {
             if (!floatItem.layoutBox() || !floatItem.placedByLine())
@@ -650,7 +650,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
             auto visualMarginBoxRect = LayoutRect { Layout::BoxGeometry::marginBoxRect(visualGeometry) };
             auto visualBorderBoxRect = LayoutRect { Layout::BoxGeometry::borderBoxRect(visualGeometry) };
 
-            auto paginationOffset = floatPaginationOffsetMap.get(layoutBox);
+            auto paginationOffset = floatPaginationOffsetMap.getOptional(layoutBox);
 
             if (paginationOffset) {
                 visualMarginBoxRect.move(*paginationOffset);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp
@@ -80,9 +80,7 @@ Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent& inli
     auto accumulatedOffset = 0_lu;
     for (size_t lineIndex = 0; lineIndex < lineCount;) {
         auto line = InlineIterator::lineBoxFor(inlineContent, lineIndex);
-
-        auto it = lineFloatBottomMap.find(lineIndex);
-        auto floatMinimumBottom = it != lineFloatBottomMap.end() ? it->value : 0_lu;
+        auto floatMinimumBottom = lineFloatBottomMap.getOptional(lineIndex).value_or(0_lu);
 
         auto adjustment = flow.computeLineAdjustmentForPagination(line, accumulatedOffset, floatMinimumBottom);
 

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -413,10 +413,8 @@ RuleSet::CollectedMediaQueryChanges RuleSet::evaluateDynamicMediaQueryRules(cons
         return collectedChanges;
 
     traverseRuleDatas([&](RuleData& ruleData) {
-        auto it = affectedRulePositionsAndResults.find(ruleData.position());
-        if (it == affectedRulePositionsAndResults.end())
-            return;
-        ruleData.setEnabled(it->value);
+        if (auto result = affectedRulePositionsAndResults.getOptional(ruleData.position()))
+            ruleData.setEnabled(*result);
     });
 
     return collectedChanges;

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -1215,4 +1215,52 @@ TEST(WTF_HashMap, Clear_Reenter)
     EXPECT_TRUE(map.isEmpty());
 }
 
+TEST(WTF_HashMap, GetOptional)
+{
+    {
+        struct Value {
+            int a;
+            int b;
+        };
+
+        HashMap<unsigned, Value> map;
+        map.add(2, Value { 1, 2 });
+        map.add(1000, Value { 3, 4 });
+
+        auto optionalValue = map.getOptional(1);
+        EXPECT_FALSE(optionalValue.has_value());
+
+        optionalValue = map.getOptional(2);
+        EXPECT_TRUE(optionalValue.has_value());
+        EXPECT_EQ(1, optionalValue->a);
+        EXPECT_EQ(2, optionalValue->b);
+
+        optionalValue = map.getOptional(1000);
+        EXPECT_TRUE(optionalValue.has_value());
+        EXPECT_EQ(3, optionalValue->a);
+        EXPECT_EQ(4, optionalValue->b);
+
+        optionalValue = map.getOptional(10000);
+        EXPECT_FALSE(optionalValue.has_value());
+    }
+
+    {
+        struct CountedValue : public RefCounted<CountedValue> {
+            CountedValue() = default;
+            int a { 123 };
+        };
+
+        HashMap<unsigned, Ref<CountedValue>> map;
+        map.add(2, adoptRef(*new CountedValue { }));
+
+        auto optionalValue = map.getOptional(1);
+        EXPECT_FALSE(optionalValue.has_value());
+
+        optionalValue = map.getOptional(2);
+        EXPECT_TRUE(optionalValue.has_value());
+        EXPECT_EQ(123, optionalValue.value().get().a);
+    }
+
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### ec5bee2d9c22a92e4db7ddfaecec2f1c5958c4b0
<pre>
Add HashMap::getOptional
<a href="https://bugs.webkit.org/show_bug.cgi?id=261800">https://bugs.webkit.org/show_bug.cgi?id=261800</a>
rdar://problem/115764318

Reviewed by Kimmo Kinnunen.

Add a version of get() that returns std::optional for convenience.

* Source/WTF/wtf/HashMap.h:
(WTF::Y&gt;::getOptional const):

Note that this returns std::optional&lt;MappedType&gt; instead of std::optional&lt;MappedPeakType&gt;,
making it safer to use with reference counting smart pointers. This mean it is not usable with
maps containing std::unique_ptr and similar values but for those it would not add anything over
plain get() anyway.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):

Also use it in a few places.

* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::evaluateDynamicMediaQueryRules):
* Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268207@main">https://commits.webkit.org/268207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fc9a8dbc1cb170e1f50a653ec6be8a9fa8a3e32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19446 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21732 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23699 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16468 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21640 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18306 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18044 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22357 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17126 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4522 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21487 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23604 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17878 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5293 "Passed tests") | 
<!--EWS-Status-Bubble-End-->