### PR TITLE
[ Ventura+ wk1 ] editing/spelling/retro-correction-spelling-markers.html is a constant failure.

### DIFF
--- a/LayoutTests/editing/spelling/retro-correction-spelling-markers.html
+++ b/LayoutTests/editing/spelling/retro-correction-spelling-markers.html
@@ -1,17 +1,25 @@
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <script src="../editing.js"></script>
 
 <script>
-function runTest() {
-    jsTestIsAsync = true;
-
+jsTestIsAsync = true;
+async function runTest() {
     if (window.internals) {
         internals.settings.setUnifiedTextCheckerEnabled(true);
         internals.settings.setAsynchronousSpellCheckingEnabled(true);
         internals.setAutomaticTextReplacementEnabled(false);
         internals.setAutomaticSpellingCorrectionEnabled(false);
+
+        await UIHelper.setSpellCheckerResults({
+            "It's muhc to late too finish this.": [
+                { "type": "spelling", "from": 5, "to": 9 },
+                { "type": "spelling", "from": 10, "to": 12, },
+                { "type": "spelling", "from": 18, "to": 21, },
+            ]
+        });
     }
 
     document.getElementById("editor").focus();

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1873,7 +1873,6 @@ imported/w3c/web-platform-tests/fetch/stale-while-revalidate [ Skip ]
 # rdar://53137847 (macOS WK1: editing/spelling/retro-correction-spelling-markers.html, editing/spelling/grammar.html, and editing/spelling/markers.html are flaky)
 webkit.org/b/206071 editing/spelling/grammar.html [ Skip ]
 webkit.org/b/206071 editing/spelling/markers.html [ Skip ]
-webkit.org/b/206071 editing/spelling/retro-correction-spelling-markers.html [ Pass Failure ]
 
 webkit.org/b/199117 [ Debug ] storage/indexeddb/modern/objectstore-autoincrement-types.html [ Timeout ]
 

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1867,6 +1867,9 @@ window.UIHelper = class UIHelper {
 
     static async setSpellCheckerResults(results)
     {
+        if (!this.isMac() && !this.isIOSFamily())
+            return Promise.resolve();
+
         return new Promise(resolve => {
             testRunner.runUIScript(`(() => {
                 uiController.setSpellCheckerResults(${JSON.stringify(results)});

--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -552,6 +552,16 @@ static JSValueRef goBackCallback(JSContextRef context, JSObjectRef function, JSO
     return JSValueMakeUndefined(context);
 }
 
+static JSValueRef isMacCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+#if PLATFORM(MAC)
+    bool isMac = true;
+#else
+    bool isMac = false;
+#endif
+    return JSValueMakeBoolean(context, isMac);
+}
+
 static JSValueRef isCommandEnabledCallback(JSContextRef context, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
     // Has Mac implementation.
@@ -2035,6 +2045,7 @@ const JSStaticFunction* TestRunner::staticFunctions()
         { "ignoreLegacyWebNotificationPermissionRequests", ignoreLegacyWebNotificationPermissionRequestsCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "isGeolocationProviderActive", isGeolocationProviderActiveCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "isCommandEnabled", isCommandEnabledCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { "isMac", isMacCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "keepWebHistory", keepWebHistoryCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "numberOfPendingGeolocationPermissionRequests", numberOfPendingGeolocationPermissionRequestsCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "notifyDone", notifyDoneCallback, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },


### PR DESCRIPTION
#### d4d733cacadd7dad7ebbb0ab405c4c463372531c
<pre>
[ Ventura+ wk1 ] editing/spelling/retro-correction-spelling-markers.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261495">https://bugs.webkit.org/show_bug.cgi?id=261495</a>
rdar://115411037

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Make this test more robust against underlying changes to spell checking on macOS, by ensuring
consistent text checking results via `LayoutTestSpellChecker`.

* LayoutTests/editing/spelling/retro-correction-spelling-markers.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/resources/ui-helper.js:

Ensure that this helper function doesn&apos;t trigger a crash on non-Cocoa ports by bailing gracefully in
the case where we&apos;re neither macOS nor iOS.

(window.UIHelper.async setSpellCheckerResults):
* Tools/DumpRenderTree/TestRunner.cpp:
(isMacCallback):
(TestRunner::staticFunctions):

Implement `TestRunner.isMac` so that the above check in `ui-helper.js` works as intended.

Canonical link: <a href="https://commits.webkit.org/268222@main">https://commits.webkit.org/268222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1e4b3195a4f1fa7bb5aceb9781417c27ad29e79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20899 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19500 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21782 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23739 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21685 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18091 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4540 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->