### PR TITLE
Implement wheel WPT actions in WebKit's test vendor JS

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -245,9 +245,6 @@ imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reporting-to-e
 # Only Mac and iOS have an implementation of UIScriptController::doAsyncTask().
 fast/harness/uiscriptcontroller [ Skip ]
 
-# Only iOS has an implementation of UIScriptController::sendEventStream().
-imported/w3c/web-platform-tests/dom/events/scrolling [ Skip ]
-
 # Only Mac and iOS WK2 have an implementation right now.
 imported/w3c/web-platform-tests/video-rvfc [ Skip ]
 fast/mediastream/getUserMedia-rvfc.html [ Skip ]
@@ -6166,7 +6163,6 @@ imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-values/dynamic-viewport-units-rule-cache.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-variables/variable-reference-refresh.html [ Skip ]
 imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation.html [ Skip ]
-imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/api/abort/serviceworker-intercepted.https.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/corb/preload-image-png-mislabeled-as-html-nosniff.tentative.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/corb/script-html-correctly-labeled.tentative.sub.html [ Skip ]
@@ -6819,3 +6815,15 @@ webkit.org/b/245032 imported/w3c/web-platform-tests/css/compositing/root-element
 webkit.org/b/261916 media/video-pause-while-seeking.html [ Pass Failure ]
 
 webkit.org/b/262734 http/tests/security/service-worker-network-load.html [ Pass Timeout ]
+
+webkit.org/b/263434 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-basic.html [ Skip ]
+
+webkit.org/b/261810 imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel.html [ Skip ]
+
+webkit.org/b/237552 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash.html [ Pass Failure ]
+
+# webkit.org/b/263438 Three dom/events/scrolling WPTs are constantly timing out
+imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-deltas.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-document.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-when-using-arrow-keys.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "wheel".
 
 overscroll-behavior
 
@@ -9,7 +8,5 @@ Repeat the same scrolls as in step 1 and then tap on DONE.
 Repeat the same scrolls as in step 1 and then tap on DONE.
 Make two separate scrolls on GREEN, in this order: scroll UP (or drag down), then scroll LEFT (or drag right). Scroll (or drag) until nothing is scrolling. Then tap on DONE.
 
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
-
-NOTRUN overscroll-behavior prevents scroll-propagation in the area and direction as specified
+FAIL overscroll-behavior prevents scroll-propagation in the area and direction as specified assert_equals: expected 0 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL Wheel-scroll triggers snap to target position immediately. promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Wheel-scroll triggers snap to target position immediately. Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt
@@ -2,5 +2,5 @@ Header 1Footer 1
 Header 2Footer 2
 
 FAIL Keyboard scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 39 but got 449
-FAIL Mouse-wheel scrolling with vertical snap-area overflow promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+FAIL Mouse-wheel scrolling with vertical snap-area overflow assert_equals: End boundary of snap-area is valid snap target expected 100 but got 101
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt
@@ -1,13 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "wheel".
-CSSScrollSnap
 
-Tests that the window can snap at user scroll end.
-
-Scroll the page vertically and horizontally. Keep scrolling until background has turned yellow.
-Press the button "Done"
-
-
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
-
-NOTRUN Tests that window should snap at user scroll end.
+PASS Tests that window should snap at user scroll end.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d-expected.txt
@@ -1,5 +1,5 @@
 Gazing into the stars
 
 
-FAIL Element is scrollable over preserve-3d descendant promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS Element is scrollable over preserve-3d descendant
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-body-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-body-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive mousewheel event listener on body promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive mousewheel event listener on body
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive mousewheel event listener on div promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive mousewheel event listener on div
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-document-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive mousewheel event listener on document promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive mousewheel event listener on document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-root-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-root-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive mousewheel event listener on root promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive mousewheel event listener on root
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive mousewheel event listener on window promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive mousewheel event listener on window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-body-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-body-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive wheel event listener on body promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive wheel event listener on body
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive wheel event listener on div promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive wheel event listener on div
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-document-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive wheel event listener on document promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive wheel event listener on document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-root-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-root-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive wheel event listener on root promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive wheel event listener on root
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL non-passive wheel event listener on window promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS non-passive wheel event listener on window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-body-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-body-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive mousewheel event listener on body promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS passive mousewheel event listener on body
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive mousewheel event listener on div promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+FAIL passive mousewheel event listener on div assert_equals: expected false but got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-document-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive mousewheel event listener on document promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS passive mousewheel event listener on document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-root-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-root-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive mousewheel event listener on root promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS passive mousewheel event listener on root
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive mousewheel event listener on window promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS passive mousewheel event listener on window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-body-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-body-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive wheel event listener on body promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS passive wheel event listener on body
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive wheel event listener on div promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+FAIL passive wheel event listener on div assert_equals: expected false but got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-document-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive wheel event listener on document promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS passive wheel event listener on document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-root-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-root-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive wheel event listener on root promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS passive wheel event listener on root
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL passive wheel event listener on window promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS passive wheel event listener on window
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Wheel scroll in iframe chains to containing element. promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS Wheel scroll in iframe chains to containing element.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-when-using-arrow-keys-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-when-using-arrow-keys-expected.txt
@@ -1,0 +1,9 @@
+Moving the cursor using the arrow keys into an input element fires scroll events when text has to scroll into view. Uses arrow keys to move forward and backwards in the input element.
+
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT Scroll event fired for <input> element. Test timed out
+NOTRUN Scroll event fired for <textarea> element.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-deltas-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-deltas-expected.txt
@@ -1,3 +1,12 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: No scrollend event received for target [object HTMLDivElement]
 
-FAIL Tests that the document gets overscroll event with right deltaX/Y attributes. promise_test: Unhandled rejection with value: "Document did not receive scrollend event."
+Harness Error (FAIL), message = Unhandled rejection
+
+FAIL testing, vertical promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
+TIMEOUT testing, horizontal Test timed out
+
+Harness Error (FAIL), message = Unhandled rejection
+
+FAIL testing, vertical promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
+TIMEOUT testing, horizontal Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-sequence-of-scrolls.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-sequence-of-scrolls.tentative-expected.txt
@@ -1,3 +1,4 @@
 
-FAIL Move down, up and down again, receive scrollend event only once promise_test: Unhandled rejection with value: "target_div did not receive scrollend event after sequence of scrolls on target."
+PASS Move down, up and down again, receive scrollend event only once
+PASS Move right, left and right again, receive scrollend event only once
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-document-expected.txt
@@ -1,3 +1,12 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: No scrollend event received for target [object HTMLDivElement]
 
-FAIL Tests that the document gets scrollend event when no element scrolls by touch. promise_test: Unhandled rejection with value: "Document did not receive scrollend event after scroll left on target."
+Harness Error (FAIL), message = Unhandled rejection
+
+FAIL testing, vertical promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
+TIMEOUT testing, horizontal Test timed out
+
+Harness Error (FAIL), message = Unhandled rejection
+
+FAIL testing, vertical promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
+TIMEOUT testing, horizontal Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-element-with-overscroll-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-element-with-overscroll-behavior-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Tests that the last element in the cut scroll chain gets scrollend event when no element scrolls by touch. promise_test: Unhandled rejection with value: "Expected element did not receive scrollend event after scroll left on target."
+FAIL Tests that the scroll is not propagated beyond div with non-auto overscroll-behavior. promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Tests that the window gets scrollend event when no element scrolls after touch scrolling. promise_test: Unhandled rejection with value: "Window did not receive scrollend event after scroll up on target."
+FAIL testing, vertical promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll-expected.txt
@@ -1,8 +1,7 @@
 
-Harness Error (TIMEOUT), message = null
-
-FAIL Tests that the target_div gets scrollend event when dragging scroll on target. promise_test: Unhandled rejection with value: "target_div did not receive scrollend event after dragging scroll on target."
-FAIL Tests that the target_div gets scrollend event when click scrollbar on target. promise_test: Unhandled rejection with value: "target_div did not receive scrollend event after clicking scrollbar on target."
-TIMEOUT Tests that the target_div gets scrollend event when drag the thumb of target. Test timed out
-NOTRUN Tests that the target_div gets scrollend event when send DOWN key to target.
+PASS Tests that the target_div gets scrollend event when touch dragging.
+FAIL Tests that the target_div gets scrollend event when clicking scrollbar. promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
+FAIL Tests that the target_div gets scrollend event when dragging the scrollbar thumb. promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
+FAIL Tests that the target_div gets scrollend event when mouse wheel scrolling. promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
+FAIL Tests that the target_div gets scrollend event when sending DOWN key to the target. promise_test: Unhandled rejection with value: "No scrollend event received for target [object HTMLDivElement]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll-expected.txt
@@ -1,8 +1,11 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: No scrollend event received for target [object HTMLDocument]
 target
 doc
 
-FAIL No scroll via wheel on div shouldn't fire scrollend. promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
-PASS No scroll via keys on div shouldn't fire scrollend.
-FAIL No scroll via wheel on document shouldn't fire scrollend. promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
-PASS No scroll via keys on document shouldn't fire scrollend.
+Harness Error (FAIL), message = Unhandled rejection
+
+PASS No scroll via wheel on div shouldn't fire scrollend.
+TIMEOUT No scroll via keys on div shouldn't fire scrollend. Test timed out
+NOTRUN No scroll via wheel on document shouldn't fire scrollend.
+NOTRUN No scroll via keys on document shouldn't fire scrollend.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -17,7 +17,7 @@ PASS Clicking on anchor element (that isn't an invoking element) shouldn't preve
 FAIL Dragging from an open popover outside an open popover should leave the popover open assert_true: expected true got false
 PASS A popover inside an invoking element doesn't participate in that invoker's ancestor chain
 PASS An invoking element that was not used to invoke the popover is not part of the ancestor chain
-FAIL Scrolling within a popover should not close the popover promise_test: Unhandled rejection with value: object "Error: Unknown source type "wheel"."
+PASS Scrolling within a popover should not close the popover
 PASS Clicking inside a shadow DOM popover does not close that popover
 PASS Clicking outside a shadow DOM popover should close that popover
 PASS Moving focus back to the anchor element should not dismiss the popover

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "wheel".
 
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
-
-TIMEOUT Wheel-scroll over pointer-events: none scroller skips that scroller Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
-
-TIMEOUT Wheel-scroll over pointer-events: none scroller skips that scroller Test timed out
+PASS Wheel-scroll over pointer-events: none scroller skips that scroller
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "wheel".
 
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
-
-TIMEOUT Wheel-scroll over pointer-events: auto descendant scrolls pointer-events: none scroller. Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
-
-TIMEOUT Wheel-scroll over pointer-events: auto descendant scrolls pointer-events: none scroller. Test timed out
+FAIL Wheel-scroll over pointer-events: auto descendant scrolls pointer-events: none scroller. assert_equals: Incorrect element scrolled expected "overlay" but got "root"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse-expected.txt
@@ -1,7 +1,6 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "wheel".
 Pointer Events touch-action attribute support
 
-Test Description: Try to scroll text down using mouse (use mouse wheel or click on the scrollbar). Wait for description update.
+Test Description: Test complete
 
 Note: this test is for mouse only
 
@@ -74,7 +73,5 @@ touch-action: none
 The following pointer types were detected: (none).
 
 
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
-
-NOTRUN touch-action attribute test
+PASS touch-action attribute test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-basic-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "wheel".
 Description: Verifies that wheel events are captured and sent
 
 Instructions:
@@ -10,7 +9,7 @@ Scroll the mouse wheel again to change this box's color
 Test Passes if the box turns green and the word 'PASS' appears below
 
 
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
+Harness Error (TIMEOUT), message = null
 
 NOTRUN wheel event test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: Unknown source type "wheel".
 Description: Verifies that we can scroll the page when wheel events are captured
 
 Instructions:
@@ -26,7 +25,5 @@ Nullam in tempor tellus, ac ullamcorper tortor. Cras vel aliquet magna, in congu
 Ut porttitor metus et mauris euismod iaculis. Ut in lorem neque. Nam a sollicitudin ligula, non lobortis sapien. Curabitur ullamcorper justo quis vulputate cursus. Aliquam rhoncus volutpat quam non condimentum. Donec dictum aliquam metus tempor vehicula. Curabitur lorem urna, venenatis vel tellus et, mollis ornare sapien. Aliquam erat elit, tristique at suscipit efficitur, condimentum eget quam. Quisque vel metus nisl. Integer eget cursus neque, sed auctor purus. Sed ac urna nec lectus elementum laoreet. Donec posuere diam ut nibh vestibulum efficitur. Nam ut rhoncus enim, semper sollicitudin libero.
 
 
-Harness Error (FAIL), message = Unhandled rejection: Unknown source type "wheel".
-
-NOTRUN wheel scrolling test
+PASS wheel scrolling test
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3361,7 +3361,6 @@ webkit.org/b/258157 fast/hidpi/filters-drop-shadow.html [ Crash ImageOnlyFailure
 webkit.org/b/252878 http/tests/media/modern-media-controls/skip-back-support/skip-back-support-live-broadcast.html [ Timeout ]
 webkit.org/b/252878 http/tests/workers/service/shownotification-allowed.html [ Pass Timeout ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/fetch/http-cache/split-cache.html [ Failure ]
-webkit.org/b/252878 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash.html [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/service-workers/service-worker/navigation-timing.https.html [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/wasm/webapi/instantiateStreaming.any.serviceworker.html [ Failure Pass ]
@@ -3539,6 +3538,34 @@ imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/restri
 
 # Flakily crashing on GTK and WPE bots
 webkit.org/b/262949 media/media-garbage-collection.html [ Pass Crash ]
+
+# webkit.org/b/263473 [ GLib ] Implement wheel WPT actions in WebKit's test vendor JS without UIScriptController.sendEventStream
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive [ Skip ]
+imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
+imported/w3c/web-platform-tests/css/cssom-view/dom-element-scroll.html [ Skip ]
+imported/w3c/web-platform-tests/css/cssom-view/elementScroll.html [ Skip ]
+imported/w3c/web-platform-tests/css/cssom-view/scroll-no-layout-box.html [ Skip ]
+imported/w3c/web-platform-tests/css/cssom-view/scrolling-no-browsing-context.html [ Skip ]
+imported/w3c/web-platform-tests/css/cssom-view/scrolling-quirks-vs-nonquirks.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-event-fired-to-document.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-event-fired-to-element-with-overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-event-fired-to-window.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-sequence-of-scrolls.tentative.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-snap.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-window.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/abspos-dialog-layout.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/multiple-centered-dialogs.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]
+imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling.html [ Skip ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -53,6 +53,10 @@ fast/events/keyboardevent-modifier.html [ Pass ]
 # PointerEvents not enabled globally, but enabled for GTK (EXPERIMENTAL_FEATURES)
 pointerevents/mouse [ Pass ]
 imported/w3c/web-platform-tests/pointerevents [ Pass ]
+# These tests crash because UIScriptController.sendEventStream is not implemented on GTK
+webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll.html [ Skip ]
+webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant.html [ Skip ]
+webkit.org/b/263473 imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]
 # PointerEvents currently only supports mouse on GTK (no Touch/Pen support)
 webkit.org/b/204115 imported/w3c/web-platform-tests/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html [ Skip ]
 webkit.org/b/204115 imported/w3c/web-platform-tests/pointerevents/pointerevent_pointercancel_touch.html [ Skip ]
@@ -2412,9 +2416,6 @@ webkit.org/b/252953 imported/w3c/web-platform-tests/html/rendering/replaced-elem
 webkit.org/b/257752 imported/w3c/web-platform-tests/html/rendering/the-details-element/summary-text-decoration.html [ ImageOnlyFailure ]
 # Ftp code is disabled in gtk port
 http/tests/misc/ftp-eplf-directory.py [ Skip ]
-
-# These tests hit an assertion in JSUIScriptController::sendEventStream() since their import.
-imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive [ Skip ]
 
 webkit.org/b/238885 imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?1001-2000 [ Failure Timeout ]
 webkit.org/b/238885 imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?2001-3000 [ Failure Timeout ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3665,8 +3665,6 @@ webkit.org/b/240037 css3/background/background-repeat-space-content.html [ Pass 
 
 webkit.org/b/240069 fast/css/continuationCrash.html [ Pass Failure ]
 
-webkit.org/b/237552 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash.html [ Pass Failure ]
-
 webkit.org/b/240123 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Pass Failure ]
 
 webkit.org/b/239568 imported/w3c/web-platform-tests/content-security-policy/inheritance/blob-url-in-main-window-self-navigate-inherits.sub.html [ Pass Failure DumpJSConsoleLogInStdErr ]
@@ -4544,7 +4542,6 @@ imported/w3c/web-platform-tests/fetch/range/non-matching-range-response.html [ F
 imported/w3c/web-platform-tests/html/semantics/disabled-elements/disabled-event-dispatch.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/popovers/light-dismiss-event-ordering.html [ Failure ]
 imported/w3c/web-platform-tests/html/semantics/popovers/popover-anchor-nesting.html [ Failure ]
-imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-request-redirect.https.html [ Failure ]
 imported/w3c/web-platform-tests/xhr/open-method-case-sensitive.htm [ Failure ]
 media/media-can-play-h265-video.html [ Failure ]
@@ -4644,12 +4641,42 @@ imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.a
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.html [ Crash ]
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_X25519.https.any.worker.html  [ Crash ]
 
- webkit.org/b/263136 imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-011.html [ ImageOnlyFailure ]
+webkit.org/b/263136 imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-011.html [ ImageOnlyFailure ]
 
- webkit.org/b/263466 fast/mediastream/getDisplayMedia-max-constraints4.html [ Failure ]
+webkit.org/b/263466 fast/mediastream/getDisplayMedia-max-constraints4.html [ Failure ]
 
- webkit.org/b/263471 fast/forms/ios/keydown-in-hidden-contenteditable-with-inputmode-none.html [ Pass Failure ]
+webkit.org/b/263471 fast/forms/ios/keydown-in-hidden-contenteditable-with-inputmode-none.html [ Pass Failure ]
 
 webkit.org/b/263479 platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html [ Pass Failure ]
 
 webkit.org/b/263396 css3/color/text.html [ Skip ]
+
+# webkit.org/b/263439 [ iOS ] Several WPTs using wheel actions are timing out after b243272
+imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-body.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-document.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-root.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-window.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-body.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-document.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-root.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-window.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-body.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-document.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-root.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-window.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-body.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-document.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-root.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-window.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2355,8 +2355,6 @@ webkit.org/b/229659 imported/w3c/web-platform-tests/css/css-contain/container-qu
 
 webkit.org/b/237783 imported/w3c/web-platform-tests/html/semantics/forms/input-change-event-properties.html [ Timeout ]
 
-webkit.org/b/237552 imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/same-hash.html [ Pass Failure ]
-
 # Flaky since their import.
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/window-open-self-during-load.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/window-open-self-during-pageshow.html [ Failure Pass ]

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-body-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-body-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL passive mousewheel event listener on body assert_equals: expected false but got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-document-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-document-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL passive mousewheel event listener on document assert_equals: expected false but got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-root-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-root-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL passive mousewheel event listener on root assert_equals: expected false but got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-window-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL passive mousewheel event listener on window assert_equals: expected false but got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-body-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-body-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL passive wheel event listener on body assert_equals: expected false but got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-document-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-document-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL passive wheel event listener on document assert_equals: expected false but got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-root-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-root-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL passive wheel event listener on root assert_equals: expected false but got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-window-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL passive wheel event listener on window assert_equals: expected false but got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Wheel-scroll over pointer-events: auto descendant scrolls pointer-events: none scroller.
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1479,8 +1479,6 @@ imported/w3c/web-platform-tests/pointerevents/pointerevent_contextmenu_is_a_poin
 imported/w3c/web-platform-tests/pointerevents/pointerevent_disabled_form_control.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_disabled_form_control.html?touch [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_fractional_coordinates.html?touch [ Skip ]
-imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll.html [ Skip ]
-imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_iframe-touch-action-none_touch.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_mouse_pointercapture_inactivate_pointer.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/pointerevent_movementxy.html?touch [ Skip ]
@@ -2879,3 +2877,17 @@ imported/w3c/web-platform-tests/media-source/mediasource-play.html [ Pass Failur
 imported/w3c/web-platform-tests/media-source/mediasource-redundant-seek.html [ Pass Failure ]
 imported/w3c/web-platform-tests/media-source/mediasource-remove-preserves-currentTime.html [ Pass Failure ]
 imported/w3c/web-platform-tests/media-source/mediasource-remove.html [ Pass Failure ]
+
+# webkit.org/b/263441 [ mac-wk1 ] Several WPTs using wheel actions are timing out after b243272
+# webkit.org/b/263476 [ mac-wk2 ] Some WPTs exercising wheel actions interface timing out on pre-Sonoma MacOS after b243272
+imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains.html [ Skip ]
+imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html [ Skip ]
+imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse.html [ Skip ]


### PR DESCRIPTION
#### f02a46525ce0af9eff66a93c118f486332d7fcf1
<pre>
Implement wheel WPT actions in WebKit&apos;s test vendor JS
<a href="https://bugs.webkit.org/show_bug.cgi?id=243272">https://bugs.webkit.org/show_bug.cgi?id=243272</a>
rdar://97691874

Reviewed by Tim Nguyen.

This commit implements wheel WPT actions (namely scroll/pause) in our
testdriver-vendor.js instance, allowing WKTR infra to run WPTs that
generate wheel actions.

This implementation has generally been guided by the directions provided
in <a href="https://w3c.github.io/webdriver/#wheel-actions">https://w3c.github.io/webdriver/#wheel-actions</a>, but is not a faithful
reproduction of every step, particularly in performing the scroll action
with tick durations. This effort is tracked in webkit.org/b/261810, and
is acceptable to hold off on for now because only a small set of tests
rely on the &quot;does not send events instantly&quot; behavior.

We also update WPT expectations as appropriate now that wheel actions
are supported.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overscroll-behavior/overscroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/mouse-wheel-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/input/snap-area-overflow-boundary-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-at-user-scroll-end-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/scroll-preserve-3d-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-body-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-div-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-root-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-mousewheel-event-listener-on-window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-body-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-div-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-root-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/non-passive-wheel-event-listener-on-window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-body-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-root-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-body-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-root-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/iframe-chains-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/input-text-scroll-event-when-using-arrow-keys-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/overscroll-deltas-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-sequence-of-scrolls.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-element-with-overscroll-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-to-window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-for-user-scroll-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-not-fired-on-no-scroll-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_touch-action-mouse-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js:
(async renderingUpdate):
(async waitForScrollCompletion.await.new.Promise.):
(async waitForScrollCompletion.await.new.Promise):
(async waitForScrollCompletion):
(async ensurePresentationUpdate.return.new.Promise):
(async ensurePresentationUpdate):
(async dispatchWheelActions.switch.await.new.Promise):
(async dispatchWheelActions):
(async let):
(window.test_driver_internal.action_sequence):
* LayoutTests/imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/wheel-scrolling-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-body-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-document-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-root-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-window-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-body-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-document-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-root-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-window-expected.txt: Added.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/pointerevents/pointerevent_hit_test_scroll_visible_descendant-expected.txt: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269632@main">https://commits.webkit.org/269632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65a03d4edf331ef6caa49a9d8c77b89997e9f404

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21345 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22202 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25845 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27069 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24936 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/512 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5514 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/992 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->