### PR TITLE
Increase fuzziness of css-color serialization WPTs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt
@@ -1,488 +1,146 @@
 
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.32941177 0.36078432 0.23921569)
-Expected: color(srgb 0.33 0.36 0.24).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.33 +/- 0.0001, expected 0.33 but got 0.32941177
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451)
-Expected: color(srgb 0.4375 0.415625 0.2625).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20%), hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451)
-Expected: color(srgb 0.4375 0.415625 0.2625).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), 25% hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.23921569 0.28627452 0.21176471)
-Expected: color(srgb 0.240625 0.2875 0.2125).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.240625 +/- 0.0001, expected 0.240625 but got 0.23921569
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%) 25%)' Colors do not match.
-Actual:   color(srgb 0.23921569 0.28627452 0.21176471)
-Expected: color(srgb 0.240625 0.2875 0.2125).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.240625 +/- 0.0001, expected 0.240625 but got 0.23921569
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%) 75%)' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451)
-Expected: color(srgb 0.4375 0.415625 0.2625).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 30%, hsl(30deg 30% 40%) 90%)' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451)
-Expected: color(srgb 0.4375 0.415625 0.2625).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 12.5%, hsl(30deg 30% 40%) 37.5%)' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451 / 0.5019608)
-Expected: color(srgb 0.4375 0.415625 0.2625 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.52156866 0.4 0.2784314)
-Expected: color(srgb 0.52 0.4 0.28).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.37254903 0.4117647 0.25490198 / 0.6)
-Expected: color(srgb 0.372222 0.411111 0.255556 / 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.372222 +/- 0.0001, expected 0.372222 but got 0.37254903
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.42352942 0.40392157 0.25882354 / 0.8509804)
-Expected: color(srgb 0.42346 0.402889 0.258893 / 0.85).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.402889 +/- 0.0001, expected 0.402889 but got 0.40392157
-FAIL Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.4745098 0.44705883 0.27058825 / 0.7019608)
-Expected: color(srgb 0.472245 0.447041 0.270612 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.472245 +/- 0.0001, expected 0.472245 but got 0.4745098
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), 25% hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.26666668 0.32941177 0.23137255 / 0.5019608)
-Expected: color(srgb 0.2674 0.3304 0.2296 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2674 +/- 0.0001, expected 0.2674 but got 0.26666668
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8) 25%)' Colors do not match.
-Actual:   color(srgb 0.26666668 0.32941177 0.23137255 / 0.5019608)
-Expected: color(srgb 0.2674 0.3304 0.2296 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2674 +/- 0.0001, expected 0.2674 but got 0.26666668
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 25%, hsl(30deg 30% 40% / .8) 75%)' Colors do not match.
-Actual:   color(srgb 0.4745098 0.44705883 0.27058825 / 0.7019608)
-Expected: color(srgb 0.472245 0.447041 0.270612 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.472245 +/- 0.0001, expected 0.472245 but got 0.4745098
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 30%, hsl(30deg 30% 40% / .8) 90%)' Colors do not match.
-Actual:   color(srgb 0.4745098 0.44705883 0.27058825 / 0.7019608)
-Expected: color(srgb 0.472245 0.447041 0.270612 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.472245 +/- 0.0001, expected 0.472245 but got 0.4745098
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 12.5%, hsl(30deg 30% 40% / .8) 37.5%)' Colors do not match.
-Actual:   color(srgb 0.4745098 0.44705883 0.27058825 / 0.34901962)
-Expected: color(srgb 0.472245 0.447041 0.270612 / 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.472245 +/- 0.0001, expected 0.472245 but got 0.4745098
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.52156866 0.4 0.2784314 / 0.8)
-Expected: color(srgb 0.52 0.4 0.28 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20%), hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), 25% hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%) 25%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%) 75%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 30%, hsl(30deg 30% 40%) 90%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 12.5%, hsl(30deg 30% 40%) 37.5%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), 25% hsl(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8) 25%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 25%, hsl(30deg 30% 40% / .8) 75%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 30%, hsl(30deg 30% 40% / .8) 90%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 12.5%, hsl(30deg 30% 40% / .8) 37.5%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8))'
 FAIL Property color value 'color-mix(in hsl, transparent, hsl(30deg 30% 40%))' Colors do not match.
 Actual:   color(srgb 0.52156866 0.34117648 0.2784314 / 0.5019608)
 Expected: color(srgb 0.52 0.4 0.28 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.01, expected 0.4 but got 0.34117648
 FAIL Property color value 'color-mix(in hsl, transparent 10%, hsl(30deg 30% 40%))' Colors do not match.
 Actual:   color(srgb 0.52156866 0.3882353 0.2784314 / 0.9019608)
 Expected: color(srgb 0.52 0.4 0.28 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0), hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.4627451 0.52156866 0.2784314 / 0.5019608)
-Expected: color(srgb 0.46 0.52 0.28 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.46 +/- 0.0001, expected 0.46 but got 0.4627451
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0) 10%, hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.52156866 0.43529412 0.2784314 / 0.9019608)
-Expected: color(srgb 0.52 0.436 0.28 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
-FAIL Property color value 'color-mix(in hsl, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.33333334 0.7490196)
-Expected: color(srgb 0.25 0.333333 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.33333334 0.7490196)
-Expected: color(srgb 0.25 0.333333 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.6666667 0.7490196)
-Expected: color(srgb 0.25 0.666667 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.6666667 0.7490196)
-Expected: color(srgb 0.25 0.666667 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.7490196 0.6666667)
-Expected: color(srgb 0.25 0.75 0.666667).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.7490196 0.6666667)
-Expected: color(srgb 0.25 0.75 0.666667).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.33333334 0.7490196)
-Expected: color(srgb 0.25 0.333333 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.6666667 0.7490196)
-Expected: color(srgb 0.25 0.666667 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.7490196 0.6666667)
-Expected: color(srgb 0.25 0.75 0.666667).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.33333334 0.7490196)
-Expected: color(srgb 0.25 0.333333 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.6666667 0.7490196)
-Expected: color(srgb 0.25 0.666667 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.7490196 0.6666667)
-Expected: color(srgb 0.25 0.75 0.666667).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.01, expected 0.4 but got 0.3882353
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0), hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0) 10%, hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
 FAIL Property color value 'color-mix(in hsl, hsl(none none none), hsl(none none none))' Colors do not match.
 Actual:   color(srgb 0 0 0)
 Expected: color(srgb none none none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 0 got 3
-FAIL Property color value 'color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))' Colors do not match.
-Actual:   color(srgb 0.8784314 0.8 0.72156864)
-Expected: color(srgb 0.88 0.8 0.72).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.88 +/- 0.0001, expected 0.88 but got 0.8784314
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))' Colors do not match.
-Actual:   color(srgb 0.32156864 0.47843137 0.32156864)
-Expected: color(srgb 0.32 0.48 0.32).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.32 +/- 0.0001, expected 0.32 but got 0.32156864
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))' Colors do not match.
-Actual:   color(srgb 0.65882355 0.72156864 0.47843137)
-Expected: color(srgb 0.66 0.72 0.48).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.66 +/- 0.0001, expected 0.66 but got 0.65882355
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))' Colors do not match.
-Actual:   color(srgb 0.4392157 0.47843137 0.32156864)
-Expected: color(srgb 0.44 0.48 0.32).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.44 +/- 0.0001, expected 0.44 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))' Colors do not match.
-Actual:   color(srgb 0.6784314 0.6 0.52156866)
-Expected: color(srgb 0.68 0.6 0.52).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.68 +/- 0.0001, expected 0.68 but got 0.6784314
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))' Colors do not match.
-Actual:   color(srgb 0.56078434 0.56078434 0.23921569)
-Expected: color(srgb 0.56 0.56 0.24).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.56 +/- 0.0001, expected 0.56 but got 0.56078434
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))' Colors do not match.
-Actual:   color(srgb 0.56078434 0.56078434 0.23921569 / 0.5019608)
-Expected: color(srgb 0.56 0.56 0.24 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.56 +/- 0.0001, expected 0.56 but got 0.56078434
+PASS Property color value 'color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))'
+PASS Property color value 'color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))'
 FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))' Colors do not match.
 Actual:   color(srgb 0.56078434 0.56078434 0.23921569 / 0)
 Expected: color(srgb 0.56 0.56 0.24 / none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.5764706 0.7019608 0.20392157)
-Expected: color(srgb 0.575 0.7 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.575 +/- 0.0001, expected 0.575 but got 0.5764706
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804)
-Expected: color(srgb 0.65 0.6 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804)
-Expected: color(srgb 0.65 0.6 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3764706 0.7490196 0.15294118)
-Expected: color(srgb 0.375 0.75 0.15).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.375 +/- 0.0001, expected 0.375 but got 0.3764706
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%) 25%)' Colors do not match.
-Actual:   color(srgb 0.3764706 0.7490196 0.15294118)
-Expected: color(srgb 0.375 0.75 0.15).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.375 +/- 0.0001, expected 0.375 but got 0.3764706
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%) 75%)' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804)
-Expected: color(srgb 0.65 0.6 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 30%, hwb(30deg 30% 40%) 90%)' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804)
-Expected: color(srgb 0.65 0.6 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 12.5%, hwb(30deg 30% 40%) 37.5%)' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804 / 0.5019608)
-Expected: color(srgb 0.65 0.6 0.25 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.4509804 0.3019608)
-Expected: color(srgb 0.6 0.45 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.4509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.56078434 0.6666667 0.23529412 / 0.6)
-Expected: color(srgb 0.558333 0.666667 0.233333 / 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.558333 +/- 0.0001, expected 0.558333 but got 0.56078434
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.7019608)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.7019608)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.37254903 0.75686276 0.14509805 / 0.9490196)
-Expected: color(srgb 0.373026 0.757895 0.142105 / 0.95).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.373026 +/- 0.0001, expected 0.373026 but got 0.37254903
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8) 25%)' Colors do not match.
-Actual:   color(srgb 0.38431373 0.72156864 0.18039216 / 0.5019608)
-Expected: color(srgb 0.3825 0.72 0.18 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3825 +/- 0.0001, expected 0.3825 but got 0.38431373
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8) 75%)' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.7019608)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 30%, hwb(30deg 30% 40% / .8) 90%)' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.7019608)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 12.5%, hwb(30deg 30% 40% / .8) 37.5%)' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.34901962)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.6 0.4509804 0.3019608 / 0.8)
-Expected: color(srgb 0.6 0.45 0.3 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.4509804
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%) 25%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%) 75%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 30%, hwb(30deg 30% 40%) 90%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 12.5%, hwb(30deg 30% 40%) 37.5%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8) 25%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8) 75%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 30%, hwb(30deg 30% 40% / .8) 90%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 12.5%, hwb(30deg 30% 40% / .8) 37.5%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8))'
 FAIL Property color value 'color-mix(in hwb, transparent, hwb(30deg 30% 40%))' Colors do not match.
 Actual:   color(srgb 0.6 0.3764706 0.3019608 / 0.5019608)
 Expected: color(srgb 0.6 0.45 0.3 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.3764706
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.01, expected 0.45 but got 0.3764706
 FAIL Property color value 'color-mix(in hwb, transparent 10%, hwb(30deg 30% 40%))' Colors do not match.
 Actual:   color(srgb 0.6 0.43529412 0.3019608 / 0.9019608)
 Expected: color(srgb 0.6 0.45 0.3 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.43529412
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.5254902 0.6 0.3019608 / 0.5019608)
-Expected: color(srgb 0.525 0.6 0.3 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.525 +/- 0.0001, expected 0.525 but got 0.5254902
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0) 10%, hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.49411765 0.3019608 / 0.9019608)
-Expected: color(srgb 0.6 0.495 0.3 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.495 +/- 0.0001, expected 0.495 but got 0.49411765
-FAIL Property color value 'color-mix(in hwb, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.5529412 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.5529412
-FAIL Property color value 'color-mix(in hwb, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.5529412 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.5529412
-FAIL Property color value 'color-mix(in hwb, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.5529412 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.5529412
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.5529412 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.5529412
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.34901962 0.6)
-Expected: color(srgb 0.3 0.35 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.34901962 0.6)
-Expected: color(srgb 0.3 0.35 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.5529412 0.6)
-Expected: color(srgb 0.3 0.55 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.5529412 0.6)
-Expected: color(srgb 0.3 0.55 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.6 0.5529412)
-Expected: color(srgb 0.3 0.6 0.55).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.6 0.5529412)
-Expected: color(srgb 0.3 0.6 0.55).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.5529412 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.5529412
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.34901962 0.6)
-Expected: color(srgb 0.3 0.35 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.5529412 0.6)
-Expected: color(srgb 0.3 0.55 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.6 0.5529412)
-Expected: color(srgb 0.3 0.6 0.55).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.34901962 0.6)
-Expected: color(srgb 0.3 0.35 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.5529412 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.5529412
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.5529412 0.6)
-Expected: color(srgb 0.3 0.55 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.6 0.5529412)
-Expected: color(srgb 0.3 0.6 0.55).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.01, expected 0.45 but got 0.43529412
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0) 10%, hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
 FAIL Property color value 'color-mix(in hwb, hwb(none none none), hwb(none none none))' Colors do not match.
 Actual:   color(srgb 1 0 0)
 Expected: color(srgb none none none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 0 got 3
-FAIL Property color value 'color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.4509804 0.3019608)
-Expected: color(srgb 0.6 0.45 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.4509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))' Colors do not match.
-Actual:   color(srgb 0.101960786 0.8 0.101960786)
-Expected: color(srgb 0.1 0.8 0.1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.1 +/- 0.0001, expected 0.1 but got 0.101960786
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.5019608 0.6 0.2)
-Expected: color(srgb 0.5 0.6 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 0.5019608
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))' Colors do not match.
-Actual:   color(srgb 0.6509804 0.8 0.2)
-Expected: color(srgb 0.65 0.8 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))' Colors do not match.
-Actual:   color(srgb 0.7019608 0.4 0.101960786)
-Expected: color(srgb 0.7 0.4 0.1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.7 +/- 0.0001, expected 0.7 but got 0.7019608
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.5764706 0.7019608 0.2)
-Expected: color(srgb 0.575 0.7 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.575 +/- 0.0001, expected 0.575 but got 0.5764706
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))' Colors do not match.
-Actual:   color(srgb 0.5764706 0.7019608 0.2 / 0.5019608)
-Expected: color(srgb 0.575 0.7 0.2 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.575 +/- 0.0001, expected 0.575 but got 0.5764706
+PASS Property color value 'color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))'
+PASS Property color value 'color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))'
 FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))' Colors do not match.
 Actual:   color(srgb 0.5764706 0.7019608 0.2 / 0)
 Expected: color(srgb 0.575 0.7 0.2 / none).
@@ -508,11 +166,11 @@ PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4) 0%, lch(50 60
 FAIL Property color value 'color-mix(in lch, transparent, lch(0.3 0.4 30deg))' Colors do not match.
 Actual:   lch(0.3 0.4 15 / 0.5)
 Expected: lch(0.3 0.4 30 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.0001, expected 30 but got 15
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.01, expected 30 but got 15
 FAIL Property color value 'color-mix(in lch, transparent 10%, lch(0.3 0.4 30deg))' Colors do not match.
 Actual:   lch(0.3 0.40000004 27 / 0.9)
 Expected: lch(0.3 0.4 30 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.0001, expected 30 but got 27
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.01, expected 30 but got 27
 PASS Property color value 'color-mix(in lch, lch(0.1 0.2 120deg / 0), lch(0.3 0.4 30deg))'
 PASS Property color value 'color-mix(in lch, lch(0.1 0.2 120deg / 0) 10%, lch(0.3 0.4 30deg))'
 PASS Property color value 'color-mix(in lch, lch(100 0 40deg), lch(100 0 60deg))'
@@ -575,11 +233,11 @@ PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4) 0%, okl
 FAIL Property color value 'color-mix(in oklch, transparent, oklch(0.3 40 30deg))' Colors do not match.
 Actual:   oklch(0.3 40 15 / 0.5)
 Expected: oklch(0.3 40 30 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.0001, expected 30 but got 15
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.01, expected 30 but got 15
 FAIL Property color value 'color-mix(in oklch, transparent 10%, oklch(0.3 40 30deg))' Colors do not match.
 Actual:   oklch(0.3 40 27 / 0.9)
 Expected: oklch(0.3 40 30 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.0001, expected 30 but got 27
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.01, expected 30 but got 27
 PASS Property color value 'color-mix(in oklch, oklch(0.1 20 120deg / 0), oklch(0.3 40 30deg))'
 PASS Property color value 'color-mix(in oklch, oklch(0.1 20 120deg / 0) 10%, oklch(0.3 40 30deg))'
 PASS Property color value 'color-mix(in oklch, oklch(1 0 40deg), oklch(1 0 60deg))'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt
@@ -2,23 +2,23 @@
 FAIL Property color value 'rgb(from rebeccapurple r g b)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r g b / alpha)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r g b / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from hsl(120deg 20% 50% / .5) r g b / alpha)' Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rgb(from rebeccapurple r g b) r g b)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple 0 0 0)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -30,139 +30,139 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL Property color value 'rgb(from rebeccapurple 0 g b / alpha)' Colors do not match.
 Actual:   rgb(0, 51, 153)
 Expected: color(srgb 0 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rebeccapurple r 0 b / alpha)' Colors do not match.
 Actual:   rgb(102, 0, 153)
 Expected: color(srgb 0.4 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r g 0 / alpha)' Colors do not match.
 Actual:   rgb(102, 51, 0)
 Expected: color(srgb 0.4 0.2 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r g b / 0)' Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) 0 g b / alpha)' Colors do not match.
 Actual:   rgba(0, 102, 153, 0.8)
 Expected: color(srgb 0 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r 0 b / alpha)' Colors do not match.
 Actual:   rgba(51, 0, 153, 0.8)
 Expected: color(srgb 0.2 0 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r g 0 / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 0, 0.8)
 Expected: color(srgb 0.2 0.4 0 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r g b / 0)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rebeccapurple 25 g b / alpha)' Colors do not match.
 Actual:   rgb(25, 51, 153)
 Expected: color(srgb 0.098 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL Property color value 'rgb(from rebeccapurple r 25 b / alpha)' Colors do not match.
 Actual:   rgb(102, 25, 153)
 Expected: color(srgb 0.4 0.098 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r g 25 / alpha)' Colors do not match.
 Actual:   rgb(102, 51, 25)
 Expected: color(srgb 0.4 0.2 0.098).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r g b / .25)' Colors do not match.
 Actual:   rgba(102, 51, 153, 0.25)
 Expected: color(srgb 0.4 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / alpha)' Colors do not match.
 Actual:   rgba(25, 102, 153, 0.8)
 Expected: color(srgb 0.098 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / alpha)' Colors do not match.
 Actual:   rgba(51, 25, 153, 0.8)
 Expected: color(srgb 0.2 0.098 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 25, 0.8)
 Expected: color(srgb 0.2 0.4 0.098 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r g b / .20)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rebeccapurple 20% g b / alpha)' Colors do not match.
 Actual:   rgb(51, 51, 153)
 Expected: color(srgb 0.2 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rebeccapurple r 20% b / alpha)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r g 20% / alpha)' Colors do not match.
 Actual:   rgb(102, 51, 51)
 Expected: color(srgb 0.4 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r g b / 20%)' Colors do not match.
 Actual:   rgba(102, 51, 153, 0.2)
 Expected: color(srgb 0.4 0.2 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) 20% g b / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r 20% b / alpha)' Colors do not match.
 Actual:   rgba(51, 51, 153, 0.8)
 Expected: color(srgb 0.2 0.2 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r g 20% / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 51, 0.8)
 Expected: color(srgb 0.2 0.4 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r g b / 20%)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rebeccapurple 25 g b / 25%)' Colors do not match.
 Actual:   rgba(25, 51, 153, 0.25)
 Expected: color(srgb 0.098 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL Property color value 'rgb(from rebeccapurple r 25 b / 25%)' Colors do not match.
 Actual:   rgba(102, 25, 153, 0.25)
 Expected: color(srgb 0.4 0.098 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r g 25 / 25%)' Colors do not match.
 Actual:   rgba(102, 51, 25, 0.25)
 Expected: color(srgb 0.4 0.2 0.098 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / 25%)' Colors do not match.
 Actual:   rgba(25, 102, 153, 0.25)
 Expected: color(srgb 0.098 0.4 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / 25%)' Colors do not match.
 Actual:   rgba(51, 25, 153, 0.25)
 Expected: color(srgb 0.2 0.098 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / 25%)' Colors do not match.
 Actual:   rgba(51, 102, 25, 0.25)
 Expected: color(srgb 0.2 0.4 0.098 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rebeccapurple g b r)' Colors do not match.
 Actual:   rgb(51, 153, 102)
 Expected: color(srgb 0.2 0.6 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rebeccapurple b alpha r / g)' Colors do not match.
 Actual:   rgba(153, 255, 102, 0.2)
 Expected: color(srgb 0.6 1 0.4 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'rgb(from rebeccapurple r r r / r)' Colors do not match.
 Actual:   rgba(102, 102, 102, 0.4)
 Expected: color(srgb 0.4 0.4 0.4 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple alpha alpha alpha / alpha)' Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1 1 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) g b r)' Colors do not match.
 Actual:   rgb(102, 153, 51)
 Expected: color(srgb 0.4 0.6 0.2 / 0.8).
@@ -170,27 +170,27 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) b alpha r / g)' Colors do not match.
 Actual:   rgba(153, 204, 51, 0.4)
 Expected: color(srgb 0.6 0.8 0.2 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r r r / r)' Colors do not match.
 Actual:   rgba(51, 51, 51, 0.2)
 Expected: color(srgb 0.2 0.2 0.2 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) alpha alpha alpha / alpha)' Colors do not match.
 Actual:   rgba(204, 204, 204, 0.8)
 Expected: color(srgb 0.8 0.8 0.8 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.0001, expected 0.8 but got 204
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.01, expected 0.8 but got 204
 FAIL Property color value 'rgb(from rebeccapurple r 20% 10)' Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r 10 20%)' Colors do not match.
 Actual:   rgb(102, 10, 51)
 Expected: color(srgb 0.4 0.0392 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple 0% 10 10)' Colors do not match.
 Actual:   rgb(0, 10, 10)
 Expected: color(srgb 0 0.0392 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.0392 +/- 0.0001, expected 0.0392 but got 10
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.0392 +/- 0.01, expected 0.0392 but got 10
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) r 20% 10)' Colors do not match.
 Actual:   rgb(51, 51, 10)
 Expected: color(srgb 0.2 0.2 0.0392 / 0.8).
@@ -206,27 +206,27 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL Property color value 'rgb(from rebeccapurple calc(r) calc(g) calc(b))' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r calc(g * 2) 10)' Colors do not match.
 Actual:   rgb(102, 102, 10)
 Expected: color(srgb 0.4 0.4 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple b calc(r * .5) 10)' Colors do not match.
 Actual:   rgb(153, 51, 10)
 Expected: color(srgb 0.6 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'rgb(from rebeccapurple r calc(g * .5 + g * .5) 10)' Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rebeccapurple r calc(b * .5 - g * .5) 10)' Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'rgb(from rgb(20%, 40%, 60%, 80%) calc(r) calc(g) calc(b) / calc(alpha))' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rebeccapurple none none none)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb none none none).
@@ -266,31 +266,31 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL Property color value 'rgb(from rgb(20% none 60%) r g b)' Colors do not match.
 Actual:   rgb(51, 0, 153)
 Expected: color(srgb 0.2 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'rgb(from rgb(20% 40% 60% / none) r g b / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hsl(from rebeccapurple h s l)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rebeccapurple h s l / alpha)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h s l / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hsl(from hsl(120deg 20% 50% / .5) h s l / alpha)' Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from hsl(from rebeccapurple h s l) h s l)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rebeccapurple 0 0% 0%)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -310,15 +310,15 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL Property color value 'hsl(from rebeccapurple 0 s l / alpha)' Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hsl(from rebeccapurple 0deg s l / alpha)' Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hsl(from rebeccapurple h 0% l / alpha)' Colors do not match.
 Actual:   rgb(102, 102, 102)
 Expected: color(srgb 0.4 0.4 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rebeccapurple h s 0% / alpha)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -326,19 +326,19 @@ Error: assert_equals: Color format is correct. expected "color(srgb   )" but got
 FAIL Property color value 'hsl(from rebeccapurple h s l / 0)' Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) 0 s l / alpha)' Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) 0deg s l / alpha)' Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h 0% l / alpha)' Colors do not match.
 Actual:   rgba(102, 102, 102, 0.8)
 Expected: color(srgb 0.4 0.4 0.4 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h s 0% / alpha)' Colors do not match.
 Actual:   rgba(0, 0, 0, 0.8)
 Expected: color(srgb 0 0 0 / 0.8).
@@ -346,63 +346,63 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h s l / 0)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hsl(from rebeccapurple 25 s l / alpha)' Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hsl(from rebeccapurple 25deg s l / alpha)' Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hsl(from rebeccapurple h 20% l / alpha)' Colors do not match.
 Actual:   rgb(102, 82, 122)
 Expected: color(srgb 0.4 0.32 0.48).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rebeccapurple h s 20% / alpha)' Colors do not match.
 Actual:   rgb(51, 25, 77)
 Expected: color(srgb 0.2 0.1 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hsl(from rebeccapurple h s l / .25)' Colors do not match.
 Actual:   rgba(102, 51, 153, 0.25)
 Expected: color(srgb 0.4 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) 25 s l / alpha)' Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) 25deg s l / alpha)' Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h 20% l / alpha)' Colors do not match.
 Actual:   rgba(82, 102, 122, 0.8)
 Expected: color(srgb 0.32 0.4 0.48 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.32 +/- 0.0001, expected 0.32 but got 82
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.32 +/- 0.01, expected 0.32 but got 82
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h s 20% / alpha)' Colors do not match.
 Actual:   rgba(25, 51, 77, 0.8)
 Expected: color(srgb 0.1 0.2 0.3 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.1 +/- 0.0001, expected 0.1 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.1 +/- 0.01, expected 0.1 but got 25
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h s l / .2)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hsl(from rebeccapurple h l s)' Colors do not match.
 Actual:   rgb(128, 77, 179)
 Expected: color(srgb 0.5 0.3 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL Property color value 'hsl(from rebeccapurple h alpha l / s)' Colors do not match.
 Actual:   rgba(102, 0, 204, 0.5)
 Expected: color(srgb 0.4 0 0.8 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rebeccapurple h l l / l)' Colors do not match.
 Actual:   rgba(102, 61, 143, 0.4)
 Expected: color(srgb 0.4 0.24 0.56 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rebeccapurple h alpha alpha / alpha)' Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1 1 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h l s)' Colors do not match.
 Actual:   rgb(77, 128, 179)
 Expected: color(srgb 0.3 0.5 0.7 / 0.8).
@@ -410,23 +410,23 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h alpha l / s)' Colors do not match.
 Actual:   rgba(20, 102, 184, 0.5)
 Expected: color(srgb 0.08 0.4 0.72 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.08 +/- 0.0001, expected 0.08 but got 20
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.08 +/- 0.01, expected 0.08 but got 20
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h l l / l)' Colors do not match.
 Actual:   rgba(61, 102, 143, 0.4)
 Expected: color(srgb 0.24 0.4 0.56 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.24 +/- 0.0001, expected 0.24 but got 61
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.24 +/- 0.01, expected 0.24 but got 61
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)' Colors do not match.
 Actual:   rgba(163, 204, 245, 0.8)
 Expected: color(srgb 0.64 0.8 0.96 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.64 +/- 0.0001, expected 0.64 but got 163
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.64 +/- 0.01, expected 0.64 but got 163
 FAIL Property color value 'hsl(from rebeccapurple calc(h) calc(s) calc(l))' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from rgb(20%, 40%, 60%, 80%) calc(h) calc(s) calc(l) / calc(alpha))' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hsl(from rebeccapurple none none none)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb none none none).
@@ -478,143 +478,143 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL Property color value 'hsl(from hsl(120deg 20% 50% / none) h s l / alpha)' Colors do not match.
 Actual:   rgba(102, 153, 102, 0)
 Expected: color(srgb 0.4 0.6 0.4 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hsl(from hsl(none 20% 50% / .5) h s l / alpha)' Colors do not match.
 Actual:   rgba(153, 102, 102, 0.5)
 Expected: color(srgb 0.6 0.4 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rebeccapurple h w b)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hwb(from rebeccapurple h w b / alpha)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h w b / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from hsl(120deg 20% 50% / .5) h w b / alpha)' Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hwb(from hwb(from rebeccapurple h w b) h w b)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hwb(from rebeccapurple 0 0% 0%)' Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hwb(from rebeccapurple 0deg 0% 0%)' Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hwb(from rebeccapurple 0 0% 0% / 0)' Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hwb(from rebeccapurple 0deg 0% 0% / 0)' Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hwb(from rebeccapurple 0 w b / alpha)' Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rebeccapurple 0deg w b / alpha)' Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rebeccapurple h 0% b / alpha)' Colors do not match.
 Actual:   rgb(77, 0, 153)
 Expected: color(srgb 0.3 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 77
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.01, expected 0.3 but got 77
 FAIL Property color value 'hwb(from rebeccapurple h w 0% / alpha)' Colors do not match.
 Actual:   rgb(153, 51, 255)
 Expected: color(srgb 0.6 0.2 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rebeccapurple h w b / 0)' Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) 0 w b / alpha)' Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) 0deg w b / alpha)' Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h 0% b / alpha)' Colors do not match.
 Actual:   rgba(0, 77, 153, 0.8)
 Expected: color(srgb 0 0.3 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 77
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.01, expected 0.3 but got 77
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h w 0% / alpha)' Colors do not match.
 Actual:   rgba(51, 153, 255, 0.8)
 Expected: color(srgb 0.2 0.6 1 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h w b / 0)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from rebeccapurple 25 w b / alpha)' Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rebeccapurple 25deg w b / alpha)' Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rebeccapurple h 20% b / alpha)' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hwb(from rebeccapurple h w 20% / alpha)' Colors do not match.
 Actual:   rgb(128, 51, 204)
 Expected: color(srgb 0.5 0.2 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL Property color value 'hwb(from rebeccapurple h w b / .2)' Colors do not match.
 Actual:   rgba(102, 51, 153, 0.2)
 Expected: color(srgb 0.4 0.2 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) 25 w b / alpha)' Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) 25deg w b / alpha)' Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h 20% b / alpha)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h w 20% / alpha)' Colors do not match.
 Actual:   rgba(51, 128, 204, 0.8)
 Expected: color(srgb 0.2 0.5 0.8 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h w b / .2)' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from rebeccapurple h b w)' Colors do not match.
 Actual:   rgb(153, 102, 204)
 Expected: color(srgb 0.6 0.4 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL Property color value 'hwb(from rebeccapurple h alpha w / b)' Colors do not match.
 Actual:   rgba(213, 213, 213, 0.4)
 Expected: color(srgb 0.8333 0.8333 0.8333 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8333 +/- 0.0001, expected 0.8333 but got 213
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8333 +/- 0.01, expected 0.8333 but got 213
 FAIL Property color value 'hwb(from rebeccapurple h w w / w)' Colors do not match.
 Actual:   rgba(128, 51, 204, 0.2)
 Expected: color(srgb 0.5 0.2 0.8 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL Property color value 'hwb(from rebeccapurple h alpha alpha / alpha)' Colors do not match.
 Actual:   rgb(128, 128, 128)
 Expected: color(srgb 0.5 0.5 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h b w)' Colors do not match.
 Actual:   rgb(102, 153, 204)
 Expected: color(srgb 0.4 0.6 0.8 / 0.8).
@@ -622,23 +622,23 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h alpha w / b)' Colors do not match.
 Actual:   rgba(204, 204, 204, 0.4)
 Expected: color(srgb 0.8 0.8 0.8 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.0001, expected 0.8 but got 204
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.01, expected 0.8 but got 204
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h w w / w)' Colors do not match.
 Actual:   rgba(51, 128, 204, 0.2)
 Expected: color(srgb 0.2 0.5 0.8 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)' Colors do not match.
 Actual:   rgba(128, 128, 128, 0.8)
 Expected: color(srgb 0.5 0.5 0.5 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL Property color value 'hwb(from rebeccapurple calc(h) calc(w) calc(b))' Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL Property color value 'hwb(from rgb(20%, 40%, 60%, 80%) calc(h) calc(w) calc(b) / calc(alpha))' Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from rebeccapurple none none none)' Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb none none none).
@@ -678,11 +678,11 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL Property color value 'hwb(from hwb(none none none) h w b)' Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hwb(from hwb(none none none / none) h w b / alpha)' Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL Property color value 'hwb(from hwb(120deg none 50% / .5) h w b)' Colors do not match.
 Actual:   rgb(0, 128, 0)
 Expected: color(srgb 0 0.5 0 / 0.5).
@@ -690,11 +690,11 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL Property color value 'hwb(from hwb(120deg 20% 50% / none) h w b / alpha)' Colors do not match.
 Actual:   rgba(51, 128, 51, 0)
 Expected: color(srgb 0.2 0.5 0.2 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL Property color value 'hwb(from hwb(none 20% 50% / .5) h w b / alpha)' Colors do not match.
 Actual:   rgba(128, 51, 51, 0.5)
 Expected: color(srgb 0.5 0.2 0.2 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 PASS Property color value 'lab(from lab(25 20 50) l a b)'
 PASS Property color value 'lab(from lab(25 20 50) l a b / alpha)'
 PASS Property color value 'lab(from lab(25 20 50 / 40%) l a b / alpha)'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-mix-out-of-gamut-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-mix-out-of-gamut-expected.txt
@@ -2,73 +2,73 @@
 FAIL Property color value 'color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0 0.9764706 0.25882354)
 Expected: color(srgb -0.511814 1.01832 -0.310726).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.0001, expected -0.511814 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.01, expected -0.511814 but got 0
 FAIL Property color value 'color-mix(in hsl, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 1 1 1)
 Expected: color(srgb 1.59343 0.58802 1.40564).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.0001, expected 1.59343 but got 1
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.01, expected 1.59343 but got 1
 FAIL Property color value 'color-mix(in hsl, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0.16470589 0 0.13333334)
 Expected: color(srgb 0.351376 -0.213938 0.299501).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.0001, expected 0.351376 but got 0.16470589
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.01, expected 0.351376 but got 0.16470589
 FAIL Property color value 'color-mix(in hsl, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 1 1 1)
 Expected: color(srgb 1.59328 0.588284 1.40527).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 1
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 1
 FAIL Property color value 'color-mix(in hsl, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0.16470589 0 0.13333334)
 Expected: color(srgb 0.351307 -0.213865 0.299236).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.0001, expected 0.351307 but got 0.16470589
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.01, expected 0.351307 but got 0.16470589
 FAIL Property color value 'color-mix(in hsl, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 1 0.9764706 1)
 Expected: color(srgb 1.59295 0.360371 1.38571).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.0001, expected 1.59295 but got 1
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.01, expected 1.59295 but got 1
 FAIL Property color value 'color-mix(in hsl, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0 0 0)
 Expected: color(srgb 0.0763893 -0.0456266 0.0932598).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763893 +/- 0.0001, expected 0.0763893 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763893 +/- 0.01, expected 0.0763893 but got 0
 FAIL Property color value 'color-mix(in hsl, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 1 0.9764706 1)
 Expected: color(srgb 1.59328 0.358734 1.38664).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 1
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 1
 FAIL Property color value 'color-mix(in hsl, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0 0 0)
 Expected: color(srgb 0.076536 -0.045825 0.0937443).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.076536 +/- 0.0001, expected 0.076536 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.076536 +/- 0.01, expected 0.076536 but got 0
 FAIL Property color value 'color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0 0.9764706 0.25882354)
 Expected: color(srgb -0.511814 1.01832 -0.310726).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.0001, expected -0.511814 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.01, expected -0.511814 but got 0
 FAIL Property color value 'color-mix(in hwb, lab(100 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 1 1 1)
 Expected: color(srgb 1.59343 0.58802 1.40564).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.0001, expected 1.59343 but got 1
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.01, expected 1.59343 but got 1
 FAIL Property color value 'color-mix(in hwb, lab(0 104.3 -50.9) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0.16470589 0 0.13333334)
 Expected: color(srgb 0.351376 -0.213938 0.299501).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.0001, expected 0.351376 but got 0.16470589
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.01, expected 0.351376 but got 0.16470589
 FAIL Property color value 'color-mix(in hwb, lch(100 116 334) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 1 1 1)
 Expected: color(srgb 1.59328 0.588284 1.40527).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 1
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 1
 FAIL Property color value 'color-mix(in hwb, lch(0 116 334) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0.16470589 0 0.13333334)
 Expected: color(srgb 0.351307 -0.213865 0.299236).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.0001, expected 0.351307 but got 0.16470589
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.01, expected 0.351307 but got 0.16470589
 FAIL Property color value 'color-mix(in hwb, oklab(1 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 1 0.9764706 1)
 Expected: color(srgb 1.59295 0.360371 1.38571).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.0001, expected 1.59295 but got 1
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.01, expected 1.59295 but got 1
 FAIL Property color value 'color-mix(in hwb, oklab(0 0.365 -0.16) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0 0 0)
 Expected: color(srgb 0.0763893 -0.0456266 0.0932598).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763893 +/- 0.0001, expected 0.0763893 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763893 +/- 0.01, expected 0.0763893 but got 0
 FAIL Property color value 'color-mix(in hwb, oklch(1 0.399 336.3) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 1 0.9764706 1)
 Expected: color(srgb 1.59328 0.358736 1.38664).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 1
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 1
 FAIL Property color value 'color-mix(in hwb, oklch(0 0.399 336.3) 100%, rgb(0, 0, 0) 0%)' Colors do not match.
 Actual:   color(srgb 0 0 0)
 Expected: color(srgb 0.0765361 -0.045825 0.0937443).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0765361 +/- 0.0001, expected 0.0765361 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0765361 +/- 0.01, expected 0.0765361 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
@@ -2,23 +2,23 @@
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from hsl(120deg 20% 50% / .5) r g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(from rebeccapurple r g b) r g b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple 0 0 0)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -30,139 +30,139 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL e.style['color'] = "rgb(from rebeccapurple 0 g b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(0, 51, 153)
 Expected: color(srgb 0 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple r 0 b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 0, 153)
 Expected: color(srgb 0.4 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g 0 / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 0)
 Expected: color(srgb 0.4 0.2 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b / 0)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) 0 g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(0, 102, 153, 0.8)
 Expected: color(srgb 0 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 0 b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 0, 153, 0.8)
 Expected: color(srgb 0.2 0 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g 0 / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 0, 0.8)
 Expected: color(srgb 0.2 0.4 0 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g b / 0)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple 25 g b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(25, 51, 153)
 Expected: color(srgb 0.098 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL e.style['color'] = "rgb(from rebeccapurple r 25 b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 25, 153)
 Expected: color(srgb 0.4 0.098 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g 25 / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 25)
 Expected: color(srgb 0.4 0.2 0.098).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b / .25)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0.25)
 Expected: color(srgb 0.4 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(25, 102, 153, 0.8)
 Expected: color(srgb 0.098 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 25, 153, 0.8)
 Expected: color(srgb 0.2 0.098 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 25, 0.8)
 Expected: color(srgb 0.2 0.4 0.098 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g b / .20)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple 20% g b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(51, 51, 153)
 Expected: color(srgb 0.2 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple r 20% b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 51)
 Expected: color(srgb 0.4 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b / 20%)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0.2)
 Expected: color(srgb 0.4 0.2 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) 20% g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 20% b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 51, 153, 0.8)
 Expected: color(srgb 0.2 0.2 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 51, 0.8)
 Expected: color(srgb 0.2 0.4 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g b / 20%)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple 25 g b / 25%)" should set the property value Colors do not match.
 Actual:   rgba(25, 51, 153, 0.25)
 Expected: color(srgb 0.098 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL e.style['color'] = "rgb(from rebeccapurple r 25 b / 25%)" should set the property value Colors do not match.
 Actual:   rgba(102, 25, 153, 0.25)
 Expected: color(srgb 0.4 0.098 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g 25 / 25%)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 25, 0.25)
 Expected: color(srgb 0.4 0.2 0.098 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / 25%)" should set the property value Colors do not match.
 Actual:   rgba(25, 102, 153, 0.25)
 Expected: color(srgb 0.098 0.4 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / 25%)" should set the property value Colors do not match.
 Actual:   rgba(51, 25, 153, 0.25)
 Expected: color(srgb 0.2 0.098 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / 25%)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 25, 0.25)
 Expected: color(srgb 0.2 0.4 0.098 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple g b r)" should set the property value Colors do not match.
 Actual:   rgb(51, 153, 102)
 Expected: color(srgb 0.2 0.6 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple b alpha r / g)" should set the property value Colors do not match.
 Actual:   rgba(153, 255, 102, 0.2)
 Expected: color(srgb 0.6 1 0.4 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "rgb(from rebeccapurple r r r / r)" should set the property value Colors do not match.
 Actual:   rgba(102, 102, 102, 0.4)
 Expected: color(srgb 0.4 0.4 0.4 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple alpha alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1 1 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) g b r)" should set the property value Colors do not match.
 Actual:   rgb(102, 153, 51)
 Expected: color(srgb 0.4 0.6 0.2 / 0.8).
@@ -170,27 +170,27 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) b alpha r / g)" should set the property value Colors do not match.
 Actual:   rgba(153, 204, 51, 0.4)
 Expected: color(srgb 0.6 0.8 0.2 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r r r / r)" should set the property value Colors do not match.
 Actual:   rgba(51, 51, 51, 0.2)
 Expected: color(srgb 0.2 0.2 0.2 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) alpha alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(204, 204, 204, 0.8)
 Expected: color(srgb 0.8 0.8 0.8 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.0001, expected 0.8 but got 204
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.01, expected 0.8 but got 204
 FAIL e.style['color'] = "rgb(from rebeccapurple r 20% 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r 10 20%)" should set the property value Colors do not match.
 Actual:   rgb(102, 10, 51)
 Expected: color(srgb 0.4 0.0392 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple 0% 10 10)" should set the property value Colors do not match.
 Actual:   rgb(0, 10, 10)
 Expected: color(srgb 0 0.0392 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.0392 +/- 0.0001, expected 0.0392 but got 10
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.0392 +/- 0.01, expected 0.0392 but got 10
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 20% 10)" should set the property value Colors do not match.
 Actual:   rgb(51, 51, 10)
 Expected: color(srgb 0.2 0.2 0.0392 / 0.8).
@@ -206,27 +206,27 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "rgb(from rebeccapurple calc(r) calc(g) calc(b))" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r calc(g * 2) 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 102, 10)
 Expected: color(srgb 0.4 0.4 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple b calc(r * .5) 10)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 10)
 Expected: color(srgb 0.6 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "rgb(from rebeccapurple r calc(g * .5 + g * .5) 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r calc(b * .5 - g * .5) 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) calc(r) calc(g) calc(b) / calc(alpha))" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple none none none)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb none none none).
@@ -266,32 +266,32 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL e.style['color'] = "rgb(from rgb(20% none 60%) r g b)" should set the property value Colors do not match.
 Actual:   rgb(51, 0, 153)
 Expected: color(srgb 0.2 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20% 40% 60% / none) r g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from currentColor r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from hsl(120deg 20% 50% / .5) h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from hsl(from rebeccapurple h s l) h s l)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple 0 0% 0%)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -311,15 +311,15 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL e.style['color'] = "hsl(from rebeccapurple 0 s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rebeccapurple 0deg s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rebeccapurple h 0% l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 102, 102)
 Expected: color(srgb 0.4 0.4 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h s 0% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -327,19 +327,19 @@ Error: assert_equals: Color format is correct. expected "color(srgb   )" but got
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l / 0)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) 0 s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) 0deg s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h 0% l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 102, 102, 0.8)
 Expected: color(srgb 0.4 0.4 0.4 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s 0% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(0, 0, 0, 0.8)
 Expected: color(srgb 0 0 0 / 0.8).
@@ -347,63 +347,63 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s l / 0)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple 25 s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rebeccapurple 25deg s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rebeccapurple h 20% l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 82, 122)
 Expected: color(srgb 0.4 0.32 0.48).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h s 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(51, 25, 77)
 Expected: color(srgb 0.2 0.1 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l / .25)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0.25)
 Expected: color(srgb 0.4 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) 25 s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) 25deg s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h 20% l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(82, 102, 122, 0.8)
 Expected: color(srgb 0.32 0.4 0.48 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.32 +/- 0.0001, expected 0.32 but got 82
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.32 +/- 0.01, expected 0.32 but got 82
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(25, 51, 77, 0.8)
 Expected: color(srgb 0.1 0.2 0.3 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.1 +/- 0.0001, expected 0.1 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.1 +/- 0.01, expected 0.1 but got 25
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s l / .2)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple h l s)" should set the property value Colors do not match.
 Actual:   rgb(128, 77, 179)
 Expected: color(srgb 0.5 0.3 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hsl(from rebeccapurple h alpha l / s)" should set the property value Colors do not match.
 Actual:   rgba(102, 0, 204, 0.5)
 Expected: color(srgb 0.4 0 0.8 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h l l / l)" should set the property value Colors do not match.
 Actual:   rgba(102, 61, 143, 0.4)
 Expected: color(srgb 0.4 0.24 0.56 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1 1 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h l s)" should set the property value Colors do not match.
 Actual:   rgb(77, 128, 179)
 Expected: color(srgb 0.3 0.5 0.7 / 0.8).
@@ -411,23 +411,23 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h alpha l / s)" should set the property value Colors do not match.
 Actual:   rgba(20, 102, 184, 0.5)
 Expected: color(srgb 0.08 0.4 0.72 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.08 +/- 0.0001, expected 0.08 but got 20
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.08 +/- 0.01, expected 0.08 but got 20
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h l l / l)" should set the property value Colors do not match.
 Actual:   rgba(61, 102, 143, 0.4)
 Expected: color(srgb 0.24 0.4 0.56 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.24 +/- 0.0001, expected 0.24 but got 61
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.24 +/- 0.01, expected 0.24 but got 61
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(163, 204, 245, 0.8)
 Expected: color(srgb 0.64 0.8 0.96 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.64 +/- 0.0001, expected 0.64 but got 163
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.64 +/- 0.01, expected 0.64 but got 163
 FAIL e.style['color'] = "hsl(from rebeccapurple calc(h) calc(s) calc(l))" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) calc(h) calc(s) calc(l) / calc(alpha))" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple none none none)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb none none none).
@@ -479,144 +479,144 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hsl(from hsl(120deg 20% 50% / none) h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0)
 Expected: color(srgb 0.4 0.6 0.4 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from hsl(none 20% 50% / .5) h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 102, 102, 0.5)
 Expected: color(srgb 0.6 0.4 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from currentColor h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from hsl(120deg 20% 50% / .5) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from hwb(from rebeccapurple h w b) h w b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rebeccapurple 0 0% 0%)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple 0deg 0% 0%)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple 0 0% 0% / 0)" should set the property value Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple 0deg 0% 0% / 0)" should set the property value Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple 0 w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple 0deg w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h 0% b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(77, 0, 153)
 Expected: color(srgb 0.3 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 77
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.01, expected 0.3 but got 77
 FAIL e.style['color'] = "hwb(from rebeccapurple h w 0% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 255)
 Expected: color(srgb 0.6 0.2 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b / 0)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) 0 w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) 0deg w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h 0% b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(0, 77, 153, 0.8)
 Expected: color(srgb 0 0.3 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 77
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.01, expected 0.3 but got 77
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w 0% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 153, 255, 0.8)
 Expected: color(srgb 0.2 0.6 1 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w b / 0)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rebeccapurple 25 w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple 25deg w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h 20% b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rebeccapurple h w 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(128, 51, 204)
 Expected: color(srgb 0.5 0.2 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b / .2)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0.2)
 Expected: color(srgb 0.4 0.2 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) 25 w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) 25deg w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h 20% b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 128, 204, 0.8)
 Expected: color(srgb 0.2 0.5 0.8 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w b / .2)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rebeccapurple h b w)" should set the property value Colors do not match.
 Actual:   rgb(153, 102, 204)
 Expected: color(srgb 0.6 0.4 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h alpha w / b)" should set the property value Colors do not match.
 Actual:   rgba(213, 213, 213, 0.4)
 Expected: color(srgb 0.8333 0.8333 0.8333 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8333 +/- 0.0001, expected 0.8333 but got 213
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8333 +/- 0.01, expected 0.8333 but got 213
 FAIL e.style['color'] = "hwb(from rebeccapurple h w w / w)" should set the property value Colors do not match.
 Actual:   rgba(128, 51, 204, 0.2)
 Expected: color(srgb 0.5 0.2 0.8 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rebeccapurple h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(128, 128, 128)
 Expected: color(srgb 0.5 0.5 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h b w)" should set the property value Colors do not match.
 Actual:   rgb(102, 153, 204)
 Expected: color(srgb 0.4 0.6 0.8 / 0.8).
@@ -624,23 +624,23 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h alpha w / b)" should set the property value Colors do not match.
 Actual:   rgba(204, 204, 204, 0.4)
 Expected: color(srgb 0.8 0.8 0.8 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.0001, expected 0.8 but got 204
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.01, expected 0.8 but got 204
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w w / w)" should set the property value Colors do not match.
 Actual:   rgba(51, 128, 204, 0.2)
 Expected: color(srgb 0.2 0.5 0.8 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(128, 128, 128, 0.8)
 Expected: color(srgb 0.5 0.5 0.5 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rebeccapurple calc(h) calc(w) calc(b))" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) calc(h) calc(w) calc(b) / calc(alpha))" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rebeccapurple none none none)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb none none none).
@@ -680,11 +680,11 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hwb(from hwb(none none none) h w b)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from hwb(none none none / none) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from hwb(120deg none 50% / .5) h w b)" should set the property value Colors do not match.
 Actual:   rgb(0, 128, 0)
 Expected: color(srgb 0 0.5 0 / 0.5).
@@ -692,11 +692,11 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hwb(from hwb(120deg 20% 50% / none) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 128, 51, 0)
 Expected: color(srgb 0.2 0.5 0.2 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from hwb(none 20% 50% / .5) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(128, 51, 51, 0.5)
 Expected: color(srgb 0.5 0.2 0.2 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from currentColor h w b)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "lab(from lab(25 20 50) l a b)" should set the property value
 PASS e.style['color'] = "lab(from lab(25 20 50) l a b / alpha)" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/relative-color-out-of-gamut-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/relative-color-out-of-gamut-expected.txt
@@ -2,109 +2,109 @@
 FAIL Property color value 'rgb(from color(display-p3 0 1 0) r g b / alpha)' Colors do not match.
 Actual:   rgb(0, 249, 66)
 Expected: color(srgb -0.511814 1.01832 -0.310726).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.0001, expected -0.511814 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.01, expected -0.511814 but got 0
 FAIL Property color value 'rgb(from lab(100 104.3 -50.9) r g b)' Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1.59343 0.58802 1.40564).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.0001, expected 1.59343 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.01, expected 1.59343 but got 255
 FAIL Property color value 'rgb(from lab(0 104.3 -50.9) r g b)' Colors do not match.
 Actual:   rgb(42, 0, 34)
 Expected: color(srgb 0.351376 -0.213938 0.299501).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.0001, expected 0.351376 but got 42
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.01, expected 0.351376 but got 42
 FAIL Property color value 'rgb(from lch(100 116 334) r g b)' Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1.59328 0.58828 1.40527).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 255
 FAIL Property color value 'rgb(from lch(0 116 334) r g b)' Colors do not match.
 Actual:   rgb(42, 0, 34)
 Expected: color(srgb 0.351307 -0.213865 0.299236).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.0001, expected 0.351307 but got 42
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.01, expected 0.351307 but got 42
 FAIL Property color value 'rgb(from oklab(1 0.365 -0.16) r g b)' Colors do not match.
 Actual:   rgb(255, 249, 255)
 Expected: color(srgb 1.59295 0.360371 1.38571).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.0001, expected 1.59295 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.01, expected 1.59295 but got 255
 FAIL Property color value 'rgb(from oklab(0 0.365 -0.16) r g b)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0.0763893 -0.0456266 0.0932598).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763893 +/- 0.0001, expected 0.0763893 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763893 +/- 0.01, expected 0.0763893 but got 0
 FAIL Property color value 'rgb(from oklch(1 0.399 336.3) r g b)' Colors do not match.
 Actual:   rgb(255, 249, 255)
 Expected: color(srgb 1.59328 0.358736 1.38663).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 255
 FAIL Property color value 'rgb(from oklch(0 0.399 336.3) r g b)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0.0765362 -0.045825 0.0937443).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0765362 +/- 0.0001, expected 0.0765362 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0765362 +/- 0.01, expected 0.0765362 but got 0
 FAIL Property color value 'hsl(from color(display-p3 0 1 0) h s l / alpha)' Colors do not match.
 Actual:   rgb(0, 249, 66)
 Expected: color(srgb -0.511814 1.01832 -0.310726).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.0001, expected -0.511814 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.01, expected -0.511814 but got 0
 FAIL Property color value 'hsl(from lab(100 104.3 -50.9) h s l)' Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1.59343 0.58802 1.40564).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.0001, expected 1.59343 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.01, expected 1.59343 but got 255
 FAIL Property color value 'hsl(from lab(0 104.3 -50.9) h s l)' Colors do not match.
 Actual:   rgb(42, 0, 34)
 Expected: color(srgb 0.351376 -0.213938 0.299502).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.0001, expected 0.351376 but got 42
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.01, expected 0.351376 but got 42
 FAIL Property color value 'hsl(from lch(100 116 334) h s l)' Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1.59328 0.58828 1.40527).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 255
 FAIL Property color value 'hsl(from lch(0 116 334) h s l)' Colors do not match.
 Actual:   rgb(42, 0, 34)
 Expected: color(srgb 0.351307 -0.213865 0.299236).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.0001, expected 0.351307 but got 42
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.01, expected 0.351307 but got 42
 FAIL Property color value 'hsl(from oklab(1 0.365 -0.16) h s l)' Colors do not match.
 Actual:   rgb(255, 249, 255)
 Expected: color(srgb 1.59295 0.360371 1.38571).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.0001, expected 1.59295 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.01, expected 1.59295 but got 255
 FAIL Property color value 'hsl(from oklab(0 0.365 -0.16) h s l)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0.0763893 -0.0456266 0.0932598).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763893 +/- 0.0001, expected 0.0763893 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763893 +/- 0.01, expected 0.0763893 but got 0
 FAIL Property color value 'hsl(from oklch(1 0.399 336.3) h s l)' Colors do not match.
 Actual:   rgb(255, 249, 255)
 Expected: color(srgb 1.59328 0.358736 1.38663).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 255
 FAIL Property color value 'hsl(from oklch(0 0.399 336.3) h s l)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0.0765362 -0.045825 0.0937443).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0765362 +/- 0.0001, expected 0.0765362 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0765362 +/- 0.01, expected 0.0765362 but got 0
 FAIL Property color value 'hwb(from color(display-p3 0 1 0) h w b / alpha)' Colors do not match.
 Actual:   rgb(0, 249, 66)
 Expected: color(srgb -0.511814 1.01832 -0.310726).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.0001, expected -0.511814 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected -0.511814 +/- 0.01, expected -0.511814 but got 0
 FAIL Property color value 'hwb(from lab(100 104.3 -50.9) h w b)' Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1.59343 0.58802 1.40564).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.0001, expected 1.59343 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59343 +/- 0.01, expected 1.59343 but got 255
 FAIL Property color value 'hwb(from lab(0 104.3 -50.9) h w b)' Colors do not match.
 Actual:   rgb(42, 0, 34)
 Expected: color(srgb 0.351376 -0.213938 0.299502).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.0001, expected 0.351376 but got 42
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351376 +/- 0.01, expected 0.351376 but got 42
 FAIL Property color value 'hwb(from lch(100 116 334) h w b)' Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1.59328 0.58828 1.40527).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 255
 FAIL Property color value 'hwb(from lch(0 116 334) h w b)' Colors do not match.
 Actual:   rgb(42, 0, 34)
 Expected: color(srgb 0.351307 -0.213865 0.299236).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.0001, expected 0.351307 but got 42
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.351307 +/- 0.01, expected 0.351307 but got 42
 FAIL Property color value 'hwb(from oklab(1 0.365 -0.16) h w b)' Colors do not match.
 Actual:   rgb(255, 249, 255)
 Expected: color(srgb 1.59295 0.360371 1.38571).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.0001, expected 1.59295 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59295 +/- 0.01, expected 1.59295 but got 255
 FAIL Property color value 'hwb(from oklab(0 0.365 -0.16) h w b)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0.0763894 -0.0456266 0.0932598).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763894 +/- 0.0001, expected 0.0763894 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0763894 +/- 0.01, expected 0.0763894 but got 0
 FAIL Property color value 'hwb(from oklch(1 0.399 336.3) h w b)' Colors do not match.
 Actual:   rgb(255, 249, 255)
 Expected: color(srgb 1.59328 0.358736 1.38664).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.0001, expected 1.59328 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1.59328 +/- 0.01, expected 1.59328 but got 255
 FAIL Property color value 'hwb(from oklch(0 0.399 336.3) h w b)' Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0.0765362 -0.045825 0.0937443).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0765362 +/- 0.0001, expected 0.0765362 but got 0
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.0765362 +/- 0.01, expected 0.0765362 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/support/color-testcommon.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/support/color-testcommon.js
@@ -9,7 +9,7 @@
  */
 function set_up_fuzzy_color_test(epsilon) {
   if (!epsilon) {
-    epsilon = 0.0001;
+    epsilon = 0.01;
   }
 
   // The function

--- a/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt
+++ b/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt
@@ -1,488 +1,146 @@
 
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.32941177 0.36078432 0.23921569)
-Expected: color(srgb 0.33 0.36 0.24).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.33 +/- 0.0001, expected 0.33 but got 0.32941177
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451)
-Expected: color(srgb 0.4375 0.415625 0.2625).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20%), hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451)
-Expected: color(srgb 0.4375 0.415625 0.2625).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), 25% hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.23921569 0.28627452 0.21176471)
-Expected: color(srgb 0.240625 0.2875 0.2125).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.240625 +/- 0.0001, expected 0.240625 but got 0.23921569
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%) 25%)' Colors do not match.
-Actual:   color(srgb 0.23921569 0.28627452 0.21176471)
-Expected: color(srgb 0.240625 0.2875 0.2125).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.240625 +/- 0.0001, expected 0.240625 but got 0.23921569
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%) 75%)' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451)
-Expected: color(srgb 0.4375 0.415625 0.2625).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 30%, hsl(30deg 30% 40%) 90%)' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451)
-Expected: color(srgb 0.4375 0.415625 0.2625).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 12.5%, hsl(30deg 30% 40%) 37.5%)' Colors do not match.
-Actual:   color(srgb 0.4392157 0.41568628 0.2627451 / 0.5019608)
-Expected: color(srgb 0.4375 0.415625 0.2625 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4375 +/- 0.0001, expected 0.4375 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.52156866 0.4 0.2784314)
-Expected: color(srgb 0.52 0.4 0.28).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.37254903 0.4117647 0.25490198 / 0.6)
-Expected: color(srgb 0.372222 0.411111 0.255556 / 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.372222 +/- 0.0001, expected 0.372222 but got 0.37254903
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.42352942 0.40392157 0.25882354 / 0.8509804)
-Expected: color(srgb 0.42346 0.402889 0.258893 / 0.85).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.402889 +/- 0.0001, expected 0.402889 but got 0.40392157
-FAIL Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.4745098 0.44705883 0.27058825 / 0.7019608)
-Expected: color(srgb 0.472245 0.447041 0.270612 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.472245 +/- 0.0001, expected 0.472245 but got 0.4745098
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), 25% hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.26666668 0.32941177 0.23137255 / 0.5019608)
-Expected: color(srgb 0.2674 0.3304 0.2296 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2674 +/- 0.0001, expected 0.2674 but got 0.26666668
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8) 25%)' Colors do not match.
-Actual:   color(srgb 0.26666668 0.32941177 0.23137255 / 0.5019608)
-Expected: color(srgb 0.2674 0.3304 0.2296 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2674 +/- 0.0001, expected 0.2674 but got 0.26666668
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 25%, hsl(30deg 30% 40% / .8) 75%)' Colors do not match.
-Actual:   color(srgb 0.4745098 0.44705883 0.27058825 / 0.7019608)
-Expected: color(srgb 0.472245 0.447041 0.270612 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.472245 +/- 0.0001, expected 0.472245 but got 0.4745098
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 30%, hsl(30deg 30% 40% / .8) 90%)' Colors do not match.
-Actual:   color(srgb 0.4745098 0.44705883 0.27058825 / 0.7019608)
-Expected: color(srgb 0.472245 0.447041 0.270612 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.472245 +/- 0.0001, expected 0.472245 but got 0.4745098
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 12.5%, hsl(30deg 30% 40% / .8) 37.5%)' Colors do not match.
-Actual:   color(srgb 0.4745098 0.44705883 0.27058825 / 0.34901962)
-Expected: color(srgb 0.472245 0.447041 0.270612 / 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.472245 +/- 0.0001, expected 0.472245 but got 0.4745098
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.52156866 0.4 0.2784314 / 0.8)
-Expected: color(srgb 0.52 0.4 0.28 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20%), hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), 25% hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%) 25%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%) 75%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 30%, hsl(30deg 30% 40%) 90%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 12.5%, hsl(30deg 30% 40%) 37.5%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), 25% hsl(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8) 25%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 25%, hsl(30deg 30% 40% / .8) 75%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 30%, hsl(30deg 30% 40% / .8) 90%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 12.5%, hsl(30deg 30% 40% / .8) 37.5%)'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8))'
 FAIL Property color value 'color-mix(in hsl, transparent, hsl(30deg 30% 40%))' Colors do not match.
 Actual:   color(srgb 0.52156866 0.34117648 0.2784314 / 0.5019608)
 Expected: color(srgb 0.52 0.4 0.28 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.01, expected 0.4 but got 0.34117648
 FAIL Property color value 'color-mix(in hsl, transparent 10%, hsl(30deg 30% 40%))' Colors do not match.
 Actual:   color(srgb 0.52156866 0.3882353 0.2784314 / 0.9019608)
 Expected: color(srgb 0.52 0.4 0.28 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0), hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.4627451 0.52156866 0.2784314 / 0.5019608)
-Expected: color(srgb 0.46 0.52 0.28 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.46 +/- 0.0001, expected 0.46 but got 0.4627451
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0) 10%, hsl(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.52156866 0.43529412 0.2784314 / 0.9019608)
-Expected: color(srgb 0.52 0.436 0.28 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.52 +/- 0.0001, expected 0.52 but got 0.52156866
-FAIL Property color value 'color-mix(in hsl, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl shorter hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.33333334 0.7490196)
-Expected: color(srgb 0.25 0.333333 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.33333334 0.7490196)
-Expected: color(srgb 0.25 0.333333 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.6666667 0.7490196)
-Expected: color(srgb 0.25 0.666667 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.6666667 0.7490196)
-Expected: color(srgb 0.25 0.666667 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.7490196 0.6666667)
-Expected: color(srgb 0.25 0.75 0.666667).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl longer hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.7490196 0.6666667)
-Expected: color(srgb 0.25 0.75 0.666667).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.33333334 0.7490196)
-Expected: color(srgb 0.25 0.333333 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.6666667 0.7490196)
-Expected: color(srgb 0.25 0.666667 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.7490196 0.6666667)
-Expected: color(srgb 0.25 0.75 0.666667).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl increasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.33333334 0.7490196)
-Expected: color(srgb 0.25 0.333333 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.6666667 0.2509804)
-Expected: color(srgb 0.75 0.666667 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.33333334 0.2509804)
-Expected: color(srgb 0.75 0.333333 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.6666667 0.7490196)
-Expected: color(srgb 0.25 0.666667 0.75).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.7490196 0.2509804 0.33333334)
-Expected: color(srgb 0.75 0.25 0.333333).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.75 +/- 0.0001, expected 0.75 but got 0.7490196
-FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' Colors do not match.
-Actual:   color(srgb 0.2509804 0.7490196 0.6666667)
-Expected: color(srgb 0.25 0.75 0.666667).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.25 +/- 0.0001, expected 0.25 but got 0.2509804
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.01, expected 0.4 but got 0.3882353
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0), hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0) 10%, hsl(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl shorter hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl longer hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl increasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))'
+PASS Property color value 'color-mix(in hsl decreasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))'
 FAIL Property color value 'color-mix(in hsl, hsl(none none none), hsl(none none none))' Colors do not match.
 Actual:   color(srgb 0 0 0)
 Expected: color(srgb none none none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 0 got 3
-FAIL Property color value 'color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))' Colors do not match.
-Actual:   color(srgb 0.8784314 0.8 0.72156864)
-Expected: color(srgb 0.88 0.8 0.72).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.88 +/- 0.0001, expected 0.88 but got 0.8784314
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))' Colors do not match.
-Actual:   color(srgb 0.32156864 0.47843137 0.32156864)
-Expected: color(srgb 0.32 0.48 0.32).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.32 +/- 0.0001, expected 0.32 but got 0.32156864
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))' Colors do not match.
-Actual:   color(srgb 0.65882355 0.72156864 0.47843137)
-Expected: color(srgb 0.66 0.72 0.48).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.66 +/- 0.0001, expected 0.66 but got 0.65882355
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))' Colors do not match.
-Actual:   color(srgb 0.4392157 0.47843137 0.32156864)
-Expected: color(srgb 0.44 0.48 0.32).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.44 +/- 0.0001, expected 0.44 but got 0.4392157
-FAIL Property color value 'color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))' Colors do not match.
-Actual:   color(srgb 0.6784314 0.6 0.52156866)
-Expected: color(srgb 0.68 0.6 0.52).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.68 +/- 0.0001, expected 0.68 but got 0.6784314
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))' Colors do not match.
-Actual:   color(srgb 0.56078434 0.56078434 0.23921569)
-Expected: color(srgb 0.56 0.56 0.24).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.56 +/- 0.0001, expected 0.56 but got 0.56078434
-FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))' Colors do not match.
-Actual:   color(srgb 0.56078434 0.56078434 0.23921569 / 0.5019608)
-Expected: color(srgb 0.56 0.56 0.24 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.56 +/- 0.0001, expected 0.56 but got 0.56078434
+PASS Property color value 'color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))'
+PASS Property color value 'color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))'
+PASS Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))'
 FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))' Colors do not match.
 Actual:   color(srgb 0.56078434 0.56078434 0.23921569 / 0)
 Expected: color(srgb 0.56 0.56 0.24 / none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.5764706 0.7019608 0.20392157)
-Expected: color(srgb 0.575 0.7 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.575 +/- 0.0001, expected 0.575 but got 0.5764706
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804)
-Expected: color(srgb 0.65 0.6 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804)
-Expected: color(srgb 0.65 0.6 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3764706 0.7490196 0.15294118)
-Expected: color(srgb 0.375 0.75 0.15).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.375 +/- 0.0001, expected 0.375 but got 0.3764706
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%) 25%)' Colors do not match.
-Actual:   color(srgb 0.3764706 0.7490196 0.15294118)
-Expected: color(srgb 0.375 0.75 0.15).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.375 +/- 0.0001, expected 0.375 but got 0.3764706
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%) 75%)' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804)
-Expected: color(srgb 0.65 0.6 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 30%, hwb(30deg 30% 40%) 90%)' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804)
-Expected: color(srgb 0.65 0.6 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 12.5%, hwb(30deg 30% 40%) 37.5%)' Colors do not match.
-Actual:   color(srgb 0.6509804 0.6 0.2509804 / 0.5019608)
-Expected: color(srgb 0.65 0.6 0.25 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.4509804 0.3019608)
-Expected: color(srgb 0.6 0.45 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.4509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.56078434 0.6666667 0.23529412 / 0.6)
-Expected: color(srgb 0.558333 0.666667 0.233333 / 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.558333 +/- 0.0001, expected 0.558333 but got 0.56078434
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.7019608)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.7019608)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.37254903 0.75686276 0.14509805 / 0.9490196)
-Expected: color(srgb 0.373026 0.757895 0.142105 / 0.95).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.373026 +/- 0.0001, expected 0.373026 but got 0.37254903
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8) 25%)' Colors do not match.
-Actual:   color(srgb 0.38431373 0.72156864 0.18039216 / 0.5019608)
-Expected: color(srgb 0.3825 0.72 0.18 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3825 +/- 0.0001, expected 0.3825 but got 0.38431373
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8) 75%)' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.7019608)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 30%, hwb(30deg 30% 40% / .8) 90%)' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.7019608)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 12.5%, hwb(30deg 30% 40% / .8) 37.5%)' Colors do not match.
-Actual:   color(srgb 0.627451 0.58431375 0.27450982 / 0.34901962)
-Expected: color(srgb 0.628571 0.583929 0.271429 / 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.628571 +/- 0.0001, expected 0.628571 but got 0.627451
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8))' Colors do not match.
-Actual:   color(srgb 0.6 0.4509804 0.3019608 / 0.8)
-Expected: color(srgb 0.6 0.45 0.3 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.4509804
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%) 25%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%) 75%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 30%, hwb(30deg 30% 40%) 90%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 12.5%, hwb(30deg 30% 40%) 37.5%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40% / .8))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8) 25%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8) 75%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 30%, hwb(30deg 30% 40% / .8) 90%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 12.5%, hwb(30deg 30% 40% / .8) 37.5%)'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8))'
 FAIL Property color value 'color-mix(in hwb, transparent, hwb(30deg 30% 40%))' Colors do not match.
 Actual:   color(srgb 0.6 0.3764706 0.3019608 / 0.5019608)
 Expected: color(srgb 0.6 0.45 0.3 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.3764706
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.01, expected 0.45 but got 0.3764706
 FAIL Property color value 'color-mix(in hwb, transparent 10%, hwb(30deg 30% 40%))' Colors do not match.
 Actual:   color(srgb 0.6 0.43529412 0.3019608 / 0.9019608)
 Expected: color(srgb 0.6 0.45 0.3 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.43529412
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.5254902 0.6 0.3019608 / 0.5019608)
-Expected: color(srgb 0.525 0.6 0.3 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.525 +/- 0.0001, expected 0.525 but got 0.5254902
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0) 10%, hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.49411765 0.3019608 / 0.9019608)
-Expected: color(srgb 0.6 0.495 0.3 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.495 +/- 0.0001, expected 0.495 but got 0.49411765
-FAIL Property color value 'color-mix(in hwb, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.54901963 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.54901963
-FAIL Property color value 'color-mix(in hwb, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.54901963 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.54901963
-FAIL Property color value 'color-mix(in hwb, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.54901963 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.54901963
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.54901963 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.54901963
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb shorter hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.34901962 0.6)
-Expected: color(srgb 0.3 0.35 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.34901962 0.6)
-Expected: color(srgb 0.3 0.35 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.54901963 0.6)
-Expected: color(srgb 0.3 0.55 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.54901963 0.6)
-Expected: color(srgb 0.3 0.55 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.6 0.54901963)
-Expected: color(srgb 0.3 0.6 0.55).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb longer hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.6 0.54901963)
-Expected: color(srgb 0.3 0.6 0.55).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.54901963 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.54901963
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.34901962 0.6)
-Expected: color(srgb 0.3 0.35 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.54901963 0.6)
-Expected: color(srgb 0.3 0.55 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.6 0.54901963)
-Expected: color(srgb 0.3 0.6 0.55).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb increasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.34901962 0.6)
-Expected: color(srgb 0.3 0.35 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.54901963 0.3019608)
-Expected: color(srgb 0.6 0.55 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.55 +/- 0.0001, expected 0.55 but got 0.54901963
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.34901962 0.3019608)
-Expected: color(srgb 0.6 0.35 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.35 +/- 0.0001, expected 0.35 but got 0.34901962
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.54901963 0.6)
-Expected: color(srgb 0.3 0.55 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.3019608 0.34901962)
-Expected: color(srgb 0.6 0.3 0.35).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
-FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.3019608 0.6 0.54901963)
-Expected: color(srgb 0.3 0.6 0.55).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 0.3019608
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.01, expected 0.45 but got 0.43529412
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0) 10%, hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb shorter hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb longer hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb increasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb decreasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))'
 FAIL Property color value 'color-mix(in hwb, hwb(none none none), hwb(none none none))' Colors do not match.
 Actual:   color(srgb 1 0 0)
 Expected: color(srgb none none none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 0 got 3
-FAIL Property color value 'color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.6 0.4509804 0.3019608)
-Expected: color(srgb 0.6 0.45 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.45 +/- 0.0001, expected 0.45 but got 0.4509804
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))' Colors do not match.
-Actual:   color(srgb 0.101960786 0.8 0.101960786)
-Expected: color(srgb 0.1 0.8 0.1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.1 +/- 0.0001, expected 0.1 but got 0.101960786
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.5019608 0.6 0.2)
-Expected: color(srgb 0.5 0.6 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 0.5019608
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))' Colors do not match.
-Actual:   color(srgb 0.6509804 0.8 0.2)
-Expected: color(srgb 0.65 0.8 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.65 +/- 0.0001, expected 0.65 but got 0.6509804
-FAIL Property color value 'color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))' Colors do not match.
-Actual:   color(srgb 0.7019608 0.4 0.101960786)
-Expected: color(srgb 0.7 0.4 0.1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.7 +/- 0.0001, expected 0.7 but got 0.7019608
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))' Colors do not match.
-Actual:   color(srgb 0.5764706 0.7019608 0.2)
-Expected: color(srgb 0.575 0.7 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.575 +/- 0.0001, expected 0.575 but got 0.5764706
-FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))' Colors do not match.
-Actual:   color(srgb 0.5764706 0.7019608 0.2 / 0.5019608)
-Expected: color(srgb 0.575 0.7 0.2 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.575 +/- 0.0001, expected 0.575 but got 0.5764706
+PASS Property color value 'color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))'
+PASS Property color value 'color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))'
+PASS Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))'
 FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))' Colors do not match.
 Actual:   color(srgb 0.5764706 0.7019608 0.2 / 0)
 Expected: color(srgb 0.575 0.7 0.2 / none).
@@ -508,11 +166,11 @@ PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4) 0%, lch(50 60
 FAIL Property color value 'color-mix(in lch, transparent, lch(0.3 0.4 30deg))' Colors do not match.
 Actual:   lch(0.3 0.4 15 / 0.5)
 Expected: lch(0.3 0.4 30 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.0001, expected 30 but got 15
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.01, expected 30 but got 15
 FAIL Property color value 'color-mix(in lch, transparent 10%, lch(0.3 0.4 30deg))' Colors do not match.
 Actual:   lch(0.3 0.40000004 27 / 0.9)
 Expected: lch(0.3 0.4 30 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.0001, expected 30 but got 27
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.01, expected 30 but got 27
 PASS Property color value 'color-mix(in lch, lch(0.1 0.2 120deg / 0), lch(0.3 0.4 30deg))'
 PASS Property color value 'color-mix(in lch, lch(0.1 0.2 120deg / 0) 10%, lch(0.3 0.4 30deg))'
 PASS Property color value 'color-mix(in lch, lch(100 0 40deg), lch(100 0 60deg))'
@@ -575,11 +233,11 @@ PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4) 0%, okl
 FAIL Property color value 'color-mix(in oklch, transparent, oklch(0.3 40 30deg))' Colors do not match.
 Actual:   oklch(0.3 40 15 / 0.5)
 Expected: oklch(0.3 40 30 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.0001, expected 30 but got 15
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.01, expected 30 but got 15
 FAIL Property color value 'color-mix(in oklch, transparent 10%, oklch(0.3 40 30deg))' Colors do not match.
 Actual:   oklch(0.3 40 27 / 0.9)
 Expected: oklch(0.3 40 30 / 0.9).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.0001, expected 30 but got 27
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected 30 +/- 0.01, expected 30 but got 27
 PASS Property color value 'color-mix(in oklch, oklch(0.1 20 120deg / 0), oklch(0.3 40 30deg))'
 PASS Property color value 'color-mix(in oklch, oklch(0.1 20 120deg / 0) 10%, oklch(0.3 40 30deg))'
 PASS Property color value 'color-mix(in oklch, oklch(1 0 40deg), oklch(1 0 60deg))'

--- a/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
+++ b/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
@@ -2,23 +2,23 @@
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from hsl(120deg 20% 50% / .5) r g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(from rebeccapurple r g b) r g b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple 0 0 0)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -30,139 +30,139 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL e.style['color'] = "rgb(from rebeccapurple 0 g b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(0, 51, 153)
 Expected: color(srgb 0 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple r 0 b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 0, 153)
 Expected: color(srgb 0.4 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g 0 / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 0)
 Expected: color(srgb 0.4 0.2 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b / 0)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) 0 g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(0, 102, 153, 0.8)
 Expected: color(srgb 0 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 0 b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 0, 153, 0.8)
 Expected: color(srgb 0.2 0 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g 0 / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 0, 0.8)
 Expected: color(srgb 0.2 0.4 0 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g b / 0)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple 25 g b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(25, 51, 153)
 Expected: color(srgb 0.098 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL e.style['color'] = "rgb(from rebeccapurple r 25 b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 25, 153)
 Expected: color(srgb 0.4 0.098 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g 25 / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 25)
 Expected: color(srgb 0.4 0.2 0.098).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b / .25)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0.25)
 Expected: color(srgb 0.4 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(25, 102, 153, 0.8)
 Expected: color(srgb 0.098 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 25, 153, 0.8)
 Expected: color(srgb 0.2 0.098 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 25, 0.8)
 Expected: color(srgb 0.2 0.4 0.098 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g b / .20)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple 20% g b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(51, 51, 153)
 Expected: color(srgb 0.2 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple r 20% b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 51)
 Expected: color(srgb 0.4 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g b / 20%)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0.2)
 Expected: color(srgb 0.4 0.2 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) 20% g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 20% b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 51, 153, 0.8)
 Expected: color(srgb 0.2 0.2 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 51, 0.8)
 Expected: color(srgb 0.2 0.4 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g b / 20%)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple 25 g b / 25%)" should set the property value Colors do not match.
 Actual:   rgba(25, 51, 153, 0.25)
 Expected: color(srgb 0.098 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL e.style['color'] = "rgb(from rebeccapurple r 25 b / 25%)" should set the property value Colors do not match.
 Actual:   rgba(102, 25, 153, 0.25)
 Expected: color(srgb 0.4 0.098 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r g 25 / 25%)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 25, 0.25)
 Expected: color(srgb 0.4 0.2 0.098 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) 25 g b / 25%)" should set the property value Colors do not match.
 Actual:   rgba(25, 102, 153, 0.25)
 Expected: color(srgb 0.098 0.4 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.0001, expected 0.098 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.098 +/- 0.01, expected 0.098 but got 25
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 25 b / 25%)" should set the property value Colors do not match.
 Actual:   rgba(51, 25, 153, 0.25)
 Expected: color(srgb 0.2 0.098 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r g 25 / 25%)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 25, 0.25)
 Expected: color(srgb 0.2 0.4 0.098 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple g b r)" should set the property value Colors do not match.
 Actual:   rgb(51, 153, 102)
 Expected: color(srgb 0.2 0.6 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple b alpha r / g)" should set the property value Colors do not match.
 Actual:   rgba(153, 255, 102, 0.2)
 Expected: color(srgb 0.6 1 0.4 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "rgb(from rebeccapurple r r r / r)" should set the property value Colors do not match.
 Actual:   rgba(102, 102, 102, 0.4)
 Expected: color(srgb 0.4 0.4 0.4 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple alpha alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1 1 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) g b r)" should set the property value Colors do not match.
 Actual:   rgb(102, 153, 51)
 Expected: color(srgb 0.4 0.6 0.2 / 0.8).
@@ -170,27 +170,27 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) b alpha r / g)" should set the property value Colors do not match.
 Actual:   rgba(153, 204, 51, 0.4)
 Expected: color(srgb 0.6 0.8 0.2 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r r r / r)" should set the property value Colors do not match.
 Actual:   rgba(51, 51, 51, 0.2)
 Expected: color(srgb 0.2 0.2 0.2 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) alpha alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(204, 204, 204, 0.8)
 Expected: color(srgb 0.8 0.8 0.8 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.0001, expected 0.8 but got 204
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.01, expected 0.8 but got 204
 FAIL e.style['color'] = "rgb(from rebeccapurple r 20% 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r 10 20%)" should set the property value Colors do not match.
 Actual:   rgb(102, 10, 51)
 Expected: color(srgb 0.4 0.0392 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple 0% 10 10)" should set the property value Colors do not match.
 Actual:   rgb(0, 10, 10)
 Expected: color(srgb 0 0.0392 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.0392 +/- 0.0001, expected 0.0392 but got 10
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.0392 +/- 0.01, expected 0.0392 but got 10
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r 20% 10)" should set the property value Colors do not match.
 Actual:   rgb(51, 51, 10)
 Expected: color(srgb 0.2 0.2 0.0392 / 0.8).
@@ -206,27 +206,27 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "rgb(from rebeccapurple calc(r) calc(g) calc(b))" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r calc(g * 2) 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 102, 10)
 Expected: color(srgb 0.4 0.4 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple b calc(r * .5) 10)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 10)
 Expected: color(srgb 0.6 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "rgb(from rebeccapurple r calc(g * .5 + g * .5) 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rebeccapurple r calc(b * .5 - g * .5) 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) calc(r) calc(g) calc(b) / calc(alpha))" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple none none none)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb none none none).
@@ -266,32 +266,32 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL e.style['color'] = "rgb(from rgb(20% none 60%) r g b)" should set the property value Colors do not match.
 Actual:   rgb(51, 0, 153)
 Expected: color(srgb 0.2 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rgb(20% 40% 60% / none) r g b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from currentColor r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from hsl(120deg 20% 50% / .5) h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from hsl(from rebeccapurple h s l) h s l)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple 0 0% 0%)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -311,15 +311,15 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL e.style['color'] = "hsl(from rebeccapurple 0 s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rebeccapurple 0deg s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rebeccapurple h 0% l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 102, 102)
 Expected: color(srgb 0.4 0.4 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h s 0% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -327,19 +327,19 @@ Error: assert_equals: Color format is correct. expected "color(srgb   )" but got
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l / 0)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) 0 s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) 0deg s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h 0% l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 102, 102, 0.8)
 Expected: color(srgb 0.4 0.4 0.4 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s 0% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(0, 0, 0, 0.8)
 Expected: color(srgb 0 0 0 / 0.8).
@@ -347,63 +347,63 @@ Error: assert_equals: Color format is correct. expected "color(srgb    / )" but 
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s l / 0)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple 25 s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rebeccapurple 25deg s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rebeccapurple h 20% l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 82, 122)
 Expected: color(srgb 0.4 0.32 0.48).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h s 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(51, 25, 77)
 Expected: color(srgb 0.2 0.1 0.3).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l / .25)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0.25)
 Expected: color(srgb 0.4 0.2 0.6 / 0.25).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) 25 s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) 25deg s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h 20% l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(82, 102, 122, 0.8)
 Expected: color(srgb 0.32 0.4 0.48 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.32 +/- 0.0001, expected 0.32 but got 82
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.32 +/- 0.01, expected 0.32 but got 82
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(25, 51, 77, 0.8)
 Expected: color(srgb 0.1 0.2 0.3 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.1 +/- 0.0001, expected 0.1 but got 25
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.1 +/- 0.01, expected 0.1 but got 25
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h s l / .2)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple h l s)" should set the property value Colors do not match.
 Actual:   rgb(128, 77, 179)
 Expected: color(srgb 0.5 0.3 0.7).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hsl(from rebeccapurple h alpha l / s)" should set the property value Colors do not match.
 Actual:   rgba(102, 0, 204, 0.5)
 Expected: color(srgb 0.4 0 0.8 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h l l / l)" should set the property value Colors do not match.
 Actual:   rgba(102, 61, 143, 0.4)
 Expected: color(srgb 0.4 0.24 0.56 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rebeccapurple h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(255, 255, 255)
 Expected: color(srgb 1 1 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h l s)" should set the property value Colors do not match.
 Actual:   rgb(77, 128, 179)
 Expected: color(srgb 0.3 0.5 0.7 / 0.8).
@@ -411,23 +411,23 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h alpha l / s)" should set the property value Colors do not match.
 Actual:   rgba(20, 102, 184, 0.5)
 Expected: color(srgb 0.08 0.4 0.72 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.08 +/- 0.0001, expected 0.08 but got 20
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.08 +/- 0.01, expected 0.08 but got 20
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h l l / l)" should set the property value Colors do not match.
 Actual:   rgba(61, 102, 143, 0.4)
 Expected: color(srgb 0.24 0.4 0.56 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.24 +/- 0.0001, expected 0.24 but got 61
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.24 +/- 0.01, expected 0.24 but got 61
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(163, 204, 245, 0.8)
 Expected: color(srgb 0.64 0.8 0.96 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.64 +/- 0.0001, expected 0.64 but got 163
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.64 +/- 0.01, expected 0.64 but got 163
 FAIL e.style['color'] = "hsl(from rebeccapurple calc(h) calc(s) calc(l))" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) calc(h) calc(s) calc(l) / calc(alpha))" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple none none none)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb none none none).
@@ -479,144 +479,144 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hsl(from hsl(120deg 20% 50% / none) h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0)
 Expected: color(srgb 0.4 0.6 0.4 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hsl(from hsl(none 20% 50% / .5) h s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 102, 102, 0.5)
 Expected: color(srgb 0.6 0.4 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from currentColor h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from hsl(120deg 20% 50% / .5) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0.5)
 Expected: color(srgb 0.4 0.6 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from hwb(from rebeccapurple h w b) h w b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rebeccapurple 0 0% 0%)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple 0deg 0% 0%)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple 0 0% 0% / 0)" should set the property value Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple 0deg 0% 0% / 0)" should set the property value Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple 0 w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple 0deg w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
 Expected: color(srgb 0.6 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h 0% b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(77, 0, 153)
 Expected: color(srgb 0.3 0 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.0001, expected 0.3 but got 77
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.3 +/- 0.01, expected 0.3 but got 77
 FAIL e.style['color'] = "hwb(from rebeccapurple h w 0% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 255)
 Expected: color(srgb 0.6 0.2 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b / 0)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) 0 w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) 0deg w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 51, 51, 0.8)
 Expected: color(srgb 0.6 0.2 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h 0% b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(0, 77, 153, 0.8)
 Expected: color(srgb 0 0.3 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.0001, expected 0.3 but got 77
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 1, expected 0.3 +/- 0.01, expected 0.3 but got 77
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w 0% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 153, 255, 0.8)
 Expected: color(srgb 0.2 0.6 1 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w b / 0)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rebeccapurple 25 w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple 25deg w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 94, 51)
 Expected: color(srgb 0.6 0.3667 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h 20% b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rebeccapurple h w 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgb(128, 51, 204)
 Expected: color(srgb 0.5 0.2 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b / .2)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0.2)
 Expected: color(srgb 0.4 0.2 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) 25 w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) 25deg w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 94, 51, 0.8)
 Expected: color(srgb 0.6 0.3667 0.2 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h 20% b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w 20% / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 128, 204, 0.8)
 Expected: color(srgb 0.2 0.5 0.8 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w b / .2)" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.2)
 Expected: color(srgb 0.2 0.4 0.6 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rebeccapurple h b w)" should set the property value Colors do not match.
 Actual:   rgb(153, 102, 204)
 Expected: color(srgb 0.6 0.4 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.0001, expected 0.6 but got 153
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h alpha w / b)" should set the property value Colors do not match.
 Actual:   rgba(213, 213, 213, 0.4)
 Expected: color(srgb 0.8333 0.8333 0.8333 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8333 +/- 0.0001, expected 0.8333 but got 213
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8333 +/- 0.01, expected 0.8333 but got 213
 FAIL e.style['color'] = "hwb(from rebeccapurple h w w / w)" should set the property value Colors do not match.
 Actual:   rgba(128, 51, 204, 0.2)
 Expected: color(srgb 0.5 0.2 0.8 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rebeccapurple h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(128, 128, 128)
 Expected: color(srgb 0.5 0.5 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h b w)" should set the property value Colors do not match.
 Actual:   rgb(102, 153, 204)
 Expected: color(srgb 0.4 0.6 0.8 / 0.8).
@@ -624,23 +624,23 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h alpha w / b)" should set the property value Colors do not match.
 Actual:   rgba(204, 204, 204, 0.4)
 Expected: color(srgb 0.8 0.8 0.8 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.0001, expected 0.8 but got 204
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.01, expected 0.8 but got 204
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w w / w)" should set the property value Colors do not match.
 Actual:   rgba(51, 128, 204, 0.2)
 Expected: color(srgb 0.2 0.5 0.8 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(128, 128, 128, 0.8)
 Expected: color(srgb 0.5 0.5 0.5 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rebeccapurple calc(h) calc(w) calc(b))" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.0001, expected 0.4 but got 102
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) calc(h) calc(w) calc(b) / calc(alpha))" should set the property value Colors do not match.
 Actual:   rgba(51, 102, 153, 0.8)
 Expected: color(srgb 0.2 0.4 0.6 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rebeccapurple none none none)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb none none none).
@@ -680,11 +680,11 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hwb(from hwb(none none none) h w b)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from hwb(none none none / none) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
 Expected: color(srgb 1 0 0 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.0001, expected 1 but got 255
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from hwb(120deg none 50% / .5) h w b)" should set the property value Colors do not match.
 Actual:   rgb(0, 128, 0)
 Expected: color(srgb 0 0.5 0 / 0.5).
@@ -692,11 +692,11 @@ Error: assert_array_approx_equals: Numeric parameters are approximately equal. l
 FAIL e.style['color'] = "hwb(from hwb(120deg 20% 50% / none) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 128, 51, 0)
 Expected: color(srgb 0.2 0.5 0.2 / 0).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.0001, expected 0.2 but got 51
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from hwb(none 20% 50% / .5) h w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(128, 51, 51, 0.5)
 Expected: color(srgb 0.5 0.2 0.2 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.0001, expected 0.5 but got 128
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from currentColor h w b)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "lab(from lab(25 20 50) l a b)" should set the property value
 PASS e.style['color'] = "lab(from lab(25 20 50) l a b / alpha)" should set the property value

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a button assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 7 got 3
+FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a button assert_equals: expected "rgba(0, 0, 0, 0.847) rgb(192, 192, 192)" but got "rgb(255, 255, 255)"
 PASS Property color value 'ButtonFace' resolves to the same color as the background-color of a button
 PASS Property color value 'ButtonText' resolves to the same color as text on a button
-FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a submit button assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 7 got 3
+FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a submit button assert_equals: expected "rgba(0, 0, 0, 0.847) rgb(192, 192, 192)" but got "rgb(255, 255, 255)"
 PASS Property color value 'ButtonFace' resolves to the same color as the background-color of a submit button
 PASS Property color value 'ButtonText' resolves to the same color as text on a submit button
-FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a reset button assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 7 got 3
+FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a reset button assert_equals: expected "rgba(0, 0, 0, 0.847) rgb(192, 192, 192)" but got "rgb(255, 255, 255)"
 PASS Property color value 'ButtonFace' resolves to the same color as the background-color of a reset button
 PASS Property color value 'ButtonText' resolves to the same color as text on a reset button
-FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a color picker assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 128 +/- 1, expected 128 but got 255
-FAIL Property color value 'ButtonFace' resolves to the same color as the background-color of a color picker assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 255 +/- 1, expected 255 but got 192
-FAIL Property color value 'ButtonText' resolves to the same color as text on a color picker assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+FAIL Property color value 'ButtonBorder' resolves to the same color as the border-color of a color picker assert_equals: expected "rgb(128, 128, 128)" but got "rgb(255, 255, 255)"
+FAIL Property color value 'ButtonFace' resolves to the same color as the background-color of a color picker assert_equals: expected "rgb(255, 255, 255)" but got "rgb(192, 192, 192)"
+FAIL Property color value 'ButtonText' resolves to the same color as text on a color picker assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
 PASS Property color value 'CanvasText' has the same color as the color of the html element
 PASS Property color value 'Field' resolves to the same color as the background-color of a text field
-FAIL Property color value 'FieldText' resolves to the same color as text on a text field assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+FAIL Property color value 'FieldText' resolves to the same color as text on a text field assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
 PASS Property color value 'Field' resolves to the same color as the background-color of a password field
-FAIL Property color value 'FieldText' resolves to the same color as text on a password field assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+FAIL Property color value 'FieldText' resolves to the same color as text on a password field assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
 PASS Property color value 'Field' resolves to the same color as the background-color of a email field
-FAIL Property color value 'FieldText' resolves to the same color as text on a email field assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+FAIL Property color value 'FieldText' resolves to the same color as text on a email field assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
 PASS Property color value 'Field' resolves to the same color as the background-color of a number field
-FAIL Property color value 'FieldText' resolves to the same color as text on a number field assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+FAIL Property color value 'FieldText' resolves to the same color as text on a number field assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
 PASS Property color value 'Field' resolves to the same color as the background-color of a date field
-FAIL Property color value 'FieldText' resolves to the same color as text on a date field assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+FAIL Property color value 'FieldText' resolves to the same color as text on a date field assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
 PASS Property color value 'Field' resolves to the same color as the background-color of a text area
-FAIL Property color value 'FieldText' resolves to the same color as text on a text area assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+FAIL Property color value 'FieldText' resolves to the same color as text on a text area assert_equals: expected "rgb(0, 0, 0)" but got "rgba(0, 0, 0, 0.847)"
 PASS Property color value 'Mark' has the same color as the background-color of a mark element
 PASS Property color value 'MarkText' has the same color as the color of a mark element
 


### PR DESCRIPTION
#### b5c9f2b58dc3e9774980bc4c071f96180db01e80
<pre>
Increase fuzziness of css-color serialization WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=261929">https://bugs.webkit.org/show_bug.cgi?id=261929</a>
rdar://115872312

Reviewed by Youenn Fablet.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-mix-out-of-gamut-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/relative-color-out-of-gamut-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/support/color-testcommon.js:
* LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt:
* LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt:

Canonical link: <a href="https://commits.webkit.org/268311@main">https://commits.webkit.org/268311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67cd745b69cc04f64e5c8fd5ee774dc273b794f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/19315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20332 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/21206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19858 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/21206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/19534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/22075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/22075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/22075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/17481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2359 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->