### PR TITLE
REGRESSION (267539@main): [iOS] Webpage unexpectedly scrolls down while typing in the find bar

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1422,6 +1422,10 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
     auto scrollViewInsets = [_scrollView adjustedContentInset];
     WebCore::FloatPoint minimumContentOffset(-scrollViewInsets.left, -scrollViewInsets.top);
+    if (_haveSetObscuredInsets) {
+        minimumContentOffset.move(_obscuredInsets.left, _obscuredInsets.top);
+        minimumContentOffset = minimumContentOffset.constrainedBetween(minimumContentOffset, WebCore::FloatPoint());
+    }
 
     // Center the target rect in the scroll view.
     // If the target doesn't fit in the scroll view, center on the gesture location instead.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm
@@ -806,6 +806,26 @@ TEST(WebKit, ScrollToFoundRangeAtTopWithContentInsets)
     EXPECT_TRUE(CGPointEqualToPoint([webView scrollView].contentOffset, CGPointMake(0, -[webView scrollView].contentInset.top)));
 }
 
+TEST(WebKit, ScrollToFoundRangeAtTopWithObscuredContentInsets)
+{
+    UIEdgeInsets obscuredInsets = UIEdgeInsetsMake(30, 0, 0, 0);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);
+    [webView scrollView].contentInset = obscuredInsets;
+    [webView _setObscuredInsets:obscuredInsets];
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><div contenteditable><p>Top</p><p style='margin-top: 800px'>Bottom</p></div>"];
+    [webView objectByEvaluatingJavaScript:@"let p = document.querySelector('p'); document.getSelection().setBaseAndExtent(p, 0, p, 1)"];
+
+    CGPoint initialContentOffset = CGPointMake(0, -30);
+    [webView scrollView].contentOffset = initialContentOffset;
+
+    auto ranges = textRangesForQueryString(webView.get(), @"Top");
+    [webView scrollRangeToVisible:[ranges firstObject] inDocument:nil];
+
+    TestWebKitAPI::Util::runFor(500_ms);
+    EXPECT_TRUE(CGPointEqualToPoint([webView scrollView].contentOffset, initialContentOffset));
+}
+
 TEST(WebKit, CannotHaveMultipleFindOverlays)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 200, 200)]);


### PR DESCRIPTION
#### 5aa322f6a3dd1e38efa13dfcc2d367b6a3f26e3a
<pre>
REGRESSION (267539@main): [iOS] Webpage unexpectedly scrolls down while typing in the find bar
<a href="https://bugs.webkit.org/show_bug.cgi?id=261913">https://bugs.webkit.org/show_bug.cgi?id=261913</a>
rdar://115796405

Reviewed by Wenson Hsieh.

267539@main adjusted WKWebView&apos;s &quot;scroll to target rect&quot; logic to account for
content insets, to ensure that content in the inset area does not hide the
target rect. However, it did not account for `-[WKWebView _obscuredInsets]`

Specifically, the targeted scrolling logic works by computing the scroll
delta between the current unobscured offset, and a new offset which reveals
the target. Following, 267539@main found matches at the top of the page, could
have a negative target offset for content with insets, which was necessary to
fix the issue described in that change. However, the unobscured offset is
effectively clamped to (0, 0), as it comes from
`-[WKWebView _contentRectForUserInteraction]`, which adds obscured insets prior
to converting to content view coordinates. Consequently, a constant scroll delta
of `-_obscuredInsets.top` is computed when the page is scrolled to the top, and
there are obscured insets. This results in repeating scrolling as matches are
found at the top of the page.

Fix by accounting for the `_obscuredInsets` when determining the minimum
scroll position.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _scrollToRect:origin:minimumScrollDistance:]):

Add the obscured insets to the minimum content offset to determine a more
accurate minimum scrolling position. The logic additionally enforces a
maximum minimum content offset of (0, 0), as was the case before 267539@main.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FindInPage.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/268295@main">https://commits.webkit.org/268295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c02489c363d74778740d7f64d6548b22a023b78a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21132 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19784 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22000 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23863 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18275 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17410 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4603 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->