### PR TITLE
Regression(268215@main): imported/w3c/web-platform-tests/css/css-transitions/changing-while-transition-001.html is flakily crashing

### DIFF
--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -58,7 +58,7 @@ DeclarativeAnimation::~DeclarativeAnimation()
 const std::optional<const Styleable> DeclarativeAnimation::owningElement() const
 {
     if (m_owningElement)
-        return Styleable(*m_owningElement.get(), m_owningPseudoId);
+        return Styleable(*m_owningElement, m_owningPseudoId);
     return std::nullopt;
 }
 
@@ -117,7 +117,7 @@ void DeclarativeAnimation::initialize(const RenderStyle* oldStyle, const RenderS
     ASSERT(m_owningElement);
 
     setEffect(KeyframeEffect::create(*m_owningElement, m_owningPseudoId));
-    setTimeline(&m_owningElement.get()->document().timeline());
+    setTimeline(&m_owningElement->document().timeline());
     downcast<KeyframeEffect>(effect())->computeDeclarativeAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
     syncPropertiesWithBackingAnimation();
     if (backingAnimation().playState() == AnimationPlayState::Playing)
@@ -264,7 +264,7 @@ auto DeclarativeAnimation::shouldFireDOMEvents() const -> ShouldFireEvents
     if (!m_owningElement)
         return ShouldFireEvents::No;
 
-    auto& document = m_owningElement.get()->document();
+    auto& document = m_owningElement->document();
     if (is<CSSAnimation>(*this)) {
         if (document.hasListenerType(Document::ListenerType::CSSAnimation))
             return ShouldFireEvents::YesForCSSAnimation;

--- a/Source/WebCore/animation/DeclarativeAnimation.h
+++ b/Source/WebCore/animation/DeclarativeAnimation.h
@@ -94,7 +94,7 @@ private:
     bool m_wasPending { false };
     AnimationEffectPhase m_previousPhase { AnimationEffectPhase::Idle };
 
-    CheckedPtr<Element> m_owningElement;
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_owningElement;
     PseudoId m_owningPseudoId;
     Ref<Animation> m_backingAnimation;
     double m_previousIteration;


### PR DESCRIPTION
#### 92891095fc280595f23ccd453d817f7cb958b867
<pre>
Regression(268215@main): imported/w3c/web-platform-tests/css/css-transitions/changing-while-transition-001.html is flakily crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=261886">https://bugs.webkit.org/show_bug.cgi?id=261886</a>

Unreviewed partial revert of 268215@main to address crashes on the bots.

* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::owningElement const):
(WebCore::DeclarativeAnimation::initialize):
(WebCore::DeclarativeAnimation::shouldFireDOMEvents const):
* Source/WebCore/animation/DeclarativeAnimation.h:

Canonical link: <a href="https://commits.webkit.org/268260@main">https://commits.webkit.org/268260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/802971da5de95f7ef64e18d3c776dd563c1a3d4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19179 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/19591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20189 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/21069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/17952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19394 "Failed to checkout and rebase branch from PR 18025") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/22865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/19720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/21069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/19400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/22865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/22865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/21945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/22865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/21945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/19720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/17356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2335 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->