### PR TITLE
[WGSL] Texture read needs unsigned coordinates

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2022,36 +2022,36 @@ fn testTrunc()
 
 // 16.7. Texture Built-in Functions (https://gpuweb.github.io/gpuweb/wgsl/#texture-builtin-functions)
 
-var s: sampler;
+@group(0) @binding( 0) var s: sampler;
 
-var t1d: texture_1d<f32>;
-var t1di: texture_1d<i32>;
-var t1du: texture_1d<u32>;
+@group(0) @binding( 1) var t1d: texture_1d<f32>;
+@group(0) @binding( 2) var t1di: texture_1d<i32>;
+@group(0) @binding( 3) var t1du: texture_1d<u32>;
 
-var t2d: texture_2d<f32>;
-var t2di: texture_2d<i32>;
-var t2du: texture_2d<u32>;
+@group(0) @binding( 4) var t2d: texture_2d<f32>;
+@group(0) @binding( 5) var t2di: texture_2d<i32>;
+@group(0) @binding( 6) var t2du: texture_2d<u32>;
 
-var t2da: texture_2d_array<f32>;
-var t2dai: texture_2d_array<i32>;
-var t2dau: texture_2d_array<u32>;
+@group(0) @binding( 7) var t2da: texture_2d_array<f32>;
+@group(0) @binding( 8) var t2dai: texture_2d_array<i32>;
+@group(0) @binding( 9) var t2dau: texture_2d_array<u32>;
 
-var t3d: texture_3d<f32>;
-var t3di: texture_3d<i32>;
-var t3du: texture_3d<u32>;
+@group(0) @binding(10) var t3d: texture_3d<f32>;
+@group(0) @binding(11) var t3di: texture_3d<i32>;
+@group(0) @binding(12) var t3du: texture_3d<u32>;
 
-var tm2d: texture_multisampled_2d<f32>;
-var tm2di: texture_multisampled_2d<i32>;
-var tm2du: texture_multisampled_2d<u32>;
+@group(0) @binding(13) var tm2d: texture_multisampled_2d<f32>;
+@group(0) @binding(14) var tm2di: texture_multisampled_2d<i32>;
+@group(0) @binding(15) var tm2du: texture_multisampled_2d<u32>;
 
-var te: texture_external;
-var tc: texture_cube<f32>;
-var tca: texture_cube_array<f32>;
+@group(0) @binding(16) var te: texture_external;
+@group(0) @binding(17) var tc: texture_cube<f32>;
+@group(0) @binding(18) var tca: texture_cube_array<f32>;
 
-var ts1d: texture_storage_2d<rgba8unorm, read>;
-var ts2d: texture_storage_2d<rgba16uint, write>;
-var ts2da: texture_storage_2d<r32sint, read_write>;
-var ts3d: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(19) var ts1d: texture_storage_2d<rgba8unorm, read>;
+@group(0) @binding(20) var ts2d: texture_storage_2d<rgba16uint, write>;
+@group(0) @binding(21) var ts2da: texture_storage_2d<r32sint, read_write>;
+@group(0) @binding(22) var ts3d: texture_storage_2d<rgba32float, write>;
 
 var td2d: texture_depth_2d;
 var td2da: texture_depth_2d_array;
@@ -2163,6 +2163,8 @@ fn testTextureGather()
 // FIXME: this only applies to texture_depth, implement
 
 // 16.7.4
+// RUN: %metal-compile testTextureLoad
+@compute @workgroup_size(1)
 fn testTextureLoad()
 {
     // [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture1d], T, U) => Vector[S, 4],


### PR DESCRIPTION
#### 88ae5ffc56ea933878163867990134c30cb94740
<pre>
[WGSL] Texture read needs unsigned coordinates
<a href="https://bugs.webkit.org/show_bug.cgi?id=261885">https://bugs.webkit.org/show_bug.cgi?id=261885</a>
rdar://115843632

Reviewed by Dan Glastonbury.

We convert textureLoad(texture, coordinate) into texture.read(coordinate), but
the problem is that texture load allows either signed or unsigned values in
the coordinate argument, but metal only allows unsigned values.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):

Canonical link: <a href="https://commits.webkit.org/268388@main">https://commits.webkit.org/268388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f4311d5a4a8110539de21c8a25122f51dc79de4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18070 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19714 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22072 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16768 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23917 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21884 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17478 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4673 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->