### PR TITLE
[WebGPU] https://webgpu.github.io/webgpu-samples/samples/samplerParameters does not work as expected

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -473,12 +473,12 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
             return BindGroup::createInvalid(*this);
 
         for (ShaderStage stage : stages) {
-            auto optionalIndex = bindGroupLayout.indexForBinding(entry.binding, stage);
-            if (!optionalIndex)
+            auto optionalAccess = bindGroupLayout.bindingAccessForBindingIndex(entry.binding, stage);
+            if (!optionalAccess)
                 continue;
 
-            auto index = optionalIndex->first;
-            MTLResourceUsage resourceUsage = resourceUsageForBindingAcccess(optionalIndex->second);
+            auto index = entry.binding;
+            MTLResourceUsage resourceUsage = resourceUsageForBindingAcccess(*optionalAccess);
 
             if (bufferIsPresent) {
                 id<MTLBuffer> buffer = WebGPU::fromAPI(entry.buffer).buffer();

--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -67,7 +67,7 @@ public:
     static constexpr auto BindingAccessReadWrite = MTLBindingAccessReadWrite;
     static constexpr auto BindingAccessWriteOnly = MTLBindingAccessWriteOnly;
 #endif
-    using StageMapValue = std::pair<NSUInteger, BindingAccess>;
+    using StageMapValue = BindingAccess;
     using StageMapTable = HashMap<uint64_t, StageMapValue, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
 
     static Ref<BindGroupLayout> create(StageMapTable&& stageMapTable, id<MTLArgumentEncoder> vertexArgumentEncoder, id<MTLArgumentEncoder> fragmentArgumentEncoder, id<MTLArgumentEncoder> computeArgumentEncoder, Vector<Entry>&& entries)
@@ -91,7 +91,7 @@ public:
     id<MTLArgumentEncoder> fragmentArgumentEncoder() const { return m_fragmentArgumentEncoder; }
     id<MTLArgumentEncoder> computeArgumentEncoder() const { return m_computeArgumentEncoder; }
 
-    std::optional<StageMapValue> indexForBinding(uint32_t bindingIndex, ShaderStage renderStage) const;
+    std::optional<StageMapValue> bindingAccessForBindingIndex(uint32_t bindingIndex, ShaderStage renderStage) const;
 
     static bool isPresent(const WGPUBufferBindingLayout&);
     static bool isPresent(const WGPUSamplerBindingLayout&);

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -500,7 +500,7 @@ void Device::addPipelineLayouts(Vector<Vector<WGPUBindGroupLayoutEntry>>& pipeli
                 };
                 entries.append(bufferEntry);
 
-                bufferEntry.binding = newEntry.binding + 1;
+                bufferEntry.binding = newEntry.binding + 2;
                 bufferEntry.buffer = WGPUBufferBindingLayout {
                     .nextInChain = nullptr,
                     .type = static_cast<WGPUBufferBindingType>(WGPUBufferBindingType_Float4x3),


### PR DESCRIPTION
#### 9cb0f24c1250164563771ba123730f0be8d1e42d
<pre>
[WebGPU] <a href="https://webgpu.github.io/webgpu-samples/samples/samplerParameters">https://webgpu.github.io/webgpu-samples/samples/samplerParameters</a> does not work as expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=260233">https://bugs.webkit.org/show_bug.cgi?id=260233</a>
&lt;radar://113939360&gt;

Reviewed by Tadeu Zagallo.

Get another github sample working.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
entry.binding should always be the index.

* Source/WebGPU/WebGPU/BindGroupLayout.h:
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::addDescriptor):
arguments.count is not the correct value, pass it instead.

(WebGPU::Device::createBindGroupLayout):
The array of MTLArgumentDescriptor instances must be sorted by index
otherwise the validation layer fails and it doesn&apos;t appear to work
either.

(WebGPU::BindGroupLayout::bindingAccessForBindingIndex const):
(WebGPU::BindGroupLayout::indexForBinding const): Deleted.
No longer returns a pair, just a single optional.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::addPipelineLayouts):
Fix off by one error.

Canonical link: <a href="https://commits.webkit.org/268200@main">https://commits.webkit.org/268200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30f8e724e6e90cab9b5b7c45f13f8c6a66a9effc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17711 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19495 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21697 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16489 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23673 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21608 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18015 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17096 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4518 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21456 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->