### PR TITLE
[CSSTransition] Do not list up all properties for transition: all

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3777,7 +3777,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<PrintColorAdjust>(CSSPropertyPrintColorAdjust, &RenderStyle::printColorAdjust, &RenderStyle::setPrintColorAdjust),
         new DiscretePropertyWrapper<ColumnFill>(CSSPropertyColumnFill, &RenderStyle::columnFill, &RenderStyle::setColumnFill),
         new DiscretePropertyWrapper<BorderStyle>(CSSPropertyColumnRuleStyle, &RenderStyle::columnRuleStyle, &RenderStyle::setColumnRuleStyle),
-        new DiscretePropertyWrapper<BorderStyle>(CSSPropertyColumnRuleStyle, &RenderStyle::columnRuleStyle, &RenderStyle::setColumnRuleStyle),
         new DiscretePropertyWrapper<CursorType>(CSSPropertyCursor, &RenderStyle::cursor, &RenderStyle::setCursor),
         new DiscretePropertyWrapper<EmptyCell>(CSSPropertyEmptyCells, &RenderStyle::emptyCells, &RenderStyle::setEmptyCells),
         new DiscretePropertyWrapper<FlexDirection>(CSSPropertyFlexDirection, &RenderStyle::flexDirection, &RenderStyle::setFlexDirection),
@@ -3857,7 +3856,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new OffsetRotateWrapper,
 
         new PropertyWrapperContent,
-        new OffsetRotateWrapper,
         new DiscretePropertyWrapper<TextDecorationSkipInk>(CSSPropertyTextDecorationSkipInk, &RenderStyle::textDecorationSkipInk, &RenderStyle::setTextDecorationSkipInk),
         new DiscreteSVGPropertyWrapper<ColorInterpolation>(CSSPropertyColorInterpolation, &SVGRenderStyle::colorInterpolation, &SVGRenderStyle::setColorInterpolation),
         new DiscreteFontDescriptionTypedWrapper<Kerning>(CSSPropertyFontKerning, &FontCascadeDescription::kerning, &FontCascadeDescription::setKerning),

--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -27,6 +27,7 @@
 
 #include "CSSPropertyNames.h"
 #include "CSSValue.h"
+#include <wtf/BitSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/Markable.h>
@@ -70,6 +71,10 @@ using CSSAnimationCollection = ListHashSet<Ref<CSSAnimation>>;
 
 using AnimatableProperty = std::variant<CSSPropertyID, AtomString>;
 using AnimatablePropertyToTransitionMap = HashMap<AnimatableProperty, Ref<CSSTransition>>;
+
+struct CSSPropertiesBitSet {
+    WTF::BitSet<numCSSProperties> m_properties { };
+};
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -24,6 +24,7 @@
 #include "CSSPropertyNames.h"
 #include "CSSValue.h"
 #include "WritingMode.h"
+#include <wtf/BitSet.h>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
@@ -78,12 +79,18 @@ public:
     static bool isInLogicalPropertyGroup(CSSPropertyID);
     static bool areInSameLogicalPropertyGroupWithDifferentMappingLogic(CSSPropertyID, CSSPropertyID);
     static bool isDescriptorOnly(CSSPropertyID);
-    static bool isColorProperty(CSSPropertyID);
     static UChar listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }
     static bool allowsNumberOrIntegerInput(CSSPropertyID);
 
     const StylePropertyMetadata& metadata() const { return m_metadata; }
+    static bool isColorProperty(CSSPropertyID propertyId)
+    {
+        return colorProperties.get(propertyId);
+    }
+
+    static const WEBCORE_EXPORT WTF::BitSet<numCSSProperties> colorProperties;
+    static const WEBCORE_EXPORT WTF::BitSet<numCSSProperties> physicalProperties;
 
     bool operator==(const CSSProperty& other) const
     {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4539,6 +4539,20 @@ bool Element::hasRunningTransitions(PseudoId pseudoId) const
     return false;
 }
 
+const AnimatablePropertyToTransitionMap* Element::completedTransitionsByProperty(PseudoId pseudoId) const
+{
+    if (auto* animationData = animationRareData(pseudoId))
+        return &animationData->completedTransitionsByProperty();
+    return nullptr;
+}
+
+const AnimatablePropertyToTransitionMap* Element::runningTransitionsByProperty(PseudoId pseudoId) const
+{
+    if (auto* animationData = animationRareData(pseudoId))
+        return &animationData->runningTransitionsByProperty();
+    return nullptr;
+}
+
 AnimationCollection& Element::ensureAnimations(PseudoId pseudoId)
 {
     return ensureAnimationRareData(pseudoId).animations();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -568,6 +568,9 @@ public:
     bool hasRunningTransitions(PseudoId) const;
     AnimationCollection& ensureAnimations(PseudoId);
 
+    const AnimatablePropertyToTransitionMap* completedTransitionsByProperty(PseudoId) const;
+    const AnimatablePropertyToTransitionMap* runningTransitionsByProperty(PseudoId) const;
+
     AnimatablePropertyToTransitionMap& ensureCompletedTransitionsByProperty(PseudoId);
     AnimatablePropertyToTransitionMap& ensureRunningTransitionsByProperty(PseudoId);
     CSSAnimationCollection& animationsCreatedByMarkup(PseudoId);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -37,6 +37,7 @@ class AutosizeStatus;
 class BorderData;
 class BorderValue;
 class CSSCustomPropertyValue;
+struct CSSPropertiesBitSet;
 class Color;
 class ContentData;
 class CounterContent;
@@ -1712,6 +1713,7 @@ public:
 
     StyleDifference diff(const RenderStyle&, OptionSet<StyleDifferenceContextSensitiveProperty>& changedContextSensitiveProperties) const;
     bool diffRequiresLayerRepaint(const RenderStyle&, bool isComposited) const;
+    void conservativelyCollectChangedAnimatableProperties(const RenderStyle&, CSSPropertiesBitSet&) const;
 
     constexpr bool isDisplayInlineType() const;
     constexpr bool isOriginalDisplayInlineType() const;

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -232,4 +232,139 @@ bool SVGRenderStyle::changeRequiresRepaint(const SVGRenderStyle& other, bool cur
     return false;
 }
 
+void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGRenderStyle& other, CSSPropertiesBitSet& changingProperties) const
+{
+    // FIXME: Consider auto-generating this function from CSSProperties.json.
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaFillData = [&](auto& first, auto& second) {
+        if (first.opacity != second.opacity)
+            changingProperties.m_properties.set(CSSPropertyFillOpacity);
+        if (first.paintColor != second.paintColor
+            || first.visitedLinkPaintColor != second.visitedLinkPaintColor
+            || first.paintUri != second.paintUri
+            || first.visitedLinkPaintUri != second.visitedLinkPaintUri
+            || first.paintType != second.paintType
+            || first.visitedLinkPaintType != second.visitedLinkPaintType)
+            changingProperties.m_properties.set(CSSPropertyFill);
+    };
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaStrokeData = [&](auto& first, auto& second) {
+        if (first.opacity != second.opacity)
+            changingProperties.m_properties.set(CSSPropertyStrokeOpacity);
+        if (first.dashOffset != second.dashOffset)
+            changingProperties.m_properties.set(CSSPropertyStrokeDashoffset);
+        if (first.dashArray != second.dashArray)
+            changingProperties.m_properties.set(CSSPropertyStrokeDasharray);
+        if (first.paintColor != second.paintColor
+            || first.visitedLinkPaintColor != second.visitedLinkPaintColor
+            || first.paintUri != second.paintUri
+            || first.visitedLinkPaintUri != second.visitedLinkPaintUri
+            || first.paintType != second.paintType
+            || first.visitedLinkPaintType != second.visitedLinkPaintType)
+            changingProperties.m_properties.set(CSSPropertyStroke);
+    };
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaTextData = [&](auto& first, auto& second) {
+        if (first.kerning != second.kerning)
+            changingProperties.m_properties.set(CSSPropertyKerning);
+    };
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaStopData = [&](auto& first, auto& second) {
+        if (first.opacity != second.opacity)
+            changingProperties.m_properties.set(CSSPropertyStopOpacity);
+        if (first.color != second.color)
+            changingProperties.m_properties.set(CSSPropertyStopColor);
+    };
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaMiscData = [&](auto& first, auto& second) {
+        if (first.floodOpacity != second.floodOpacity)
+            changingProperties.m_properties.set(CSSPropertyFloodOpacity);
+        if (first.floodColor != second.floodColor)
+            changingProperties.m_properties.set(CSSPropertyFloodColor);
+        if (first.lightingColor != second.lightingColor)
+            changingProperties.m_properties.set(CSSPropertyLightingColor);
+        if (first.baselineShiftValue != second.baselineShiftValue)
+            changingProperties.m_properties.set(CSSPropertyBaselineShift);
+    };
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaLayoutData = [&](auto& first, auto& second) {
+        if (first.cx != second.cx)
+            changingProperties.m_properties.set(CSSPropertyCx);
+        if (first.cy != second.cy)
+            changingProperties.m_properties.set(CSSPropertyCy);
+        if (first.r != second.r)
+            changingProperties.m_properties.set(CSSPropertyR);
+        if (first.rx != second.rx)
+            changingProperties.m_properties.set(CSSPropertyRx);
+        if (first.ry != second.ry)
+            changingProperties.m_properties.set(CSSPropertyRy);
+        if (first.x != second.x)
+            changingProperties.m_properties.set(CSSPropertyX);
+        if (first.y != second.y)
+            changingProperties.m_properties.set(CSSPropertyY);
+    };
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaInheritedResourceData = [&](auto& first, auto& second) {
+        if (first.markerStart != second.markerStart)
+            changingProperties.m_properties.set(CSSPropertyMarkerStart);
+        if (first.markerMid != second.markerMid)
+            changingProperties.m_properties.set(CSSPropertyMarkerMid);
+        if (first.markerEnd != second.markerEnd)
+            changingProperties.m_properties.set(CSSPropertyMarkerEnd);
+    };
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaInheritedFlags = [&](auto& first, auto& second) {
+        if (first.shapeRendering != second.shapeRendering)
+            changingProperties.m_properties.set(CSSPropertyShapeRendering);
+        if (first.clipRule != second.clipRule)
+            changingProperties.m_properties.set(CSSPropertyClipRule);
+        if (first.fillRule != second.fillRule)
+            changingProperties.m_properties.set(CSSPropertyFillRule);
+        if (first.textAnchor != second.textAnchor)
+            changingProperties.m_properties.set(CSSPropertyTextAnchor);
+        if (first.colorInterpolation != second.colorInterpolation)
+            changingProperties.m_properties.set(CSSPropertyColorInterpolation);
+        if (first.colorInterpolationFilters != second.colorInterpolationFilters)
+            changingProperties.m_properties.set(CSSPropertyColorInterpolationFilters);
+
+        // Non animated styles are followings.
+        // glyphOrientationHorizontal
+        // glyphOrientationVertical
+    };
+
+    auto conservativelyCollectChangedAnimatablePropertiesViaNonInheritedFlags = [&](auto& first, auto& second) {
+        if (first.flagBits.dominantBaseline != second.flagBits.dominantBaseline)
+            changingProperties.m_properties.set(CSSPropertyDominantBaseline);
+        if (first.flagBits.baselineShift != second.flagBits.baselineShift)
+            changingProperties.m_properties.set(CSSPropertyBaselineShift);
+        if (first.flagBits.vectorEffect != second.flagBits.vectorEffect)
+            changingProperties.m_properties.set(CSSPropertyVectorEffect);
+        if (first.flagBits.maskType != second.flagBits.maskType)
+            changingProperties.m_properties.set(CSSPropertyMaskType);
+
+        // Non animated styles are followings.
+        // alignmentBaseline
+        // bufferedRendering
+    };
+
+    if (m_fillData.ptr() != other.m_fillData.ptr())
+        conservativelyCollectChangedAnimatablePropertiesViaFillData(*m_fillData, *other.m_fillData);
+    if (m_strokeData != other.m_strokeData)
+        conservativelyCollectChangedAnimatablePropertiesViaStrokeData(*m_strokeData, *other.m_strokeData);
+    if (m_textData != other.m_textData)
+        conservativelyCollectChangedAnimatablePropertiesViaTextData(*m_textData, *other.m_textData);
+    if (m_stopData != other.m_stopData)
+        conservativelyCollectChangedAnimatablePropertiesViaStopData(*m_stopData, *other.m_stopData);
+    if (m_miscData != other.m_miscData)
+        conservativelyCollectChangedAnimatablePropertiesViaMiscData(*m_miscData, *other.m_miscData);
+    if (m_layoutData != other.m_layoutData)
+        conservativelyCollectChangedAnimatablePropertiesViaLayoutData(*m_layoutData, *other.m_layoutData);
+    if (m_inheritedResourceData != other.m_inheritedResourceData)
+        conservativelyCollectChangedAnimatablePropertiesViaInheritedResourceData(*m_inheritedResourceData, *other.m_inheritedResourceData);
+    if (m_inheritedFlags != other.m_inheritedFlags)
+        conservativelyCollectChangedAnimatablePropertiesViaInheritedFlags(m_inheritedFlags, other.m_inheritedFlags);
+    if (m_nonInheritedFlags != other.m_nonInheritedFlags)
+        conservativelyCollectChangedAnimatablePropertiesViaNonInheritedFlags(m_nonInheritedFlags, other.m_nonInheritedFlags);
+}
+
 }

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -182,6 +182,8 @@ public:
     bool hasStroke() const { return strokePaintType() != SVGPaintType::None; }
     bool hasFill() const { return fillPaintType() != SVGPaintType::None; }
 
+    void conservativelyCollectChangedAnimatableProperties(const SVGRenderStyle&, CSSPropertiesBitSet&) const;
+
 private:
     SVGRenderStyle();
     SVGRenderStyle(const SVGRenderStyle&);
@@ -213,9 +215,9 @@ private:
                 unsigned alignmentBaseline : 4; // AlignmentBaseline
                 unsigned dominantBaseline : 4; // DominantBaseline
                 unsigned baselineShift : 2; // BaselineShift
-                unsigned vectorEffect: 1; // VectorEffect
-                unsigned bufferedRendering: 2; // BufferedRendering
-                unsigned maskType: 1; // MaskType
+                unsigned vectorEffect : 1; // VectorEffect
+                unsigned bufferedRendering : 2; // BufferedRendering
+                unsigned maskType : 1; // MaskType
                 // 18 bits unused
             } flagBits;
             uint32_t flags;


### PR DESCRIPTION
#### 66eb8a0eb60e88dc4a31d1ee690e7fe132267708
<pre>
[CSSTransition] Do not list up all properties for transition: all
<a href="https://bugs.webkit.org/show_bug.cgi?id=261917">https://bugs.webkit.org/show_bug.cgi?id=261917</a>
rdar://115861030

Reviewed by Antti Koivisto.

When `transition: all ...` CSS rule is applied, we end up listing all animatable properties.
This is incredibly costly since there are so many CSS properties. And all properties are queried,
checked equality via very slow virtual function. Many hash table lookups etc.
We found that we are using massive amount of time in this transitioning in Speedometer3/NewsSite-Next / NewsSite-Nuxt.

But in almost all cases, almost all properties are not related at all.

In this patch, we do RenderStyle comparison and collect all affected CSS properties candidate which needs to be visited in
updateCSSTransitions. We can conservatively say &quot;this property needs to be visited&quot;. But if we know that this
is totally equal, then we can skip that.

We cannot use RenderStyle::diff for this purpose. It is highly tailored to rendering purpose. And a lof of
properties changes are not reported when it is unrelated to layout (but it is necessary for updateCSSTransitions).
Example is `top` / `left`. So instead, we have more tailored path collecting necessary properties in this patch.

With this patch, we always collect all possible affected properties. So we no longer need to list up all animatable properties.
It results in 0.7% progression in Speedometer3.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hasAnimations const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::hasAnimations const):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSTransitions const):

Canonical link: <a href="https://commits.webkit.org/268412@main">https://commits.webkit.org/268412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6f45adf314540f2ca2740c10924bf7d40b2e17d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20174 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22361 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24149 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22125 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15789 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22125 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2400 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->