### PR TITLE
[macOS] Add syscall mig telemetry

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2114,15 +2114,10 @@
         (when (defined? 'mach_vm_range_create) mach_vm_range_create))) ;; <rdar://105161083>
 #endif
 
-(define (kernel-mig-routines-common) (kernel-mig-routine
+(define (kernel-mig-routines-in-use) (kernel-mig-routine
     _mach_make_memory_entry
     host_get_io_master
     host_info
-    io_connect_add_client
-    io_connect_async_method
-    io_connect_method
-    io_connect_method_var_output
-    io_connect_set_notification_port_64
     io_iterator_is_valid
     io_iterator_next
     io_object_conforms_to
@@ -2130,24 +2125,14 @@
     io_registry_entry_from_path
     io_registry_entry_get_parent_iterator
     io_registry_entry_get_property_bin_buf
-    io_registry_entry_get_property_bytes
     io_registry_entry_get_registry_entry_id
     io_server_version
-    io_service_add_interest_notification_64
-    io_service_add_notification_bin_64
-    io_service_get_matching_service_bin
-    io_service_get_matching_services_bin
-    io_service_open_extended
-    mach_exception_raise
     mach_memory_entry_ownership
-    mach_port_extract_right
-    mach_port_get_context_from_user
     mach_port_get_refs
     mach_port_request_notification
     mach_port_set_attributes
     mach_vm_copy
     mach_vm_map_external
-    mach_vm_region
     mach_vm_region_recurse
     mach_vm_remap_external
     semaphore_create
@@ -2161,6 +2146,25 @@
     thread_resume
     thread_suspend))
 
+(define (kernel-mig-routines-possibly-in-use) (kernel-mig-routine
+    io_connect_add_client
+    io_connect_async_method
+    io_connect_method
+    io_connect_method_var_output
+    io_connect_set_notification_port_64
+    io_registry_entry_get_property_bytes
+    mach_exception_raise
+    mach_port_extract_right
+    mach_port_get_context_from_user
+    mach_vm_region))
+
+(define (kernel-mig-routines-iokit-service) (kernel-mig-routine
+    io_service_add_interest_notification_64
+    io_service_add_notification_bin_64
+    io_service_get_matching_service_bin
+    io_service_get_matching_services_bin
+    io_service_open_extended))
+
 (define (kernel-mig-routines-blocked-in-lockdown-mode) (kernel-mig-routine
     clock_get_time
     host_request_notification
@@ -2173,9 +2177,12 @@
     io_registry_get_root_entry
     io_service_close
     task_threads_from_user
-    thread_info
     thread_policy
     thread_policy_set))
+
+(define (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry) (kernel-mig-routine
+    thread_info
+    thread_set_exception_ports))
 
 (if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
     (allow mach-kernel-endpoint
@@ -2183,16 +2190,19 @@
             (deny mach-message-send)
 #if ENABLE(LOCKDOWN_MODE_TELEMETRY)
             (with-filter (require-not (lockdown-mode))
-                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode)))
+                (allow mach-message-send (with report) (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode))
+                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry)))
             (with-filter (lockdown-mode)
-                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode)))
+                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode))
+                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry)))
 #else
             (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
+            (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry))
 #endif
-            (with-filter (require-not (lockdown-mode))
-                (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
 
-            (allow mach-message-send (kernel-mig-routines-common))
+            (allow mach-message-send (kernel-mig-routines-in-use))
+            (allow mach-message-send (kernel-mig-routines-iokit-service))
+            (allow mach-message-send (with report) (with telemetry) (kernel-mig-routines-possibly-in-use))
                 
 #if HAVE(SANDBOX_STATE_FLAGS) && HAVE(MACH_RANGE_CREATE)
             (with-filter (require-not (state-flag "WebContentProcessLaunched"))


### PR DESCRIPTION
#### 3e1f054f956f635a44c0e9220eef8f4d7eb0007f
<pre>
[macOS] Add syscall mig telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=261903">https://bugs.webkit.org/show_bug.cgi?id=261903</a>

Reviewed by Brent Fulgham.

Add syscall mig telemetry in the WebContent process on macOS to detect which are currently in use.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/268281@main">https://commits.webkit.org/268281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/598ae201a0697dc55e842d25385857bd6c0bc494

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21110 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17984 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19762 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21980 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16697 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21810 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17391 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4595 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21748 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->