### PR TITLE
[LBSE] Add RenderSVGResourceContainer

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2769,6 +2769,7 @@ rendering/svg/RenderSVGModelObject.cpp
 rendering/svg/RenderSVGPath.cpp
 rendering/svg/RenderSVGRect.cpp
 rendering/svg/RenderSVGResource.cpp
+rendering/svg/RenderSVGResourceContainer.cpp
 rendering/svg/RenderSVGResourceFilter.cpp
 rendering/svg/RenderSVGResourceFilterPrimitive.cpp
 rendering/svg/RenderSVGResourceGradient.cpp

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -54,6 +54,7 @@ class LegacyRenderSVGResourceContainer;
 class IdTargetObserverRegistry;
 class Node;
 class RadioButtonGroups;
+class RenderSVGResourceContainer;
 class SVGElement;
 class ShadowRoot;
 class TreeScopeOrderedMap;
@@ -131,6 +132,7 @@ public:
     std::span<const RefPtr<CSSStyleSheet>> adoptedStyleSheets() const;
     ExceptionOr<void> setAdoptedStyleSheets(Vector<RefPtr<CSSStyleSheet>>&&);
 
+    void addSVGResource(const AtomString& id, RenderSVGResourceContainer&);
     void addSVGResource(const AtomString& id, LegacyRenderSVGResourceContainer&);
     void removeSVGResource(const AtomString& id);
     LegacyRenderSVGResourceContainer* svgResourceById(const AtomString& id) const;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -465,6 +465,7 @@ public:
     bool isLegacySVGForeignObject() const { return type() == Type::LegacySVGForeignObject; }
     bool isSVGForeignObject() const { return type() == Type::SVGForeignObject; }
     virtual bool isSVGResourceContainer() const { return false; }
+    virtual bool isLegacySVGResourceContainer() const { return false; }
     bool isSVGResourceFilter() const { return type() == Type::SVGResourceFilter; }
     bool isSVGResourceClipper() const { return type() == Type::LegacySVGResourceClipper; }
     bool isSVGResourceFilterPrimitive() const { return type() == Type::SVGResourceFilterPrimitive; }

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
@@ -30,8 +30,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGHiddenContainer);
 
-RenderSVGHiddenContainer::RenderSVGHiddenContainer(SVGElement& element, RenderStyle&& style)
-    : RenderSVGContainer(Type::SVGHiddenContainer, element, WTFMove(style))
+RenderSVGHiddenContainer::RenderSVGHiddenContainer(Type type, SVGElement& element, RenderStyle&& style)
+    : RenderSVGContainer(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
@@ -29,13 +29,15 @@ class SVGElement;
 
 // This class is for containers which are never drawn, but do need to support style
 // <defs>, <linearGradient>, <radialGradient> are all good examples
-class RenderSVGHiddenContainer final : public RenderSVGContainer {
+class RenderSVGHiddenContainer : public RenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGHiddenContainer);
 public:
-    RenderSVGHiddenContainer(SVGElement&, RenderStyle&&);
+    RenderSVGHiddenContainer(Type, SVGElement&, RenderStyle&&);
 
 protected:
     void layout() override;
+
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
 private:
     ASCIILiteral renderName() const override { return "RenderSVGHiddenContainer"_s; }
@@ -53,7 +55,6 @@ private:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect&, OptionSet<RenderStyle::TransformOperationOption>) const final { }
     void updateFromStyle() final { }
     bool needsHasSVGTransformFlags() const final { return false; }
-    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) Research In Motion Limited 2010. All rights reserved.
+ * Copyright (c) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "RenderSVGResourceContainer.h"
+
+#include "RenderLayer.h"
+#include "RenderSVGRoot.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGResourcesCache.h"
+#include <wtf/IsoMallocInlines.h>
+#include <wtf/SetForScope.h>
+#include <wtf/StackStats.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceContainer);
+
+RenderSVGResourceContainer::RenderSVGResourceContainer(Type type, SVGElement& element, RenderStyle&& style)
+    : RenderSVGHiddenContainer(type, element, WTFMove(style))
+    , m_id(element.getIdAttribute())
+{
+}
+
+RenderSVGResourceContainer::~RenderSVGResourceContainer() = default;
+
+void RenderSVGResourceContainer::willBeDestroyed()
+{
+    if (m_registered) {
+        treeScopeForSVGReferences().removeSVGResource(m_id);
+        m_registered = false;
+    }
+
+    RenderSVGHiddenContainer::willBeDestroyed();
+}
+
+void RenderSVGResourceContainer::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
+{
+    RenderSVGHiddenContainer::styleDidChange(diff, oldStyle);
+
+    if (!m_registered) {
+        m_registered = true;
+        registerResource();
+    }
+}
+
+void RenderSVGResourceContainer::idChanged()
+{
+    // Remove old id, that is guaranteed to be present in cache.
+    treeScopeForSVGReferences().removeSVGResource(m_id);
+    m_id = element().getIdAttribute();
+
+    registerResource();
+}
+
+void RenderSVGResourceContainer::registerResource()
+{
+    auto& treeScope = this->treeScopeForSVGReferences();
+    if (!treeScope.isIdOfPendingSVGResource(m_id)) {
+        treeScope.addSVGResource(m_id, *this);
+        return;
+    }
+
+    auto elements = copyToVectorOf<Ref<SVGElement>>(treeScope.removePendingSVGResource(m_id));
+
+    treeScope.addSVGResource(m_id, *this);
+}
+
+}

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Research In Motion Limited 2010. All rights reserved.
+ * Copyright (c) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "RenderSVGHiddenContainer.h"
+#include "RenderSVGResource.h"
+
+namespace WebCore {
+
+class RenderLayer;
+
+class RenderSVGResourceContainer : public RenderSVGHiddenContainer, public RenderSVGResource {
+    WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceContainer);
+public:
+    virtual ~RenderSVGResourceContainer();
+
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
+
+    bool isSVGResourceContainer() const final { return true; }
+
+    void idChanged();
+
+protected:
+    RenderSVGResourceContainer(Type, SVGElement&, RenderStyle&&);
+
+private:
+    friend class SVGResourcesCache;
+    void addClient(RenderElement&);
+    void removeClient(RenderElement&);
+
+    void willBeDestroyed() final;
+    void registerResource();
+
+    AtomString m_id;
+    bool m_registered { false };
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderSVGResourceContainer, isSVGResourceContainer())

--- a/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp
@@ -46,7 +46,7 @@ bool SVGResourcesCycleSolver::resourceContainsCycles(LegacyRenderSVGResourceCont
 
     RenderObject* node = &resource;
     while (node) {
-        if (node != &resource && node->isSVGResourceContainer()) {
+        if (node != &resource && node->isLegacySVGResourceContainer()) {
             node = node->nextInPreOrderAfterChildren(&resource);
             continue;
         }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -33,6 +33,8 @@
 #include "RenderStyleInlines.h"
 #include "SVGPathElement.h"
 #include "SVGRenderStyle.h"
+#include "SVGResources.h"
+#include "SVGResourcesCache.h"
 #include "SVGSubpathData.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -37,7 +37,7 @@ public:
     void layout() override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
 
-    bool isSVGResourceContainer() const final { return true; }
+    bool isLegacySVGResourceContainer() const final { return true; }
 
     static float computeTextPaintingScale(const RenderElement&);
     static AffineTransform transformOnNonScalingStroke(RenderObject*, const AffineTransform& resourceTransform);
@@ -105,4 +105,4 @@ Renderer* getRenderSVGResourceById(TreeScope& treeScope, const AtomString& id)
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGResourceContainer, isSVGResourceContainer())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(LegacyRenderSVGResourceContainer, isLegacySVGResourceContainer())

--- a/Source/WebCore/svg/SVGDefsElement.cpp
+++ b/Source/WebCore/svg/SVGDefsElement.cpp
@@ -51,7 +51,7 @@ RenderPtr<RenderElement> SVGDefsElement::createElementRenderer(RenderStyle&& sty
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (document().settings().layerBasedSVGEngineEnabled())
-        return createRenderer<RenderSVGHiddenContainer>(*this, WTFMove(style));
+        return createRenderer<RenderSVGHiddenContainer>(RenderObject::Type::SVGHiddenContainer, *this, WTFMove(style));
 #endif
     return createRenderer<LegacyRenderSVGHiddenContainer>(RenderObject::Type::LegacySVGHiddenContainer, *this, WTFMove(style));
 }

--- a/Source/WebCore/svg/SVGGElement.cpp
+++ b/Source/WebCore/svg/SVGGElement.cpp
@@ -57,7 +57,7 @@ RenderPtr<RenderElement> SVGGElement::createElementRenderer(RenderStyle&& style,
     // FIXME: [LBSE] Support hidden containers
     if (document().settings().layerBasedSVGEngineEnabled()) {
         if (style.display() == DisplayType::None)
-            return createRenderer<RenderSVGHiddenContainer>(*this, WTFMove(style));
+            return createRenderer<RenderSVGHiddenContainer>(RenderObject::Type::SVGHiddenContainer, *this, WTFMove(style));
         return createRenderer<RenderSVGTransformableContainer>(*this, WTFMove(style));
     }
 #endif

--- a/Source/WebCore/svg/SVGSymbolElement.cpp
+++ b/Source/WebCore/svg/SVGSymbolElement.cpp
@@ -59,7 +59,7 @@ RenderPtr<RenderElement> SVGSymbolElement::createElementRenderer(RenderStyle&& s
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (document().settings().layerBasedSVGEngineEnabled())
-        return createRenderer<RenderSVGHiddenContainer>(*this, WTFMove(style));
+        return createRenderer<RenderSVGHiddenContainer>(RenderObject::Type::SVGHiddenContainer, *this, WTFMove(style));
 #endif
     return createRenderer<LegacyRenderSVGHiddenContainer>(RenderObject::Type::LegacySVGHiddenContainer, *this, WTFMove(style));
 }


### PR DESCRIPTION
#### a9d6d01a743c404d3c502d0bf663b87088cc3772
<pre>
[LBSE] Add RenderSVGResourceContainer
<a href="https://bugs.webkit.org/show_bug.cgi?id=261880">https://bugs.webkit.org/show_bug.cgi?id=261880</a>

Reviewed by Nikolas Zimmermann.

Add RenderSVGResourceContainer for LBSE which knows how to handle RenderLayer
and will act for future LBSE specific SVG resources.
Start keeping track of RenderSVGResourceContainer in ShadowRoot and adjust
RenderObject to be able to distinguish between LBSE and legacy SVG resources.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::addSVGResource):
(WebCore::TreeScope::removeSVGResource):
(WebCore::TreeScope::svgResourceById const):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isLegacySVGResourceContainer const):
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp:
(WebCore::RenderSVGHiddenContainer::RenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h:
(WebCore::RenderObject::isLegacySVGResourceContainer const):
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp: Added.
(WebCore::RenderSVGResourceContainer::RenderSVGResourceContainer):
(WebCore::RenderSVGResourceContainer::willBeDestroyed):
(WebCore::RenderSVGResourceContainer::styleDidChange):
(WebCore::RenderSVGResourceContainer::idChanged):
(WebCore::RenderSVGResourceContainer::registerResource):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.h: Added.
* Source/WebCore/rendering/svg/SVGResourcesCycleSolver.cpp:
(WebCore::SVGResourcesCycleSolver::resourceContainsCycles):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
* Source/WebCore/svg/SVGDefsElement.cpp:
(WebCore::SVGDefsElement::createElementRenderer):
* Source/WebCore/svg/SVGGElement.cpp:
(WebCore::SVGGElement::createElementRenderer):
* Source/WebCore/svg/SVGSymbolElement.cpp:
(WebCore::SVGSymbolElement::createElementRenderer):

Canonical link: <a href="https://commits.webkit.org/269522@main">https://commits.webkit.org/269522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40cf4b9994e5547b4a108a75d0f1f012d1bc3188

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24722 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23340 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25575 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20665 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18170 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/279 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5434 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->