### PR TITLE
Fix serialization of “autocomplete” with “webauthn” token

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt
@@ -65,7 +65,7 @@ PASS Test maximum number of tokens
 PASS Unknown field
 PASS Test 'wearing the autofill anchor mantle' with off/on
 PASS Serialize combinations of section, mode, contact, and field
-FAIL Serialize combinations of section, mode, contact, field, and credential assert_equals: expected "section-login shipping work tel webauthn" but got ""
+PASS Serialize combinations of section, mode, contact, field, and credential
 
 
 

--- a/Source/WebCore/html/Autofill.cpp
+++ b/Source/WebCore/html/Autofill.cpp
@@ -247,9 +247,12 @@ AutofillData AutofillData::createFromHTMLFormControlElement(const HTMLFormContro
             return defaultLabel();
 
         category = mapEntry->category;
+        // 5. If category is not Normal and category is not Contact, then jump to the step labeled default.
         if (category != AutofillCategory::Normal && category != AutofillCategory::Contact)
             return defaultLabel();
-        if (tokens.size() > maxTokensForAutofillFieldCategory(category))
+        // 6. If index is greater than maximum tokens minus one (i.e. if the number of remaining tokens is
+        // greater than maximum tokens), then jump to the step labeled default
+        if (index > maxTokensForAutofillFieldCategory(category) - 1)
             return defaultLabel();
         idlValue = makeString(tokens[index], " ", idlValue);
     }


### PR DESCRIPTION
#### 4dfeafc934022d7c54e3777057f7046ba3430b00
<pre>
Fix serialization of “autocomplete” with “webauthn” token
<a href="https://bugs.webkit.org/show_bug.cgi?id=261808">https://bugs.webkit.org/show_bug.cgi?id=261808</a>

Reviewed by Pascoe.

This change makes WebKit fully conform to the spec requirements at
<a href="https://html.spec.whatwg.org/#autofill-processing-model">https://html.spec.whatwg.org/#autofill-processing-model</a>:attr-fe-autocomplete-webauthn
for serializing the value of the “autocomplete” attribute when it
contains a “webauthn” token.

Specifically, this change fixes handling for a condition in a substep of
that spec algorithm that checks against the maximum tokens allowed.
The code was comparing the number of tokens to the maximum number of
allowed tokens but instead needs to compare the value of a (decremented)
index counter to the maximum number of allowed tokens minus 1.

This change gets WebKit passing all cases in the WPT test at
<a href="https://wpt.fyi/results/html/semantics/forms/the-form-element/form-autocomplete.html">https://wpt.fyi/results/html/semantics/forms/the-form-element/form-autocomplete.html</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-form-element/form-autocomplete-expected.txt:
* Source/WebCore/html/Autofill.cpp:
(WebCore::AutofillData::createFromHTMLFormControlElement):

Canonical link: <a href="https://commits.webkit.org/268520@main">https://commits.webkit.org/268520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f12e298ddd8f99ab5638735ef7d519fd7ce3354

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20011 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22490 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24239 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22232 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15875 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17892 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4772 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->