### PR TITLE
Revert [268205@main] AutoInstaller should name directory based on ABI

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py
@@ -28,7 +28,7 @@ from flask_cors import CORS
 autoinstall_path = os.environ.get('AUTOINSTALL_PATH')
 if autoinstall_path:
     from webkitcorepy import AutoInstall
-    AutoInstall.set_directory(autoinstall_path, create_platform_subdirectory=False)
+    AutoInstall.set_directory(autoinstall_path)
 
 from flask import Flask, current_app, json as fjson
 from reporelaypy import Checkout, CheckoutRoute, Redirector, HookReceiver

--- a/Tools/Scripts/libraries/resultsdbpy/container
+++ b/Tools/Scripts/libraries/resultsdbpy/container
@@ -35,7 +35,7 @@ if sys.platform == 'darwin':
     does_own_libraries = os.stat(libraries).st_uid == os.getuid()
     if (is_root or not does_own_libraries):
         libraries = os.path.expanduser('~/Library/webkitpy')
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}'.format(sys.version_info[0])))
 
 from resultsdbpy.model.docker import Docker
 

--- a/Tools/Scripts/libraries/resultsdbpy/run
+++ b/Tools/Scripts/libraries/resultsdbpy/run
@@ -38,7 +38,7 @@ if sys.platform == 'darwin':
     does_own_libraries = os.stat(libraries).st_uid == os.getuid()
     if (is_root or not does_own_libraries):
         libraries = os.path.expanduser('~/Library/webkitpy')
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}'.format(sys.version_info[0])))
 
 from resultsdbpy.model.docker import Docker
 from multiprocessing import Process

--- a/Tools/Scripts/libraries/resultsdbpy/run-tests
+++ b/Tools/Scripts/libraries/resultsdbpy/run-tests
@@ -39,7 +39,7 @@ if sys.platform == 'darwin':
     does_own_libraries = os.stat(libraries).st_uid == os.getuid()
     if (is_root or not does_own_libraries):
         libraries = os.path.expanduser('~/Library/webkitpy')
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}'.format(sys.version_info[0])))
 
 from cassandra.cqlengine.management import CQLENG_ALLOW_SCHEMA_MANAGEMENT
 

--- a/Tools/Scripts/libraries/webkitbugspy/run-tests
+++ b/Tools/Scripts/libraries/webkitbugspy/run-tests
@@ -33,7 +33,7 @@ from webkitcorepy.testing import PythonTestRunner
 
 
 libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.WARNING)

--- a/Tools/Scripts/libraries/webkitcorepy/run-tests
+++ b/Tools/Scripts/libraries/webkitcorepy/run-tests
@@ -32,7 +32,7 @@ from webkitcorepy.testing import PythonTestRunner
 
 
 libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.WARNING)

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -30,7 +30,6 @@ import shutil
 import ssl
 import subprocess
 import sys
-import sysconfig
 import tarfile
 import tempfile
 import time
@@ -493,61 +492,7 @@ class AutoInstall(object):
                 os.chown(os.path.join(root, file), uid, gid)
 
     @classmethod
-    def _platform_compatibility_tag(cls):
-        try:
-            impl = sys.implementation.name
-        except AttributeError:
-            # Python 2
-            impl = platform.python_implementation().lower()
-
-        INTERPRETER_SHORT_NAMES = {
-            "python": "py",
-            "cpython": "cp",
-            "pypy": "pp",
-            "ironpython": "ip",
-            "jython": "jy",
-        }
-
-        impl = INTERPRETER_SHORT_NAMES.get(impl, impl)
-
-        version = "".join(map(str, sys.version_info[:2]))
-
-        try:
-            abi = sys.abiflags
-        except AttributeError:
-            # Python 2
-            abi = ""
-
-        if platform.system() == "Darwin":
-            mac_version_str, _, mac_arch = platform.mac_ver()
-            mac_version = tuple(map(int, mac_version_str.split(".")))
-            tag_platform = "macosx_{}_{}_{}".format(
-                mac_version[0], 0 if mac_version[0] >= 11 else mac_version[1], mac_arch
-            )
-        else:
-            tag_platform = (
-                sysconfig.get_platform()
-                .replace(".", "_")
-                .replace("-", "_")
-                .replace(" ", "_")
-            )
-            if platform.system() == "Linux" and sys.maxsize <= 2**32:
-                if tag_platform == "linux_x86_64":
-                    tag_platform = "linux_i686"
-                elif tag_platform == "linux_aarch64":
-                    tag_platform = "linux_armv7l"
-
-        if impl == "cp":
-            return "{impl}{version}-{impl}{version}{abi}-{platform}".format(
-                impl=impl, version=version, abi=abi, platform=tag_platform
-            )
-        else:
-            return "{impl}{version}-{abi}-{platform}".format(
-                impl=impl, version=version, abi=abi, platform=tag_platform
-            )
-
-    @classmethod
-    def set_directory(cls, directory, create_platform_subdirectory=True):
+    def set_directory(cls, directory):
         if not directory or not isinstance(directory, str):
             raise ValueError('{} is an invalid autoinstall directory'.format(directory))
 
@@ -558,9 +503,6 @@ class AutoInstall(object):
                 os.environ.get(cls.DISABLE_ENV_VAR),
             ))
             return
-
-        if create_platform_subdirectory:
-            directory = os.path.join(directory, cls._platform_compatibility_tag())
 
         directory = os.path.abspath(directory)
         if not os.path.isdir(directory):

--- a/Tools/Scripts/libraries/webkitscmpy/run-tests
+++ b/Tools/Scripts/libraries/webkitscmpy/run-tests
@@ -34,7 +34,7 @@ from webkitcorepy.testing import PythonTestRunner
 
 
 libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.WARNING)

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -32,7 +32,7 @@ if sys.platform == 'darwin':
         libraries = os.path.expanduser('~/Library/webkitpy')
 
 from webkitcorepy import AutoInstall, Package, Version
-AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled'))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
 
 if sys.version_info >= (3, 7):
     AutoInstall.register(Package('pylint', Version(2, 6, 0)))
@@ -57,10 +57,10 @@ else:
     sys.stderr.write("pytest, pylint and websockets do not support Python version! (%s)\n" % sys.version)
 
 if sys.version_info >= (3, 6):
-    AutoInstall.register(Package('importlib_metadata', Version(4, 8, 1), implicit_deps=['zipp', 'typing_extensions']))
+    AutoInstall.register(Package('importlib_metadata', Version(4, 8, 1)))
     AutoInstall.register(Package('typing_extensions', Version(3, 10, 0)))
 else:
-    AutoInstall.register(Package('importlib_metadata', Version(1, 7, 0), implicit_deps=['zipp']))
+    AutoInstall.register(Package('importlib_metadata', Version(1, 7, 0)))
 
 AutoInstall.register(Package('atomicwrites', Version(1, 1, 5)))
 AutoInstall.register(Package('attr', Version(20, 3, 0), pypi_name='attrs'))


### PR DESCRIPTION
#### 01641ad43827670d2ca177bc8bfe47aa391000dc
<pre>
Revert [268205@main] AutoInstaller should name directory based on ABI
<a href="https://bugs.webkit.org/show_bug.cgi?id=224669">https://bugs.webkit.org/show_bug.cgi?id=224669</a>

Unreviewed revert.

Broke contributors local tools.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py:
* Tools/Scripts/libraries/resultsdbpy/container:
* Tools/Scripts/libraries/resultsdbpy/run:
* Tools/Scripts/libraries/resultsdbpy/run-tests:
* Tools/Scripts/libraries/webkitbugspy/run-tests:
* Tools/Scripts/libraries/webkitcorepy/run-tests:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(AutoInstall.set_directory):
(AutoInstall._platform_compatibility_tag): Deleted.
* Tools/Scripts/libraries/webkitscmpy/run-tests:
* Tools/Scripts/webkitpy/__init__.py:

Canonical link: <a href="https://commits.webkit.org/268230@main">https://commits.webkit.org/268230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a0375a0f1310b1b971353178a567990b9f2d83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20050 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20963 "Failed to checkout and rebase branch from PR 18004") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/19293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22733 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/19583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/20963 "Failed to checkout and rebase branch from PR 18004") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/19319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21845 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19269 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/19583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/18928 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/17237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2329 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->