### PR TITLE
REGRESSION(266260@main): [ Monterey+ ] http/tests/media/hls/track-in-band-multiple-cues.html is a flaky failure

### DIFF
--- a/LayoutTests/http/tests/media/hls/track-in-band-multiple-cues-expected.txt
+++ b/LayoutTests/http/tests/media/hls/track-in-band-multiple-cues-expected.txt
@@ -2,7 +2,6 @@
 Test that multiple cues in a sample buffer are parsed correctly.
 
 EVENT(addtrack)
-EVENT(playing)
 EVENT(cuechange)
 EXPECTED (track.cues.length === '5') OK
 

--- a/LayoutTests/http/tests/media/hls/track-in-band-multiple-cues.html
+++ b/LayoutTests/http/tests/media/hls/track-in-band-multiple-cues.html
@@ -18,10 +18,7 @@
                 track = video.textTracks[0];
                 track.mode = 'showing';
 
-                await Promise.all([
-                    waitFor(video, 'playing'),
-                    waitFor(track, 'cuechange')
-                ]);
+                await waitFor(track, 'cuechange')
                 await testExpectedEventually('track.cues.length', 5, '===', 4000);
 
                 consoleWrite('');

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2730,8 +2730,6 @@ webkit.org/b/252322 [ X86_64 ] media/media-source/media-source-video-renders.htm
 
 webkit.org/b/259712 [ Monterey+ ] media/media-source/media-source-paint-after-display-none.html [ Skip ]
 
-webkit.org/b/259489 [ Monterey+ ] http/tests/media/hls/track-in-band-multiple-cues.html [ Pass Failure ]
-
 # rdar://110876540 ASSERTION FAILED: firstChild(): [ macOS ] (258183)
 [ Debug ] media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html [ Pass Crash ]
 


### PR DESCRIPTION
#### 33b8e8e1b0317bd2ef60ffc781b68dc5a1fa505d
<pre>
REGRESSION(266260@main): [ Monterey+ ] http/tests/media/hls/track-in-band-multiple-cues.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=259489">https://bugs.webkit.org/show_bug.cgi?id=259489</a>
rdar://112844842

Reviewed by Eric Carlson.

De-flake the test by getting rid of the racy check for both the &apos;playing&apos;
and &apos;cuechange&apos; events.

* LayoutTests/http/tests/media/hls/track-in-band-multiple-cues-expected.txt:
* LayoutTests/http/tests/media/hls/track-in-band-multiple-cues.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/268328@main">https://commits.webkit.org/268328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25c9153d44892656b70dbf32014b9ef9c7bac3da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17951 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19633 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21944 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23832 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21785 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15444 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17299 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4627 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->