### PR TITLE
Make http/tests/site-isolation/post-message.html not flaky

### DIFF
--- a/LayoutTests/http/tests/site-isolation/post-message-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/post-message-expected.txt
@@ -1,5 +1,5 @@
-PASS postMessage received
 PASS successfullyParsed is true
 
 TEST COMPLETE
+PASS received 'iframe received hello'
 

--- a/LayoutTests/http/tests/site-isolation/post-message.html
+++ b/LayoutTests/http/tests/site-isolation/post-message.html
@@ -6,9 +6,12 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
-addEventListener("message", () => {
-    testPassed("postMessage received");
+addEventListener("message", (event) => {
+    testPassed("received '" + event.data + "'");
     testRunner.notifyDone();
 });
+
+onload = ()=>{ frame.contentWindow.postMessage("hello", "*") }
+
 </script>
-<iframe src="http://localhost:8000/site-isolation/resources/post-message-to-parent.html"></iframe>
+<iframe src="http://localhost:8000/site-isolation/resources/post-message-to-parent.html" id="frame"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-to-parent.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-to-parent.html
@@ -1,3 +1,5 @@
 <script>
-window.parent.postMessage("message", "*");
+addEventListener("message", (event) => {
+    window.parent.postMessage("iframe received " + event.data, "*")
+});
 </script>


### PR DESCRIPTION
#### e41d88f5cd2fc3f52bd19c56e1163d9f4be7fbe8
<pre>
Make http/tests/site-isolation/post-message.html not flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=261853">https://bugs.webkit.org/show_bug.cgi?id=261853</a>
rdar://115812816

Reviewed by Pascoe.

It has been flaky since its introduction because of a race condition between
the load event and the iframe sending the first message.  To resolve this,
wait until the load event then send a message.  Also, test sending the message
in both directions.

* LayoutTests/http/tests/site-isolation/post-message-expected.txt:
* LayoutTests/http/tests/site-isolation/post-message.html:
* LayoutTests/http/tests/site-isolation/resources/post-message-to-parent.html:

Canonical link: <a href="https://commits.webkit.org/268226@main">https://commits.webkit.org/268226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09e1c8bfe60b857875d7eba28cb36fd5918a8ed9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17835 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22714 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/19567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19394 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21826 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/19567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/17219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/17221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2328 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->