### PR TITLE
media/video-pause-while-seeking.html is a flaky failure.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6703,5 +6703,3 @@ imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-l
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-003.html [ Pass Failure ]
 
 webkit.org/b/245032 imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004.html [ ImageOnlyFailure ]
-
-webkit.org/b/261916 media/video-pause-while-seeking.html [ Pass Failure ]

--- a/LayoutTests/media/video-pause-while-seeking-expected.txt
+++ b/LayoutTests/media/video-pause-while-seeking-expected.txt
@@ -8,7 +8,7 @@ Verify that the video is paused when seek finishes.
 
 ++ Playing the video
 
-RUN(video.play())
+RUN(video.play().catch((error)=>{}))
 EVENT(play)
 
 ++ Video started to play, seeking

--- a/LayoutTests/media/video-pause-while-seeking.html
+++ b/LayoutTests/media/video-pause-while-seeking.html
@@ -50,7 +50,7 @@
                 consoleWrite("");
                 consoleWrite("<br><em>++ Playing the video");
                 consoleWrite("");
-                run("video.play()");
+                run("video.play().catch((error)=>{})");
                 waitForEventOnce('play', play);
             }
         </script>


### PR DESCRIPTION
#### a42505977bd3c9fecc659c6cbdfd07a723b3aa15
<pre>
media/video-pause-while-seeking.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261916">https://bugs.webkit.org/show_bug.cgi?id=261916</a>

Reviewed by NOBODY (OOPS!).

Guard the play promise with a catch().

* LayoutTests/TestExpectations: Removed flaky test.
* LayoutTests/media/video-pause-while-seeking-expected.txt: Expect new play().catch() line.
* LayoutTests/media/video-pause-while-seeking.html: Use play().catch() to guard against failed play() promise.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a42505977bd3c9fecc659c6cbdfd07a723b3aa15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21193 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18060 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19703 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22060 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23905 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21870 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15523 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17468 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17403 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->