### PR TITLE
Add unprefixed backdrop-filter behind a pref.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5031,10 +5031,6 @@ webkit.org/b/224902 [ Debug ] imported/w3c/web-platform-tests/css/css-will-chang
 webkit.org/b/139128 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixpos-cb-offset-path-1.html [ ImageOnlyFailure ]
 webkit.org/b/139128 imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-offset-path-1.html [ ImageOnlyFailure ]
 
-# Needs -webkit-backdrop-filter to be unprefixed
-webkit.org/b/224899 imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-backdrop-filter-1.html [ ImageOnlyFailure ]
-webkit.org/b/224899 imported/w3c/web-platform-tests/css/css-will-change/will-change-abspos-cb-003.html [ ImageOnlyFailure ]
-webkit.org/b/224899 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-004.html [ ImageOnlyFailure ]
 webkit.org/b/224899 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-005.html [ ImageOnlyFailure ]
 
 webkit.org/b/31278 [ Debug ] fast/multicol/spanner-get-re-added-on-move-crash.html [ Skip ]

--- a/LayoutTests/compositing/layer-creation/will-change-on-normal-flow-content-expected.txt
+++ b/LayoutTests/compositing/layer-creation/will-change-on-normal-flow-content-expected.txt
@@ -10,9 +10,14 @@ clip-path
 (GraphicsLayer
 (bounds 800.00 600.00)
 (contentsOpaque 1)
-(children 2
+(children 3
 (GraphicsLayer
 (position 8.00 8.00)
+(bounds 784.00 18.00)
+(drawsContent 1)
+)
+(GraphicsLayer
+(position 8.00 44.00)
 (bounds 784.00 18.00)
 (drawsContent 1)
 )

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -20,6 +20,7 @@ PASS animation-play-state
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
+PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -17,6 +17,7 @@ PASS animation-play-state
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
+PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Can set 'backdrop-filter' to CSS-wide keywords: initial Invalid property backdrop-filter
-FAIL Can set 'backdrop-filter' to CSS-wide keywords: inherit Invalid property backdrop-filter
-FAIL Can set 'backdrop-filter' to CSS-wide keywords: unset Invalid property backdrop-filter
-FAIL Can set 'backdrop-filter' to CSS-wide keywords: revert Invalid property backdrop-filter
-FAIL Can set 'backdrop-filter' to var() references:  var(--A) Invalid property backdrop-filter
-FAIL Can set 'backdrop-filter' to the 'none' keyword: none Invalid property backdrop-filter
+PASS Can set 'backdrop-filter' to CSS-wide keywords: initial
+PASS Can set 'backdrop-filter' to CSS-wide keywords: inherit
+PASS Can set 'backdrop-filter' to CSS-wide keywords: unset
+PASS Can set 'backdrop-filter' to CSS-wide keywords: revert
+PASS Can set 'backdrop-filter' to var() references:  var(--A)
+PASS Can set 'backdrop-filter' to the 'none' keyword: none
 PASS Setting 'backdrop-filter' to a length: 0px throws TypeError
 PASS Setting 'backdrop-filter' to a length: -3.14em throws TypeError
 PASS Setting 'backdrop-filter' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/inheritance-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Property backdrop-filter has initial value none assert_true: backdrop-filter doesn't seem to be supported in the computed style expected true got false
-FAIL Property backdrop-filter does not inherit assert_true: expected true got false
+PASS Property backdrop-filter has initial value none
+PASS Property backdrop-filter does not inherit
 PASS Property color-interpolation-filters has initial value linearrgb
 PASS Property color-interpolation-filters inherits
 PASS Property filter has initial value none

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -20,6 +20,7 @@ PASS animation-play-state
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
+PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -20,6 +20,7 @@ PASS animation-play-state
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
+PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/LayoutTests/platform/ios/compositing/layer-creation/will-change-on-normal-flow-content-expected.txt
+++ b/LayoutTests/platform/ios/compositing/layer-creation/will-change-on-normal-flow-content-expected.txt
@@ -10,9 +10,14 @@ clip-path
 (GraphicsLayer
 (bounds 800.00 600.00)
 (contentsOpaque 1)
-(children 2
+(children 3
 (GraphicsLayer
 (position 8.00 8.00)
+(bounds 784.00 20.00)
+(drawsContent 1)
+)
+(GraphicsLayer
+(position 8.00 48.00)
 (bounds 784.00 20.00)
 (drawsContent 1)
 )

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -20,6 +20,7 @@ PASS animation-play-state
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
+PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -17,6 +17,7 @@ PASS animation-play-state
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
+PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -20,6 +20,7 @@ PASS animation-play-state
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
+PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1495,6 +1495,25 @@ CSSTypedOMEnabled:
     WebCore:
       default: true
 
+CSSUnprefixedBackdropFilterEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS Unprefixed Backdrop Filter"
+  humanReadableDescription: "Enable unprefixed backdrop-filter CSS property"
+  condition: ENABLE(FILTERS_LEVEL_2)
+  defaultValue:
+    WebKitLegacy:
+      "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
+      default: false
+    WebKit:
+      "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
+      default: false
+    WebCore:
+      "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
+      default: false
+
+
 CSSWhiteSpaceLonghandsEnabled:
   type: bool
   status: testable

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -626,6 +626,9 @@
 #define ENABLE_CFPREFS_DIRECT_MODE 0
 #endif
 
+#if !defined(ENABLE_UNPREFIXED_BACKDROP_FILTER)
+#define ENABLE_UNPREFIXED_BACKDROP_FILTER 0
+#endif
 
 
 /* FIXME: This section of the file has not been cleaned up yet and needs major work. */

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -1470,6 +1470,7 @@ private:
     {
         return property() == CSSPropertyFilter
 #if ENABLE(FILTERS_LEVEL_2)
+            || property() == CSSPropertyBackdropFilter
             || property() == CSSPropertyWebkitBackdropFilter
 #endif
             ;
@@ -3672,6 +3673,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
 
         new PropertyWrapperFilter(CSSPropertyFilter, &RenderStyle::filter, &RenderStyle::setFilter),
 #if ENABLE(FILTERS_LEVEL_2)
+        new PropertyWrapperFilter(CSSPropertyBackdropFilter, &RenderStyle::backdropFilter, &RenderStyle::setBackdropFilter),
         new PropertyWrapperFilter(CSSPropertyWebkitBackdropFilter, &RenderStyle::backdropFilter, &RenderStyle::setBackdropFilter),
 #endif
         new PropertyWrapperFilter(CSSPropertyAppleColorFilter, &RenderStyle::appleColorFilter, &RenderStyle::setAppleColorFilter),

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2603,7 +2603,7 @@ void KeyframeEffect::computeHasReferenceFilter()
             if (m_blendingKeyframes.containsProperty(CSSPropertyFilter))
                 return true;
 #if ENABLE(FILTERS_LEVEL_2)
-            if (m_blendingKeyframes.containsProperty(CSSPropertyWebkitBackdropFilter))
+            if (m_blendingKeyframes.containsProperty(CSSPropertyWebkitBackdropFilter) || m_blendingKeyframes.containsProperty(CSSPropertyBackdropFilter))
                 return true;
 #endif
             return false;
@@ -2736,6 +2736,7 @@ static bool acceleratedPropertyDidChange(AnimatableProperty property, const Rend
     case CSSPropertyFilter:
         return previousStyle.filter() != currentStyle.filter();
 #if ENABLE(FILTERS_LEVEL_2)
+    case CSSPropertyBackdropFilter:
     case CSSPropertyWebkitBackdropFilter:
         return previousStyle.backdropFilter() != currentStyle.backdropFilter();
 #endif

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7399,6 +7399,7 @@
         },
         "-webkit-backdrop-filter": {
             "codegen-properties": {
+                "related-property": "backdrop-filter",
                 "conditional-converter": "FilterOperations",
                 "enable-if": "ENABLE_FILTERS_LEVEL_2",
                 "parser-function": "consumeFilter",
@@ -7406,6 +7407,26 @@
                 "parser-function-requires-additional-parameters": ["AllowedFilterFunctions::PixelFilters"],
                 "parser-grammar-unused": "none | <filter-value-list>",
                 "parser-grammar-unused-reason": "Needs support for functional syntax groupings and '+' multipliers."
+            },
+            "status": {
+                "status": "experimental"
+            },
+            "specification": {
+                "category": "css-filters",
+                "url": "https://drafts.fxtf.org/filters-2/#BackdropFilterProperty"
+            }
+        },
+        "backdrop-filter": {
+            "codegen-properties": {
+                "related-property": "-webkit-backdrop-filter",
+                "conditional-converter": "FilterOperations",
+                "enable-if": "ENABLE_FILTERS_LEVEL_2",
+                "parser-function": "consumeFilter",
+                "parser-function-requires-context": true,
+                "parser-function-requires-additional-parameters": ["AllowedFilterFunctions::PixelFilters"],
+                "parser-grammar-unused": "none | <filter-value-list>",
+                "parser-grammar-unused-reason": "Needs support for functional syntax groupings and '+' multipliers.",
+                "settings-flag": "cssUnprefixedBackdropFilterEnabled"
             },
             "status": {
                 "status": "experimental"

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2479,6 +2479,7 @@ static bool isLayoutDependent(CSSPropertyID propertyID, const RenderStyle* style
     case CSSPropertyTransform:
     case CSSPropertyFilter: // Why are filters layout-dependent?
 #if ENABLE(FILTERS_LEVEL_2)
+    case CSSPropertyBackdropFilter:
     case CSSPropertyWebkitBackdropFilter: // Ditto for backdrop-filter.
 #endif
         return true;
@@ -4093,6 +4094,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return valueForFilter(style, style.appleColorFilter());
 #if ENABLE(FILTERS_LEVEL_2)
     case CSSPropertyWebkitBackdropFilter:
+    case CSSPropertyBackdropFilter:
         return valueForFilter(style, style.backdropFilter());
 #endif
     case CSSPropertyMathStyle:

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -92,6 +92,7 @@ static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatablePr
     case CSSPropertyFilter:
         return AcceleratedEffectProperty::Filter;
 #if ENABLE(FILTERS_LEVEL_2)
+    case CSSPropertyBackdropFilter:
     case CSSPropertyWebkitBackdropFilter:
         return AcceleratedEffectProperty::BackdropFilter;
 #endif

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -612,6 +612,9 @@ bool RenderLayer::shouldBeCSSStackingContext() const
 
 bool RenderLayer::computeCanBeBackdropRoot() const
 {
+    if (!renderer().settings().cssUnprefixedBackdropFilterEnabled())
+        return false;
+
     return renderer().isTransparent()
         || renderer().hasBackdropFilter()
         || renderer().hasClipPath()

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3952,7 +3952,7 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& anim
 
     bool hasBackdropFilter = false;
 #if ENABLE(FILTERS_LEVEL_2)
-    hasBackdropFilter = keyframes.containsProperty(CSSPropertyWebkitBackdropFilter);
+    hasBackdropFilter = keyframes.containsProperty(CSSPropertyWebkitBackdropFilter) || keyframes.containsProperty(CSSPropertyBackdropFilter);
 #endif
 
     if (!hasOpacity && !hasRotate && !hasScale && !hasTranslate && !hasTransform && !hasFilter && !hasBackdropFilter)
@@ -3996,7 +3996,7 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const Animation& anim
             filterVector.insert(makeUnique<FilterAnimationValue>(key, keyframeStyle->filter(), tf));
 
 #if ENABLE(FILTERS_LEVEL_2)
-        if (currentKeyframe.containsProperty(CSSPropertyWebkitBackdropFilter))
+        if (currentKeyframe.containsProperty(CSSPropertyWebkitBackdropFilter) || currentKeyframe.containsProperty(CSSPropertyBackdropFilter))
             backdropFilterVector.insert(makeUnique<FilterAnimationValue>(key, keyframeStyle->backdropFilter(), tf));
 #endif
     }
@@ -4214,6 +4214,7 @@ AnimatedProperty RenderLayerBacking::cssToGraphicsLayerProperty(CSSPropertyID cs
     case CSSPropertyFilter:
         return AnimatedProperty::Filter;
 #if ENABLE(FILTERS_LEVEL_2)
+    case CSSPropertyBackdropFilter:
     case CSSPropertyWebkitBackdropFilter:
         return AnimatedProperty::WebkitBackdropFilter;
 #endif

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3293,6 +3293,7 @@ bool RenderLayerCompositor::requiresCompositingForAnimation(RenderLayerModelObje
                 && (usesCompositing() || (m_compositingTriggers & ChromeClient::AnimatedOpacityTrigger)))
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyFilter)
 #if ENABLE(FILTERS_LEVEL_2)
+                || effectsStack->isCurrentlyAffectingProperty(CSSPropertyBackdropFilter)
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyWebkitBackdropFilter)
 #endif
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyTranslate)

--- a/Source/WebCore/rendering/style/WillChangeData.cpp
+++ b/Source/WebCore/rendering/style/WillChangeData.cpp
@@ -79,6 +79,7 @@ bool WillChangeData::createsContainingBlockForOutOfFlowPositioned(bool isRootEle
         // CSS filter & backdrop-filter
         // FIXME: exclude root element for those properties (bug 225034)
 #if ENABLE(FILTERS_LEVEL_2)
+        || (containsProperty(CSSPropertyBackdropFilter) && !isRootElement)
         || (containsProperty(CSSPropertyWebkitBackdropFilter) && !isRootElement)
 #endif
         || containsProperty(CSSPropertyFilter);
@@ -88,6 +89,7 @@ bool WillChangeData::canBeBackdropRoot() const
 {
     return containsProperty(CSSPropertyOpacity)
 #if ENABLE(FILTERS_LEVEL_2)
+        || containsProperty(CSSPropertyBackdropFilter)
         || containsProperty(CSSPropertyWebkitBackdropFilter)
 #endif
         || containsProperty(CSSPropertyClipPath)
@@ -121,6 +123,7 @@ bool WillChangeData::propertyCreatesStackingContext(CSSPropertyID property)
 #endif
     case CSSPropertyFilter:
 #if ENABLE(FILTERS_LEVEL_2)
+    case CSSPropertyBackdropFilter:
     case CSSPropertyWebkitBackdropFilter:
 #endif
     case CSSPropertyMaskImage:
@@ -142,6 +145,7 @@ static bool propertyTriggersCompositing(CSSPropertyID property)
     case CSSPropertyOpacity:
     case CSSPropertyFilter:
 #if ENABLE(FILTERS_LEVEL_2)
+    case CSSPropertyBackdropFilter:
     case CSSPropertyWebkitBackdropFilter:
 #endif
         return true;


### PR DESCRIPTION
#### c950ad9bd9cc4f7d07bafd0cf2e739bc9421740d
<pre>
Add unprefixed backdrop-filter behind a pref.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261923">https://bugs.webkit.org/show_bug.cgi?id=261923</a>
&lt;rdar://115869595&gt;

Reviewed by Simon Fraser.

We want to start being able to test this, before it&apos;s fully ready.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeHasReferenceFilter):
(WebCore::acceleratedPropertyDidChange):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::isLayoutDependent):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::acceleratedPropertyFromCSSProperty):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::startAnimation):
(WebCore::RenderLayerBacking::cssToGraphicsLayerProperty):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForAnimation const):
* Source/WebCore/rendering/style/WillChangeData.cpp:
(WebCore::WillChangeData::createsContainingBlockForOutOfFlowPositioned const):
(WebCore::WillChangeData::canBeBackdropRoot const):
(WebCore::WillChangeData::propertyCreatesStackingContext):
(WebCore::propertyTriggersCompositing):

Canonical link: <a href="https://commits.webkit.org/268367@main">https://commits.webkit.org/268367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd8c628fb042180db9e4979800027ceb6ead347b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21373 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20045 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22230 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24029 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16927 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22000 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18845 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15669 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22877 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17644 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4658 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22000 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24129 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18328 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5384 "Passed tests") | 
<!--EWS-Status-Bubble-End-->