### PR TITLE
RemoteImageDecoderAVFProxy does not attribute the frames to the owner process

### DIFF
--- a/Source/WebCore/platform/graphics/ImageDecoder.cpp
+++ b/Source/WebCore/platform/graphics/ImageDecoder.cpp
@@ -46,9 +46,14 @@ namespace WebCore {
 #if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
 using FactoryVector = Vector<ImageDecoder::ImageDecoderFactory>;
 
+static RefPtr<ImageDecoder> createInProcessImageDecoderAVFObjC(FragmentedSharedBuffer& buffer, const String& mimeType, AlphaOption alphaOption, GammaAndColorProfileOption gammaOption)
+{
+    return ImageDecoderAVFObjC::create(buffer, mimeType, alphaOption, gammaOption, ProcessIdentity { ProcessIdentity::CurrentProcess });
+}
+
 static void platformRegisterFactories(FactoryVector& factories)
 {
-    factories.append({ ImageDecoderAVFObjC::supportsMediaType, ImageDecoderAVFObjC::canDecodeType, ImageDecoderAVFObjC::create });
+    factories.append({ ImageDecoderAVFObjC::supportsMediaType, ImageDecoderAVFObjC::canDecodeType, createInProcessImageDecoderAVFObjC });
 }
 
 static FactoryVector& installedFactories()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
@@ -28,6 +28,7 @@
 #if HAVE(AVASSETREADER)
 
 #include "ImageDecoder.h"
+#include "ProcessIdentity.h"
 #include "SampleMap.h"
 #include <wtf/Lock.h>
 #include <wtf/Vector.h>
@@ -53,7 +54,7 @@ class WebCoreDecompressionSession;
 
 class ImageDecoderAVFObjC : public ImageDecoder {
 public:
-    WEBCORE_EXPORT static RefPtr<ImageDecoderAVFObjC> create(const FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption);
+    WEBCORE_EXPORT static RefPtr<ImageDecoderAVFObjC> create(const FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption, ProcessIdentity resourceOwner);
     virtual ~ImageDecoderAVFObjC();
 
     WEBCORE_EXPORT static bool supportsMediaType(MediaType);
@@ -94,7 +95,7 @@ public:
     WEBCORE_EXPORT Vector<ImageDecoder::FrameInfo> frameInfos() const;
 
 private:
-    ImageDecoderAVFObjC(const FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption);
+    ImageDecoderAVFObjC(const FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption, ProcessIdentity resourceOwner);
 
     AVAssetTrack *firstEnabledTrack();
     void readSamples();
@@ -120,6 +121,7 @@ private:
     Lock m_sampleGeneratorLock;
     bool m_isAllDataReceived { false };
     std::optional<IntSize> m_size;
+    ProcessIdentity m_resourceOwner;
 };
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
@@ -44,12 +44,13 @@ using namespace WebCore;
 
 RemoteImageDecoderAVFProxy::RemoteImageDecoderAVFProxy(GPUConnectionToWebProcess& connectionToWebProcess)
     : m_connectionToWebProcess(connectionToWebProcess)
+    , m_resourceOwner(connectionToWebProcess.webProcessIdentity())
 {
 }
 
 void RemoteImageDecoderAVFProxy::createDecoder(const IPC::SharedBufferReference& data, const String& mimeType, CompletionHandler<void(std::optional<ImageDecoderIdentifier>&&)>&& completionHandler)
 {
-    auto imageDecoder = ImageDecoderAVFObjC::create(data.isNull() ? SharedBuffer::create() : data.unsafeBuffer().releaseNonNull(), mimeType, AlphaOption::Premultiplied, GammaAndColorProfileOption::Ignored);
+    auto imageDecoder = ImageDecoderAVFObjC::create(data.isNull() ? SharedBuffer::create() : data.unsafeBuffer().releaseNonNull(), mimeType, AlphaOption::Premultiplied, GammaAndColorProfileOption::Ignored, m_resourceOwner);
 
     std::optional<ImageDecoderIdentifier> imageDecoderIdentifier;
     if (!imageDecoder)

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/ImageDecoderAVFObjC.h>
 #include <WebCore/ImageDecoderIdentifier.h>
+#include <WebCore/ProcessIdentity.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/WeakPtr.h>
@@ -67,6 +68,7 @@ private:
 
     WeakPtr<GPUConnectionToWebProcess> m_connectionToWebProcess;
     HashMap<WebCore::ImageDecoderIdentifier, RefPtr<WebCore::ImageDecoderAVFObjC>> m_imageDecoders;
+    WebCore::ProcessIdentity m_resourceOwner;
 };
 
 }


### PR DESCRIPTION
#### 146c1b7c9159eb722750086e5c2691d5fa72da00
<pre>
RemoteImageDecoderAVFProxy does not attribute the frames to the owner process
<a href="https://bugs.webkit.org/show_bug.cgi?id=261877">https://bugs.webkit.org/show_bug.cgi?id=261877</a>
rdar://115838448

Reviewed by Brent Fulgham.

Attribute the IOSurface-backed CVPixelBuffers to the WebContent process
that instantiated the RemoteImageDecoderAVFProxy.

Note: this captures only subset of the CVPixelBuffers in flight.
Subsequent work is still needed.

* Source/WebCore/platform/graphics/ImageDecoder.cpp:
(WebCore::createInProcessImageDecoderAVFObjC):
(WebCore::platformRegisterFactories):
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjC::create):
(WebCore::ImageDecoderAVFObjC::ImageDecoderAVFObjC):
(WebCore::ImageDecoderAVFObjC::storeSampleBuffer):
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp:
(WebKit::RemoteImageDecoderAVFProxy::RemoteImageDecoderAVFProxy):
(WebKit::RemoteImageDecoderAVFProxy::createDecoder):
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h:

Canonical link: <a href="https://commits.webkit.org/268325@main">https://commits.webkit.org/268325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65dbf14755ad6db7838352a610032ea37169a046

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21232 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18098 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19886 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22101 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17606 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21902 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17506 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4625 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21866 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->