### PR TITLE
Stop using the `UIApp` static variable to access the shared UIApplication

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1330,14 +1330,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @property (nonatomic, copy, setter=_setSuggestedColors:) NSArray<UIColor *> *_suggestedColors;
 @end
 
-#if HAVE(UI_FOCUS_EFFECT)
-@class UIFocusEffect;
-
-@interface UIView (Staging_75759822)
-@property (nonatomic, readwrite, copy) UIFocusEffect *focusEffect;
-@end
-#endif
-
 #if HAVE(UIFINDINTERACTION)
 
 @interface _UIFindInteraction (Staging_84486967)
@@ -1372,7 +1364,6 @@ extern NSString * const UIKeyboardPrivateDidRequestDismissalNotification;
 
 extern NSString * const UIKeyboardIsLocalUserInfoKey;
 
-extern UIApplication *UIApp;
 BOOL _UIApplicationIsExtension(void);
 void _UIApplicationLoadWebKit(void);
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1391,7 +1391,7 @@ void NavigationState::didChangeIsLoading()
     if (webView && webView->_page->pageLoadState().isLoading()) {
 #if PLATFORM(IOS_FAMILY)
         // We do not start a network activity if a load starts after the screen has been locked.
-        if ([UIApp isSuspendedUnderLock])
+        if (UIApplication.sharedApplication.isSuspendedUnderLock)
             return;
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -407,9 +407,9 @@ static bool isJavaScriptURL(NSURL *url)
             return;
 
         if (!alternateURL && userInfo) {
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            [UIApp _cancelAllTouches];
-ALLOW_DEPRECATED_DECLARATIONS_END
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+            [UIApplication.sharedApplication _cancelAllTouches];
+            ALLOW_DEPRECATED_DECLARATIONS_END
             return;
         }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8496,7 +8496,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
             // Prevent tap-and-hold and panning.
             if (shouldCancelAllTouches)
-                [UIApp _cancelAllTouches];
+                [UIApplication.sharedApplication _cancelAllTouches];
 
             return YES;
         }

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -628,7 +628,7 @@ void WebPageProxy::applicationDidEnterBackground()
 {
     m_lastObservedStateWasBackground = true;
 
-    bool isSuspendedUnderLock = [UIApp isSuspendedUnderLock];
+    bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationDidEnterBackground: isSuspendedUnderLock? %d", isSuspendedUnderLock);
 
@@ -661,7 +661,7 @@ void WebPageProxy::applicationWillEnterForeground()
 {
     m_lastObservedStateWasBackground = false;
 
-    bool isSuspendedUnderLock = [UIApp isSuspendedUnderLock];
+    bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationWillEnterForeground: isSuspendedUnderLock? %d", isSuspendedUnderLock);
 
     m_process->send(Messages::WebPage::ApplicationWillEnterForeground(isSuspendedUnderLock), webPageID());
@@ -675,7 +675,7 @@ void WebPageProxy::applicationWillResignActive()
 
 void WebPageProxy::applicationDidEnterBackgroundForMedia()
 {
-    bool isSuspendedUnderLock = [UIApp isSuspendedUnderLock];
+    bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationWillEnterForegroundForMedia: isSuspendedUnderLock? %d", isSuspendedUnderLock);
 
     m_process->send(Messages::WebPage::ApplicationDidEnterBackgroundForMedia(isSuspendedUnderLock), webPageID());
@@ -683,7 +683,7 @@ void WebPageProxy::applicationDidEnterBackgroundForMedia()
 
 void WebPageProxy::applicationWillEnterForegroundForMedia()
 {
-    bool isSuspendedUnderLock = [UIApp isSuspendedUnderLock];
+    bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationWillEnterForegroundForMedia: isSuspendedUnderLock? %d", isSuspendedUnderLock);
 
     m_process->send(Messages::WebPage::ApplicationWillEnterForegroundForMedia(isSuspendedUnderLock), webPageID());

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -673,9 +673,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [self._webView _beginAnimatedResizeWithUpdates:^{
             [self._webView _overrideLayoutParametersWithMinimumLayoutSize:size maximumUnobscuredSizeOverride:size];
         }];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [self._webView _setInterfaceOrientationOverride:[UIApp statusBarOrientation]];
-ALLOW_DEPRECATED_DECLARATIONS_END
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        [self._webView _setInterfaceOrientationOverride:UIApplication.sharedApplication.statusBarOrientation];
+        ALLOW_DEPRECATED_DECLARATIONS_END
     } completion:^(id <UIViewControllerTransitionCoordinatorContext>context) {
         [self._webView _endAnimatedResize];
     }];

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -778,7 +778,7 @@ RetainPtr<WebView> createWebViewAndOffscreenWindow()
     [[webView window] makeFirstResponder:[[[webView mainFrame] frameView] documentView]];
 
     CGRect uiWindowRect = layoutTestViewportRect;
-    uiWindowRect.origin.y += [UIApp statusBarHeight];
+    uiWindowRect.origin.y += UIApplication.sharedApplication.statusBarHeight;
     auto uiWindow = adoptNS([[UIWindow alloc] initWithFrame:uiWindowRect]);
 
     auto viewController = adoptNS([[UIViewController alloc] init]);
@@ -2010,7 +2010,7 @@ static void runTest(const std::string& inputLine)
     }
 
 #if PLATFORM(IOS_FAMILY)
-    [(DumpRenderTree *)UIApp _waitForWebThread];
+    [(DumpRenderTree *)UIApplication.sharedApplication _waitForWebThread];
     WebThreadLockAfterDelegateCallbacksHaveCompleted();
 #endif
 


### PR DESCRIPTION
#### fceec3484288b9c6e4289a5ced7a1ccf5b082cc2
<pre>
Stop using the `UIApp` static variable to access the shared UIApplication
<a href="https://bugs.webkit.org/show_bug.cgi?id=261861">https://bugs.webkit.org/show_bug.cgi?id=261861</a>

Reviewed by Richard Robinson.

Replace uses of `UIApp` with the equivalent `+[UIApplication sharedApplication]`. Also, remove a
staging declaration for the `-[UIView focusEffect]` property that&apos;s no longer necessary.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::didChangeIsLoading):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant showImageSheet]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView actionSheetAssistant:showCustomSheetForElement:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::applicationDidEnterBackground):
(WebKit::WebPageProxy::applicationWillEnterForeground):
(WebKit::WebPageProxy::applicationDidEnterBackgroundForMedia):
(WebKit::WebPageProxy::applicationWillEnterForegroundForMedia):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController viewWillTransitionToSize:withTransitionCoordinator:]):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(createWebViewAndOffscreenWindow):
(runTest):

Canonical link: <a href="https://commits.webkit.org/268235@main">https://commits.webkit.org/268235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/992bcbf916598d7acd9286f62542b0020aaa75b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19585 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21847 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16610 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17399 "1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23776 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18142 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17239 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4552 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21595 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/17972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->