### PR TITLE
[WGSL] Bring ruby DSL syntax closer to WGSL

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -151,10 +151,10 @@ const Type* concretize(const Type* type, TypeStore& types)
             return satisfyOrPromote(type, Constraints::ConcreteScalar, types);
         },
         [&](const Vector& vector) -> const Type* {
-            return types.vectorType(concretize(vector.element, types), vector.size);
+            return types.vectorType(vector.size, concretize(vector.element, types));
         },
         [&](const Matrix& matrix) -> const Type* {
-            return types.matrixType(concretize(matrix.element, types), matrix.columns, matrix.rows);
+            return types.matrixType(matrix.columns, matrix.rows, concretize(matrix.element, types));
         },
         [&](const Array& array) -> const Type* {
             return types.arrayType(concretize(array.element, types), array.size);

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -153,7 +153,7 @@ const Type* OverloadResolver::materialize(const AbstractType& abstractType) cons
         [&](const AbstractVector& vector) -> const Type* {
             if (auto* element = materialize(vector.element)) {
                 auto size = materialize(vector.size);
-                return m_types.vectorType(element, size);
+                return m_types.vectorType(size, element);
             }
             return nullptr;
         },
@@ -161,13 +161,13 @@ const Type* OverloadResolver::materialize(const AbstractType& abstractType) cons
             if (auto* element = materialize(matrix.element)) {
                 auto columns = materialize(matrix.columns);
                 auto rows = materialize(matrix.rows);
-                return m_types.matrixType(element, columns, rows);
+                return m_types.matrixType(columns, rows, element);
             }
             return nullptr;
         },
         [&](const AbstractTexture& texture) -> const Type* {
             if (auto* element = materialize(texture.element))
-                return m_types.textureType(element, texture.kind);
+                return m_types.textureType(texture.kind, element);
             return nullptr;
         },
         [&](const AbstractReference& reference) -> const Type* {

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -60,19 +60,19 @@ using AbstractTypeImpl = std::variant<
 using AbstractType = std::unique_ptr<AbstractTypeImpl>;
 
 struct AbstractVector {
-    AbstractType element;
     AbstractValue size;
+    AbstractType element;
 };
 
 struct AbstractMatrix {
-    AbstractType element;
     AbstractValue columns;
     AbstractValue rows;
+    AbstractType element;
 };
 
 struct AbstractTexture {
-    AbstractType element;
     Types::Texture::Kind kind;
+    AbstractType element;
 };
 
 struct AbstractReference {

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1050,7 +1050,7 @@ const Type* TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::Fie
         return nullptr;
     }
 
-    return m_types.vectorType(vector.element, length);
+    return m_types.vectorType(length, vector.element);
 }
 
 template<typename CallArguments>
@@ -1220,7 +1220,7 @@ void TypeChecker::allocateSimpleConstructor(ASCIILiteral name, TargetConstructor
             if (isBottom(elementType))
                 return m_types.bottomType();
 
-            return (m_types.*constructor)(elementType, arguments...);
+            return (m_types.*constructor)(arguments..., elementType);
         }
     ));
 }

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -1,19 +1,20 @@
 # FIXME: add all the missing type declarations here
 
 suffixes = {
-    f: F32,
-    i: I32,
-    u: U32,
+    f: f32,
+    i: i32,
+    u: u32,
 }
 
 [2, 3, 4].each do |n|
     suffixes.each do |suffix, type|
-        type_alias :"vec#{n}#{suffix}", Vector[type, n]
+        type_alias :"vec#{n}#{suffix}", vec[n][type]
     end
 
     [2, 3, 4].each do |m|
         # FIXME: add alias for F16 once we support it
-        type_alias :"mat#{n}x#{m}f", Matrix[F32, n, m]
+        #type_alias :"mat#{n}x#{m}f", mat[n][m](f32)[f32, n, m]
+        type_alias :"mat#{n}x#{m}f", mat[n,m][f32]
     end
 end
 
@@ -21,119 +22,119 @@ operator :+, {
     [T < Number].(T, T) => T,
 
     # vector addition
-    [T < Number, N].(Vector[T, N], T) => Vector[T, N],
-    [T < Number, N].(T, Vector[T, N]) => Vector[T, N],
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T], T) => vec[N][T],
+    [T < Number, N].(T, vec[N][T]) => vec[N][T],
+    [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 
     # matrix-matrix addition
-    [T < Float, C, R].(Matrix[T, C, R], Matrix[T, C, R]) => Matrix[T, C, R],
+    [T < Float, C, R].(mat[C,R][T], mat[C,R][T]) => mat[C,R][T],
 }
 
 operator :-, {
     # unary
     [T < SignedNumber].(T) => T,
-    [T < SignedNumber, N].(Vector[T, N]) => Vector[T, N],
+    [T < SignedNumber, N].(vec[N][T]) => vec[N][T],
 
     # binary
     [T < Number].(T, T) => T,
-    [T < Number, N].(Vector[T, N], T) => Vector[T, N],
-    [T < Number, N].(T, Vector[T, N]) => Vector[T, N],
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T], T) => vec[N][T],
+    [T < Number, N].(T, vec[N][T]) => vec[N][T],
+    [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 operator :*, {
     # unary
-    [AS, T, AM].(Ptr[AS, T, AM]) => Ref[AS, T, AM],
+    [AS, T, AM].(ptr[AS, T, AM]) => ref[AS, T, AM],
 
     # binary
     [T < Number].(T, T) => T,
 
     # vector scaling
-    [T < Number, N].(Vector[T, N], T) => Vector[T, N],
-    [T < Number, N].(T, Vector[T, N]) => Vector[T, N],
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T], T) => vec[N][T],
+    [T < Number, N].(T, vec[N][T]) => vec[N][T],
+    [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 
     # matrix-vector multiplication
-    [T < Float, C, R].(Matrix[T, C, R], Vector[T, C]) => Vector[T, R],
-    [T < Float, C, R].(Vector[T, R], Matrix[T, C, R]) => Vector[T, C],
+    [T < Float, C, R].(mat[C,R][T], vec[C][T]) => vec[R][T],
+    [T < Float, C, R].(vec[R][T], mat[C,R][T]) => vec[C][T],
 
     # matrix-matrix multiplication
-    [T < Float, C, R, K].(Matrix[T, K, R], Matrix[T, C, K]) => Matrix[T, C, R],
+    [T < Float, C, R, K].(mat[K,R][T], mat[C,K][T]) => mat[C,R][T],
 }
 
 operator :/, {
     [T < Number].(T, T) => T,
 
     # vector scaling
-    [T < Number, N].(Vector[T, N], T) => Vector[T, N],
-    [T < Number, N].(T, Vector[T, N]) => Vector[T, N],
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T], T) => vec[N][T],
+    [T < Number, N].(T, vec[N][T]) => vec[N][T],
+    [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 operator :%, {
     [T < Number].(T, T) => T,
 
     # vector scaling
-    [T < Number, N].(Vector[T, N], T) => Vector[T, N],
-    [T < Number, N].(T, Vector[T, N]) => Vector[T, N],
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T], T) => vec[N][T],
+    [T < Number, N].(T, vec[N][T]) => vec[N][T],
+    [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # Comparison operations
 ["==", "!="].each do |op|
     operator :"#{op}", {
-        [T < Scalar].(T, T) => Bool,
-        [T < Scalar, N].(Vector[T, N], Vector[T, N]) => Vector[Bool, N],
+        [T < Scalar].(T, T) => bool,
+        [T < Scalar, N].(vec[N][T], vec[N][T]) => vec[N][bool],
     }
 end
 
 ["<", "<=", ">", ">="].each do |op|
     operator :"#{op}", {
-        [T < Number].(T, T) => Bool,
-        [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[Bool, N],
+        [T < Number].(T, T) => bool,
+        [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][bool],
     }
 end
 
 # 8.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
 
 operator :!, {
-    [].(Bool) => Bool,
-    [N].(Vector[Bool, N]) => Vector[Bool, N],
+    [].(bool) => bool,
+    [N].(vec[N][bool]) => vec[N][bool],
 }
 
 operator :'||', {
-    [].(Bool, Bool) => Bool,
+    [].(bool, bool) => bool,
 }
 
 operator :'&&', {
-    [].(Bool, Bool) => Bool,
+    [].(bool, bool) => bool,
 }
 
 operator :'|', {
-    [].(Bool, Bool) => Bool,
-    [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
+    [].(bool, bool) => bool,
+    [N].(vec[N][bool], vec[N][bool]) => vec[N][bool],
 }
 
 operator :'&', {
     # unary
-    [AS, T, AM].(Ref[AS, T, AM]) => Ptr[AS, T, AM],
+    [AS, T, AM].(ref[AS, T, AM]) => ptr[AS, T, AM],
 
     # binary
-    [].(Bool, Bool) => Bool,
-    [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
+    [].(bool, bool) => bool,
+    [N].(vec[N][bool], vec[N][bool]) => vec[N][bool],
 }
 
 # 8.9. Bit Expressions (https://www.w3.org/TR/WGSL/#bit-expr)
 
 operator :~, {
     [T < Integer].(T) => T,
-    [T < Integer, N].(Vector[T, N]) => Vector[T, N]
+    [T < Integer, N].(vec[N][T]) => vec[N][T]
 }
 
 ["|", "&", "^", "<<", ">>"].each do |op|
     operator :"#{op}", {
         [T < Integer].(T, T) => T,
-        [T < Integer, N].(Vector[T, N], Vector[T, N]) => Vector[T, N]
+        [T < Integer, N].(vec[N][T], vec[N][T]) => vec[N][T]
     }
 end
 
@@ -141,30 +142,30 @@ end
 
 # 16.1.1. Zero Value Built-in Functions
 operator :bool, {
-    [].() => Bool,
+    [].() => bool,
 }
 operator :i32, {
-    [].() => I32,
+    [].() => i32,
 }
 operator :u32, {
-    [].() => U32,
+    [].() => u32,
 }
 operator :f32, {
-    [].() => F32,
+    [].() => f32,
 }
 operator :vec2, {
-    [T < ConcreteScalar].() => Vector[T, 2],
+    [T < ConcreteScalar].() => vec2[T],
 }
 operator :vec3, {
-    [T < ConcreteScalar].() => Vector[T, 3],
+    [T < ConcreteScalar].() => vec3[T],
 }
 operator :vec4, {
-    [T < ConcreteScalar].() => Vector[T, 4],
+    [T < ConcreteScalar].() => vec4[T],
 }
 (2..4).each do |columns|
     (2..4).each do |rows|
         operator :"mat#{columns}x#{rows}", {
-            [T < ConcreteFloat].() => Matrix[T, columns, rows],
+            [T < ConcreteFloat].() => mat[columns,rows][T],
         }
     end
 end
@@ -176,7 +177,7 @@ end
 
 # 16.1.2.2.
 operator :bool, {
-    [T < ConcreteScalar].(T) => Bool,
+    [T < ConcreteScalar].(T) => bool,
 }
 
 # 16.1.2.3. f16
@@ -184,22 +185,22 @@ operator :bool, {
 
 # 16.1.2.4.
 operator :f32, {
-    [T < ConcreteScalar].(T) => F32,
+    [T < ConcreteScalar].(T) => f32,
 }
 
 # 16.1.2.5.
 operator :i32, {
-    [T < ConcreteScalar].(T) => I32,
+    [T < ConcreteScalar].(T) => i32,
 }
 
 # 16.1.2.6 - 14: matCxR
 (2..4).each do |columns|
     (2..4).each do |rows|
         operator :"mat#{columns}x#{rows}", {
-            [T < ConcreteFloat, S < Float].(Matrix[S, columns, rows]) => Matrix[T, columns, rows],
-            [T < Float].(Matrix[T, columns, rows]) => Matrix[T, columns, rows],
-            [T < Float].(*([T] * columns * rows)) => Matrix[T, columns, rows],
-            [T < Float].(*([Vector[T, rows]] * columns)) => Matrix[T, columns, rows],
+            [T < ConcreteFloat, S < Float].(mat[columns,rows][S]) => mat[columns,rows][T],
+            [T < Float].(mat[columns,rows][T]) => mat[columns,rows][T],
+            [T < Float].(*([T] * columns * rows)) => mat[columns,rows][T],
+            [T < Float].(*([vec[rows][T]] * columns)) => mat[columns,rows][T],
         }
     end
 end
@@ -209,42 +210,42 @@ end
 
 # 16.1.2.16.
 operator :u32, {
-    [T < ConcreteScalar].(T) => U32,
+    [T < ConcreteScalar].(T) => u32,
 }
 
 # 16.1.2.17.
 operator :vec2, {
-    [T < Scalar].(T) => Vector[T, 2],
-    [T < ConcreteScalar, S < Scalar].(Vector[S, 2]) => Vector[T, 2],
-    [S < Scalar].(Vector[S, 2]) => Vector[S, 2],
-    [T < Scalar].(T, T) => Vector[T, 2],
-    [].() => Vector[AbstractInt, 2],
+    [T < Scalar].(T) => vec2[T],
+    [T < ConcreteScalar, S < Scalar].(vec2[S]) => vec2[T],
+    [S < Scalar].(vec2[S]) => vec2[S],
+    [T < Scalar].(T, T) => vec2[T],
+    [].() => vec2[abstract_int],
 }
 
 # 16.1.2.18.
 operator :vec3, {
-    [T < Scalar].(T) => Vector[T, 3],
-    [T < ConcreteScalar, S < Scalar].(Vector[S, 3]) => Vector[T, 3],
-    [S < Scalar].(Vector[S, 3]) => Vector[S, 3],
-    [T < Scalar].(T, T, T) => Vector[T, 3],
-    [T < Scalar].(Vector[T, 2], T) => Vector[T, 3],
-    [T < Scalar].(T, Vector[T, 2]) => Vector[T, 3],
-    [].() => Vector[AbstractInt, 3],
+    [T < Scalar].(T) => vec3[T],
+    [T < ConcreteScalar, S < Scalar].(vec3[S]) => vec3[T],
+    [S < Scalar].(vec3[S]) => vec3[S],
+    [T < Scalar].(T, T, T) => vec3[T],
+    [T < Scalar].(vec2[T], T) => vec3[T],
+    [T < Scalar].(T, vec2[T]) => vec3[T],
+    [].() => vec3[abstract_int],
 }
 
 # 16.1.2.19.
 operator :vec4, {
-    [T < Scalar].(T) => Vector[T, 4],
-    [T < ConcreteScalar, S < Scalar].(Vector[S, 4]) => Vector[T, 4],
-    [S < Scalar].(Vector[S, 4]) => Vector[S, 4],
-    [T < Scalar].(T, T, T, T) => Vector[T, 4],
-    [T < Scalar].(T, Vector[T, 2], T) => Vector[T, 4],
-    [T < Scalar].(T, T, Vector[T, 2]) => Vector[T, 4],
-    [T < Scalar].(Vector[T, 2], T, T) => Vector[T, 4],
-    [T < Scalar].(Vector[T, 2], Vector[T, 2]) => Vector[T, 4],
-    [T < Scalar].(Vector[T, 3], T) => Vector[T, 4],
-    [T < Scalar].(T, Vector[T, 3]) => Vector[T, 4],
-    [].() => Vector[AbstractInt, 4],
+    [T < Scalar].(T) => vec4[T],
+    [T < ConcreteScalar, S < Scalar].(vec4[S]) => vec4[T],
+    [S < Scalar].(vec4[S]) => vec4[S],
+    [T < Scalar].(T, T, T, T) => vec4[T],
+    [T < Scalar].(T, vec2[T], T) => vec4[T],
+    [T < Scalar].(T, T, vec2[T]) => vec4[T],
+    [T < Scalar].(vec2[T], T, T) => vec4[T],
+    [T < Scalar].(vec2[T], vec2[T]) => vec4[T],
+    [T < Scalar].(vec3[T], T) => vec4[T],
+    [T < Scalar].(T, vec3[T]) => vec4[T],
+    [].() => vec4[abstract_int],
 }
 
 # 17.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)
@@ -252,24 +253,24 @@ operator :vec4, {
 # 17.3.1 & 17.3.2
 ["all", "any"].each do |op|
     operator :"#{op}", {
-        [N].(Vector[Bool, N]) => Bool,
-        [N].(Bool) => Bool,
+        [N].(vec[N][bool]) => bool,
+        [N].(bool) => bool,
     }
 end
 
 # 17.3.3
 operator :select, {
-    [T < Scalar].(T, T, Bool) => T,
-    [T < Scalar, N].(Vector[T, N], Vector[T, N], Bool) => Vector[T, N],
-    [T < Scalar, N].(Vector[T, N], Vector[T, N], Vector[Bool, N]) => Vector[T, N],
+    [T < Scalar].(T, T, bool) => T,
+    [T < Scalar, N].(vec[N][T], vec[N][T], bool) => vec[N][T],
+    [T < Scalar, N].(vec[N][T], vec[N][T], vec[N][bool]) => vec[N][T],
 }
 
 # 16.4. Array Built-in Functions
 
 # 16.4.1.
 operator :arrayLength, {
-  [T].(Ptr[Storage, Array[T], Read]) => U32,
-  [T].(Ptr[Storage, Array[T], ReadWrite]) => U32,
+  [T].(ptr[storage, array[T], read]) => u32,
+  [T].(ptr[storage, array[T], read_write]) => u32,
 }
 
 # 17.5. Numeric Built-in Functions (https://www.w3.org/TR/WGSL/#numeric-builtin-functions)
@@ -279,14 +280,14 @@ operator :arrayLength, {
  "acosh", "asinh", "atanh", "cosh", "sinh", "tanh"].each do |op|
     operator :"#{op}", {
         [T < Float].(T) => T,
-        [T < Float, N].(Vector[T, N]) => Vector[T, N],
+        [T < Float, N].(vec[N][T]) => vec[N][T],
     }
 end
 
 # 17.5.1
 operator :abs, {
     [T < Number].(T) => T,
-    [T < Number, N].(Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.2. acos
@@ -300,19 +301,19 @@ operator :abs, {
 # 17.5.8
 operator :atan2, {
     [T < Float].(T, T) => T,
-    [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.9
 operator :ceil, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.10
 operator :clamp, {
     [T < Number].(T, T, T) => T,
-    [T < Number, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.11. cos
@@ -323,94 +324,94 @@ operator :clamp, {
 ["countLeadingZeros", "countOneBits", "countTrailingZeros"].each do |op|
     operator :"#{op}", {
         [T < ConcreteInteger].(T) => T,
-        [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+        [T < ConcreteInteger, N].(vec[N][T]) => vec[N][T],
     }
 end
 
 # 17.5.16
 operator :cross, {
-    [T < Float].(Vector[T, 3], Vector[T, 3]) => Vector[T, 3],
+    [T < Float].(vec3[T], vec3[T]) => vec3[T],
 }
 
 # 17.5.17
 operator :degrees, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.18
 operator :determinant, {
-    [T < Float, C].(Matrix[T, C, C]) => T,
+    [T < Float, C].(mat[C,C][T]) => T,
 }
 
 # 17.5.19
 operator :distance, {
     [T < Float].(T, T) => T,
-    [T < Float, N].(Vector[T, N], Vector[T, N]) => T,
+    [T < Float, N].(vec[N][T], vec[N][T]) => T,
 }
 
 # 17.5.20
 operator :dot, {
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => T
+    [T < Number, N].(vec[N][T], vec[N][T]) => T
 }
 
 # 17.5.21 & 17.5.22
 ["exp", "exp2"].each do |op|
     operator :"#{op}", {
         [T < Float].(T) => T,
-        [T < Float, N].(Vector[T, N]) => Vector[T, N],
+        [T < Float, N].(vec[N][T]) => vec[N][T],
     }
 end
 
 # 17.5.23 & 17.5.24
 operator :extractBits, {
     # signed
-    [].(I32, U32, U32) => I32,
-    [N].(Vector[I32, N], U32, U32) => Vector[I32, N],
+    [].(i32, u32, u32) => i32,
+    [N].(vec[N][i32], u32, u32) => vec[N][i32],
 
     # unsigned
-    [].(U32, U32, U32) => U32,
-    [N].(Vector[U32, N], U32, U32) => Vector[U32, N],
+    [].(u32, u32, u32) => u32,
+    [N].(vec[N][u32], u32, u32) => vec[N][u32],
 }
 
 # 17.5.25
 operator :faceForward, {
-    [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.26 & 17.5.27
 operator :firstLeadingBit, {
     # signed
-    [].(I32) => I32,
-    [N].(Vector[I32, N]) => Vector[I32, N],
+    [].(i32) => i32,
+    [N].(vec[N][i32]) => vec[N][i32],
 
     # unsigned
-    [].(U32) => U32,
-    [N].(Vector[U32, N]) => Vector[U32, N],
+    [].(u32) => u32,
+    [N].(vec[N][u32]) => vec[N][u32],
 }
 
 # 17.5.28
 operator :firstTrailingBit, {
     [T < ConcreteInteger].(T) => T,
-    [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+    [T < ConcreteInteger, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.29
 operator :floor, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.30
 operator :fma, {
     [T < Float].(T, T, T) => T,
-    [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.31
 operator :fract, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.32
@@ -420,55 +421,55 @@ operator :frexp, {
 
 # 17.5.33
 operator :insertBits, {
-    [T < ConcreteInteger].(T, T, U32, U32) => T,
-    [T < ConcreteInteger, N].(Vector[T, N], Vector[T, N], U32, U32) => Vector[T, N],
+    [T < ConcreteInteger].(T, T, u32, u32) => T,
+    [T < ConcreteInteger, N].(vec[N][T], vec[N][T], u32, u32) => vec[N][T],
 }
 
 # 17.5.34
 operator :inverseSqrt, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.35
 operator :ldexp, {
-    [T < ConcreteFloat].(T, I32) => T,
-    [].(AbstractFloat, AbstractInt) => AbstractFloat,
-    [T < ConcreteFloat, N].(Vector[T, N], Vector[I32, N]) => Vector[T, N],
-    [N].(Vector[AbstractFloat, N], Vector[AbstractInt, N]) => Vector[AbstractFloat, N],
+    [T < ConcreteFloat].(T, i32) => T,
+    [].(abstract_float, abstract_int) => abstract_float,
+    [T < ConcreteFloat, N].(vec[N][T], vec[N][i32]) => vec[N][T],
+    [N].(vec[N][abstract_float], vec[N][abstract_int]) => vec[N][abstract_float],
 }
 
 # 17.5.36
 operator :length, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => T,
+    [T < Float, N].(vec[N][T]) => T,
 }
 
 # 17.5.37 & 17.5.38
 ["log", "log2"].each do |op|
     operator :"#{op}", {
         [T < Float].(T) => T,
-        [T < Float, N].(Vector[T, N]) => Vector[T, N],
+        [T < Float, N].(vec[N][T]) => vec[N][T],
     }
 end
 
 # 17.5.39
 operator :max, {
     [T < Number].(T, T) => T,
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.40
 operator :min, {
     [T < Number].(T, T) => T,
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Number, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.41
 operator :mix, {
     [T < Float].(T, T, T) => T,
-    [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
-    [T < Float, N].(Vector[T, N], Vector[T, N], T) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
+    [T < Float, N].(vec[N][T], vec[N][T], T) => vec[N][T],
 }
 
 # 17.5.42
@@ -478,59 +479,59 @@ operator :modf, {
 
 # 17.5.43
 operator :normalize, {
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.44
 operator :pow, {
     [T < Float].(T, T) => T,
-    [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.45
 operator :quantizeToF16, {
-    [].(F32) => F32,
-    [N].(Vector[F32, N]) => Vector[F32, N],
+    [].(f32) => f32,
+    [N].(vec[N][f32]) => vec[N][f32],
 }
 
 # 17.5.46
 operator :radians, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.47
 operator :reflect, {
-    [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.48
 operator :refract, {
-    [T < Float, N].(Vector[T, N], Vector[T, N], T) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T], T) => vec[N][T],
 }
 
 # 17.5.49
 operator :reverseBits, {
     [T < ConcreteInteger].(T) => T,
-    [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+    [T < ConcreteInteger, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.50
 operator :round, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.51
 operator :saturate, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.52
 operator :sign, {
     [T < SignedNumber].(T) => T,
-    [T < SignedNumber, N].(Vector[T, N]) => Vector[T, N],
+    [T < SignedNumber, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.53. sin
@@ -540,19 +541,19 @@ operator :sign, {
 # 17.5.55
 operator :smoothstep, {
     [T < Float].(T, T, T) => T,
-    [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.56
 operator :sqrt, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 17.5.57
 operator :step, {
     [T < Float].(T, T) => T,
-    [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T], vec[N][T]) => vec[N][T],
 }
 
 # 17.5.58. tan
@@ -561,13 +562,13 @@ operator :step, {
 
 # 17.5.60
 operator :transpose, {
-    [T < Float, C, R].(Matrix[T, C, R]) => Matrix[T, R, C],
+    [T < Float, C, R].(mat[C,R][T]) => mat[R,C][T],
 }
 
 # 17.5.61
 operator :trunc, {
     [T < Float].(T) => T,
-    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
 # 16.7. Texture Built-in Functions (https://gpuweb.github.io/gpuweb/wgsl/#texture-builtin-functions)
@@ -579,95 +580,95 @@ operator :textureDimensions, {
     # A is an access mode
     # T is texture_1d<ST> or texture_storage_1d<F,A>
     # @must_use fn textureDimensions(t: T) -> u32
-    [S < Concrete32BitNumber].(Texture[S, Texture1d]) => U32,
+    [S < Concrete32BitNumber].(texture_1d[S]) => u32,
     # FIXME: add declarations for texture storage
 
     # ST is i32, u32, or f32
     # T is texture_1d<ST>
     # L is i32, or u32
     # @must_use fn textureDimensions(t: T, level: L) -> u32
-    [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture1d], T) => U32,
+    [S < Concrete32BitNumber, T < ConcreteInteger].(texture_1d[S], T) => u32,
 
     # ST is i32, u32, or f32
     # F is a texel format
     # A is an access mode
     # T is texture_2d<ST>, texture_2d_array<ST>, texture_cube<ST>, texture_cube_array<ST>, texture_multisampled_2d<ST>, texture_depth_2d, texture_depth_2d_array, texture_depth_cube, texture_depth_cube_array, texture_depth_multisampled_2d, texture_storage_2d<F,A>, texture_storage_2d_array<F,A>, or texture_external
     # @must_use fn textureDimensions(t: T) -> vec2<u32>
-    [S < Concrete32BitNumber].(Texture[S, Texture2d]) => Vector[U32, 2],
-    [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => Vector[U32, 2],
-    [S < Concrete32BitNumber].(Texture[S, TextureCube]) => Vector[U32, 2],
-    [S < Concrete32BitNumber].(Texture[S, TextureCubeArray]) => Vector[U32, 2],
-    [S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d]) => Vector[U32, 2],
-    [].(texture_depth_2d) => Vector[U32, 2],
-    [].(texture_depth_2d_array) => Vector[U32, 2],
-    [].(texture_depth_cube) => Vector[U32, 2],
-    [].(texture_depth_cube_array) => Vector[U32, 2],
-    [].(texture_depth_multisampled_2d) => Vector[U32, 2],
+    [S < Concrete32BitNumber].(texture_2d[S]) => vec2[u32],
+    [S < Concrete32BitNumber].(texture_2d_array[S]) => vec2[u32],
+    [S < Concrete32BitNumber].(texture_cube[S]) => vec2[u32],
+    [S < Concrete32BitNumber].(texture_cube_array[S]) => vec2[u32],
+    [S < Concrete32BitNumber].(texture_multisampled_2d[S]) => vec2[u32],
+    [].(texture_depth_2d) => vec2[u32],
+    [].(texture_depth_2d_array) => vec2[u32],
+    [].(texture_depth_cube) => vec2[u32],
+    [].(texture_depth_cube_array) => vec2[u32],
+    [].(texture_depth_multisampled_2d) => vec2[u32],
     # FIXME: add declarations for texture storage
-    [].(TextureExternal) => Vector[U32, 2],
+    [].(texture_external) => vec2[u32],
 
     # ST is i32, u32, or f32
     # T is texture_2d<ST>, texture_2d_array<ST>, texture_cube<ST>, texture_cube_array<ST>, texture_depth_2d, texture_depth_2d_array, texture_depth_cube, or texture_depth_cube_array
     # L is i32, or u32
     # @must_use fn textureDimensions(t: T, level: L) -> vec2<u32>
-    [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture2d], T) => Vector[U32, 2],
-    [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture2dArray], T) => Vector[U32, 2],
-    [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, TextureCube], T) => Vector[U32, 2],
-    [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, TextureCubeArray], T) => Vector[U32, 2],
-    [T < ConcreteInteger].(texture_depth_2d, T) => Vector[U32, 2],
-    [T < ConcreteInteger].(texture_depth_2d_array, T) => Vector[U32, 2],
-    [T < ConcreteInteger].(texture_depth_cube, T) => Vector[U32, 2],
-    [T < ConcreteInteger].(texture_depth_cube_array, T) => Vector[U32, 2],
+    [S < Concrete32BitNumber, T < ConcreteInteger].(texture_2d[S], T) => vec2[u32],
+    [S < Concrete32BitNumber, T < ConcreteInteger].(texture_2d_array[S], T) => vec2[u32],
+    [S < Concrete32BitNumber, T < ConcreteInteger].(texture_cube[S], T) => vec2[u32],
+    [S < Concrete32BitNumber, T < ConcreteInteger].(texture_cube_array[S], T) => vec2[u32],
+    [T < ConcreteInteger].(texture_depth_2d, T) => vec2[u32],
+    [T < ConcreteInteger].(texture_depth_2d_array, T) => vec2[u32],
+    [T < ConcreteInteger].(texture_depth_cube, T) => vec2[u32],
+    [T < ConcreteInteger].(texture_depth_cube_array, T) => vec2[u32],
 
     # ST is i32, u32, or f32
     # F is a texel format
     # A is an access mode
     # T is texture_3d<ST> or texture_storage_3d<F,A>
     # @must_use fn textureDimensions(t: T) -> vec3<u32>
-    [S < Concrete32BitNumber].(Texture[S, Texture3d]) => Vector[U32, 3],
+    [S < Concrete32BitNumber].(texture_3d[S]) => vec3[u32],
     # FIXME: add declarations for texture storage
 
     # ST is i32, u32, or f32
     # T is texture_3d<ST>
     # L is i32, or u32
     # @must_use fn textureDimensions(t: T, level: L) -> vec3<u32>
-    [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture3d], T) => Vector[U32, 3],
+    [S < Concrete32BitNumber, T < ConcreteInteger].(texture_3d[S], T) => vec3[u32],
 }
 
 # 16.7.2
 operator :textureGather, {
-    [T < ConcreteInteger, S < Concrete32BitNumber].(T, Texture[S, Texture2d], Sampler, Vector[F32, 2]) => Vector[S, 4],
+    [T < ConcreteInteger, S < Concrete32BitNumber].(T, texture_2d[S], sampler, vec2[f32]) => vec4[S],
 
-    [T < ConcreteInteger, S < Concrete32BitNumber].(T, Texture[S, Texture2d], Sampler, Vector[F32, 2], Vector[I32, 2]) => Vector[S, 4],
+    [T < ConcreteInteger, S < Concrete32BitNumber].(T, texture_2d[S], sampler, vec2[f32], vec2[i32]) => vec4[S],
 
-    [T < ConcreteInteger, S < Concrete32BitNumber, U < ConcreteInteger].(T, Texture[S, Texture2dArray], Sampler, Vector[F32, 2], U) => Vector[S, 4],
+    [T < ConcreteInteger, S < Concrete32BitNumber, U < ConcreteInteger].(T, texture_2d_array[S], sampler, vec2[f32], U) => vec4[S],
 
-    [T < ConcreteInteger, S < Concrete32BitNumber, U < ConcreteInteger].(T, Texture[S, Texture2dArray], Sampler, Vector[F32, 2], U, Vector[I32, 2]) => Vector[S, 4],
+    [T < ConcreteInteger, S < Concrete32BitNumber, U < ConcreteInteger].(T, texture_2d_array[S], sampler, vec2[f32], U, vec2[i32]) => vec4[S],
 
-    [T < ConcreteInteger, S < Concrete32BitNumber].(T, Texture[S, TextureCube], Sampler, Vector[F32, 3]) => Vector[S, 4],
+    [T < ConcreteInteger, S < Concrete32BitNumber].(T, texture_cube[S], sampler, vec3[f32]) => vec4[S],
 
-    [T < ConcreteInteger, S < Concrete32BitNumber, U < ConcreteInteger].(T, Texture[S, TextureCubeArray], Sampler, Vector[F32, 3], U) => Vector[S, 4],
+    [T < ConcreteInteger, S < Concrete32BitNumber, U < ConcreteInteger].(T, texture_cube_array[S], sampler, vec3[f32], U) => vec4[S],
 
     # @must_use fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> vec4<f32>
-    [].(texture_depth_2d, Sampler, Vector[F32, 2]) => Vector[F32, 4],
+    [].(texture_depth_2d, sampler, vec2[f32]) => vec4[f32],
 
     # @must_use fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
-    [].(texture_depth_2d, Sampler, Vector[F32, 2], Vector[I32, 2]) => Vector[F32, 4],
+    [].(texture_depth_2d, sampler, vec2[f32], vec2[i32]) => vec4[f32],
 
     # @must_use fn textureGather(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> vec4<f32>
-    [].(texture_depth_cube, Sampler, Vector[F32, 3]) => Vector[F32, 4],
+    [].(texture_depth_cube, sampler, vec3[f32]) => vec4[f32],
 
     # A is i32, or u32
     # @must_use fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A) -> vec4<f32>
-    [U < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], U) => Vector[F32, 4],
+    [U < ConcreteInteger].(texture_depth_2d_array, sampler, vec2[f32], U) => vec4[f32],
 
     # A is i32, or u32
     # @must_use fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, offset: vec2<i32>) -> vec4<f32>
-    [U < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], U, Vector[I32, 2]) => Vector[F32, 4],
+    [U < ConcreteInteger].(texture_depth_2d_array, sampler, vec2[f32], U, vec2[i32]) => vec4[f32],
 
     # A is i32, or u32
     # @must_use fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: A) -> vec4<f32>
-    [U < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], U) => Vector[F32, 4],
+    [U < ConcreteInteger].(texture_depth_cube_array, sampler, vec3[f32], U) => vec4[f32],
 }
 
 # 16.7.3 textureGatherCompare
@@ -675,30 +676,30 @@ operator :textureGather, {
 
 # 16.7.4
 operator :textureLoad, {
-    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture1d], T, U) => Vector[S, 4],
-    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture2d], Vector[T, 2], U) => Vector[S, 4],
-    [T < ConcreteInteger, V < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture2dArray], Vector[T, 2], V, U) => Vector[S, 4],
-    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture3d], Vector[T, 3], U) => Vector[S, 4],
-    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d], Vector[T, 2], U) => Vector[S, 4],
+    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_1d[S], T, U) => vec4[S],
+    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_2d[S], vec2[T], U) => vec4[S],
+    [T < ConcreteInteger, V < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_2d_array[S], vec2[T], V, U) => vec4[S],
+    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_3d[S], vec3[T], U) => vec4[S],
+    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(texture_multisampled_2d[S], vec2[T], U) => vec4[S],
 
 
     # C is i32, or u32
     # L is i32, or u32
     # @must_use fn textureLoad(t: texture_depth_2d, coords: vec2<C>, level: L) -> f32
-    [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d, Vector[T, 2], U) => F32,
+    [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d, vec2[T], U) => f32,
 
     # C is i32, or u32
     # A is i32, or u32
     # L is i32, or u32
     # @must_use fn textureLoad(t: texture_depth_2d_array, coords: vec2<C>, array_index: A, level: L) -> f32
-    [T < ConcreteInteger, S < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d_array, Vector[T, 2], S, U) => F32,
+    [T < ConcreteInteger, S < ConcreteInteger, U < ConcreteInteger].(texture_depth_2d_array, vec2[T], S, U) => f32,
 
     # C is i32, or u32
     # S is i32, or u32
     # @must_use fn textureLoad(t: texture_depth_multisampled_2d, coords: vec2<C>, sample_index: S)-> f32
-    [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_multisampled_2d, Vector[T, 2], U) => F32,
+    [T < ConcreteInteger, U < ConcreteInteger].(texture_depth_multisampled_2d, vec2[T], U) => f32,
 
-    [T < ConcreteInteger].(TextureExternal, Vector[T, 2]) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_external, vec2[T]) => vec4[f32],
 }
 
 # 16.7.5
@@ -708,10 +709,10 @@ operator :textureNumLayers, {
     # ST is i32, u32, or f32
     # T is texture_2d_array<ST>, texture_cube_array<ST>, texture_depth_2d_array, texture_depth_cube_array, or texture_storage_2d_array<F,A>
     # @must_use fn textureNumLayers(t: T) -> u32
-    [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => U32,
-    [S < Concrete32BitNumber].(Texture[S, TextureCubeArray]) => U32,
-    [].(texture_depth_2d_array) => U32,
-    [].(texture_depth_cube_array) => U32,
+    [S < Concrete32BitNumber].(texture_2d_array[S]) => u32,
+    [S < Concrete32BitNumber].(texture_cube_array[S]) => u32,
+    [].(texture_depth_2d_array) => u32,
+    [].(texture_depth_cube_array) => u32,
     # FIXME: add declarations for texture storage
 }
 
@@ -720,16 +721,16 @@ operator :textureNumLevels, {
     # ST is i32, u32, or f32
     # T is texture_1d<ST>, texture_2d<ST>, texture_2d_array<ST>, texture_3d<ST>, texture_cube<ST>, texture_cube_array<ST>, texture_depth_2d, texture_depth_2d_array, texture_depth_cube, or texture_depth_cube_array
     # @must_use fn textureNumLevels(t: T) -> u32
-    [S < Concrete32BitNumber].(Texture[S, Texture1d]) => U32,
-    [S < Concrete32BitNumber].(Texture[S, Texture2d]) => U32,
-    [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => U32,
-    [S < Concrete32BitNumber].(Texture[S, Texture3d]) => U32,
-    [S < Concrete32BitNumber].(Texture[S, TextureCube]) => U32,
-    [S < Concrete32BitNumber].(Texture[S, TextureCubeArray]) => U32,
-    [].(texture_depth_2d) => U32,
-    [].(texture_depth_2d_array) => U32,
-    [].(texture_depth_cube) => U32,
-    [].(texture_depth_cube_array) => U32,
+    [S < Concrete32BitNumber].(texture_1d[S]) => u32,
+    [S < Concrete32BitNumber].(texture_2d[S]) => u32,
+    [S < Concrete32BitNumber].(texture_2d_array[S]) => u32,
+    [S < Concrete32BitNumber].(texture_3d[S]) => u32,
+    [S < Concrete32BitNumber].(texture_cube[S]) => u32,
+    [S < Concrete32BitNumber].(texture_cube_array[S]) => u32,
+    [].(texture_depth_2d) => u32,
+    [].(texture_depth_2d_array) => u32,
+    [].(texture_depth_cube) => u32,
+    [].(texture_depth_cube_array) => u32,
 }
 
 # 16.7.7
@@ -737,67 +738,67 @@ operator :textureNumSamples, {
     # ST is i32, u32, or f32
     # T is texture_multisampled_2d<ST> or texture_depth_multisampled_2d
     # @must_use fn textureNumSamples(t: T) -> u32
-    [S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d]) => U32,
-    [].(texture_depth_multisampled_2d) => U32,
+    [S < Concrete32BitNumber].(texture_multisampled_2d[S]) => u32,
+    [].(texture_depth_multisampled_2d) => u32,
 }
 
 # 16.7.8
 operator :textureSample, {
-    [].(Texture[F32, Texture1d], Sampler, F32) => Vector[F32, 4],
+    [].(texture_1d[f32], sampler, f32) => vec4[f32],
 
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],
+    [].(texture_2d[f32], sampler, vec2[f32]) => vec4[f32],
 
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], Vector[I32, 2]) => Vector[F32, 4],
+    [].(texture_2d[f32], sampler, vec2[f32], vec2[i32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_2d_array[f32], sampler, vec2[f32], T) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T, Vector[I32, 2]) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_2d_array[f32], sampler, vec2[f32], T, vec2[i32]) => vec4[f32],
 
-    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3]) => Vector[F32, 4],
-    [].(Texture[F32, TextureCube], Sampler, Vector[F32, 3]) => Vector[F32, 4],
+    [].(texture_3d[f32], sampler, vec3[f32]) => vec4[f32],
+    [].(texture_cube[f32], sampler, vec3[f32]) => vec4[f32],
 
-    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], Vector[I32, 3]) => Vector[F32, 4],
+    [].(texture_3d[f32], sampler, vec3[f32], vec3[i32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_cube_array[f32], sampler, vec3[f32], T) => vec4[f32],
 
     # @must_use fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> f32
-    [].(texture_depth_2d, Sampler, Vector[F32, 2]) => F32,
+    [].(texture_depth_2d, sampler, vec2[f32]) => f32,
 
     # @must_use fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> f32
-    [].(texture_depth_2d, Sampler, Vector[F32, 2], Vector[I32, 2]) => F32,
+    [].(texture_depth_2d, sampler, vec2[f32], vec2[i32]) => f32,
 
     # A is i32, or u32
     # @must_use fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A) -> f32
-    [T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], T) => F32,
+    [T < ConcreteInteger].(texture_depth_2d_array, sampler, vec2[f32], T) => f32,
 
     # A is i32, or u32
     # @must_use fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, offset: vec2<i32>) -> f32
-    [T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], T, Vector[I32, 2]) => F32,
+    [T < ConcreteInteger].(texture_depth_2d_array, sampler, vec2[f32], T, vec2[i32]) => f32,
 
     # @must_use fn textureSample(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> f32
-    [].(texture_depth_cube, Sampler, Vector[F32, 3]) => F32,
+    [].(texture_depth_cube, sampler, vec3[f32]) => f32,
 
     # A is i32, or u32
     # @must_use fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: A) -> f32
-    [T < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], T) => F32,
+    [T < ConcreteInteger].(texture_depth_cube_array, sampler, vec3[f32], T) => f32,
 }
 
 # 16.7.9
 operator :textureSampleBias, {
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32) => Vector[F32, 4],
+    [].(texture_2d[f32], sampler, vec2[f32], f32) => vec4[f32],
 
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32, Vector[I32, 2]) => Vector[F32, 4],
+    [].(texture_2d[f32], sampler, vec2[f32], f32, vec2[i32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T, F32) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_2d_array[f32], sampler, vec2[f32], T, f32) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T, F32, Vector[I32, 2]) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_2d_array[f32], sampler, vec2[f32], T, f32, vec2[i32]) => vec4[f32],
 
-    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], F32) => Vector[F32, 4],
-    [].(Texture[F32, TextureCube], Sampler, Vector[F32, 3], F32) => Vector[F32, 4],
+    [].(texture_3d[f32], sampler, vec3[f32], f32) => vec4[f32],
+    [].(texture_cube[f32], sampler, vec3[f32], f32) => vec4[f32],
 
-    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], F32, Vector[I32, 3]) => Vector[F32, 4],
+    [].(texture_3d[f32], sampler, vec3[f32], f32, vec3[i32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T, F32) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_cube_array[f32], sampler, vec3[f32], T, f32) => vec4[f32],
 }
 
 # 16.7.10 textureSampleCompare
@@ -808,71 +809,71 @@ operator :textureSampleBias, {
 
 # 16.7.12
 operator :textureSampleGrad, {
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], Vector[F32, 2], Vector[F32, 2]) => Vector[F32, 4],
+    [].(texture_2d[f32], sampler, vec2[f32], vec2[f32], vec2[f32]) => vec4[f32],
 
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], Vector[F32, 2], Vector[F32, 2], Vector[I32, 2]) => Vector[F32, 4],
+    [].(texture_2d[f32], sampler, vec2[f32], vec2[f32], vec2[f32], vec2[i32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T, Vector[F32, 2], Vector[F32, 2]) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_2d_array[f32], sampler, vec2[f32], T, vec2[f32], vec2[f32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T, Vector[F32, 2], Vector[F32, 2], Vector[I32, 2]) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_2d_array[f32], sampler, vec2[f32], T, vec2[f32], vec2[f32], vec2[i32]) => vec4[f32],
 
-    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], Vector[F32, 3], Vector[F32, 3]) => Vector[F32, 4],
-    [].(Texture[F32, TextureCube], Sampler, Vector[F32, 3], Vector[F32, 3], Vector[F32, 3]) => Vector[F32, 4],
+    [].(texture_3d[f32], sampler, vec3[f32], vec3[f32], vec3[f32]) => vec4[f32],
+    [].(texture_cube[f32], sampler, vec3[f32], vec3[f32], vec3[f32]) => vec4[f32],
 
-    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], Vector[F32, 3], Vector[F32, 3], Vector[I32, 3]) => Vector[F32, 4],
+    [].(texture_3d[f32], sampler, vec3[f32], vec3[f32], vec3[f32], vec3[i32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T, Vector[F32, 3], Vector[F32, 3]) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_cube_array[f32], sampler, vec3[f32], T, vec3[f32], vec3[f32]) => vec4[f32],
 }
 
 # 16.7.13
 operator :textureSampleLevel, {
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32) => Vector[F32, 4],
+    [].(texture_2d[f32], sampler, vec2[f32], f32) => vec4[f32],
 
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32, Vector[I32, 2]) => Vector[F32, 4],
+    [].(texture_2d[f32], sampler, vec2[f32], f32, vec2[i32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T, F32) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_2d_array[f32], sampler, vec2[f32], T, f32) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, Texture2dArray], Sampler, Vector[F32, 2], T, F32, Vector[I32, 2]) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_2d_array[f32], sampler, vec2[f32], T, f32, vec2[i32]) => vec4[f32],
 
-    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], F32) => Vector[F32, 4],
-    [].(Texture[F32, TextureCube], Sampler, Vector[F32, 3], F32) => Vector[F32, 4],
+    [].(texture_3d[f32], sampler, vec3[f32], f32) => vec4[f32],
+    [].(texture_cube[f32], sampler, vec3[f32], f32) => vec4[f32],
 
-    [].(Texture[F32, Texture3d], Sampler, Vector[F32, 3], F32, Vector[I32, 3]) => Vector[F32, 4],
+    [].(texture_3d[f32], sampler, vec3[f32], f32, vec3[i32]) => vec4[f32],
 
-    [T < ConcreteInteger].(Texture[F32, TextureCubeArray], Sampler, Vector[F32, 3], T, F32) => Vector[F32, 4],
+    [T < ConcreteInteger].(texture_cube_array[f32], sampler, vec3[f32], T, f32) => vec4[f32],
 
     # L is i32, or u32
     # @must_use fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: L) -> f32
-    [T < ConcreteInteger].(texture_depth_2d, Sampler, Vector[F32, 2], T) => F32,
+    [T < ConcreteInteger].(texture_depth_2d, sampler, vec2[f32], T) => f32,
 
     # L is i32, or u32
     # @must_use fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: L, offset: vec2<i32>) -> f32
-    [T < ConcreteInteger].(texture_depth_2d, Sampler, Vector[F32, 2], T, Vector[I32, 2]) => F32,
+    [T < ConcreteInteger].(texture_depth_2d, sampler, vec2[f32], T, vec2[i32]) => f32,
 
     # A is i32, or u32
     # L is i32, or u32
     # @must_use fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, level: L) -> f32
-    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], S, T) => F32,
+    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_2d_array, sampler, vec2[f32], S, T) => f32,
 
     # A is i32, or u32
     # L is i32, or u32
     # @must_use fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, level: L, offset: vec2<i32>) -> f32
-    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_2d_array, Sampler, Vector[F32, 2], S, T, Vector[I32, 2]) => F32,
+    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_2d_array, sampler, vec2[f32], S, T, vec2[i32]) => f32,
 
     # L is i32, or u32
     # @must_use fn textureSampleLevel(t: texture_depth_cube, s: sampler, coords: vec3<f32>, level: L) -> f32
-    [T < ConcreteInteger].(texture_depth_cube, Sampler, Vector[F32, 3], T) => F32,
+    [T < ConcreteInteger].(texture_depth_cube, sampler, vec3[f32], T) => f32,
 
     # A is i32, or u32
     # L is i32, or u32
     # @must_use fn textureSampleLevel(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: A, level: L) -> f32
-    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_cube_array, Sampler, Vector[F32, 3], S, T) => F32,
+    [S < ConcreteInteger, T < ConcreteInteger].(texture_depth_cube_array, sampler, vec3[f32], S, T) => f32,
 }
 
 # 16.7.14
 operator :textureSampleBaseClampToEdge, {
-    [].(TextureExternal, Sampler, Vector[F32, 2]) => Vector[F32, 4],
-    [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],
+    [].(texture_external, sampler, vec2[f32]) => vec4[f32],
+    [].(texture_2d[f32], sampler, vec2[f32]) => vec4[f32],
 }
 
 # 16.7.15 textureStore

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -140,7 +140,7 @@ const Type* TypeStore::arrayType(const Type* elementType, std::optional<unsigned
     return type;
 }
 
-const Type* TypeStore::vectorType(const Type* elementType, uint8_t size)
+const Type* TypeStore::vectorType(uint8_t size, const Type* elementType)
 {
     VectorKey key { elementType, size };
     const Type* type = m_cache.find(key);
@@ -151,7 +151,7 @@ const Type* TypeStore::vectorType(const Type* elementType, uint8_t size)
     return type;
 }
 
-const Type* TypeStore::matrixType(const Type* elementType, uint8_t columns, uint8_t rows)
+const Type* TypeStore::matrixType(uint8_t columns, uint8_t rows, const Type* elementType)
 {
     MatrixKey key { elementType, columns, rows };
     const Type* type = m_cache.find(key);
@@ -162,7 +162,7 @@ const Type* TypeStore::matrixType(const Type* elementType, uint8_t columns, uint
     return type;
 }
 
-const Type* TypeStore::textureType(const Type* elementType, Texture::Kind kind)
+const Type* TypeStore::textureType(Texture::Kind kind, const Type* elementType)
 {
     TextureKey key { elementType, kind };
     const Type* type = m_cache.find(key);

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -91,9 +91,9 @@ public:
 
     const Type* structType(AST::Structure&, HashMap<String, const Type*>&& = { });
     const Type* arrayType(const Type*, std::optional<unsigned>);
-    const Type* vectorType(const Type*, uint8_t);
-    const Type* matrixType(const Type*, uint8_t columns, uint8_t rows);
-    const Type* textureType(const Type*, Types::Texture::Kind);
+    const Type* vectorType(uint8_t, const Type*);
+    const Type* matrixType(uint8_t columns, uint8_t rows, const Type*);
+    const Type* textureType(Types::Texture::Kind, const Type*);
     const Type* textureStorageType(Types::TextureStorage::Kind, TexelFormat, AccessMode);
     const Type* functionType(Vector<const Type*>&&, const Type*);
     const Type* referenceType(AddressSpace, const Type*, AccessMode);


### PR DESCRIPTION
#### fdfe9a0be98697d7ce2597cc4517f550417f40df
<pre>
[WGSL] Bring ruby DSL syntax closer to WGSL
<a href="https://bugs.webkit.org/show_bug.cgi?id=261954">https://bugs.webkit.org/show_bug.cgi?id=261954</a>
rdar://115897869

Reviewed by Dan Glastonbury.

Just a small cosmetic update to the ruby DSL, which makes the way types are written
more similar to WGSL. This makes it easier to translate the declarations from the
spec into our DSL (and hopefully a little more readable).

* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::concretize):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::materialize const):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::vectorFieldAccess):
(WGSL::TypeChecker::allocateSimpleConstructor):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::vectorType):
(WGSL::TypeStore::matrixType):
(WGSL::TypeStore::textureType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/generator/main.rb:

Canonical link: <a href="https://commits.webkit.org/268392@main">https://commits.webkit.org/268392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c81df65a99ddc26a2e77362e02049d3b577857d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19888 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22302 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16977 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24097 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22069 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15737 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17713 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4676 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->