### PR TITLE
REGRESSION(266134@main): 3D border-style have very low contrast with very dark border-color

### DIFF
--- a/Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp
+++ b/Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp
@@ -174,14 +174,24 @@ void BorderPainter::calculateBorderStyleColor(BorderStyle style, BoxSide side, C
 
     Operation operation = (side == BoxSide::Top || side == BoxSide::Left) == (style == BorderStyle::Inset) ? Darken : Lighten;
 
-    // Here we will darken the border decoration color when needed. This will yield a similar behavior as in FF.
-    if (operation == Darken) {
-        if (color.luminance() > baseDarkColorLuminance)
-            color = color.darkened();
-    } else {
-        if (color.luminance() < baseLightColorLuminance)
-            color = color.lightened();
+    bool isVeryDarkColor = color.luminance() <= baseDarkColorLuminance;
+    bool isVeryLightColor = color.luminance() > baseLightColorLuminance;
+
+    // Special case very dark colors to give them extra contrast.
+    if (isVeryDarkColor) {
+        color = operation == Darken ? color.lightened() : color.lightened().lightened();
+        return;
     }
+
+    // Here we will darken the border decoration color when needed.
+    if (operation == Darken) {
+        color = color.darkened();
+        return;
+    }
+
+    ASSERT(operation == Lighten);
+
+    color = isVeryLightColor ? color : color.lightened();
 }
 
 // This assumes that we draw in order: top, bottom, left, right.


### PR DESCRIPTION
#### a4497016d608d8288e1921042b2ec71e6f538fe1
<pre>
REGRESSION(266134@main): 3D border-style have very low contrast with very dark border-color
<a href="https://bugs.webkit.org/show_bug.cgi?id=261847">https://bugs.webkit.org/show_bug.cgi?id=261847</a>
rdar://115812372

Reviewed by Darin Adler.

266134@main made 3D border styles like groove, ridge, inset, and outset honor the border-color instead of hardcoding a gray color.

Unfortunately, when a dark border-color is used, there is very little contrast between the light border and the dark border.

To fix this, we follow Firefox&apos;s algorithm of special casing very dark colors by contrasting 2 lightened versions of the border-color.

See Firefox&apos;s algorithm for reference:
<a href="https://searchfox.org/mozilla-central/rev/077fc34d03b85b09add26b5f99f1a3a3a72c8720/gfx/wr/webrender/res/cs_border_segment.glsl#112-132">https://searchfox.org/mozilla-central/rev/077fc34d03b85b09add26b5f99f1a3a3a72c8720/gfx/wr/webrender/res/cs_border_segment.glsl#112-132</a>

* Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp:
(WebCore::Display::BorderPainter::calculateBorderStyleColor):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::calculateBorderStyleColor):

Canonical link: <a href="https://commits.webkit.org/268265@main">https://commits.webkit.org/268265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7582479747c8914f4b80064b37dce6989d1531dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21067 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16681 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/21943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17641 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17353 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4586 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->