### PR TITLE
Obtain Location from appropriate Window directly, rather then Frame

### DIFF
--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html
@@ -38,7 +38,7 @@ if (document.location.search.indexOf("?actually-attack") !== -1) {
 
 function checkDidLoadVictim()
 {
-    if (openerDocument.location.href == "about:blank") {
+    if (openerDocument.location.href == "http://127.0.0.1:8000/security/xss-DENIED-script-inject-into-inactive-window2-pson.html") {
         // Victim loaded.
         window.clearInterval(intervalId);
 

--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2.html
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2.html
@@ -39,7 +39,7 @@ if (document.location.search.indexOf("?actually-attack") !== -1) {
 
 function checkDidLoadVictim()
 {
-    if (openerDocument.location.href == "about:blank") {
+    if (openerDocument.location.href == "http://127.0.0.1:8000/security/xss-DENIED-script-inject-into-inactive-window2.html") {
         // Victim loaded.
         window.clearInterval(intervalId);
 

--- a/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3.html
+++ b/LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3.html
@@ -57,7 +57,7 @@ if (!window.location.search) {
 
 function checkDidLoadVictim()
 {
-    if (secondOpenerDocument.location.href == "about:blank") {
+    if (secondOpenerDocument.location.href == "http://127.0.0.1:8000/security/xss-DENIED-script-inject-into-inactive-window3.html?actually-actually-attack") {
         // Victim loaded.
         window.clearInterval(intervalId);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 Harness Error (TIMEOUT), message = null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-claim.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-claim.https-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 Harness Error (TIMEOUT), message = null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 Harness Error (TIMEOUT), message = null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 Harness Error (TIMEOUT), message = null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 Harness Error (TIMEOUT), message = null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/storage-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/storage-events-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 Harness Error (TIMEOUT), message = null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigate-cross-origin-iframe-to-same-url-with-fragment-fire-load-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigate-cross-origin-iframe-to-same-url-with-fragment-fire-load-event-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Changing the URL hash of a cross-origin iframe should fire a load event Test timed out
+PASS Changing the URL hash of a cross-origin iframe should fire a load event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/001-expected.txt
@@ -28,7 +28,7 @@ PASS pushState must be able to set location.pathname
 PASS pushState must be able to set absolute URLs to the same host
 PASS pushState must not be able to use a function as data
 PASS pushState must not be able to use a DOM node as data
-FAIL pushState must be able to use an error object as data The object can not be cloned.
+PASS pushState must be able to use an error object as data
 PASS security errors are expected to be thrown in the context of the document that owns the history object (2)
 PASS pushState must be able to make structured clones of complex objects
 PASS history.state should also reference a clone of the original object

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/002-expected.txt
@@ -26,7 +26,7 @@ PASS .go must queue a task with the history traversal task source (run asynchron
 PASS replaceState must not fire hashchange events
 PASS replaceState must not be able to use a function as data
 PASS replaceState must not be able to use a DOM node as data
-FAIL replaceState must be able to use an error object as data The object can not be cloned.
+PASS replaceState must be able to use an error object as data
 PASS security errors are expected to be thrown in the context of the document that owns the history object (2)
 PASS replaceState must be able to make structured clones of complex objects
 PASS history.state should also reference a clone of the original object

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/no_window_open_when_term_nesting_level_nonzero.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/no_window_open_when_term_nesting_level_nonzero.window-expected.txt
@@ -5,7 +5,7 @@ CONSOLE MESSAGE: Error: assert_equals: expected no popup during unload expected 
 Harness Error (FAIL), message = Error: assert_equals: expected no popup during unload expected null but got object "[object Window]"
 
 PASS no popups with frame removal
-FAIL no popups with frame navigation assert_equals: expected no popup during beforeunload expected null but got object "[object Window]"
+FAIL no popups with frame navigation assert_equals: expected no popup during visibilitychange expected null but got object "[object Window]"
 FAIL no popups from synchronously reachable window assert_equals: expected no popup during beforeunload expected null but got object "[object Window]"
 FAIL no popups from another synchronously reachable window assert_equals: expected no popup during beforeunload expected null but got object "[object Window]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window-expected.txt
@@ -1,8 +1,6 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS document.open should throw an InvalidStateError with XML document even when there is an active parser executing script
-TIMEOUT document.open should throw an InvalidStateError with XML document even when the ignore-opens-during-unload counter is greater than 0 (during beforeunload event) Test timed out
+PASS document.open should throw an InvalidStateError with XML document even when the ignore-opens-during-unload counter is greater than 0 (during beforeunload event)
 PASS document.open should throw an InvalidStateError with XML document even when the ignore-opens-during-unload counter is greater than 0 (during pagehide event)
 PASS document.open should throw an InvalidStateError with XML document even when the ignore-opens-during-unload counter is greater than 0 (during unload event)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/ignore-opens-during-unload.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/ignore-opens-during-unload.window-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during beforeunload event (in top-level browsing context)
 PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during beforeunload event (open(parent) while unloading parent and child)
 PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during beforeunload event (open(parent) while unloading child only)
@@ -10,7 +8,7 @@ PASS document.open should bail out when ignore-opens-during-unload is greater th
 PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during unload event (in top-level browsing context)
 PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during unload event (open(parent) while unloading parent and child)
 PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during unload event (open(parent) while unloading child only)
-TIMEOUT document.open should bail out when ignore-opens-during-unload is greater than 0 during visibilitychange event (in top-level browsing context) Test timed out
-TIMEOUT document.open should bail out when ignore-opens-during-unload is greater than 0 during visibilitychange event (open(parent) while unloading parent and child) Test timed out
-TIMEOUT document.open should bail out when ignore-opens-during-unload is greater than 0 during visibilitychange event (open(parent) while unloading child only) Test timed out
+PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during visibilitychange event (in top-level browsing context)
+PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during visibilitychange event (open(parent) while unloading parent and child)
+PASS document.open should bail out when ignore-opens-during-unload is greater than 0 during visibilitychange event (open(parent) while unloading child only)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window-expected.txt
@@ -1,6 +1,6 @@
 
 PASS document.open() changes document's URL (fully active document)
-FAIL document.open() does not change document's URL (active but not fully active document) assert_equals: expected "http://localhost:8800/common/blank.html" but got "about:blank"
+PASS document.open() does not change document's URL (active but not fully active document)
 PASS document.open() does not change document's URL (non-active document with an associated Window object; frame is removed)
 PASS document.open() does not change document's URL (non-active document with an associated Window object; navigated away)
 PASS document.open() does not change document's URL (non-active document without an associated Window object)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/fully_active_document.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/fully_active_document.window-expected.txt
@@ -1,5 +1,3 @@
-#PID UNRESPONSIVE - WebKitTestRunner (pid 35524)
 FAIL: Timed out waiting for notifyDone to be called
 
-#EOF
-#EOF
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/allow-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/allow-crossorigin-expected.txt
@@ -1,6 +1,4 @@
-Blocked access to external URL http://www1.localhost:8800/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/support/promise-access-control.py?allow=true
+CONSOLE MESSAGE: Unhandled Promise Rejection: 42
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Promise rejection event should be received for the cross-origin CORS script Test timed out
+PASS Promise rejection event should be received for the cross-origin CORS script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin-expected.txt
@@ -1,6 +1,7 @@
-Blocked access to external URL http://www1.localhost:8800/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/support/promise-access-control.py?allow=false
+CONSOLE MESSAGE: Unhandled Promise Rejection: 42
+CONSOLE MESSAGE: Unhandled Promise Rejection: 42
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Promise rejection event should be muted for cross-origin non-CORS script Test timed out
+FAIL Promise rejection event should be muted for cross-origin non-CORS script assert_unreached: unhandledrejection event should never be triggered Reached unreachable code
+PASS Promise rejection should be muted if the rejected promise is handled in cross-origin non-CORS script
+PASS Promise rejection should be muted if the rejected promise is handled in unhandledrejection event handler in cross-origin non-CORS script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-expected.txt
@@ -5,24 +5,21 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'e.error')
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error
+CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
 CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'e.error')
 CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
-CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'e.error')
 CONSOLE MESSAGE: Unhandled Promise Rejection: undefined
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot create an ImageBitmap from an empty buffer
-
-Harness Error (TIMEOUT), message = null
 
 PASS unhandledrejection: from Promise.reject
 PASS unhandledrejection: from a synchronous rejection in new Promise
@@ -64,7 +61,7 @@ PASS delayed handling: a nested-queueTask after promise creation/rejection, plus
 PASS delayed handling: delaying handling by setTimeout(,10) will cause both events to fire
 PASS delayed handling: delaying handling rejected promise created from createImageBitmap will cause both events to fire
 PASS mutationObserverMicrotask vs. queueTask ordering is not disturbed inside unhandledrejection events
-FAIL queueTask ordering vs. the task queued for unhandled rejection notification (1) assert_array_equals: property 1, expected "queueTask" but got object "[object Promise]"
-FAIL queueTask ordering vs. the task queued for unhandled rejection notification (2) assert_array_equals: property 0, expected "queueTask" but got object "[object Promise]"
-TIMEOUT rejectionhandled is dispatched from a queued task, and not immediately Test timed out
+FAIL queueTask ordering vs. the task queued for unhandled rejection notification (1) assert_array_equals: expected property 1 to be "queueTask" but got object "[object Promise]" (expected array [object "[object Promise]", "queueTask", object "[object Promise]"] got [object "[object Promise]", object "[object Promise]", "queueTask"])
+FAIL queueTask ordering vs. the task queued for unhandled rejection notification (2) assert_array_equals: expected property 0 to be "queueTask" but got object "[object Promise]" (expected array ["queueTask", object "[object Promise]"] got [object "[object Promise]", "queueTask"])
+FAIL rejectionhandled is dispatched from a queued task, and not immediately assert_array_equals: expected property 4 to be "handled" but got "task after catch" (expected array ["unhandled", "after catch", "catch", "task before catch", "handled", "task after catch"] got ["unhandled", "after catch", "catch", "task before catch", "task after catch", "handled"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-iframe-expected.txt
@@ -1,8 +1,7 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT unhandledrejection: promise is created in iframe and being rejected elsewhere Test timed out
+PASS unhandledrejection: promise is created in iframe and being rejected elsewhere
 PASS no unhandledrejection/rejectionhandled: promise is created in iframe and being rejected elsewhere
-TIMEOUT delayed handling: promise is created in iframe and being rejected elsewhere Test timed out
+PASS delayed handling: promise is created in iframe and being rejected elsewhere
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/update-rendering/child-document-raf-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/update-rendering/child-document-raf-order-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Ordering of steps in "Update the Rendering" - child document requestAnimationFrame order assert_array_equals: expected order of notifications lengths differ, expected 3 got 6
+FAIL Ordering of steps in "Update the Rendering" - child document requestAnimationFrame order assert_array_equals: expected order of notifications expected property 1 to be "first_child_raf" but got "second_child_raf" (expected array ["parent_raf", "first_child_raf", "second_child_raf"] got ["parent_raf", "second_child_raf", "first_child_raf"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/user-prompts/cannot-show-simple-dialogs/confirm-different-origin-frame.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/user-prompts/cannot-show-simple-dialogs/confirm-different-origin-frame.sub-expected.txt
@@ -1,4 +1,3 @@
-Blocked access to external URL http://www.127.0.0.1:8800/html/webappapis/user-prompts/cannot-show-simple-dialogs/support/confirm.html
 
 
 Harness Error (TIMEOUT), message = null

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/user-prompts/cannot-show-simple-dialogs/prompt-different-origin-frame.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/user-prompts/cannot-show-simple-dialogs/prompt-different-origin-frame.sub-expected.txt
@@ -1,4 +1,3 @@
-Blocked access to external URL http://www.127.0.0.1:8800/html/webappapis/user-prompts/cannot-show-simple-dialogs/support/prompt.html
 
 
 Harness Error (TIMEOUT), message = null

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window-expected.txt
@@ -1,6 +1,6 @@
 
 PASS document.open() changes document's URL (fully active document)
-FAIL document.open() does not change document's URL (active but not fully active document) assert_equals: expected "http://web-platform.test:8800/common/blank.html" but got "about:blank"
+PASS document.open() does not change document's URL (active but not fully active document)
 PASS document.open() does not change document's URL (non-active document with an associated Window object; frame is removed)
 PASS document.open() does not change document's URL (non-active document with an associated Window object; navigated away)
 PASS document.open() does not change document's URL (non-active document without an associated Window object)

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "FrameLoader.h"
 #include "LocalDOMWindow.h"
+#include "LocalDOMWindowProperty.h"
 #include "LocalFrame.h"
 #include "NavigationScheduler.h"
 #include "SecurityOrigin.h"
@@ -64,11 +65,13 @@ const Frame* Location::frame() const
 
 const URL& Location::url() const
 {
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame());
-    if (!localFrame)
-        return aboutBlankURL();
+    RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(*m_window);
+    if (!localWindow) {
+        static NeverDestroyed<URL> nullURL;
+        return nullURL.get();
+    }
 
-    const URL& url = localFrame->document()->urlForBindings();
+    const URL& url = localWindow->document()->urlForBindings();
     if (!url.isValid())
         return aboutBlankURL(); // Use "about:blank" while the page is still loading (before we have a frame).
 


### PR DESCRIPTION
#### 5bf1af1ceb7a05c6f0bfc2bf4c890c0bcade1c7a
<pre>
Obtain Location from appropriate Window directly, rather then Frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=261889">https://bugs.webkit.org/show_bug.cgi?id=261889</a>

Reviewed by Chris Dumez.

This change causes Location::url() to be obtained from the appropriate
Window instance directly, rather than a Frame.

Otherwise, without this change, the “document.open() does not change
document&apos;s URL (active but not fully active document)” test case from
<a href="https://wpt.fyi/results/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window.html">https://wpt.fyi/results/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window.html</a>
fails in WebKit, and a number of other tests time out unexpectedly.

Note: This change incidentally also corrects the expectations for the test at
<a href="https://wpt.fyi/results/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin.html">https://wpt.fyi/results/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin.html</a>
In its WebKit expectations file, that test been marked as a TIMEOUT —
but it’s marked as a FAIL in the wpt.fyi results.

* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2-pson.html:
* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window2.html:
* LayoutTests/http/tests/security/xss-DENIED-script-inject-into-inactive-window3.html:
Adjusted expected location.href

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/pushstate.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-claim.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-clients-matchall.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-controlled-after-restore.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/storage-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigate-cross-origin-iframe-to-same-url-with-fragment-fire-load-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/no_window_open_when_term_nesting_level_nonzero.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/bailout-exception-vs-return-xml.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/ignore-opens-during-unload.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/event-loops/fully_active_document.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/allow-crossorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/update-rendering/child-document-raf-order-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/user-prompts/cannot-show-simple-dialogs/confirm-different-origin-frame.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/user-prompts/cannot-show-simple-dialogs/prompt-different-origin-frame.sub-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url.window-expected.txt:
* Source/WebCore/page/Location.cpp:
(WebCore::Location::url const):

Canonical link: <a href="https://commits.webkit.org/269235@main">https://commits.webkit.org/269235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/156334190765db38b9c158bbd5a43df5fe9418df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20305 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22459 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24661 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26136 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23999 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17488 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5237 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24084 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->