### PR TITLE
[WGSL] Add code generation for textureDimensions

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2044,14 +2044,14 @@ fn testTrunc()
 @group(0) @binding(14) var tm2di: texture_multisampled_2d<i32>;
 @group(0) @binding(15) var tm2du: texture_multisampled_2d<u32>;
 
-@group(0) @binding(16) var te: texture_external;
-@group(0) @binding(17) var tc: texture_cube<f32>;
-@group(0) @binding(18) var tca: texture_cube_array<f32>;
+@group(0) @binding(16) var tc: texture_cube<f32>;
+@group(0) @binding(17) var tca: texture_cube_array<f32>;
 
-@group(0) @binding(19) var ts1d: texture_storage_2d<rgba8unorm, read>;
-@group(0) @binding(20) var ts2d: texture_storage_2d<rgba16uint, write>;
-@group(0) @binding(21) var ts2da: texture_storage_2d<r32sint, read_write>;
-@group(0) @binding(22) var ts3d: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(18) var ts1d: texture_storage_2d<rgba8unorm, read>;
+@group(0) @binding(19) var ts2d: texture_storage_2d<rgba16uint, write>;
+@group(0) @binding(20) var ts2da: texture_storage_2d<r32sint, read_write>;
+@group(0) @binding(21) var ts3d: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(22) var te: texture_external;
 
 var td2d: texture_depth_2d;
 var td2da: texture_depth_2d_array;
@@ -2060,6 +2060,8 @@ var tdca: texture_depth_cube_array;
 var tdms2d: texture_depth_multisampled_2d;
 
 // 16.7.1
+// RUN: %metal-compile testTextureDimensions
+@compute @workgroup_size(1)
 fn testTextureDimensions()
 {
     // FIXME: add declarations for texture storage


### PR DESCRIPTION
#### 115ce0122bad1637e028a1d23b27c01b2fdc75cf
<pre>
[WGSL] Add code generation for textureDimensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=261951">https://bugs.webkit.org/show_bug.cgi?id=261951</a>
rdar://115895843

Reviewed by Dan Glastonbury.

Emit the correct Metal code using `get_(height|width|depth)`

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268389@main">https://commits.webkit.org/268389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18e774f4c0dc1fd058c1092d7c82ce690e10d619

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18292 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20118 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19772 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22304 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/16980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24098 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22070 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15740 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17715 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4674 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->