### PR TITLE
ImageBuffer filter operations should return NativeImage

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -319,7 +319,7 @@ RefPtr<ImageBuffer> ImageBuffer::sinkIntoBufferForDifferentThread()
     return this;
 }
 
-RefPtr<Image> ImageBuffer::filteredImage(Filter& filter)
+RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter)
 {
     ASSERT(!filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
 
@@ -336,10 +336,10 @@ RefPtr<Image> ImageBuffer::filteredImage(Filter& filter)
     if (!imageBuffer)
         return nullptr;
 
-    return imageBuffer->copyImage();
+    return copyImageBufferToNativeImage(*imageBuffer, CopyBackingStore, PreserveResolution::No);
 }
 
-RefPtr<Image> ImageBuffer::filteredImage(Filter& filter, std::function<void(GraphicsContext&)> drawCallback)
+RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter, Function<void(GraphicsContext&)> drawCallback)
 {
     std::unique_ptr<FilterTargetSwitcher> targetSwitcher;
 
@@ -355,10 +355,10 @@ RefPtr<Image> ImageBuffer::filteredImage(Filter& filter, std::function<void(Grap
     if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext)) {
         ASSERT(targetSwitcher);
         targetSwitcher->endDrawSourceImage(context());
-        return copyImage();
+        return copyImageBufferToNativeImage(*this, CopyBackingStore, PreserveResolution::No);
     }
 
-    return filteredImage(filter);
+    return filteredNativeImage(filter);
 }
 
 #if USE(CAIRO)

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -33,6 +33,7 @@
 #include "ProcessIdentity.h"
 #include "RenderingMode.h"
 #include "RenderingResourceIdentifier.h"
+#include <wtf/Function.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -157,8 +158,8 @@ public:
     WEBCORE_EXPORT virtual RefPtr<NativeImage> createNativeImageReference() const;
 
     WEBCORE_EXPORT RefPtr<Image> copyImage(BackingStoreCopy = CopyBackingStore, PreserveResolution = PreserveResolution::No) const;
-    WEBCORE_EXPORT virtual RefPtr<Image> filteredImage(Filter&);
-    RefPtr<Image> filteredImage(Filter&, std::function<void(GraphicsContext&)> drawCallback);
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> filteredNativeImage(Filter&);
+    RefPtr<NativeImage> filteredNativeImage(Filter&, Function<void(GraphicsContext&)> drawCallback);
 
 #if USE(CAIRO)
     WEBCORE_EXPORT RefPtr<cairo_surface_t> createCairoSurface();

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "StyleFilterImage.h"
 
+#include "BitmapImage.h"
 #include "CSSFilter.h"
 #include "CSSFilterImageValue.h"
 #include "CSSValuePool.h"
@@ -137,11 +138,12 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderer, const Float
     if (!sourceImage)
         return &Image::nullImage();
 
-    auto filteredImage = sourceImage->filteredImage(*cssFilter, [&](GraphicsContext& context) {
+    auto filteredImage = sourceImage->filteredNativeImage(*cssFilter, [&](GraphicsContext& context) {
         context.drawImage(*image, sourceImageRect);
     });
-
-    return filteredImage ? filteredImage : &Image::nullImage();
+    if (!filteredImage)
+        return &Image::nullImage();
+    return BitmapImage::create(WTFMove(filteredImage));
 }
 
 bool StyleFilterImage::knownToBeOpaque(const RenderElement&) const

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -132,22 +132,22 @@ void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveR
     completionHandler(WTFMove(handle));
 }
 
-void RemoteImageBuffer::getFilteredImage(Ref<WebCore::Filter> filter, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&& completionHandler)
+void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     std::optional<ShareableBitmap::Handle> handle;
     [&]() {
-        auto image = m_imageBuffer->filteredImage(filter);
+        auto image = m_imageBuffer->filteredNativeImage(filter);
         if (!image)
             return;
         auto imageSize = image->size();
-        auto bitmap = ShareableBitmap::create({ IntSize(imageSize), m_imageBuffer->colorSpace() });
+        auto bitmap = ShareableBitmap::create({ imageSize, m_imageBuffer->colorSpace() });
         if (!bitmap)
             return;
         auto context = bitmap->createGraphicsContext();
         if (!context)
             return;
-        context->drawImage(*image, FloatPoint());
+        context->drawNativeImage(*image, imageSize, FloatRect { { }, imageSize }, FloatRect { { }, imageSize });
         handle = bitmap->createHandle();
     }();
     completionHandler(WTFMove(handle));

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -62,7 +62,7 @@ private:
     void getPixelBufferWithNewMemory(SharedMemory::Handle&&, WebCore::PixelBufferFormat, WebCore::IntRect, CompletionHandler<void()>&&);
     void putPixelBuffer(Ref<WebCore::PixelBuffer>, WebCore::IntRect srcRect, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat);
     void getShareableBitmap(WebCore::PreserveResolution, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&&);
-    void getFilteredImage(Ref<WebCore::Filter>, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&&);
+    void filteredNativeImage(Ref<WebCore::Filter>, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&&);
     void convertToLuminanceMask();
     void transformToColorSpace(const WebCore::DestinationColorSpace&);
     void setFlushSignal(IPC::Signal&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -28,7 +28,7 @@ messages -> RemoteImageBuffer NotRefCounted Stream {
     GetPixelBufferWithNewMemory(WebKit::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous NotStreamEncodable
     PutPixelBuffer(Ref<WebCore::PixelBuffer> pixelBuffer,  WebCore::IntRect srcRect, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)
     GetShareableBitmap(enum:bool WebCore::PreserveResolution preserveResolution) -> (std::optional<WebKit::ShareableBitmap::Handle> handle) Synchronous NotStreamEncodableReply
-    GetFilteredImage(Ref<WebCore::Filter> filter) -> (std::optional<WebKit::ShareableBitmap::Handle> handle) Synchronous NotStreamEncodableReply
+    FilteredNativeImage(Ref<WebCore::Filter> filter) -> (std::optional<WebKit::ShareableBitmap::Handle> handle) Synchronous NotStreamEncodableReply
     ConvertToLuminanceMask()
     TransformToColorSpace(WebCore::DestinationColorSpace colorSpace)
     SetFlushSignal(IPC::Signal signal) NotStreamEncodable

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -81,7 +81,7 @@ private:
 
     RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread() final;
 
-    RefPtr<WebCore::Image> filteredImage(WebCore::Filter&) final;
+    RefPtr<WebCore::NativeImage> filteredNativeImage(WebCore::Filter&) final;
 
     WebCore::GraphicsContext& context() const final;
 
@@ -99,7 +99,7 @@ private:
 
     void assertDispatcherIsCurrent() const;
     template<typename T> void send(T&& message);
-    template<typename T> void sendSync(T&& message);
+    template<typename T> auto sendSync(T&& message);
 
     IPC::StreamClientConnection& streamConnection() const;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -250,21 +250,6 @@ RefPtr<ShareableBitmap> RemoteRenderingBackendProxy::getShareableBitmap(Renderin
     return ShareableBitmap::create(WTFMove(*handle));
 }
 
-RefPtr<Image> RemoteRenderingBackendProxy::getFilteredImage(RenderingResourceIdentifier imageBuffer, Filter& filter)
-{
-    auto sendResult = sendSync(Messages::RemoteImageBuffer::GetFilteredImage(filter), imageBuffer);
-    auto [handle] = sendResult.takeReply();
-    if (!handle)
-        return { };
-
-    handle->takeOwnershipOfMemory(MemoryLedger::Graphics);
-    auto bitmap = ShareableBitmap::create(WTFMove(*handle));
-    if (!bitmap)
-        return { };
-
-    return bitmap->createImage();
-}
-
 void RemoteRenderingBackendProxy::cacheNativeImage(ShareableBitmap::Handle&& handle, RenderingResourceIdentifier renderingResourceIdentifier)
 {
     send(Messages::RemoteRenderingBackend::CacheNativeImage(WTFMove(handle), renderingResourceIdentifier));

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -98,7 +98,6 @@ public:
     bool getPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, std::span<uint8_t> result);
     void putPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBuffer&, const WebCore::IntRect& srcRect, const WebCore::IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat);
     RefPtr<ShareableBitmap> getShareableBitmap(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution);
-    RefPtr<WebCore::Image> getFilteredImage(WebCore::RenderingResourceIdentifier, WebCore::Filter&);
     void cacheNativeImage(ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void cacheFont(const WebCore::Font::Attributes&, const WebCore::FontPlatformData::Attributes&, std::optional<WebCore::RenderingResourceIdentifier>);
     void cacheFontCustomPlatformData(Ref<const WebCore::FontCustomPlatformData>&&);


### PR DESCRIPTION
#### f0576678c27689432df0e1cd90e77acf379af245
<pre>
ImageBuffer filter operations should return NativeImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=261866">https://bugs.webkit.org/show_bug.cgi?id=261866</a>
rdar://115829020

Reviewed by Antti Koivisto.

ImageBuffer operates on NativeImages, WebCore::Image is a higher level
type. The filter operations anyway flatten the results into a
NativeImage, from which the WebCore::Image was always created.

Construct the WebCore::Image at the caller if needed.

Since this renames the function, move the GPUP implementation from
the RemoteRenderingBackendProxy to the real caller which is the
RemoteImageBufferProxy. The messages have already been moved previously.

This is work towards simplifying ImageBuffer API use NativeImage only.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::filteredNativeImage):
(WebCore::ImageBuffer::filteredImage): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::filteredNativeImage):
(WebKit::RemoteImageBuffer::getFilteredImage): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::sendSync):
(WebKit::RemoteImageBufferProxy::filteredNativeImage):
(WebKit::RemoteImageBufferProxy::filteredImage): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::getFilteredImage): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:

Canonical link: <a href="https://commits.webkit.org/268301@main">https://commits.webkit.org/268301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ab53dcfb76ff3770240ae98c3c01f46cadbb079

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19628 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21935 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23828 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21787 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15437 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17346 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4608 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->