### PR TITLE
[Filters] Filters with outsets have to repaint all the filterRegion if GraphicsStyles are used

### DIFF
--- a/LayoutTests/css3/filters/drop-shadow-target-clipped-expected.html
+++ b/LayoutTests/css3/filters/drop-shadow-target-clipped-expected.html
@@ -1,0 +1,28 @@
+<style>
+    .box {
+        width: 300px;
+        height: 300px;
+        position: absolute;
+    }
+    .background-red {
+        top: 0;
+        left: 0;
+        background-color: red;
+    }
+    .background-green {
+        top: -100px;
+        left: -100px;
+        background-color: green;
+    }
+    .background-blue {
+        top: -200px;
+        left: -200px;
+        background-color: blue;
+    }
+</style>
+<body>
+    Three overlapping boxes should be displayed.
+    <div class="box background-red"></div>
+    <div class="box background-green"></div>
+    <div class="box background-blue"></div>
+</body>

--- a/LayoutTests/css3/filters/drop-shadow-target-clipped.html
+++ b/LayoutTests/css3/filters/drop-shadow-target-clipped.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ GraphicsContextFiltersEnabled=true ] -->
+<style>
+    .box {
+        width: 300px;
+        height: 300px;
+        position: absolute;
+        background-color: black;
+    }
+    .drop-shadow-red {
+        top: -1000px;
+        left: -1000px;
+        filter: drop-shadow(1000px 1000px 0 red);
+    }
+    .drop-shadow-green {
+        top: -1000px;
+        left: -1000px;
+        filter: drop-shadow(900px 900px 0 green);
+    }
+    .drop-shadow-blue {
+        top: -1000px;
+        left: -1000px;
+        filter: drop-shadow(800px 800px 0 blue);
+    }
+</style>
+<body>
+    Three overlapping boxes should be displayed.
+    <div class="box drop-shadow-red"></div>
+    <div class="box drop-shadow-green"></div>
+    <div class="box drop-shadow-blue"></div>
+</body>

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -62,6 +62,11 @@ bool RenderLayerFilters::hasFilterThatShouldBeRestrictedBySecurityOrigin() const
     return m_filter && m_filter->hasFilterThatShouldBeRestrictedBySecurityOrigin();
 }
 
+bool RenderLayerFilters::needsRedrawSourceImage() const
+{
+    return m_targetSwitcher && m_targetSwitcher->needsRedrawSourceImage();
+}
+
 void RenderLayerFilters::notifyFinished(CachedResource&, const NetworkLoadMetrics&)
 {
     // FIXME: This really shouldn't have to invalidate layer composition,
@@ -173,7 +178,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
 
     if (!filter.hasFilterThatMovesPixels())
         m_repaintRect = dirtyRect;
-    else if (hasUpdatedBackingStore)
+    else if (hasUpdatedBackingStore || needsRedrawSourceImage())
         m_repaintRect = filterRegion;
     else {
         m_repaintRect = dirtyRect;

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -73,6 +73,8 @@ public:
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:
+    bool needsRedrawSourceImage() const;
+
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
     void resetDirtySourceRect() { m_dirtySourceRect = LayoutRect(); }
 


### PR DESCRIPTION
#### 39763b0eba704c47027dffc65c907386376c8590
<pre>
[Filters] Filters with outsets have to repaint all the filterRegion if GraphicsStyles are used
<a href="https://bugs.webkit.org/show_bug.cgi?id=261856">https://bugs.webkit.org/show_bug.cgi?id=261856</a>
rdar://115817290

Reviewed by Simon Fraser.

The bounding box of a target element might all be clipped. But a filter effect,
like drop shadow, may still be visible in the current viewport. If GraphicsStyles
are used, we need to redraw the whole filterRegion.

* LayoutTests/css3/filters/drop-shadow-target-clipped-expected.html: Added.
* LayoutTests/css3/filters/drop-shadow-target-clipped.html: Added.
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::needsRedrawSourceImage const):
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:

Canonical link: <a href="https://commits.webkit.org/268282@main">https://commits.webkit.org/268282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/206a8b88a402846982a526887a31385656bb09e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19749 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21969 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17490 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21803 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18255 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17328 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4592 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->