### PR TITLE
Use more smart pointers in editing code

### DIFF
--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -39,15 +39,15 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-ApplyBlockElementCommand::ApplyBlockElementCommand(Document& document, const QualifiedName& tagName, const AtomString& inlineStyle)
-    : CompositeEditCommand(document)
+ApplyBlockElementCommand::ApplyBlockElementCommand(Ref<Document>&& document, const QualifiedName& tagName, const AtomString& inlineStyle)
+    : CompositeEditCommand(WTFMove(document))
     , m_tagName(tagName)
     , m_inlineStyle(inlineStyle)
 {
 }
 
-ApplyBlockElementCommand::ApplyBlockElementCommand(Document& document, const QualifiedName& tagName)
-    : CompositeEditCommand(document)
+ApplyBlockElementCommand::ApplyBlockElementCommand(Ref<Document>&& document, const QualifiedName& tagName)
+    : CompositeEditCommand(WTFMove(document))
     , m_tagName(tagName)
 {
 }

--- a/Source/WebCore/editing/ApplyBlockElementCommand.h
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.h
@@ -37,8 +37,8 @@ namespace WebCore {
 
 class ApplyBlockElementCommand : public CompositeEditCommand {
 protected:
-    ApplyBlockElementCommand(Document&, const QualifiedName& tagName, const AtomString& inlineStyle);
-    ApplyBlockElementCommand(Document&, const QualifiedName& tagName);
+    ApplyBlockElementCommand(Ref<Document>&&, const QualifiedName& tagName, const AtomString& inlineStyle);
+    ApplyBlockElementCommand(Ref<Document>&&, const QualifiedName& tagName);
 
     virtual void formatSelection(const VisiblePosition& startOfSelection, const VisiblePosition& endOfSelection);
     Ref<HTMLElement> createBlockElement();

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -121,8 +121,8 @@ Ref<HTMLElement> createStyleSpanElement(Document& document)
     return createHTMLElement(document, spanTag);
 }
 
-ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* style, EditAction editingAction, PropertyLevel propertyLevel)
-    : CompositeEditCommand(document, editingAction)
+ApplyStyleCommand::ApplyStyleCommand(Ref<Document>&& document, const EditingStyle* style, EditAction editingAction, PropertyLevel propertyLevel)
+    : CompositeEditCommand(WTFMove(document), editingAction)
     , m_style(style->copy())
     , m_propertyLevel(propertyLevel)
     , m_start(endingSelection().start().downstream())
@@ -132,8 +132,8 @@ ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* sty
 {
 }
 
-ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* style, const Position& start, const Position& end, EditAction editingAction, PropertyLevel propertyLevel)
-    : CompositeEditCommand(document, editingAction)
+ApplyStyleCommand::ApplyStyleCommand(Ref<Document>&& document, const EditingStyle* style, const Position& start, const Position& end, EditAction editingAction, PropertyLevel propertyLevel)
+    : CompositeEditCommand(WTFMove(document), editingAction)
     , m_style(style->copy())
     , m_propertyLevel(propertyLevel)
     , m_start(start)
@@ -154,8 +154,8 @@ ApplyStyleCommand::ApplyStyleCommand(Ref<Element>&& element, bool removeOnly, Ed
 {
 }
 
-ApplyStyleCommand::ApplyStyleCommand(Document& document, const EditingStyle* style, IsInlineElementToRemoveFunction isInlineElementToRemoveFunction, EditAction editingAction)
-    : CompositeEditCommand(document, editingAction)
+ApplyStyleCommand::ApplyStyleCommand(Ref<Document>&& document, const EditingStyle* style, IsInlineElementToRemoveFunction isInlineElementToRemoveFunction, EditAction editingAction)
+    : CompositeEditCommand(WTFMove(document), editingAction)
     , m_style(style->copy())
     , m_start(endingSelection().start().downstream())
     , m_end(endingSelection().end().upstream())

--- a/Source/WebCore/editing/ApplyStyleCommand.h
+++ b/Source/WebCore/editing/ApplyStyleCommand.h
@@ -47,28 +47,28 @@ public:
     enum class AddStyledElement : bool { No, Yes };
     typedef bool (*IsInlineElementToRemoveFunction)(const Element*);
 
-    static Ref<ApplyStyleCommand> create(Document& document, const EditingStyle* style, EditAction action = EditAction::ChangeAttributes, PropertyLevel level = PropertyLevel::Default)
+    static Ref<ApplyStyleCommand> create(Ref<Document>&& document, const EditingStyle* style, EditAction action = EditAction::ChangeAttributes, PropertyLevel level = PropertyLevel::Default)
     {
-        return adoptRef(*new ApplyStyleCommand(document, style, action, level));
+        return adoptRef(*new ApplyStyleCommand(WTFMove(document), style, action, level));
     }
-    static Ref<ApplyStyleCommand> create(Document& document, const EditingStyle* style, const Position& start, const Position& end, EditAction action = EditAction::ChangeAttributes, PropertyLevel level = PropertyLevel::Default)
+    static Ref<ApplyStyleCommand> create(Ref<Document>&& document, const EditingStyle* style, const Position& start, const Position& end, EditAction action = EditAction::ChangeAttributes, PropertyLevel level = PropertyLevel::Default)
     {
-        return adoptRef(*new ApplyStyleCommand(document, style, start, end, action, level));
+        return adoptRef(*new ApplyStyleCommand(WTFMove(document), style, start, end, action, level));
     }
     static Ref<ApplyStyleCommand> create(Ref<Element>&& element, bool removeOnly = false, EditAction action = EditAction::ChangeAttributes)
     {
         return adoptRef(*new ApplyStyleCommand(WTFMove(element), removeOnly, action));
     }
-    static Ref<ApplyStyleCommand> create(Document& document, const EditingStyle* style, IsInlineElementToRemoveFunction isInlineElementToRemoveFunction, EditAction action = EditAction::ChangeAttributes)
+    static Ref<ApplyStyleCommand> create(Ref<Document>&& document, const EditingStyle* style, IsInlineElementToRemoveFunction isInlineElementToRemoveFunction, EditAction action = EditAction::ChangeAttributes)
     {
-        return adoptRef(*new ApplyStyleCommand(document, style, isInlineElementToRemoveFunction, action));
+        return adoptRef(*new ApplyStyleCommand(WTFMove(document), style, isInlineElementToRemoveFunction, action));
     }
 
 private:
-    ApplyStyleCommand(Document&, const EditingStyle*, EditAction, PropertyLevel);
-    ApplyStyleCommand(Document&, const EditingStyle*, const Position& start, const Position& end, EditAction, PropertyLevel);
+    ApplyStyleCommand(Ref<Document>&&, const EditingStyle*, EditAction, PropertyLevel);
+    ApplyStyleCommand(Ref<Document>&&, const EditingStyle*, const Position& start, const Position& end, EditAction, PropertyLevel);
     ApplyStyleCommand(Ref<Element>&&, bool removeOnly, EditAction);
-    ApplyStyleCommand(Document&, const EditingStyle*, bool (*isInlineElementToRemove)(const Element*), EditAction);
+    ApplyStyleCommand(Ref<Document>&&, const EditingStyle*, bool (*isInlineElementToRemove)(const Element*), EditAction);
 
     void doApply() override;
     bool shouldDispatchInputEvents() const final { return false; }

--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -41,8 +41,8 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-BreakBlockquoteCommand::BreakBlockquoteCommand(Document& document)
-    : CompositeEditCommand(document)
+BreakBlockquoteCommand::BreakBlockquoteCommand(Ref<Document>&& document)
+    : CompositeEditCommand(WTFMove(document))
 {
 }
 

--- a/Source/WebCore/editing/BreakBlockquoteCommand.h
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.h
@@ -31,13 +31,13 @@ namespace WebCore {
 
 class BreakBlockquoteCommand : public CompositeEditCommand {
 public:
-    static Ref<BreakBlockquoteCommand> create(Document& document)
+    static Ref<BreakBlockquoteCommand> create(Ref<Document>&& document)
     {
-        return adoptRef(*new BreakBlockquoteCommand(document));
+        return adoptRef(*new BreakBlockquoteCommand(WTFMove(document)));
     }
 
 private:
-    explicit BreakBlockquoteCommand(Document&);
+    explicit BreakBlockquoteCommand(Ref<Document>&&);
     void doApply() override;
 };
 

--- a/Source/WebCore/editing/ChangeListTypeCommand.h
+++ b/Source/WebCore/editing/ChangeListTypeCommand.h
@@ -38,14 +38,14 @@ class ChangeListTypeCommand final : public CompositeEditCommand {
 public:
     enum class Type : uint8_t { ConvertToOrderedList, ConvertToUnorderedList };
     static std::optional<Type> listConversionType(Document&);
-    static Ref<ChangeListTypeCommand> create(Document& document, Type type)
+    static Ref<ChangeListTypeCommand> create(Ref<Document>&& document, Type type)
     {
-        return adoptRef(*new ChangeListTypeCommand(document, type));
+        return adoptRef(*new ChangeListTypeCommand(WTFMove(document), type));
     }
 
 private:
-    ChangeListTypeCommand(Document& document, Type type)
-        : CompositeEditCommand(document)
+    ChangeListTypeCommand(Ref<Document>&& document, Type type)
+        : CompositeEditCommand(WTFMove(document))
         , m_type(type)
     {
     }

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -130,7 +130,7 @@ public:
     virtual RefPtr<DataTransfer> inputEventDataTransfer() const;
 
 protected:
-    explicit CompositeEditCommand(Document&, EditAction = EditAction::Unspecified);
+    explicit CompositeEditCommand(Ref<Document>&&, EditAction = EditAction::Unspecified);
 
     // If willApplyCommand returns false, we won't proceed with applying the command.
     virtual bool willApplyCommand();

--- a/Source/WebCore/editing/CreateLinkCommand.cpp
+++ b/Source/WebCore/editing/CreateLinkCommand.cpp
@@ -32,8 +32,8 @@
 
 namespace WebCore {
 
-CreateLinkCommand::CreateLinkCommand(Document& document, const String& url)
-    : CompositeEditCommand(document)
+CreateLinkCommand::CreateLinkCommand(Ref<Document>&& document, const String& url)
+    : CompositeEditCommand(WTFMove(document))
     , m_url(url)
 {
 }

--- a/Source/WebCore/editing/CreateLinkCommand.h
+++ b/Source/WebCore/editing/CreateLinkCommand.h
@@ -31,15 +31,15 @@ namespace WebCore {
 
 class CreateLinkCommand : public CompositeEditCommand {
 public:
-    static Ref<CreateLinkCommand> create(Document& document, const String& linkURL)
+    static Ref<CreateLinkCommand> create(Ref<Document>&& document, const String& linkURL)
     {
-        return adoptRef(*new CreateLinkCommand(document, linkURL));
+        return adoptRef(*new CreateLinkCommand(WTFMove(document), linkURL));
     }
 
     bool isCreateLinkCommand() const override { return true; }
 
 private:
-    CreateLinkCommand(Document&, const String& linkURL);
+    CreateLinkCommand(Ref<Document>&&, const String& linkURL);
 
     void doApply() override;
     EditAction editingAction() const override { return EditAction::CreateLink; }

--- a/Source/WebCore/editing/DeleteSelectionCommand.h
+++ b/Source/WebCore/editing/DeleteSelectionCommand.h
@@ -33,9 +33,9 @@ class EditingStyle;
 
 class DeleteSelectionCommand : public CompositeEditCommand { 
 public:
-    static Ref<DeleteSelectionCommand> create(Document& document, bool smartDelete = false, bool mergeBlocksAfterDelete = true, bool replace = false, bool expandForSpecialElements = false, bool sanitizeMarkup = true, EditAction editingAction = EditAction::Delete)
+    static Ref<DeleteSelectionCommand> create(Ref<Document>&& document, bool smartDelete = false, bool mergeBlocksAfterDelete = true, bool replace = false, bool expandForSpecialElements = false, bool sanitizeMarkup = true, EditAction editingAction = EditAction::Delete)
     {
-        return adoptRef(*new DeleteSelectionCommand(document, smartDelete, mergeBlocksAfterDelete, replace, expandForSpecialElements, sanitizeMarkup, editingAction));
+        return adoptRef(*new DeleteSelectionCommand(WTFMove(document), smartDelete, mergeBlocksAfterDelete, replace, expandForSpecialElements, sanitizeMarkup, editingAction));
     }
     static Ref<DeleteSelectionCommand> create(const VisibleSelection& selection, bool smartDelete = false, bool mergeBlocksAfterDelete = true, bool replace = false, bool expandForSpecialElements = false, bool sanitizeMarkup = true, EditAction editingAction = EditAction::Delete)
     {
@@ -43,7 +43,7 @@ public:
     }
 
 protected:
-    DeleteSelectionCommand(Document&, bool smartDelete, bool mergeBlocksAfterDelete, bool replace, bool expandForSpecialElements, bool santizeMarkup, EditAction = EditAction::Delete);
+    DeleteSelectionCommand(Ref<Document>&&, bool smartDelete, bool mergeBlocksAfterDelete, bool replace, bool expandForSpecialElements, bool santizeMarkup, EditAction = EditAction::Delete);
 
 private:
     DeleteSelectionCommand(const VisibleSelection&, bool smartDelete, bool mergeBlocksAfterDelete, bool replace, bool expandForSpecialElements, bool sanitizeMarkup, EditAction);

--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -81,16 +81,16 @@ private:
     Vector<DictationAlternative> m_alternatives;
 };
 
-DictationCommand::DictationCommand(Document& document, const String& text, const Vector<DictationAlternative>& alternatives)
-    : TextInsertionBaseCommand(document)
+DictationCommand::DictationCommand(Ref<Document>&& document, const String& text, const Vector<DictationAlternative>& alternatives)
+    : TextInsertionBaseCommand(WTFMove(document))
     , m_textToInsert(text)
     , m_alternatives(alternatives)
 {
 }
 
-void DictationCommand::insertText(Document& document, const String& text, const Vector<DictationAlternative>& alternatives, const VisibleSelection& selectionForInsertion)
+void DictationCommand::insertText(Ref<Document>&& document, const String& text, const Vector<DictationAlternative>& alternatives, const VisibleSelection& selectionForInsertion)
 {
-    RefPtr frame { document.frame() };
+    RefPtr frame { document->frame() };
     ASSERT(frame);
 
     VisibleSelection currentSelection = frame->selection().selection();
@@ -99,11 +99,11 @@ void DictationCommand::insertText(Document& document, const String& text, const 
 
     RefPtr<DictationCommand> cmd;
     if (newText == text)
-        cmd = DictationCommand::create(document, newText, alternatives);
+        cmd = DictationCommand::create(WTFMove(document), newText, alternatives);
     else
         // If the text was modified before insertion, the location of dictation alternatives
         // will not be valid anymore. We will just drop the alternatives.
-        cmd = DictationCommand::create(document, newText, Vector<DictationAlternative>());
+        cmd = DictationCommand::create(WTFMove(document), newText, Vector<DictationAlternative>());
     applyTextInsertionCommand(frame.get(), *cmd, selectionForInsertion, currentSelection);
 }
 
@@ -127,7 +127,7 @@ void DictationCommand::insertParagraphSeparator()
     if (!canAppendNewLineFeedToSelection(endingSelection()))
         return;
 
-    applyCommandToComposite(InsertParagraphSeparatorCommand::create(document(), false, false, EditAction::Dictation));
+    applyCommandToComposite(InsertParagraphSeparatorCommand::create(protectedDocument(), false, false, EditAction::Dictation));
 }
 
 void DictationCommand::collectDictationAlternativesInRange(size_t rangeStart, size_t rangeLength, Vector<DictationAlternative>& alternatives)

--- a/Source/WebCore/editing/DictationCommand.h
+++ b/Source/WebCore/editing/DictationCommand.h
@@ -33,15 +33,15 @@ namespace WebCore {
 class DictationCommand : public TextInsertionBaseCommand {
     friend class DictationCommandLineOperation;
 public:
-    static void insertText(Document&, const String&, const Vector<DictationAlternative>& alternatives, const VisibleSelection&);
+    static void insertText(Ref<Document>&&, const String&, const Vector<DictationAlternative>& alternatives, const VisibleSelection&);
     bool isDictationCommand() const override { return true; }
 private:
-    static Ref<DictationCommand> create(Document& document, const String& text, const Vector<DictationAlternative>& alternatives)
+    static Ref<DictationCommand> create(Ref<Document>&& document, const String& text, const Vector<DictationAlternative>& alternatives)
     {
-        return adoptRef(*new DictationCommand(document, text, alternatives));
+        return adoptRef(*new DictationCommand(WTFMove(document), text, alternatives));
     }
 
-    DictationCommand(Document&, const String& text, const Vector<DictationAlternative>& alternatives);
+    DictationCommand(Ref<Document>&&, const String& text, const Vector<DictationAlternative>& alternatives);
     
     void doApply() override;
 

--- a/Source/WebCore/editing/EditCommand.cpp
+++ b/Source/WebCore/editing/EditCommand.cpp
@@ -135,16 +135,16 @@ bool isInputMethodComposingForEditingAction(EditAction action)
     return false;
 }
 
-EditCommand::EditCommand(Document& document, EditAction editingAction)
-    : m_document { document }
+EditCommand::EditCommand(Ref<Document>&& document, EditAction editingAction)
+    : m_document { WTFMove(document) }
     , m_startingSelection { m_document->selection().selection() }
     , m_endingSelection { m_startingSelection }
     , m_editingAction { editingAction }
 {
 }
 
-EditCommand::EditCommand(Document& document, const VisibleSelection& startingSelection, const VisibleSelection& endingSelection)
-    : m_document { document }
+EditCommand::EditCommand(Ref<Document>&& document, const VisibleSelection& startingSelection, const VisibleSelection& endingSelection)
+    : m_document { WTFMove(document) }
     , m_startingSelection { startingSelection }
     , m_endingSelection { endingSelection }
 {
@@ -219,8 +219,8 @@ void EditCommand::postTextStateChangeNotification(AXTextEditType type, const Str
     cache->postTextStateChangeNotification(node.get(), type, text, position);
 }
 
-SimpleEditCommand::SimpleEditCommand(Document& document, EditAction editingAction)
-    : EditCommand(document, editingAction)
+SimpleEditCommand::SimpleEditCommand(Ref<Document>&& document, EditAction editingAction)
+    : EditCommand(WTFMove(document), editingAction)
 {
 }
 

--- a/Source/WebCore/editing/EditCommand.h
+++ b/Source/WebCore/editing/EditCommand.h
@@ -62,8 +62,8 @@ public:
     virtual void doApply() = 0;
 
 protected:
-    explicit EditCommand(Document&, EditAction = EditAction::Unspecified);
-    EditCommand(Document&, const VisibleSelection&, const VisibleSelection&);
+    explicit EditCommand(Ref<Document>&&, EditAction = EditAction::Unspecified);
+    EditCommand(Ref<Document>&&, const VisibleSelection&, const VisibleSelection&);
 
     Ref<Document> protectedDocument() const { return m_document.copyRef(); }
     const Document& document() const { return m_document; }
@@ -100,7 +100,7 @@ public:
 #endif
 
 protected:
-    explicit SimpleEditCommand(Document&, EditAction = EditAction::Unspecified);
+    explicit SimpleEditCommand(Ref<Document>&&, EditAction = EditAction::Unspecified);
 
 #ifndef NDEBUG
     void addNodeAndDescendants(Node*, HashSet<Ref<Node>>&);

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -407,6 +407,7 @@ public:
 
     // getting international text input composition state (for use by LegacyInlineTextBox)
     Text* compositionNode() const { return m_compositionNode.get(); }
+    RefPtr<Text> protectedCompositionNode() const { return m_compositionNode; }
     unsigned compositionStart() const { return m_compositionStart; }
     unsigned compositionEnd() const { return m_compositionEnd; }
     bool compositionUsesCustomUnderlines() const { return !m_customCompositionUnderlines.isEmpty(); }
@@ -600,7 +601,8 @@ public:
     bool isCopyingFromMenuOrKeyBinding() const { return m_copyingFromMenuOrKeyBinding; }
 
 private:
-    Document& document() const { return m_document; }
+    Document& document() const { return m_document.get(); }
+    Ref<Document> protectedDocument() const { return m_document.get(); }
 
     bool canDeleteRange(const SimpleRange&) const;
     bool canSmartReplaceWithPasteboard(Pasteboard&);
@@ -656,7 +658,7 @@ private:
     void postTextStateChangeNotificationForCut(const String&, const VisibleSelection&);
 
     WeakPtr<EditorClient> m_client;
-    Document& m_document;
+    CheckedRef<Document> m_document;
     RefPtr<CompositeEditCommand> m_lastEditCommand;
     RefPtr<Text> m_compositionNode;
     unsigned m_compositionStart;

--- a/Source/WebCore/editing/FormatBlockCommand.cpp
+++ b/Source/WebCore/editing/FormatBlockCommand.cpp
@@ -48,8 +48,8 @@ static inline bool isElementForFormatBlock(Node* node)
     return is<Element>(*node) && isElementForFormatBlock(downcast<Element>(*node).tagQName());
 }
 
-FormatBlockCommand::FormatBlockCommand(Document& document, const QualifiedName& tagName)
-    : ApplyBlockElementCommand(document, tagName)
+FormatBlockCommand::FormatBlockCommand(Ref<Document>&& document, const QualifiedName& tagName)
+    : ApplyBlockElementCommand(WTFMove(document), tagName)
     , m_didApply(false)
 {
 }

--- a/Source/WebCore/editing/FormatBlockCommand.h
+++ b/Source/WebCore/editing/FormatBlockCommand.h
@@ -39,9 +39,9 @@ class VisiblePosition;
 
 class FormatBlockCommand : public ApplyBlockElementCommand {
 public:
-    static Ref<FormatBlockCommand> create(Document& document, const QualifiedName& tagName)
+    static Ref<FormatBlockCommand> create(Ref<Document>&& document, const QualifiedName& tagName)
     {
-        return adoptRef(*new FormatBlockCommand(document, tagName));
+        return adoptRef(*new FormatBlockCommand(WTFMove(document), tagName));
     }
     
     bool preservesTypingStyle() const override { return true; }
@@ -50,7 +50,7 @@ public:
     bool didApply() const { return m_didApply; }
 
 private:
-    FormatBlockCommand(Document&, const QualifiedName& tagName);
+    FormatBlockCommand(Ref<Document>&&, const QualifiedName& tagName);
 
     void formatSelection(const VisiblePosition& startOfSelection, const VisiblePosition& endOfSelection) override;
     void formatRange(const Position& start, const Position& end, const Position& endOfSelection, RefPtr<Element>&) override;

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -49,8 +49,8 @@ static bool isListOrIndentBlockquote(const Node* node)
     return node && (node->hasTagName(ulTag) || node->hasTagName(olTag) || node->hasTagName(blockquoteTag));
 }
 
-IndentOutdentCommand::IndentOutdentCommand(Document& document, EIndentType typeOfAction)
-    : ApplyBlockElementCommand(document, blockquoteTag, "margin: 0 0 0 40px; border: none; padding: 0px;"_s)
+IndentOutdentCommand::IndentOutdentCommand(Ref<Document>&& document, EIndentType typeOfAction)
+    : ApplyBlockElementCommand(WTFMove(document), blockquoteTag, "margin: 0 0 0 40px; border: none; padding: 0px;"_s)
     , m_typeOfAction(typeOfAction)
 {
 }
@@ -143,11 +143,11 @@ void IndentOutdentCommand::outdentParagraph()
     // Use InsertListCommand to remove the selection from the list
     auto document = protectedDocument();
     if (enclosingNode->hasTagName(olTag)) {
-        applyCommandToComposite(InsertListCommand::create(document, InsertListCommand::Type::OrderedList));
+        applyCommandToComposite(InsertListCommand::create(WTFMove(document), InsertListCommand::Type::OrderedList));
         return;        
     }
     if (enclosingNode->hasTagName(ulTag)) {
-        applyCommandToComposite(InsertListCommand::create(document, InsertListCommand::Type::UnorderedList));
+        applyCommandToComposite(InsertListCommand::create(WTFMove(document), InsertListCommand::Type::UnorderedList));
         return;
     }
     

--- a/Source/WebCore/editing/IndentOutdentCommand.h
+++ b/Source/WebCore/editing/IndentOutdentCommand.h
@@ -33,15 +33,15 @@ namespace WebCore {
 class IndentOutdentCommand : public ApplyBlockElementCommand {
 public:
     enum EIndentType { Indent, Outdent };
-    static Ref<IndentOutdentCommand> create(Document& document, EIndentType type)
+    static Ref<IndentOutdentCommand> create(Ref<Document>&& document, EIndentType type)
     {
-        return adoptRef(*new IndentOutdentCommand(document, type));
+        return adoptRef(*new IndentOutdentCommand(WTFMove(document), type));
     }
 
     bool preservesTypingStyle() const override { return true; }
 
 private:
-    IndentOutdentCommand(Document&, EIndentType);
+    IndentOutdentCommand(Ref<Document>&&, EIndentType);
 
     EditAction editingAction() const override { return m_typeOfAction == Indent ? EditAction::Indent : EditAction::Outdent; }
 

--- a/Source/WebCore/editing/InsertLineBreakCommand.h
+++ b/Source/WebCore/editing/InsertLineBreakCommand.h
@@ -31,13 +31,13 @@ namespace WebCore {
 
 class InsertLineBreakCommand : public CompositeEditCommand {
 public:
-    static Ref<InsertLineBreakCommand> create(Document& document)
+    static Ref<InsertLineBreakCommand> create(Ref<Document>&& document)
     {
-        return adoptRef(*new InsertLineBreakCommand(document));
+        return adoptRef(*new InsertLineBreakCommand(WTFMove(document)));
     }
 
 private:
-    explicit InsertLineBreakCommand(Document&);
+    explicit InsertLineBreakCommand(Ref<Document>&&);
 
     void doApply() override;
 

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -49,9 +49,9 @@ static Node* enclosingListChild(Node* node, Node* listNode)
     return listChild;
 }
 
-RefPtr<HTMLElement> InsertListCommand::insertList(Document& document, Type type)
+RefPtr<HTMLElement> InsertListCommand::insertList(Ref<Document>&& document, Type type)
 {
-    RefPtr<InsertListCommand> insertCommand = create(document, type);
+    RefPtr<InsertListCommand> insertCommand = create(WTFMove(document), type);
     insertCommand->apply();
     return insertCommand->m_listElement;
 }
@@ -110,8 +110,8 @@ bool InsertListCommand::selectionHasListOfType(const VisibleSelection& selection
     return true;
 }
 
-InsertListCommand::InsertListCommand(Document& document, Type type)
-    : CompositeEditCommand(document)
+InsertListCommand::InsertListCommand(Ref<Document>&& document, Type type)
+    : CompositeEditCommand(WTFMove(document))
     , m_type(type)
 {
 }

--- a/Source/WebCore/editing/InsertListCommand.h
+++ b/Source/WebCore/editing/InsertListCommand.h
@@ -36,17 +36,17 @@ class InsertListCommand final : public CompositeEditCommand {
 public:
     enum class Type : uint8_t { OrderedList, UnorderedList };
 
-    static Ref<InsertListCommand> create(Document& document, Type listType)
+    static Ref<InsertListCommand> create(Ref<Document>&& document, Type listType)
     {
-        return adoptRef(*new InsertListCommand(document, listType));
+        return adoptRef(*new InsertListCommand(WTFMove(document), listType));
     }
 
-    static RefPtr<HTMLElement> insertList(Document&, Type);
+    static RefPtr<HTMLElement> insertList(Ref<Document>&&, Type);
     
     bool preservesTypingStyle() const final { return true; }
 
 private:
-    InsertListCommand(Document&, Type);
+    InsertListCommand(Ref<Document>&&, Type);
 
     void doApply() final;
     EditAction editingAction() const final;

--- a/Source/WebCore/editing/InsertNestedListCommand.h
+++ b/Source/WebCore/editing/InsertNestedListCommand.h
@@ -38,13 +38,13 @@ public:
 private:
     enum class Type : uint8_t { OrderedList, UnorderedList };
 
-    static Ref<InsertNestedListCommand> create(Document& document, Type type)
+    static Ref<InsertNestedListCommand> create(Ref<Document>&& document, Type type)
     {
-        return adoptRef(*new InsertNestedListCommand(document, type));
+        return adoptRef(*new InsertNestedListCommand(WTFMove(document), type));
     }
 
-    InsertNestedListCommand(Document& document, Type type)
-        : CompositeEditCommand(document)
+    InsertNestedListCommand(Ref<Document>&& document, Type type)
+        : CompositeEditCommand(WTFMove(document))
         , m_type(type)
     {
     }

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -61,8 +61,8 @@ static Element* highestVisuallyEquivalentDivBelowRoot(Element* startBlock)
     return curBlock;
 }
 
-InsertParagraphSeparatorCommand::InsertParagraphSeparatorCommand(Document& document, bool mustUseDefaultParagraphElement, bool pasteBlockqutoeIntoUnquotedArea, EditAction editingAction)
-    : CompositeEditCommand(document, editingAction)
+InsertParagraphSeparatorCommand::InsertParagraphSeparatorCommand(Ref<Document>&& document, bool mustUseDefaultParagraphElement, bool pasteBlockqutoeIntoUnquotedArea, EditAction editingAction)
+    : CompositeEditCommand(WTFMove(document), editingAction)
     , m_mustUseDefaultParagraphElement(mustUseDefaultParagraphElement)
     , m_pasteBlockqutoeIntoUnquotedArea(pasteBlockqutoeIntoUnquotedArea)
 {

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.h
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.h
@@ -33,13 +33,13 @@ class EditingStyle;
 
 class InsertParagraphSeparatorCommand : public CompositeEditCommand {
 public:
-    static Ref<InsertParagraphSeparatorCommand> create(Document& document, bool useDefaultParagraphElement = false, bool pasteBlockqutoeIntoUnquotedArea = false, EditAction editingAction = EditAction::Insert)
+    static Ref<InsertParagraphSeparatorCommand> create(Ref<Document>&& document, bool useDefaultParagraphElement = false, bool pasteBlockqutoeIntoUnquotedArea = false, EditAction editingAction = EditAction::Insert)
     {
-        return adoptRef(*new InsertParagraphSeparatorCommand(document, useDefaultParagraphElement, pasteBlockqutoeIntoUnquotedArea, editingAction));
+        return adoptRef(*new InsertParagraphSeparatorCommand(WTFMove(document), useDefaultParagraphElement, pasteBlockqutoeIntoUnquotedArea, editingAction));
     }
 
 private:
-    InsertParagraphSeparatorCommand(Document&, bool useDefaultParagraphElement, bool pasteBlockqutoeIntoUnquotedArea, EditAction);
+    InsertParagraphSeparatorCommand(Ref<Document>&&, bool useDefaultParagraphElement, bool pasteBlockqutoeIntoUnquotedArea, EditAction);
 
     void doApply() override;
 

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -37,16 +37,16 @@
 
 namespace WebCore {
 
-InsertTextCommand::InsertTextCommand(Document& document, const String& text, bool selectInsertedText, RebalanceType rebalanceType, EditAction editingAction)
-    : CompositeEditCommand(document, editingAction)
+InsertTextCommand::InsertTextCommand(Ref<Document>&& document, const String& text, bool selectInsertedText, RebalanceType rebalanceType, EditAction editingAction)
+    : CompositeEditCommand(WTFMove(document), editingAction)
     , m_text(text)
     , m_selectInsertedText(selectInsertedText)
     , m_rebalanceType(rebalanceType)
 {
 }
 
-InsertTextCommand::InsertTextCommand(Document& document, const String& text, Ref<TextInsertionMarkerSupplier>&& markerSupplier, EditAction editingAction)
-    : CompositeEditCommand(document, editingAction)
+InsertTextCommand::InsertTextCommand(Ref<Document>&& document, const String& text, Ref<TextInsertionMarkerSupplier>&& markerSupplier, EditAction editingAction)
+    : CompositeEditCommand(WTFMove(document), editingAction)
     , m_text(text)
     , m_selectInsertedText(false)
     , m_rebalanceType(RebalanceLeadingAndTrailingWhitespaces)

--- a/Source/WebCore/editing/InsertTextCommand.h
+++ b/Source/WebCore/editing/InsertTextCommand.h
@@ -47,20 +47,20 @@ public:
         RebalanceAllWhitespaces
     };
 
-    static Ref<InsertTextCommand> create(Document& document, const String& text, bool selectInsertedText = false,
+    static Ref<InsertTextCommand> create(Ref<Document>&& document, const String& text, bool selectInsertedText = false,
         RebalanceType rebalanceType = RebalanceLeadingAndTrailingWhitespaces, EditAction editingAction = EditAction::Insert)
     {
-        return adoptRef(*new InsertTextCommand(document, text, selectInsertedText, rebalanceType, editingAction));
+        return adoptRef(*new InsertTextCommand(WTFMove(document), text, selectInsertedText, rebalanceType, editingAction));
     }
 
-    static Ref<InsertTextCommand> createWithMarkerSupplier(Document& document, const String& text, Ref<TextInsertionMarkerSupplier>&& markerSupplier, EditAction editingAction = EditAction::Insert)
+    static Ref<InsertTextCommand> createWithMarkerSupplier(Ref<Document>&& document, const String& text, Ref<TextInsertionMarkerSupplier>&& markerSupplier, EditAction editingAction = EditAction::Insert)
     {
-        return adoptRef(*new InsertTextCommand(document, text, WTFMove(markerSupplier), editingAction));
+        return adoptRef(*new InsertTextCommand(WTFMove(document), text, WTFMove(markerSupplier), editingAction));
     }
 
 protected:
-    InsertTextCommand(Document&, const String& text, Ref<TextInsertionMarkerSupplier>&&, EditAction);
-    InsertTextCommand(Document&, const String& text, bool selectInsertedText, RebalanceType, EditAction);
+    InsertTextCommand(Ref<Document>&&, const String& text, Ref<TextInsertionMarkerSupplier>&&, EditAction);
+    InsertTextCommand(Ref<Document>&&, const String& text, bool selectInsertedText, RebalanceType, EditAction);
 
 private:
 

--- a/Source/WebCore/editing/ModifySelectionListLevel.cpp
+++ b/Source/WebCore/editing/ModifySelectionListLevel.cpp
@@ -37,8 +37,8 @@
 
 namespace WebCore {
 
-ModifySelectionListLevelCommand::ModifySelectionListLevelCommand(Document& document)
-    : CompositeEditCommand(document)
+ModifySelectionListLevelCommand::ModifySelectionListLevelCommand(Ref<Document>&& document)
+    : CompositeEditCommand(WTFMove(document))
 {
 }
 
@@ -140,8 +140,8 @@ void ModifySelectionListLevelCommand::appendSiblingNodeRange(Node* startNode, No
     ASSERT_NOT_REACHED();
 }
 
-IncreaseSelectionListLevelCommand::IncreaseSelectionListLevelCommand(Document& document, Type listType)
-    : ModifySelectionListLevelCommand(document)
+IncreaseSelectionListLevelCommand::IncreaseSelectionListLevelCommand(Ref<Document>&& document, Type listType)
+    : ModifySelectionListLevelCommand(WTFMove(document))
     , m_listType(listType)
 {
 }
@@ -239,8 +239,8 @@ RefPtr<Node> IncreaseSelectionListLevelCommand::increaseSelectionListLevelUnorde
     return increaseSelectionListLevel(document, Type::UnorderedList);
 }
 
-DecreaseSelectionListLevelCommand::DecreaseSelectionListLevelCommand(Document& document)
-    : ModifySelectionListLevelCommand(document)
+DecreaseSelectionListLevelCommand::DecreaseSelectionListLevelCommand(Ref<Document>&& document)
+    : ModifySelectionListLevelCommand(WTFMove(document))
 {
 }
 

--- a/Source/WebCore/editing/ModifySelectionListLevel.h
+++ b/Source/WebCore/editing/ModifySelectionListLevel.h
@@ -34,7 +34,7 @@ namespace WebCore {
 // It is not used on its own.
 class ModifySelectionListLevelCommand : public CompositeEditCommand {
 protected:
-    explicit ModifySelectionListLevelCommand(Document&);
+    explicit ModifySelectionListLevelCommand(Ref<Document>&&);
     
     void appendSiblingNodeRange(Node* startNode, Node* endNode, Element* newParent);
     void insertSiblingNodeRangeBefore(Node* startNode, Node* endNode, Node* refNode);
@@ -61,7 +61,7 @@ public:
 private:
     static RefPtr<Node> increaseSelectionListLevel(Document*, Type);
     
-    IncreaseSelectionListLevelCommand(Document&, Type);
+    IncreaseSelectionListLevelCommand(Ref<Document>&&, Type);
 
     void doApply() override;
 
@@ -76,12 +76,12 @@ public:
     static void decreaseSelectionListLevel(Document*);
 
 private:
-    static Ref<DecreaseSelectionListLevelCommand> create(Document& document)
+    static Ref<DecreaseSelectionListLevelCommand> create(Ref<Document>&& document)
     {
-        return adoptRef(*new DecreaseSelectionListLevelCommand(document));
+        return adoptRef(*new DecreaseSelectionListLevelCommand(WTFMove(document)));
     }
 
-    explicit DecreaseSelectionListLevelCommand(Document&);
+    explicit DecreaseSelectionListLevelCommand(Ref<Document>&&);
 
     void doApply() override;
 };

--- a/Source/WebCore/editing/RemoveFormatCommand.cpp
+++ b/Source/WebCore/editing/RemoveFormatCommand.cpp
@@ -41,8 +41,8 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-RemoveFormatCommand::RemoveFormatCommand(Document& document)
-    : CompositeEditCommand(document)
+RemoveFormatCommand::RemoveFormatCommand(Ref<Document>&& document)
+    : CompositeEditCommand(WTFMove(document))
 {
 }
 

--- a/Source/WebCore/editing/RemoveFormatCommand.h
+++ b/Source/WebCore/editing/RemoveFormatCommand.h
@@ -31,13 +31,13 @@ namespace WebCore {
 
 class RemoveFormatCommand : public CompositeEditCommand {
 public:
-    static Ref<RemoveFormatCommand> create(Document& document)
+    static Ref<RemoveFormatCommand> create(Ref<Document>&& document)
     {
-        return adoptRef(*new RemoveFormatCommand(document));
+        return adoptRef(*new RemoveFormatCommand(WTFMove(document)));
     }
 
 private:
-    explicit RemoveFormatCommand(Document&);
+    explicit RemoveFormatCommand(Ref<Document>&&);
 
     void doApply() override;
     EditAction editingAction() const override { return EditAction::Unspecified; }

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -458,8 +458,8 @@ inline void ReplaceSelectionCommand::InsertedNodes::didReplaceNode(Node* node, N
         m_lastNodeInserted = newNode;
 }
 
-ReplaceSelectionCommand::ReplaceSelectionCommand(Document& document, RefPtr<DocumentFragment>&& fragment, OptionSet<CommandOption> options, EditAction editAction)
-    : CompositeEditCommand(document, editAction)
+ReplaceSelectionCommand::ReplaceSelectionCommand(Ref<Document>&& document, RefPtr<DocumentFragment>&& fragment, OptionSet<CommandOption> options, EditAction editAction)
+    : CompositeEditCommand(WTFMove(document), editAction)
     , m_selectReplacement(options & SelectReplacement)
     , m_smartReplace(options & SmartReplace)
     , m_matchStyle(options & MatchStyle)

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -46,9 +46,9 @@ public:
         IgnoreMailBlockquote = 1 << 6,
     };
 
-    static Ref<ReplaceSelectionCommand> create(Document& document, RefPtr<DocumentFragment>&& fragment, OptionSet<CommandOption> options, EditAction editingAction = EditAction::Insert)
+    static Ref<ReplaceSelectionCommand> create(Ref<Document>&& document, RefPtr<DocumentFragment>&& fragment, OptionSet<CommandOption> options, EditAction editingAction = EditAction::Insert)
     {
-        return adoptRef(*new ReplaceSelectionCommand(document, WTFMove(fragment), options, editingAction));
+        return adoptRef(*new ReplaceSelectionCommand(WTFMove(document), WTFMove(fragment), options, editingAction));
     }
 
     VisibleSelection visibleSelectionForInsertedText() const { return m_visibleSelectionForInsertedText; }
@@ -57,7 +57,7 @@ public:
     std::optional<SimpleRange> insertedContentRange() const;
 
 private:
-    ReplaceSelectionCommand(Document&, RefPtr<DocumentFragment>&&, OptionSet<CommandOption>, EditAction);
+    ReplaceSelectionCommand(Ref<Document>&&, RefPtr<DocumentFragment>&&, OptionSet<CommandOption>, EditAction);
 
     String inputEventData() const final;
     RefPtr<DataTransfer> inputEventDataTransfer() const final;

--- a/Source/WebCore/editing/SimplifyMarkupCommand.cpp
+++ b/Source/WebCore/editing/SimplifyMarkupCommand.cpp
@@ -34,8 +34,8 @@
 
 namespace WebCore {
 
-SimplifyMarkupCommand::SimplifyMarkupCommand(Document& document, Node* firstNode, Node* nodeAfterLast)
-    : CompositeEditCommand(document)
+SimplifyMarkupCommand::SimplifyMarkupCommand(Ref<Document>&& document, Node* firstNode, Node* nodeAfterLast)
+    : CompositeEditCommand(WTFMove(document))
     , m_firstNode(firstNode)
     , m_nodeAfterLast(nodeAfterLast)
 {

--- a/Source/WebCore/editing/SimplifyMarkupCommand.h
+++ b/Source/WebCore/editing/SimplifyMarkupCommand.h
@@ -31,13 +31,13 @@ namespace WebCore {
 
 class SimplifyMarkupCommand : public CompositeEditCommand {
 public:
-    static Ref<SimplifyMarkupCommand> create(Document& document, Node* firstNode, Node* nodeAfterLast)
+    static Ref<SimplifyMarkupCommand> create(Ref<Document>&& document, Node* firstNode, Node* nodeAfterLast)
     {
-        return adoptRef(*new SimplifyMarkupCommand(document, firstNode, nodeAfterLast));
+        return adoptRef(*new SimplifyMarkupCommand(WTFMove(document), firstNode, nodeAfterLast));
     }
 
 private:
-    SimplifyMarkupCommand(Document&, Node* firstNode, Node* nodeAfterLast);
+    SimplifyMarkupCommand(Ref<Document>&&, Node* firstNode, Node* nodeAfterLast);
 
     void doApply() override;
     int pruneSubsequentAncestorsToRemove(Vector<Ref<Node>>& nodesToRemove, size_t startNodeIndex);

--- a/Source/WebCore/editing/SpellingCorrectionCommand.cpp
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.cpp
@@ -45,13 +45,13 @@ namespace WebCore {
 // This information is needed by spell checking service to update user specific data.
 class SpellingCorrectionRecordUndoCommand : public SimpleEditCommand {
 public:
-    static Ref<SpellingCorrectionRecordUndoCommand> create(Document& document, const String& corrected, const String& correction)
+    static Ref<SpellingCorrectionRecordUndoCommand> create(Ref<Document>&& document, const String& corrected, const String& correction)
     {
-        return adoptRef(*new SpellingCorrectionRecordUndoCommand(document, corrected, correction));
+        return adoptRef(*new SpellingCorrectionRecordUndoCommand(WTFMove(document), corrected, correction));
     }
 private:
-    SpellingCorrectionRecordUndoCommand(Document& document, const String& corrected, const String& correction)
-        : SimpleEditCommand(document)
+    SpellingCorrectionRecordUndoCommand(Ref<Document>&& document, const String& corrected, const String& correction)
+        : SimpleEditCommand(WTFMove(document))
         , m_corrected(corrected)
         , m_correction(correction)
         , m_hasBeenUndone(false)

--- a/Source/WebCore/editing/TextInsertionBaseCommand.cpp
+++ b/Source/WebCore/editing/TextInsertionBaseCommand.cpp
@@ -35,8 +35,8 @@
 
 namespace WebCore {
 
-TextInsertionBaseCommand::TextInsertionBaseCommand(Document& document, EditAction editingAction)
-    : CompositeEditCommand(document, editingAction)
+TextInsertionBaseCommand::TextInsertionBaseCommand(Ref<Document>&& document, EditAction editingAction)
+    : CompositeEditCommand(WTFMove(document), editingAction)
 {
 }
 

--- a/Source/WebCore/editing/TextInsertionBaseCommand.h
+++ b/Source/WebCore/editing/TextInsertionBaseCommand.h
@@ -35,10 +35,10 @@ class VisibleSelection;
 
 class TextInsertionBaseCommand : public CompositeEditCommand {
 public:
-    virtual ~TextInsertionBaseCommand() { };
+    virtual ~TextInsertionBaseCommand() { }
 
 protected:
-    explicit TextInsertionBaseCommand(Document&, EditAction = EditAction::Unspecified);
+    explicit TextInsertionBaseCommand(Ref<Document>&&, EditAction = EditAction::Unspecified);
     static void applyTextInsertionCommand(LocalFrame*, TextInsertionBaseCommand&, const VisibleSelection& selectionForInsertion, const VisibleSelection& endingSelection);
 };
 

--- a/Source/WebCore/editing/TypingCommand.h
+++ b/Source/WebCore/editing/TypingCommand.h
@@ -56,14 +56,14 @@ public:
         IsAutocompletion = 1 << 5,
     };
 
-    static void deleteSelection(Document&, OptionSet<Option> = { }, TextCompositionType = TextCompositionType::None);
-    static void deleteKeyPressed(Document&, OptionSet<Option> = { }, TextGranularity = TextGranularity::CharacterGranularity);
-    static void forwardDeleteKeyPressed(Document&, OptionSet<Option> = { }, TextGranularity = TextGranularity::CharacterGranularity);
-    static void insertText(Document&, const String&, OptionSet<Option>, TextCompositionType = TextCompositionType::None);
-    static void insertText(Document&, const String&, const VisibleSelection&, OptionSet<Option>, TextCompositionType = TextCompositionType::None);
-    static void insertLineBreak(Document&, OptionSet<Option>);
-    static void insertParagraphSeparator(Document&, OptionSet<Option>);
-    static void insertParagraphSeparatorInQuotedContent(Document&);
+    static void deleteSelection(Ref<Document>&&, OptionSet<Option> = { }, TextCompositionType = TextCompositionType::None);
+    static void deleteKeyPressed(Ref<Document>&&, OptionSet<Option> = { }, TextGranularity = TextGranularity::CharacterGranularity);
+    static void forwardDeleteKeyPressed(Ref<Document>&&, OptionSet<Option> = { }, TextGranularity = TextGranularity::CharacterGranularity);
+    static void insertText(Ref<Document>&&, const String&, OptionSet<Option>, TextCompositionType = TextCompositionType::None);
+    static void insertText(Ref<Document>&&, const String&, const VisibleSelection&, OptionSet<Option>, TextCompositionType = TextCompositionType::None);
+    static void insertLineBreak(Ref<Document>&&, OptionSet<Option>);
+    static void insertParagraphSeparator(Ref<Document>&&, OptionSet<Option>);
+    static void insertParagraphSeparatorInQuotedContent(Ref<Document>&&);
     static void closeTyping(Document&);
 #if PLATFORM(IOS_FAMILY)
     static void ensureLastEditCommandHasCurrentSelectionIfOpenForMoreTyping(Document&, const VisibleSelection&);
@@ -85,17 +85,17 @@ public:
 #endif
 
 private:
-    static Ref<TypingCommand> create(Document& document, Type command, const String& text = emptyString(), OptionSet<Option> options = { }, TextGranularity granularity = TextGranularity::CharacterGranularity, TextCompositionType compositionType = TextCompositionType::None)
+    static Ref<TypingCommand> create(Ref<Document>&& document, Type command, const String& text = emptyString(), OptionSet<Option> options = { }, TextGranularity granularity = TextGranularity::CharacterGranularity, TextCompositionType compositionType = TextCompositionType::None)
     {
-        return adoptRef(*new TypingCommand(document, command, text, options, granularity, compositionType));
+        return adoptRef(*new TypingCommand(WTFMove(document), command, text, options, granularity, compositionType));
     }
 
-    static Ref<TypingCommand> create(Document& document, Type command, const String& text, OptionSet<Option> options, TextCompositionType compositionType)
+    static Ref<TypingCommand> create(Ref<Document>&& document, Type command, const String& text, OptionSet<Option> options, TextCompositionType compositionType)
     {
-        return adoptRef(*new TypingCommand(document, command, text, options, TextGranularity::CharacterGranularity, compositionType));
+        return adoptRef(*new TypingCommand(WTFMove(document), command, text, options, TextGranularity::CharacterGranularity, compositionType));
     }
 
-    TypingCommand(Document&, Type, const String& text, OptionSet<Option>, TextGranularity, TextCompositionType);
+    TypingCommand(Ref<Document>&&, Type, const String& text, OptionSet<Option>, TextGranularity, TextCompositionType);
 
     bool smartDelete() const { return m_smartDelete; }
     void setSmartDelete(bool smartDelete) { m_smartDelete = smartDelete; }

--- a/Source/WebCore/editing/UnlinkCommand.cpp
+++ b/Source/WebCore/editing/UnlinkCommand.cpp
@@ -30,8 +30,8 @@
 
 namespace WebCore {
 
-UnlinkCommand::UnlinkCommand(Document& document)
-    : CompositeEditCommand(document)
+UnlinkCommand::UnlinkCommand(Ref<Document>&& document)
+    : CompositeEditCommand(WTFMove(document))
 {
 }
 

--- a/Source/WebCore/editing/UnlinkCommand.h
+++ b/Source/WebCore/editing/UnlinkCommand.h
@@ -31,13 +31,13 @@ namespace WebCore {
 
 class UnlinkCommand : public CompositeEditCommand {
 public:
-    static Ref<UnlinkCommand> create(Document& document)
+    static Ref<UnlinkCommand> create(Ref<Document>&& document)
     {
-        return adoptRef(*new UnlinkCommand(document));
+        return adoptRef(*new UnlinkCommand(WTFMove(document)));
     }
 
 private:
-    explicit UnlinkCommand(Document&);
+    explicit UnlinkCommand(Ref<Document>&&);
 
     void doApply() override;
     EditAction editingAction() const override { return EditAction::Unlink; }

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -598,7 +598,7 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
     
         // The selection ends in editable content or non-editable content inside a different editable ancestor, 
         // move backward until non-editable content inside the same lowest editable ancestor is reached.
-        auto* endEditableAncestor = lowestEditableAncestor(m_end.containerNode());
+        auto* endEditableAncestor = lowestEditableAncestor(m_end.protectedContainerNode().get());
         if (endRoot || endEditableAncestor != baseEditableAncestor) {
             
             Position p = previousVisuallyDistinctCandidate(m_end);

--- a/Source/WebCore/editing/gtk/EditorGtk.cpp
+++ b/Source/WebCore/editing/gtk/EditorGtk.cpp
@@ -116,14 +116,14 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
     PasteboardWebContent pasteboardContent;
     pasteboardContent.canSmartCopyOrDelete = canSmartCopyOrDelete();
     pasteboardContent.text = selectedTextForDataTransfer();
-    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes);
-    pasteboardContent.contentOrigin = m_document.originIdentifierForPasteboard();
+    pasteboardContent.markup = serializePreservingVisualAppearance(document().selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes);
+    pasteboardContent.contentOrigin = document().originIdentifierForPasteboard();
     pasteboard.write(pasteboardContent);
 }
 
 RefPtr<DocumentFragment> Editor::webContentFromPasteboard(Pasteboard& pasteboard, const SimpleRange& context, bool allowPlainText, bool& chosePlainText)
 {
-    WebContentReader reader(*m_document.frame(), context, allowPlainText);
+    WebContentReader reader(*document().frame(), context, allowPlainText);
     pasteboard.read(reader);
     chosePlainText = reader.madeFragmentFromPlainText;
     return WTFMove(reader.fragment);

--- a/Source/WebCore/editing/ios/DictationCommandIOS.cpp
+++ b/Source/WebCore/editing/ios/DictationCommandIOS.cpp
@@ -38,16 +38,16 @@
 
 namespace WebCore {
 
-DictationCommandIOS::DictationCommandIOS(Document& document, Vector<Vector<String>>&& dictationPhrases, id metadata)
-    : CompositeEditCommand(document, EditAction::Dictation)
+DictationCommandIOS::DictationCommandIOS(Ref<Document>&& document, Vector<Vector<String>>&& dictationPhrases, id metadata)
+    : CompositeEditCommand(WTFMove(document), EditAction::Dictation)
     , m_dictationPhrases(WTFMove(dictationPhrases))
     , m_metadata(metadata)
 {
 }
 
-Ref<DictationCommandIOS> DictationCommandIOS::create(Document& document, Vector<Vector<String>>&& dictationPhrases, id metadata)
+Ref<DictationCommandIOS> DictationCommandIOS::create(Ref<Document>&& document, Vector<Vector<String>>&& dictationPhrases, id metadata)
 {
-    return adoptRef(*new DictationCommandIOS(document, WTFMove(dictationPhrases), metadata));
+    return adoptRef(*new DictationCommandIOS(WTFMove(document), WTFMove(dictationPhrases), metadata));
 }
 
 void DictationCommandIOS::doApply()

--- a/Source/WebCore/editing/ios/DictationCommandIOS.h
+++ b/Source/WebCore/editing/ios/DictationCommandIOS.h
@@ -34,10 +34,10 @@ namespace WebCore {
 
 class DictationCommandIOS final : public CompositeEditCommand {
 public:
-    static Ref<DictationCommandIOS> create(Document&, Vector<Vector<String>>&& dictationPhrases, id metadata);
+    static Ref<DictationCommandIOS> create(Ref<Document>&&, Vector<Vector<String>>&& dictationPhrases, id metadata);
 
 private:
-    DictationCommandIOS(Document&, Vector<Vector<String>>&& dictationPhrases, id metadata);
+    DictationCommandIOS(Ref<Document>&&, Vector<Vector<String>>&& dictationPhrases, id metadata);
 
     void doApply() final;
 

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -69,7 +69,8 @@ void Editor::setTextAlignmentForChangedBaseWritingDirection(WritingDirection dir
     // If the text has left or right alignment, flip left->right and right->left. 
     // Otherwise, do nothing.
 
-    auto selectionStyle = EditingStyle::styleAtSelectionStart(m_document.selection().selection());
+    Ref document = protectedDocument();
+    auto selectionStyle = EditingStyle::styleAtSelectionStart(document->selection().selection());
     if (!selectionStyle || !selectionStyle->style())
          return;
 
@@ -114,14 +115,14 @@ void Editor::setTextAlignmentForChangedBaseWritingDirection(WritingDirection dir
         return;
     }
 
-    Element* focusedElement = m_document.focusedElement();
+    RefPtr focusedElement = document->focusedElement();
     if (focusedElement && (is<HTMLTextAreaElement>(*focusedElement) || (is<HTMLInputElement>(*focusedElement)
         && (downcast<HTMLInputElement>(*focusedElement).isTextField()
             || downcast<HTMLInputElement>(*focusedElement).isSearchField())))) {
         if (direction == WritingDirection::Natural)
             return;
         downcast<HTMLElement>(*focusedElement).setAttributeWithoutSynchronization(alignAttr, nameString(newValue));
-        m_document.updateStyleIfNeeded();
+        document->updateStyleIfNeeded();
         return;
     }
 
@@ -134,7 +135,7 @@ void Editor::removeUnchangeableStyles()
 {
     // This function removes styles that the user cannot modify by applying their default values.
     
-    auto editingStyle = EditingStyle::create(m_document.bodyOrFrameset());
+    auto editingStyle = EditingStyle::create(document().bodyOrFrameset());
     auto defaultStyle = editingStyle->style()->mutableCopy();
     
     // Text widgets implement background color via the UIView property. Their body element will not have one.
@@ -205,7 +206,7 @@ void Editor::pasteWithPasteboard(Pasteboard* pasteboard, OptionSet<PasteOption> 
 {
     auto range = selectedRange();
     bool allowPlainText = options.contains(PasteOption::AllowPlainText);
-    WebContentReader reader(*m_document.frame(), *range, allowPlainText);
+    WebContentReader reader(*document().frame(), *range, allowPlainText);
     int numberOfPasteboardItems = client()->getPasteboardItemsCount();
     for (int i = 0; i < numberOfPasteboardItems; ++i) {
         auto fragment = client()->documentFragmentFromDelegate(i);
@@ -237,13 +238,14 @@ void Editor::platformPasteFont()
 
 void Editor::insertDictationPhrases(Vector<Vector<String>>&& dictationPhrases, id metadata)
 {
-    if (m_document.selection().isNone())
+    Ref document = protectedDocument();
+    if (document->selection().isNone())
         return;
 
     if (dictationPhrases.isEmpty())
         return;
 
-    DictationCommandIOS::create(document(), WTFMove(dictationPhrases), metadata)->apply();
+    DictationCommandIOS::create(WTFMove(document), WTFMove(dictationPhrases), metadata)->apply();
 }
 
 void Editor::setDictationPhrasesAsChildOfElement(const Vector<Vector<String>>& dictationPhrases, id metadata, Element& element)
@@ -255,7 +257,8 @@ void Editor::setDictationPhrasesAsChildOfElement(const Vector<Vector<String>>& d
     // Some day we could make them Undoable, and let callers clear the Undo stack explicitly if they wish.
     clearUndoRedoOperations();
 
-    m_document.selection().clear();
+    Ref document = protectedDocument();
+    document->selection().clear();
 
     element.removeChildren();
 
@@ -275,7 +278,7 @@ void Editor::setDictationPhrasesAsChildOfElement(const Vector<Vector<String>>& d
     WeakPtr weakElement { element };
 
     // We need a layout in order to add markers below.
-    document().updateLayout();
+    document->updateLayout();
 
     if (!weakElement)
         return;
@@ -307,11 +310,12 @@ void Editor::confirmMarkedText()
 {
     // FIXME: This is a hacky workaround for the keyboard calling this method too late -
     // after the selection and focus have already changed. See <rdar://problem/5975559>.
-    RefPtr focused = document().focusedElement();
+    Ref document = protectedDocument();
+    RefPtr focused = document->focusedElement();
     RefPtr composition = compositionNode();
     if (composition && focused && !composition->isDescendantOrShadowDescendantOf(*focused)) {
         cancelComposition();
-        document().setFocusedElement(focused.get());
+        document->setFocusedElement(focused.get());
     } else
         confirmComposition();
 }
@@ -332,14 +336,15 @@ void Editor::setTextAsChildOfElement(String&& text, Element& element)
 
     // As a side effect this function sets a caret selection after the inserted content.
     // What follows is more expensive if there is a selection, so clear it since it's going to change anyway.
-    m_document.selection().clear();
+    Ref document = protectedDocument();
+    document->selection().clear();
 
     element.stringReplaceAll(WTFMove(text));
 
     VisiblePosition afterContents = makeContainerOffsetPosition(&element, element.countChildNodes());
     if (afterContents.isNull())
         return;
-    m_document.selection().setSelection(afterContents);
+    document->selection().setSelection(afterContents);
 
     client()->respondToChangedContents();
 }
@@ -348,7 +353,8 @@ void Editor::setTextAsChildOfElement(String&& text, Element& element)
 // have a stale selection.
 void Editor::ensureLastEditCommandHasCurrentSelectionIfOpenForMoreTyping()
 {
-    TypingCommand::ensureLastEditCommandHasCurrentSelectionIfOpenForMoreTyping(m_document, m_document.selection().selection());
+    Ref document = protectedDocument();
+    TypingCommand::ensureLastEditCommandHasCurrentSelectionIfOpenForMoreTyping(document, document->selection().selection());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
+++ b/Source/WebCore/editing/libwpe/EditorLibWPE.cpp
@@ -66,7 +66,7 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
 {
     PasteboardWebContent pasteboardContent;
     pasteboardContent.text = selectedTextForDataTransfer();
-    pasteboardContent.markup = serializePreservingVisualAppearance(m_document.selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes);
+    pasteboardContent.markup = serializePreservingVisualAppearance(document().selection().selection(), ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::Yes, IgnoreUserSelectNone::Yes);
     pasteboard.write(pasteboardContent);
 }
 
@@ -82,7 +82,7 @@ void Editor::pasteWithPasteboard(Pasteboard* pasteboard, OptionSet<PasteOption> 
         return;
 
     bool chosePlainText;
-    auto fragment = createFragmentFromPasteboardData(*pasteboard, *m_document.frame(), *range, options.contains(PasteOption::AllowPlainText), chosePlainText);
+    auto fragment = createFragmentFromPasteboardData(*pasteboard, *document().frame(), *range, options.contains(PasteOption::AllowPlainText), chosePlainText);
 
     if (fragment && options.contains(PasteOption::AsQuotation))
         quoteFragmentForPasting(*fragment);

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -87,13 +87,13 @@ void Editor::pasteWithPasteboard(Pasteboard* pasteboard, OptionSet<PasteOption> 
 
 void Editor::platformCopyFont()
 {
-    Pasteboard pasteboard(PagePasteboardContext::create(m_document.pageID()), NSPasteboardNameFont);
+    Pasteboard pasteboard(PagePasteboardContext::create(document().pageID()), NSPasteboardNameFont);
 
     auto fontSampleString = adoptNS([[NSAttributedString alloc] initWithString:@"x" attributes:fontAttributesAtSelectionStart().createDictionary().get()]);
     auto fontData = RetainPtr([fontSampleString RTFFromRange:NSMakeRange(0, [fontSampleString length]) documentAttributes:@{ }]);
 
     PasteboardBuffer pasteboardBuffer;
-    pasteboardBuffer.contentOrigin = m_document.originIdentifierForPasteboard();
+    pasteboardBuffer.contentOrigin = document().originIdentifierForPasteboard();
     pasteboardBuffer.type = legacyFontPasteboardType();
     pasteboardBuffer.data = SharedBuffer::create(fontData.get());
     pasteboard.write(pasteboardBuffer);
@@ -101,7 +101,7 @@ void Editor::platformCopyFont()
 
 void Editor::platformPasteFont()
 {
-    Pasteboard pasteboard(PagePasteboardContext::create(m_document.pageID()), NSPasteboardNameFont);
+    Pasteboard pasteboard(PagePasteboardContext::create(document().pageID()), NSPasteboardNameFont);
 
     client()->setInsertionPasteboard(pasteboard.name());
 
@@ -216,7 +216,7 @@ static void getImage(Element& imageElement, RefPtr<Image>& image, CachedImage*& 
 
 void Editor::selectionWillChange()
 {
-    if (!hasComposition() || ignoreSelectionChanges() || m_document.selection().isNone() || !m_document.hasLivingRenderTree())
+    if (!hasComposition() || ignoreSelectionChanges() || document().selection().isNone() || !document().hasLivingRenderTree())
         return;
 
     cancelComposition();

--- a/Source/WebCore/editing/win/EditorWin.cpp
+++ b/Source/WebCore/editing/win/EditorWin.cpp
@@ -44,7 +44,7 @@ void Editor::pasteWithPasteboard(Pasteboard* pasteboard, OptionSet<PasteOption> 
         return;
 
     bool chosePlainText;
-    auto fragment = pasteboard->documentFragment(*m_document.frame(), *range, options.contains(PasteOption::AllowPlainText), chosePlainText);
+    auto fragment = pasteboard->documentFragment(*document().frame(), *range, options.contains(PasteOption::AllowPlainText), chosePlainText);
 
     if (fragment && options.contains(PasteOption::AsQuotation))
         quoteFragmentForPasting(*fragment);
@@ -79,9 +79,9 @@ static RefPtr<DocumentFragment> createFragmentFromPlatformData(PlatformDragData&
 RefPtr<DocumentFragment> Editor::webContentFromPasteboard(Pasteboard& pasteboard, const SimpleRange&, bool /*allowPlainText*/, bool& /*chosePlainText*/)
 {
     if (COMPtr<IDataObject> platformDragData = pasteboard.dataObject())
-        return createFragmentFromPlatformData(*platformDragData, *m_document.frame());
+        return createFragmentFromPlatformData(*platformDragData, *document().frame());
 
-    return createFragmentFromPlatformData(pasteboard.dragDataMap(), *m_document.frame());
+    return createFragmentFromPlatformData(pasteboard.dragDataMap(), *document().frame());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 46e64865e4eda18aa70e6e8061ffd78359f57b63
<pre>
Use more smart pointers in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=261844">https://bugs.webkit.org/show_bug.cgi?id=261844</a>

Reviewed by Brent Fulgham.

* Source/WebCore/editing/ApplyBlockElementCommand.cpp:
(WebCore::ApplyBlockElementCommand::ApplyBlockElementCommand):
* Source/WebCore/editing/ApplyBlockElementCommand.h:
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::ApplyStyleCommand):
* Source/WebCore/editing/ApplyStyleCommand.h:
(WebCore::ApplyStyleCommand::create):
* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
(WebCore::BreakBlockquoteCommand::BreakBlockquoteCommand):
* Source/WebCore/editing/BreakBlockquoteCommand.h:
(WebCore::BreakBlockquoteCommand::create):
* Source/WebCore/editing/ChangeListTypeCommand.h:
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::CompositeEditCommand):
(WebCore::CompositeEditCommand::apply):
(WebCore::CompositeEditCommand::ensureComposition):
(WebCore::CompositeEditCommand::applyStyle):
(WebCore::CompositeEditCommand::insertParagraphSeparator):
(WebCore::CompositeEditCommand::insertLineBreak):
(WebCore::CompositeEditCommand::inputText):
(WebCore::CompositeEditCommand::deleteSelection):
(WebCore::CompositeEditCommand::deleteInsignificantText):
(WebCore::CompositeEditCommand::appendBlockPlaceholder):
(WebCore::CompositeEditCommand::insertBlockPlaceholder):
(WebCore::CompositeEditCommand::addBlockPlaceholderIfNeeded):
(WebCore::CompositeEditCommand::insertNewDefaultParagraphElementAt):
(WebCore::CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary):
(WebCore::CompositeEditCommand::moveParagraphWithClones):
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/CompositeEditCommand.h:
* Source/WebCore/editing/CreateLinkCommand.cpp:
(WebCore::CreateLinkCommand::CreateLinkCommand):
* Source/WebCore/editing/CreateLinkCommand.h:
(WebCore::CreateLinkCommand::create):
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::DeleteSelectionCommand):
(WebCore::DeleteSelectionCommand::removeNode):
(WebCore::DeleteSelectionCommand::handleGeneralDelete):
* Source/WebCore/editing/DeleteSelectionCommand.h:
(WebCore::DeleteSelectionCommand::create):
* Source/WebCore/editing/DictationCommand.cpp:
(WebCore::DictationCommand::DictationCommand):
(WebCore::DictationCommand::insertText):
(WebCore::DictationCommand::insertParagraphSeparator):
* Source/WebCore/editing/DictationCommand.h:
(WebCore::DictationCommand::create):
* Source/WebCore/editing/EditCommand.cpp:
(WebCore::EditCommand::EditCommand):
(WebCore::SimpleEditCommand::SimpleEditCommand):
* Source/WebCore/editing/EditCommand.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::ClearTextCommand::ClearTextCommand):
(WebCore::ClearTextCommand::CreateAndApply):
(WebCore::TemporarySelectionChange::TemporarySelectionChange):
(WebCore::Editor::selectionForCommand):
(WebCore::Editor::behavior const):
(WebCore::Editor::client const):
(WebCore::Editor::canEdit const):
(WebCore::Editor::canEditRichly const):
(WebCore::Editor::canDHTMLCut):
(WebCore::Editor::canDHTMLCopy):
(WebCore::Editor::canCopy const):
(WebCore::Editor::canPaste const):
(WebCore::Editor::canDelete const):
(WebCore::Editor::shouldSmartDelete):
(WebCore::Editor::deleteWithDirection):
(WebCore::Editor::deleteSelectionWithSmartDelete):
(WebCore::Editor::clearText):
(WebCore::Editor::pasteAsPlainText):
(WebCore::Editor::pasteAsPlainTextBypassingDHTML):
(WebCore::Editor::replaceSelectionWithFragment):
(WebCore::Editor::selectedRange):
(WebCore::Editor::tryDHTMLCopy):
(WebCore::Editor::tryDHTMLCut):
(WebCore::Editor::shouldInsertText const):
(WebCore::Editor::hasBidiSelection const):
(WebCore::Editor::selectionUnorderedListState const):
(WebCore::Editor::selectionOrderedListState const):
(WebCore::Editor::insertOrderedList):
(WebCore::Editor::insertUnorderedList):
(WebCore::Editor::increaseSelectionListLevel):
(WebCore::Editor::increaseSelectionListLevelOrdered):
(WebCore::Editor::increaseSelectionListLevelUnordered):
(WebCore::Editor::decreaseSelectionListLevel):
(WebCore::Editor::removeFormattingAndStyle):
(WebCore::Editor::findEventTargetFromSelection const):
(WebCore::Editor::applyStyle):
(WebCore::Editor::applyParagraphStyle):
(WebCore::Editor::applyStyleToSelection):
(WebCore::Editor::applyParagraphStyleToSelection):
(WebCore::Editor::selectionStartHasStyle const):
(WebCore::Editor::selectionHasStyle const):
(WebCore::Editor::selectionStartCSSPropertyValue):
(WebCore::Editor::indent):
(WebCore::Editor::outdent):
(WebCore::Editor::appliedEditing):
(WebCore::Editor::unappliedEditing):
(WebCore::Editor::reappliedEditing):
(WebCore::Editor::clear):
(WebCore::Editor::insertText):
(WebCore::Editor::insertTextForConfirmedComposition):
(WebCore::Editor::insertTextWithoutSendingTextEvent):
(WebCore::Editor::insertLineBreak):
(WebCore::Editor::insertParagraphSeparator):
(WebCore::Editor::insertParagraphSeparatorInQuotedContent):
(WebCore::Editor::canCopyFont const):
(WebCore::Editor::performCutOrCopy):
(WebCore::Editor::paste):
(WebCore::Editor::pasteAsQuotation):
(WebCore::Editor::quoteFragmentForPasting):
(WebCore::Editor::changeSelectionListType):
(WebCore::Editor::simplifyMarkup):
(WebCore::Editor::copyURL):
(WebCore::Editor::copyImage):
(WebCore::Editor::revealSelectionIfNeededAfterLoadingImageForElement):
(WebCore::Editor::renderLayerDidScroll):
(WebCore::Editor::registerCustomUndoStep):
(WebCore::Editor::setBaseWritingDirection):
(WebCore::Editor::baseWritingDirectionForSelectionStart const):
(WebCore::Editor::selectComposition):
(WebCore::Editor::confirmOrCancelCompositionAndNotifyClient):
(WebCore::SetCompositionScope::SetCompositionScope):
(WebCore::Editor::setComposition):
(WebCore::Editor::ignoreSpelling):
(WebCore::Editor::learnSpelling):
(WebCore::Editor::advanceToNextMisspelling):
(WebCore::Editor::misspelledWordAtCaretOrRange const):
(WebCore::Editor::guessesForMisspelledWord const):
(WebCore::Editor::guessesForMisspelledOrUngrammatical):
(WebCore::Editor::markMisspellingsAfterTypingToWord):
(WebCore::Editor::isSpellCheckingEnabledInFocusedNode const):
(WebCore::Editor::markAllMisspellingsAndBadGrammarInRanges):
(WebCore::Editor::markAndReplaceFor):
(WebCore::Editor::updateMarkersForWordsAffectedByEditing):
(WebCore::Editor::rangeForPoint):
(WebCore::Editor::revealSelectionAfterEditingOperation):
(WebCore::Editor::setIgnoreSelectionChanges):
(WebCore::Editor::getCompositionSelection const):
(WebCore::Editor::transpose):
(WebCore::Editor::changeSelectionAfterCommand):
(WebCore::Editor::selectedText const):
(WebCore::Editor::selectedTextForDataTransfer const):
(WebCore::Editor::insertTextPlaceholder):
(WebCore::Editor::removeTextPlaceholder):
(WebCore::Editor::shouldChangeSelection const):
(WebCore::Editor::computeAndSetTypingStyle):
(WebCore::Editor::findString):
(WebCore::Editor::rangeOfString):
(WebCore::Editor::countMatchesForText):
(WebCore::Editor::respondToChangedSelection):
(WebCore::Editor::shouldDetectTelephoneNumbers const):
(WebCore::Editor::scanSelectionForTelephoneNumbers):
(WebCore::Editor::editorUIUpdateTimerFired):
(WebCore::Editor::selectionStartHasMarkerFor const):
(WebCore::Editor::stringForCandidateRequest const):
(WebCore::Editor::contextRangeForCandidateRequest const):
(WebCore::Editor::fontAttributesAtSelectionStart):
(WebCore::Editor::notifyClientOfAttachmentUpdates):
(WebCore::Editor::insertAttachment):
(WebCore::Editor::handleAcceptedCandidate):
(WebCore::Editor::unifiedTextCheckerEnabled const):
(WebCore::Editor::toggleOverwriteModeEnabled):
(WebCore::Editor::styleForSelectionStart):
(WebCore::Editor::fontForSelection):
(WebCore::Editor::canCopyExcludingStandaloneImages const):
* Source/WebCore/editing/Editor.h:
(WebCore::Editor::protectedCompositionNode const):
(WebCore::Editor::document const):
(WebCore::Editor::protectedDocument const):
* Source/WebCore/editing/FormatBlockCommand.cpp:
(WebCore::FormatBlockCommand::FormatBlockCommand):
* Source/WebCore/editing/FormatBlockCommand.h:
(WebCore::FormatBlockCommand::create):
* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::IndentOutdentCommand::IndentOutdentCommand):
(WebCore::IndentOutdentCommand::outdentParagraph):
* Source/WebCore/editing/IndentOutdentCommand.h:
(WebCore::IndentOutdentCommand::create):
* Source/WebCore/editing/InsertLineBreakCommand.cpp:
(WebCore::InsertLineBreakCommand::InsertLineBreakCommand):
(WebCore::InsertLineBreakCommand::doApply):
* Source/WebCore/editing/InsertLineBreakCommand.h:
(WebCore::InsertLineBreakCommand::create):
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::InsertListCommand::insertList):
(WebCore::InsertListCommand::InsertListCommand):
* Source/WebCore/editing/InsertListCommand.h:
* Source/WebCore/editing/InsertNestedListCommand.h:
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::InsertParagraphSeparatorCommand::InsertParagraphSeparatorCommand):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.h:
(WebCore::InsertParagraphSeparatorCommand::create):
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::InsertTextCommand):
* Source/WebCore/editing/InsertTextCommand.h:
(WebCore::InsertTextCommand::create):
(WebCore::InsertTextCommand::createWithMarkerSupplier):
* Source/WebCore/editing/ModifySelectionListLevel.cpp:
(WebCore::ModifySelectionListLevelCommand::ModifySelectionListLevelCommand):
(WebCore::IncreaseSelectionListLevelCommand::IncreaseSelectionListLevelCommand):
(WebCore::DecreaseSelectionListLevelCommand::DecreaseSelectionListLevelCommand):
* Source/WebCore/editing/ModifySelectionListLevel.h:
(WebCore::DecreaseSelectionListLevelCommand::create):
* Source/WebCore/editing/RemoveFormatCommand.cpp:
(WebCore::RemoveFormatCommand::RemoveFormatCommand):
* Source/WebCore/editing/RemoveFormatCommand.h:
(WebCore::RemoveFormatCommand::create):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::ReplaceSelectionCommand):
* Source/WebCore/editing/ReplaceSelectionCommand.h:
(WebCore::ReplaceSelectionCommand::create):
* Source/WebCore/editing/SimplifyMarkupCommand.cpp:
(WebCore::SimplifyMarkupCommand::SimplifyMarkupCommand):
* Source/WebCore/editing/SimplifyMarkupCommand.h:
(WebCore::SimplifyMarkupCommand::create):
* Source/WebCore/editing/SpellingCorrectionCommand.cpp:
(WebCore::SpellingCorrectionRecordUndoCommand::create):
(WebCore::SpellingCorrectionRecordUndoCommand::SpellingCorrectionRecordUndoCommand):
* Source/WebCore/editing/TextInsertionBaseCommand.cpp:
(WebCore::TextInsertionBaseCommand::TextInsertionBaseCommand):
* Source/WebCore/editing/TextInsertionBaseCommand.h:
(WebCore::TextInsertionBaseCommand::~TextInsertionBaseCommand):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::advance):
(WebCore::TextIterator::handleTextNode):
(WebCore::TextIterator::handleTextRun):
(WebCore::TextIterator::shouldRepresentNodeOffsetZero):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::TypingCommand):
(WebCore::TypingCommand::deleteSelection):
(WebCore::TypingCommand::deleteKeyPressed):
(WebCore::TypingCommand::forwardDeleteKeyPressed):
(WebCore::TypingCommand::insertText):
(WebCore::TypingCommand::insertLineBreak):
(WebCore::TypingCommand::insertParagraphSeparatorInQuotedContent):
(WebCore::TypingCommand::insertParagraphSeparator):
* Source/WebCore/editing/TypingCommand.h:
* Source/WebCore/editing/UnlinkCommand.cpp:
(WebCore::UnlinkCommand::UnlinkCommand):
* Source/WebCore/editing/UnlinkCommand.h:
(WebCore::UnlinkCommand::create):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries):
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::selectionInHTMLFormat):
(WebCore::Editor::writeSelectionToPasteboard):
(WebCore::Editor::writeSelection):
(WebCore::Editor::selectionInWebArchiveFormat):
(WebCore::Editor::replaceSelectionWithAttributedString):
(WebCore::Editor::webContentFromPasteboard):
(WebCore::Editor::takeFindStringFromSelection):
(WebCore::Editor::readSelectionFromPasteboard):
(WebCore::Editor::replaceNodeFromPasteboard):
* Source/WebCore/editing/ios/DictationCommandIOS.cpp:
(WebCore::DictationCommandIOS::DictationCommandIOS):
(WebCore::DictationCommandIOS::create):
* Source/WebCore/editing/ios/DictationCommandIOS.h:
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::setTextAsChildOfElement):
(WebCore::Editor::ensureLastEditCommandHasCurrentSelectionIfOpenForMoreTyping):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::Editor::platformCopyFont):
(WebCore::Editor::platformPasteFont):
(WebCore::Editor::selectionWillChange):

Canonical link: <a href="https://commits.webkit.org/268286@main">https://commits.webkit.org/268286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e30b5bd4a03a3e71988fa28ad0e67e391bed460

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19236 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17998 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19778 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21995 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17511 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21824 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17406 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4597 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21763 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->