### PR TITLE
[WGSL] Add support for pointer types

### DIFF
--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -283,6 +283,7 @@ void ConstantRewriter::materialize(Node& expression, const ConstantValue& value)
             case Primitive::TextureExternal:
             case Primitive::AccessMode:
             case Primitive::TexelFormat:
+            case Primitive::AddressSpace:
                 RELEASE_ASSERT_NOT_REACHED();
             }
         },
@@ -299,6 +300,9 @@ void ConstantRewriter::materialize(Node& expression, const ConstantValue& value)
             // Do not materialize complex types
         },
         [&](const Reference&) {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Pointer&) {
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Function&) {

--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -60,6 +60,7 @@ bool satisfies(const Type* type, Constraint constraint)
     case Types::Primitive::TextureExternal:
     case Types::Primitive::AccessMode:
     case Types::Primitive::TexelFormat:
+    case Types::Primitive::AddressSpace:
         return false;
     }
 }
@@ -130,6 +131,7 @@ const Type* satisfyOrPromote(const Type* type, Constraint constraint, const Type
     case Types::Primitive::TextureExternal:
     case Types::Primitive::AccessMode:
     case Types::Primitive::TexelFormat:
+    case Types::Primitive::AddressSpace:
         return nullptr;
     }
 }
@@ -154,6 +156,12 @@ const Type* concretize(const Type* type, TypeStore& types)
         [&](const Struct&) -> const Type* {
             return type;
         },
+        [&](const Pointer&) -> const Type* {
+            return type;
+        },
+        [&](const Bottom&) -> const Type* {
+            return type;
+        },
         [&](const Function&) -> const Type* {
             RELEASE_ASSERT_NOT_REACHED();
         },
@@ -168,9 +176,6 @@ const Type* concretize(const Type* type, TypeStore& types)
         },
         [&](const TypeConstructor&) -> const Type* {
             RELEASE_ASSERT_NOT_REACHED();
-        },
-        [&](const Bottom&) -> const Type* {
-            return type;
         });
 }
 

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -623,6 +623,7 @@ static BindGroupLayoutEntry::BindingMember bindingMemberForGlobal(auto& global)
             return ExternalTextureBindingLayout { };
         case Types::Primitive::AccessMode:
         case Types::Primitive::TexelFormat:
+        case Types::Primitive::AddressSpace:
             RELEASE_ASSERT_NOT_REACHED();
         }
     }, [&](const Vector& vector) -> BindGroupLayoutEntry::BindingMember {
@@ -709,6 +710,8 @@ static BindGroupLayoutEntry::BindingMember bindingMemberForGlobal(auto& global)
         };
     }, [&](const Reference&) -> BindGroupLayoutEntry::BindingMember {
         RELEASE_ASSERT_NOT_REACHED();
+    }, [&](const Pointer&) -> BindGroupLayoutEntry::BindingMember {
+        RELEASE_ASSERT_NOT_REACHED();
     }, [&](const Function&) -> BindGroupLayoutEntry::BindingMember {
         RELEASE_ASSERT_NOT_REACHED();
     }, [&](const TypeConstructor&) -> BindGroupLayoutEntry::BindingMember {
@@ -794,6 +797,7 @@ void RewriteGlobalVariables::usesOverride(AST::Variable& variable)
     case Types::Primitive::TextureExternal:
     case Types::Primitive::AccessMode:
     case Types::Primitive::TexelFormat:
+    case Types::Primitive::AddressSpace:
         RELEASE_ASSERT_NOT_REACHED();
     }
     m_entryPointInformation->specializationConstants.add(variable.name(), Reflection::SpecializationConstant { String(), constantType });

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -78,6 +78,14 @@ struct ReferenceKey {
     TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Reference, WTF::enumToUnderlyingType(addressSpace), WTF::enumToUnderlyingType(accessMode), 0, bitwise_cast<uintptr_t>(elementType)); }
 };
 
+struct PointerKey {
+    const Type* elementType;
+    AddressSpace addressSpace;
+    AccessMode accessMode;
+
+    TypeCache::EncodedKey encode() const { return std::tuple(TypeCache::Pointer, WTF::enumToUnderlyingType(addressSpace), WTF::enumToUnderlyingType(accessMode), 0, bitwise_cast<uintptr_t>(elementType)); }
+};
+
 template<typename Key>
 const Type* TypeCache::find(const Key& key) const
 {
@@ -108,6 +116,7 @@ TypeStore::TypeStore()
     m_textureExternal = allocateType<Primitive>(Primitive::TextureExternal);
     m_accessMode = allocateType<Primitive>(Primitive::AccessMode);
     m_texelFormat = allocateType<Primitive>(Primitive::TexelFormat);
+    m_addressSpace = allocateType<Primitive>(Primitive::AddressSpace);
 }
 
 const Type* TypeStore::structType(AST::Structure& structure, HashMap<String, const Type*>&& fields)
@@ -182,6 +191,17 @@ const Type* TypeStore::referenceType(AddressSpace addressSpace, const Type* elem
     if (type)
         return type;
     type = allocateType<Reference>(addressSpace, accessMode, element);
+    m_cache.insert(key, type);
+    return type;
+}
+
+const Type* TypeStore::pointerType(AddressSpace addressSpace, const Type* element, AccessMode accessMode)
+{
+    PointerKey key { element, addressSpace, accessMode };
+    const Type* type = m_cache.find(key);
+    if (type)
+        return type;
+    type = allocateType<Pointer>(addressSpace, accessMode, element);
     m_cache.insert(key, type);
     return type;
 }

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -48,6 +48,7 @@ public:
         Texture,
         TextureStorage,
         Reference,
+        Pointer,
     };
 
     using EncodedKey = std::tuple<uint8_t, uint8_t, uint16_t, uint32_t, uintptr_t>;
@@ -80,6 +81,7 @@ public:
     const Type* textureExternalType() const { return m_textureExternal; }
     const Type* accessModeType() const { return m_accessMode; }
     const Type* texelFormatType() const { return m_texelFormat; }
+    const Type* addressSpaceType() const { return m_addressSpace; }
 
     const Type* structType(AST::Structure&, HashMap<String, const Type*>&& = { });
     const Type* arrayType(const Type*, std::optional<unsigned>);
@@ -89,6 +91,7 @@ public:
     const Type* textureStorageType(Types::TextureStorage::Kind, TexelFormat, AccessMode);
     const Type* functionType(Vector<const Type*>&&, const Type*);
     const Type* referenceType(AddressSpace, const Type*, AccessMode);
+    const Type* pointerType(AddressSpace, const Type*, AccessMode);
     const Type* typeConstructorType(ASCIILiteral, std::function<const Type*(AST::ElaboratedTypeExpression&)>&&);
 
 private:
@@ -110,6 +113,7 @@ private:
     const Type* m_textureExternal;
     const Type* m_accessMode;
     const Type* m_texelFormat;
+    const Type* m_addressSpace;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -186,6 +186,9 @@ void Type::dump(PrintStream& out) const
         [&](const Reference& reference) {
             out.print("ref<", reference.addressSpace, ", ", *reference.element, ", ", reference.accessMode, ">");
         },
+        [&](const Pointer& reference) {
+            out.print("ptr<", reference.addressSpace, ", ", *reference.element, ", ", reference.accessMode, ">");
+        },
         [&](const TypeConstructor& constructor) {
             out.print(constructor.name);
         },
@@ -303,6 +306,7 @@ unsigned Type::size() const
             case Types::Primitive::TextureExternal:
             case Types::Primitive::AccessMode:
             case Types::Primitive::TexelFormat:
+            case Types::Primitive::AddressSpace:
                 RELEASE_ASSERT_NOT_REACHED();
             }
         },
@@ -344,6 +348,9 @@ unsigned Type::size() const
         [&](const Reference&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const Pointer&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const TypeConstructor&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
@@ -369,6 +376,7 @@ unsigned Type::alignment() const
             case Types::Primitive::TextureExternal:
             case Types::Primitive::AccessMode:
             case Types::Primitive::TexelFormat:
+            case Types::Primitive::AddressSpace:
                 RELEASE_ASSERT_NOT_REACHED();
             }
         },
@@ -403,6 +411,9 @@ unsigned Type::alignment() const
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Reference&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Pointer&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const TypeConstructor&) -> unsigned {

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -85,6 +85,7 @@ namespace Types {
     f(TextureExternal, "texture_external") \
     f(AccessMode, "access_mode") \
     f(TexelFormat, "texel_format") \
+    f(AddressSpace, "address_space") \
 
 struct Primitive {
     enum Kind : uint8_t {
@@ -156,6 +157,12 @@ struct Reference {
     const Type* element;
 };
 
+struct Pointer {
+    AddressSpace addressSpace;
+    AccessMode accessMode;
+    const Type* element;
+};
+
 struct TypeConstructor {
     ASCIILiteral name;
     std::function<const Type*(AST::ElaboratedTypeExpression&)> construct;
@@ -176,6 +183,7 @@ struct Type : public std::variant<
     Types::Texture,
     Types::TextureStorage,
     Types::Reference,
+    Types::Pointer,
     Types::TypeConstructor,
     Types::Bottom
 > {
@@ -189,6 +197,7 @@ struct Type : public std::variant<
         Types::Texture,
         Types::TextureStorage,
         Types::Reference,
+        Types::Pointer,
         Types::TypeConstructor,
         Types::Bottom
         >::variant;

--- a/Source/WebGPU/WGSL/tests/invalid/pointers.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/pointers.wgsl
@@ -1,0 +1,9 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: only pointers in <storage> address space may specify an access mode
+fn f1(x: ptr<function, i32, read>) { }
+
+// FIXME: these pointers are not allowed as parameter types, but validation is not yet implemented
+// fn f2(x: ptr<storage, i32>) { }
+// fn f3(x: ptr<workgroup, i32>) { }
+// fn f4(x: ptr<uniform, i32>) { }

--- a/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
@@ -1,0 +1,4 @@
+// RUN: %wgslc
+
+fn f1(x: ptr<function, i32>) { }
+fn f2(x: ptr<private, i32>) { }


### PR DESCRIPTION
#### ca2ac1200f9963da87fa7f437ef15c573464e04c
<pre>
[WGSL] Add support for pointer types
<a href="https://bugs.webkit.org/show_bug.cgi?id=261831">https://bugs.webkit.org/show_bug.cgi?id=261831</a>
&lt;rdar://problem/115794611&gt;

Reviewed by Dan Glastonbury.

Add support for pointer types in the type system, which allows explicitly writing
types of the form `ptr&lt;AddressSpace, T, AccessMode&gt;`.

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::materialize):
* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::satisfies):
(WGSL::satisfyOrPromote):
(WGSL::concretize):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::bindingMemberForGlobal):
(WGSL::RewriteGlobalVariables::usesOverride):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitPackedVector):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::allocateTextureStorageConstructor):
(WGSL::TypeChecker::texelFormat):
(WGSL::TypeChecker::accessMode):
(WGSL::TypeChecker::addressSpace):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::PointerKey::encode const):
(WGSL::TypeStore::TypeStore):
(WGSL::TypeStore::pointerType):
* Source/WebGPU/WGSL/TypeStore.h:
(WGSL::TypeStore::addressSpaceType const):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
(WGSL::Type::size const):
(WGSL::Type::alignment const):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/tests/invalid/pointers.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/pointers.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/268238@main">https://commits.webkit.org/268238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c4aad5f55fae5cef03576b1d9b09dff57ab012

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17779 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21769 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16557 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23727 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21673 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17164 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4555 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17913 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->