### PR TITLE
[macOS] Add syscall mach telemetry

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2200,13 +2200,12 @@
 #endif
         )))
 
-(define (syscall-mach-common) (machtrap-number
+(define (syscall-mach-in-use) (machtrap-number
     MSC__kernelrpc_mach_port_allocate_trap
     MSC__kernelrpc_mach_port_construct_trap
     MSC__kernelrpc_mach_port_deallocate_trap
     MSC__kernelrpc_mach_port_destruct_trap
     MSC__kernelrpc_mach_port_extract_member_trap
-    MSC__kernelrpc_mach_port_get_attributes_trap
     MSC__kernelrpc_mach_port_guard_trap
     MSC__kernelrpc_mach_port_insert_member_trap
     MSC__kernelrpc_mach_port_insert_right_trap
@@ -2220,21 +2219,24 @@
     MSC__kernelrpc_mach_vm_protect_trap
     MSC__kernelrpc_mach_vm_purgable_control_trap
     MSC_host_self_trap
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
-    MSC_iokit_user_client_trap
-#endif
     MSC_mach_generate_activity_id
     MSC_mk_timer_arm
     MSC_mk_timer_cancel
     MSC_mk_timer_create
     MSC_mk_timer_destroy
-    MSC_pid_for_task
     MSC_semaphore_signal_trap
     MSC_semaphore_timedwait_trap
-    MSC_semaphore_wait_trap
     MSC_syscall_thread_switch
-    MSC_task_name_for_pid
     MSC_thread_get_special_reply_port))
+
+(define (syscall-mach-possibly-in-use) (machtrap-number
+    MSC__kernelrpc_mach_port_get_attributes_trap
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
+    MSC_iokit_user_client_trap
+#endif
+    MSC_pid_for_task
+    MSC_semaphore_wait_trap
+    MSC_task_name_for_pid))
 
 (define (syscall-mach-blocked-in-lockdown-mode) (machtrap-number
     MSC_host_create_mach_voucher_trap
@@ -2246,10 +2248,11 @@
 
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'syscall-mach))
     (deny syscall-mach)
-    (allow syscall-mach (syscall-mach-common))
+    (allow syscall-mach (syscall-mach-in-use))
+    (allow syscall-mach (with report) (with telemetry) (syscall-mach-possibly-in-use))
 #if ENABLE(LOCKDOWN_MODE_TELEMETRY)
     (with-filter (require-not (lockdown-mode))
-        (allow syscall-mach (syscall-mach-blocked-in-lockdown-mode)))
+        (allow syscall-mach (with report) (with telemetry) (syscall-mach-blocked-in-lockdown-mode)))
     (with-filter (lockdown-mode)
         (deny syscall-mach (with telemetry) (syscall-mach-blocked-in-lockdown-mode)))
 #else


### PR DESCRIPTION
#### 4d0e3132ca52cd47faac65af360a1078bbeeab3a
<pre>
[macOS] Add syscall mach telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=261888">https://bugs.webkit.org/show_bug.cgi?id=261888</a>

Reviewed by Brent Fulgham.

Add syscall mach telemetry in the WebContent process on macOS to detect which are currently in use.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/268280@main">https://commits.webkit.org/268280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96616a4b93daed93d259a144e3daad18a2223b4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21065 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17948 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21941 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16671 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23830 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21783 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18229 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17351 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4594 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->