### PR TITLE
ASSERTION FAILED: foundContainer on media/modern-media-controls/pip-support/pip-support-click.html.

### DIFF
--- a/LayoutTests/compositing/geometry/geometry-map-compositing-layer-without-containing-block-expected.html
+++ b/LayoutTests/compositing/geometry/geometry-map-compositing-layer-without-containing-block-expected.html
@@ -1,0 +1,9 @@
+<!doctype HTML>
+<html style="opacity:0.5;">
+<body>
+ <div style="position: absolute; opacity: 0.5">
+   <div id="inner" style="width:200px; height: 100px; background: blue"></div></div>
+ </div>
+
+</body>
+</html>

--- a/LayoutTests/compositing/geometry/geometry-map-compositing-layer-without-containing-block.html
+++ b/LayoutTests/compositing/geometry/geometry-map-compositing-layer-without-containing-block.html
@@ -1,0 +1,22 @@
+<!doctype HTML>
+<html style="opacity:0.5; will-change:opacity">
+<head>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+requestAnimationFrame(function() {
+  document.getElementById('inner').style.width = "200px";
+  if (window.testRunner)
+    testRunner.notifyDone();
+});
+
+</script>
+</head>
+<body>
+ <div style="position: absolute; opacity: 0.5">
+ <div style="contain:strict; position: absolute; width: 400px; height: 400px"><div id="inner" style="width:100px; height: 100px; background: blue"></div></div>
+ </div>
+
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1771,8 +1771,6 @@ webkit.org/b/256217 [ Debug ] imported/w3c/web-platform-tests/background-fetch/p
 
 webkit.org/b/238749 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html [ Pass Failure ]
 
-webkit.org/b/258325 [ Debug ] media/modern-media-controls/pip-support/pip-support-click.html [ Crash ]
-
 # webkit.org/b/258328 Umbrella Bug: Batch mark expectations slowing down EWS (258328)
 [ Debug ] imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -171,6 +171,19 @@ static bool canMapBetweenRenderersViaLayers(const RenderLayerModelObject& render
 
 void RenderGeometryMap::pushMappingsToAncestor(const RenderLayer* layer, const RenderLayer* ancestorLayer, bool respectTransforms)
 {
+    if (!ancestorLayer) {
+        ASSERT(!m_mapping.size());
+        pushMappingsToAncestor(&layer->renderer().view(), nullptr);
+
+        SetForScope positionChange(m_insertionPosition, m_mapping.size());
+        while (layer->parent()) {
+            pushMappingsToAncestor(layer, layer->parent(), respectTransforms);
+            layer = layer->parent();
+        }
+        ASSERT(m_mapping[0].m_renderer->isRenderView());
+        return;
+    }
+
     OptionSet<MapCoordinatesMode> newFlags = m_mapCoordinatesFlags;
     if (!respectTransforms)
         newFlags.remove(UseTransforms);
@@ -181,9 +194,7 @@ void RenderGeometryMap::pushMappingsToAncestor(const RenderLayer* layer, const R
 
     // We have to visit all the renderers to detect flipped blocks. This might defeat the gains
     // from mapping via layers.
-    bool canConvertInLayerTree = ancestorLayer ? canMapBetweenRenderersViaLayers(layer->renderer(), ancestorLayer->renderer()) : false;
-
-    if (canConvertInLayerTree) {
+    if (canMapBetweenRenderersViaLayers(renderer, ancestorLayer->renderer())) {
         LayoutSize layerOffset = layer->offsetFromAncestor(ancestorLayer);
         
         // The RenderView must be pushed first.
@@ -196,7 +207,7 @@ void RenderGeometryMap::pushMappingsToAncestor(const RenderLayer* layer, const R
         push(&renderer, layerOffset, /*accumulatingTransform*/ true, /*isNonUniform*/ false, /*isFixedPosition*/ false, /*hasTransform*/ false);
         return;
     }
-    const RenderLayerModelObject* ancestorRenderer = ancestorLayer ? &ancestorLayer->renderer() : nullptr;
+    const RenderLayerModelObject* ancestorRenderer = &ancestorLayer->renderer();
     pushMappingsToAncestor(&renderer, ancestorRenderer);
 }
 


### PR DESCRIPTION
#### f20a3ce20e867a081396437e684de72bf8d52320
<pre>
ASSERTION FAILED: foundContainer on media/modern-media-controls/pip-support/pip-support-click.html.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258325">https://bugs.webkit.org/show_bug.cgi?id=258325</a>
&lt;rdar://111065468&gt;

Reviewed by Simon Fraser.

Running layout for a subtree calls RenderGeometryMap::pushMappingsToAncestor with a nullptr ancestor layer to push
all the mappings up to the RenderView. Since we don&apos;t have an ancestor layer, we instead walk up the render tree.

The render tree container walk can jump over repaint containers (see containerForElement in RenderObject.cpp) to
the nearest containing block ancestor.

The expected behaviour for pushMappingsToAncestor is that the ancestor layer provided is the nearest repaint container,
so that any render tree walk with be bounded by that. In this case we don&apos;t have one, so we fail to push mappings for
repaint containers in some cases and then crash when trying to find them later.

This adds code for the nullptr case, and breaks the render tree walk down into per-layer-ancestor chunks to prevent
this.

Also adds a test that crashes without the fix.

* LayoutTests/compositing/geometry/geometry-map-compositing-layer-without-containing-block-expected.html: Added.
* LayoutTests/compositing/geometry/geometry-map-compositing-layer-without-containing-block.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/rendering/RenderGeometryMap.cpp:
(WebCore::RenderGeometryMap::pushMappingsToAncestor):

Canonical link: <a href="https://commits.webkit.org/268304@main">https://commits.webkit.org/268304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec28ce9aea62cd305c98e2bfd6fd315949fec226

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18032 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19681 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22032 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23881 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21846 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15501 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17380 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4610 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->