### PR TITLE
Add support for tabs.sendMessage to Web Extension content scripts.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -191,6 +191,7 @@ $(PROJECT_DIR)/Shared/Extensions/WebExtensionAlarmParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionContextParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionControllerParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionEventListenerType.serialization.in
+$(PROJECT_DIR)/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionTab.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionTabParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionWindow.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -505,6 +505,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Extensions/WebExtensionContextParameters.serialization.in \
 	Shared/Extensions/WebExtensionControllerParameters.serialization.in \
 	Shared/Extensions/WebExtensionEventListenerType.serialization.in \
+	Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in \
 	Shared/Extensions/WebExtensionTab.serialization.in \
 	Shared/Extensions/WebExtensionWindow.serialization.in \
 	Shared/FileSystemSyncAccessHandleInfo.serialization.in \

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -42,6 +42,10 @@ OBJC_CLASS NSUUID;
     if (UNLIKELY(!(condition))) \
         [NSException raise:NSInternalInconsistencyException format:message]
 
+namespace API {
+class Data;
+}
+
 namespace WebKit {
 
 template<typename T> T *filterObjects(T *container, bool NS_NOESCAPE (^block)(__kindof id key, __kindof id value));
@@ -81,13 +85,16 @@ T *objectForKey(const RetainPtr<NSDictionary>& dictionary, id key, bool returnin
     return objectForKey<T>(dictionary.get(), key, returningNilIfEmpty, containingObjectsOfClass);
 }
 
-// MARK: NSDictionary helper methods.
+NSDictionary *parseJSON(NSString *, NSError ** = nullptr);
+NSDictionary *parseJSON(NSData *, NSError ** = nullptr);
+NSDictionary *parseJSON(API::Data&, NSError ** = nullptr);
+
+NSString *encodeJSONString(NSDictionary *, NSError ** = nullptr);
+NSData *encodeJSONData(NSDictionary *, NSError ** = nullptr);
 
 NSDictionary *dictionaryWithLowercaseKeys(NSDictionary *);
 NSDictionary *mergeDictionaries(NSDictionary *, NSDictionary *);
 NSDictionary *mergeDictionariesAndSetValues(NSDictionary *, NSDictionary *);
-
-// MARK: NSError helper methods.
 
 NSString *privacyPreservingDescription(NSError *);
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -28,7 +28,9 @@
 #endif
 
 #import "config.h"
+#import "APIData.h"
 #import "CocoaHelpers.h"
+#import "WKNSData.h"
 
 namespace WebKit {
 
@@ -188,7 +190,42 @@ NSSet *objectForKey<NSSet>(NSDictionary *dictionary, id key, bool nilIfEmpty, Cl
     });
 }
 
-// MARK: NSDictionary helper methods.
+// MARK: JSON Helpers
+
+NSDictionary *parseJSON(NSData *json, NSError **error)
+{
+    if (!json)
+        return nil;
+    return dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:json options:0 error:error]);
+}
+
+NSDictionary *parseJSON(NSString *json, NSError **error)
+{
+    return parseJSON([json dataUsingEncoding:NSUTF8StringEncoding], error);
+}
+
+NSDictionary *parseJSON(API::Data& json, NSError **error)
+{
+    return parseJSON(wrapper(json), error);
+}
+
+NSString *encodeJSONString(NSDictionary *dictionary, NSError **error)
+{
+    if (auto *data = encodeJSONData(dictionary, error))
+        return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    return nil;
+}
+
+NSData *encodeJSONData(NSDictionary *dictionary, NSError **error)
+{
+    if (!dictionary)
+        return nil;
+
+    ASSERT([NSJSONSerialization isValidJSONObject:dictionary]);
+    return [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:error];
+}
+
+// MARK: NSDictionary Helpers
 
 NSDictionary *dictionaryWithLowercaseKeys(NSDictionary *dictionary)
 {
@@ -242,7 +279,7 @@ NSDictionary *mergeDictionariesAndSetValues(NSDictionary *dictionaryA, NSDiction
     return [newDictionary copy];
 }
 
-// MARK: NSError helper methods
+// MARK: NSError Helpers
 
 NSString *privacyPreservingDescription(NSError *error)
 {

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -363,6 +363,7 @@ def serialized_identifiers():
         'WebKit::VideoEncoderIdentifier',
         'WebKit::WebExtensionContextIdentifier',
         'WebKit::WebExtensionControllerIdentifier',
+        'WebKit::WebExtensionFrameIdentifier',
         'WebKit::WebExtensionTabIdentifier',
         'WebKit::WebExtensionWindowIdentifier',
         'WebKit::WebGPUIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -86,6 +86,7 @@
 #include "VideoEncoderIdentifier.h"
 #include "WebExtensionContextIdentifier.h"
 #include "WebExtensionControllerIdentifier.h"
+#include "WebExtensionFrameIdentifier.h"
 #include "WebExtensionTabIdentifier.h"
 #include "WebExtensionWindowIdentifier.h"
 #include "WebGPUIdentifier.h"
@@ -537,6 +538,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebKit::VideoEncoderIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionContextIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionControllerIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionFrameIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionTabIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionWindowIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebGPUIdentifier));
@@ -641,6 +643,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebKit::VideoEncoderIdentifier"_s,
         "WebKit::WebExtensionContextIdentifier"_s,
         "WebKit::WebExtensionControllerIdentifier"_s,
+        "WebKit::WebExtensionFrameIdentifier"_s,
         "WebKit::WebExtensionTabIdentifier"_s,
         "WebKit::WebExtensionWindowIdentifier"_s,
         "WebKit::WebGPUIdentifier"_s,

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebFrame.h"
+#include "WebPage.h"
+#include <WebCore/Frame.h>
+#include <WebCore/FrameIdentifier.h>
+#include <wtf/ObjectIdentifier.h>
+
+namespace WebKit {
+
+struct WebExtensionFrameIdentifierType;
+using WebExtensionFrameIdentifier = ObjectIdentifier<WebExtensionFrameIdentifierType>;
+
+namespace WebExtensionFrameConstants {
+
+static constexpr double MainFrame { 0 };
+
+static constexpr const WebExtensionFrameIdentifier MainFrameIdentifier { std::numeric_limits<uint64_t>::max() - 1 };
+
+}
+
+inline bool isMainFrame(WebExtensionFrameIdentifier identifier)
+{
+    return identifier == WebExtensionFrameConstants::MainFrameIdentifier;
+}
+
+inline bool isMainFrame(std::optional<WebExtensionFrameIdentifier> identifier)
+{
+    return identifier && isMainFrame(identifier.value());
+}
+
+inline WebCore::FrameIdentifier toWebCoreFrameIdentifier(const WebExtensionFrameIdentifier& identifier, const WebPage& page)
+{
+    if (isMainFrame(identifier))
+        return page.mainWebFrame().frameID();
+
+    WebCore::FrameIdentifier result { ObjectIdentifier<WebCore::FrameIdentifierType> { identifier.toUInt64() }, WebCore::Process::identifier() };
+    ASSERT(result.object().isValid());
+    return result;
+}
+
+inline bool matchesFrame(const WebExtensionFrameIdentifier& identifier, const WebFrame& frame)
+{
+    if (auto* coreFrame = frame.coreFrame(); coreFrame->isMainFrame() && isMainFrame(identifier))
+        return true;
+
+    if (auto* page = frame.page(); &page->mainWebFrame() == &frame && isMainFrame(identifier))
+        return true;
+
+    return frame.frameID().object().toUInt64() == identifier.toUInt64();
+}
+
+inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame& frame)
+{
+    if (auto* coreFrame = frame.coreFrame(); coreFrame->isMainFrame())
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    if (auto* page = frame.page(); &page->mainWebFrame() == &frame)
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    WebExtensionFrameIdentifier result { frame.frameID().object().toUInt64() };
+    ASSERT(result.isValid());
+    return result;
+}
+
+inline std::optional<WebExtensionFrameIdentifier> toWebExtensionFrameIdentifier(double identifier)
+{
+    if (identifier == WebExtensionFrameConstants::MainFrame)
+        return WebExtensionFrameConstants::MainFrameIdentifier;
+
+    if (!std::isfinite(identifier) || identifier <= 0 || identifier >= static_cast<double>(WebExtensionFrameConstants::MainFrameIdentifier.toUInt64()))
+        return std::nullopt;
+
+    double integral;
+    if (std::modf(identifier, &integral) != 0.0) {
+        // Only integral numbers can be used.
+        return std::nullopt;
+    }
+
+    WebExtensionFrameIdentifier result { static_cast<uint64_t>(identifier) };
+    ASSERT(result.isValid());
+    return result;
+}
+
+inline double toWebAPI(const WebExtensionFrameIdentifier& identifier)
+{
+    ASSERT(identifier.isValid());
+
+    if (isMainFrame(identifier))
+        return WebExtensionFrameConstants::MainFrame;
+
+    return static_cast<double>(identifier.toUInt64());
+}
+
+}

--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,22 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPIRuntime {
+#pragma once
 
-    [URL, ConvertNullStringTo=Null, RaisesException] DOMString getURL(DOMString resourcePath);
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-    [NSDictionary] any getManifest();
+#include "WebExtensionFrameIdentifier.h"
+#include "WebExtensionTabParameters.h"
+#include <wtf/Forward.h>
 
-    [ImplementedAs=runtimeIdentifier] readonly attribute DOMString id;
+namespace WebKit {
 
-    [MainWorldOnly] void getPlatformInfo([Optional, CallbackHandler] function callback);
-
-    [MainWorldOnly] readonly attribute any lastError;
-
-    // readonly attribute WebExtensionAPIEvent onConnect;
-    readonly attribute WebExtensionAPIEvent onMessage;
-
+struct WebExtensionMessageSenderParameters {
+    std::optional<WebExtensionTabParameters> tabParameters;
+    std::optional<WebExtensionFrameIdentifier> frameIdentifier;
+    URL url;
 };
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+struct WebKit::WebExtensionMessageSenderParameters {
+    std::optional<WebKit::WebExtensionTabParameters> tabParameters;
+    std::optional<WebKit::WebExtensionFrameIdentifier> frameIdentifier;
+    URL url;
+}
+
+#endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
@@ -74,7 +74,7 @@ inline std::optional<WebExtensionTabIdentifier> toWebExtensionTabIdentifier(doub
     return result;
 }
 
-inline double toWebAPI(WebExtensionTabIdentifier identifier)
+inline double toWebAPI(const WebExtensionTabIdentifier& identifier)
 {
     ASSERT(identifier.isValid());
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -31,6 +31,9 @@
 
 namespace WebKit {
 
+class WebFrame;
+struct WebExtensionMessageSenderParameters;
+
 /// Verifies that a dictionary:
 ///  - Contains a required set of string keys, as listed in `requiredKeys`, all other types specified in `keyTypes` are optional keys.
 ///  - Has values that are the appropriate type for each key, as specified by `keyTypes`. The keys in this dictionary
@@ -58,6 +61,10 @@ NSString *toErrorString(NSString *callingAPIName, NSString *sourceKey, NSString 
 JSObjectRef toJSError(JSContextRef, NSString *callingAPIName, NSString *sourceKey, NSString *underlyingErrorString);
 
 NSString *toWebAPI(NSLocale *);
+NSDictionary *toWebAPI(const WebExtensionMessageSenderParameters&);
+
+/// This matches the maximum message length enforced by Chromium in its `MessageFromJSONString()` function.
+constexpr size_t webExtensionMaxMessageLength = 1024 * 1024 * 64;
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -35,7 +35,13 @@
 #import "CocoaHelpers.h"
 #import "JSWebExtensionWrapper.h"
 #import "Logging.h"
+#import "WebExtensionAPITabs.h"
+#import "WebExtensionMessageSenderParameters.h"
 #import <objc/runtime.h>
+
+static NSString * const frameIdKey = @"frameId";
+static NSString * const tabKey = @"tab";
+static NSString * const urlKey = @"url";
 
 namespace WebKit {
 
@@ -337,6 +343,22 @@ NSString *toWebAPI(NSLocale *locale)
     if (locale.countryCode.length)
         return [NSString stringWithFormat:@"%@-%@", locale.languageCode, locale.countryCode];
     return locale.languageCode;
+}
+
+NSDictionary *toWebAPI(const WebExtensionMessageSenderParameters& parameters)
+{
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+
+    if (parameters.tabParameters)
+        result[tabKey] = toWebAPI(parameters.tabParameters.value());
+
+    if (parameters.frameIdentifier)
+        result[frameIdKey] = @(toWebAPI(parameters.frameIdentifier.value()));
+
+    if (parameters.url.isValid())
+        result[urlKey] = (NSURL *)parameters.url;
+
+    return [result copy];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
@@ -90,7 +90,7 @@ inline std::optional<WebExtensionWindowIdentifier> toWebExtensionWindowIdentifie
     return result;
 }
 
-inline double toWebAPI(WebExtensionWindowIdentifier identifier)
+inline double toWebAPI(const WebExtensionWindowIdentifier& identifier)
 {
     ASSERT(identifier.isValid());
 

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm
@@ -221,10 +221,7 @@ using namespace WebKit;
 {
     NSString *path = [NSString stringWithFormat:pathToJSONFile, locale];
     NSData *data = [NSData dataWithData:webExtension.resourceDataForPath(path)];
-    if (!data)
-        return nil;
-
-    return [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];;
+    return parseJSON(data);
 }
 
 - (LocalizationDictionary *)_predefinedMessagesForLocale:(NSLocale *)locale

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -422,6 +422,28 @@ void WebExtensionContext::tabsToggleReaderMode(WebPageProxyIdentifier webPagePro
     tab->toggleReaderMode(WTFMove(completionHandler));
 }
 
+void WebExtensionContext::tabsSendMessage(WebExtensionTabIdentifier tabIdentifier, String messageJSON, std::optional<WebExtensionFrameIdentifier> frameIdentifier, const WebExtensionMessageSenderParameters& senderParameters, CompletionHandler<void(std::optional<String> replyJSON, WebExtensionTab::Error)>&& completionHandler)
+{
+    auto tab = getTab(tabIdentifier);
+    if (!tab) {
+        completionHandler(nullString(), toErrorString(@"tabs.sendMessage()", nil, @"tab not found"));
+        return;
+    }
+
+    WebProcessProxySet processes = tab->processes(WebExtensionEventListenerType::RuntimeOnMessage);
+    if (processes.isEmpty()) {
+        completionHandler(std::nullopt, std::nullopt);
+        return;
+    }
+
+    ASSERT(processes.size() == 1);
+    auto process = processes.takeAny();
+
+    process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeContentScriptMessageEvent(messageJSON, frameIdentifier, senderParameters), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](std::optional<String> replyJSON) mutable {
+        completionHandler(replyJSON, std::nullopt);
+    }, identifier());
+}
+
 void WebExtensionContext::tabsGetZoom(WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(std::optional<double>, WebExtensionTab::Error)>&& completionHandler)
 {
     auto tab = getTab(webPageProxyIdentifier, tabIdentifier);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -26,13 +26,6 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 messages -> WebExtensionContext {
-    // Test APIs
-    TestResult(bool result, String message, String sourceURL, unsigned lineNumber);
-    TestEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
-    TestMessage(String message, String sourceURL, unsigned lineNumber);
-    TestYielded(String message, String sourceURL, unsigned lineNumber);
-    TestFinished(bool result, String message, String sourceURL, unsigned lineNumber);
-
     // Alarms APIs
     AlarmsCreate(String name, Seconds initialInterval, Seconds repeatInterval);
     AlarmsGet(String name) -> (std::optional<WebKit::WebExtensionAlarmParameters> alarmInfo);
@@ -63,9 +56,17 @@ messages -> WebExtensionContext {
     TabsDetectLanguage(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> language, WebKit::WebExtensionTab::Error error);
     TabsToggleReaderMode(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (WebKit::WebExtensionTab::Error error);
     TabsCaptureVisibleTab(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, WebKit::WebExtensionTab::ImageFormat imageFormat, uint8_t imageQuality) -> (std::optional<URL> imageDataURL, WebKit::WebExtensionTab::Error error);
+    TabsSendMessage(WebKit::WebExtensionTabIdentifier tabIdentifier, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON, WebKit::WebExtensionTab::Error error);
     TabsGetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<double> zoomFactor, WebKit::WebExtensionTab::Error error);
     TabsSetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, double zoomFactor) -> (WebKit::WebExtensionTab::Error error);
     TabsRemove(Vector<WebKit::WebExtensionTabIdentifier> tabIdentifiers) -> (WebKit::WebExtensionWindow::Error error);
+
+    // Test APIs
+    TestResult(bool result, String message, String sourceURL, unsigned lineNumber);
+    TestEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
+    TestMessage(String message, String sourceURL, unsigned lineNumber);
+    TestYielded(String message, String sourceURL, unsigned lineNumber);
+    TestFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 
     // Windows APIs
     WindowsCreate(WebKit::WebExtensionWindowParameters creationParameters) -> (std::optional<WebKit::WebExtensionWindowParameters> windowParameters, WebKit::WebExtensionWindow::Error error);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "CocoaImage.h"
+#include "WebExtensionEventListenerType.h"
 #include "WebExtensionTabIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include <wtf/Forward.h>
@@ -42,6 +43,7 @@ namespace WebKit {
 
 class WebExtensionContext;
 class WebExtensionWindow;
+class WebProcessProxy;
 struct WebExtensionTabParameters;
 struct WebExtensionTabQueryParameters;
 
@@ -79,8 +81,10 @@ public:
 
     enum class AssumeWindowMatches : bool { No, Yes };
     enum class SkipContainsCheck : bool { No, Yes };
+    enum class MainWebViewOnly : bool { No, Yes };
 
     using Error = std::optional<String>;
+    using WebProcessProxySet = HashSet<Ref<WebProcessProxy>>;
 
     WebExtensionTabIdentifier identifier() const { return m_identifier; }
     WebExtensionTabParameters parameters() const;
@@ -153,6 +157,8 @@ public:
     void duplicate(const WebExtensionTabParameters&, CompletionHandler<void(RefPtr<WebExtensionTab>, Error)>&&);
 
     void close(CompletionHandler<void(Error)>&&);
+
+    WebProcessProxySet processes(WebExtensionEventListenerType, MainWebViewOnly = MainWebViewOnly::Yes) const;
 
 #ifdef __OBJC__
     _WKWebExtensionTab *delegate() const { return m_delegate.getAutoreleased(); }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -435,6 +435,8 @@
 		1C49579B2A9813AA007D0B64 /* WebExtensionContextAPIWindowsCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C49579A2A9813AA007D0B64 /* WebExtensionContextAPIWindowsCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C49579D2A983DE4007D0B64 /* WebExtensionWindowParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C49579C2A983DE4007D0B64 /* WebExtensionWindowParameters.h */; };
 		1C4957A12A983E2B007D0B64 /* WebExtensionTabParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4957A02A983E2B007D0B64 /* WebExtensionTabParameters.h */; };
+		1C4A14C62ABB710E00A1018C /* WebExtensionFrameIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4A14C52ABB710E00A1018C /* WebExtensionFrameIdentifier.h */; };
+		1C4EBD722ABA47610005868F /* WebExtensionMessageSenderParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C4EBD712ABA47610005868F /* WebExtensionMessageSenderParameters.h */; };
 		1C56557F2745C5A1006300AF /* UnifiedSource101.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557C2745C5A0006300AF /* UnifiedSource101.cpp */; };
 		1C5655802745C5A1006300AF /* UnifiedSource102.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557D2745C5A1006300AF /* UnifiedSource102.cpp */; };
 		1C5655812745C5A1006300AF /* UnifiedSource103.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557E2745C5A1006300AF /* UnifiedSource103.cpp */; };
@@ -3525,7 +3527,10 @@
 		1C49579E2A983DF1007D0B64 /* WebExtensionWindow.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionWindow.serialization.in; sourceTree = "<group>"; };
 		1C4957A02A983E2B007D0B64 /* WebExtensionTabParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionTabParameters.h; sourceTree = "<group>"; };
 		1C4957A22A983E39007D0B64 /* WebExtensionTab.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionTab.serialization.in; sourceTree = "<group>"; };
+		1C4A14C52ABB710E00A1018C /* WebExtensionFrameIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionFrameIdentifier.h; sourceTree = "<group>"; };
 		1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionControllerParameters.serialization.in; sourceTree = "<group>"; };
+		1C4EBD712ABA47610005868F /* WebExtensionMessageSenderParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionMessageSenderParameters.h; sourceTree = "<group>"; };
+		1C4EBD732ABA481B0005868F /* WebExtensionMessageSenderParameters.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionMessageSenderParameters.serialization.in; sourceTree = "<group>"; };
 		1C4F5A1C297CB57A005BBEE9 /* RemoteCompositorIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteCompositorIntegration.h; sourceTree = "<group>"; };
 		1C4F5A1D297CB57B005BBEE9 /* RemoteCompositorIntegration.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteCompositorIntegration.messages.in; sourceTree = "<group>"; };
 		1C4F5A1E297CB57B005BBEE9 /* RemoteCompositorIntegration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteCompositorIntegration.cpp; sourceTree = "<group>"; };
@@ -12183,6 +12188,9 @@
 				1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */,
 				B6114A8B293AE05200380B1B /* WebExtensionEventListenerType.h */,
 				8696CE2F297EB3C90081C800 /* WebExtensionEventListenerType.serialization.in */,
+				1C4A14C52ABB710E00A1018C /* WebExtensionFrameIdentifier.h */,
+				1C4EBD712ABA47610005868F /* WebExtensionMessageSenderParameters.h */,
+				1C4EBD732ABA481B0005868F /* WebExtensionMessageSenderParameters.serialization.in */,
 				1C4957A22A983E39007D0B64 /* WebExtensionTab.serialization.in */,
 				1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */,
 				1C4957A02A983E2B007D0B64 /* WebExtensionTabParameters.h */,
@@ -15218,6 +15226,8 @@
 				1C3BEB7D2888A01600E66E38 /* WebExtensionControllerProxy.h in Headers */,
 				1C3BEB512887492F00E66E38 /* WebExtensionControllerProxyMessages.h in Headers */,
 				B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */,
+				1C4A14C62ABB710E00A1018C /* WebExtensionFrameIdentifier.h in Headers */,
+				1C4EBD722ABA47610005868F /* WebExtensionMessageSenderParameters.h in Headers */,
 				1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */,
 				1C66BDDA2A8ADB8A009D4452 /* WebExtensionTabIdentifier.h in Headers */,
 				1C4957A12A983E2B007D0B64 /* WebExtensionTabParameters.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "JSWebExtensionAPIRuntime.h"
+#include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
 
 OBJC_CLASS NSDictionary;
@@ -59,15 +60,18 @@ public:
     WebExtensionAPIRuntime& runtime() final { return *this; }
 
 #if PLATFORM(COCOA)
-    NSURL *getURL(NSString *resourcePath, NSString **errorString);
-
+    NSURL *getURL(NSString *resourcePath, NSString **outExceptionString);
     NSDictionary *getManifest();
+    void getPlatformInfo(Ref<WebExtensionCallbackHandler>&&);
 
     NSString *runtimeIdentifier();
 
-    void getPlatformInfo(Ref<WebExtensionCallbackHandler>&&);
-
     JSValueRef lastError();
+
+    WebExtensionAPIEvent& onMessage();
+
+private:
+    RefPtr<WebExtensionAPIEvent> m_onMessage;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -30,6 +30,7 @@
 #include "JSWebExtensionAPITabs.h"
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
+#include "WebExtensionFrameIdentifier.h"
 #include "WebExtensionTab.h"
 
 OBJC_CLASS NSDictionary;
@@ -67,10 +68,10 @@ public:
     void setZoom(WebPage*, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void detectLanguage(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-
     void toggleReaderMode(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-
     void captureVisibleTab(WebPage*, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+
+    void sendMessage(WebFrame*, double tabID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     double tabIdentifierNone() const { return -1; }
 
@@ -90,6 +91,7 @@ private:
     static bool parseTabDuplicateOptions(NSDictionary *, WebExtensionTabParameters&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseTabQueryOptions(NSDictionary *, WebExtensionTabQueryParameters&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseCaptureVisibleTabOptions(NSDictionary *, WebExtensionTab::ImageFormat&, uint8_t& imageQuality, NSString *sourceKey, NSString **outExceptionString);
+    static bool parseSendMessageOptions(NSDictionary *, std::optional<WebExtensionFrameIdentifier>&, NSString *sourceKey, NSString **outExceptionString);
 
     RefPtr<WebExtensionAPIEvent> m_onActivated;
     RefPtr<WebExtensionAPIEvent> m_onAttached;

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -29,6 +29,7 @@
 
 #include "Logging.h"
 #include "WebFrame.h"
+#include "WebPage.h"
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <JavaScriptCore/JavaScriptCore.h>
 #include <wtf/WeakPtr.h>
@@ -104,7 +105,7 @@ inline RefPtr<WebFrame> toWebFrame(JSContextRef context)
     return WebFrame::frameForContext(JSContextGetGlobalContext(context));
 }
 
-inline WebPage* toWebPage(JSContextRef context)
+inline RefPtr<WebPage> toWebPage(JSContextRef context)
 {
     ASSERT(context);
     auto frame = toWebFrame(context);

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -185,6 +185,8 @@ EOF
 
 namespace WebKit {
 
+using namespace WTF;
+
 class ${implementationClassName};
 
 class ${className} : public ${parentClassName} {
@@ -582,7 +584,7 @@ EOF
 
                     push(@contents, "        JSValueRef currentArgument = nullptr;\n");
 
-                    push(@contents, "        const size_t allowedOptionalArgumentCount = argumentCount - requiredArgumentCount;\n") if $requiredArgumentCount;
+                    push(@contents, "        size_t allowedOptionalArgumentCount = argumentCount - requiredArgumentCount;\n") if $requiredArgumentCount;
                     push(@contents, "        size_t processedOptionalArgumentCount = 0;\n") if $requiredArgumentCount;
                     push(@contents, "        argumentIndex = argumentCount - 1;\n") unless $processArgumentsLeftToRight;
                     push(@contents, "        argumentIndex = 0;\n") if $processArgumentsLeftToRight;
@@ -677,10 +679,10 @@ EOF
             unshift(@parameters, "context") if $needsScriptContext;
 
             unshift(@methodSignatureNames, "page") if $needsPage;
-            unshift(@parameters, "toWebPage(context)") if $needsPage;
+            unshift(@parameters, "toWebPage(context).get()") if $needsPage;
 
             unshift(@methodSignatureNames, "frame") if $needsFrame;
-            unshift(@parameters, "toWebFrame(context)") if $needsFrame;
+            unshift(@parameters, "toWebFrame(context).get()") if $needsFrame;
 
             push(@methodSignatureNames, "outExceptionString") if $needsExceptionString;
             push(@parameters, "&exceptionString") if $needsExceptionString;
@@ -817,10 +819,10 @@ EOF
             push(@parameters, "context") if $attribute->extendedAttributes->{"NeedsScriptContext"};
 
             push(@methodSignatureNames, "page") if $attribute->extendedAttributes->{"NeedsPage"};
-            push(@parameters, "toWebPage(context)") if $attribute->extendedAttributes->{"NeedsPage"};
+            push(@parameters, "toWebPage(context).get()") if $attribute->extendedAttributes->{"NeedsPage"};
 
             push(@methodSignatureNames, "frame") if $attribute->extendedAttributes->{"NeedsFrame"};
-            push(@parameters, "toWebFrame(context)") if $attribute->extendedAttributes->{"NeedsFrame"};
+            push(@parameters, "toWebFrame(context).get()") if $attribute->extendedAttributes->{"NeedsFrame"};
 
             my $getterExpression = $self->_functionCall($attribute, \@methodSignatureNames, \@parameters, $interface, $getterName);
 
@@ -1428,7 +1430,7 @@ sub _returnExpression
     return "JSValueMakeUndefined(context)" if $returnIDLTypeName eq "void";
     return "JSValueMakeBoolean(context, ${expression})" if $returnIDLTypeName eq "boolean";
     return "JSValueMakeNumber(context, ${expression})" if $$self{codeGenerator}->IsPrimitiveType($returnIDLType);
-    return "toJS(context, WTF::getPtr(${expression}))";
+    return "toJS(context, getPtr(${expression}))";
 }
 
 sub _setterName
@@ -1578,7 +1580,7 @@ EOF
         my @conditions = ();
         push(@conditions, "isForMainWorld") if $interface->extendedAttributes->{"MainWorldOnly"};
         push(@conditions, $middleCondition) if $middleCondition;
-        push(@conditions, "impl->isPropertyAllowed(\"${name}\"_s, toWebPage(context))") if $interface->extendedAttributes->{"Dynamic"};
+        push(@conditions, "impl->isPropertyAllowed(\"${name}\"_s, toWebPage(context).get())") if $interface->extendedAttributes->{"Dynamic"};
         return join(" && ", @conditions);
     };
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -58,7 +58,7 @@
     // [RaisesException, Dynamic] void insertCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
     // [RaisesException, Dynamic] void removeCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
 
-    // [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage(double tabID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
+    [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage(double tabID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
     // [NeedsFrame] WebExtensionAPIPort connect(double tabID, [Optional, NSDictionary] any connectInfo);
 
     [ImplementedAs=tabIdentifierNone] readonly attribute double TAB_ID_NONE;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -32,6 +32,9 @@ messages -> WebExtensionContextProxy {
     // Permissions
     DispatchPermissionsEvent(WebKit::WebExtensionEventListenerType type, HashSet<String> permissions, HashSet<String> origins)
 
+    // Runtime
+    DispatchRuntimeContentScriptMessageEvent(String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON)
+
     // Tabs Events
     DispatchTabsCreatedEvent(WebKit::WebExtensionTabParameters tabParameters)
     DispatchTabsUpdatedEvent(WebKit::WebExtensionTabParameters tabParameters, WebKit::WebExtensionTabParameters changedParameters)


### PR DESCRIPTION
#### cf1260f203c173044feb28d2f481501ac8d313ee
<pre>
Add support for tabs.sendMessage to Web Extension content scripts.
<a href="https://webkit.org/b/261842">https://webkit.org/b/261842</a>
rdar://problem/115805311

Reviewed by Brian Weinstein.

* This adds support for browser.tabs.sendMessage, and browser.runtime.onMessage.
* Cleans up JSON parsing/encoding with some helper functions.
* Introduces WebExtensionFrameIdentifier with conversion to and from WebCore::FrameIdentifier.

* Source/WebKit/DerivedSources-input.xcfilelist: Added WebExtensionMessageSenderParameters.serialization.in.
* Source/WebKit/DerivedSources.make: Ditto.
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::parseJSON): Added.
(WebKit::encodeJSONString): Added.
(WebKit::encodeJSONData): Added.
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers): Added WebExtensionMessageSenderParameters.
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h: Added.
(WebKit::isMainFrame):
(WebKit::toWebCoreFrameIdentifier):
(WebKit::matchesFrame):
(WebKit::toWebExtensionFrameIdentifier):
(WebKit::toWebAPI):
* Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h: Copied from Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl.
* Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in: Added.
* Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h:
(WebKit::toWebAPI): Added const.
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::toWebAPI): Added.
* Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h:
(WebKit::toWebAPI): Added const.
* Source/WebKit/Shared/Extensions/_WKWebExtensionLocalization.mm:
(-[_WKWebExtensionLocalization _localizationDictionaryForWebExtension:withLocale:]): Drive-by cleanup.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsSendMessage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::WebExtension): Use JSON helper.
(WebKit::WebExtension::parseManifest): Ditto.
(WebKit::WebExtension::serializeManifest): Ditto.
(WebKit::WebExtension::serializeLocalization): Ditto.
(WebKit::WebExtension::resourceDataForPath): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::processes const): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::pageListensForEvent const): Added.
(WebKit::WebExtensionContext::processes const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::sendToProcesses): Added.
(WebKit::WebExtensionContext::sendToProcessesForEvent): Use sendToProcesses().
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::onMessage): Added.
(WebKit::WebExtensionContextProxy::dispatchRuntimeMessageEvent): Added.
(WebKit::WebExtensionContextProxy::dispatchRuntimeContentScriptMessageEvent): Added.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::parseSendMessageOptions): Added.
(WebKit::WebExtensionAPITabs::sendMessage): Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
(WebKit::toWebPage): Made a RefPtr to match toWebFrame.
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile): Added using WTF. Remove a const that was giving a build error.
(_returnExpression): Added .get() in a few places since a RefPtr is used now.
(_dynamicAttributesImplementation): Ditto.
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::webExtensionContextProxies): Moved here due to ARC issues with the JSON helpers.
(WebKit::WebExtensionContextProxy::get): Ditto.
(WebKit::WebExtensionContextProxy::WebExtensionContextProxy): Ditto.
(WebKit::WebExtensionContextProxy::~WebExtensionContextProxy): Ditto.
(WebKit::WebExtensionContextProxy::getOrCreate): Ditto.
(WebKit::WebExtensionContextProxy::parseLocalization): Ditto.
(WebKit::WebExtensionContextProxy::parseJSON): Deleted.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::enumerateFramesAndNamespaceObjects):
(WebKit::webExtensionContextProxies): Deleted. Moved to WebExtensionContextProxyCocoa.mm.
(WebKit::WebExtensionContextProxy::get): Deleted. Ditto.
(WebKit::WebExtensionContextProxy::getOrCreate): Deleted. Ditto.
(WebKit::WebExtensionContextProxy::WebExtensionContextProxy): Deleted. Ditto.
(WebKit::WebExtensionContextProxy::~WebExtensionContextProxy): Deleted. Ditto.
(WebKit::WebExtensionContextProxy::enumerateNamespaceObjects): Deleted.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST): Added new tabs.sendMessage tests.

Canonical link: <a href="https://commits.webkit.org/268270@main">https://commits.webkit.org/268270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a06da48d0a12a2ff7db16237d0ed4b9c5b6baaa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19199 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/19614 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/20212 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21088 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17968 "Failed to checkout and rebase branch from PR 17990") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19741 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21961 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19374 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17487 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21797 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21732 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2343 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->