### PR TITLE
WebCodecs AudioData constructor should throw if failing to create an internal audio buffer

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -45,6 +45,9 @@ ExceptionOr<Ref<WebCodecsAudioData>> WebCodecsAudioData::create(ScriptExecutionC
     auto rawData = init.data.span();
     auto data = PlatformRawAudioData::create(WTFMove(rawData), init.format, init.sampleRate, init.timestamp, init.numberOfFrames, init.numberOfChannels);
 
+    if (!data)
+        return Exception { NotSupportedError, "AudioData creation failed"_s };
+
     return adoptRef(*new WebCodecsAudioData(context, WebCodecsAudioInternalData { WTFMove(data) }));
 }
 


### PR DESCRIPTION
#### 3c501184993c162397c0912111c7456977416300
<pre>
WebCodecs AudioData constructor should throw if failing to create an internal audio buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=261807">https://bugs.webkit.org/show_bug.cgi?id=261807</a>
rdar://115749541

Reviewed by Philippe Normand.

Make sure to throw instead of having an AudioData object without buffer.
This ensures we do not hit ASSERTs like in WebCodecsAudioEncoder::encode.

* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp:
(WebCore::WebCodecsAudioData::create):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/268195@main">https://commits.webkit.org/268195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0726a20a598d4682929e1881b0d4c909db1aa6d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19419 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19176 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19287 "layout-tests (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21704 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16497 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17265 "6 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23678 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21624 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18021 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17102 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4515 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->