### PR TITLE
[WGSL] Add support for address-of and indirection operators

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -32,6 +32,9 @@ namespace WGSL {
 
 bool satisfies(const Type* type, Constraint constraint)
 {
+    if (constraint == Constraints::None)
+        return true;
+
     auto* primitive = std::get_if<Types::Primitive>(type);
     if (!primitive) {
         if (auto* reference = std::get_if<Types::Reference>(type))
@@ -67,6 +70,9 @@ bool satisfies(const Type* type, Constraint constraint)
 
 const Type* satisfyOrPromote(const Type* type, Constraint constraint, const TypeStore& types)
 {
+    if (constraint == Constraints::None)
+        return type;
+
     auto* primitive = std::get_if<Types::Primitive>(type);
     if (!primitive) {
         if (auto* reference = std::get_if<Types::Reference>(type))

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -725,6 +725,7 @@ void FunctionDefinitionWriter::visit(const Type* type)
             const char* addressSpace = nullptr;
             switch (pointer.addressSpace) {
             case AddressSpace::Function:
+            case AddressSpace::Private:
                 addressSpace = "thread";
                 break;
             case AddressSpace::Workgroup:
@@ -737,16 +738,12 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 addressSpace = "device";
                 break;
             case AddressSpace::Handle:
-            case AddressSpace::Private:
-                break;
-            }
-            if (!addressSpace) {
-                visit(pointer.element);
-                return;
+                RELEASE_ASSERT_NOT_REACHED();
             }
             if (pointer.accessMode == AccessMode::Read)
                 m_stringBuilder.append("const ");
-            m_stringBuilder.append(addressSpace, " ");
+            if (addressSpace)
+                m_stringBuilder.append(addressSpace, " ");
             visit(pointer.element);
             m_stringBuilder.append("*");
         },
@@ -1025,11 +1022,11 @@ void FunctionDefinitionWriter::visit(AST::UnaryExpression& unary)
     case AST::UnaryOperation::Not:
         m_stringBuilder.append("!");
         break;
-
     case AST::UnaryOperation::AddressOf:
+        m_stringBuilder.append("&");
+        break;
     case AST::UnaryOperation::Dereference:
-        // FIXME: Implement these
-        RELEASE_ASSERT_NOT_REACHED();
+        m_stringBuilder.append("*");
         break;
     }
     visit(unary.expression());

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -30,11 +30,10 @@
 
 namespace WGSL {
 
-struct NumericVariable {
+struct ValueVariable {
     unsigned id;
 };
-
-using AbstractValue = std::variant<NumericVariable, unsigned>;
+using AbstractValue = std::variant<ValueVariable, unsigned>;
 
 struct TypeVariable {
     unsigned id;
@@ -44,10 +43,14 @@ struct TypeVariable {
 struct AbstractVector;
 struct AbstractMatrix;
 struct AbstractTexture;
+struct AbstractReference;
+struct AbstractPointer;
 using AbstractType = std::variant<
     AbstractVector,
     AbstractMatrix,
     AbstractTexture,
+    AbstractReference,
+    AbstractPointer,
     TypeVariable,
     const Type*
 >;
@@ -73,9 +76,21 @@ struct AbstractTexture {
     Types::Texture::Kind kind;
 };
 
+struct AbstractReference {
+    AbstractValue addressSpace;
+    AbstractScalarType element;
+    AbstractValue accessMode;
+};
+
+struct AbstractPointer {
+    AbstractValue addressSpace;
+    AbstractScalarType element;
+    AbstractValue accessMode;
+};
+
 struct OverloadCandidate {
     Vector<TypeVariable, 1> typeVariables;
-    Vector<NumericVariable, 2> numericVariables;
+    Vector<ValueVariable, 2> valueVariables;
     Vector<AbstractType, 2> parameters;
     AbstractType result;
 };
@@ -90,7 +105,7 @@ std::optional<SelectedOverload> resolveOverloads(TypeStore&, const Vector<Overlo
 } // namespace WGSL
 
 namespace WTF {
-void printInternal(PrintStream&, const WGSL::NumericVariable&);
+void printInternal(PrintStream&, const WGSL::ValueVariable&);
 void printInternal(PrintStream&, const WGSL::AbstractValue&);
 void printInternal(PrintStream&, const WGSL::TypeVariable&);
 void printInternal(PrintStream&, const WGSL::AbstractType&);

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -42,6 +42,10 @@ operator :-, {
 }
 
 operator :*, {
+    # unary
+    [AS, T, AM].(Ptr[AS, T, AM]) => Ref[AS, T, AM],
+
+    # binary
     [T < Number].(T, T) => T,
 
     # vector scaling
@@ -111,6 +115,10 @@ operator :'|', {
 }
 
 operator :'&', {
+    # unary
+    [AS, T, AM].(Ref[AS, T, AM]) => Ptr[AS, T, AM],
+
+    # binary
     [].(Bool, Bool) => Bool,
     [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
 }

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -63,7 +63,7 @@ class Variable
         if @kind == DSL::type_variable
             "candidate.typeVariables.append(#{name});"
         else
-            "candidate.numericVariables.append(#{name});"
+            "candidate.valueVariables.append(#{name});"
         end
     end
 end
@@ -227,14 +227,16 @@ module DSL
     @aliases = {}
     @operators = {}
     @TypeVariable = VariableKind.new(:TypeVariable)
-    @NumericVariable = VariableKind.new(:NumericVariable)
+    @ValueVariable = VariableKind.new(:ValueVariable)
+    @AddressSpace = VariableKind.new(:AddressSpace)
+    @AccessMode = VariableKind.new(:AccessMode)
 
     def self.type_variable
         @TypeVariable
     end
 
     def self.numeric_variable
-        @NumericVariable
+        @ValueVariable
     end
 
     def self.operator(name, map)
@@ -277,6 +279,8 @@ module DSL
         Matrix = AbstractType.new(:Matrix)
         Array = AbstractType.new(:Array)
         Texture = AbstractType.new(:Texture)
+        Ref = AbstractType.new(:Reference)
+        Ptr = AbstractType.new(:Pointer)
 
         Texture1d = Variable.new(:"Types::Texture::Kind::Texture1d", nil)
         Texture2d = Variable.new(:"Types::Texture::Kind::Texture2d", nil)
@@ -300,10 +304,13 @@ module DSL
         T = Variable.new(:T, @TypeVariable)
         U = Variable.new(:U, @TypeVariable)
         V = Variable.new(:V, @TypeVariable)
-        N = Variable.new(:N, @NumericVariable)
-        C = Variable.new(:C, @NumericVariable)
-        R = Variable.new(:R, @NumericVariable)
-        K = Variable.new(:K, @NumericVariable)
+        N = Variable.new(:N, @ValueVariable)
+        C = Variable.new(:C, @ValueVariable)
+        R = Variable.new(:R, @ValueVariable)
+        K = Variable.new(:K, @ValueVariable)
+
+        AS = Variable.new(:AS, @ValueVariable)
+        AM = Variable.new(:AM, @ValueVariable)
 
         Number = Constraint.new(:Number)
         Integer = Constraint.new(:Integer)

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -186,6 +186,23 @@ fn testComparison() {
   }
 }
 
+fn testAddressOf()
+{
+    var x = 1;
+    testPointerDeference(&x);
+
+    let y: ptr<function, i32> = &x;
+    testPointerDeference(y);
+
+    let z = &x;
+    testPointerDeference(z);
+}
+
+fn testPointerDeference(x: ptr<function, i32>) -> i32
+{
+    return *x;
+}
+
 // 8.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
 
 fn testLogicalNegation()

--- a/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
@@ -1,4 +1,22 @@
-// RUN: %wgslc
+// RUN: %metal-compile main
 
-fn f1(x: ptr<function, i32>) { }
-fn f2(x: ptr<private, i32>) { }
+fn f1(x: ptr<function, i32>) -> i32
+{
+    return *x;
+}
+
+fn f2(x: ptr<private, i32>) -> i32
+{
+    return *x;
+}
+
+var<private> global: i32;
+
+@compute @workgroup_size(1)
+fn main()
+{
+    var local: i32;
+
+    f1(&local);
+    f2(&global);
+}


### PR DESCRIPTION
#### 3d505c75ee55d8c58313680465defe3e9a145d8d
<pre>
[WGSL] Add support for address-of and indirection operators
<a href="https://bugs.webkit.org/show_bug.cgi?id=261833">https://bugs.webkit.org/show_bug.cgi?id=261833</a>
&lt;rdar://problem/115795658&gt;

Reviewed by Dan Glastonbury.

Add the type declarations for address-of (&amp;x, spec[1]) and indirection (*x, spec[2])
operators. This required introducing AbstractReference and AbstractPointer to the
overload resolution algorithm and exposing them to the ruby DSL, as well as exposing
address space and access mode, which was done by generalizing NumericVariables to
use the underlying enum type.

[1]: <a href="https://www.w3.org/TR/WGSL/#address-of-expr">https://www.w3.org/TR/WGSL/#address-of-expr</a>
[2]: <a href="https://www.w3.org/TR/WGSL/#indirection-expr">https://www.w3.org/TR/WGSL/#indirection-expr</a>

* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::satisfies):
(WGSL::satisfyOrPromote):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::OverloadResolver):
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::considerCandidate):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WGSL::OverloadResolver::assign):
(WGSL::OverloadResolver::resolve const):
(WGSL::resolveOverloads):
(WTF::printInternal):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:
* Source/WebGPU/WGSL/tests/valid/pointers.wgsl:

Canonical link: <a href="https://commits.webkit.org/268245@main">https://commits.webkit.org/268245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73ea6a25c35ea0ecf7b755b0bd17aff74840b754

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17872 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19605 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21872 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23795 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21746 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18159 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17264 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4561 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->