### PR TITLE
Port NetworkLoadMetrics to the new IPC serialization format

### DIFF
--- a/Source/WTF/wtf/persistence/PersistentDecoder.h
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.h
@@ -90,8 +90,6 @@ public:
 
     WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN const uint8_t* bufferPointerForDirectRead(size_t numBytes);
 
-    static constexpr bool isIPCDecoder = false;
-
 private:
     WTF_EXPORT_PRIVATE WARN_UNUSED_RETURN bool bufferIsLargeEnoughToContain(size_t) const;
     template<typename Type> Decoder& decodeNumber(std::optional<Type>&);

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
@@ -32,6 +32,35 @@ namespace WebCore {
 
 NetworkLoadMetrics::NetworkLoadMetrics() = default;
 
+NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, PrivacyStance privacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&& additionalNetworkLoadMetricsForWebInspector)
+    : redirectStart(WTFMove(redirectStart))
+    , fetchStart(WTFMove(fetchStart))
+    , domainLookupStart(WTFMove(domainLookupStart))
+    , domainLookupEnd(WTFMove(domainLookupEnd))
+    , connectStart(WTFMove(connectStart))
+    , secureConnectionStart(WTFMove(secureConnectionStart))
+    , connectEnd(WTFMove(connectEnd))
+    , requestStart(WTFMove(requestStart))
+    , responseStart(WTFMove(responseStart))
+    , responseEnd(responseEnd)
+    , workerStart(workerStart)
+    , protocol(protocol)
+    , redirectCount(redirectCount)
+    , complete(complete)
+    , cellular(cellular)
+    , expensive(expensive)
+    , constrained(constrained)
+    , multipath(multipath)
+    , isReusedConnection(isReusedConnection)
+    , failsTAOCheck(failsTAOCheck)
+    , hasCrossOriginRedirect(hasCrossOriginRedirect)
+    , privacyStance(privacyStance)
+    , responseBodyBytesReceived(responseBodyBytesReceived)
+    , responseBodyDecodedSize(responseBodyDecodedSize)
+    , additionalNetworkLoadMetricsForWebInspector(WTFMove(additionalNetworkLoadMetricsForWebInspector))
+{
+}
+
 void NetworkLoadMetrics::updateFromFinalMetrics(const NetworkLoadMetrics& other)
 {
     MonotonicTime originalRedirectStart = redirectStart;
@@ -136,6 +165,26 @@ NetworkLoadMetrics NetworkLoadMetrics::isolatedCopy() const
         copy.additionalNetworkLoadMetricsForWebInspector = additionalNetworkLoadMetricsForWebInspector->isolatedCopy();
 
     return copy;
+}
+
+Ref<AdditionalNetworkLoadMetricsForWebInspector> AdditionalNetworkLoadMetricsForWebInspector::create(NetworkLoadPriority&& priority, String&& remoteAddress, String&& connectionIdentifier, String&& tlsProtocol, String&& tlsCipher, HTTPHeaderMap&& requestHeaders, uint64_t requestHeaderBytesSent, uint64_t responseHeaderBytesReceived, uint64_t requestBodyBytesSent, bool isProxyConnection)
+{
+    return adoptRef(*new AdditionalNetworkLoadMetricsForWebInspector(WTFMove(priority), WTFMove(remoteAddress), WTFMove(connectionIdentifier), WTFMove(tlsProtocol), WTFMove(tlsCipher), WTFMove(requestHeaders), requestHeaderBytesSent, responseHeaderBytesReceived, requestBodyBytesSent, isProxyConnection));
+}
+
+AdditionalNetworkLoadMetricsForWebInspector::AdditionalNetworkLoadMetricsForWebInspector(NetworkLoadPriority&& priority, String&& remoteAddress, String&& connectionIdentifier, String&& tlsProtocol, String&& tlsCipher, HTTPHeaderMap&& requestHeaders, uint64_t requestHeaderBytesSent, uint64_t responseHeaderBytesReceived, uint64_t requestBodyBytesSent, bool isProxyConnection)
+    : priority(WTFMove(priority))
+    , remoteAddress(WTFMove(remoteAddress))
+    , connectionIdentifier(WTFMove(connectionIdentifier))
+    , tlsProtocol(WTFMove(tlsProtocol))
+    , tlsCipher(WTFMove(tlsCipher))
+    , requestHeaders(WTFMove(requestHeaders))
+    , requestHeaderBytesSent(requestHeaderBytesSent)
+    , responseHeaderBytesReceived(responseHeaderBytesReceived)
+    , requestBodyBytesSent(requestBodyBytesSent)
+    , isProxyConnection(isProxyConnection)
+{
+
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.h
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.h
@@ -64,6 +64,7 @@ class NetworkLoadMetrics {
     WTF_MAKE_FAST_ALLOCATED(NetworkLoadMetrics);
 public:
     WEBCORE_EXPORT NetworkLoadMetrics();
+    WEBCORE_EXPORT NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicTime&& fetchStart, MonotonicTime&& domainLookupStart, MonotonicTime&& domainLookupEnd, MonotonicTime&& connectStart, MonotonicTime&& secureConnectionStart, MonotonicTime&& connectEnd, MonotonicTime&& requestStart, MonotonicTime&& responseStart, MonotonicTime&& responseEnd, MonotonicTime&& workerStart, String&& protocol, uint16_t redirectCount, bool complete, bool cellular, bool expensive, bool constrained, bool multipath, bool isReusedConnection, bool failsTAOCheck, bool hasCrossOriginRedirect, PrivacyStance, uint64_t responseBodyBytesReceived, uint64_t responseBodyDecodedSize, RefPtr<AdditionalNetworkLoadMetricsForWebInspector>&&);
 
     WEBCORE_EXPORT static const NetworkLoadMetrics& emptyMetrics();
 
@@ -73,6 +74,13 @@ public:
     template<class Decoder> static std::optional<NetworkLoadMetrics> decode(Decoder&);
 
     bool isComplete() const { return complete; }
+    bool isCellular() const { return cellular; }
+    bool isExpensive() const { return expensive; }
+    bool isConstrained() const { return constrained; }
+    bool isMultipath() const { return multipath; }
+    bool reusedConnection() const { return isReusedConnection; }
+    bool doesFailTAOCheck() const { return failsTAOCheck; }
+    bool crossOriginRedirect() const { return hasCrossOriginRedirect; }
     void markComplete() { complete = true; }
 
     void updateFromFinalMetrics(const NetworkLoadMetrics&);
@@ -115,10 +123,8 @@ public:
 struct AdditionalNetworkLoadMetricsForWebInspector : public RefCounted<AdditionalNetworkLoadMetricsForWebInspector> {
 
     static Ref<AdditionalNetworkLoadMetricsForWebInspector> create() { return adoptRef(*new AdditionalNetworkLoadMetricsForWebInspector()); }
+    WEBCORE_EXPORT static Ref<AdditionalNetworkLoadMetricsForWebInspector> create(NetworkLoadPriority&&, String&& remoteAddress, String&& connectionIdentifier, String&& tlsProtocol, String&& tlsCipher, HTTPHeaderMap&& requestHeaders, uint64_t requestHeaderBytesSent, uint64_t responseHeaderBytesReceived, uint64_t requestBodyBytesSent, bool isProxyConnection);
     Ref<AdditionalNetworkLoadMetricsForWebInspector> isolatedCopy() const;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static RefPtr<AdditionalNetworkLoadMetricsForWebInspector> decode(Decoder&);
     Ref<AdditionalNetworkLoadMetricsForWebInspector> isolatedCopy();
 
     NetworkLoadPriority priority { NetworkLoadPriority::Unknown };
@@ -138,289 +144,12 @@ struct AdditionalNetworkLoadMetricsForWebInspector : public RefCounted<Additiona
     bool isProxyConnection { false };
 private:
     AdditionalNetworkLoadMetricsForWebInspector() { }
+    AdditionalNetworkLoadMetricsForWebInspector(NetworkLoadPriority&&, String&& remoteAddress, String&& connectionIdentifier, String&& tlsProtocol, String&& tlsCipher, HTTPHeaderMap&& requestHeaders, uint64_t requestHeaderBytesSent, uint64_t responseHeaderBytesReceived, uint64_t requestBodyBytesSent, bool isProxyConnection);
 };
 
 #if PLATFORM(COCOA)
 Box<NetworkLoadMetrics> copyTimingData(NSURLConnection *, const ResourceHandle&);
 WEBCORE_EXPORT Box<NetworkLoadMetrics> copyTimingData(NSURLSessionTaskMetrics *incompleteMetrics, const NetworkLoadMetrics&);
 #endif
-
-template<class Encoder>
-void NetworkLoadMetrics::encode(Encoder& encoder) const
-{
-    static_assert(Encoder::isIPCEncoder, "NetworkLoadMetrics should not be stored by the WTF::Persistence::Encoder");
-
-    encoder << redirectStart;
-    encoder << fetchStart;
-    encoder << domainLookupStart;
-    encoder << domainLookupEnd;
-    encoder << connectStart;
-    encoder << secureConnectionStart;
-    encoder << connectEnd;
-    encoder << requestStart;
-    encoder << responseStart;
-    encoder << responseEnd;
-    encoder << workerStart;
-
-    encoder << protocol;
-
-    encoder << redirectCount;
-
-    encoder << complete;
-    encoder << cellular;
-    encoder << expensive;
-    encoder << constrained;
-    encoder << multipath;
-    encoder << isReusedConnection;
-    encoder << failsTAOCheck;
-    encoder << hasCrossOriginRedirect;
-
-    encoder << privacyStance;
-
-    encoder << responseBodyBytesReceived;
-    encoder << responseBodyDecodedSize;
-    
-    if (additionalNetworkLoadMetricsForWebInspector) {
-        encoder << true;
-        encoder << *additionalNetworkLoadMetricsForWebInspector;
-    } else
-        encoder << false;
-}
-
-template<class Decoder>
-std::optional<NetworkLoadMetrics> NetworkLoadMetrics::decode(Decoder& decoder)
-{
-    static_assert(Decoder::isIPCDecoder, "NetworkLoadMetrics should not be stored by the WTF::Persistence::Encoder");
-
-    NetworkLoadMetrics metrics;
-
-    std::optional<MonotonicTime> redirectStart;
-    decoder >> redirectStart;
-    if (!redirectStart)
-        return std::nullopt;
-    metrics.redirectStart = WTFMove(*redirectStart);
-
-    std::optional<MonotonicTime> fetchStart;
-    decoder >> fetchStart;
-    if (!fetchStart)
-        return std::nullopt;
-    metrics.fetchStart = WTFMove(*fetchStart);
-
-    std::optional<MonotonicTime> domainLookupStart;
-    decoder >> domainLookupStart;
-    if (!domainLookupStart)
-        return std::nullopt;
-    metrics.domainLookupStart = WTFMove(*domainLookupStart);
-
-    std::optional<MonotonicTime> domainLookupEnd;
-    decoder >> domainLookupEnd;
-    if (!domainLookupEnd)
-        return std::nullopt;
-    metrics.domainLookupEnd = WTFMove(*domainLookupEnd);
-
-    std::optional<MonotonicTime> connectStart;
-    decoder >> connectStart;
-    if (!connectStart)
-        return std::nullopt;
-    metrics.connectStart = WTFMove(*connectStart);
-
-    std::optional<MonotonicTime> secureConnectionStart;
-    decoder >> secureConnectionStart;
-    if (!secureConnectionStart)
-        return std::nullopt;
-    metrics.secureConnectionStart = WTFMove(*secureConnectionStart);
-
-    std::optional<MonotonicTime> connectEnd;
-    decoder >> connectEnd;
-    if (!connectEnd)
-        return std::nullopt;
-    metrics.connectEnd = WTFMove(*connectEnd);
-
-    std::optional<MonotonicTime> requestStart;
-    decoder >> requestStart;
-    if (!requestStart)
-        return std::nullopt;
-    metrics.requestStart = WTFMove(*requestStart);
-
-    std::optional<MonotonicTime> responseStart;
-    decoder >> responseStart;
-    if (!responseStart)
-        return std::nullopt;
-    metrics.responseStart = WTFMove(*responseStart);
-
-    std::optional<MonotonicTime> responseEnd;
-    decoder >> responseEnd;
-    if (!responseEnd)
-        return std::nullopt;
-    metrics.responseEnd = WTFMove(*responseEnd);
-
-    std::optional<MonotonicTime> workerStart;
-    decoder >> workerStart;
-    if (!workerStart)
-        return std::nullopt;
-    metrics.workerStart = WTFMove(*workerStart);
-
-    std::optional<String> protocol;
-    decoder >> protocol;
-    if (!protocol)
-        return std::nullopt;
-    metrics.protocol = WTFMove(*protocol);
-
-    std::optional<uint16_t> redirectCount;
-    decoder >> redirectCount;
-    if (!redirectCount)
-        return std::nullopt;
-    metrics.redirectCount = WTFMove(*redirectCount);
-
-    std::optional<bool> complete;
-    decoder >> complete;
-    if (!complete)
-        return std::nullopt;
-    metrics.complete = WTFMove(*complete);
-
-    std::optional<bool> cellular;
-    decoder >> cellular;
-    if (!cellular)
-        return std::nullopt;
-    metrics.cellular = WTFMove(*cellular);
-
-    std::optional<bool> expensive;
-    decoder >> expensive;
-    if (!expensive)
-        return std::nullopt;
-    metrics.expensive = WTFMove(*expensive);
-
-    std::optional<bool> constrained;
-    decoder >> constrained;
-    if (!constrained)
-        return std::nullopt;
-    metrics.constrained = WTFMove(*constrained);
-
-    std::optional<bool> multipath;
-    decoder >> multipath;
-    if (!multipath)
-        return std::nullopt;
-    metrics.multipath = WTFMove(*multipath);
-
-    std::optional<bool> isReusedConnection;
-    decoder >> isReusedConnection;
-    if (!isReusedConnection)
-        return std::nullopt;
-    metrics.isReusedConnection = WTFMove(*isReusedConnection);
-
-    std::optional<bool> failsTAOCheck;
-    decoder >> failsTAOCheck;
-    if (!failsTAOCheck)
-        return std::nullopt;
-    metrics.failsTAOCheck = WTFMove(*failsTAOCheck);
-
-    std::optional<bool> hasCrossOriginRedirect;
-    decoder >> hasCrossOriginRedirect;
-    if (!hasCrossOriginRedirect)
-        return std::nullopt;
-    metrics.hasCrossOriginRedirect = WTFMove(*hasCrossOriginRedirect);
-
-    if (!(decoder.decode(metrics.privacyStance)
-        && decoder.decode(metrics.responseBodyBytesReceived)
-        && decoder.decode(metrics.responseBodyDecodedSize)))
-        return std::nullopt;
-
-    std::optional<bool> hasAdditionalNetworkLoadMetricsForWebInspector;
-    decoder >> hasAdditionalNetworkLoadMetricsForWebInspector;
-    if (!hasAdditionalNetworkLoadMetricsForWebInspector)
-        return std::nullopt;
-    if (*hasAdditionalNetworkLoadMetricsForWebInspector) {
-        metrics.additionalNetworkLoadMetricsForWebInspector = AdditionalNetworkLoadMetricsForWebInspector::decode(decoder);
-        if (!metrics.additionalNetworkLoadMetricsForWebInspector)
-            return std::nullopt;
-    }
-    return metrics;
-}
-
-template<class Encoder>
-void AdditionalNetworkLoadMetricsForWebInspector::encode(Encoder& encoder) const
-{
-    encoder << priority;
-    encoder << remoteAddress;
-    encoder << connectionIdentifier;
-
-    encoder << tlsProtocol;
-    encoder << tlsCipher;
-
-    encoder << requestHeaders;
-
-    encoder << requestHeaderBytesSent;
-    encoder << responseHeaderBytesReceived;
-    encoder << requestBodyBytesSent;
-
-    encoder << isProxyConnection;
-}
-
-template<class Decoder>
-RefPtr<AdditionalNetworkLoadMetricsForWebInspector> AdditionalNetworkLoadMetricsForWebInspector::decode(Decoder& decoder)
-{
-    std::optional<NetworkLoadPriority> priority;
-    decoder >> priority;
-    if (!priority)
-        return nullptr;
-    
-    std::optional<String> remoteAddress;
-    decoder >> remoteAddress;
-    if (!remoteAddress)
-        return nullptr;
-
-    std::optional<String> connectionIdentifier;
-    decoder >> connectionIdentifier;
-    if (!connectionIdentifier)
-        return nullptr;
-
-    std::optional<String> tlsProtocol;
-    decoder >> tlsProtocol;
-    if (!tlsProtocol)
-        return nullptr;
-
-    std::optional<String> tlsCipher;
-    decoder >> tlsCipher;
-    if (!tlsCipher)
-        return nullptr;
-
-    std::optional<HTTPHeaderMap> requestHeaders;
-    decoder >> requestHeaders;
-    if (!requestHeaders)
-        return nullptr;
-
-    std::optional<uint64_t> requestHeaderBytesSent;
-    decoder >> requestHeaderBytesSent;
-    if (!requestHeaderBytesSent)
-        return nullptr;
-
-    std::optional<uint64_t> responseHeaderBytesReceived;
-    decoder >> responseHeaderBytesReceived;
-    if (!responseHeaderBytesReceived)
-        return nullptr;
-
-    std::optional<uint64_t> requestBodyBytesSent;
-    decoder >> requestBodyBytesSent;
-    if (!requestBodyBytesSent)
-        return nullptr;
-
-    std::optional<bool> isProxyConnection;
-    decoder >> isProxyConnection;
-    if (!isProxyConnection)
-        return nullptr;
-
-    auto decoded = AdditionalNetworkLoadMetricsForWebInspector::create();
-    decoded->priority = WTFMove(*priority);
-    decoded->remoteAddress = WTFMove(*remoteAddress);
-    decoded->connectionIdentifier = WTFMove(*connectionIdentifier);
-    decoded->tlsProtocol = WTFMove(*tlsProtocol);
-    decoded->tlsCipher = WTFMove(*tlsCipher);
-    decoded->requestHeaders = WTFMove(*requestHeaders);
-    decoded->requestHeaderBytesSent = WTFMove(*requestHeaderBytesSent);
-    decoded->responseHeaderBytesReceived = WTFMove(*responseHeaderBytesReceived);
-    decoded->requestBodyBytesSent = WTFMove(*requestBodyBytesSent);
-    decoded->isProxyConnection = WTFMove(*isProxyConnection);
-    return decoded;
-}
 
 } // namespace WebCore

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -149,8 +149,6 @@ public:
 
     std::optional<Attachment> takeLastAttachment();
 
-    static constexpr bool isIPCDecoder = true;
-
 private:
     Decoder(DataReference buffer, BufferDeallocator&&, Vector<Attachment>&&);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5969,3 +5969,51 @@ struct WebCore::LinkDecorationFilteringData {
     std::optional<bool> silent;
 };
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)
+
+class WebCore::NetworkLoadMetrics {
+    MonotonicTime redirectStart;
+    MonotonicTime fetchStart;
+    MonotonicTime domainLookupStart;
+    MonotonicTime domainLookupEnd;
+    MonotonicTime connectStart;
+    MonotonicTime secureConnectionStart;
+    MonotonicTime connectEnd;
+    MonotonicTime requestStart;
+    MonotonicTime responseStart;
+    MonotonicTime responseEnd;
+    MonotonicTime workerStart;
+
+    String protocol;
+
+    uint16_t redirectCount;
+
+    bool isComplete();
+    bool isCellular();
+    bool isExpensive();
+    bool isConstrained();
+    bool isMultipath();
+    bool reusedConnection();
+    bool doesFailTAOCheck();
+    bool crossOriginRedirect();
+
+    WebCore::PrivacyStance privacyStance;
+
+    uint64_t responseBodyBytesReceived;
+    uint64_t responseBodyDecodedSize;
+
+    RefPtr<WebCore::AdditionalNetworkLoadMetricsForWebInspector> additionalNetworkLoadMetricsForWebInspector;
+}
+
+header: <WebCore/NetworkLoadMetrics.h>
+[RefCounted, CustomHeader] struct WebCore::AdditionalNetworkLoadMetricsForWebInspector {
+    WebCore::NetworkLoadPriority priority;
+    String remoteAddress;
+    String connectionIdentifier;
+    String tlsProtocol;
+    String tlsCipher;
+    WebCore::HTTPHeaderMap requestHeaders;
+    uint64_t requestHeaderBytesSent;
+    uint64_t responseHeaderBytesReceived;
+    uint64_t requestBodyBytesSent;
+    bool isProxyConnection;
+}


### PR DESCRIPTION
#### 2b60b51040b3000f8525601fe30895f84b08865b
<pre>
Port NetworkLoadMetrics to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=261883">https://bugs.webkit.org/show_bug.cgi?id=261883</a>
rdar://115842910

Reviewed by Alex Christensen.

Ports NetworkLoadMetrics and AdditionalNetworkLoadMetricsForWebInspector
to the new IPC serialization format.

* Source/WebCore/platform/network/NetworkLoadMetrics.cpp:
(WebCore::NetworkLoadMetrics::NetworkLoadMetrics):
(WebCore::AdditionalNetworkLoadMetricsForWebInspector::create):
(WebCore::AdditionalNetworkLoadMetricsForWebInspector::AdditionalNetworkLoadMetricsForWebInspector):
* Source/WebCore/platform/network/NetworkLoadMetrics.h:
(WebCore::NetworkLoadMetrics::encode const): Deleted.
(WebCore::NetworkLoadMetrics::decode): Deleted.
(WebCore::AdditionalNetworkLoadMetricsForWebInspector::encode const): Deleted.
(WebCore::AdditionalNetworkLoadMetricsForWebInspector::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268314@main">https://commits.webkit.org/268314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95ac97c0ffbd5d2bd0924eded7d88960d020eddb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21187 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19699 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22053 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23901 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16747 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21866 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18625 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15518 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22689 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17462 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/5614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4620 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21822 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23939 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18159 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5352 "Passed tests") | 
<!--EWS-Status-Bubble-End-->