### PR TITLE
[WGSL] Crash when measuring size of struct that contains a runtime array

### DIFF
--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -322,8 +322,7 @@ unsigned Type::size() const
             return matrix.columns * WTF::roundUpToMultipleOf(rowAlignment, rowSize);
         },
         [&](const Array& array) -> unsigned {
-            ASSERT(array.size.has_value());
-            return *array.size * WTF::roundUpToMultipleOf(array.element->alignment(), array.element->size());
+            return array.size.value_or(1) * WTF::roundUpToMultipleOf(array.element->alignment(), array.element->size());
         },
         [&](const Struct& structure) -> unsigned {
             unsigned alignment = 0;

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -396,6 +396,18 @@ fn testCall() -> i32
     return 0;
 }
 
+struct S {
+    @size(16) x: i32,
+    @align(32) y: array<i32>,
+}
+@group(0) @binding(6) var<storage, read_write> s: S;
+
+fn testRuntimeArray()
+{
+    s.x = 0;
+    s.y[0] = 0;
+}
+
 @compute @workgroup_size(1)
 fn main()
 {
@@ -406,4 +418,5 @@ fn main()
     _ = testBinaryOperations();
     _ = testUnaryOperations();
     _ = testCall();
+    _ = testRuntimeArray();
 }


### PR DESCRIPTION
#### 6a7d10f61b6b4f3853415c3a3fad23a536a227be
<pre>
[WGSL] Crash when measuring size of struct that contains a runtime array
<a href="https://bugs.webkit.org/show_bug.cgi?id=261884">https://bugs.webkit.org/show_bug.cgi?id=261884</a>
rdar://115843512

Reviewed by Dan Glastonbury.

We had an assertion that we would never ask for the size of a runtime-sized
array. However, we ask for the size of all member types for a struct that
intend to pack, and those can contain runtime-sized array, so the assertion
is incorrect. We just return the size of the element if it&apos;s runtime-sized,
which should be ok size @size attributes are not allowed on runtime-sized
arrays and they are always the last item in the struct.

* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::size const):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/268306@main">https://commits.webkit.org/268306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4049f5c701ac8119f24bcb6a437d0747f73686c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17935 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19623 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21927 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16655 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23820 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21773 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15430 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17338 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4612 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21699 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->