### PR TITLE
Cloned video MediaStreamTrack has another resolution than original track

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1820,6 +1820,8 @@ fast/mediastream/video-rotation.html [ Skip ]
 webrtc/video-rotation-no-cvo.html [ Failure Timeout ]
 webrtc/video-rotation-black.html [ Crash Failure Pass Timeout ]
 
+webkit.org/b/261329 webrtc/video-clone-track.html [ Failure ]
+
 webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]
 
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]

--- a/LayoutTests/webrtc/video-clone-track-expected.txt
+++ b/LayoutTests/webrtc/video-clone-track-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Ensure cloned track gets the expected width and height
+

--- a/LayoutTests/webrtc/video-clone-track.html
+++ b/LayoutTests/webrtc/video-clone-track.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay=""></video>
+        <script src ="routines.js"></script>
+        <script>
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video: {width:640, height:360 }});
+    const localStream2 = localStream.clone();
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            const sender = firstConnection.addTrack(localStream2.getVideoTracks()[0], localStream2);
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+    await video.play();
+
+    assert_equals(video.videoWidth, 640);
+    assert_equals(video.videoHeight, 360);
+}, "Ensure cloned track gets the expected width and height");
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
#### a55b02b30969b388345ad2879313b4877d978120
<pre>
Cloned video MediaStreamTrack has another resolution than original track
<a href="https://bugs.webkit.org/show_bug.cgi?id=261329">https://bugs.webkit.org/show_bug.cgi?id=261329</a>
rdar://115551680

Reviewed by Jean-Yves Avenard.

When cloning a track, we are adding a new SourceProxy as obserer of the underlying source.
This works fine for video tracks in case the SourceProxy is not resizing/reducing frame rate of the source via addVideoFrameObserver size/frame rate parameters.
This resizing may happen for instance if the application wants a resolution that is not directly supported by the camera.

Before the patch, the clone would register itself via addVideoFrameObserver without parameters, which would trigger no resizing/reducing frame rate.
After the patch, we first copy the settings from the original source to the cloned source.
We then call addVideoFrameObserver with the right parameters.

Covered by added test.

* LayoutTests/webrtc/video-clone-track-expected.txt: Added.
* LayoutTests/webrtc/video-clone-track.html: Added.
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::SourceProxy):
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::~SourceProxy):
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::observeMedia):
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
(WebKit::UserMediaCaptureManagerProxy::clone):

Canonical link: <a href="https://commits.webkit.org/268307@main">https://commits.webkit.org/268307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ebebe3fa75409ab0c5239838bc5d50681f6af8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21026 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17912 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19607 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21902 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16641 "7 flakes 5 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23804 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21756 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15413 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4615 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->