### PR TITLE
IPInt should decode LEB for extended opcodes

### DIFF
--- a/JSTests/wasm/stress/non-canonical-extended-ops.js
+++ b/JSTests/wasm/stress/non-canonical-extended-ops.js
@@ -1,0 +1,120 @@
+load("../spec-harness.js", "caller relative");
+
+instance = (() => {
+  let builder = new WasmModuleBuilder();
+  builder.addFunction('I32TruncSatF32S_2', makeSig([kWasmF32], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x80, 0x00])
+    .exportFunc();
+  builder.addFunction('I32TruncSatF32S_3', makeSig([kWasmF32], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x80, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I32TruncSatF32U_2', makeSig([kWasmF32], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x81, 0x00])
+    .exportFunc();
+  builder.addFunction('I32TruncSatF32U_3', makeSig([kWasmF32], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x81, 0x80, 0x00])
+    .exportFunc();
+
+
+  builder.addFunction('I32TruncSatF64S_2', makeSig([kWasmF64], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x82, 0x00])
+    .exportFunc();
+  builder.addFunction('I32TruncSatF64S_3', makeSig([kWasmF64], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x82, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I32TruncSatF64U_2', makeSig([kWasmF64], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x83, 0x00])
+    .exportFunc();
+  builder.addFunction('I32TruncSatF64U_3', makeSig([kWasmF64], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x83, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I64TruncSatF32S_2', makeSig([kWasmF32], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x84, 0x00])
+    .exportFunc();
+  builder.addFunction('I64TruncSatF32S_3', makeSig([kWasmF32], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x84, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I64TruncSatF32U_2', makeSig([kWasmF32], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x85, 0x00])
+    .exportFunc();
+  builder.addFunction('I64TruncSatF32U_3', makeSig([kWasmF32], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x85, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I64TruncSatF64S_2', makeSig([kWasmF64], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x86, 0x00])
+    .exportFunc();
+  builder.addFunction('I64TruncSatF64S_3', makeSig([kWasmF64], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x86, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I64TruncSatF64U_2', makeSig([kWasmF64], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x87, 0x00])
+    .exportFunc();
+  builder.addFunction('I64TruncSatF64U_3', makeSig([kWasmF64], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x87, 0x80, 0x00])
+    .exportFunc();
+
+  return builder.instantiate({});
+})();
+
+assert.eq(instance.exports.I32TruncSatF32S_2(1), 1);
+assert.eq(instance.exports.I32TruncSatF32S_3(1), 1);
+
+assert.eq(instance.exports.I32TruncSatF32U_2(1), 1);
+assert.eq(instance.exports.I32TruncSatF32U_3(1), 1);
+
+assert.eq(instance.exports.I32TruncSatF64S_2(1), 1);
+assert.eq(instance.exports.I32TruncSatF64S_3(1), 1);
+
+assert.eq(instance.exports.I32TruncSatF64U_2(1), 1);
+assert.eq(instance.exports.I32TruncSatF64U_3(1), 1);
+
+assert.eq(instance.exports.I64TruncSatF32S_2(1), 1n);
+assert.eq(instance.exports.I64TruncSatF32S_3(1), 1n);
+
+assert.eq(instance.exports.I64TruncSatF32U_2(1), 1n);
+assert.eq(instance.exports.I64TruncSatF32U_3(1), 1n);
+
+assert.eq(instance.exports.I64TruncSatF64S_2(1), 1n);
+assert.eq(instance.exports.I64TruncSatF64S_3(1), 1n);
+
+assert.eq(instance.exports.I64TruncSatF64U_2(1), 1n);
+assert.eq(instance.exports.I64TruncSatF64U_3(1), 1n);
+

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -508,7 +508,7 @@ auto FunctionParser<Context>::truncSaturated(Ext1OpType op, Type returnType, Typ
     TypedExpression value;
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "unary");
 
-    WASM_VALIDATOR_FAIL_IF(value.type() != operandType, "trunc-saturated value type mismatch");
+    WASM_VALIDATOR_FAIL_IF(value.type() != operandType, "trunc-saturated value type mismatch. Expected: ", operandType, " but expression stack has ", value.type());
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(truncSaturated(op, value, result, returnType, operandType));

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -54,6 +54,8 @@
  * through many bytes to find their target, constants are stored in LEB128, and a myriad of other reasons.
  * For IPInt, we design metadata to act as "supporting information" for the interpreter, allowing it to quickly
  * find important values such as constants, indices, and branch targets.
+ *
+ * FIXME: We should consider not aligning on Apple ARM64 cores since they don't typically have a penatly for unaligned loads/stores.
  * 
  * 2. Metadata Structure
  * ---------------------
@@ -712,7 +714,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::setGlobal(uint32_t index, Expre
 
 // Loads and Stores
 
-// Implementation status: UNIMPLEMENTED
+// Implementation status: DONE.
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::load(LoadOpType, ExpressionType, ExpressionType&, uint32_t offset)
 {
@@ -727,12 +729,20 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::store(StoreOpType, ExpressionTy
 
 // Memories
 
-// Implementation status: UNIMPLEMENTED
+// Implementation status: DONE.
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addGrowMemory(ExpressionType, ExpressionType&) { return { }; }
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCurrentMemory(ExpressionType&) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryFill(ExpressionType, ExpressionType, ExpressionType) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryCopy(ExpressionType, ExpressionType, ExpressionType) { return { }; }
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryFill(ExpressionType, ExpressionType, ExpressionType)
+{
+    m_metadata->addLength(getCurrentInstructionLength());
+    return { };
+}
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryCopy(ExpressionType, ExpressionType, ExpressionType)
+{
+    m_metadata->addLength(getCurrentInstructionLength());
+    return { };
+}
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryInit(unsigned dataIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     m_metadata->addLEB128ConstantInt32AndLength(dataIndex, getCurrentInstructionLength());
@@ -969,7 +979,11 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncSF32(ExpressionType,
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncUF64(ExpressionType, ExpressionType&) { return { }; }
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncUF32(ExpressionType, ExpressionType&) { return { }; }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type) { return { }; }
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type)
+{
+    m_metadata->addLength(getCurrentInstructionLength());
+    return { };
+}
 
 // Conversions
 


### PR DESCRIPTION
#### 370d7ae576389f08b9d9e4ae477c35dff89e4d08
<pre>
IPInt should decode LEB for extended opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261894">https://bugs.webkit.org/show_bug.cgi?id=261894</a>

Reviewed by Yusuke Suzuki.

Right now it assumes they are 1 byte, which 99.9% of the time they will be.
It&apos;s technically correct, however, to non-canonically encode them as more
than one byte. This patch adds a simple LEB UInt32 decoder to IPInt
and uses it to decode the extended opcode.

* JSTests/wasm/stress/non-canonical-extended-ops.js: Added.
(instance):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::truncSaturated):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addMemoryFill):
(JSC::Wasm::IPIntGenerator::addMemoryCopy):
(JSC::Wasm::IPIntGenerator::truncSaturated):

Canonical link: <a href="https://commits.webkit.org/268300@main">https://commits.webkit.org/268300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eab49a96c53b053f1b21db1550951cfcc30fc53e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17972 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19650 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21965 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16687 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23848 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16668 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21802 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18534 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15459 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22593 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17376 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/5494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4605 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21736 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23843 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18088 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5336 "Passed tests") | 
<!--EWS-Status-Bubble-End-->