### PR TITLE
Fix build with legacy media controls

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -69,7 +69,6 @@ list(APPEND WebCore_SOURCES
 
 list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
     ${WEBCORE_DIR}/Modules/mediacontrols/mediaControlsBase.css
-    ${WEBCORE_DIR}/css/mediaControls.css
 )
 
 set(WebCore_USER_AGENT_SCRIPTS

--- a/Source/WebCore/platform/Adwaita.cmake
+++ b/Source/WebCore/platform/Adwaita.cmake
@@ -17,13 +17,19 @@ list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
     ${WEBCORE_DIR}/css/themeAdwaita.css
 )
 
-list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
-    ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.css
-)
+if (ENABLE_MODERN_MEDIA_CONTROLS)
+    list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
+        ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.css
+    )
 
-list(APPEND WebCore_USER_AGENT_SCRIPTS
-    ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.js
-)
+    list(APPEND WebCore_USER_AGENT_SCRIPTS
+        ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.js
+    )
+else ()
+    list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
+        ${WEBCORE_DIR}/css/mediaControls.css
+    )
+endif ()
 
 set(WebCore_USER_AGENT_SCRIPTS_DEPENDENCIES ${WEBCORE_DIR}/rendering/RenderThemeAdwaita.cpp)
 


### PR DESCRIPTION
#### cd2d810df2548a392640b1aa038f867705e8a754
<pre>
Fix build with legacy media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=261878">https://bugs.webkit.org/show_bug.cgi?id=261878</a>

Reviewed by Michael Catanzaro.

Build failed with ENABLE_MODERN_MEDIA_CONTROLS disabled, because
css/mediaControls.css was not added in WebCore_USER_AGENT_STYLE_SHEETS,
since 255715@main.

* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/platform/Adwaita.cmake:

Canonical link: <a href="https://commits.webkit.org/268355@main">https://commits.webkit.org/268355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/504da482969609abf0a69ce2018741da69c470bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19697 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22048 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23898 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21863 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15511 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17456 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4649 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->