### PR TITLE
[Filters] Don't override the alpha channel of the GraphicsDropShadow color by the shadow opacity

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsStyle.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.cpp
@@ -36,6 +36,7 @@ TextStream& operator<<(TextStream& ts, const GraphicsDropShadow& dropShadow)
     ts.dumpProperty("radius", dropShadow.radius);
     ts.dumpProperty("color", dropShadow.color);
     ts.dumpProperty("shadows-use-legacy-radius", dropShadow.radiusMode == ShadowRadiusMode::Legacy);
+    ts.dumpProperty("opacity", dropShadow.opacity);
     return ts;
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsStyle.h
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.h
@@ -46,7 +46,8 @@ struct GraphicsDropShadow {
     FloatSize offset;
     float radius;
     Color color;
-    ShadowRadiusMode radiusMode;
+    ShadowRadiusMode radiusMode { ShadowRadiusMode::Default };
+    float opacity { 1 };
 
     bool isVisible() const { return color.isVisible(); }
     bool isBlurred() const { return isVisible() && radius; }
@@ -95,6 +96,8 @@ void GraphicsDropShadow::encode(Encoder& encoder) const
     encoder << offset;
     encoder << radius;
     encoder << color;
+    encoder << radiusMode;
+    encoder << opacity;
 }
 
 template<class Decoder>
@@ -115,13 +118,17 @@ std::optional<GraphicsDropShadow> GraphicsDropShadow::decode(Decoder& decoder)
     if (!color)
         return std::nullopt;
 
-
     std::optional<ShadowRadiusMode> radiusMode;
     decoder >> radiusMode;
     if (!radius)
         return std::nullopt;
 
-    return GraphicsDropShadow { *offset, *radius, *color, *radiusMode };
+    std::optional<float> opacity;
+    decoder >> opacity;
+    if (!opacity)
+        return std::nullopt;
+
+    return GraphicsDropShadow { *offset, *radius, *color, *radiusMode, *opacity };
 }
 
 template<class Encoder>

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1134,6 +1134,8 @@ void GraphicsContextCG::setCGShadow(const GraphicsDropShadow& shadow, bool shado
     if (renderingMode() != RenderingMode::Accelerated)
         applyShadowOffsetWorkaroundIfNeeded(context, xOffset, yOffset);
 
+    CGContextSetAlpha(context, shadow.opacity);
+
 #if HAVE(CGSTYLE_CREATE_SHADOW2)
     auto style = adoptCF(CGStyleCreateShadow2(CGSizeMake(xOffset, yOffset), blurRadius, cachedCGColor(shadow.color).get()));
     CGContextSetStyle(context, style.get());

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
@@ -226,7 +226,7 @@ void DrawGlyphsRecorder::updateShadow(CGStyleRef style)
     auto shadowOffset = FloatSize(std::cos(rad), std::sin(rad)) * shadowStyle.height;
     auto shadowRadius = static_cast<float>(shadowStyle.radius);
     auto shadowColor = CGStyleGetColor(style);
-    updateShadow({ { shadowOffset, shadowRadius, Color::createAndPreserveColorSpace(shadowColor), ShadowRadiusMode::Default } }, ShadowsIgnoreTransforms::Yes);
+    updateShadow({ { shadowOffset, shadowRadius, Color::createAndPreserveColorSpace(shadowColor) } }, ShadowsIgnoreTransforms::Yes);
 }
 
 void DrawGlyphsRecorder::recordBeginLayer(CGRenderingStateRef, CGGStateRef gstate, CGRect)

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -148,9 +148,8 @@ std::optional<GraphicsStyle> FEDropShadow::createGraphicsStyle(const Filter& fil
 
     auto offset = filter.resolvedSize({ m_dx, m_dy });
     auto radius = FEGaussianBlur::calculateUnscaledKernelSize(filter.resolvedSize({ m_stdX, m_stdY }));
-    auto color = m_shadowColor.colorWithAlpha(m_shadowOpacity);
 
-    return GraphicsDropShadow { offset, static_cast<float>(radius.width()), color, ShadowRadiusMode::Default };
+    return GraphicsDropShadow { offset, static_cast<float>(radius.width()), m_shadowColor, ShadowRadiusMode::Default, m_shadowOpacity };
 }
 
 std::unique_ptr<FilterEffectApplier> FEDropShadow::createSoftwareApplier() const

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -74,7 +74,7 @@ ShadowApplier::ShadowApplier(const RenderStyle& style, GraphicsContext& context,
     }
 
     if (!m_avoidDrawingShadow)
-        context.setDropShadow({ shadowOffset, shadowRadius.value(), shadowColor, ShadowRadiusMode::Default });
+        context.setDropShadow({ shadowOffset, shadowRadius.value(), shadowColor });
 }
 
 inline bool ShadowApplier::isLastShadowIteration()


### PR DESCRIPTION
#### db985ec58914e7fe75e5d947e31bcb4f8e82a545
<pre>
[Filters] Don&apos;t override the alpha channel of the GraphicsDropShadow color by the shadow opacity
<a href="https://bugs.webkit.org/show_bug.cgi?id=261841">https://bugs.webkit.org/show_bug.cgi?id=261841</a>
rdar://115812347

Reviewed by Cameron McCormack.

The shadow opacity should be applied to GraphicsContext before setting the drop
shadow style. The color of the drop shadow should preserve its alpha channel.

* Source/WebCore/platform/graphics/GraphicsStyle.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/GraphicsStyle.h:
(WebCore::GraphicsDropShadow::encode const):
(WebCore::GraphicsDropShadow::decode):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::setCGShadow):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::DrawGlyphsRecorder::updateShadow):
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::createGraphicsStyle const):
* Source/WebCore/rendering/TextPainter.cpp:

Canonical link: <a href="https://commits.webkit.org/268233@main">https://commits.webkit.org/268233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d13766fd330a99234c446fa8291d592277f71af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19566 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21825 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23763 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18126 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17218 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4548 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->