### PR TITLE
Have RenderObject subclass CanMakeCheckedPtr

### DIFF
--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -105,9 +105,10 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderElement);
 
 struct SameSizeAsRenderElement : public RenderObject {
-    unsigned bitfields : 25;
-    void* firstChild;
-    void* lastChild;
+    PackedPtr<RenderObject> firstChild;
+    unsigned bitfields1 : 12;
+    PackedPtr<RenderObject> lastChild;
+    unsigned bitfields2 : 13;
     RenderStyle style;
 };
 
@@ -115,6 +116,7 @@ static_assert(sizeof(RenderElement) == sizeof(SameSizeAsRenderElement), "RenderE
 
 inline RenderElement::RenderElement(ContainerNode& elementOrDocument, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
     : RenderObject(elementOrDocument)
+    , m_firstChild(nullptr)
     , m_baseTypeFlags(baseTypeFlags)
     , m_ancestorLineBoxDirty(false)
     , m_hasInitializedStyle(false)
@@ -122,6 +124,7 @@ inline RenderElement::RenderElement(ContainerNode& elementOrDocument, RenderStyl
     , m_hasPausedImageAnimations(false)
     , m_hasCounterNodeMap(false)
     , m_hasContinuationChainNode(false)
+    , m_lastChild(nullptr)
     , m_isContinuation(false)
     , m_isFirstLetter(false)
     , m_renderBlockHasMarginBeforeQuirk(false)
@@ -132,8 +135,6 @@ inline RenderElement::RenderElement(ContainerNode& elementOrDocument, RenderStyl
     , m_isRegisteredForVisibleInViewportCallback(false)
     , m_visibleInViewportState(static_cast<unsigned>(VisibleInViewportState::Unknown))
     , m_didContributeToVisuallyNonEmptyPixelCount(false)
-    , m_firstChild(nullptr)
-    , m_lastChild(nullptr)
     , m_style(WTFMove(style))
 {
 }
@@ -589,7 +590,7 @@ RenderObject* RenderElement::attachRendererInternal(RenderPtr<RenderObject> chil
     }
     if (m_lastChild)
         m_lastChild->setNextSibling(child.get());
-    child->setPreviousSibling(m_lastChild);
+    child->setPreviousSibling(m_lastChild.get());
     m_lastChild = child.get();
     return child.release();
 }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -25,6 +25,7 @@
 #include "HitTestRequest.h"
 #include "LengthFunctions.h"
 #include "RenderObject.h"
+#include <wtf/Packed.h>
 
 namespace WebCore {
 
@@ -86,8 +87,8 @@ public:
     Element* nonPseudoElement() const { return downcast<Element>(RenderObject::nonPseudoNode()); }
     Element* generatingElement() const;
 
-    RenderObject* firstChild() const { return m_firstChild; }
-    RenderObject* lastChild() const { return m_lastChild; }
+    RenderObject* firstChild() const { return m_firstChild.get(); }
+    RenderObject* lastChild() const { return m_lastChild.get(); }
     RenderObject* firstInFlowChild() const;
     RenderObject* lastInFlowChild() const;
 
@@ -387,6 +388,7 @@ private:
     void updateReferencedSVGResources();
     void clearReferencedSVGResources();
 
+    PackedPtr<RenderObject> m_firstChild;
     unsigned m_baseTypeFlags : 6;
     unsigned m_ancestorLineBoxDirty : 1;
     unsigned m_hasInitializedStyle : 1;
@@ -395,6 +397,9 @@ private:
     unsigned m_hasPausedImageAnimations : 1;
     unsigned m_hasCounterNodeMap : 1;
     unsigned m_hasContinuationChainNode : 1;
+
+    PackedPtr<RenderObject> m_lastChild;
+
     unsigned m_isContinuation : 1;
     unsigned m_isFirstLetter : 1;
 
@@ -408,9 +413,6 @@ private:
     unsigned m_visibleInViewportState : 2;
 
     unsigned m_didContributeToVisuallyNonEmptyPixelCount : 1;
-
-    RenderObject* m_firstChild;
-    RenderObject* m_lastChild;
 
     RenderStyle m_style;
 };

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -113,15 +113,19 @@ RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope()
 struct SameSizeAsRenderObject : CanMakeWeakPtr<SameSizeAsRenderObject> {
     virtual ~SameSizeAsRenderObject() = default; // Allocate vtable pointer.
 #if ASSERT_ENABLED
-    WeakHashSet<void*> cachedResourceClientAssociatedResources;
+    WeakHashSet<void*> cachedResourceClientAssociatedResources; // CachedImageClient.
 #endif
-    CheckedRef<Node> node;
-    void* pointers[3];
-    CheckedPtr<Layout::Box> layoutBox;
+    uint32_t m_checkedPtrCount; // CanMakeCheckedPtr.
+#if ASSERT_ENABLED && !USE(WEB_THREAD)
+    Ref<Thread> m_thread; // CanMakeCheckedPtr.
+#endif
 #if ASSERT_ENABLED
     unsigned m_debugBitfields : 2;
 #endif
     unsigned m_bitfields;
+    CheckedRef<Node> node;
+    void* pointers[3];
+    CheckedPtr<Layout::Box> layoutBox;
 };
 
 #if CPU(ADDRESS64)
@@ -137,15 +141,15 @@ void RenderObjectDeleter::operator() (RenderObject* renderer) const
 
 RenderObject::RenderObject(Node& node)
     : CachedImageClient()
-    , m_node(node)
-    , m_parent(nullptr)
-    , m_previous(nullptr)
-    , m_next(nullptr)
 #if ASSERT_ENABLED
     , m_hasAXObject(false)
     , m_setNeedsLayoutForbidden(false)
 #endif
     , m_bitfields(node)
+    , m_node(node)
+    , m_parent(nullptr)
+    , m_previous(nullptr)
+    , m_next(nullptr)
 {
     if (RenderView* renderView = node.document().renderView())
         renderView->didCreateRenderer();

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -96,7 +96,7 @@ class PseudoElementRequest;
 }
 
 // Base class for all rendering tree objects.
-class RenderObject : public CachedImageClient {
+class RenderObject : public CachedImageClient, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(RenderObject);
     friend class RenderBlock;
     friend class RenderBlockFlow;
@@ -863,14 +863,6 @@ private:
     void checkBlockPositionedObjectsNeedLayout();
 #endif
 
-    CheckedRef<Node> m_node;
-
-    RenderElement* m_parent;
-    RenderObject* m_previous;
-    RenderObject* m_next;
-
-    CheckedPtr<Layout::Box> m_layoutBox;
-
 #if ASSERT_ENABLED
     bool m_hasAXObject : 1;
     mutable bool m_setNeedsLayoutForbidden : 1;
@@ -991,6 +983,14 @@ private:
     };
 
     RenderObjectBitfields m_bitfields;
+
+    CheckedRef<Node> m_node;
+
+    RenderElement* m_parent;
+    RenderObject* m_previous;
+    RenderObject* m_next;
+
+    CheckedPtr<Layout::Box> m_layoutBox;
 
     // FIXME: This should be RenderElementRareData.
     class RenderObjectRareData {


### PR DESCRIPTION
#### 60da0af827823f29aa62dd74f9dc71deafab48f8
<pre>
Have RenderObject subclass CanMakeCheckedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=261902">https://bugs.webkit.org/show_bug.cgi?id=261902</a>

Reviewed by Simon Fraser.

Have RenderObject subclass CanMakeCheckedPtr so that we can adopt CheckedPtr / CheckedRef
in rendering code for safety. We were previously relying on WeakPtr but it turned out to
be too costly and cause performance regressions.

This tested as perf-neutral on Speedometer, Membuster and MotionMark.

In order to do this without regressing Membuster, I had to re-order some data members and
rely on PackedPtr&lt;&gt; to not increase the size of renderers.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
(WebCore::RenderElement::attachRendererInternal):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::firstChild const):
(WebCore::RenderElement::lastChild const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::RenderObject):
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/268298@main">https://commits.webkit.org/268298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3895802849993bee9db0acb28eb279b89bcc7eac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19786 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22002 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23866 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21827 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15478 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17412 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4607 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->