### PR TITLE
[WGSL] Add support for arrayLength

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -264,6 +264,14 @@ operator :select, {
     [T < Scalar, N].(Vector[T, N], Vector[T, N], Vector[Bool, N]) => Vector[T, N],
 }
 
+# 16.4. Array Built-in Functions
+
+# 16.4.1.
+operator :arrayLength, {
+  [T].(Ptr[Storage, Array[T], Read]) => U32,
+  [T].(Ptr[Storage, Array[T], ReadWrite]) => U32,
+}
+
 # 17.5. Numeric Built-in Functions (https://www.w3.org/TR/WGSL/#numeric-builtin-functions)
 
 # Trigonometric

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -605,6 +605,21 @@ fn testSelect()
     }
 }
 
+// 16.4. Array Built-in Functions
+
+var<storage, read> a1: array<i32>;
+var<storage, read_write> a2: array<i32>;
+
+// 16.4.1.
+fn testArrayLength()
+{
+    // [T].(Ptr[Storage, Array[T], Read]) => U32,
+    _ = arrayLength(&a1);
+
+    // [T].(Ptr[Storage, Array[T], ReadWrite]) => U32,
+    _ = arrayLength(&a2);
+}
+
 // 17.5. Numeric Built-in Functions (https://www.w3.org/TR/WGSL/#numeric-builtin-functions)
 
 // Trigonometric


### PR DESCRIPTION
#### 2030cec54f581d09fee9c6cbade9b8e84c87bca3
<pre>
[WGSL] Add support for arrayLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=261835">https://bugs.webkit.org/show_bug.cgi?id=261835</a>
&lt;rdar://problem/115796109&gt;

Reviewed by Dan Glastonbury.

Add support for the arrayLength built-in function according to the spec[1]. So far, our
DSL/overload resolution did not support nested abstract types, e.g. ptr&lt;AS, array&lt;T&gt;&gt;,
which is required by arrayLength, so it required changing the AbstractType represention
to allow nesting. Some minor tweaks were also required on the generator to correctly
serialized these nested types.

[1]: <a href="https://www.w3.org/TR/WGSL/#arrayLength-builtin">https://www.w3.org/TR/WGSL/#arrayLength-builtin</a>

* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WTF::printInternal):
* Source/WebGPU/WGSL/Overload.h:
(WGSL::allocateAbstractType):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268305@main">https://commits.webkit.org/268305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6e2fe98cadc608467017176b8aa83df12219a38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21038 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17923 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19617 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21915 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16648 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23814 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21766 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15424 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17326 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4577 "layout-tests (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21687 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2358 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->