### PR TITLE
Remove warnings in NativePromise when both log and release log are disabled.

### DIFF
--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -359,6 +359,9 @@ private:
     {
         static_assert(std::is_convertible_v<RejectValueType_, RejectValueT>, "reject() argument must be implicitly convertible to NativePromise's RejectValueT");
         Locker lock { m_lock };
+#if LOG_DISABLED && RELEASE_LOG_DISABLED
+        UNUSED_PARAM(rejectSite);
+#endif
         PROMISE_LOG("%s rejecting NativePromise (%p created at %s)", rejectSite, this, m_creationSite);
         ASSERT(isNothing());
         m_result = Unexpected<RejectValueT>(std::forward<RejectValueType_>(rejectValue));
@@ -370,6 +373,9 @@ private:
     {
         Locker lock { m_lock };
         ASSERT(isNothing());
+#if LOG_DISABLED && RELEASE_LOG_DISABLED
+        UNUSED_PARAM(site);
+#endif
         PROMISE_LOG("%s resolveOrRejecting NativePromise (%p created at %s)", site, this, m_creationSite);
         m_result = std::forward<ResolveOrRejectValue_>(result);
         dispatchAll(lock);
@@ -379,6 +385,9 @@ private:
     {
         static_assert(IsExclusive, "setDispatchMode can only be used with exclusive promises");
         Locker lock { m_lock };
+#if LOG_DISABLED && RELEASE_LOG_DISABLED
+        UNUSED_PARAM(site);
+#endif
         PROMISE_LOG("%s runSynchronouslyOnTarget NativePromise (%p created at %s)", site, this, m_creationSite);
         ASSERT(isNothing(), "A Promise must not have been already resolved or rejected to set dispatch state");
         m_dispatchMode = dispatchMode;
@@ -664,6 +673,9 @@ private:
         Locker lock { m_lock };
         ASSERT(!IsExclusive || !m_haveRequest, "Using an exclusive promise in a non-exclusive fashion");
         m_haveRequest = true;
+#if LOG_DISABLED && RELEASE_LOG_DISABLED
+        UNUSED_PARAM(callSite);
+#endif
         PROMISE_LOG("%s invoking then() [this:%p, callback:%p, isNothing:%d]", callSite, this, thenCallback.ptr(), isNothing());
         if (!isNothing())
             thenCallback->dispatch(*this, lock);


### PR DESCRIPTION
#### c24c48984502bd991c37671f60c089e0104454a3
<pre>
Remove warnings in NativePromise when both log and release log are disabled.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261899">https://bugs.webkit.org/show_bug.cgi?id=261899</a>

Reviewed by Youenn Fablet.

Add conditional UNUSED_PARAMs to additional methods in NativePromise when
both LOG_DISABLED and RELEASE_LOG_DISABLED are true.

* Source/WTF/wtf/NativePromise.h:

Canonical link: <a href="https://commits.webkit.org/268318@main">https://commits.webkit.org/268318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8dbc90b7ece46891fce92d2ffdc5e8f347cb91c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17971 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19652 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21964 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23845 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16667 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21799 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18532 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15460 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22592 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17375 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/5492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4623 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21735 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23842 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18087 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5335 "Passed tests") | 
<!--EWS-Status-Bubble-End-->