### PR TITLE
ImageBuffer::copyImage is redundant, should use copyNativeImage instead

### DIFF
--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -65,7 +65,7 @@ public:
 
     void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final { }
 
-    AffineTransform baseTransform() const final { ASSERT(m_copiedBuffer); return m_copiedBuffer->baseTransform(); }
+    AffineTransform baseTransform() const final;
     Image* copiedImage() const final;
     void clearCopiedImage() const final;
 
@@ -87,7 +87,6 @@ private:
 
     std::unique_ptr<CanvasRenderingContext> m_context;
     mutable std::unique_ptr<DisplayList::DrawingContext> m_recordingContext;
-    mutable RefPtr<ImageBuffer> m_copiedBuffer;
     mutable RefPtr<Image> m_copiedImage;
 };
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "HTMLCanvasElement.h"
 
+#include "BitmapImage.h"
 #include "Blob.h"
 #include "BlobCallback.h"
 #include "CanvasGradient.h"
@@ -923,7 +924,7 @@ Image* HTMLCanvasElement::copiedImage() const
     if (!m_copiedImage && buffer()) {
         if (m_context)
             m_context->paintRenderingResultsToCanvas();
-        m_copiedImage = buffer()->copyImage(CopyBackingStore, PreserveResolution::Yes);
+        m_copiedImage = BitmapImage::create(buffer()->copyNativeImage());
     }
     return m_copiedImage.get();
 }

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -656,7 +656,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
         return;
     }
 
-    auto imageForRender = existingImageBitmap->buffer()->copyImage();
+    auto imageForRender = BitmapImage::create(existingImageBitmap->buffer()->copyNativeImage());
 
     FloatRect destRect(FloatPoint(), outputSize);
     bitmapData->context().drawImage(*imageForRender, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::Orientation::None) });

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(OFFSCREEN_CANVAS)
 
+#include "BitmapImage.h"
 #include "CSSValuePool.h"
 #include "CanvasRenderingContext.h"
 #include "Chrome.h"
@@ -430,7 +431,7 @@ Image* OffscreenCanvas::copiedImage() const
     if (!m_copiedImage && buffer()) {
         if (m_context)
             m_context->paintRenderingResultsToCanvas();
-        m_copiedImage = buffer()->copyImage(CopyBackingStore, PreserveResolution::Yes);
+        m_copiedImage = BitmapImage::create(buffer()->copyNativeImage());
     }
     return m_copiedImage.get();
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -534,7 +534,7 @@ protected:
     RefPtr<Image> drawImageIntoBuffer(Image&, int width, int height, int deviceScaleFactor, const char* functionName);
 
 #if ENABLE(VIDEO)
-    RefPtr<Image> videoFrameToImage(HTMLVideoElement&, BackingStoreCopy, const char* functionName);
+    RefPtr<Image> videoFrameToImage(HTMLVideoElement&, const char* functionName);
 #endif
 
     WebGLTexture::TextureExtensionFlag textureExtensionFlags() const;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -403,8 +403,8 @@ void GraphicsContext::drawPattern(ImageBuffer& image, const FloatRect& destRect,
 {
     FloatRect scaledSource = source;
     scaledSource.scale(image.resolutionScale());
-    if (auto copiedImage = image.copyImage(this == &image.context() ? CopyBackingStore : DontCopyBackingStore))
-        copiedImage->drawPattern(*this, destRect, scaledSource, patternTransform, phase, spacing, options);
+    if (auto nativeImage = nativeImageForDrawing(image))
+        drawPattern(*nativeImage, destRect, source, patternTransform, phase, spacing, options);
 }
 
 void GraphicsContext::drawControlPart(ControlPart& part, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -30,6 +30,7 @@
 
 #if ENABLE(WEBGL)
 
+#include "BitmapImage.h"
 #include "FormatConverter.h"
 #include "GCGLSpan.h"
 #include "GraphicsContext.h"
@@ -652,9 +653,8 @@ RefPtr<Image> GraphicsContextGL::videoFrameToImage(VideoFrame& frame)
     auto imageBuffer = ImageBuffer::create(size, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
     if (!imageBuffer)
         return { };
-
     imageBuffer->context().paintVideoFrame(frame, { { }, size }, true);
-    return imageBuffer->copyImage(DontCopyBackingStore);
+    return BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTFMove(imageBuffer)));
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -385,14 +385,6 @@ RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage(RefPtr<ImageBuffer> source)
     return source->sinkIntoNativeImage();
 }
 
-RefPtr<Image> ImageBuffer::copyImage(BackingStoreCopy copyBehavior, PreserveResolution preserveResolution) const
-{
-    auto image = copyImageBufferToNativeImage(const_cast<ImageBuffer&>(*this), copyBehavior, preserveResolution);
-    if (!image)
-        return nullptr;
-    return BitmapImage::create(image.releaseNonNull());
-}
-
 void ImageBuffer::convertToLuminanceMask()
 {
     if (auto* backend = ensureBackendCreated())

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -162,7 +162,6 @@ public:
     // Useful when caller can guarantee the use of the NativeImage ends "immediately", before the next draw to this ImageBuffer.
     WEBCORE_EXPORT virtual RefPtr<NativeImage> createNativeImageReference() const;
 
-    WEBCORE_EXPORT RefPtr<Image> copyImage(BackingStoreCopy = CopyBackingStore, PreserveResolution = PreserveResolution::No) const;
     WEBCORE_EXPORT virtual RefPtr<NativeImage> filteredNativeImage(Filter&);
     RefPtr<NativeImage> filteredNativeImage(Filter&, Function<void(GraphicsContext&)> drawCallback);
 

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
@@ -564,11 +564,7 @@ void CairoOperationRecorder::drawImageBuffer(ImageBuffer& buffer, const FloatRec
         }
     };
 
-    RefPtr<Image> image = buffer.copyImage(DontCopyBackingStore);
-    if (!image)
-        return;
-
-    auto nativeImage = image->nativeImageForCurrentFrame();
+    auto nativeImage = buffer.createNativeImageReference();
     if (!nativeImage)
         return;
 
@@ -602,11 +598,7 @@ void CairoOperationRecorder::drawFilteredImageBuffer(ImageBuffer* srcImage, cons
     if (!imageBuffer)
         return;
 
-    RefPtr<Image> image = imageBuffer->copyImage(DontCopyBackingStore);
-    if (!image)
-        return;
-
-    auto nativeImage = image->nativeImageForCurrentFrame();
+    auto nativeImage = imageBuffer->createNativeImageReference();
     if (!nativeImage)
         return;
 
@@ -1161,11 +1153,7 @@ void CairoOperationRecorder::clipToImageBuffer(ImageBuffer& buffer, const FloatR
         }
     };
 
-    RefPtr<Image> image = buffer.copyImage(DontCopyBackingStore);
-    if (!image)
-        return;
-
-    if (auto nativeImage = image->nativeImageForCurrentFrame())
+    if (auto nativeImage = buffer.createNativeImageReference())
         append(createCommand<ClipToImageBuffer>(nativeImage->platformImage(), destRect));
 }
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -54,7 +54,7 @@ void BitmapTexture::updateContents(GraphicsLayer* sourceLayer, const IntRect& ta
 
     sourceLayer->paintGraphicsLayerContents(context, sourceRect);
 
-    RefPtr<Image> image = imageBuffer->copyImage(DontCopyBackingStore);
+    auto image = ImageBuffer::sinkIntoNativeImage(WTFMove(imageBuffer));
     if (!image)
         return;
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class FilterOperations;
 class GraphicsLayer;
-class Image;
+class NativeImage;
 class TextureMapper;
 
 // A 2D texture that can be the target of software or GL rendering.
@@ -60,7 +60,7 @@ public:
     virtual bool isBackedByOpenGL() const { return false; }
 
     virtual IntSize size() const = 0;
-    virtual void updateContents(Image*, const IntRect&, const IntPoint& offset) = 0;
+    virtual void updateContents(NativeImage*, const IntRect&, const IntPoint& offset) = 0;
     void updateContents(GraphicsLayer*, const IntRect& target, const IntPoint& offset, float scale = 1);
     virtual void updateContents(const void*, const IntRect& target, const IntPoint& offset, int bytesPerLine) = 0;
     virtual bool isValid() const = 0;

--- a/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.cpp
@@ -142,11 +142,8 @@ void BitmapTextureGL::updateContents(const void* srcData, const IntRect& targetR
     }
 }
 
-void BitmapTextureGL::updateContents(Image* image, const IntRect& targetRect, const IntPoint& offset)
+void BitmapTextureGL::updateContents(NativeImage* frameImage, const IntRect& targetRect, const IntPoint& offset)
 {
-    if (!image)
-        return;
-    auto frameImage = image->nativeImageForCurrentFrame();
     if (!frameImage)
         return;
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h
@@ -26,7 +26,6 @@
 #include "BitmapTexture.h"
 #include "ClipStack.h"
 #include "FilterOperation.h"
-#include "Image.h"
 #include "IntSize.h"
 #include "TextureMapperContextAttributes.h"
 #include "TextureMapperGL.h"
@@ -37,6 +36,7 @@ namespace WebCore {
 class TextureMapper;
 class TextureMapperGL;
 class FilterOperation;
+class NativeImage;
 
 #if OS(WINDOWS)
 #define USE_TEXMAP_DEPTH_STENCIL_BUFFER 1
@@ -62,7 +62,7 @@ public:
     virtual uint32_t id() const { return m_id; }
     uint32_t textureTarget() const { return GL_TEXTURE_2D; }
     IntSize textureSize() const { return m_textureSize; }
-    void updateContents(Image*, const IntRect&, const IntPoint&) override;
+    void updateContents(NativeImage*, const IntRect&, const IntPoint&) override;
     void updateContents(const void*, const IntRect& target, const IntPoint& sourceOffset, int bytesPerLine) override;
     bool isBackedByOpenGL() const override { return true; }
 
@@ -100,10 +100,6 @@ private:
     ClipStack m_clipStack;
     TextureMapperContextAttributes m_contextAttributes;
     TextureMapperGL::Flags m_colorConvertFlags { TextureMapperGL::NoFlag };
-
-#if ENABLE(WEBGL)
-    RefPtr<Image> m_pendingContents { nullptr };
-#endif
 
     void clearIfNeeded();
     void createFboIfNeeded();

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperTile.cpp
@@ -45,7 +45,8 @@ void TextureMapperTile::updateContents(TextureMapper& textureMapper, Image* imag
         m_texture->reset(targetRect.size(), image->currentFrameKnownToBeOpaque() ? 0 : BitmapTexture::SupportsAlpha);
     }
 
-    m_texture->updateContents(image, targetRect, sourceOffset);
+    auto nativeImage = image->nativeImageForCurrentFrame();
+    m_texture->updateContents(nativeImage.get(), targetRect, sourceOffset);
 }
 
 void TextureMapperTile::updateContents(TextureMapper& textureMapper, GraphicsLayer* sourceLayer, const IntRect& dirtyRect, float scale)

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
@@ -92,7 +92,7 @@ void MockRealtimeVideoSourceMac::updateSampleBuffer()
     }
 
     PlatformImagePtr platformImage;
-    if (auto nativeImage = imageBuffer->copyImage()->nativeImage())
+    if (auto nativeImage = imageBuffer->copyNativeImage())
         platformImage = nativeImage->platformImage();
 
     auto presentationTime = MediaTime::createWithDouble((elapsedTime() + 100_ms).seconds());


### PR DESCRIPTION
#### b5117f4636f67c6f8f8efb3f4a6ca1ce0914866d
<pre>
ImageBuffer::copyImage is redundant, should use copyNativeImage instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=261944">https://bugs.webkit.org/show_bug.cgi?id=261944</a>
rdar://115891269

Reviewed by Matt Woodrow.

Remove ImageBuffer::copyImaage(). WebCore::Image is higher level
type. Callers should call sinkIntoNativeImage and then convert the
NativeImage into Image, if needed. Note: most callers should use
NativeImage, as that is the lowest level source image.

These are identical:
copyImage(CopyBackingStore, PreserveResolution::Yes) -&gt; copyNativeImage()
copyImage(DontCopyBackingStore, PreserveResolution::No) + scale 1
 -&gt; createNativeImageReference()

Other variants wouldn&apos;t have corresponding NativeImage call, but they
do not exist.

This is work towards simplifying ImageBuffer by making it operate
with NativeImage as its primary primitive image source.

* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::copiedImage const):
Fix an issue where the code would nullptr deref if Context2D call
would try to reset the transform to default.
The idea of CanvasBase::baseTransform() is that it would return the
transform to be set, but this cannot happen because ImageBuffer has not
been created at the time of the call. The transform reset is recorded.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::copiedImage const):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createCompletionHandler):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::copiedImage const):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource):
(WebCore::WebGLRenderingContextBase::drawImageIntoBuffer):
(WebCore::WebGLRenderingContextBase::videoFrameToImage):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawPattern):
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::videoFrameToImage):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::copyImage const): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp:
(Nicosia::CairoOperationRecorder::drawImageBuffer):
(Nicosia::CairoOperationRecorder::drawFilteredImageBuffer):
(Nicosia::CairoOperationRecorder::clipToImageBuffer):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::updateContents):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTextureGL.cpp:
(WebCore::BitmapTextureGL::updateContents):
* Source/WebCore/platform/graphics/texmap/BitmapTextureGL.h:
* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm:
(WebCore::MockRealtimeVideoSourceMac::updateSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/268643@main">https://commits.webkit.org/268643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02368c516a6ef2a9f1bcd8b455449e910d2bdfbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20211 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22810 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24488 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22478 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16126 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18198 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4866 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->