### PR TITLE
[WGSL] Add type declarations for textureSample overloads that operate on texture_depth_*

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -574,32 +574,68 @@ operator :trunc, {
 
 # 16.7.1
 operator :textureDimensions, {
-    # FIXME: add declarations for texture storage and texture depth
+    # ST is i32, u32, or f32
+    # F is a texel format
+    # A is an access mode
+    # T is texture_1d<ST> or texture_storage_1d<F,A>
+    # @must_use fn textureDimensions(t: T) -> u32
     [S < Concrete32BitNumber].(Texture[S, Texture1d]) => U32,
+    # FIXME: add declarations for texture storage
 
+    # ST is i32, u32, or f32
+    # T is texture_1d<ST>
+    # L is i32, or u32
+    # @must_use fn textureDimensions(t: T, level: L) -> u32
     [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture1d], T) => U32,
 
+    # ST is i32, u32, or f32
+    # F is a texel format
+    # A is an access mode
+    # T is texture_2d<ST>, texture_2d_array<ST>, texture_cube<ST>, texture_cube_array<ST>, texture_multisampled_2d<ST>, texture_depth_2d, texture_depth_2d_array, texture_depth_cube, texture_depth_cube_array, texture_depth_multisampled_2d, texture_storage_2d<F,A>, texture_storage_2d_array<F,A>, or texture_external
+    # @must_use fn textureDimensions(t: T) -> vec2<u32>
     [S < Concrete32BitNumber].(Texture[S, Texture2d]) => Vector[U32, 2],
     [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => Vector[U32, 2],
     [S < Concrete32BitNumber].(Texture[S, TextureCube]) => Vector[U32, 2],
     [S < Concrete32BitNumber].(Texture[S, TextureCubeArray]) => Vector[U32, 2],
     [S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d]) => Vector[U32, 2],
+    [].(texture_depth_2d) => Vector[U32, 2],
+    [].(texture_depth_2d_array) => Vector[U32, 2],
+    [].(texture_depth_cube) => Vector[U32, 2],
+    [].(texture_depth_cube_array) => Vector[U32, 2],
+    [].(texture_depth_multisampled_2d) => Vector[U32, 2],
+    # FIXME: add declarations for texture storage
     [].(TextureExternal) => Vector[U32, 2],
 
+    # ST is i32, u32, or f32
+    # T is texture_2d<ST>, texture_2d_array<ST>, texture_cube<ST>, texture_cube_array<ST>, texture_depth_2d, texture_depth_2d_array, texture_depth_cube, or texture_depth_cube_array
+    # L is i32, or u32
+    # @must_use fn textureDimensions(t: T, level: L) -> vec2<u32>
     [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture2d], T) => Vector[U32, 2],
     [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture2dArray], T) => Vector[U32, 2],
     [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, TextureCube], T) => Vector[U32, 2],
     [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, TextureCubeArray], T) => Vector[U32, 2],
+    [T < ConcreteInteger].(texture_depth_2d, T) => Vector[U32, 2],
+    [T < ConcreteInteger].(texture_depth_2d_array, T) => Vector[U32, 2],
+    [T < ConcreteInteger].(texture_depth_cube, T) => Vector[U32, 2],
+    [T < ConcreteInteger].(texture_depth_cube_array, T) => Vector[U32, 2],
 
+    # ST is i32, u32, or f32
+    # F is a texel format
+    # A is an access mode
+    # T is texture_3d<ST> or texture_storage_3d<F,A>
+    # @must_use fn textureDimensions(t: T) -> vec3<u32>
     [S < Concrete32BitNumber].(Texture[S, Texture3d]) => Vector[U32, 3],
+    # FIXME: add declarations for texture storage
 
+    # ST is i32, u32, or f32
+    # T is texture_3d<ST>
+    # L is i32, or u32
+    # @must_use fn textureDimensions(t: T, level: L) -> vec3<u32>
     [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture3d], T) => Vector[U32, 3],
 }
 
 # 16.7.2
-
 operator :textureGather, {
-    # FIXME: add declarations for texture depth
     [T < ConcreteInteger, S < Concrete32BitNumber].(T, Texture[S, Texture2d], Sampler, Vector[F32, 2]) => Vector[S, 4],
 
     [T < ConcreteInteger, S < Concrete32BitNumber].(T, Texture[S, Texture2d], Sampler, Vector[F32, 2], Vector[I32, 2]) => Vector[S, 4],
@@ -611,10 +647,31 @@ operator :textureGather, {
     [T < ConcreteInteger, S < Concrete32BitNumber].(T, Texture[S, TextureCube], Sampler, Vector[F32, 3]) => Vector[S, 4],
 
     [T < ConcreteInteger, S < Concrete32BitNumber, U < ConcreteInteger].(T, Texture[S, TextureCubeArray], Sampler, Vector[F32, 3], U) => Vector[S, 4],
+
+    # @must_use fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> vec4<f32>
+    [].(texture_depth_2d, Sampler, Vector[F32, 2]) => Vector[F32, 4],
+
+    # @must_use fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
+    [].(texture_depth_2d, Sampler, Vector[F32, 2], Vector[I32, 2]) => Vector[F32, 4],
+
+    # @must_use fn textureGather(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> vec4<f32>
+    [].(texture_depth_cube, Sampler, Vector[F32, 3]) => Vector[F32, 4],
+
+    # A is i32, or u32
+    # @must_use fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A) -> vec4<f32>
+    [U < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], U) => Vector[F32, 4],
+
+    # A is i32, or u32
+    # @must_use fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, offset: vec2<i32>) -> vec4<f32>
+    [U < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], U, Vector[I32, 2]) => Vector[F32, 4],
+
+    # A is i32, or u32
+    # @must_use fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: A) -> vec4<f32>
+    [U < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], U) => Vector[F32, 4],
 }
 
 # 16.7.3 textureGatherCompare
-# FIXME: this only applies to texture_depth, implement
+# FIXME: Implement sampler_comparison
 
 # 16.7.4
 operator :textureLoad, {
@@ -624,34 +681,64 @@ operator :textureLoad, {
     [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture3d], Vector[T, 3], U) => Vector[S, 4],
     [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d], Vector[T, 2], U) => Vector[S, 4],
 
-    [T < ConcreteInteger].(TextureExternal, Vector[T, 2]) => Vector[F32, 4],
 
-    # FIXME: add overloads for texture_depth
-    # https://bugs.webkit.org/show_bug.cgi?id=254515
+    # C is i32, or u32
+    # L is i32, or u32
+    # @must_use fn textureLoad(t: texture_depth_2d, coords: vec2<C>, level: L) -> f32
+    [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d, Vector[T, 2], U) => F32,
+
+    # C is i32, or u32
+    # A is i32, or u32
+    # L is i32, or u32
+    # @must_use fn textureLoad(t: texture_depth_2d_array, coords: vec2<C>, array_index: A, level: L) -> f32
+    [T < ConcreteInteger, S < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d_array, Vector[T, 2], S, U) => F32,
+
+    # C is i32, or u32
+    # S is i32, or u32
+    # @must_use fn textureLoad(t: texture_depth_multisampled_2d, coords: vec2<C>, sample_index: S)-> f32
+    [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_multisampled_2d, Vector[T, 2], U) => F32,
+
+    [T < ConcreteInteger].(TextureExternal, Vector[T, 2]) => Vector[F32, 4],
 }
 
 # 16.7.5
 operator :textureNumLayers, {
-    # FIXME: add declarations for texture storage and texture depth
+    # F is a texel format
+    # A is an access mode
+    # ST is i32, u32, or f32
+    # T is texture_2d_array<ST>, texture_cube_array<ST>, texture_depth_2d_array, texture_depth_cube_array, or texture_storage_2d_array<F,A>
+    # @must_use fn textureNumLayers(t: T) -> u32
     [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => U32,
     [S < Concrete32BitNumber].(Texture[S, TextureCubeArray]) => U32,
+    [].(texture_depth_2d_array) => U32,
+    [].(texture_depth_cube_array) => U32,
+    # FIXME: add declarations for texture storage
 }
 
 # 16.7.6
 operator :textureNumLevels, {
-    # FIXME: add declarations for texture depth
+    # ST is i32, u32, or f32
+    # T is texture_1d<ST>, texture_2d<ST>, texture_2d_array<ST>, texture_3d<ST>, texture_cube<ST>, texture_cube_array<ST>, texture_depth_2d, texture_depth_2d_array, texture_depth_cube, or texture_depth_cube_array
+    # @must_use fn textureNumLevels(t: T) -> u32
     [S < Concrete32BitNumber].(Texture[S, Texture1d]) => U32,
     [S < Concrete32BitNumber].(Texture[S, Texture2d]) => U32,
     [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => U32,
     [S < Concrete32BitNumber].(Texture[S, Texture3d]) => U32,
     [S < Concrete32BitNumber].(Texture[S, TextureCube]) => U32,
     [S < Concrete32BitNumber].(Texture[S, TextureCubeArray]) => U32,
+    [].(texture_depth_2d) => U32,
+    [].(texture_depth_2d_array) => U32,
+    [].(texture_depth_cube) => U32,
+    [].(texture_depth_cube_array) => U32,
 }
 
 # 16.7.7
 operator :textureNumSamples, {
-    # FIXME: add declarations for texture depth
+    # ST is i32, u32, or f32
+    # T is texture_multisampled_2d<ST> or texture_depth_multisampled_2d
+    # @must_use fn textureNumSamples(t: T) -> u32
     [S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d]) => U32,
+    [].(texture_depth_multisampled_2d) => U32,
 }
 
 # 16.7.8
@@ -673,8 +760,26 @@ operator :textureSample, {
 
     [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T) => Vector[F32, 4],
 
-    # FIXME: add overloads for texture_depth
-    # https://bugs.webkit.org/show_bug.cgi?id=254515
+    # @must_use fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> f32
+    [].(texture_depth_2d, Sampler, Vector[F32, 2]) => F32,
+
+    # @must_use fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> f32
+    [].(texture_depth_2d, Sampler, Vector[F32, 2], Vector[I32, 2]) => F32,
+
+    # A is i32, or u32
+    # @must_use fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A) -> f32
+    [T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], T) => F32,
+
+    # A is i32, or u32
+    # @must_use fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, offset: vec2<i32>) -> f32
+    [T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], T, Vector[I32, 2]) => F32,
+
+    # @must_use fn textureSample(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> f32
+    [].(texture_depth_cube, Sampler, Vector[F32, 3]) => F32,
+
+    # A is i32, or u32
+    # @must_use fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: A) -> f32
+    [T < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], T) => F32,
 }
 
 # 16.7.9
@@ -696,10 +801,10 @@ operator :textureSampleBias, {
 }
 
 # 16.7.10 textureSampleCompare
-# FIXME: this only applies to texture_depth, implement
+# FIXME: Implement sampler_comparison
 
 # 16.7.11 textureSampleCompareLevel
-# FIXME: this only applies to texture_depth, implement
+# FIXME: Implement sampler_comparison
 
 # 16.7.12
 operator :textureSampleGrad, {
@@ -721,7 +826,6 @@ operator :textureSampleGrad, {
 
 # 16.7.13
 operator :textureSampleLevel, {
-    # FIXME: add declarations for texture depth
     [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32) => Vector[F32, 4],
 
     [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32, Vector[I32, 2]) => Vector[F32, 4],
@@ -736,6 +840,33 @@ operator :textureSampleLevel, {
     [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], F32, Vector[I32, 3]) => Vector[F32, 4],
 
     [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T, F32) => Vector[F32, 4],
+
+    # L is i32, or u32
+    # @must_use fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: L) -> f32
+    [T < ConcreteInteger].(texture_depth_2d, Sampler, Vector[F32, 2], T) => F32,
+
+    # L is i32, or u32
+    # @must_use fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: L, offset: vec2<i32>) -> f32
+    [T < ConcreteInteger].(texture_depth_2d, Sampler, Vector[F32, 2], T, Vector[I32, 2]) => F32,
+
+    # A is i32, or u32
+    # L is i32, or u32
+    # @must_use fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, level: L) -> f32
+    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], S, T) => F32,
+
+    # A is i32, or u32
+    # L is i32, or u32
+    # @must_use fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, level: L, offset: vec2<i32>) -> f32
+    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], S, T, Vector[I32, 2]) => F32,
+
+    # L is i32, or u32
+    # @must_use fn textureSampleLevel(t: texture_depth_cube, s: sampler, coords: vec3<f32>, level: L) -> f32
+    [T < ConcreteInteger].(texture_depth_cube, Sampler, Vector[F32, 3], T) => F32,
+
+    # A is i32, or u32
+    # L is i32, or u32
+    # @must_use fn textureSampleLevel(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: A, level: L) -> f32
+    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], S, T) => F32,
 }
 
 # 16.7.14

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -327,6 +327,12 @@ module DSL
         Read = AbstractValue.new(:"AccessMode::Read")
         ReadWrite = AbstractValue.new(:"AccessMode::ReadWrite")
 
+        texture_depth_2d = PrimitiveType.new(:TextureDepth2d)
+        texture_depth_2d_array = PrimitiveType.new(:TextureDepth2dArray)
+        texture_depth_cube = PrimitiveType.new(:TextureDepthCube)
+        texture_depth_cube_array = PrimitiveType.new(:TextureDepthCubeArray)
+        texture_depth_multisampled_2d = PrimitiveType.new(:TextureDepthMultisampled2d)
+
         Bool = PrimitiveType.new(:Bool)
         I32 = PrimitiveType.new(:I32)
         U32 = PrimitiveType.new(:U32)
@@ -335,7 +341,6 @@ module DSL
         TextureExternal = PrimitiveType.new(:TextureExternal)
         AbstractInt = PrimitiveType.new(:AbstractInt)
         AbstractFloat = PrimitiveType.new(:AbstractFloat)
-
 
         S = Variable.new(:S, @TypeVariable)
         T = Variable.new(:T, @TypeVariable)

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2053,10 +2053,16 @@ var ts2d: texture_storage_2d<rgba16uint, write>;
 var ts2da: texture_storage_2d<r32sint, read_write>;
 var ts3d: texture_storage_2d<rgba32float, write>;
 
+var td2d: texture_depth_2d;
+var td2da: texture_depth_2d_array;
+var tdc: texture_depth_cube;
+var tdca: texture_depth_cube_array;
+var tdms2d: texture_depth_multisampled_2d;
+
 // 16.7.1
 fn testTextureDimensions()
 {
-    // FIXME: add declarations for texture storage and texture depth
+    // FIXME: add declarations for texture storage
 
     // [S < Concrete32BitNumber].(Texture[S, Texture1d]) => U32,
     _ = textureDimensions(t1d);
@@ -2074,6 +2080,18 @@ fn testTextureDimensions()
     _ = textureDimensions(tca);
     // [S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d]) => Vector[U32, 2],
     _ = textureDimensions(tm2d);
+
+    // [].(texture_depth_2d) => Vector[U32, 2],
+    _ = textureDimensions(td2d);
+    // [].(texture_depth_2d_array) => Vector[U32, 2],
+    _ = textureDimensions(td2da);
+    // [].(texture_depth_cube) => Vector[U32, 2],
+    _ = textureDimensions(tdc);
+    // [].(texture_depth_cube_array) => Vector[U32, 2],
+    _ = textureDimensions(tdca);
+    // [].(texture_depth_multisampled_2d) => Vector[U32, 2],
+    _ = textureDimensions(tdms2d);
+
     // [].(TextureExternal) => Vector[U32, 2],
     _ = textureDimensions(te);
 
@@ -2085,6 +2103,14 @@ fn testTextureDimensions()
     _ = textureDimensions(tc, 0);
     // [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, TextureCubeArray], T) => Vector[U32, 2],
     _ = textureDimensions(tca, 0);
+    // [T < ConcreteInteger].(texture_depth_2d, T) => Vector[U32, 2],
+    _ = textureDimensions(td2d, 0);
+    // [T < ConcreteInteger].(texture_depth_2d_array, T) => Vector[U32, 2],
+    _ = textureDimensions(td2da, 0);
+    // [T < ConcreteInteger].(texture_depth_cube, T) => Vector[U32, 2],
+    _ = textureDimensions(tdc, 0);
+    // [T < ConcreteInteger].(texture_depth_cube_array, T) => Vector[U32, 2],
+    _ = textureDimensions(tdca, 0);
 
     // [S < Concrete32BitNumber].(Texture[S, Texture3d]) => Vector[U32, 3],
     _ = textureDimensions(t3d);
@@ -2096,8 +2122,6 @@ fn testTextureDimensions()
 // 16.7.2
 fn testTextureGather()
 {
-    // FIXME: add declarations for texture depth
-
     // [T < ConcreteInteger, S < Concrete32BitNumber].(T, Texture[S, Texture2d], Sampler, Vector[F32, 2]) => Vector[S, 4],
     _ = textureGather(0, t2d, s, vec2f(0));
 
@@ -2115,6 +2139,24 @@ fn testTextureGather()
 
     // [T < ConcreteInteger, S < Concrete32BitNumber, U < ConcreteInteger].(T, Texture[S, TextureCubeArray], Sampler, Vector[F32, 3], U) => Vector[S, 4],
     _ = textureGather(0, tca, s, vec3f(0), 0);
+
+    // [].(texture_depth_2d, Sampler, Vector[F32, 2]) => Vector[F32, 4],
+    _ = textureGather(td2d, s, vec2f(0));
+
+    // [].(texture_depth_2d, Sampler, Vector[F32, 2], Vector[I32, 2]) => Vector[F32, 4],
+    _ = textureGather(td2d, s, vec2f(0), vec2i(0));
+
+    // [].(texture_depth_cube, Sampler, Vector[F32, 3]) => Vector[F32, 4],
+    _ = textureGather(tdc, s, vec3f(0));
+
+    // [U < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], U) => Vector[F32, 4],
+    _ = textureGather(td2da, s, vec2f(0), 0);
+
+    // [U < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], U, Vector[I32, 2]) => Vector[F32, 4],
+    _ = textureGather(td2da, s, vec2f(0), 0, vec2i(0));
+
+    // [U < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], U) => Vector[F32, 4],
+    _ = textureGather(tdca, s, vec3f(0), 0);
 }
 
 // 16.7.3 textureGatherCompare
@@ -2224,25 +2266,50 @@ fn testTextureLoad()
         _ = textureLoad(te, vec2(0i));
         _ = textureLoad(te, vec2(0u));
     }
+
+    // [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d, Vector[T, 2], U) => F32,
+    {
+        _ = textureLoad(td2d, vec2(0), 0);
+        _ = textureLoad(td2d, vec2(0i), 0i);
+        _ = textureLoad(td2d, vec2(0u), 0u);
+    }
+
+    // [T < ConcreteInteger, S < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d_array, Vector[T, 2], S, U) => F32,
+    {
+        _ = textureLoad(td2da, vec2(0), 0, 0);
+        _ = textureLoad(td2da, vec2(0i), 0i, 0i);
+        _ = textureLoad(td2da, vec2(0u), 0u, 0u);
+    }
+
+    // [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_multisampled_2d, Vector[T, 2], U) => F32,
+    {
+        _ = textureLoad(tdms2d, vec2(0), 0);
+        _ = textureLoad(tdms2d, vec2(0i), 0i);
+        _ = textureLoad(tdms2d, vec2(0u), 0u);
+    }
 }
 
 // 16.7.5
 fn testTextureNumLayers()
 {
-    // FIXME: add declarations for texture storage and texture depth
+    // FIXME: add declarations for texture storage
 
     // [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => U32,
     _ = textureNumLayers(t2da);
 
     // [S < Concrete32BitNumber].(Texture[S, TextureCubeArray]) => U32,
     _ = textureNumLayers(tca);
+
+    // [].(texture_depth_2d_array) => U32,
+    _ = textureNumLayers(td2da);
+
+    // [].(texture_depth_cube_array) => U32,
+    _ = textureNumLayers(tdca);
 }
 
 // 16.7.6
 fn testTextureNumLevels()
 {
-    // FIXME: add declarations for texture depth
-
     // [S < Concrete32BitNumber].(Texture[S, Texture1d]) => U32,
     _ = textureNumLevels(t1d);
 
@@ -2260,22 +2327,33 @@ fn testTextureNumLevels()
 
     // [S < Concrete32BitNumber].(Texture[S, TextureCubeArray]) => U32,
     _ = textureNumLevels(tca);
+
+    // [].(texture_depth_2d) => U32,
+    _ = textureNumLevels(td2d);
+
+    // [].(texture_depth_2d_array) => U32,
+    _ = textureNumLevels(td2da);
+
+    // [].(texture_depth_cube) => U32,
+    _ = textureNumLevels(tdc);
+
+    // [].(texture_depth_cube_array) => U32,
+    _ = textureNumLevels(tdca);
 }
 
 // 16.7.7
 fn testTextureNumSamples()
 {
-    // FIXME: add declarations for texture depth
-
     // [S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d]) => U32,
     _ = textureNumSamples(tm2d);
+
+    // [].(texture_depth_multisampled_2d) => U32,
+    _ = textureNumSamples(tdms2d);
 }
 
 // 16.7.8
-fn testTextureSample() {
-    // FIXME: add overloads for texture_depth
-    // https://bugs.webkit.org/show_bug.cgi?id=254515
-
+fn testTextureSample()
+{
     // [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
     _ = textureSample(t1d, s, 1);
 
@@ -2302,6 +2380,24 @@ fn testTextureSample() {
 
     // [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T) => Vector[F32, 4],
     _ = textureSample(tca, s, vec3<f32>(0, 0, 0), 0);
+
+    // [].(texture_depth_2d, Sampler, Vector[F32, 2]) => F32,
+    _ = textureSample(td2d, s, vec2f(0));
+
+    // [].(texture_depth_2d, Sampler, Vector[F32, 2], Vector[I32, 2]) => F32,
+    _ = textureSample(td2d, s, vec2f(0), vec2i(0));
+
+    // [T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], T) => F32,
+    _ = textureSample(td2da, s, vec2f(0), 0);
+
+    // [T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], T, Vector[I32, 2]) => F32,
+    _ = textureSample(td2da, s, vec2f(0), 0, vec2i(0));
+
+    // [].(texture_depth_cube, Sampler, Vector[F32, 3]) => F32,
+    _ = textureSample(tdc, s, vec3f(0));
+
+    // [T < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], T) => F32,
+    _ = textureSample(tdca, s, vec3f(0), 0);
 }
 
 
@@ -2395,6 +2491,24 @@ fn testTextureSampleLevel()
 
     // [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T, F32) => Vector[F32, 4],
     _ = textureSampleLevel(tca, s, vec3f(0), 0i, 0f);
+
+    // [T < ConcreteInteger].(texture_depth_2d, Sampler, Vector[F32, 2], T) => F32,
+    _ = textureSampleLevel(td2d, s, vec2f(0), 0i);
+
+    // [T < ConcreteInteger].(texture_depth_2d, Sampler, Vector[F32, 2], T, Vector[I32, 2]) => F32,
+    _ = textureSampleLevel(td2d, s, vec2f(0), 0i, vec2i(0));
+
+    // [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], S, T) => F32,
+    _ = textureSampleLevel(td2da, s, vec2f(0), 0i, 0u);
+
+    // [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], S, T, Vector[I32, 2]) => F32,
+    _ = textureSampleLevel(td2da, s, vec2f(0), 0i, 0u, vec2i(0));
+
+    // [T < ConcreteInteger].(texture_depth_cube, Sampler, Vector[F32, 3], T) => F32,
+    _ = textureSampleLevel(tdc, s, vec3f(0), 0u);
+
+    // [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], S, T) => F32,
+    _ = textureSampleLevel(tdca, s, vec3f(0), 0i, 0u);
 }
 
 // 16.7.14


### PR DESCRIPTION
#### d7e9dd0b2334305eb70d6f6a200347488ba6b1f0
<pre>
[WGSL] Add type declarations for textureSample overloads that operate on texture_depth_*
<a href="https://bugs.webkit.org/show_bug.cgi?id=254515">https://bugs.webkit.org/show_bug.cgi?id=254515</a>
rdar://107556432

Reviewed by Dan Glastonbury.

In 268117@main I added declarations for all built-in functions that operate on textures, but
since we didn&apos;t support texture_depth yet, I skipped those. This patch fills in all the texture
depth functions. Now we&apos;re only missing the functions/overloads that depend on texture storage
or sampler_comparison.

* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268315@main">https://commits.webkit.org/268315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/590a860b8a86a32dfb79eaaabaf02437145a64db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21209 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18076 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19861 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19716 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22078 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16773 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21888 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15539 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17484 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4621 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21844 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->