### PR TITLE
[WGSL] call to 'max' is ambiguous as decimal is not added to floating point number

### DIFF
--- a/Source/WTF/wtf/dtoa.cpp
+++ b/Source/WTF/wtf/dtoa.cpp
@@ -38,6 +38,14 @@ const char* numberToString(double d, NumberToStringBuffer& buffer)
     return builder.Finalize();
 }
 
+const char* numberToStringWithTrailingPoint(double d, NumberToStringBuffer& buffer)
+{
+    double_conversion::StringBuilder builder(&buffer[0], sizeof(buffer));
+    auto& converter = double_conversion::DoubleToStringConverter::EcmaScriptConverterWithTrailingPoint();
+    converter.ToShortest(d, &builder);
+    return builder.Finalize();
+}
+
 static inline void truncateTrailingZeros(const char* buffer, double_conversion::StringBuilder& builder)
 {
     size_t length = builder.position();

--- a/Source/WTF/wtf/dtoa.h
+++ b/Source/WTF/wtf/dtoa.h
@@ -41,6 +41,7 @@ WTF_EXPORT_PRIVATE const char* numberToFixedPrecisionString(float, unsigned sign
 WTF_EXPORT_PRIVATE const char* numberToFixedWidthString(float, unsigned decimalPlaces, NumberToStringBuffer&);
 
 WTF_EXPORT_PRIVATE const char* numberToString(double, NumberToStringBuffer&);
+WTF_EXPORT_PRIVATE const char* numberToStringWithTrailingPoint(double, NumberToStringBuffer&);
 WTF_EXPORT_PRIVATE const char* numberToFixedPrecisionString(double, unsigned significantFigures, NumberToStringBuffer&, bool truncateTrailingZeros = false);
 WTF_EXPORT_PRIVATE const char* numberToFixedWidthString(double, unsigned decimalPlaces, NumberToStringBuffer&);
 

--- a/Source/WTF/wtf/dtoa/double-conversion.cc
+++ b/Source/WTF/wtf/dtoa/double-conversion.cc
@@ -51,6 +51,12 @@ const DoubleToStringConverter& DoubleToStringConverter::EcmaScriptConverter() {
   return converter;
 }
 
+const DoubleToStringConverter& DoubleToStringConverter::EcmaScriptConverterWithTrailingPoint() {
+  constexpr int flags = UNIQUE_ZERO | EMIT_POSITIVE_EXPONENT_SIGN | EMIT_TRAILING_DECIMAL_POINT;
+  static constexpr DoubleToStringConverter converter(flags, "Infinity", "NaN", 'e', -6, 21, 6, 0);
+  return converter;
+}
+
 const DoubleToStringConverter& DoubleToStringConverter::CSSConverter() {
   constexpr int flags = UNIQUE_ZERO | EMIT_POSITIVE_EXPONENT_SIGN;
   static constexpr DoubleToStringConverter converter(flags, "infinity", "NaN", 'e', -6, 21, 6, 0);

--- a/Source/WTF/wtf/dtoa/double-conversion.h
+++ b/Source/WTF/wtf/dtoa/double-conversion.h
@@ -131,6 +131,7 @@ class DoubleToStringConverter {
 
   // Returns a converter following the EcmaScript specification.
   WTF_EXPORT_PRIVATE static const DoubleToStringConverter& EcmaScriptConverter();
+  WTF_EXPORT_PRIVATE static const DoubleToStringConverter& EcmaScriptConverterWithTrailingPoint();
 
   WTF_EXPORT_PRIVATE static const DoubleToStringConverter& CSSConverter();
 

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1138,13 +1138,19 @@ void FunctionDefinitionWriter::visit(AST::Unsigned32Literal& literal)
 void FunctionDefinitionWriter::visit(AST::AbstractFloatLiteral& literal)
 {
     // FIXME: this might not serialize all values correctly
-    m_stringBuilder.append(literal.value());
+    NumberToStringBuffer buffer;
+    WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
+
+    m_stringBuilder.append(&buffer[0]);
 }
 
 void FunctionDefinitionWriter::visit(AST::Float32Literal& literal)
 {
     // FIXME: this might not serialize all values correctly
-    m_stringBuilder.append(literal.value());
+    NumberToStringBuffer buffer;
+    WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
+
+    m_stringBuilder.append(&buffer[0]);
 }
 
 void FunctionDefinitionWriter::visit(AST::Statement& statement)

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -59,7 +59,7 @@ using namespace metal;
 
 [[fragment]] vec<float, 4> function0()
 {
-    return vec<float, 4>(1, 0, 0, 1);
+    return vec<float, 4>(1., 0., 0., 1.);
 }
 
 )"_s);


### PR DESCRIPTION
#### e0a4e0edfaa5e790d6d5c407e41110053958cc11
<pre>
[WGSL] call to &apos;max&apos; is ambiguous as decimal is not added to floating point number
<a href="https://bugs.webkit.org/show_bug.cgi?id=261854">https://bugs.webkit.org/show_bug.cgi?id=261854</a>
&lt;radar://115813155&gt;

Reviewed by Tadeu Zagallo.

Make sure doubles contain a decimal point. Otherwise we will end up with
compiler errors due to ambiguous function overloads like max(d, 0) where
d is a double.

* Source/WTF/wtf/dtoa.cpp:
(WTF::numberToString):
(WTF::numberToStringWithTrailingPoint):
* Source/WTF/wtf/dtoa.h:
* Source/WTF/wtf/dtoa/double-conversion.cc:
* Source/WTF/wtf/dtoa/double-conversion.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):

* Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp:
(TestWGSLAPI::TEST):
Update test expectation

Canonical link: <a href="https://commits.webkit.org/268237@main">https://commits.webkit.org/268237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bfd093d7e62816e41ab036a7bb099f315ce5f07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19105 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20972 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19592 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21854 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17407 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16584 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21737 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18435 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18148 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22488 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17246 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5451 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4554 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21601 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23738 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17978 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5315 "Passed tests") | 
<!--EWS-Status-Bubble-End-->