### PR TITLE
NativePromise should be forward-declared in WTF/Forwards.h

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -122,6 +122,7 @@ template<typename Key, typename Value, typename Extractor, typename HashFunction
 template<typename Value, typename = DefaultHash<Value>, typename = HashTraits<Value>> class HashCountedSet;
 template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits> class HashMap;
 template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits> class HashSet;
+template<typename ResolveValueT, typename RejectValueT, bool IsExclusive> class NativePromise;
 
 }
 
@@ -155,6 +156,7 @@ using WTF::Logger;
 using WTF::MachSendRight;
 using WTF::makeUniqueRef;
 using WTF::MonotonicTime;
+using WTF::NativePromise;
 using WTF::NeverDestroyed;
 using WTF::ObjectIdentifier;
 using WTF::ObjectIdentifierGeneric;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -547,8 +547,6 @@ def generate_messages_header(receiver):
     result.append(forward_declarations)
     result.append('\n')
 
-    result.append('namespace WTF {\ntemplate<typename ResolveValueT, typename RejectValueT, bool IsExclusive>\nclass NativePromise;\n} // namespace WTF\n\n')
-
     result.append('namespace Messages {\nnamespace %s {\n' % receiver.name)
     result.append('\n')
     result.append('static inline IPC::ReceiverName messageReceiverName()\n')

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
@@ -35,11 +35,6 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithCVPixelBuffer {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessages.h
@@ -32,11 +32,6 @@
 #include <wtf/text/WTFString.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithEnabledIf {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
@@ -32,11 +32,6 @@
 #include <wtf/text/WTFString.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithIfMessage {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
@@ -33,11 +33,6 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithImageData {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -54,11 +54,6 @@ class WebPreferencesStore;
 class WebTouchEvent;
 }
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithLegacyReceiver {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
@@ -32,11 +32,6 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithSemaphore {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
@@ -32,11 +32,6 @@
 #include <wtf/text/WTFString.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithStreamBatched {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
@@ -34,11 +34,6 @@ namespace IPC {
 class StreamConnectionBuffer;
 }
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithStreamBuffer {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -33,11 +33,6 @@
 #include <wtf/text/WTFString.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithStream {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
@@ -32,11 +32,6 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithStreamServerConnectionHandle {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
@@ -37,11 +37,6 @@ namespace WebKit {
 enum class TestTwoStateEnum : bool;
 }
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithSuperclass {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -54,11 +54,6 @@ class WebPreferencesStore;
 class WebTouchEvent;
 }
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithoutAttributes {
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h
@@ -32,11 +32,6 @@
 #include <wtf/text/WTFString.h>
 
 
-namespace WTF {
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive>
-class NativePromise;
-} // namespace WTF
-
 namespace Messages {
 namespace TestWithoutUsingIPCConnection {
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -29,6 +29,7 @@
 #include "Connection.h"
 #include "Utilities.h"
 #include <optional>
+#include <wtf/Forward.h>
 
 namespace TestWebKitAPI {
 


### PR DESCRIPTION
#### fad6397d597a5f40e53052b85149b5f1e411b6ae
<pre>
NativePromise should be forward-declared in WTF/Forwards.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=261864">https://bugs.webkit.org/show_bug.cgi?id=261864</a>
rdar://115826365

Reviewed by Kimmo Kinnunen.

Have NativePromise forward declaration in wtf/Forward.h

* Source/WTF/wtf/Forward.h:
* Source/WebKit/Scripts/webkit/messages.py:
(generate_messages_header):
(generate_messages_header.NativePromise): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h:
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:

Canonical link: <a href="https://commits.webkit.org/268246@main">https://commits.webkit.org/268246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8958ec8ffe814f224f99dab442a66e9438b0f43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17873 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19606 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21873 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19299 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17420 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16596 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21753 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18450 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18160 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22509 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17265 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5462 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4558 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21619 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23759 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17990 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5324 "Passed tests") | 
<!--EWS-Status-Bubble-End-->