### PR TITLE
Store fewer raw pointers in containers in Source/WebKit

### DIFF
--- a/Source/JavaScriptCore/inspector/InspectorTarget.h
+++ b/Source/JavaScriptCore/inspector/InspectorTarget.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "InspectorFrontendChannel.h"
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace Inspector {
@@ -38,7 +39,7 @@ enum class InspectorTargetType : uint8_t {
     ServiceWorker,
 };
 
-class JS_EXPORT_PRIVATE InspectorTarget {
+class JS_EXPORT_PRIVATE InspectorTarget : public CanMakeWeakPtr<InspectorTarget> {
 public:
     virtual ~InspectorTarget() = default;
 

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -37,6 +37,7 @@
 #include "PositionOptions.h"
 #include "ScriptWrappable.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 
@@ -51,7 +52,7 @@ class ScriptExecutionContext;
 class SecurityOrigin;
 struct PositionOptions;
 
-class Geolocation final : public ScriptWrappable, public RefCounted<Geolocation>, public ActiveDOMObject {
+class Geolocation final : public ScriptWrappable, public RefCounted<Geolocation>, public ActiveDOMObject, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(Geolocation, WEBCORE_EXPORT);
     friend class GeoNotifier;
 public:

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "JSDOMGlobalObject.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -30,7 +31,7 @@ class WindowProxy;
 
 typedef HashMap<void*, JSC::Weak<JSC::JSObject>> DOMObjectWrapperMap;
 
-class DOMWrapperWorld : public RefCounted<DOMWrapperWorld> {
+class DOMWrapperWorld : public RefCounted<DOMWrapperWorld>, public CanMakeCheckedPtr {
 public:
     enum class Type {
         Normal,   // Main (e.g. Page)

--- a/Source/WebCore/css/CSSStyleDeclaration.h
+++ b/Source/WebCore/css/CSSStyleDeclaration.h
@@ -23,6 +23,7 @@
 #include "CSSPropertyNames.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -35,7 +36,7 @@ class MutableStyleProperties;
 class StyleProperties;
 class StyledElement;
 
-class CSSStyleDeclaration : public ScriptWrappable {
+class CSSStyleDeclaration : public ScriptWrappable, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(CSSStyleDeclaration);
     WTF_MAKE_ISO_ALLOCATED(CSSStyleDeclaration);
 public:

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -26,6 +26,7 @@
 
 #include "AbstractRange.h"
 #include "RangeBoundaryPoint.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -39,7 +40,7 @@ class Text;
 
 struct SimpleRange;
 
-class Range final : public AbstractRange, public CanMakeWeakPtr<Range> {
+class Range final : public AbstractRange, public CanMakeWeakPtr<Range>, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(Range);
 public:
     WEBCORE_EXPORT static Ref<Range> create(Document&);

--- a/Source/WebCore/page/DOMWindowExtension.h
+++ b/Source/WebCore/page/DOMWindowExtension.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "LocalDOMWindow.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
@@ -35,7 +36,7 @@ namespace WebCore {
 class DOMWrapperWorld;
 class LocalFrame;
 
-class DOMWindowExtension final : public RefCounted<DOMWindowExtension>, public LocalDOMWindow::Observer {
+class DOMWindowExtension final : public RefCounted<DOMWindowExtension>, public LocalDOMWindow::Observer, public CanMakeCheckedPtr {
 public:
     static Ref<DOMWindowExtension> create(LocalDOMWindow* window, DOMWrapperWorld& world)
     {

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -29,6 +29,7 @@
 #include "FloatPoint.h"
 #include "IntRect.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/RefCounted.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
@@ -42,7 +43,7 @@ class Page;
 class PageOverlayController;
 class PlatformMouseEvent;
 
-class PageOverlay final : public RefCounted<PageOverlay> {
+class PageOverlay final : public RefCounted<PageOverlay>, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(PageOverlay);
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -28,16 +28,17 @@
 
 #include "WebSharedWorkerServer.h"
 #include "WebSharedWorkerServerToContextConnection.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 
 namespace WebKit {
 
-static HashMap<WebCore::SharedWorkerIdentifier, WebSharedWorker*>& allWorkers()
+static HashMap<WebCore::SharedWorkerIdentifier, CheckedPtr<WebSharedWorker>>& allWorkers()
 {
     ASSERT(RunLoop::isMain());
-    static NeverDestroyed<HashMap<WebCore::SharedWorkerIdentifier, WebSharedWorker*>> allWorkers;
+    static NeverDestroyed<HashMap<WebCore::SharedWorkerIdentifier, CheckedPtr<WebSharedWorker>>> allWorkers;
     return allWorkers;
 }
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -32,6 +32,7 @@
 #include <WebCore/WorkerFetchResult.h>
 #include <WebCore/WorkerInitializationData.h>
 #include <WebCore/WorkerOptions.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -44,7 +45,7 @@ namespace WebKit {
 class WebSharedWorkerServer;
 class WebSharedWorkerServerToContextConnection;
 
-class WebSharedWorker : public CanMakeWeakPtr<WebSharedWorker> {
+class WebSharedWorker : public CanMakeWeakPtr<WebSharedWorker>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WebSharedWorker(WebSharedWorkerServer&, const WebCore::SharedWorkerKey&, const WebCore::WorkerOptions&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -32,6 +32,7 @@
 #include <WebCore/SharedWorkerKey.h>
 #include <WebCore/SharedWorkerObjectIdentifier.h>
 #include <WebCore/TransferredMessagePort.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace PAL {
@@ -84,7 +85,7 @@ private:
 
     NetworkSession& m_session;
     HashMap<WebCore::ProcessIdentifier, std::unique_ptr<WebSharedWorkerServerConnection>> m_connections;
-    HashMap<WebCore::RegistrableDomain, WebSharedWorkerServerToContextConnection*> m_contextConnections;
+    HashMap<WebCore::RegistrableDomain, CheckedPtr<WebSharedWorkerServerToContextConnection>> m_contextConnections;
     HashSet<WebCore::RegistrableDomain> m_pendingContextConnectionDomains;
     HashMap<WebCore::SharedWorkerKey, std::unique_ptr<WebSharedWorker>> m_sharedWorkers;
 };

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -33,6 +33,7 @@
 #include <WebCore/SharedWorkerObjectIdentifier.h>
 #include <WebCore/Timer.h>
 #include <WebCore/TransferredMessagePort.h>
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 class RegistrableDomain;
@@ -48,7 +49,7 @@ class NetworkConnectionToWebProcess;
 class WebSharedWorker;
 class WebSharedWorkerServer;
 
-class WebSharedWorkerServerToContextConnection final : public IPC::MessageSender, public IPC::MessageReceiver {
+class WebSharedWorkerServerToContextConnection final : public IPC::MessageSender, public IPC::MessageReceiver, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WebSharedWorkerServerToContextConnection(NetworkConnectionToWebProcess&, const WebCore::RegistrableDomain&, WebSharedWorkerServer&);

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -303,9 +303,9 @@ Ref<Connection> Connection::createClientConnection(Identifier identifier)
     return adoptRef(*new Connection(identifier, false));
 }
 
-HashMap<IPC::Connection::UniqueID, Connection*>& Connection::connectionMap()
+HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>& Connection::connectionMap()
 {
-    static NeverDestroyed<HashMap<IPC::Connection::UniqueID, Connection*>> map;
+    static NeverDestroyed<HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>> map;
     return map;
 }
 
@@ -338,7 +338,7 @@ RefPtr<Connection> Connection::connection(UniqueID uniqueID)
 {
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=238493): Removing with lock in destructor is not thread-safe.
     Locker locker { s_connectionMapLock };
-    return connectionMap().get(uniqueID);
+    return connectionMap().get(uniqueID).get();
 
 }
 

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -493,7 +493,7 @@ private:
 
     bool isIncomingMessagesThrottlingEnabled() const { return m_incomingMessagesThrottlingLevel.has_value(); }
 
-    static HashMap<IPC::Connection::UniqueID, Connection*>& connectionMap() WTF_REQUIRES_LOCK(s_connectionMapLock);
+    static HashMap<IPC::Connection::UniqueID, ThreadSafeWeakPtr<Connection>>& connectionMap() WTF_REQUIRES_LOCK(s_connectionMapLock);
 
     DecoderOrError waitForMessage(MessageName, uint64_t destinationID, Timeout, OptionSet<WaitForOption>);
 
@@ -693,7 +693,7 @@ template<typename T>
 Error Connection::send(UniqueID connectionID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> qos)
 {
     Locker locker { s_connectionMapLock };
-    RefPtr connection = connectionMap().get(connectionID);
+    RefPtr connection = connectionMap().get(connectionID).get();
     if (!connection)
         return Error::NoConnectionForIdentifier;
     return connection->send(std::forward<T>(message), destinationID, sendOptions, qos);

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -60,10 +60,10 @@ WebBackForwardListItem::~WebBackForwardListItem()
     removeFromBackForwardCache();
 }
 
-HashMap<BackForwardItemIdentifier, WebBackForwardListItem*>& WebBackForwardListItem::allItems()
+HashMap<BackForwardItemIdentifier, CheckedPtr<WebBackForwardListItem>>& WebBackForwardListItem::allItems()
 {
     RELEASE_ASSERT(RunLoop::isMain());
-    static NeverDestroyed<HashMap<BackForwardItemIdentifier, WebBackForwardListItem*>> items;
+    static NeverDestroyed<HashMap<BackForwardItemIdentifier, CheckedPtr<WebBackForwardListItem>>> items;
     return items;
 }
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -28,6 +28,7 @@
 #include "APIObject.h"
 #include "SessionState.h"
 #include "WebPageProxyIdentifier.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -47,13 +48,13 @@ class SuspendedPageProxy;
 class WebBackForwardCache;
 class WebBackForwardCacheEntry;
 
-class WebBackForwardListItem : public API::ObjectImpl<API::Object::Type::BackForwardListItem>, public CanMakeWeakPtr<WebBackForwardListItem> {
+class WebBackForwardListItem : public API::ObjectImpl<API::Object::Type::BackForwardListItem>, public CanMakeWeakPtr<WebBackForwardListItem>, public CanMakeCheckedPtr {
 public:
     static Ref<WebBackForwardListItem> create(BackForwardListItemState&&, WebPageProxyIdentifier);
     virtual ~WebBackForwardListItem();
 
     static WebBackForwardListItem* itemForID(const WebCore::BackForwardItemIdentifier&);
-    static HashMap<WebCore::BackForwardItemIdentifier, WebBackForwardListItem*>& allItems();
+    static HashMap<WebCore::BackForwardItemIdentifier, CheckedPtr<WebBackForwardListItem>>& allItems();
 
     const WebCore::BackForwardItemIdentifier& itemID() const { return m_itemState.identifier; }
     const BackForwardListItemState& itemState() { return m_itemState; }

--- a/Source/WebKit/UIProcess/API/APIContentWorld.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.cpp
@@ -28,20 +28,21 @@
 
 #include "ContentWorldShared.h"
 #include "WebUserContentControllerProxy.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/StringHash.h>
 
 namespace API {
 
-static HashMap<WTF::String, ContentWorld*>& sharedWorldNameMap()
+static HashMap<WTF::String, CheckedPtr<ContentWorld>>& sharedWorldNameMap()
 {
-    static NeverDestroyed<HashMap<WTF::String, ContentWorld*>> sharedMap;
+    static NeverDestroyed<HashMap<WTF::String, CheckedPtr<ContentWorld>>> sharedMap;
     return sharedMap;
 }
 
-static HashMap<WebKit::ContentWorldIdentifier, ContentWorld*>& sharedWorldIdentifierMap()
+static HashMap<WebKit::ContentWorldIdentifier, CheckedPtr<ContentWorld>>& sharedWorldIdentifierMap()
 {
-    static NeverDestroyed<HashMap<WebKit::ContentWorldIdentifier, ContentWorld*>> sharedMap;
+    static NeverDestroyed<HashMap<WebKit::ContentWorldIdentifier, CheckedPtr<ContentWorld>>> sharedMap;
     return sharedMap;
 }
 
@@ -77,7 +78,7 @@ Ref<ContentWorld> ContentWorld::sharedWorldWithName(const WTF::String& name)
     auto result = sharedWorldNameMap().add(name, nullptr);
     if (result.isNewEntry) {
         result.iterator->value = new ContentWorld(name);
-        return adoptRef(*result.iterator->value);
+        return adoptRef(*result.iterator->value.get());
     }
 
     return *result.iterator->value;
@@ -100,15 +101,15 @@ ContentWorld::~ContentWorld()
     ASSERT(m_identifier != WebKit::pageContentWorldIdentifier());
 
     auto result = sharedWorldIdentifierMap().take(m_identifier);
-    ASSERT_UNUSED(result, result == this || m_identifier == WebKit::pageContentWorldIdentifier());
+    ASSERT_UNUSED(result, result.get() == this || m_identifier == WebKit::pageContentWorldIdentifier());
 
     if (!name().isNull()) {
         auto taken = sharedWorldNameMap().take(name());
-        ASSERT_UNUSED(taken, taken == this);
+        ASSERT_UNUSED(taken, taken.get() == this);
     }
 
-    for (auto& proxy : m_associatedContentControllerProxies)
-        Ref { proxy }->contentWorldDestroyed(*this);
+    for (Ref proxy : m_associatedContentControllerProxies)
+        proxy->contentWorldDestroyed(*this);
 }
 
 void ContentWorld::addAssociatedUserContentControllerProxy(WebKit::WebUserContentControllerProxy& proxy)

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "ContentWorldShared.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -36,7 +37,7 @@ class WebUserContentControllerProxy;
 
 namespace API {
 
-class ContentWorld final : public API::ObjectImpl<API::Object::Type::ContentWorld> {
+class ContentWorld final : public API::ObjectImpl<API::Object::Type::ContentWorld>, public CanMakeCheckedPtr {
 public:
     static ContentWorld* worldForIdentifier(WebKit::ContentWorldIdentifier);
     static Ref<ContentWorld> sharedWorldWithName(const WTF::String&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -60,6 +60,7 @@
 #import <WebCore/Pagination.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/CheckedPtr.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/CFURLExtras.h>
@@ -86,9 +87,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-static HashMap<WebKit::WebPageProxy*, __unsafe_unretained WKBrowsingContextController *>& browsingContextControllerMap()
+static HashMap<CheckedPtr<WebKit::WebPageProxy>, __unsafe_unretained WKBrowsingContextController *>& browsingContextControllerMap()
 {
-    static NeverDestroyed<HashMap<WebKit::WebPageProxy*, __unsafe_unretained WKBrowsingContextController *>> browsingContextControllerMap;
+    static NeverDestroyed<HashMap<CheckedPtr<WebKit::WebPageProxy>, __unsafe_unretained WKBrowsingContextController *>> browsingContextControllerMap;
     return browsingContextControllerMap;
 }
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -42,6 +42,7 @@
 #include "WebUserContentControllerMessages.h"
 #include "WebUserContentControllerProxyMessages.h"
 #include <WebCore/SerializedScriptValue.h>
+#include <wtf/CheckedPtr.h>
 
 #if ENABLE(CONTENT_EXTENSIONS)
 #include "APIContentRuleList.h"
@@ -52,12 +53,11 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<UserContentControllerIdentifier, WebUserContentControllerProxy*>& webUserContentControllerProxies()
+static HashMap<UserContentControllerIdentifier, CheckedPtr<WebUserContentControllerProxy>>& webUserContentControllerProxies()
 {
-    static NeverDestroyed<HashMap<UserContentControllerIdentifier, WebUserContentControllerProxy*>> proxies;
+    static NeverDestroyed<HashMap<UserContentControllerIdentifier, CheckedPtr<WebUserContentControllerProxy>>> proxies;
     return proxies;
 }
-
 
 WebUserContentControllerProxy* WebUserContentControllerProxy::get(UserContentControllerIdentifier identifier)
 {

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -33,6 +33,7 @@
 #include "WebPageProxyIdentifier.h"
 #include "WebUserContentControllerProxyMessages.h"
 #include <WebCore/PageIdentifier.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
@@ -66,7 +67,7 @@ struct WebPageCreationParameters;
 struct UserContentControllerParameters;
 enum class InjectUserScriptImmediately : bool;
 
-class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, public IPC::MessageReceiver {
+class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, public IPC::MessageReceiver, public CanMakeCheckedPtr {
 public:
     static Ref<WebUserContentControllerProxy> create()
     { 

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -36,6 +36,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <WebCore/UserInterfaceLayoutDirection.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
@@ -65,10 +66,10 @@ static const float minimumScrollEventRatioForSwipe = 0.5;
 static const float swipeSnapshotRemovalRenderTreeSizeTargetFraction = 0.5;
 #endif
 
-static HashMap<WebPageProxyIdentifier, ViewGestureController*>& viewGestureControllersForAllPages()
+static HashMap<WebPageProxyIdentifier, CheckedPtr<ViewGestureController>>& viewGestureControllersForAllPages()
 {
     // The key in this map is the associated page ID.
-    static NeverDestroyed<HashMap<WebPageProxyIdentifier, ViewGestureController*>> viewGestureControllers;
+    static NeverDestroyed<HashMap<WebPageProxyIdentifier, CheckedPtr<ViewGestureController>>> viewGestureControllers;
     return viewGestureControllers.get();
 }
 
@@ -120,9 +121,9 @@ ViewGestureController* ViewGestureController::controllerForGesture(WebPageProxyI
     auto gestureControllerIter = viewGestureControllersForAllPages().find(pageID);
     if (gestureControllerIter == viewGestureControllersForAllPages().end())
         return nullptr;
-    if (gestureControllerIter->value->m_currentGestureID != gestureID)
+    if (gestureControllerIter->value.get()->m_currentGestureID != gestureID)
         return nullptr;
-    return gestureControllerIter->value;
+    return gestureControllerIter->value.get();
 }
 
 ViewGestureController::GestureID ViewGestureController::takeNextGestureID()

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -31,6 +31,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/FloatSize.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
@@ -96,7 +97,7 @@ class WebBackForwardListItem;
 class WebPageProxy;
 class WebProcessProxy;
 
-class ViewGestureController : private IPC::MessageReceiver {
+class ViewGestureController : private IPC::MessageReceiver, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ViewGestureController);
 public:

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -51,6 +51,7 @@
 #include <WebCore/Image.h>
 #include <WebCore/MIMETypeRegistry.h>
 #include <stdio.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/text/WTFString.h>
 
@@ -61,10 +62,10 @@ using namespace WebCore;
 
 class WebPageProxy;
 
-static HashMap<FrameIdentifier, WebFrameProxy*>& allFrames()
+static HashMap<FrameIdentifier, CheckedPtr<WebFrameProxy>>& allFrames()
 {
     ASSERT(RunLoop::isMain());
-    static NeverDestroyed<HashMap<FrameIdentifier, WebFrameProxy*>> map;
+    static NeverDestroyed<HashMap<FrameIdentifier, CheckedPtr<WebFrameProxy>>> map;
     return map.get();
 }
 

--- a/Source/WebKit/UIProcess/WebPageGroup.h
+++ b/Source/WebKit/UIProcess/WebPageGroup.h
@@ -30,6 +30,7 @@
 #include "WebPageGroupData.h"
 #include "WebProcessProxy.h"
 #include <WebCore/UserStyleSheetTypes.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
@@ -39,7 +40,7 @@ class WebPreferences;
 class WebPageProxy;
 class WebUserContentControllerProxy;
 
-class WebPageGroup : public API::ObjectImpl<API::Object::Type::PageGroup> {
+class WebPageGroup : public API::ObjectImpl<API::Object::Type::PageGroup>, public CanMakeCheckedPtr {
 public:
     explicit WebPageGroup(const String& identifier = { });
     static Ref<WebPageGroup> create(const String& identifier = { });

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -66,6 +66,7 @@
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/WebLockRegistry.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/FileSystem.h>
@@ -106,10 +107,10 @@ static HashMap<String, PAL::SessionID>& activeGeneralStorageDirectories()
     return directoryToSessionMap;
 }
 
-static HashMap<PAL::SessionID, WebsiteDataStore*>& allDataStores()
+static HashMap<PAL::SessionID, CheckedPtr<WebsiteDataStore>>& allDataStores()
 {
     RELEASE_ASSERT(isUIThread());
-    static NeverDestroyed<HashMap<PAL::SessionID, WebsiteDataStore*>> map;
+    static NeverDestroyed<HashMap<PAL::SessionID, CheckedPtr<WebsiteDataStore>>> map;
     return map;
 }
 
@@ -121,7 +122,7 @@ WorkQueue& WebsiteDataStore::websiteDataStoreIOQueue()
 
 void WebsiteDataStore::forEachWebsiteDataStore(Function<void(WebsiteDataStore&)>&& function)
 {
-    for (auto* dataStore : allDataStores().values())
+    for (auto& dataStore : allDataStores().values())
         function(*dataStore);
 }
 
@@ -245,9 +246,9 @@ bool WebsiteDataStore::defaultDataStoreExists()
 
 RefPtr<WebsiteDataStore> WebsiteDataStore::existingDataStoreForIdentifier(const WTF::UUID& identifier)
 {
-    for (auto* dataStore : allDataStores().values()) {
-        if (dataStore && dataStore->configuration().identifier() == identifier)
-            return dataStore;
+    for (auto& dataStore : allDataStores().values()) {
+        if (dataStore && dataStore.get()->configuration().identifier() == identifier)
+            return dataStore.get();
     }
 
     return nullptr;
@@ -259,8 +260,8 @@ Ref<WebsiteDataStore> WebsiteDataStore::dataStoreForIdentifier(const WTF::UUID& 
     RELEASE_ASSERT(uuid.isValid());
 
     InitializeWebKit2();
-    for (auto* dataStore : allDataStores().values()) {
-        if (dataStore && dataStore->configuration().identifier() == uuid)
+    for (auto& dataStore : allDataStores().values()) {
+        if (dataStore && dataStore.get()->configuration().identifier() == uuid)
             return Ref { *dataStore };
     }
 
@@ -296,9 +297,9 @@ static Ref<NetworkProcessProxy> networkProcessForSession(PAL::SessionID sessionI
 #if ((PLATFORM(GTK) || PLATFORM(WPE)) && !ENABLE(2022_GLIB_API))
     if (sessionID.isEphemeral()) {
         // Reuse a previous persistent session network process for ephemeral sessions.
-        for (auto* dataStore : allDataStores().values()) {
-            if (dataStore->isPersistent())
-                return dataStore->networkProcess();
+        for (auto& dataStore : allDataStores().values()) {
+            if (dataStore.get()->isPersistent())
+                return dataStore.get()->networkProcess();
         }
     }
     return NetworkProcessProxy::create();
@@ -1830,7 +1831,7 @@ void WebsiteDataStore::setCacheModelSynchronouslyForTesting(CacheModel cacheMode
 Vector<WebsiteDataStoreParameters> WebsiteDataStore::parametersFromEachWebsiteDataStore()
 {
     return WTF::map(allDataStores(), [](auto& entry) {
-        return entry.value->parameters();
+        return entry.value.get()->parameters();
     });
 }
 
@@ -2245,8 +2246,8 @@ void WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized(CompletionHandle
 
     propagateAppBoundDomains(globalDefaultDataStore().get(), *appBoundDomains);
 
-    for (auto* store : allDataStores().values())
-        propagateAppBoundDomains(store, *appBoundDomains);
+    for (auto& store : allDataStores().values())
+        propagateAppBoundDomains(store.get(), *appBoundDomains);
 }
 
 void WebsiteDataStore::setAppBoundDomainsForITP(const HashSet<WebCore::RegistrableDomain>& domains, CompletionHandler<void()>&& completionHandler)
@@ -2276,8 +2277,8 @@ void WebsiteDataStore::forwardManagedDomainsToITPIfInitialized(CompletionHandler
 
     propagateManagedDomains(globalDefaultDataStore().get(), *managedDomains);
 
-    for (auto* store : allDataStores().values())
-        propagateManagedDomains(store, *managedDomains);
+    for (auto& store : allDataStores().values())
+        propagateManagedDomains(store.get(), *managedDomains);
 }
 
 void WebsiteDataStore::setManagedDomainsForITP(const HashSet<WebCore::RegistrableDomain>& domains, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -39,6 +39,7 @@
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/SecurityOriginHash.h>
 #include <pal/SessionID.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/Identified.h>
@@ -117,7 +118,7 @@ enum class StorageAccessStatus : uint8_t;
 enum class StorageAccessPromptStatus;
 #endif
 
-class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public Identified<WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore>  {
+class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public Identified<WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore>, public CanMakeCheckedPtr {
 public:
     static Ref<WebsiteDataStore> defaultDataStore();
     static bool defaultDataStoreExists();

--- a/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp
+++ b/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp
@@ -29,15 +29,16 @@
 #include "NetworkProcessConnection.h"
 #include "WebIDBConnectionToServer.h"
 #include "WebProcess.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<PageGroupIdentifier, WebDatabaseProvider*>& databaseProviders()
+static HashMap<PageGroupIdentifier, CheckedPtr<WebDatabaseProvider>>& databaseProviders()
 {
-    static NeverDestroyed<HashMap<PageGroupIdentifier, WebDatabaseProvider*>> databaseProviders;
+    static NeverDestroyed<HashMap<PageGroupIdentifier, CheckedPtr<WebDatabaseProvider>>> databaseProviders;
 
     return databaseProviders;
 }

--- a/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.h
+++ b/Source/WebKit/WebProcess/Databases/WebDatabaseProvider.h
@@ -27,11 +27,12 @@
 
 #include "IdentifierTypes.h"
 #include <WebCore/DatabaseProvider.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 
 namespace WebKit {
 
-class WebDatabaseProvider final : public WebCore::DatabaseProvider {
+class WebDatabaseProvider final : public WebCore::DatabaseProvider, public CanMakeCheckedPtr {
 public:
     static Ref<WebDatabaseProvider> getOrCreate(PageGroupIdentifier);
     virtual ~WebDatabaseProvider();

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
@@ -50,6 +50,8 @@ GeolocationPermissionRequestManager::GeolocationPermissionRequestManager(WebPage
 {
 }
 
+GeolocationPermissionRequestManager::~GeolocationPermissionRequestManager() = default;
+
 void GeolocationPermissionRequestManager::startRequestForGeolocation(Geolocation& geolocation)
 {
     auto* frame = geolocation.frame();
@@ -86,10 +88,10 @@ void GeolocationPermissionRequestManager::cancelRequestForGeolocation(Geolocatio
 
 void GeolocationPermissionRequestManager::didReceiveGeolocationPermissionDecision(GeolocationIdentifier geolocationID, const String& authorizationToken)
 {
-    Geolocation* geolocation = m_idToGeolocationMap.take(geolocationID);
+    RefPtr geolocation = m_idToGeolocationMap.take(geolocationID).get();
     if (!geolocation)
         return;
-    m_geolocationToIDMap.remove(geolocation);
+    m_geolocationToIDMap.remove(geolocation.get());
 
     geolocation->setIsAllowed(!authorizationToken.isNull(), authorizationToken);
 }

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "GeolocationIdentifier.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 
@@ -41,6 +42,7 @@ class GeolocationPermissionRequestManager {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit GeolocationPermissionRequestManager(WebPage&);
+    ~GeolocationPermissionRequestManager();
 
     void startRequestForGeolocation(WebCore::Geolocation&);
     void cancelRequestForGeolocation(WebCore::Geolocation&);
@@ -49,8 +51,8 @@ public:
     void didReceiveGeolocationPermissionDecision(GeolocationIdentifier, const String& authorizationToken);
 
 private:
-    typedef HashMap<GeolocationIdentifier, WebCore::Geolocation*> IDToGeolocationMap;
-    typedef HashMap<WebCore::Geolocation*, GeolocationIdentifier> GeolocationToIDMap;
+    using IDToGeolocationMap = HashMap<GeolocationIdentifier, CheckedPtr<WebCore::Geolocation>>;
+    using GeolocationToIDMap = HashMap<CheckedPtr<WebCore::Geolocation>, GeolocationIdentifier>;
     IDToGeolocationMap m_idToGeolocationMap;
     GeolocationToIDMap m_geolocationToIDMap;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp
@@ -29,13 +29,14 @@
 #include <JavaScriptCore/APICast.h>
 #include <WebCore/CSSStyleDeclaration.h>
 #include <WebCore/JSCSSStyleDeclaration.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-typedef HashMap<CSSStyleDeclaration*, InjectedBundleCSSStyleDeclarationHandle*> DOMStyleDeclarationHandleCache;
+using DOMStyleDeclarationHandleCache = HashMap<CheckedPtr<CSSStyleDeclaration>, CheckedPtr<InjectedBundleCSSStyleDeclarationHandle>>;
 
 static DOMStyleDeclarationHandleCache& domStyleDeclarationHandleCache()
 {
@@ -56,7 +57,7 @@ RefPtr<InjectedBundleCSSStyleDeclarationHandle> InjectedBundleCSSStyleDeclaratio
 
     DOMStyleDeclarationHandleCache::AddResult result = domStyleDeclarationHandleCache().add(styleDeclaration, nullptr);
     if (!result.isNewEntry)
-        return result.iterator->value;
+        return result.iterator->value.get();
 
     auto styleDeclarationHandle = adoptRef(*new InjectedBundleCSSStyleDeclarationHandle(*styleDeclaration));
     result.iterator->value = styleDeclarationHandle.ptr();

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.h
@@ -28,6 +28,7 @@
 
 #include "APIObject.h"
 #include <JavaScriptCore/JSBase.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 
@@ -37,7 +38,7 @@ class CSSStyleDeclaration;
 
 namespace WebKit {
 
-class InjectedBundleCSSStyleDeclarationHandle : public API::ObjectImpl<API::Object::Type::BundleCSSStyleDeclarationHandle> {
+class InjectedBundleCSSStyleDeclarationHandle : public API::ObjectImpl<API::Object::Type::BundleCSSStyleDeclarationHandle>, public CanMakeCheckedPtr {
 public:
     static RefPtr<InjectedBundleCSSStyleDeclarationHandle> getOrCreate(JSContextRef, JSObjectRef);
     static RefPtr<InjectedBundleCSSStyleDeclarationHandle> getOrCreate(WebCore::CSSStyleDeclaration*);

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -54,6 +54,7 @@
 #include <WebCore/SimpleRange.h>
 #include <WebCore/Text.h>
 #include <WebCore/VisiblePosition.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/WTFString.h>
@@ -62,7 +63,7 @@ namespace WebKit {
 using namespace WebCore;
 using namespace HTMLNames;
 
-typedef HashMap<Node*, InjectedBundleNodeHandle*> DOMNodeHandleCache;
+using DOMNodeHandleCache = HashMap<CheckedPtr<Node>, CheckedPtr<InjectedBundleNodeHandle>>;
 
 static DOMNodeHandleCache& domNodeHandleCache()
 {
@@ -86,7 +87,7 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(Node* nod
 
 Ref<InjectedBundleNodeHandle> InjectedBundleNodeHandle::getOrCreate(Node& node)
 {
-    if (auto* existingHandle = domNodeHandleCache().get(&node))
+    if (auto existingHandle = domNodeHandleCache().get(&node))
         return Ref<InjectedBundleNodeHandle>(*existingHandle);
 
     auto nodeHandle = InjectedBundleNodeHandle::create(node);

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -29,6 +29,7 @@
 #include "ImageOptions.h"
 #include <JavaScriptCore/JSBase.h>
 #include <WebCore/ActiveDOMObject.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 
@@ -45,7 +46,7 @@ class InjectedBundleScriptWorld;
 class WebFrame;
 class WebImage;
 
-class InjectedBundleNodeHandle : public API::ObjectImpl<API::Object::Type::BundleNodeHandle>, public WebCore::ActiveDOMObject {
+class InjectedBundleNodeHandle : public API::ObjectImpl<API::Object::Type::BundleNodeHandle>, public WebCore::ActiveDOMObject, public CanMakeCheckedPtr {
 public:
     static RefPtr<InjectedBundleNodeHandle> getOrCreate(JSContextRef, JSObjectRef);
     static RefPtr<InjectedBundleNodeHandle> getOrCreate(WebCore::Node*);

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -46,6 +46,7 @@
 #include <WebCore/SimpleRange.h>
 #include <WebCore/TextIterator.h>
 #include <WebCore/VisibleSelection.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -56,7 +57,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-using DOMRangeHandleCache = HashMap<WebCore::Range*, InjectedBundleRangeHandle*>;
+using DOMRangeHandleCache = HashMap<CheckedPtr<WebCore::Range>, CheckedPtr<InjectedBundleRangeHandle>>;
 
 static DOMRangeHandleCache& domRangeHandleCache()
 {
@@ -75,7 +76,7 @@ RefPtr<InjectedBundleRangeHandle> InjectedBundleRangeHandle::getOrCreate(WebCore
         return nullptr;
     auto result = domRangeHandleCache().add(range, nullptr);
     if (!result.isNewEntry)
-        return result.iterator->value;
+        return result.iterator->value.get();
     auto rangeHandle = adoptRef(*new InjectedBundleRangeHandle(*range));
     result.iterator->value = rangeHandle.ptr();
     return rangeHandle;

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.h
@@ -28,6 +28,7 @@
 #include "APIObject.h"
 #include "ImageOptions.h"
 #include <JavaScriptCore/JSBase.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 
@@ -43,7 +44,7 @@ class InjectedBundleNodeHandle;
 class InjectedBundleScriptWorld;
 class WebImage;
 
-class InjectedBundleRangeHandle : public API::ObjectImpl<API::Object::Type::BundleRangeHandle> {
+class InjectedBundleRangeHandle : public API::ObjectImpl<API::Object::Type::BundleRangeHandle>, public CanMakeCheckedPtr {
 public:
     static RefPtr<InjectedBundleRangeHandle> getOrCreate(JSContextRef, JSObjectRef);
     static RefPtr<InjectedBundleRangeHandle> getOrCreate(WebCore::Range*);

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -33,13 +33,14 @@
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/LocalFrame.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-typedef HashMap<WebCore::DOMWindowExtension*, InjectedBundleDOMWindowExtension*> ExtensionMap;
+using ExtensionMap = HashMap<CheckedPtr<WebCore::DOMWindowExtension>, CheckedPtr<InjectedBundleDOMWindowExtension>>;
 static ExtensionMap& allExtensions()
 {
     static NeverDestroyed<ExtensionMap> map;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h
@@ -27,6 +27,7 @@
 #define InjectedBundleDOMWindowExtension_h
 
 #include "APIObject.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
@@ -40,7 +41,7 @@ namespace WebKit {
 class InjectedBundleScriptWorld;
 class WebFrame;
 
-class InjectedBundleDOMWindowExtension : public API::ObjectImpl<API::Object::Type::BundleDOMWindowExtension> {
+class InjectedBundleDOMWindowExtension : public API::ObjectImpl<API::Object::Type::BundleDOMWindowExtension>, public CanMakeCheckedPtr {
 public:
     static Ref<InjectedBundleDOMWindowExtension> create(WebFrame*, InjectedBundleScriptWorld*);
     static InjectedBundleDOMWindowExtension* get(WebCore::DOMWindowExtension*);

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -28,6 +28,7 @@
 
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/ScriptController.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringConcatenate.h>
@@ -36,7 +37,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-typedef HashMap<DOMWrapperWorld*, InjectedBundleScriptWorld*> WorldMap;
+typedef HashMap<CheckedPtr<DOMWrapperWorld>, CheckedPtr<InjectedBundleScriptWorld>> WorldMap;
 
 static WorldMap& allWorlds()
 {
@@ -65,7 +66,7 @@ Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::getOrCreate(DOMWrapper
     if (&world == &mainThreadNormalWorld())
         return normalWorld();
 
-    if (InjectedBundleScriptWorld* existingWorld = allWorlds().get(&world))
+    if (auto existingWorld = allWorlds().get(&world))
         return *existingWorld;
 
     return adoptRef(*new InjectedBundleScriptWorld(world, uniqueWorldName()));
@@ -73,9 +74,9 @@ Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::getOrCreate(DOMWrapper
 
 InjectedBundleScriptWorld* InjectedBundleScriptWorld::find(const String& name)
 {
-    for (auto* world : allWorlds().values()) {
-        if (world->name() == name)
-            return world;
+    for (auto& world : allWorlds().values()) {
+        if (world.get()->name() == name)
+            return world.get();
     }
     return nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -27,6 +27,7 @@
 #define InjectedBundleScriptWorld_h
 
 #include "APIObject.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>
@@ -37,7 +38,7 @@ namespace WebCore {
 
 namespace WebKit {
 
-class InjectedBundleScriptWorld : public API::ObjectImpl<API::Object::Type::BundleScriptWorld> {
+class InjectedBundleScriptWorld : public API::ObjectImpl<API::Object::Type::BundleScriptWorld>, public CanMakeCheckedPtr {
 public:
     enum class Type { User, Internal };
     static Ref<InjectedBundleScriptWorld> create(Type = Type::Internal);

--- a/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WebPageInspectorTarget.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/WTFString.h>
 
@@ -53,7 +54,7 @@ public:
 private:
     WebPage& m_page;
     WebPageInspectorTarget m_pageTarget;
-    HashMap<String, Inspector::InspectorTarget*> m_targets;
+    HashMap<String, WeakPtr<Inspector::InspectorTarget>> m_targets;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -588,7 +588,7 @@ void WebLoaderStrategy::remove(ResourceLoader* resourceLoader)
         return;
     }
 
-    if (auto task = m_urlSchemeTasks.take(resourceLoader->identifier())) {
+    if (RefPtr task = m_urlSchemeTasks.take(resourceLoader->identifier()).get()) {
         ASSERT(!m_internallyFailedResourceLoaders.contains(resourceLoader));
         task->stopLoading();
         return;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -31,6 +31,7 @@
 #include <WebCore/ResourceError.h>
 #include <WebCore/ResourceLoader.h>
 #include <WebCore/ResourceResponse.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
 
@@ -134,7 +135,7 @@ private:
     RunLoop::Timer m_internallyFailedLoadTimer;
     
     HashMap<WebCore::ResourceLoaderIdentifier, RefPtr<WebResourceLoader>> m_webResourceLoaders;
-    HashMap<WebCore::ResourceLoaderIdentifier, WebURLSchemeTaskProxy*> m_urlSchemeTasks;
+    HashMap<WebCore::ResourceLoaderIdentifier, CheckedPtr<WebURLSchemeTaskProxy>> m_urlSchemeTasks;
     HashMap<WebCore::ResourceLoaderIdentifier, PingLoadCompletionHandler> m_pingLoadCompletionHandlers;
     HashMap<WebCore::ResourceLoaderIdentifier, PreconnectCompletionHandler> m_preconnectCompletionHandlers;
     Vector<Function<void(bool)>> m_onlineStateChangeListeners;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/LibWebRTCProvider.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 
 ALLOW_COMMA_BEGIN
@@ -46,7 +47,7 @@ namespace WebKit {
 
 class LibWebRTCSocketFactory;
 
-class LibWebRTCSocket final : public rtc::AsyncPacketSocket {
+class LibWebRTCSocket final : public rtc::AsyncPacketSocket, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type { UDP, ClientTCP, ServerConnectionTCP };

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
@@ -142,8 +142,8 @@ void LibWebRTCSocketFactory::removeSocket(LibWebRTCSocket& socket)
 void LibWebRTCSocketFactory::forSocketInGroup(ScriptExecutionContextIdentifier contextIdentifier, const Function<void(LibWebRTCSocket&)>& callback)
 {
     ASSERT(!WTF::isMainRunLoop());
-    for (auto* socket : m_sockets.values()) {
-        if (socket->contextIdentifier() == contextIdentifier)
+    for (auto& socket : m_sockets.values()) {
+        if (socket.get()->contextIdentifier() == contextIdentifier)
             callback(*socket);
     }
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
@@ -32,6 +32,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/HashMap.h>
@@ -72,7 +73,7 @@ public:
 
 private:
     // We cannot own sockets, clients of the factory are responsible to free them.
-    HashMap<WebCore::LibWebRTCSocketIdentifier, LibWebRTCSocket*> m_sockets;
+    HashMap<WebCore::LibWebRTCSocketIdentifier, CheckedPtr<LibWebRTCSocket>> m_sockets;
     
     // We can own resolvers as we control their Destroy method.
     HashMap<LibWebRTCResolverIdentifier, std::unique_ptr<LibWebRTCResolver>> m_resolvers;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7705,7 +7705,7 @@ void WebPage::registerURLSchemeHandler(WebURLSchemeHandlerIdentifier handlerIden
 
 void WebPage::urlSchemeTaskWillPerformRedirection(WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, ResourceResponse&& response, ResourceRequest&& request, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
 {
-    auto* handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
+    RefPtr handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
     ASSERT(handler);
 
     auto actualNewRequest = request;
@@ -7714,7 +7714,7 @@ void WebPage::urlSchemeTaskWillPerformRedirection(WebURLSchemeHandlerIdentifier 
 
 void WebPage::urlSchemeTaskDidPerformRedirection(WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, ResourceResponse&& response, ResourceRequest&& request)
 {
-    auto* handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
+    RefPtr handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
     ASSERT(handler);
 
     handler->taskDidPerformRedirection(taskIdentifier, WTFMove(response), WTFMove(request), [] (ResourceRequest&&) {});
@@ -7722,7 +7722,7 @@ void WebPage::urlSchemeTaskDidPerformRedirection(WebURLSchemeHandlerIdentifier h
     
 void WebPage::urlSchemeTaskDidReceiveResponse(WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, const ResourceResponse& response)
 {
-    auto* handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
+    RefPtr handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
     ASSERT(handler);
 
     handler->taskDidReceiveResponse(taskIdentifier, response);
@@ -7730,7 +7730,7 @@ void WebPage::urlSchemeTaskDidReceiveResponse(WebURLSchemeHandlerIdentifier hand
 
 void WebPage::urlSchemeTaskDidReceiveData(WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, Ref<WebCore::SharedBuffer>&& data)
 {
-    auto* handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
+    RefPtr handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
     ASSERT(handler);
 
     handler->taskDidReceiveData(taskIdentifier, WTFMove(data));
@@ -7738,7 +7738,7 @@ void WebPage::urlSchemeTaskDidReceiveData(WebURLSchemeHandlerIdentifier handlerI
 
 void WebPage::urlSchemeTaskDidComplete(WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier, const ResourceError& error)
 {
-    auto* handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
+    RefPtr handler = m_identifierToURLSchemeHandlerProxyMap.get(handlerIdentifier);
     ASSERT(handler);
 
     handler->taskDidComplete(taskIdentifier, error);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2521,7 +2521,7 @@ private:
 #endif
 
     HashMap<String, RefPtr<WebURLSchemeHandlerProxy>> m_schemeToURLSchemeHandlerProxyMap;
-    HashMap<WebURLSchemeHandlerIdentifier, WebURLSchemeHandlerProxy*> m_identifierToURLSchemeHandlerProxyMap;
+    HashMap<WebURLSchemeHandlerIdentifier, CheckedPtr<WebURLSchemeHandlerProxy>> m_identifierToURLSchemeHandlerProxyMap;
 
     HashMap<uint64_t, Function<void(bool granted)>> m_storageAccessResponseCallbackMap;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
@@ -31,14 +31,15 @@
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/PageOverlay.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<PageOverlay*, WebPageOverlay*>& overlayMap()
+static HashMap<CheckedPtr<PageOverlay>, CheckedPtr<WebPageOverlay>>& overlayMap()
 {
-    static NeverDestroyed<HashMap<PageOverlay*, WebPageOverlay*>> map;
+    static NeverDestroyed<HashMap<CheckedPtr<PageOverlay>, CheckedPtr<WebPageOverlay>>> map;
     return map;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
@@ -29,6 +29,7 @@
 #include <WebCore/FloatPoint.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SimpleRange.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/RetainPtr.h>
 
 #if HAVE(SECURE_ACTION_CONTEXT)
@@ -48,7 +49,7 @@ namespace WebKit {
 class WebFrame;
 class WebPage;
 
-class WebPageOverlay : public API::ObjectImpl<API::Object::Type::BundlePageOverlay>, private WebCore::PageOverlay::Client {
+class WebPageOverlay : public API::ObjectImpl<API::Object::Type::BundlePageOverlay>, private WebCore::PageOverlay::Client, public CanMakeCheckedPtr {
 public:
     struct ActionContext;
 

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h
@@ -27,6 +27,7 @@
 
 #include "WebURLSchemeHandlerIdentifier.h"
 #include "WebURLSchemeTaskProxy.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 
@@ -42,7 +43,7 @@ namespace WebKit {
 
 class WebPage;
 
-class WebURLSchemeHandlerProxy : public RefCounted<WebURLSchemeHandlerProxy> {
+class WebURLSchemeHandlerProxy : public RefCounted<WebURLSchemeHandlerProxy>, public CanMakeCheckedPtr {
 public:
     static Ref<WebURLSchemeHandlerProxy> create(WebPage& page, WebURLSchemeHandlerIdentifier identifier)
     {

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ResourceRequest.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/RefCounted.h>
 
@@ -42,7 +43,7 @@ namespace WebKit {
 class WebFrame;
 class WebURLSchemeHandlerProxy;
 
-class WebURLSchemeTaskProxy : public RefCounted<WebURLSchemeTaskProxy> {
+class WebURLSchemeTaskProxy : public RefCounted<WebURLSchemeTaskProxy>, public CanMakeCheckedPtr {
 public:
     static Ref<WebURLSchemeTaskProxy> create(WebURLSchemeHandlerProxy& handler, WebCore::ResourceLoader& loader, WebFrame& webFrame)
     {


### PR DESCRIPTION
#### 0a038d95965aa8aaf0ac1d113577bdf6b06474f6
<pre>
Store fewer raw pointers in containers in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=261933">https://bugs.webkit.org/show_bug.cgi?id=261933</a>

Reviewed by Brent Fulgham.

* Source/JavaScriptCore/inspector/InspectorTarget.h:
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
* Source/WebCore/css/CSSStyleDeclaration.h:
* Source/WebCore/dom/Range.h:
* Source/WebCore/page/DOMWindowExtension.h:
* Source/WebCore/page/PageOverlay.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
(WebKit::allWorkers):
(): Deleted.
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::connectionMap):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::allItems):
(): Deleted.
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::sharedWorldNameMap):
(API::sharedWorldIdentifierMap):
(API::ContentWorld::sharedWorldWithName):
(API::ContentWorld::~ContentWorld):
(): Deleted.
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::webUserContentControllerProxies):
(): Deleted.
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::viewGestureControllersForAllPages):
(WebKit::ViewGestureController::controllerForGesture):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::allFrames):
(): Deleted.
* Source/WebKit/UIProcess/WebPageGroup.cpp:
(WebKit::WebPageGroup::forEach):
* Source/WebKit/UIProcess/WebPageGroup.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::allDataStores):
(WebKit::WebsiteDataStore::forEachWebsiteDataStore):
(WebKit::WebsiteDataStore::existingDataStoreForIdentifier):
(WebKit::WebsiteDataStore::dataStoreForIdentifier):
(WebKit::networkProcessForSession):
(WebKit::WebsiteDataStore::parametersFromEachWebsiteDataStore):
(WebKit::WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized):
(WebKit::WebsiteDataStore::forwardManagedDomainsToITPIfInitialized):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/WebProcess/Databases/WebDatabaseProvider.cpp:
(WebKit::databaseProviders):
(): Deleted.
* Source/WebKit/WebProcess/Databases/WebDatabaseProvider.h:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp:
(WebKit::GeolocationPermissionRequestManager::didReceiveGeolocationPermissionDecision):
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.cpp:
(WebKit::InjectedBundleCSSStyleDeclarationHandle::getOrCreate):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleCSSStyleDeclarationHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::getOrCreate):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::InjectedBundleRangeHandle::getOrCreate):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::getOrCreate):
(WebKit::InjectedBundleScriptWorld::find):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.cpp:
(WebKit::WebPageInspectorTargetController::connectInspector):
(WebKit::WebPageInspectorTargetController::disconnectInspector):
(WebKit::WebPageInspectorTargetController::sendMessageToTargetBackend):
* Source/WebKit/WebProcess/Inspector/WebPageInspectorTargetController.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::remove):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocket.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp:
(WebKit::LibWebRTCSocketFactory::forSocketInGroup):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::urlSchemeTaskWillPerformRedirection):
(WebKit::WebPage::urlSchemeTaskDidPerformRedirection):
(WebKit::WebPage::urlSchemeTaskDidReceiveResponse):
(WebKit::WebPage::urlSchemeTaskDidReceiveData):
(WebKit::WebPage::urlSchemeTaskDidComplete):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp:
(WebKit::overlayMap):
(): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.h:
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h:
* Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h:

Canonical link: <a href="https://commits.webkit.org/268346@main">https://commits.webkit.org/268346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f6054ff3309e289f6c24fce66090af026d700ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18092 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19726 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22094 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23931 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16785 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21898 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18670 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15581 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22728 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17500 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/5623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4642 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21860 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23979 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18196 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5360 "Found 1 jsc stress test failure: microbenchmarks/array-from-object-func.js.lockdown") | 
<!--EWS-Status-Bubble-End-->