### PR TITLE
Give ability for IPC calls to work with NativePromise

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
@@ -35,6 +35,11 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithCVPixelBuffer {
 
@@ -81,6 +86,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RetainPtr<CVPixelBufferRef>>;
+    using Promise = WTF::NativePromise<RetainPtr<CVPixelBufferRef>, IPC::Error, true>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessages.h
@@ -32,6 +32,11 @@
 #include <wtf/text/WTFString.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithEnabledIf {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
@@ -32,6 +32,11 @@
 #include <wtf/text/WTFString.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithIfMessage {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
@@ -33,6 +33,11 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithImageData {
 
@@ -76,6 +81,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithImageData_ReceiveImageDataReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RefPtr<WebCore::ImageData>>;
+    using Promise = WTF::NativePromise<RefPtr<WebCore::ImageData>, IPC::Error, true>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -54,6 +54,11 @@ class WebPreferencesStore;
 class WebTouchEvent;
 }
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithLegacyReceiver {
 
@@ -307,6 +312,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_CreatePluginReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
+    using Promise = WTF::NativePromise<bool, IPC::Error, true>;
     CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
         : m_arguments(pluginInstanceID, parameters)
     {
@@ -333,6 +339,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+    using Promise = WTF::NativePromise<void, IPC::Error, true>;
     RunJavaScriptAlert(uint64_t frameID, const String& message)
         : m_arguments(frameID, message)
     {
@@ -359,6 +366,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_GetPluginsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::PluginInfo>>;
+    using Promise = WTF::NativePromise<Vector<WebCore::PluginInfo>, IPC::Error, true>;
     explicit GetPlugins(bool refresh)
         : m_arguments(refresh)
     {
@@ -525,6 +533,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEventReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::KeypressCommand>>;
+    using Promise = WTF::NativePromise<Vector<WebCore::KeypressCommand>, IPC::Error, true>;
     explicit InterpretKeyEvent(uint32_t type)
         : m_arguments(type)
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
@@ -32,6 +32,11 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithSemaphore {
 
@@ -75,6 +80,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Semaphore>;
+    using Promise = WTF::NativePromise<IPC::Semaphore, IPC::Error, true>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
@@ -32,6 +32,11 @@
 #include <wtf/text/WTFString.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithStreamBatched {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
@@ -34,6 +34,11 @@ namespace IPC {
 class StreamConnectionBuffer;
 }
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithStreamBuffer {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -33,6 +33,11 @@
 #include <wtf/text/WTFString.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithStream {
 
@@ -81,6 +86,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_SendStringAsyncReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<int64_t>;
+    using Promise = WTF::NativePromise<int64_t, IPC::Error, true>;
     explicit SendStringAsync(const String& url)
         : m_arguments(url)
     {
@@ -138,6 +144,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_CallWithIdentifierReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+    using Promise = WTF::NativePromise<void, IPC::Error, true>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
@@ -32,6 +32,11 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithStreamServerConnectionHandle {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
@@ -37,6 +37,11 @@ namespace WebKit {
 enum class TestTwoStateEnum : bool;
 }
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithSuperclass {
 
@@ -81,6 +86,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::MainThread;
     using ReplyArguments = std::tuple<uint64_t>;
+    using Promise = WTF::NativePromise<uint64_t, IPC::Error, true>;
     explicit TestAsyncMessage(WebKit::TestTwoStateEnum twoStateEnum)
         : m_arguments(twoStateEnum)
     {
@@ -109,6 +115,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+    using Promise = WTF::NativePromise<void, IPC::Error, true>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);
@@ -132,6 +139,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool, uint64_t>;
+    using Promise = WTF::NativePromise<std::tuple<bool, uint64_t>, IPC::Error, true>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);
@@ -155,6 +163,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
+    using Promise = WTF::NativePromise<bool, IPC::Error, true>;
     explicit TestAsyncMessageWithConnection(const int& value)
         : m_arguments(value)
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -54,6 +54,11 @@ class WebPreferencesStore;
 class WebTouchEvent;
 }
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithoutAttributes {
 
@@ -307,6 +312,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_CreatePluginReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
+    using Promise = WTF::NativePromise<bool, IPC::Error, true>;
     CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
         : m_arguments(pluginInstanceID, parameters)
     {
@@ -333,6 +339,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlertReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+    using Promise = WTF::NativePromise<void, IPC::Error, true>;
     RunJavaScriptAlert(uint64_t frameID, const String& message)
         : m_arguments(frameID, message)
     {
@@ -359,6 +366,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_GetPluginsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::PluginInfo>>;
+    using Promise = WTF::NativePromise<Vector<WebCore::PluginInfo>, IPC::Error, true>;
     explicit GetPlugins(bool refresh)
         : m_arguments(refresh)
     {
@@ -525,6 +533,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_InterpretKeyEventReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::KeypressCommand>>;
+    using Promise = WTF::NativePromise<Vector<WebCore::KeypressCommand>, IPC::Error, true>;
     explicit InterpretKeyEvent(uint32_t type)
         : m_arguments(type)
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h
@@ -32,6 +32,11 @@
 #include <wtf/text/WTFString.h>
 
 
+namespace WTF {
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
+class NativePromise;
+} // namespace WTF
+
 namespace Messages {
 namespace TestWithoutUsingIPCConnection {
 
@@ -70,6 +75,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+    using Promise = WTF::NativePromise<void, IPC::Error, true>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);
@@ -91,6 +97,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<String>;
+    using Promise = WTF::NativePromise<String, IPC::Error, true>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);
@@ -135,6 +142,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+    using Promise = WTF::NativePromise<void, IPC::Error, true>;
     explicit MessageWithArgumentAndEmptyReply(const String& argument)
         : m_arguments(argument)
     {
@@ -161,6 +169,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<String>;
+    using Promise = WTF::NativePromise<String, IPC::Error, true>;
     explicit MessageWithArgumentAndReplyWithArgument(const String& argument)
         : m_arguments(argument)
     {

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -64,6 +64,7 @@ struct MockTestMessageWithAsyncReply1 {
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
     std::tuple<> arguments() { return { }; }
     using ReplyArguments = std::tuple<uint64_t>;
+    using Promise = WTF::NativePromise<uint64_t, IPC::Error, true>;
 };
 
 class MockConnectionClient final : public IPC::Connection::Client {

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
@@ -89,6 +89,56 @@ TEST_P(MessageSenderTest, SendAsyncAfterInvalidateCancelsAllAsyncReplies)
     }
 }
 
+// Tests that async reply messages sent to a connection after invalidate()
+// will receive the error.
+TEST_P(MessageSenderTest, SendWithPromisedReply)
+{
+    ASSERT_TRUE(openBoth());
+    b()->invalidate();
+
+    bool done = false;
+
+    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), __func__, [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+        EXPECT_FALSE(result.has_value());
+        EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
+        done = true;
+    });
+
+    while (!done)
+        RunLoop::current().cycle();
+}
+
+// Tests that async reply messages sent to a connection after invalidate()
+// will receive the error asynchronously.
+TEST_P(MessageSenderTest, SendAsyncWithErrorAsynchronousCallback)
+{
+    ASSERT_TRUE(openBoth());
+    b()->invalidate();
+
+
+    bool done = false;
+    b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&] (uint64_t value) {
+        // Value is default constructed here, and no error is actually returned.
+        done = true;
+    }, 100);
+    EXPECT_FALSE(done);
+
+    while (!done)
+        RunLoop::current().cycle();
+
+    done = false;
+    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), __func__, [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+        EXPECT_FALSE(result.has_value());
+        EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
+        done = true;
+    });
+    EXPECT_FALSE(done);
+
+    while (!done)
+        RunLoop::current().cycle();
+
+}
+
 INSTANTIATE_TEST_SUITE_P(MessageSenderTest,
     MessageSenderTest,
     testing::Values(ConnectionTestDirection::ServerIsA, ConnectionTestDirection::ClientIsA),


### PR DESCRIPTION
#### f997a9edb80cd79caeb1d0a1b87610ffd7a56e88
<pre>
Give ability for IPC calls to work with NativePromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=261720">https://bugs.webkit.org/show_bug.cgi?id=261720</a>
rdar://115704438

Reviewed by Kimmo Kinnunen.

Add the ability to send an asynchronous IPC message where the response
will be returned in the form of a NativePromise.
The NativePromise will be rejected with the IPC error if an error occurs.
Otherwise, the value returned is the value of the IPC response. Unlike the
CompletionHandler version sendWithAsyncReply, the returned value is only
wrapped in a std::tuple if more than 1 element is returned.

The Promise is defined for each asynchronous message generated like so:
```
class WaitForTarget {
public:
    using Arguments = std::tuple&lt;WebCore::SeekTarget&gt;;

    static IPC::MessageName name() { return IPC::MessageName::MediaSourcePrivateRemote_WaitForTarget; }
    static constexpr bool isSync = false;
    static constexpr bool canDispatchOutOfOrder = false;
    static constexpr bool replyCanDispatchOutOfOrder = false;

    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::MediaSourcePrivateRemote_WaitForTargetReply; }
    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
    using ReplyArguments = std::tuple&lt;MediaTime&gt;;
    using Promise = WTF::NativePromise&lt;MediaTime, IPC::Error, true&gt;;
    explicit WaitForTarget(const WebCore::SeekTarget&amp; target)
        : m_arguments(target)
    {
    }

    auto&amp;&amp; arguments()
    {
        return WTFMove(m_arguments);
    }

private:
    std::tuple&lt;const WebCore::SeekTarget&amp;&gt; m_arguments;
};
```

We need to introduce the concept of NativePromise::runSynchronouslyOnTarget
in order to ensure that processing of asynchronous results is kept in order
when mixing with the sendWithAsyncReply/CompletionHandler API.
Consider the following:
```
    m_connectionToWebProcess-&gt;connection().sendWithPromisedReply(Messages::Message1, m_identifier)
    -&gt;whenSettled(RunLoop::main(), __func__, WTFMove(completionHandler1));
    m_connectionToWebProcess-&gt;connection().sendWithAsyncReply(Messages::Message1, WTFMove(completionHandler2), m_identifier);
```

In this example, it is expected that completionHandler1 is run before
completionHandler2 (in the same order the IPC results were received)
By default a NativePromise will always dispatch a task to run the resolve/reject
callback, and so in the example above completionHandler1 would be run after
completionHandler2 as sendWithAsyncReply immediately calls the completionHandler.

By setting the NativePromise::Producer in RunSynchronouslyOnTarget mode,
it will immediately run the callback if already on the target thread.
Preserving the order of operations.
For the time being, RunSynchronouslyOnTarget is a response only to the
problem described above.
In the future we could imagine that it is up to the NativePromise consumer
to decide how the callbacks is to be run. But this is another problem for
another day.

API tests added for both IPC and NativePromise.

* Source/WTF/wtf/NativePromise.h:
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithPromisedReply):
(IPC::Connection::makeAsyncReplyHandler):
* Source/WebKit/Scripts/webkit/messages.py:
(message_to_struct_declaration):
(forward_declarations_and_headers):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
* Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268240@main">https://commits.webkit.org/268240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/577ca3e1d9d562819462f632f78ba5e6748c7488

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19116 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19597 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21863 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19289 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17412 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16589 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17668 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21739 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18441 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18153 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22499 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17255 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5456 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4551 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21609 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23749 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17983 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5320 "Passed tests") | 
<!--EWS-Status-Bubble-End-->