### PR TITLE
[git-webkit] Handle force pushed branch in checkout

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/checkout.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/checkout.py
@@ -89,7 +89,7 @@ class Checkout(Command):
 
         try:
             if isinstance(repository, local.Git):
-                commit = repository.checkout(target, prune=args.prune)
+                commit = repository.checkout(target, prune=args.prune, prompt=True)
             elif args.prune is not None:
                 sys.stderr.write("'prune' arguments only valid for 'git' checkouts\n")
                 return 1

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -124,6 +124,7 @@ class TestLand(testing.PathTestCase):
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
+                ' Local branch is tracking the remote branch.',
             ],
         )
         self.assertEqual(
@@ -159,8 +160,10 @@ class TestLand(testing.PathTestCase):
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
+                ' Local branch is tracking the remote branch.',
                 '1 commit to be edited...',
                 'Base commit is 5@main (ref d8bce26fa65c6fc8f39c17927abb77f69fab82fc)',
+                ' Local branch is tracking the remote branch.',
             ],
         )
         self.assertEqual(
@@ -239,6 +242,7 @@ class TestLand(testing.PathTestCase):
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
+                ' Local branch is tracking the remote branch.',
             ],
         )
         self.assertEqual(
@@ -288,8 +292,10 @@ class TestLand(testing.PathTestCase):
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
+                ' Local branch is tracking the remote branch.',
                 '1 commit to be edited...',
                 'Base commit is 5@main (ref d8bce26fa65c6fc8f39c17927abb77f69fab82fc)',
+                ' Local branch is tracking the remote branch.',
             ],
         )
         self.assertEqual(
@@ -467,6 +473,7 @@ class TestLandGitHub(testing.PathTestCase):
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
                 "Updating 'PR 1 | Example Change' to match landing commits...",
+                ' Local branch is tracking the remote branch.',
             ],
         )
         self.assertEqual(captured.stderr.getvalue(), '')
@@ -695,6 +702,7 @@ class TestLandBitBucket(testing.PathTestCase):
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
                 "Updating 'PR 1 | Example Change' to match landing commits...",
+                ' Local branch is tracking the remote branch.',
             ],
         )
         self.assertEqual(captured.stderr.getvalue(), '')


### PR DESCRIPTION
#### 62e8794cc8f57c914afa1146ab1e3520915a7572
<pre>
[git-webkit] Handle force pushed branch in checkout
<a href="https://bugs.webkit.org/show_bug.cgi?id=260874">https://bugs.webkit.org/show_bug.cgi?id=260874</a>
rdar://114656165

Reviewed by Jonathan Bedard.

Resets the head of tracking branch to match remote.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.checkout):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/checkout.py:
(Checkout.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(TestLand.test_default):
(TestLand.test_canonicalize):
(TestLand.test_default_with_radar):
(TestLand.test_canonicalize_with_bugzilla):
(TestLandGitHub):

Canonical link: <a href="https://commits.webkit.org/268933@main">https://commits.webkit.org/268933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8e350da4787bb9b41cab6f9d8ba228c46706234

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21110 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22988 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21350 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/24740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/21672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21334 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/24740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/23842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/21298 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/24740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/19135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/23842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/24740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/23842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/21672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/20931 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/19159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2608 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->