### PR TITLE
[user-activation] Fix html/user-activation/activation-trigger-pointerevent.html WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/activation-trigger-pointerevent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/activation-trigger-pointerevent.html
@@ -25,15 +25,15 @@
     promise_test(async () => {
         const test_pointer = pointer_type + "TestPointer";
 
-        new test_driver.Actions().addPointer(test_pointer, pointer_type)
+        let pointerdown_event = getEvent('pointerdown');
+        let pointerup_event = getEvent('pointerup');
+        let click_event = getEvent('click');
+
+        await new test_driver.Actions().addPointer(test_pointer, pointer_type)
             .pointerMove(0, 0, {origin:document.body, sourceName:test_pointer})
             .pointerDown({sourceName:test_pointer})
             .pointerUp({sourceName:test_pointer})
             .send();
-
-        let pointerdown_event = getEvent('pointerdown');
-        let pointerup_event = getEvent('pointerup');
-        let click_event = getEvent('click');
 
         await pointerdown_event;
         let consumed_pointerdown = await consumeTransientActivation();

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -424,10 +424,7 @@ void WebAutomationSessionProxy::evaluateJavaScriptFunction(WebCore::PageIdentifi
         JSValueMakeNumber(context, callbackTimeout.value_or(-1))
     };
 
-    {
-        WebCore::UserGestureIndicator gestureIndicator(WebCore::ProcessingUserGesture, frame->coreLocalFrame()->document());
-        callPropertyFunction(context, scriptObject, "evaluateJavaScriptFunction"_s, std::size(functionArguments), functionArguments, &exception);
-    }
+    callPropertyFunction(context, scriptObject, "evaluateJavaScriptFunction"_s, std::size(functionArguments), functionArguments, &exception);
 
     if (!exception)
         return;


### PR DESCRIPTION
#### df336e8effd7fddd4eb92084af4aab17bfb84ba9
<pre>
[user-activation] Fix html/user-activation/activation-trigger-pointerevent.html WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=259028">https://bugs.webkit.org/show_bug.cgi?id=259028</a>
rdar://111970701

Reviewed by Tim Nguyen.

This patch resolves two distinct issues resulting in our passing of the
html/user-activation/activation-trigger-pointerevent WPT when run
through the WebDriver tooling.

1. The WPT in question uses the Fullscreen API as a proxy to both query
for and consume transient user activation. It does so because it wants
to make certain claims about which pointer events result in user
activation. The problem is that we instantiate a user gesture indicator
(hence granting transient user activation) on _any_ script evaluation in
`WebAutomationSession`, i.e. any JS code forces a user gesture when
evaluated as part of a WPT running through our WebDriver implementation.
This behavior was introduced in 198987@main citing the Fullscreen API
_not working_ without this change.

2. As is, the WPT in question is nondeterministic because (a) it does not
wait on the promise returned by Actions.send() and (b) it sets up event
listeners after having fired off an action sequence, meaning it&apos;s
entirely likely that the event listener misses (some) events from the
action sequence.

We fix the former issue by dropping the forced user gesture on script
evaluation in WebAutomationSession. This is OK because we shouldn’t
implicitly grant user activation like this. Instead, we should follow WPT
best practices and invoke test_driver.bless() with our callbacks to
perform work requiring user activation. Some other tests even simply
create a button to click on before proceeding with their use of the
Fullscreen API, but at any rate are explicit about user activation.

We fix the latter issue by setting up the necessary event listeners
before firing an action sequence and correctly awaiting on the promise
returned by the Action interface.

* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/activation-trigger-pointerevent.html:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::evaluateJavaScriptFunction):

Canonical link: <a href="https://commits.webkit.org/268320@main">https://commits.webkit.org/268320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e487325d3ba514dafd094337fd29c626fcbfc7e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21236 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19890 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19564 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/16822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22106 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/17858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/17785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/21904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/17509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/17446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/21869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2364 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->