### PR TITLE
Use more smart pointers in the DOM

### DIFF
--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -29,6 +29,7 @@
 #include "CSSComputedStyleDeclaration.h"
 #include "CSSPropertyParser.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "Element.h"
 #include "RenderStyleInlines.h"
 #include "StylePropertyShorthand.h"
@@ -88,20 +89,21 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     if (!style)
         return values;
 
+    Ref document = m_element->protectedDocument();
     const auto& inheritedCustomProperties = style->inheritedCustomProperties();
     const auto& nonInheritedCustomProperties = style->nonInheritedCustomProperties();
-    const auto& exposedComputedCSSPropertyIDs = m_element->document().exposedComputedCSSPropertyIDs();
+    const auto& exposedComputedCSSPropertyIDs = document->exposedComputedCSSPropertyIDs();
     values.reserveInitialCapacity(exposedComputedCSSPropertyIDs.size() + inheritedCustomProperties.size() + nonInheritedCustomProperties.size());
 
     ComputedStyleExtractor extractor { m_element.ptr() };
     for (auto propertyID : exposedComputedCSSPropertyIDs) {
         auto value = extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
-        values.uncheckedAppend(makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, m_element->document())));
+        values.uncheckedAppend(makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, document)));
     }
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         map->forEach([&](auto& it) {
-            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt, m_element->document())));
+            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(const_cast<CSSCustomPropertyValue*>(it.value.get()), std::nullopt, document)));
             return IterationStatus::Continue;
         });
     }

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -100,9 +100,9 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
         ASSERT(!weakPtrFactory().isInitialized());
 #endif
         bool hadElementChild = false;
-        while (RefPtr<Node> child = m_firstChild) {
+        while (RefPtr child = m_firstChild) {
             hadElementChild |= is<Element>(*child);
-            removeBetween(nullptr, child->nextSibling(), *child);
+            removeBetween(nullptr, child->protectedNextSibling().get(), *child);
         }
         document().incDOMTreeVersion();
         return hadElementChild ? DidRemoveElements::Yes : DidRemoveElements::No;
@@ -141,7 +141,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
 
         document().nodeChildrenWillBeRemoved(*this);
 
-        while (RefPtr<Node> child = m_firstChild) {
+        while (RefPtr child = m_firstChild) {
             if (is<Element>(*child))
                 hadElementChild = true;
 
@@ -467,14 +467,14 @@ static inline ExceptionOr<void> checkPreReplacementValidity(ContainerNode& newPa
     return checkAcceptChild(newParent, newChild, &oldChild, Document::AcceptChildOperation::Replace, shouldValidateChildParent);
 }
 
-ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, Node* refChild)
+ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, RefPtr<Node>&& refChild)
 {
     // Check that this node is not "floating".
     // If it is, it can be deleted as a side effect of sending mutation events.
     ASSERT(refCount() || parentOrShadowHostNode());
 
     // Make sure adding the new child is OK.
-    auto validityCheckResult = ensurePreInsertionValidity(newChild, refChild);
+    auto validityCheckResult = ensurePreInsertionValidity(newChild, refChild.get());
     if (validityCheckResult.hasException())
         return validityCheckResult.releaseException();
 
@@ -486,7 +486,7 @@ ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, Node* refChild)
         return appendChildWithoutPreInsertionValidityCheck(newChild);
 
     Ref<ContainerNode> protectedThis(*this);
-    Ref<Node> next(*refChild);
+    Ref next = refChild.releaseNonNull();
 
     NodeVector targets;
     auto removeResult = removeSelfOrChildNodesForInsertion(newChild, targets);
@@ -556,9 +556,9 @@ void ContainerNode::appendChildCommon(Node& child)
 
     child.setParentNode(this);
 
-    if (m_lastChild) {
-        child.setPreviousSibling(m_lastChild);
-        m_lastChild->setNextSibling(&child);
+    if (auto lastChild = protectedLastChild()) {
+        child.setPreviousSibling(lastChild.get());
+        lastChild->setNextSibling(&child);
     } else
         m_firstChild = &child;
 
@@ -1080,7 +1080,7 @@ ExceptionOr<void> ContainerNode::prepend(FixedVector<NodeOrString>&& vector)
     if (!node)
         return { };
 
-    return insertBefore(*node, firstChild());
+    return insertBefore(*node, protectedFirstChild());
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-replacechildren

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -41,8 +41,10 @@ public:
     virtual ~ContainerNode();
 
     Node* firstChild() const { return m_firstChild; }
+    RefPtr<Node> protectedFirstChild() const { return m_firstChild; }
     static ptrdiff_t firstChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_firstChild); }
     Node* lastChild() const { return m_lastChild; }
+    RefPtr<Node> protectedLastChild() const { return m_lastChild; }
     static ptrdiff_t lastChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_lastChild); }
     bool hasChildNodes() const { return m_firstChild; }
     bool hasOneChild() const { return m_firstChild && m_firstChild == m_lastChild; }
@@ -53,7 +55,7 @@ public:
     WEBCORE_EXPORT unsigned countChildNodes() const;
     WEBCORE_EXPORT Node* traverseToChildAt(unsigned) const;
 
-    ExceptionOr<void> insertBefore(Node& newChild, Node* refChild);
+    ExceptionOr<void> insertBefore(Node& newChild, RefPtr<Node>&& refChild);
     ExceptionOr<void> replaceChild(Node& newChild, Node& oldChild);
     WEBCORE_EXPORT ExceptionOr<void> removeChild(Node& child);
     WEBCORE_EXPORT ExceptionOr<void> appendChild(Node& newChild);
@@ -278,6 +280,13 @@ private:
     Vector<RefPtr<Node>> m_snapshot; // Lazily instantiated.
     ChildNodesLazySnapshot* m_nextSnapshot;
 };
+
+inline void Node::setParentNode(ContainerNode* parent)
+{
+    ASSERT(isMainThread());
+    m_parentNode = parent;
+    m_refCountAndParentBit = (m_refCountAndParentBit & s_refCountMask) | !!parent;
+}
 
 inline RefPtr<ContainerNode> Node::protectedParentNode() const
 {

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -71,14 +71,16 @@ private:
 
 void ContentVisibilityDocumentState::observe(Element& element)
 {
-    auto& state = element.document().contentVisibilityDocumentState();
-    if (auto* intersectionObserver = state.intersectionObserver(element.document()))
+    Ref document = element.document();
+    auto& state = document->contentVisibilityDocumentState();
+    if (auto* intersectionObserver = state.intersectionObserver(document))
         intersectionObserver->observe(element);
 }
 
 void ContentVisibilityDocumentState::unobserve(Element& element)
 {
-    auto& state = element.document().contentVisibilityDocumentState();
+    Ref document = element.document();
+    auto& state = document->contentVisibilityDocumentState();
     if (auto& intersectionObserver = state.m_observer) {
         intersectionObserver->unobserve(element);
         state.removeViewportProximity(element);

--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -150,7 +150,8 @@ Vector<Ref<DataTransferItem>>& DataTransferItemList::ensureItems() const
             items.append(DataTransferItem::create(*this, lowercasedType));
     }
 
-    for (auto& file : m_dataTransfer.files(document()).files())
+    RefPtr document { this->document() };
+    for (auto& file : m_dataTransfer.files(*document).files())
         items.append(DataTransferItem::create(*this, file->type(), file.copyRef()));
 
     m_items = WTFMove(items);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1129,7 +1129,7 @@ ExceptionOr<Ref<Element>> Document::createElementForBindings(const AtomString& n
 
 Ref<DocumentFragment> Document::createDocumentFragment()
 {
-    return DocumentFragment::create(document());
+    return DocumentFragment::create(*this);
 }
 
 Ref<Text> Document::createTextNode(String&& data)
@@ -1835,8 +1835,9 @@ void Document::setTitle(String&& title)
     RefPtr element = documentElement();
     if (is<SVGSVGElement>(element)) {
         if (!m_titleElement) {
-            m_titleElement = SVGTitleElement::create(SVGNames::titleTag, *this);
-            element->insertBefore(*m_titleElement, element->firstChild());
+            auto titleElement = SVGTitleElement::create(SVGNames::titleTag, *this);
+            m_titleElement = titleElement.copyRef();
+            element->insertBefore(titleElement, element->protectedFirstChild());
         }
         // insertBefore above may have ran scripts which removed m_titleElement.
         if (m_titleElement)
@@ -6868,7 +6869,8 @@ bool Document::isSecureContext() const
         auto* localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
-        if (!isDocumentSecure(*localFrame->document()))
+        Ref<Document> ancestorDocument = *localFrame->document();
+        if (!isDocumentSecure(ancestorDocument))
             return false;
     }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1622,6 +1622,7 @@ public:
 #endif
 
     Logger& logger();
+    const Logger& logger() const { return const_cast<Document&>(*this).logger(); }
     WEBCORE_EXPORT static const Logger& sharedLogger();
 
     WEBCORE_EXPORT void setConsoleMessageListener(RefPtr<StringCallback>&&); // For testing.

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -123,5 +123,9 @@ inline WebCoreOpaqueRoot Node::opaqueRoot() const
 
 inline bool Document::wasLastFocusByClick() const { return m_latestFocusTrigger == FocusTrigger::Click; }
 
+inline Ref<Document> Node::protectedDocument() const
+{
+    return document();
+}
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -499,7 +499,8 @@ void DocumentMarkerController::forEachOfTypes(OptionSet<DocumentMarker::MarkerTy
             if (!types.contains(marker.type()))
                 continue;
 
-            function(*nodeMarkers.key, marker);
+            Ref node { *nodeMarkers.key };
+            function(node, marker);
         }
     }
 }

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -46,13 +46,14 @@ public:
     FullscreenManager(Document&);
     ~FullscreenManager();
 
-    Document& document() { return m_document; }
-    const Document& document() const { return m_document; }
-    Page* page() const { return m_document.page(); }
-    LocalFrame* frame() const { return m_document.frame(); }
-    Element* documentElement() const { return m_document.documentElement(); }
+    Document& document() { return m_document.get(); }
+    const Document& document() const { return m_document.get(); }
+    Ref<Document> protectedDocument() const { return m_document.get(); }
+    Page* page() const { return document().page(); }
+    LocalFrame* frame() const { return document().frame(); }
+    Element* documentElement() const { return document().documentElement(); }
     bool isSimpleFullscreenDocument() const;
-    Document::BackForwardCacheState backForwardCacheState() const { return m_document.backForwardCacheState(); }
+    Document::BackForwardCacheState backForwardCacheState() const { return document().backForwardCacheState(); }
 
     // WHATWG Fullscreen API
     WEBCORE_EXPORT Element* fullscreenElement() const;
@@ -102,7 +103,7 @@ protected:
 
 private:
 #if !RELEASE_LOG_DISABLED
-    const Logger& logger() const { return m_document.logger(); }
+    const Logger& logger() const { return document().logger(); }
     const void* logIdentifier() const { return m_logIdentifier; }
     const char* logClassName() const { return "FullscreenManager"; }
     WTFLogChannel& logChannel() const;
@@ -110,7 +111,7 @@ private:
 
     Document& topDocument() { return m_topDocument ? *m_topDocument : document().topDocument(); }
 
-    Document& m_document;
+    CheckedRef<Document> m_document;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_topDocument;
 
     RefPtr<Element> fullscreenOrPendingElement() const { return m_fullscreenElement ? m_fullscreenElement : m_pendingFullscreenElement; }

--- a/Source/WebCore/dom/NodeRareDataInlines.h
+++ b/Source/WebCore/dom/NodeRareDataInlines.h
@@ -53,7 +53,7 @@ inline void NodeListsNodeData::adoptDocument(Document& oldDocument, Document& ne
 void NodeListsNodeData::removeCachedCollection(HTMLCollection* collection, const AtomString& name)
 {
     ASSERT(collection == m_cachedCollections.get(namedCollectionKey(collection->type(), name)));
-    if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(collection->ownerNode()))
+    if (deleteThisAndUpdateNodeRareDataIfAboutToRemoveLastList(collection->protectedOwnerNode()))
         return;
     m_cachedCollections.remove(namedCollectionKey(collection->type(), name));
 }

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -111,6 +111,7 @@ public:
     WEBCORE_EXPORT Node* computeNodeAfterPosition() const;
 
     Node* anchorNode() const { return m_anchorNode.get(); }
+    RefPtr<Node> protectedAnchorNode() const { return m_anchorNode; }
 
     // FIXME: Callers should be moved off of node(), node() is not always the container for this position.
     // For nodes which editingIgnoresContent(node()) returns true, positions like [ignoredNode, 0]

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -43,18 +43,19 @@ using namespace HTMLNames;
 
 PositionIterator::operator Position() const
 {
+    auto anchorNode = protectedNode();
     if (m_nodeAfterPositionInAnchor) {
-        ASSERT(m_nodeAfterPositionInAnchor->parentNode() == m_anchorNode);
+        ASSERT(m_nodeAfterPositionInAnchor->parentNode() == anchorNode.get());
         // FIXME: This check is inadaquete because any ancestor could be ignored by editing
-        if (positionBeforeOrAfterNodeIsCandidate(*m_anchorNode))
-            return positionBeforeNode(m_anchorNode.get());
+        if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
+            return positionBeforeNode(anchorNode.get());
         return positionInParentBeforeNode(m_nodeAfterPositionInAnchor.get());
     }
-    if (positionBeforeOrAfterNodeIsCandidate(*m_anchorNode))
-        return atStartOfNode() ? positionBeforeNode(m_anchorNode.get()) : positionAfterNode(m_anchorNode.get());
-    if (m_anchorNode->hasChildNodes())
-        return lastPositionInOrAfterNode(m_anchorNode.get());
-    return makeDeprecatedLegacyPosition(m_anchorNode.copyRef(), m_offsetInAnchor);
+    if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
+        return atStartOfNode() ? positionBeforeNode(anchorNode.get()) : positionAfterNode(anchorNode.get());
+    if (anchorNode->hasChildNodes())
+        return lastPositionInOrAfterNode(anchorNode.get());
+    return makeDeprecatedLegacyPosition(WTFMove(anchorNode), m_offsetInAnchor);
 }
 
 void PositionIterator::increment()
@@ -69,10 +70,11 @@ void PositionIterator::increment()
         return;
     }
 
-    if (m_anchorNode->renderer() && !m_anchorNode->hasChildNodes() && m_offsetInAnchor < lastOffsetForEditing(*m_anchorNode))
-        m_offsetInAnchor = Position::uncheckedNextOffset(m_anchorNode.get(), m_offsetInAnchor);
+    auto anchorNode = protectedNode();
+    if (anchorNode->renderer() && !anchorNode->hasChildNodes() && m_offsetInAnchor < lastOffsetForEditing(*anchorNode))
+        m_offsetInAnchor = Position::uncheckedNextOffset(anchorNode.get(), m_offsetInAnchor);
     else {
-        m_nodeAfterPositionInAnchor = m_anchorNode;
+        m_nodeAfterPositionInAnchor = WTFMove(anchorNode);
         m_anchorNode = m_nodeAfterPositionInAnchor->parentNode();
         m_nodeAfterPositionInAnchor = m_nodeAfterPositionInAnchor->nextSibling();
         m_offsetInAnchor = 0;
@@ -86,9 +88,9 @@ void PositionIterator::decrement()
 
     if (m_nodeAfterPositionInAnchor) {
         m_anchorNode = m_nodeAfterPositionInAnchor->previousSibling();
-        if (m_anchorNode) {
+        if (auto anchorNode = protectedNode()) {
             m_nodeAfterPositionInAnchor = nullptr;
-            m_offsetInAnchor = m_anchorNode->hasChildNodes() ? 0 : lastOffsetForEditing(*m_anchorNode);
+            m_offsetInAnchor = anchorNode->hasChildNodes() ? 0 : lastOffsetForEditing(*anchorNode);
         } else {
             m_nodeAfterPositionInAnchor = m_nodeAfterPositionInAnchor->parentNode();
             m_anchorNode = m_nodeAfterPositionInAnchor->parentNode();
@@ -121,11 +123,12 @@ bool PositionIterator::atStart() const
 
 bool PositionIterator::atEnd() const
 {
-    if (!m_anchorNode)
+    auto anchorNode = protectedNode();
+    if (!anchorNode)
         return true;
     if (m_nodeAfterPositionInAnchor)
         return false;
-    return !m_anchorNode->parentNode() && (m_anchorNode->hasChildNodes() || m_offsetInAnchor >= lastOffsetForEditing(*m_anchorNode));
+    return !anchorNode->parentNode() && (anchorNode->hasChildNodes() || m_offsetInAnchor >= lastOffsetForEditing(*anchorNode));
 }
 
 bool PositionIterator::atStartOfNode() const
@@ -139,20 +142,22 @@ bool PositionIterator::atStartOfNode() const
 
 bool PositionIterator::atEndOfNode() const
 {
-    if (!m_anchorNode)
+    auto anchorNode = protectedNode();
+    if (!anchorNode)
         return true;
     if (m_nodeAfterPositionInAnchor)
         return false;
-    return m_anchorNode->hasChildNodes() || m_offsetInAnchor >= lastOffsetForEditing(*m_anchorNode);
+    return anchorNode->hasChildNodes() || m_offsetInAnchor >= lastOffsetForEditing(*anchorNode);
 }
 
 // This function should be kept in sync with Position::isCandidate().
 bool PositionIterator::isCandidate() const
 {
-    if (!m_anchorNode)
+    auto anchorNode = protectedNode();
+    if (!anchorNode)
         return false;
 
-    RenderObject* renderer = m_anchorNode->renderer();
+    RenderObject* renderer = anchorNode->renderer();
     if (!renderer)
         return false;
 
@@ -163,25 +168,25 @@ bool PositionIterator::isCandidate() const
         return Position(*this).isCandidate();
 
     if (is<RenderText>(*renderer))
-        return !Position::nodeIsUserSelectNone(m_anchorNode.get()) && downcast<RenderText>(*renderer).containsCaretOffset(m_offsetInAnchor);
+        return !Position::nodeIsUserSelectNone(anchorNode.get()) && downcast<RenderText>(*renderer).containsCaretOffset(m_offsetInAnchor);
 
-    if (positionBeforeOrAfterNodeIsCandidate(*m_anchorNode))
-        return (atStartOfNode() || atEndOfNode()) && !Position::nodeIsUserSelectNone(m_anchorNode->parentNode());
+    if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
+        return (atStartOfNode() || atEndOfNode()) && !Position::nodeIsUserSelectNone(anchorNode->parentNode());
 
-    if (is<HTMLHtmlElement>(*m_anchorNode))
+    if (is<HTMLHtmlElement>(*anchorNode))
         return false;
 
     if (is<RenderBlockFlow>(*renderer) || is<RenderGrid>(*renderer) || is<RenderFlexibleBox>(*renderer)) {
         auto& block = downcast<RenderBlock>(*renderer);
-        if (block.logicalHeight() || is<HTMLBodyElement>(*m_anchorNode) || m_anchorNode->isRootEditableElement()) {
+        if (block.logicalHeight() || is<HTMLBodyElement>(*anchorNode) || anchorNode->isRootEditableElement()) {
             if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(block))
-                return atStartOfNode() && !Position::nodeIsUserSelectNone(m_anchorNode.get());
-            return m_anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(m_anchorNode.get()) && Position(*this).atEditingBoundary();
+                return atStartOfNode() && !Position::nodeIsUserSelectNone(anchorNode.get());
+            return anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(anchorNode.get()) && Position(*this).atEditingBoundary();
         }
         return false;
     }
 
-    return m_anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(m_anchorNode.get()) && Position(*this).atEditingBoundary();
+    return anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(anchorNode.get()) && Position(*this).atEditingBoundary();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PositionIterator.h
+++ b/Source/WebCore/dom/PositionIterator.h
@@ -47,6 +47,7 @@ public:
     void decrement();
 
     Node* node() const { return m_anchorNode.get(); }
+    RefPtr<Node> protectedNode() const { return m_anchorNode; }
     int offsetInLeafNode() const { return m_offsetInAnchor; }
 
     bool atStart() const;

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -338,8 +338,8 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
         RangeBoundaryPoint originalEnd(m_end);
 
         // what is the highest node that partially selects the start / end of the range?
-        RefPtr partialStart = highestAncestorUnderCommonRoot(&originalStart.container(), commonRoot.get());
-        RefPtr partialEnd = highestAncestorUnderCommonRoot(&originalEnd.container(), commonRoot.get());
+        RefPtr partialStart = highestAncestorUnderCommonRoot(originalStart.protectedContainer().ptr(), commonRoot.get());
+        RefPtr partialEnd = highestAncestorUnderCommonRoot(originalEnd.protectedContainer().ptr(), commonRoot.get());
 
         // Start and end containers are different.
         // There are three possibilities here:
@@ -615,7 +615,7 @@ ExceptionOr<RefPtr<Node>> processAncestorsAndTheirSiblings(Range::ActionType act
                     if (result.hasException())
                         return result.releaseException();
                 } else {
-                    auto result = clonedContainer->insertBefore(child, clonedContainer->firstChild());
+                    auto result = clonedContainer->insertBefore(child, clonedContainer->protectedFirstChild());
                     if (result.hasException())
                         return result.releaseException();
                 }
@@ -626,7 +626,7 @@ ExceptionOr<RefPtr<Node>> processAncestorsAndTheirSiblings(Range::ActionType act
                     if (result.hasException())
                         return result.releaseException();
                 } else {
-                    auto result = clonedContainer->insertBefore(child->cloneNode(true), clonedContainer->firstChild());
+                    auto result = clonedContainer->insertBefore(child->cloneNode(true), clonedContainer->protectedFirstChild());
                     if (result.hasException())
                         return result.releaseException();
                 }
@@ -699,7 +699,7 @@ ExceptionOr<void> Range::insertNode(Ref<Node>&& node)
     else
         ++newOffset;
 
-    auto insertResult = parent->insertBefore(node, referenceNode.get());
+    auto insertResult = parent->insertBefore(node, WTFMove(referenceNode));
     if (insertResult.hasException())
         return insertResult.releaseException();
 
@@ -920,7 +920,7 @@ static inline void boundaryNodeWillBeRemoved(RangeBoundaryPoint& boundary, Node&
 {
     if (boundary.childBefore() == &nodeToBeRemoved)
         boundary.childBeforeWillBeRemoved();
-    else if (nodeToBeRemoved.contains(&boundary.container()))
+    else if (nodeToBeRemoved.contains(boundary.protectedContainer().ptr()))
         boundary.setToBeforeNode(nodeToBeRemoved);
 }
 

--- a/Source/WebCore/dom/RangeBoundaryPoint.h
+++ b/Source/WebCore/dom/RangeBoundaryPoint.h
@@ -35,6 +35,7 @@ public:
     explicit RangeBoundaryPoint(Node& container);
 
     Node& container() const;
+    Ref<Node> protectedContainer() const { return container(); }
     unsigned offset() const;
     Node* childBefore() const;
 

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -46,8 +46,9 @@ class ScriptElement {
 public:
     virtual ~ScriptElement() = default;
 
-    Element& element() { return m_element; }
-    const Element& element() const { return m_element; }
+    Element& element() { return m_element.get(); }
+    const Element& element() const { return m_element.get(); }
+    Ref<Element> protectedElement() const { return m_element.get(); }
 
     bool prepareScript(const TextPosition& scriptStartPosition = TextPosition());
 
@@ -127,7 +128,7 @@ private:
 
     virtual bool isScriptPreventedByAttributes() const { return false; }
 
-    Element& m_element;
+    CheckedRef<Element> m_element;
     OrdinalNumber m_startLineNumber { OrdinalNumber::beforeFirst() };
     JSC::SourceTaintedOrigin m_taintedOrigin;
     ParserInserted m_parserInserted : bitWidthOfParserInserted;

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -198,7 +198,7 @@ ExceptionOr<void> ShadowRoot::setInnerHTML(const String& markup)
         return { };
     }
 
-    auto fragment = createFragmentForInnerOuterHTML(*host(), markup, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
+    auto fragment = createFragmentForInnerOuterHTML(*protectedHost(), markup, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     if (fragment.hasException())
         return fragment.releaseException();
     return replaceChildrenWithFragment(*this, fragment.releaseReturnValue());

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -83,6 +83,7 @@ public:
     void setIsDeclarativeShadowRoot(bool flag) { m_isDeclarativeShadowRoot = flag; }
 
     Element* host() const { return m_host.get(); }
+    RefPtr<Element> protectedHost() const { return m_host.get(); }
     void setHost(CheckedPtr<Element>&& host) { m_host = WTFMove(host); }
 
     String innerHTML() const;

--- a/Source/WebCore/dom/SimpleRange.cpp
+++ b/Source/WebCore/dom/SimpleRange.cpp
@@ -118,8 +118,9 @@ void IntersectingNodeIterator::advance()
 
 void IntersectingNodeIterator::advanceSkippingChildren()
 {
-    ASSERT(m_node);
-    m_node = m_node->contains(m_pastLastNode.get()) ? nullptr : NodeTraversal::nextSkippingChildren(*m_node);
+    auto node = protectedNode();
+    ASSERT(node);
+    m_node = node->contains(m_pastLastNode.get()) ? nullptr : NodeTraversal::nextSkippingChildren(*node);
     enforceEndInvariant();
 }
 

--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -136,6 +136,8 @@ public:
 private:
     void enforceEndInvariant();
 
+    RefPtr<Node> protectedNode() const { return m_node; }
+
     RefPtr<Node> m_node;
     RefPtr<Node> m_pastLastNode;
 };

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -69,7 +69,7 @@ ExceptionOr<Ref<Text>> Text::splitText(unsigned offset)
     dispatchModifiedEvent(oldData);
 
     if (auto* parent = parentNode()) {
-        auto insertResult = parent->insertBefore(newText, nextSibling());
+        auto insertResult = parent->insertBefore(newText, protectedNextSibling());
         if (insertResult.hasException())
             return insertResult.releaseException();
     }

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -86,6 +86,7 @@ public:
     void removeElementByName(const AtomStringImpl&, Element&);
 
     Document& documentScope() const { return m_documentScope.get(); }
+    Ref<Document> protectedDocumentScope() const;
     static ptrdiff_t documentScopeMemoryOffset() { return OBJECT_OFFSETOF(TreeScope, m_documentScope); }
 
     // https://dom.spec.whatwg.org/#retarget

--- a/Source/WebCore/editing/InsertNodeBeforeCommand.cpp
+++ b/Source/WebCore/editing/InsertNodeBeforeCommand.cpp
@@ -53,7 +53,7 @@ void InsertNodeBeforeCommand::doApply()
         return;
     ASSERT(isEditableNode(*parent));
 
-    parent->insertBefore(m_insertChild, m_refChild.ptr());
+    parent->insertBefore(m_insertChild, m_refChild.copyRef());
 }
 
 void InsertNodeBeforeCommand::doUnapply()

--- a/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
+++ b/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
@@ -50,7 +50,7 @@ void MergeIdenticalElementsCommand::doApply()
         children.append(*child);
 
     for (auto& child : children)
-        m_element2->insertBefore(child, m_atChild.get());
+        m_element2->insertBefore(child, m_atChild.copyRef());
 
     m_element1->remove();
 }
@@ -63,7 +63,7 @@ void MergeIdenticalElementsCommand::doUnapply()
     if (!parent || !parent->hasEditableStyle())
         return;
 
-    if (parent->insertBefore(m_element1, m_element2.ptr()).hasException())
+    if (parent->insertBefore(m_element1, m_element2.copyRef()).hasException())
         return;
 
     Vector<Ref<Node>> children;

--- a/Source/WebCore/editing/RemoveNodeCommand.cpp
+++ b/Source/WebCore/editing/RemoveNodeCommand.cpp
@@ -62,7 +62,7 @@ void RemoveNodeCommand::doUnapply()
     if (!parent || !parent->hasEditableStyle())
         return;
 
-    parent->insertBefore(m_node, refChild.get());
+    parent->insertBefore(m_node, WTFMove(refChild));
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/SplitElementCommand.cpp
+++ b/Source/WebCore/editing/SplitElementCommand.cpp
@@ -54,7 +54,7 @@ void SplitElementCommand::executeApply()
     auto* parent = m_element2->parentNode();
     if (!parent || !parent->hasEditableStyle())
         return;
-    if (parent->insertBefore(*m_element1, m_element2.ptr()).hasException())
+    if (parent->insertBefore(*m_element1, m_element2.copyRef()).hasException())
         return;
 
     // Delete id attribute from the second element because the same id cannot be used for more than one element
@@ -83,7 +83,7 @@ void SplitElementCommand::doUnapply()
     RefPtr<Node> refChild = m_element2->firstChild();
 
     for (auto& child : children)
-        m_element2->insertBefore(child, refChild.get());
+        m_element2->insertBefore(child, refChild.copyRef());
 
     // Recover the id attribute of the original element.
     const AtomString& id = m_element1->getIdAttribute();

--- a/Source/WebCore/editing/SplitTextNodeCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeCommand.cpp
@@ -97,7 +97,7 @@ void SplitTextNodeCommand::doReapply()
 
 void SplitTextNodeCommand::insertText1AndTrimText2()
 {
-    if (m_text2->parentNode()->insertBefore(*m_text1, m_text2.ptr()).hasException())
+    if (m_text2->parentNode()->insertBefore(*m_text1, m_text2.copyRef()).hasException())
         return;
     m_text2->deleteData(0, m_offset);
 }

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -939,7 +939,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
         auto parentContainer = insertion.parentIfDifferentFromCommonAncestor;
         if (!parentContainer) {
             parentContainer = commonAncestor;
-            parentContainer->insertBefore(insertion.child, insertionPointNode.get());
+            parentContainer->insertBefore(insertion.child, insertionPointNode.copyRef());
         } else
             parentContainer->appendChild(insertion.child);
 

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -78,6 +78,7 @@ public:
     inline NodeListInvalidationType invalidationType() const;
     inline CollectionType type() const;
     inline ContainerNode& ownerNode() const;
+    inline Ref<ContainerNode> protectedOwnerNode() const;
     inline ContainerNode& rootNode() const;
     inline void invalidateCacheForAttribute(const QualifiedName& attributeName);
     WEBCORE_EXPORT virtual void invalidateCacheForDocument(Document&);
@@ -120,6 +121,11 @@ inline size_t CollectionNamedElementCache::memoryCost() const
 }
 
 inline ContainerNode& HTMLCollection::ownerNode() const
+{
+    return m_ownerNode;
+}
+
+inline Ref<ContainerNode> HTMLCollection::protectedOwnerNode() const
 {
     return m_ownerNode;
 }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -240,7 +240,7 @@ ExceptionOr<void> HTMLSelectElement::add(const OptionOrOptGroupElement& element,
     );
 
 
-    return insertBefore(toInsert, beforeElement.get());
+    return insertBefore(toInsert, WTFMove(beforeElement));
 }
 
 void HTMLSelectElement::remove(int optionIndex)

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -76,7 +76,7 @@ ExceptionOr<void> HTMLTableElement::setCaption(RefPtr<HTMLTableCaptionElement>&&
     deleteCaption();
     if (!newCaption)
         return { };
-    return insertBefore(*newCaption, firstChild());
+    return insertBefore(*newCaption, protectedFirstChild());
 }
 
 RefPtr<HTMLTableSectionElement> HTMLTableElement::tHead() const
@@ -103,7 +103,7 @@ ExceptionOr<void> HTMLTableElement::setTHead(RefPtr<HTMLTableSectionElement>&& n
             break;
     }
 
-    return insertBefore(*newHead, child.get());
+    return insertBefore(*newHead, WTFMove(child));
 }
 
 RefPtr<HTMLTableSectionElement> HTMLTableElement::tFoot() const
@@ -159,7 +159,7 @@ Ref<HTMLTableSectionElement> HTMLTableElement::createTBody()
 {
     auto body = HTMLTableSectionElement::create(tbodyTag, document());
     RefPtr<Node> referenceElement = lastBody() ? lastBody()->nextSibling() : nullptr;
-    insertBefore(body, referenceElement.get());
+    insertBefore(body, WTFMove(referenceElement));
     return body;
 }
 
@@ -228,7 +228,7 @@ ExceptionOr<Ref<HTMLElement>> HTMLTableElement::insertRow(int index)
     }
 
     auto newRow = HTMLTableRowElement::create(document());
-    auto result = parent->insertBefore(newRow, row.get());
+    auto result = parent->insertBefore(newRow, WTFMove(row));
     if (result.hasException())
         return result.releaseException();
     return Ref<HTMLElement> { WTFMove(newRow) };

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -519,7 +519,7 @@ void HTMLTextAreaElement::updatePlaceholderText()
     }
     if (!m_placeholder) {
         m_placeholder = TextControlPlaceholderElement::create(document());
-        userAgentShadowRoot()->insertBefore(*m_placeholder, innerTextElement()->nextSibling());
+        userAgentShadowRoot()->insertBefore(*m_placeholder, innerTextElement()->protectedNextSibling());
     }
     m_placeholder->setInnerText(String { placeholderText });
 }

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -120,11 +120,11 @@ void SearchInputType::createShadowSubtree()
 
     ASSERT(element());
     m_resultsButton = SearchFieldResultsButtonElement::create(element()->document());
-    container->insertBefore(*m_resultsButton, textWrapper.get());
+    container->insertBefore(*m_resultsButton, textWrapper.copyRef());
     updateResultButtonPseudoType(*m_resultsButton, element()->maxResults());
 
     m_cancelButton = SearchFieldCancelButtonElement::create(element()->document());
-    container->insertBefore(*m_cancelButton, textWrapper->nextSibling());
+    container->insertBefore(*m_cancelButton, textWrapper->protectedNextSibling());
 }
 
 HTMLElement* SearchInputType::resultsButtonElement() const

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -669,7 +669,10 @@ void TextFieldInputType::updatePlaceholderText()
     }
     if (!m_placeholder) {
         m_placeholder = TextControlPlaceholderElement::create(element()->document());
-        element()->userAgentShadowRoot()->insertBefore(*m_placeholder, m_container ? m_container.get() : innerTextElement().get());
+        if (m_container)
+            element()->userAgentShadowRoot()->insertBefore(*m_placeholder, m_container.copyRef());
+        else
+            element()->userAgentShadowRoot()->insertBefore(*m_placeholder, innerTextElement());
     }
     m_placeholder->setInnerText(WTFMove(placeholderText));
 }

--- a/Source/WebCore/inspector/DOMEditor.h
+++ b/Source/WebCore/inspector/DOMEditor.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+class ContainerNode;
 class Element;
 class InspectorHistory;
 class Node;
@@ -47,18 +48,18 @@ public:
     explicit DOMEditor(InspectorHistory&);
     ~DOMEditor();
 
-    ExceptionOr<void> insertBefore(Node& parentNode, Ref<Node>&&, Node* anchorNode);
-    ExceptionOr<void> removeChild(Node& parentNode, Node&);
+    ExceptionOr<void> insertBefore(ContainerNode& parentNode, Ref<Node>&&, Node* anchorNode);
+    ExceptionOr<void> removeChild(ContainerNode& parentNode, Node&);
     ExceptionOr<void> setAttribute(Element&, const AtomString& name, const AtomString& value);
     ExceptionOr<void> removeAttribute(Element&, const AtomString& name);
     ExceptionOr<void> setOuterHTML(Node&, const String& html, Node*& newNode);
     ExceptionOr<void> replaceWholeText(Text&, const String& text);
-    ExceptionOr<void> replaceChild(Node& parentNode, Ref<Node>&& newNode, Node& oldNode);
-    ExceptionOr<void> setNodeValue(Node& parentNode, const String& value);
+    ExceptionOr<void> replaceChild(ContainerNode& parentNode, Ref<Node>&& newNode, Node& oldNode);
+    ExceptionOr<void> setNodeValue(Node&, const String& value);
     ExceptionOr<void> insertAdjacentHTML(Element&, const String& where, const String& html);
 
-    bool insertBefore(Node& parentNode, Ref<Node>&&, Node* anchorNode, ErrorString&);
-    bool removeChild(Node& parentNode, Node&, ErrorString&);
+    bool insertBefore(ContainerNode& parentNode, Ref<Node>&&, Node* anchorNode, ErrorString&);
+    bool removeChild(ContainerNode& parentNode, Node&, ErrorString&);
     bool setAttribute(Element&, const AtomString& name, const AtomString& value, ErrorString&);
     bool removeAttribute(Element&, const AtomString& name, ErrorString&);
     bool setOuterHTML(Node&, const String& html, Node*& newNode, ErrorString&);

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -84,6 +84,7 @@ public:
 
     // This is null for anonymous renderers.
     Element* element() const { return downcast<Element>(RenderObject::node()); }
+    RefPtr<Element> protectedElement() const { return element(); }
     Element* nonPseudoElement() const { return downcast<Element>(RenderObject::nonPseudoNode()); }
     Element* generatingElement() const;
 


### PR DESCRIPTION
#### 0f2b0e3c5b5673d09a724dbad50a1ab5239cef44
<pre>
Use more smart pointers in the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=261910">https://bugs.webkit.org/show_bug.cgi?id=261910</a>

Reviewed by Brent Fulgham.

* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::ContainerNode::appendChildCommon):
(WebCore::ContainerNode::prepend):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::protectedFirstChild const):
(WebCore::ContainerNode::protectedLastChild const):
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::observe):
(WebCore::ContentVisibilityDocumentState::unobserve):
* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::DataTransferItemList::ensureItems const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createDocumentFragment):
(WebCore::Document::setTitle):
(WebCore::Document::isSecureContext const):
* Source/WebCore/dom/Document.h:
(WebCore::Document::logger const):
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Node::protectedDocument const):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::forEachOfTypes):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::detachAttribute):
(WebCore::layoutOverflowRectContainsAllDescendants):
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::setAttributeNode):
(WebCore::Element::setAttributeNodeNS):
(WebCore::Element::updateId):
(WebCore::Element::willModifyAttribute):
(WebCore::Element::didAddAttribute):
(WebCore::Element::didModifyAttribute):
(WebCore::Element::didRemoveAttribute):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::cancelFullscreen):
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::isFullscreenEnabled const):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::treeScopeForSVGReferences const):
(WebCore::Node::defaultEventHandler):
* Source/WebCore/dom/Node.h:
(WebCore::Node::previousSibling const):
(WebCore::Node::protectedPreviousSibling const):
(WebCore::Node::nextSibling const):
(WebCore::Node::protectedNextSibling const):
(WebCore::Node::parentNode const):
* Source/WebCore/dom/NodeRareDataInlines.h:
(WebCore::NodeListsNodeData::removeCachedCollection):
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::offsetForPositionAfterAnchor const):
(WebCore::Position::parentAnchoredEquivalent const):
(WebCore::Position::atFirstEditingPositionForNode const):
(WebCore::Position::atLastEditingPositionForNode const):
(WebCore::Position::atStartOfTree const):
(WebCore::Position::atEndOfTree const):
* Source/WebCore/dom/Position.h:
(WebCore::Position::protectedAnchorNode const):
* Source/WebCore/dom/PositionIterator.cpp:
(WebCore::PositionIterator::operator Position const):
(WebCore::PositionIterator::increment):
(WebCore::PositionIterator::decrement):
(WebCore::PositionIterator::atEnd const):
(WebCore::PositionIterator::atEndOfNode const):
(WebCore::PositionIterator::isCandidate const):
* Source/WebCore/dom/PositionIterator.h:
(WebCore::PositionIterator::protectedNode const):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::processContents):
(WebCore::boundaryNodeWillBeRemoved):
* Source/WebCore/dom/RangeBoundaryPoint.h:
(WebCore::RangeBoundaryPoint::protectedContainer const):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::ScriptElement):
(WebCore::ScriptElement::childrenChanged):
(WebCore::ScriptElement::dispatchErrorEvent):
(WebCore::ScriptElement::determineScriptType const):
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::requestClassicScript):
(WebCore::ScriptElement::requestModuleScript):
(WebCore::ScriptElement::requestImportMap):
(WebCore::ScriptElement::executeClassicScript):
(WebCore::ScriptElement::registerImportMap):
(WebCore::ScriptElement::executeModuleScript):
(WebCore::ScriptElement::executeScriptAndDispatchEvent):
(WebCore::ScriptElement::executePendingScript):
(WebCore::ScriptElement::ignoresLoadRequest const):
(WebCore::ScriptElement::scriptContent const):
(WebCore::ScriptElement::ref):
(WebCore::ScriptElement::deref):
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::element):
(WebCore::ScriptElement::element const):
(WebCore::ScriptElement::protectedElement const):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::setInnerHTML):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SimpleRange.cpp:
(WebCore::IntersectingNodeIterator::advanceSkippingChildren):
* Source/WebCore/dom/SimpleRange.h:
(WebCore::IntersectingNodeIterator::protectedNode const):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::nodeFromPoint):
(WebCore::TreeScope::elementsFromPoint):
(WebCore::TreeScope::focusedElementInScope):
(WebCore::TreeScope::protectedDocumentScope const):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/html/HTMLCollection.h:
(WebCore::HTMLCollection::protectedOwnerNode const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::protectedElement const):

Canonical link: <a href="https://commits.webkit.org/268329@main">https://commits.webkit.org/268329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4296743ba83e8d7f17abdcd28bb759ac611acfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19897 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22113 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17615 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21910 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15562 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17515 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21874 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2371 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->