### PR TITLE
WebCoreTestSupport.h should put export macros to the left of function declarations

### DIFF
--- a/Source/WebCore/testing/js/WebCoreTestSupport.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011, 2015 Google Inc. All rights reserved.
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,41 +44,41 @@ class LocalFrame;
 
 namespace WebCoreTestSupport {
 
-void initializeNames() TEST_SUPPORT_EXPORT;
+TEST_SUPPORT_EXPORT void initializeNames();
 
-void injectInternalsObject(JSContextRef) TEST_SUPPORT_EXPORT;
-void resetInternalsObject(JSContextRef) TEST_SUPPORT_EXPORT;
-void monitorWheelEvents(WebCore::LocalFrame&, bool clearLatchingState) TEST_SUPPORT_EXPORT;
-void setWheelEventMonitorTestCallbackAndStartMonitoring(bool expectWheelEndOrCancel, bool expectMomentumEnd, WebCore::LocalFrame&, JSContextRef, JSObjectRef) TEST_SUPPORT_EXPORT;
-void clearWheelEventTestMonitor(WebCore::LocalFrame&) TEST_SUPPORT_EXPORT;
+TEST_SUPPORT_EXPORT void injectInternalsObject(JSContextRef);
+TEST_SUPPORT_EXPORT void resetInternalsObject(JSContextRef);
+TEST_SUPPORT_EXPORT void monitorWheelEvents(WebCore::LocalFrame&, bool clearLatchingState);
+TEST_SUPPORT_EXPORT void setWheelEventMonitorTestCallbackAndStartMonitoring(bool expectWheelEndOrCancel, bool expectMomentumEnd, WebCore::LocalFrame&, JSContextRef, JSObjectRef);
+TEST_SUPPORT_EXPORT void clearWheelEventTestMonitor(WebCore::LocalFrame&);
 
-void setLogChannelToAccumulate(const String& name) TEST_SUPPORT_EXPORT;
-void clearAllLogChannelsToAccumulate() TEST_SUPPORT_EXPORT;
-void initializeLogChannelsIfNecessary() TEST_SUPPORT_EXPORT;
-void setAllowsAnySSLCertificate(bool) TEST_SUPPORT_EXPORT;
-bool allowsAnySSLCertificate() TEST_SUPPORT_EXPORT;
-void setLinkedOnOrAfterEverythingForTesting() TEST_SUPPORT_EXPORT;
+TEST_SUPPORT_EXPORT void setLogChannelToAccumulate(const String& name);
+TEST_SUPPORT_EXPORT void clearAllLogChannelsToAccumulate();
+TEST_SUPPORT_EXPORT void initializeLogChannelsIfNecessary();
+TEST_SUPPORT_EXPORT void setAllowsAnySSLCertificate(bool);
+TEST_SUPPORT_EXPORT bool allowsAnySSLCertificate();
+TEST_SUPPORT_EXPORT void setLinkedOnOrAfterEverythingForTesting();
 
-void installMockGamepadProvider() TEST_SUPPORT_EXPORT;
-void connectMockGamepad(unsigned index) TEST_SUPPORT_EXPORT;
-void disconnectMockGamepad(unsigned index) TEST_SUPPORT_EXPORT;
-void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble) TEST_SUPPORT_EXPORT;
-void setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value) TEST_SUPPORT_EXPORT;
-void setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value) TEST_SUPPORT_EXPORT;
+TEST_SUPPORT_EXPORT void installMockGamepadProvider();
+TEST_SUPPORT_EXPORT void connectMockGamepad(unsigned index);
+TEST_SUPPORT_EXPORT void disconnectMockGamepad(unsigned index);
+TEST_SUPPORT_EXPORT void setMockGamepadDetails(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble);
+TEST_SUPPORT_EXPORT void setMockGamepadAxisValue(unsigned index, unsigned axisIndex, double value);
+TEST_SUPPORT_EXPORT void setMockGamepadButtonValue(unsigned index, unsigned buttonIndex, double value);
 
-void setupNewlyCreatedServiceWorker(uint64_t serviceWorkerIdentifier) TEST_SUPPORT_EXPORT;
+TEST_SUPPORT_EXPORT void setupNewlyCreatedServiceWorker(uint64_t serviceWorkerIdentifier);
     
-void setAdditionalSupportedImageTypesForTesting(const String&) TEST_SUPPORT_EXPORT;
+TEST_SUPPORT_EXPORT void setAdditionalSupportedImageTypesForTesting(const String&);
 
 #if ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
 #if ENABLE(JIT_OPERATION_DISASSEMBLY)
-void populateDisassemblyLabels() TEST_SUPPORT_EXPORT;
+TEST_SUPPORT_EXPORT void populateDisassemblyLabels();
 #else
 inline void populateDisassemblyLabels() { }
 #endif
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
-void populateJITOperations() TEST_SUPPORT_EXPORT;
+TEST_SUPPORT_EXPORT void populateJITOperations();
 #else
 inline void populateJITOperations() { populateDisassemblyLabels(); }
 #endif


### PR DESCRIPTION
#### 3734d250efe4ee507c25e6df080ee4ffe3653a7f
<pre>
WebCoreTestSupport.h should put export macros to the left of function declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=261851">https://bugs.webkit.org/show_bug.cgi?id=261851</a>
&lt;rdar://115810109&gt;

Reviewed by Alex Christensen.

* Source/WebCore/testing/js/WebCoreTestSupport.h:
- Move TEST_SUPPORT_EXPORT to the beginning of every function
  declaration.

Canonical link: <a href="https://commits.webkit.org/268231@main">https://commits.webkit.org/268231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d47d3981a58a105ca5dcaeaaf0d52e6607ca815

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17825 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21815 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16590 "5 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23759 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21707 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18118 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15356 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17210 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21568 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2330 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->