### PR TITLE
Block notifyd in experimental sandbox

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -517,8 +517,7 @@
         (literal "/private/var/run/syslog"))
 )
 
-(allow mach-lookup
-    (global-name "com.apple.system.notification_center")
+(allow mach-lookup (global-name "com.apple.system.notification_center")
     (apply-message-filter
         (deny mach-message-send)
         (deny mach-message-send (with no-report) (message-number 1023))
@@ -526,7 +525,11 @@
             1002 1011 1012 1016 1017 1018 1021 1025 1026 1028 1029 1030 1031 1032))))
 
 (allow ipc-posix-shm-read*
-       (ipc-posix-name "apple.shm.notification_center"))
+    (ipc-posix-name "apple.shm.notification_center"))
+
+(with-filter (state-flag "EnableExperimentalSandbox")
+    (deny mach-lookup (global-name "com.apple.system.notification_center")))
+
 
 (managed-configuration-read-public)
 

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1552,35 +1552,17 @@
 #if PLATFORM(MAC)
 ;; FIXME should be removed when <rdar://problem/9347205> + related radar in Safari is fixed
 (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "NO")
-    (allow mach-lookup
-        (global-name "com.apple.system.notification_center"))
+    (allow mach-lookup (global-name "com.apple.system.notification_center"))
 ;; else
-    (allow mach-lookup
-        (global-name "com.apple.system.notification_center")
+    (allow mach-lookup (global-name "com.apple.system.notification_center")
         (apply-message-filter
             (deny mach-message-send)
             (deny mach-message-send (with no-report) (message-number 1023))
             (allow mach-message-send (message-number
-                1002
-                1010
-                1011
-                1012
-                1016
-                1017
-                1018
-                1021
-                1022
-                1025
-                1026
-                1028
-                1029
-                1030
-                1031
-                1032
-            ))
-        )
-    )
-)
+                1002 1010 1011 1012 1016 1017 1018 1021 1022 1025 1026 1028 1029 1030 1031 1032)))))
+
+(with-filter (state-flag "EnableExperimentalSandbox")
+    (deny mach-lookup (global-name "com.apple.system.notification_center")))
 #endif
 
 ;; <rdar://problem/63943836>


### PR DESCRIPTION
#### fd754ccd63610779ff1a2700274ccf5bb0fcba36
<pre>
Block notifyd in experimental sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=261860">https://bugs.webkit.org/show_bug.cgi?id=261860</a>

Reviewed by Chris Dumez.

Block notifyd in experimental sandbox in the WebContent process.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/268253@main">https://commits.webkit.org/268253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bae07575b508f28c1a542ecf042f86d7f8a8abc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17852 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19582 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21846 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16607 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23775 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21724 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15391 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17238 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4576 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21594 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->