### PR TITLE
Support finding EWS runs from GitHub PRs in update-test-expectations

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -208,7 +208,7 @@ class GitHub(bmocks.GitHub):
         if path == 'statuses':
             return mocks.Response.fromJson([dict(
                 context=status['name'],
-                url=status.get('url'),
+                target_url=status.get('url'),
                 state=status.get('status') or 'pending',
                 description=status.get('description'),
             ) for status in self.statuses.get(ref[:Commit.HASH_LABEL_SIZE], [])], url=url)

--- a/Tools/Scripts/update-test-expectations
+++ b/Tools/Scripts/update-test-expectations
@@ -31,14 +31,10 @@ import sys
 
 from webkitpy.common.net.bugzilla import test_expectation_updater
 
-# Refer to update-test-expectations in the help as the canonical form of invoking this,
-# as otherwise the auto-generated help says `update-test-expectations-from-bugzilla
-# bugzilla` which is wrong given we prepend "bugzilla" below.
 sys.exit(
     test_expectation_updater.main(
-        ["bugzilla"] + sys.argv[1:],
+        sys.argv[1:],
         sys.stdout,
         sys.stderr,
-        prog="update-test-expectations",
     )
 )

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
@@ -209,3 +209,28 @@ def lookup_ews_results_from_bugzilla(
         raise RuntimeError(msg)
 
     return lookup_ews_results_from_bugzilla_patch(patch, bot_filter_name)
+
+
+def lookup_ews_results_from_pr(pr):
+    urls = [status.url for status in pr.statuses]
+    return lookup_ews_results(urls)
+
+
+def lookup_ews_results_from_repo_via_pr(repository):
+    source_remote = repository.default_remote
+    remote_repo = repository.remote(name=source_remote)
+    if not remote_repo.pull_requests:
+        msg = "Remote repo doesn't support pull requests"
+        raise ValueError(msg)
+
+    branch = repository.branch
+    existing_pr = None
+    for pr in remote_repo.pull_requests.find(opened=None, head=branch):
+        existing_pr = pr
+        break
+
+    if existing_pr is None:
+        msg = "No PR found for current branch"
+        raise ValueError(msg)
+
+    return lookup_ews_results_from_pr(existing_pr)

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py
@@ -29,14 +29,16 @@
 import argparse
 import io
 import logging
+import sys
 import zipfile
 
 import requests
+from webkitscmpy import local
 
 from webkitpy.common.host import Host
-from webkitpy.common.net.bugzilla import bugzilla
 from webkitpy.common.net.bugzilla.results_fetcher import (
     lookup_ews_results_from_bugzilla,
+    lookup_ews_results_from_repo_via_pr,
 )
 from webkitpy.common.net.layouttestresults import LayoutTestResults
 from webkitpy.common.webkit_finder import WebKitFinder
@@ -44,7 +46,15 @@ from webkitpy.layout_tests.controllers.test_result_writer import TestResultWrite
 from webkitpy.layout_tests.models import test_expectations
 
 # Buildbot status codes referenced from https://github.com/buildbot/buildbot/blob/master/master/buildbot/process/results.py
-EWS_STATECODES = {'SUCCESS': 0, 'WARNINGS': 1, 'FAILURE': 2, 'SKIPPED': 3, 'EXCEPTION': 4, 'RETRY': 5, 'CANCELLED': 6}
+EWS_STATECODES = {
+    "SUCCESS": 0,
+    "WARNINGS": 1,
+    "FAILURE": 2,
+    "SKIPPED": 3,
+    "EXCEPTION": 4,
+    "RETRY": 5,
+    "CANCELLED": 6,
+}
 
 
 _log = logging.getLogger(__name__)
@@ -52,7 +62,6 @@ _log = logging.getLogger(__name__)
 
 def configure_logging(debug=False):
     class LogHandler(logging.StreamHandler):
-
         def format(self, record):
             if record.levelno > logging.INFO:
                 return "%s: %s" % (record.levelname, record.getMessage())
@@ -67,28 +76,63 @@ def configure_logging(debug=False):
     return handler
 
 
-def argument_parser():
-    description = """Update expected.txt files from patches submitted by EWS bots on bugzilla. Given id refers to a bug id by default."""
-    parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('-a', '--is-attachment-id', dest='is_bug_id', action='store_false', default=True, help='Whether the given id is a bugzilla attachment and not a bug id')
-    parser.add_argument('-b', '--bot-filter', dest='bot_filter_name', action='store', default=None, help='Only process EWS results for bots where BOT_FILTER_NAME its part of the name')
-    parser.add_argument('-d', '--debug', dest='debug', action='store_true', default=False, help='Log debug messages')
-    parser.add_argument('bugzilla_id', help='Bugzilla ID to lookup')
+def argument_parser(prog=None):
+    description = "Update test baselines from CI."
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        prog=prog,
+    )
+
+    parser.add_argument(
+        "-d",
+        "--debug",
+        dest="debug",
+        action="store_true",
+        default=False,
+        help="Log debug messages",
+    )
+
+    if sys.version_info >= (3, 7):
+        subparsers = parser.add_subparsers(
+            title="Subcommands", dest="subcommand", required=True
+        )
+    else:
+        subparsers = parser.add_subparsers(title="Subcommands", dest="subcommand")
+
+    bugzilla_parser = subparsers.add_parser(
+        "bugzilla", help="Update from Bugzilla patch, from EWS bots"
+    )
+
+    bugzilla_parser.add_argument(
+        "-a",
+        "--is-attachment-id",
+        dest="is_bug_id",
+        action="store_false",
+        default=True,
+        help="Search by attachment id (rather than bug id)",
+    )
+    bugzilla_parser.add_argument(
+        "-b",
+        "--bot-filter",
+        dest="bot_filter_name",
+        action="store",
+        default=None,
+        help="Only process results for bots where BOT_FILTER_NAME is a substring of the bot name",
+    )
+    bugzilla_parser.add_argument("bugzilla_id", help="Bugzilla bug ID to lookup")
+
+    github_pr_parser = subparsers.add_parser(
+        "github-pr", help="Update from GitHub PR, from EWS bots"
+    )
+
     return parser
 
 
 class TestExpectationUpdater(object):
-
-    def __init__(self, port, bugzilla_id, is_bug_id=True, bot_filter_name=None, attachment_fetcher=None):
-        self.attachment_fetcher = bugzilla.Bugzilla() if attachment_fetcher is None else attachment_fetcher
-
+    def __init__(self, port):
         self.filesystem = port.host.filesystem
-        self.bot_filter_name = bot_filter_name
-        self.bugzilla_id = bugzilla_id
-        self.is_bug_id = is_bug_id
-
         self.layout_test_repository = port.path_from_webkit_base("LayoutTests")
-
         self.ews_results = None
 
     def _tests_to_update(self, platform_name):
@@ -132,14 +176,20 @@ class TestExpectationUpdater(object):
                 _log.info("Updating " + test_name + " for " + platform_name + " ( REMOVED: " + expected_filename + ")")
                 self.filesystem.remove(expected_filename)
 
-    def do_update(self):
+    def fetch_from_bugzilla(
+        self, bugzilla_id, is_bug_id=True, bot_filter_name=None, attachment_fetcher=None
+    ):
         self.ews_results = lookup_ews_results_from_bugzilla(
-            self.bugzilla_id,
-            self.is_bug_id,
-            self.attachment_fetcher,
-            self.bot_filter_name,
+            bugzilla_id,
+            is_bug_id,
+            attachment_fetcher,
+            bot_filter_name,
         )
 
+    def fetch_from_github_pr(self, repository):
+        self.ews_results = lookup_ews_results_from_repo_via_pr(repository)
+
+    def do_update(self):
         if len(self.ews_results) == 0:
             if self.bot_filter_name:
                 msg = (
@@ -167,8 +217,8 @@ class TestExpectationUpdater(object):
             self._update_for_platform_specific_bot(platform_name)
 
 
-def main(_argv, _stdout, _stderr):
-    parser = argument_parser()
+def main(_argv, _stdout, _stderr, prog=None):
+    parser = argument_parser(prog=prog)
     options = parser.parse_args(_argv)
 
     configure_logging(options.debug)
@@ -176,5 +226,19 @@ def main(_argv, _stdout, _stderr):
     host = Host()
     port = host.port_factory.get()
 
-    updater = TestExpectationUpdater(port, options.bugzilla_id, options.is_bug_id, options.bot_filter_name)
+    updater = TestExpectationUpdater(port)
+
+    if options.subcommand == "bugzilla":
+        updater.fetch_from_bugzilla(
+            options.bugzilla_id, options.is_bug_id, options.bot_filter_name
+        )
+    elif options.subcommand == "github-pr":
+        repo_path = WebKitFinder(host.filesystem).webkit_base()
+        repository = local.Scm.from_path(
+            path=repo_path,
+        )
+        updater.fetch_from_github_pr(repository)
+    else:
+        raise NotImplementedError("unreachable")
+
     updater.do_update()

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py
@@ -601,7 +601,8 @@ class TestExpectationUpdaterTest(unittest.TestCase):
         }
 
         with mock.patch('webkitpy.common.net.bugzilla.test_expectation_updater.lookup_ews_results_from_bugzilla', mock.Mock(return_value=ews_results)), mock.patch('requests.get', MockRequestsGet):
-            updater = TestExpectationUpdater(port, "123456", True, False, None)
+            updater = TestExpectationUpdater(port)
+            updater.fetch_from_bugzilla("123456", True, False, None)
             updater.do_update()
             # mac-wk2 expectation
             self.assertTrue(self._is_matching(host, "imported/w3c/web-platform-tests/fetch/api/redirect/redirect-count-cross-origin-expected.txt", "a"))


### PR DESCRIPTION
#### 1a61da068f12ccd67a405590d8022ac115fdd67c
<pre>
Support finding EWS runs from GitHub PRs in update-test-expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=257158">https://bugs.webkit.org/show_bug.cgi?id=257158</a>

Reviewed by Jonathan Bedard.

This adds support for fetching layout test results based on GitHub PR
statuses. To do this, we refactor test_expectation_updater to be able to
support multiple sources of layout tests results, and add various
subcommands to it. With the subcommands added, we rename the script to
update-test-expectations, and add a legacy
update-test-expectations-from-bugzilla which calls the bugzilla
subcommand.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub._commit_response):
* Tools/Scripts/update-test-expectations: Copied from Tools/Scripts/update-test-expectations-from-bugzilla.
* Tools/Scripts/update-test-expectations-from-bugzilla:
* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py:
(lookup_ews_results_from_pr):
(lookup_ews_results_from_repo_via_pr):
* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher_unittest.py:
(ResultsFetcherTest.test_is_relevant_results):
(ResultsFetcherTest.test_lookup_ews_results_from_bugzilla):
(ResultsFetcherGitHubTest):
(ResultsFetcherGitHubTest.webserver):
* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py:
(configure_logging.LogHandler):
(argument_parser):
(TestExpectationUpdater.__init__):
(TestExpectationUpdater.fetch_from_bugzilla):
(TestExpectationUpdater):
(TestExpectationUpdater.fetch_from_github_pr):
(TestExpectationUpdater.do_update):
(main):
* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py:
(TestExpectationUpdaterTest.test_update_test_expectations):

Canonical link: <a href="https://commits.webkit.org/272152@main">https://commits.webkit.org/272152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/454825ba631080141920237183aa7120ed2b2baa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/30780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/9458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/32447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/33275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/27811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/31524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/11765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/6702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/33275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/31093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/11765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/32447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/33275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/30934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/11765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/32447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/34612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/11765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/32447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/34612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/6998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/6702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/34612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/30571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/8715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/32447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/7715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3988 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/7554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->