### PR TITLE
[WGSL] Add suport for depth textures

### DIFF
--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -314,6 +314,9 @@ void ConstantRewriter::materialize(Node& expression, const ConstantValue& value)
         [&](const TextureStorage&) {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const TextureDepth&) {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const TypeConstructor&) {
             RELEASE_ASSERT_NOT_REACHED();
         },

--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -177,6 +177,9 @@ const Type* concretize(const Type* type, TypeStore& types)
         [&](const TextureStorage&) -> const Type* {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const TextureDepth&) -> const Type* {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const Reference&) -> const Type* {
             RELEASE_ASSERT_NOT_REACHED();
         },

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -708,6 +708,33 @@ static BindGroupLayoutEntry::BindingMember bindingMemberForGlobal(auto& global)
         return StorageTextureBindingLayout {
             .viewDimension = viewDimension
         };
+    }, [&](const TextureDepth& texture) -> BindGroupLayoutEntry::BindingMember {
+        TextureViewDimension viewDimension;
+        bool multisampled = false;
+        switch (texture.kind) {
+        case Types::TextureDepth::Kind::TextureDepth2d:
+            viewDimension = TextureViewDimension::TwoDimensional;
+            break;
+        case Types::TextureDepth::Kind::TextureDepth2dArray:
+            viewDimension = TextureViewDimension::TwoDimensionalArray;
+            break;
+        case Types::TextureDepth::Kind::TextureDepthCube:
+            viewDimension = TextureViewDimension::Cube;
+            break;
+        case Types::TextureDepth::Kind::TextureDepthCubeArray:
+            viewDimension = TextureViewDimension::CubeArray;
+            break;
+        case Types::TextureDepth::Kind::TextureDepthMultisampled2d:
+            viewDimension = TextureViewDimension::TwoDimensional;
+            multisampled = true;
+            break;
+        }
+
+        return TextureBindingLayout {
+            .sampleType = TextureSampleType::Depth,
+            .viewDimension = viewDimension,
+            .multisampled = multisampled
+        };
     }, [&](const Reference&) -> BindGroupLayoutEntry::BindingMember {
         RELEASE_ASSERT_NOT_REACHED();
     }, [&](const Pointer&) -> BindGroupLayoutEntry::BindingMember {

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -693,6 +693,27 @@ void FunctionDefinitionWriter::visit(const Type* type)
             }
             m_stringBuilder.append(base, "<", type, ", access::", mode, ">");
         },
+        [&](const TextureDepth& texture) {
+            const char* base;
+            switch (texture.kind) {
+            case TextureDepth::Kind::TextureDepth2d:
+                base = "depth2d";
+                break;
+            case TextureDepth::Kind::TextureDepth2dArray:
+                base = "depth2d_array";
+                break;
+            case TextureDepth::Kind::TextureDepthCube:
+                base = "depthcube";
+                break;
+            case TextureDepth::Kind::TextureDepthCubeArray:
+                base = "depthcube_array";
+                break;
+            case TextureDepth::Kind::TextureDepthMultisampled2d:
+                base = "depth2d_ms";
+                break;
+            }
+            m_stringBuilder.append(base, "<float>");
+        },
         [&](const Reference& reference) {
             const char* addressSpace = nullptr;
             switch (reference.addressSpace) {

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -162,6 +162,12 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
     introduceType(AST::Identifier::make("sampler"_s), m_types.samplerType());
     introduceType(AST::Identifier::make("texture_external"_s), m_types.textureExternalType());
 
+    introduceType(AST::Identifier::make("texture_depth_2d"_s), m_types.textureDepth2dType());
+    introduceType(AST::Identifier::make("texture_depth_2d_array"_s), m_types.textureDepth2dArrayType());
+    introduceType(AST::Identifier::make("texture_depth_cube"_s), m_types.textureDepthCubeType());
+    introduceType(AST::Identifier::make("texture_depth_cube_array"_s), m_types.textureDepthCubeArrayType());
+    introduceType(AST::Identifier::make("texture_depth_multisampled_2d"_s), m_types.textureDepthMultisampled2dType());
+
     introduceType(AST::Identifier::make("ptr"_s), m_types.typeConstructorType(
         "ptr"_s,
         [this](AST::ElaboratedTypeExpression& type) -> const Type* {

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -117,6 +117,11 @@ TypeStore::TypeStore()
     m_accessMode = allocateType<Primitive>(Primitive::AccessMode);
     m_texelFormat = allocateType<Primitive>(Primitive::TexelFormat);
     m_addressSpace = allocateType<Primitive>(Primitive::AddressSpace);
+    m_textureDepth2d = allocateType<TextureDepth>(TextureDepth::Kind::TextureDepth2d);
+    m_textureDepthArray2d = allocateType<TextureDepth>(TextureDepth::Kind::TextureDepth2dArray);
+    m_textureDepthCube = allocateType<TextureDepth>(TextureDepth::Kind::TextureDepthCube);
+    m_textureDepthArrayCube = allocateType<TextureDepth>(TextureDepth::Kind::TextureDepthCubeArray);
+    m_textureDepthMultisampled2d = allocateType<TextureDepth>(TextureDepth::Kind::TextureDepthMultisampled2d);
 }
 
 const Type* TypeStore::structType(AST::Structure& structure, HashMap<String, const Type*>&& fields)

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -83,6 +83,12 @@ public:
     const Type* texelFormatType() const { return m_texelFormat; }
     const Type* addressSpaceType() const { return m_addressSpace; }
 
+    const Type* textureDepth2dType() const { return m_textureDepth2d; }
+    const Type* textureDepth2dArrayType() const { return m_textureDepthArray2d; }
+    const Type* textureDepthCubeType() const { return m_textureDepthCube; }
+    const Type* textureDepthCubeArrayType() const { return m_textureDepthArrayCube; }
+    const Type* textureDepthMultisampled2dType() const { return m_textureDepthMultisampled2d; }
+
     const Type* structType(AST::Structure&, HashMap<String, const Type*>&& = { });
     const Type* arrayType(const Type*, std::optional<unsigned>);
     const Type* vectorType(const Type*, uint8_t);
@@ -114,6 +120,11 @@ private:
     const Type* m_accessMode;
     const Type* m_texelFormat;
     const Type* m_addressSpace;
+    const Type* m_textureDepth2d;
+    const Type* m_textureDepthArray2d;
+    const Type* m_textureDepthCube;
+    const Type* m_textureDepthArrayCube;
+    const Type* m_textureDepthMultisampled2d;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -183,6 +183,25 @@ void Type::dump(PrintStream& out) const
             }
             out.print(">");
         },
+        [&](const TextureDepth& texture) {
+            switch (texture.kind) {
+            case TextureDepth::Kind::TextureDepth2d:
+                out.print("texture_depth_2d");
+                break;
+            case TextureDepth::Kind::TextureDepth2dArray:
+                out.print("texture_depth_2d_array");
+                break;
+            case TextureDepth::Kind::TextureDepthCube:
+                out.print("texture_depth_cube");
+                break;
+            case TextureDepth::Kind::TextureDepthCubeArray:
+                out.print("texture_depth_cube_array");
+                break;
+            case TextureDepth::Kind::TextureDepthMultisampled2d:
+                out.print("texture_depth_multisampled_2d");
+                break;
+            }
+        },
         [&](const Reference& reference) {
             out.print("ref<", reference.addressSpace, ", ", *reference.element, ", ", reference.accessMode, ">");
         },
@@ -344,6 +363,9 @@ unsigned Type::size() const
         [&](const TextureStorage&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const TextureDepth&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const Reference&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
@@ -407,6 +429,9 @@ unsigned Type::alignment() const
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const TextureStorage&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const TextureDepth&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Reference&) -> unsigned {

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -125,6 +125,18 @@ struct TextureStorage {
     AccessMode access;
 };
 
+struct TextureDepth {
+    enum class Kind : uint8_t {
+        TextureDepth2d = 1,
+        TextureDepth2dArray,
+        TextureDepthCube,
+        TextureDepthCubeArray,
+        TextureDepthMultisampled2d,
+    };
+
+    Kind kind;
+};
+
 struct Vector {
     const Type* element;
     uint8_t size;
@@ -182,6 +194,7 @@ struct Type : public std::variant<
     Types::Function,
     Types::Texture,
     Types::TextureStorage,
+    Types::TextureDepth,
     Types::Reference,
     Types::Pointer,
     Types::TypeConstructor,
@@ -196,6 +209,7 @@ struct Type : public std::variant<
         Types::Function,
         Types::Texture,
         Types::TextureStorage,
+        Types::TextureDepth,
         Types::Reference,
         Types::Pointer,
         Types::TypeConstructor,


### PR DESCRIPTION
#### ac3c958871aafb17a65d85e6898edb4622ffaadf
<pre>
[WGSL] Add suport for depth textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=261881">https://bugs.webkit.org/show_bug.cgi?id=261881</a>
rdar://115842732

Reviewed by Dan Glastonbury.

Add a new TextureDepth type to the type system and expose all the kinds of depth textures.
Spec reference: <a href="https://www.w3.org/TR/WGSL/#texture-depth">https://www.w3.org/TR/WGSL/#texture-depth</a>

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::materialize):
* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::concretize):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::bindingMemberForGlobal):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::TypeStore):
* Source/WebGPU/WGSL/TypeStore.h:
(WGSL::TypeStore::textureDepth2dType const):
(WGSL::TypeStore::textureDepth2dArrayType const):
(WGSL::TypeStore::textureDepthCubeType const):
(WGSL::TypeStore::textureDepthCubeArrayType const):
(WGSL::TypeStore::textureDepthMultisampled2dType const):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
(WGSL::Type::size const):
(WGSL::Type::alignment const):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/268308@main">https://commits.webkit.org/268308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/372d7fd14deff6fe0cfe851a8558e17788f6dd79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21044 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17929 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19619 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21921 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16652 "6 flakes 4 failures") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23816 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21768 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15426 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17332 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4613 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->