### PR TITLE
[iOS] REGRESSION(268041@main): Unable to scroll Twitch.tv with touch atop video area

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKVideoView.h
+++ b/Source/WebKit/UIProcess/ios/WKVideoView.h
@@ -29,7 +29,7 @@
 
 #import "RemoteLayerTreeViews.h"
 
-@interface WKVideoView : WKCompositingView <WKNativelyInteractible>
+@interface WKVideoView : WKCompositingView
 @end
 
 #endif


### PR DESCRIPTION
#### f64be53a5d379efa58adc564df047b53a1a5f769
<pre>
[iOS] REGRESSION(268041@main): Unable to scroll Twitch.tv with touch atop video area
<a href="https://bugs.webkit.org/show_bug.cgi?id=261950">https://bugs.webkit.org/show_bug.cgi?id=261950</a>
rdar://115850939

Reviewed by Simon Fraser.

Views which conform to WKNativelyInteractible (like WKModelView and WKSegmentedModelView) get special treatment inside `-_web_findDescendantViewAtPoint:`, so that touch events can be handled directly by the view itself. WKVideoView doesn&apos;t actually need to handle touch events directly, so it should just be a normal subclass of WKCompositingView.

* Source/WebKit/UIProcess/ios/WKVideoView.h:

Canonical link: <a href="https://commits.webkit.org/268331@main">https://commits.webkit.org/268331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f25cafb4d6e4e55fe059b6853afa6e3bbf53cb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18081 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19721 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22083 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16778 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23929 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21896 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17489 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4631 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->