### PR TITLE
Add atomics to IPInt

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -107,24 +107,24 @@ const WasmCodeBlock = CallerFrame - constexpr Wasm::numberOfIPIntCalleeSaveRegis
 macro saveIPIntRegisters()
     subp 2*CalleeSaveSpaceStackAligned, sp
     if ARM64 or ARM64E
-        storepairq wasmInstance, PB, -16[cfr]
-        storeq PM, -24[cfr]
+        storepairq PM, PB, -16[cfr]
+        storeq wasmInstance, -24[cfr]
     elsif X86_64 or RISCV64
         storep PB, -0x8[cfr]
-        storep wasmInstance, -0x10[cfr]
-        storep PM, -0x18[cfr]
+        storep PM, -0x10[cfr]
+        storep wasmInstance, -0x18[cfr]
     else
     end
 end
 
 macro restoreIPIntRegisters()
     if ARM64 or ARM64E
-        loadpairq -16[cfr], wasmInstance, PB
-        loadq -24[cfr], PM
+        loadpairq -16[cfr], PM, PB
+        loadq -24[cfr], wasmInstance
     elsif X86_64 or RISCV64
         loadp -0x8[cfr], PB
-        loadp -0x10[cfr], wasmInstance
-        loadp -0x18[cfr], PM
+        loadp -0x10[cfr], PM
+        loadp -0x18[cfr], wasmInstance
     else
     end
     addp 2*CalleeSaveSpaceStackAligned, sp
@@ -434,7 +434,6 @@ macro ipintException(exception)
     # addq PM, sp
     # restoreCallerPCAndCFR()
     storei constexpr Wasm::ExceptionType::%exception%, ArgumentCountIncludingThis + PayloadOffset[cfr]
-    restoreIPIntRegisters()
     jmp _wasm_throw_from_slow_path_trampoline
 end
 
@@ -1140,12 +1139,11 @@ instructionLabel(_table_set)
 
 reservedOpcode(0x27)
 
-macro ipintCheckMemoryBound(mem, size)
-    leap size - 1[mem], t2
-    bpb t2, boundsCheckingSize, .continuation
+macro ipintCheckMemoryBound(mem, scratch, size)
+    leap size - 1[mem], scratch
+    bpb scratch, boundsCheckingSize, .continuation
     ipintException(OutOfBoundsMemoryAccess)
 .continuation:
-    nop
 end
 
 instructionLabel(_i32_load_mem)
@@ -1154,7 +1152,7 @@ instructionLabel(_i32_load_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 4)
+    ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     loadi [memoryBase, t0], t1
     pushInt32(t1)
@@ -1170,7 +1168,7 @@ instructionLabel(_i64_load_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 8)
+    ipintCheckMemoryBound(t0, t2, 8)
     # load memory location
     loadq [memoryBase, t0], t1
     pushInt64(t1)
@@ -1186,7 +1184,7 @@ instructionLabel(_f32_load_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 4)
+    ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     loadf [memoryBase, t0], ft0
     pushFloat32FT0()
@@ -1202,7 +1200,7 @@ instructionLabel(_f64_load_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 8)
+    ipintCheckMemoryBound(t0, t2, 8)
     # load memory location
     loadd [memoryBase, t0], ft0
     pushFloat64FT0()
@@ -1219,7 +1217,7 @@ instructionLabel(_i32_load8s_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 1)
+    ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     loadb [memoryBase, t0], t1
     sxb2i t1, t1
@@ -1236,7 +1234,7 @@ instructionLabel(_i32_load8u_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 1)
+    ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     loadb [memoryBase, t0], t1
     pushInt32(t1)
@@ -1252,7 +1250,7 @@ instructionLabel(_i32_load16s_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 2)
+    ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     loadh [memoryBase, t0], t1
     sxh2i t1, t1
@@ -1269,7 +1267,7 @@ instructionLabel(_i32_load16u_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 2)
+    ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     loadh [memoryBase, t0], t1
     pushInt32(t1)
@@ -1286,7 +1284,7 @@ instructionLabel(_i64_load8s_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 1)
+    ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     loadb [memoryBase, t0], t1
     sxb2q t1, t1
@@ -1303,7 +1301,7 @@ instructionLabel(_i64_load8u_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 1)
+    ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     loadb [memoryBase, t0], t1
     pushInt64(t1)
@@ -1319,7 +1317,7 @@ instructionLabel(_i64_load16s_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 2)
+    ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     loadh [memoryBase, t0], t1
     sxh2q t1, t1
@@ -1336,7 +1334,7 @@ instructionLabel(_i64_load16u_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 2)
+    ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     loadh [memoryBase, t0], t1
     pushInt64(t1)
@@ -1352,7 +1350,7 @@ instructionLabel(_i64_load32s_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 4)
+    ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     loadi [memoryBase, t0], t1
     sxi2q t1, t1
@@ -1369,7 +1367,7 @@ instructionLabel(_i64_load32u_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 4)
+    ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     loadi [memoryBase, t0], t1
     pushInt64(t1)
@@ -1388,7 +1386,7 @@ instructionLabel(_i32_store_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 4)
+    ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     storei t1, [memoryBase, t0]
 
@@ -1405,7 +1403,7 @@ instructionLabel(_i64_store_mem)
     popInt64(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 8)
+    ipintCheckMemoryBound(t0, t2, 8)
     # load memory location
     storeq t1, [memoryBase, t0]
 
@@ -1422,7 +1420,7 @@ instructionLabel(_f32_store_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 4)
+    ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     storef ft0, [memoryBase, t0]
 
@@ -1439,7 +1437,7 @@ instructionLabel(_f64_store_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 8)
+    ipintCheckMemoryBound(t0, t2, 8)
     # load memory location
     stored ft0, [memoryBase, t0]
 
@@ -1456,7 +1454,7 @@ instructionLabel(_i32_store8_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 1)
+    ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     storeb t1, [memoryBase, t0]
 
@@ -1473,7 +1471,7 @@ instructionLabel(_i32_store16_mem)
     popInt32(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 2)
+    ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     storeh t1, [memoryBase, t0]
 
@@ -1490,7 +1488,7 @@ instructionLabel(_i64_store8_mem)
     popInt64(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 1)
+    ipintCheckMemoryBound(t0, t2, 1)
     # load memory location
     storeb t1, [memoryBase, t0]
 
@@ -1507,7 +1505,7 @@ instructionLabel(_i64_store16_mem)
     popInt64(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 2)
+    ipintCheckMemoryBound(t0, t2, 2)
     # load memory location
     storeh t1, [memoryBase, t0]
 
@@ -1524,7 +1522,7 @@ instructionLabel(_i64_store32_mem)
     popInt64(t0, t2)
     loadi 1[PM, MC], t2
     addq t2, t0
-    ipintCheckMemoryBound(t0, 4)
+    ipintCheckMemoryBound(t0, t2, 4)
     # load memory location
     storei t1, [memoryBase, t0]
 
@@ -3210,8 +3208,8 @@ reservedOpcode(0xfa)
 reservedOpcode(0xfb)
 instructionLabel(_fc_block)
     loadb 1[PB, PC], t0
-    biaeq t0, 18, .ipint_fc_nonexistent
     # Security guarantee: always less than 18 (0x00 -> 0x11)
+    biaeq t0, 18, .ipint_fc_nonexistent
     if ARM64 or ARM64E
         pcrtoaddr _ipint_i32_trunc_sat_f32_s, t1
         emit "add x0, x1, x0, lsl 8"
@@ -3224,7 +3222,7 @@ instructionLabel(_fc_block)
     end
 
 .ipint_fc_nonexistent:
-    ipintException(Unreachable)
+    break
 
 instructionLabel(_simd)
     # TODO: for relaxed SIMD, handle parsing the value.
@@ -3241,7 +3239,24 @@ instructionLabel(_simd)
         emit "jmp *(%eax)"
     end
 
-reservedOpcode(0xfe)
+instructionLabel(_atomic)
+    loadb 1[PB, PC], t0
+    # Security guarantee: always less than 78 (0x00 -> 0x4e)
+    biaeq t0, 0x4f, .ipint_atomic_nonexistent
+    if ARM64 or ARM64E
+        pcrtoaddr _ipint_memory_atomic_notify, t1
+        emit "add x0, x1, x0, lsl 8"
+        emit "br x0"
+    elsif X86_64
+        lshifti 4, t0
+        leap (_ipint_memory_atomic_notify), t1
+        addq t1, t0
+        emit "jmp *(%eax)"
+    end
+
+.ipint_atomic_nonexistent:
+    break
+
 reservedOpcode(0xff)
 
     #######################
@@ -3965,6 +3980,1381 @@ unimplementedInstruction(_simd_i32x4_trunc_sat_f64x2_s_zero)
 unimplementedInstruction(_simd_i32x4_trunc_sat_f64x2_u_zero)
 unimplementedInstruction(_simd_f64x2_convert_low_i32x4_s)
 unimplementedInstruction(_simd_f64x2_convert_low_i32x4_u)
+
+    #########################
+    ## Atomic instructions ##
+    #########################
+
+macro ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, size)
+    leap size - 1[mem], scratch
+    bpb scratch, boundsCheckingSize, .continuation
+.throw:
+    ipintException(OutOfBoundsMemoryAccess)
+.continuation:
+    btpnz mem, (size - 1), .throw
+end
+
+macro ipintCheckMemoryBoundWithAlignmentCheck1(mem, scratch)
+    ipintCheckMemoryBound(mem, scratch, 1)
+end
+
+macro ipintCheckMemoryBoundWithAlignmentCheck2(mem, scratch)
+    ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, 2)
+end
+
+macro ipintCheckMemoryBoundWithAlignmentCheck4(mem, scratch)
+    ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, 4)
+end
+
+macro ipintCheckMemoryBoundWithAlignmentCheck8(mem, scratch)
+    ipintCheckMemoryBoundWithAlignmentCheck(mem, scratch, 8)
+end
+
+instructionLabel(_memory_atomic_notify)
+    # pop count
+    popInt32(a3, t0)
+    # pop pointer
+    popInt32(a1, t0)
+    # load offset
+    loadi 1[PM, MC], a2
+
+    move wasmInstance, a0
+    operationCall(macro() cCall4(_ipint_extern_memory_atomic_notify) end)
+    bib r0, 0, .atomic_notify_throw
+
+    pushInt32(r0)
+    loadb [PM, MC], t0
+    advancePCByReg(t0)
+    advanceMC(5)
+    nextIPIntInstruction()
+
+.atomic_notify_throw:
+    ipintException(OutOfBoundsMemoryAccess)
+
+instructionLabel(_memory_atomic_wait32)
+    # pop timeout
+    popInt32(a3, t0)
+    # pop value
+    popInt32(a2, t0)
+    # pop pointer
+    popInt32(a1, t0)
+    # load offset
+    loadi 1[PM, MC], t0
+    # merge them since the slow path takes the combined pointer + offset.
+    addq t0, a1
+
+    move wasmInstance, a0
+    operationCall(macro() cCall4(_ipint_extern_memory_atomic_wait32) end)
+    bib r0, 0, .atomic_wait32_throw
+
+    pushInt32(r0)
+    loadb [PM, MC], t0
+    advancePCByReg(t0)
+    advanceMC(5)
+    nextIPIntInstruction()
+
+.atomic_wait32_throw:
+    ipintException(OutOfBoundsMemoryAccess)
+
+instructionLabel(_memory_atomic_wait64)
+    # pop timeout
+    popInt32(a3, t0)
+    # pop value
+    popInt64(a2, t0)
+    # pop pointer
+    popInt32(a1, t0)
+    # load offset
+    loadi 1[PM, MC], t0
+    # merge them since the slow path takes the combined pointer + offset.
+    addq t0, a1
+
+    move wasmInstance, a0
+    operationCall(macro() cCall4(_ipint_extern_memory_atomic_wait64) end)
+    bib r0, 0, .atomic_wait64_throw
+
+    pushInt32(r0)
+    loadb [PM, MC], t0
+    advancePCByReg(t0)
+    advanceMC(5)
+    nextIPIntInstruction()
+
+.atomic_wait64_throw:
+    ipintException(OutOfBoundsMemoryAccess)
+
+instructionLabel(_atomic_fence)
+    fence
+
+    loadb [PM, MC], t0
+    advancePCByReg(t0)
+    advanceMC(1)
+    nextIPIntInstruction()
+
+unimplementedInstruction(_atomic_0x4)
+unimplementedInstruction(_atomic_0x5)
+unimplementedInstruction(_atomic_0x6)
+unimplementedInstruction(_atomic_0x7)
+unimplementedInstruction(_atomic_0x8)
+unimplementedInstruction(_atomic_0x9)
+unimplementedInstruction(_atomic_0xa)
+unimplementedInstruction(_atomic_0xb)
+unimplementedInstruction(_atomic_0xc)
+unimplementedInstruction(_atomic_0xd)
+unimplementedInstruction(_atomic_0xe)
+unimplementedInstruction(_atomic_0xf)
+
+macro atomicLoadOp(boundsAndAlignmentCheck, loadAndPush)
+    # pop index
+    popInt32(t0, t2)
+    # load offset
+    loadi 1[PM, MC], t2
+    addq t2, t0
+    boundsAndAlignmentCheck(t0,  t3)
+    addq memoryBase, t0
+    loadAndPush(t0, t2)
+
+    loadb [PM, MC], t0
+    advancePCByReg(t0)
+    advanceMC(5)
+    nextIPIntInstruction()
+end
+
+instructionLabel(_i32_atomic_load)
+    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, scratch)
+        if ARM64 or ARM64E or X86_64
+            atomicloadi [mem], scratch
+        else
+            error
+        end
+        pushInt32(scratch)
+    end)
+
+instructionLabel(_i64_atomic_load)
+    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, scratch)
+        if ARM64 or ARM64E or X86_64
+            atomicloadq [mem], scratch
+        else
+            error
+        end
+        pushInt64(scratch)
+    end)
+
+instructionLabel(_i32_atomic_load8_u)
+    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, scratch)
+        if ARM64 or ARM64E or X86_64
+            atomicloadb [mem], scratch
+        else
+            error
+        end
+        pushInt32(scratch)
+    end)
+
+instructionLabel(_i32_atomic_load16_u)
+    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, scratch)
+        if ARM64 or ARM64E or X86_64
+            atomicloadh [mem], scratch
+        else
+            error
+        end
+        pushInt32(scratch)
+    end)
+
+instructionLabel(_i64_atomic_load8_u)
+    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, scratch)
+        if ARM64 or ARM64E or X86_64
+            atomicloadb [mem], scratch
+        else
+            error
+        end
+        pushInt64(scratch)
+    end)
+
+instructionLabel(_i64_atomic_load16_u)
+    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, scratch)
+        if ARM64 or ARM64E or X86_64
+            atomicloadh [mem], scratch
+        else
+            error
+        end
+        pushInt64(scratch)
+    end)
+
+instructionLabel(_i64_atomic_load32_u)
+    atomicLoadOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, scratch)
+        if ARM64 or ARM64E or X86_64
+            atomicloadi [mem], scratch
+        else
+            error
+        end
+        pushInt64(scratch)
+    end)
+
+macro weakCASLoopByte(mem, value, scratch1AndOldValue, scratch2, fn)
+    if X86_64
+        loadb [mem], scratch1AndOldValue
+    .loop:
+        move scratch1AndOldValue, scratch2
+        fn(value, scratch2)
+        batomicweakcasb scratch1AndOldValue, scratch2, [mem], .loop
+    else
+    .loop:
+        loadlinkacqb [mem], scratch1AndOldValue
+        fn(value, scratch1AndOldValue, scratch2)
+        storecondrelb ws2, scratch2, [mem]
+        bineq ws2, 0, .loop
+    end
+end
+
+macro weakCASLoopHalf(mem, value, scratch1AndOldValue, scratch2, fn)
+    if X86_64
+        loadh [mem], scratch1AndOldValue
+    .loop:
+        move scratch1AndOldValue, scratch2
+        fn(value, scratch2)
+        batomicweakcash scratch1AndOldValue, scratch2, [mem], .loop
+    else
+    .loop:
+        loadlinkacqh [mem], scratch1AndOldValue
+        fn(value, scratch1AndOldValue, scratch2)
+        storecondrelh ws2, scratch2, [mem]
+        bineq ws2, 0, .loop
+    end
+end
+
+macro weakCASLoopInt(mem, value, scratch1AndOldValue, scratch2, fn)
+    if X86_64
+        loadi [mem], scratch1AndOldValue
+    .loop:
+        move scratch1AndOldValue, scratch2
+        fn(value, scratch2)
+        batomicweakcasi scratch1AndOldValue, scratch2, [mem], .loop
+    else
+    .loop:
+        loadlinkacqi [mem], scratch1AndOldValue
+        fn(value, scratch1AndOldValue, scratch2)
+        storecondreli ws2, scratch2, [mem]
+        bineq ws2, 0, .loop
+    end
+end
+
+macro weakCASLoopQuad(mem, value, scratch1AndOldValue, scratch2, fn)
+    if X86_64
+        loadq [mem], scratch1AndOldValue
+    .loop:
+        move scratch1AndOldValue, scratch2
+        fn(value, scratch2)
+        batomicweakcasq scratch1AndOldValue, scratch2, [mem], .loop
+    else
+    .loop:
+        loadlinkacqq [mem], scratch1AndOldValue
+        fn(value, scratch1AndOldValue, scratch2)
+        storecondrelq ws2, scratch2, [mem]
+        bineq ws2, 0, .loop
+    end
+end
+
+macro atomicStoreOp(boundsAndAlignmentCheck, popAndStore)
+    # pop value
+    popInt64(t1, t0)
+    # pop index
+    popInt32(t2, t0)
+    # load offset
+    loadi 1[PM, MC], t0
+    addq t0, t2
+    boundsAndAlignmentCheck(t2, t3)
+    addq memoryBase, t2
+    popAndStore(t2, t1, t0, t3)
+
+    loadb [PM, MC], t0
+    advancePCByReg(t0)
+    advanceMC(5)
+    nextIPIntInstruction()
+end
+
+instructionLabel(_i32_atomic_store)
+    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgi value, [mem], value
+        elsif X86_64
+            atomicxchgi value, [mem]
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+    end)
+
+instructionLabel(_i64_atomic_store)
+    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgq value, [mem], value
+        elsif X86_64
+            atomicxchgq value, [mem]
+        elsif ARM64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+    end)
+
+instructionLabel(_i32_atomic_store8_u)
+    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgb value, [mem], value
+        elsif X86_64
+            atomicxchgb value, [mem]
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+    end)
+
+instructionLabel(_i32_atomic_store16_u)
+    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgh value, [mem], value
+        elsif X86_64
+            atomicxchgh value, [mem]
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+    end)
+
+instructionLabel(_i64_atomic_store8_u)
+    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgb value, [mem], value
+        elsif X86_64
+            atomicxchgb value, [mem]
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+    end)
+
+instructionLabel(_i64_atomic_store16_u)
+    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgh value, [mem], value
+        elsif X86_64
+            atomicxchgh value, [mem]
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+    end)
+
+instructionLabel(_i64_atomic_store32_u)
+    atomicStoreOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgi value, [mem], value
+        elsif X86_64
+            atomicxchgi value, [mem]
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+    end)
+
+
+macro atomicRMWOp(boundsAndAlignmentCheck, rmw)
+    # pop value
+    popInt64(t1, t0)
+    # pop index
+    popInt32(t2, t0)
+    # load offset
+    loadi 1[PM, MC], t0
+    addq t0, t2
+    boundsAndAlignmentCheck(t2, t3)
+    addq memoryBase, t2
+    rmw(t2, t1, t0, t3)
+
+    loadb [PM, MC], t0
+    advancePCByReg(t0)
+    advanceMC(5)
+    nextIPIntInstruction()
+end
+
+instructionLabel(_i32_atomic_rmw_add)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgaddi value, [mem], scratch1
+        elsif X86_64
+            atomicxchgaddi value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                addi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw_add)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgaddq value, [mem], scratch1
+        elsif X86_64
+            atomicxchgaddq value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                addq value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw8_add_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgaddb value, [mem], scratch1
+        elsif X86_64
+            atomicxchgaddb value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                addi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw16_add_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgaddh value, [mem], scratch1
+        elsif X86_64
+            atomicxchgaddh value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                addi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw8_add_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgaddb value, [mem], scratch1
+        elsif X86_64
+            atomicxchgaddb value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                addi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw16_add_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgaddh value, [mem], scratch1
+        elsif X86_64
+            atomicxchgaddh value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                addi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw32_add_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgaddi value, [mem], scratch1
+        elsif X86_64
+            atomicxchgaddi value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                addi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw_sub)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            negi value
+            atomicxchgaddi value, [mem], scratch1
+        elsif X86_64
+            negi value
+            atomicxchgaddi value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                subi oldValue, value, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+
+instructionLabel(_i64_atomic_rmw_sub)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            negq value
+            atomicxchgaddq value, [mem], scratch1
+        elsif X86_64
+            negq value
+            atomicxchgaddq value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                subq oldValue, value, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw8_sub_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            negi value
+            atomicxchgaddb value, [mem], scratch1
+        elsif X86_64
+            negi value
+            atomicxchgaddb value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                subi oldValue, value, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw16_sub_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            negi value
+            atomicxchgaddh value, [mem], scratch1
+        elsif X86_64
+            negi value
+            atomicxchgaddh value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                subi oldValue, value, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw8_sub_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            negq value
+            atomicxchgaddb value, [mem], scratch1
+        elsif X86_64
+            negq value
+            atomicxchgaddb value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                subi oldValue, value, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw16_sub_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            negq value
+            atomicxchgaddh value, [mem], scratch1
+        elsif X86_64
+            negq value
+            atomicxchgaddh value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                subi oldValue, value, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw32_sub_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            negq value
+            atomicxchgaddi value, [mem], scratch1
+        elsif X86_64
+            negq value
+            atomicxchgaddi value, [mem]
+            move value, scratch1
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                subi oldValue, value, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw_and)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            noti value
+            atomicxchgcleari value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
+                andq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                andi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw_and)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            notq value
+            atomicxchgclearq value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro (value, dst)
+                andq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                andq value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw8_and_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            noti value
+            atomicxchgclearb value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
+                andq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                andi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw16_and_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            noti value
+            atomicxchgclearh value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
+                andq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                andi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw8_and_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            notq value
+            atomicxchgclearb value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
+                andq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                andi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw16_and_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            notq value
+            atomicxchgclearh value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
+                andq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                andi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw32_and_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            notq value
+            atomicxchgcleari value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
+                andq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                andi value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw_or)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgori value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
+                ori value, dst
+            end)
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                ori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw_or)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgorq value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro (value, dst)
+                orq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                orq value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw8_or_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgorb value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
+                orq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                ori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw16_or_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgorh value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
+                orq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                ori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw8_or_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgorb value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
+                orq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                ori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw16_or_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgorh value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
+                orq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                ori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw32_or_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgori value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
+                orq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                ori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw_xor)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgxori value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
+                xorq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                xori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw_xor)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgxorq value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro (value, dst)
+                xorq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                xorq value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+
+instructionLabel(_i32_atomic_rmw8_xor_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgxorb value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
+                xorq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                xori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw16_xor_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgxorh value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
+                xorq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                xori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw8_xor_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgxorb value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
+                xorq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                xori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw16_xor_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgxorh value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
+                xorq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                xori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw32_xor_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgxori value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
+                xorq value, dst
+            end)
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                xori value, oldValue, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw_xchg)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgi value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
+                move value, dst
+            end)
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw_xchg)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgq value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro (value, dst)
+                move value, dst
+            end)
+        elsif ARM64
+            weakCASLoopQuad(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw8_xchg_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgb value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
+                move value, dst
+            end)
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i32_atomic_rmw16_xchg_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgh value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
+                move value, dst
+            end)
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+        pushInt32(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw8_xchg_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgb value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro (value, dst)
+                move value, dst
+            end)
+        elsif ARM64
+            weakCASLoopByte(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw16_xchg_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgh value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro (value, dst)
+                move value, dst
+            end)
+        elsif ARM64
+            weakCASLoopHalf(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+instructionLabel(_i64_atomic_rmw32_xchg_u)
+    atomicRMWOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, scratch1, scratch2)
+        if ARM64E
+            atomicxchgi value, [mem], scratch1
+        elsif X86_64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro (value, dst)
+                move value, dst
+            end)
+        elsif ARM64
+            weakCASLoopInt(mem, value, scratch1, scratch2, macro(value, oldValue, newValue)
+                move value, newValue
+            end)
+        else
+            error
+        end
+        pushInt64(scratch1)
+    end)
+
+macro atomicCmpxchgOp(boundsAndAlignmentCheck, cmpxchg)
+    # pop value
+    popInt64(t1, t2)
+    # pop expected
+    popInt64(t0, t2)
+    # pop index
+    popInt32(t3, t2)
+    # load offset
+    loadi 1[PM, MC], t2
+    addq t2, t3
+    boundsAndAlignmentCheck(t3, t2)
+    addq memoryBase, t3
+    cmpxchg(t3, t1, t0, t2)
+
+    loadb [PM, MC], t0
+    advancePCByReg(t0)
+    advanceMC(5)
+    nextIPIntInstruction()
+end
+
+macro weakCASExchangeByte(mem, value, expected, scratch)
+    if ARM64
+    .loop:
+        loadlinkacqb [mem], scratch
+        bqneq expected, scratch, .fail
+        storecondrelb scratch, value, [mem]
+        bieq scratch, 0, .done
+        jmp .loop
+    .fail:
+        emit "clrex"
+        move scratch, expected
+    .done:
+    else
+        error
+    end
+end
+
+macro weakCASExchangeHalf(mem, value, expected, scratch)
+    if ARM64
+    .loop:
+        loadlinkacqh [mem], scratch
+        bqneq expected, scratch, .fail
+        storecondrelh scratch, value, [mem]
+        bieq scratch, 0, .done
+        jmp .loop
+    .fail:
+        emit "clrex"
+        move scratch, expected
+    .done:
+    else
+        error
+    end
+end
+
+macro weakCASExchangeInt(mem, value, expected, scratch)
+    if ARM64
+    .loop:
+        loadlinkacqi [mem], scratch
+        bqneq expected, scratch, .fail
+        storecondreli scratch, value, [mem]
+        bieq scratch, 0, .done
+        jmp .loop
+    .fail:
+        emit "clrex"
+        move scratch, expected
+    .done:
+    else
+        error
+    end
+end
+
+macro weakCASExchangeQuad(mem, value, expected, scratch)
+    if ARM64
+    .loop:
+        loadlinkacqq [mem], scratch
+        bqneq expected, scratch, .fail
+        storecondrelq scratch, value, [mem]
+        bieq scratch, 0, .done
+        jmp .loop
+    .fail:
+        emit "clrex"
+        move scratch, expected
+    .done:
+    else
+        error
+    end
+end
+
+instructionLabel(_i32_atomic_rmw_cmpxchg)
+    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, expected, scratch2)
+        if ARM64E or X86_64
+            atomicweakcasi expected, value, [mem]
+        elsif ARM64
+            weakCASExchangeInt(mem, value, expected, scratch2)
+        else
+            error
+        end
+        pushInt32(expected)
+    end)
+
+instructionLabel(_i64_atomic_rmw_cmpxchg)
+    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck8, macro(mem, value, expected, scratch2)
+        if ARM64E or X86_64
+            atomicweakcasq expected, value, [mem]
+        elsif ARM64
+            weakCASExchangeQuad(mem, value, expected, scratch2)
+        else
+            error
+        end
+        pushInt64(expected)
+    end)
+
+instructionLabel(_i32_atomic_rmw8_cmpxchg_u)
+    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, expected, scratch2)
+        if ARM64E or X86_64
+            bqa expected , 0xff, .fail
+            atomicweakcasb expected, value, [mem]
+            jmp .done
+        .fail:
+            atomicloadb [mem], expected
+        .done:
+        elsif ARM64
+            weakCASExchangeByte(mem, value, expected, scratch2)
+        else
+            error
+        end
+        pushInt32(expected)
+    end)
+
+instructionLabel(_i32_atomic_rmw16_cmpxchg_u)
+    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, expected, scratch2)
+        if ARM64E or X86_64
+            bqa expected , 0xffff, .fail
+            atomicweakcash expected, value, [mem]
+            jmp .done
+        .fail:
+            atomicloadh [mem], expected
+        .done:
+        elsif ARM64
+            weakCASExchangeHalf(mem, value, expected, scratch2)
+        else
+            error
+        end
+        pushInt32(expected)
+    end)
+
+instructionLabel(_i64_atomic_rmw8_cmpxchg_u)
+    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck1, macro(mem, value, expected, scratch2)
+        if ARM64E or X86_64
+            bqa expected , 0xff, .fail
+            atomicweakcasb expected, value, [mem]
+            jmp .done
+        .fail:
+            atomicloadb [mem], expected
+        .done:
+        elsif ARM64
+            weakCASExchangeByte(mem, value, expected, scratch2)
+        else
+            error
+        end
+        pushInt64(expected)
+    end)
+
+instructionLabel(_i64_atomic_rmw16_cmpxchg_u)
+    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck2, macro(mem, value, expected, scratch2)
+        if ARM64E or X86_64
+            bqa expected , 0xffff, .fail
+            atomicweakcash expected, value, [mem]
+            jmp .done
+        .fail:
+            atomicloadh [mem], expected
+        .done:
+        elsif ARM64
+            weakCASExchangeHalf(mem, value, expected, scratch2)
+        else
+            error
+        end
+        pushInt64(expected)
+    end)
+
+instructionLabel(_i64_atomic_rmw32_cmpxchg_u)
+    atomicCmpxchgOp(ipintCheckMemoryBoundWithAlignmentCheck4, macro(mem, value, expected, scratch2)
+        if ARM64E or X86_64
+            bqa expected , 0xffffffff, .fail
+            atomicweakcasi expected, value, [mem]
+            jmp .done
+        .fail:
+            atomicloadi [mem], expected
+        .done:
+        elsif ARM64
+            weakCASExchangeInt(mem, value, expected, scratch2)
+        else
+            error
+        end
+        pushInt64(expected)
+    end)
 
     ##################################
     ## "Out of line" logic for call ##

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -66,12 +66,22 @@ do { \
     RELEASE_ASSERT((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256); \
 } while (false);
 
+#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_memory_atomic_notify_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    RELEASE_ASSERT((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256); \
+} while (false);
+
 void initialize()
 {
 #if !ENABLE(C_LOOP) && CPU(ADDRESS64) && (CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS)))
     FOR_EACH_IPINT_OPCODE(VALIDATE_IPINT_OPCODE);
     FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(VALIDATE_IPINT_0xFC_OPCODE);
     FOR_EACH_IPINT_SIMD_OPCODE(VALIDATE_IPINT_SIMD_OPCODE);
+    FOR_EACH_IPINT_ATOMIC_OPCODE(VALIDATE_IPINT_ATOMIC_OPCODE);
 #else
     RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now).");
 #endif

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -218,7 +218,8 @@ extern "C" void ipint_entry_simd();
     m(0xd1, ref_is_null) \
     m(0xd2, ref_func) \
     m(0xfc, fc_block) \
-    m(0xfd, simd)
+    m(0xfd, simd) \
+    m(0xfe, atomic)
 
 #define FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(m) \
     m(0x00, i32_trunc_sat_f32_s) \
@@ -478,11 +479,81 @@ extern "C" void ipint_entry_simd();
     m(0xfe, simd_f64x2_convert_low_i32x4_s) \
     m(0xff, simd_f64x2_convert_low_i32x4_u)
 
+#define FOR_EACH_IPINT_ATOMIC_OPCODE(m) \
+    m(0x00, memory_atomic_notify) \
+    m(0x01, memory_atomic_wait32) \
+    m(0x02, memory_atomic_wait64) \
+    m(0x03, atomic_fence) \
+    m(0x10, i32_atomic_load) \
+    m(0x11, i64_atomic_load) \
+    m(0x12, i32_atomic_load8_u) \
+    m(0x13, i32_atomic_load16_u) \
+    m(0x14, i64_atomic_load8_u) \
+    m(0x15, i64_atomic_load16_u) \
+    m(0x16, i64_atomic_load32_u) \
+    m(0x17, i32_atomic_store) \
+    m(0x18, i64_atomic_store) \
+    m(0x19, i32_atomic_store8_u) \
+    m(0x1a, i32_atomic_store16_u) \
+    m(0x1b, i64_atomic_store8_u) \
+    m(0x1c, i64_atomic_store16_u) \
+    m(0x1d, i64_atomic_store32_u) \
+    m(0x1e, i32_atomic_rmw_add) \
+    m(0x1f, i64_atomic_rmw_add) \
+    m(0x20, i32_atomic_rmw8_add_u) \
+    m(0x21, i32_atomic_rmw16_add_u) \
+    m(0x22, i64_atomic_rmw8_add_u) \
+    m(0x23, i64_atomic_rmw16_add_u) \
+    m(0x24, i64_atomic_rmw32_add_u) \
+    m(0x25, i32_atomic_rmw_sub) \
+    m(0x26, i64_atomic_rmw_sub) \
+    m(0x27, i32_atomic_rmw8_sub_u) \
+    m(0x28, i32_atomic_rmw16_sub_u) \
+    m(0x29, i64_atomic_rmw8_sub_u) \
+    m(0x2a, i64_atomic_rmw16_sub_u) \
+    m(0x2b, i64_atomic_rmw32_sub_u) \
+    m(0x2c, i32_atomic_rmw_and) \
+    m(0x2d, i64_atomic_rmw_and) \
+    m(0x2e, i32_atomic_rmw8_and_u) \
+    m(0x2f, i32_atomic_rmw16_and_u) \
+    m(0x30, i64_atomic_rmw8_and_u) \
+    m(0x31, i64_atomic_rmw16_and_u) \
+    m(0x32, i64_atomic_rmw32_and_u) \
+    m(0x33, i32_atomic_rmw_or) \
+    m(0x34, i64_atomic_rmw_or) \
+    m(0x35, i32_atomic_rmw8_or_u) \
+    m(0x36, i32_atomic_rmw16_or_u) \
+    m(0x37, i64_atomic_rmw8_or_u) \
+    m(0x38, i64_atomic_rmw16_or_u) \
+    m(0x39, i64_atomic_rmw32_or_u) \
+    m(0x3a, i32_atomic_rmw_xor) \
+    m(0x3b, i64_atomic_rmw_xor) \
+    m(0x3c, i32_atomic_rmw8_xor_u) \
+    m(0x3d, i32_atomic_rmw16_xor_u) \
+    m(0x3e, i64_atomic_rmw8_xor_u) \
+    m(0x3f, i64_atomic_rmw16_xor_u) \
+    m(0x40, i64_atomic_rmw32_xor_u) \
+    m(0x41, i32_atomic_rmw_xchg) \
+    m(0x42, i64_atomic_rmw_xchg) \
+    m(0x43, i32_atomic_rmw8_xchg_u) \
+    m(0x44, i32_atomic_rmw16_xchg_u) \
+    m(0x45, i64_atomic_rmw8_xchg_u) \
+    m(0x46, i64_atomic_rmw16_xchg_u) \
+    m(0x47, i64_atomic_rmw32_xchg_u) \
+    m(0x48, i32_atomic_rmw_cmpxchg) \
+    m(0x49, i64_atomic_rmw_cmpxchg) \
+    m(0x4a, i32_atomic_rmw8_cmpxchg_u) \
+    m(0x4b, i32_atomic_rmw16_cmpxchg_u) \
+    m(0x4c, i64_atomic_rmw8_cmpxchg_u) \
+    m(0x4d, i64_atomic_rmw16_cmpxchg_u) \
+    m(0x4e, i64_atomic_rmw32_cmpxchg_u) \
+
+
 #if !ENABLE(C_LOOP) && CPU(ADDRESS64) && (CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_SIMD_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-
+FOR_EACH_IPINT_ATOMIC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 #endif
 
 namespace JSC { namespace IPInt {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -562,6 +562,12 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
     v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
     v(Unsigned, thresholdForStringReplaceCache, 0x1000, Normal, nullptr) \
+    v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt.") \
+    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues") \
+    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations") \
+    v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues") \
+    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ") \
+    v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG") \
     \
     /* Feature Flags */\
     \
@@ -586,12 +592,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWebAssemblyRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec.") \
     v(Bool, useWebAssemblyTailCalls, false, Normal, "Allow the new instructions from the wasm tail calls spec.") \
     v(Bool, useWebAssemblyExtendedConstantExpressions, false, Normal, "Allow the use of global, element, and data init expressions from the extended constant expressions proposal.") \
-    v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt.") \
-    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues") \
-    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations") \
-    v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues") \
-    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ") \
-    v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG")
+
 
 
 enum OptionEquivalence {

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -54,6 +54,13 @@ void FunctionIPIntMetadataGenerator::addRawValue(uint64_t value)
     WRITE_TO_METADATA(m_metadata.data() + size, value, uint64_t);
 }
 
+void FunctionIPIntMetadataGenerator::addLength(uint32_t length)
+{
+    size_t size = m_metadata.size();
+    m_metadata.resize(size + 1);
+    WRITE_TO_METADATA(m_metadata.data() + size, length, uint8_t);
+}
+
 void FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length)
 {
     size_t size = m_metadata.size();

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -88,6 +88,7 @@ private:
 
     void addBlankSpace(uint32_t size);
     void addRawValue(uint64_t value);
+    void addLength(uint32_t length);
     void addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length);
     void addCondensedLocalIndexAndLength(uint32_t index, uint32_t length);
     void addLEB128ConstantAndLengthForType(Type, uint64_t value, uint32_t length);

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -746,15 +746,49 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addDataDrop(unsigned dataIndex)
 
 // Atomics
 
-// Implementation status: UNIMPLEMENTED
+// Implementation status: DONE.
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t) { return { }; }
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t)
+{
+    m_metadata->addLength(getCurrentInstructionLength());
+    return { };
+}
 
 // GC
 

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -571,10 +571,9 @@ static inline int32_t waitImpl(VM& vm, ValueType* pointer, ValueType expectedVal
     return static_cast<int32_t>(WaiterListManager::singleton().waitSync(vm, pointer, expectedValue, timeout));
 }
 
-inline int32_t memoryAtomicWait32(Instance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeoutInNanoseconds)
+inline int32_t memoryAtomicWait32(Instance* instance, uint64_t offsetInMemory, int32_t value, int64_t timeoutInNanoseconds)
 {
     VM& vm = instance->vm();
-    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
     if (offsetInMemory & (0x4 - 1))
         return -1;
     if (!instance->memory())
@@ -589,10 +588,14 @@ inline int32_t memoryAtomicWait32(Instance* instance, unsigned base, unsigned of
     return waitImpl<int32_t>(vm, pointer, value, timeoutInNanoseconds);
 }
 
-inline int32_t memoryAtomicWait64(Instance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeoutInNanoseconds)
+inline int32_t memoryAtomicWait32(Instance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeoutInNanoseconds)
+{
+    return memoryAtomicWait32(instance, static_cast<uint64_t>(base) + offset, value, timeoutInNanoseconds);
+}
+
+inline int32_t memoryAtomicWait64(Instance* instance, uint64_t offsetInMemory, int64_t value, int64_t timeoutInNanoseconds)
 {
     VM& vm = instance->vm();
-    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
     if (offsetInMemory & (0x8 - 1))
         return -1;
     if (!instance->memory())
@@ -605,6 +608,11 @@ inline int32_t memoryAtomicWait64(Instance* instance, unsigned base, unsigned of
         return -1;
     int64_t* pointer = bitwise_cast<int64_t*>(bitwise_cast<uint8_t*>(instance->memory()->basePointer()) + offsetInMemory);
     return waitImpl<int64_t>(vm, pointer, value, timeoutInNanoseconds);
+}
+
+inline int32_t memoryAtomicWait64(Instance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeoutInNanoseconds)
+{
+    return memoryAtomicWait64(instance, static_cast<uint64_t>(base) + offset, value, timeoutInNanoseconds);
 }
 
 inline int32_t memoryAtomicNotify(Instance* instance, unsigned base, unsigned offset, int32_t countValue)

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -1299,6 +1299,21 @@ WASM_SLOW_PATH_DECL(memory_atomic_wait32)
     WASM_RETURN(result);
 }
 
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait32, uint64_t pointerWithOffset, uint32_t value, uint64_t timeout)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicWait32(instance, pointerWithOffset, value, timeout);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(pointerWithOffset);
+    UNUSED_PARAM(value);
+    UNUSED_PARAM(timeout);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
 WASM_SLOW_PATH_DECL(memory_atomic_wait64)
 {
     auto instruction = pc->as<WasmMemoryAtomicWait64>();
@@ -1312,6 +1327,20 @@ WASM_SLOW_PATH_DECL(memory_atomic_wait64)
     WASM_RETURN(result);
 }
 
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait64, uint64_t pointerWithOffset, uint64_t value, uint64_t timeout)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicWait64(instance, pointerWithOffset, value, timeout);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(pointerWithOffset);
+    UNUSED_PARAM(value);
+    UNUSED_PARAM(timeout);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
 WASM_SLOW_PATH_DECL(memory_atomic_notify)
 {
     auto instruction = pc->as<WasmMemoryAtomicNotify>();
@@ -1322,6 +1351,20 @@ WASM_SLOW_PATH_DECL(memory_atomic_notify)
     if (result < 0)
         WASM_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
     WASM_RETURN(result);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_notify, unsigned base, unsigned offset, int32_t count)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicNotify(instance, base, offset, count);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(base);
+    UNUSED_PARAM(offset);
+    UNUSED_PARAM(count);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
 }
 
 WASM_SLOW_PATH_DECL(throw)

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.h
@@ -118,8 +118,11 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_64, unsigned, uint64_t);
 
 WASM_SLOW_PATH_HIDDEN_DECL(set_global_ref_portable_binding);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait32);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, uint64_t, uint32_t, uint64_t);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait64);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, uint64_t, uint64_t, uint64_t);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_notify);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, unsigned, unsigned, int32_t);
 WASM_SLOW_PATH_HIDDEN_DECL(throw);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw, CallFrame*, uint32_t);
 WASM_SLOW_PATH_HIDDEN_DECL(rethrow);


### PR DESCRIPTION
#### a5637e2156cb073b5fb5c820ad02b9115c88e4d7
<pre>
Add atomics to IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=261855">https://bugs.webkit.org/show_bug.cgi?id=261855</a>

Reviewed by Yusuke Suzuki.

Add support for the wasm thread proposal&apos;s atomic instructions to IPInt.
Right now this only works for arm64(e) as the IPInt seems to have other
issues when running on X86_64. Although the structure of the
atomic instructions should be implemented for X86_64.

A lot of the instructions were implemented in the LLInt so they
could be &quot;straightforwardly&quot; copied to the IPInt. The LLInt seems
to do a decent amount of extra work that doesn&apos;t seem to be necessary
(at least on ARM64E). For example, LLInt ands the low bits of the atomic
RMW result even though the instructions zero extend anyway.

Additionally, this patch fixes trapping from wasm. Previously,
the callee save registers were not saved in the same order that the
C++ code expects (in decreasing order). This was fine for IPInt code
but broke when doing `genericUnwind`.

Lastly, this patch adds an FunctionIPIntMetadataGenerator::addLength
for wasm bytecodes that have variable length but no metatdata. This
is currently only the extended opcodes since the extended instruction
is encoded as a varUInt32 and can be non-canonically encoded as
something longer than 1 byte. I believe the other extended bytecodes
are incorrect but I will fix those in a follow up patch.

* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
(JSC::IPInt::initialize):
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLength):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::atomicLoad):
(JSC::Wasm::IPIntGenerator::atomicStore):
(JSC::Wasm::IPIntGenerator::atomicBinaryRMW):
(JSC::Wasm::IPIntGenerator::atomicCompareExchange):
(JSC::Wasm::IPIntGenerator::atomicWait):
(JSC::Wasm::IPIntGenerator::atomicNotify):
(JSC::Wasm::IPIntGenerator::atomicFence):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::memoryAtomicWait32):
(JSC::Wasm::memoryAtomicWait64):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/268252@main">https://commits.webkit.org/268252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd4854c09b533ff7e8dfcf3d60bfb2b62a8df17d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17861 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19589 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21855 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16619 "4 flakes 6 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23785 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16585 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17667 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21735 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18436 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18149 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22489 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17247 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5452 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4575 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21602 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23739 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17979 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5316 "Passed tests") | 
<!--EWS-Status-Bubble-End-->