### PR TITLE
Declarative Web Push: Support `pushnotification` event for declarative messages that are mutable

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -577,6 +577,8 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/push-api/PushEventInit.idl
     Modules/push-api/PushManager.idl
     Modules/push-api/PushMessageData.idl
+    Modules/push-api/PushNotificationEvent.idl
+    Modules/push-api/PushNotificationEventInit.idl
     Modules/push-api/PushPermissionState.idl
     Modules/push-api/PushSubscription.idl
     Modules/push-api/PushSubscriptionChangeEvent.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -794,6 +794,8 @@ $(PROJECT_DIR)/Modules/push-api/PushEvent.idl
 $(PROJECT_DIR)/Modules/push-api/PushEventInit.idl
 $(PROJECT_DIR)/Modules/push-api/PushManager.idl
 $(PROJECT_DIR)/Modules/push-api/PushMessageData.idl
+$(PROJECT_DIR)/Modules/push-api/PushNotificationEvent.idl
+$(PROJECT_DIR)/Modules/push-api/PushNotificationEventInit.idl
 $(PROJECT_DIR)/Modules/push-api/PushPermissionState.idl
 $(PROJECT_DIR)/Modules/push-api/PushSubscription.idl
 $(PROJECT_DIR)/Modules/push-api/PushSubscriptionChangeEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2209,6 +2209,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushManager.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushManager.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushMessageData.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushMessageData.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushNotificationEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushNotificationEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushNotificationEventInit.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushNotificationEventInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushPermissionState.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushPermissionState.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSPushSubscription.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -566,6 +566,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/push-api/PushEventInit.idl \
     $(WebCore)/Modules/push-api/PushManager.idl \
     $(WebCore)/Modules/push-api/PushMessageData.idl \
+    $(WebCore)/Modules/push-api/PushNotificationEvent.idl \
+    $(WebCore)/Modules/push-api/PushNotificationEventInit.idl \
     $(WebCore)/Modules/push-api/PushPermissionState.idl \
     $(WebCore)/Modules/push-api/PushSubscription.idl \
     $(WebCore)/Modules/push-api/PushSubscriptionChangeEvent.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -511,6 +511,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/notifications/NotificationData.h
     Modules/notifications/NotificationDirection.h
     Modules/notifications/NotificationEventType.h
+    Modules/notifications/NotificationOptionsPayload.h
+    Modules/notifications/NotificationPayload.h
     Modules/notifications/NotificationPermission.h
     Modules/notifications/NotificationPermissionCallback.h
     Modules/notifications/NotificationResources.h

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -36,6 +36,7 @@
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
 #include "NotificationDirection.h"
+#include "NotificationPayload.h"
 #include "NotificationPermission.h"
 #include "NotificationResources.h"
 #include "ScriptExecutionContextIdentifier.h"
@@ -77,6 +78,7 @@ public:
 
     static ExceptionOr<Ref<Notification>> createForServiceWorker(ScriptExecutionContext&, String&& title, Options&&, const URL&);
     static Ref<Notification> create(ScriptExecutionContext&, NotificationData&&);
+    static Ref<Notification> create(ScriptExecutionContext&, const URL& registrationURL, const NotificationPayload&);
 
     WEBCORE_EXPORT virtual ~Notification();
 
@@ -123,7 +125,7 @@ public:
     WEBCORE_EXPORT static void ensureOnNotificationThread(const NotificationData&, Function<void(Notification*)>&&);
 
 private:
-    Notification(ScriptExecutionContext&, WTF::UUID, String&& title, Options&&, Ref<SerializedScriptValue>&&);
+    Notification(ScriptExecutionContext&, WTF::UUID, const String& title, Options&&, Ref<SerializedScriptValue>&&);
 
     NotificationClient* clientFromContext();
     EventTargetInterface eventTargetInterface() const final { return NotificationEventTargetInterfaceType; }

--- a/Source/WebCore/Modules/notifications/NotificationOptionsPayload.h
+++ b/Source/WebCore/Modules/notifications/NotificationOptionsPayload.h
@@ -24,8 +24,6 @@
  */
 #pragma once
 
-#if ENABLE(DECLARATIVE_WEB_PUSH)
-
 #include "NotificationDirection.h"
 
 OBJC_CLASS NSDictionary;
@@ -41,12 +39,25 @@ struct NotificationOptionsPayload {
     String dataJSONString;
     std::optional<bool> silent;
 
+    NotificationOptionsPayload isolatedCopy() &&
+    {
+        return NotificationOptionsPayload {
+            dir,
+            WTFMove(lang).isolatedCopy(),
+            WTFMove(body).isolatedCopy(),
+            WTFMove(tag).isolatedCopy(),
+            WTFMove(icon).isolatedCopy(),
+            WTFMove(dataJSONString).isolatedCopy(),
+            silent
+        };
+    }
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
 #if PLATFORM(COCOA)
     static std::optional<NotificationOptionsPayload> fromDictionary(NSDictionary *);
     NSDictionary *dictionaryRepresentation() const;
 #endif
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)
 };
 
 } // namespace WebCore
-
-#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/Modules/notifications/NotificationPayload.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationPayload.cpp
@@ -45,6 +45,13 @@ ExceptionOr<NotificationPayload> NotificationPayload::parseJSON(const String& js
     return NotificationJSONParser::parseNotificationPayload(*object);
 }
 
+NotificationPayload NotificationPayload::fromNotificationData(const NotificationData& data)
+{
+    NotificationOptionsPayload options { data.direction, data.language, data.body, data.tag, data.iconURL, { }, data.silent };
+
+    return { data.defaultActionURL, data.title, std::nullopt, WTFMove(options), false };
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/Modules/push-api/PushNotificationEvent.cpp
+++ b/Source/WebCore/Modules/push-api/PushNotificationEvent.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PushNotificationEvent.h"
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(PushNotificationEvent);
+
+PushNotificationEvent::PushNotificationEvent(const AtomString& type, ExtendableEventInit&& eventInit, Notification* proposedNotification, std::optional<uint64_t> proposedAppBadge, IsTrusted isTrusted)
+    : ExtendableEvent(type, WTFMove(eventInit), isTrusted)
+    , m_proposedNotification(proposedNotification)
+    , m_proposedAppBadge(proposedAppBadge)
+{
+}
+
+Ref<PushNotificationEvent> PushNotificationEvent::create(const AtomString& type, PushNotificationEventInit&& eventInit, IsTrusted isTrusted)
+{
+    return adoptRef(*new PushNotificationEvent(type, WTFMove(eventInit), nullptr, std::nullopt, isTrusted));
+}
+
+Ref<PushNotificationEvent> PushNotificationEvent::create(const AtomString& type, ExtendableEventInit&& eventInit, Notification& notification, std::optional<uint64_t> proposedAppBadge, IsTrusted isTrusted)
+{
+    return adoptRef(*new PushNotificationEvent(type, WTFMove(eventInit), &notification, proposedAppBadge, isTrusted));
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/Modules/push-api/PushNotificationEvent.h
+++ b/Source/WebCore/Modules/push-api/PushNotificationEvent.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+
+#include "ExtendableEvent.h"
+#include "Notification.h"
+#include "NotificationData.h"
+#include "PushNotificationEventInit.h"
+
+namespace WebCore {
+
+class PushNotificationEvent final : public ExtendableEvent {
+    WTF_MAKE_ISO_ALLOCATED(PushNotificationEvent);
+public:
+    static Ref<PushNotificationEvent> create(const AtomString&, PushNotificationEventInit&&, IsTrusted = IsTrusted::No);
+    static Ref<PushNotificationEvent> create(const AtomString&, ExtendableEventInit&&, Notification&, std::optional<uint64_t> proposedAppBadge, IsTrusted);
+
+    ~PushNotificationEvent() = default;
+
+    Notification* proposedNotification() const { return m_proposedNotification.get(); }
+    std::optional<uint64_t> proposedAppBadge() const { return m_proposedAppBadge; }
+
+    void setUpdatedNotificationData(NotificationData&& updatedData) { m_updatedNotificationData = WTFMove(updatedData); }
+    const std::optional<NotificationData>& updatedNotificationData() const { return m_updatedNotificationData; }
+
+    void setUpdatedAppBadge(std::optional<uint64_t>&& updatedAppBadge) { m_updatedAppBadge = WTFMove(updatedAppBadge); }
+    const std::optional<std::optional<uint64_t>>& updatedAppBadge() const { return m_updatedAppBadge; }
+
+private:
+    PushNotificationEvent(const AtomString&, ExtendableEventInit&&, Notification*, std::optional<uint64_t> proposedAppBadge, IsTrusted);
+
+    EventInterface eventInterface() const final { return PushNotificationEventInterfaceType; }
+
+    RefPtr<Notification> m_proposedNotification;
+    std::optional<uint64_t> m_proposedAppBadge;
+    std::optional<NotificationData> m_updatedNotificationData;
+    std::optional<std::optional<uint64_t>> m_updatedAppBadge;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/Modules/push-api/PushNotificationEvent.idl
+++ b/Source/WebCore/Modules/push-api/PushNotificationEvent.idl
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Experimental but standards tracked
+[
+    Conditional=DECLARATIVE_WEB_PUSH,
+    EnabledBySetting=DeclarativeWebPush,
+    ExportMacro=WEBCORE_EXPORT,
+    Exposed=ServiceWorker,
+    JSGenerateToNativeObject,
+    SecureContext
+] interface PushNotificationEvent {
+    constructor([AtomString] DOMString type, optional PushNotificationEventInit eventInitDict);
+    readonly attribute Notification proposedNotification;
+    readonly attribute unsigned long long? proposedAppBadge;
+};

--- a/Source/WebCore/Modules/push-api/PushNotificationEventInit.h
+++ b/Source/WebCore/Modules/push-api/PushNotificationEventInit.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+
+#include "ExtendableEventInit.h"
+
+namespace WebCore {
+
+struct PushNotificationEventInit : ExtendableEventInit {
+    RefPtr<Notification> proposedNotification;
+    std::optional<unsigned long long> proposedAppBadge;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebCore/Modules/push-api/PushNotificationEventInit.idl
+++ b/Source/WebCore/Modules/push-api/PushNotificationEventInit.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=DECLARATIVE_WEB_PUSH,
+    EnabledBySetting=DeclarativeWebPush
+] dictionary PushNotificationEventInit : ExtendableEventInit {
+    Notification proposedNotification;
+    unsigned long long proposedAppBadge;
+};

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -38,6 +38,7 @@
 #include "JSWebCodecsAudioEncoderSupport.h"
 #include "Logging.h"
 #include "OpusEncoderConfig.h"
+#include "SecurityOrigin.h"
 #include "WebCodecsAudioData.h"
 #include "WebCodecsAudioEncoderConfig.h"
 #include "WebCodecsEncodedAudioChunk.h"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -310,6 +310,7 @@ Modules/push-api/PushDatabase.cpp
 Modules/push-api/PushEvent.cpp
 Modules/push-api/PushMessageCrypto.cpp
 Modules/push-api/PushMessageData.cpp
+Modules/push-api/PushNotificationEvent.cpp
 Modules/push-api/PushSubscription.cpp
 Modules/push-api/PushSubscriptionChangeEvent.cpp
 Modules/push-api/PushSubscriptionData.cpp
@@ -3980,6 +3981,8 @@ JSPushEvent.cpp
 JSPushEventInit.cpp
 JSPushManager.cpp
 JSPushMessageData.cpp
+JSPushNotificationEvent.cpp
+JSPushNotificationEventInit.cpp
 JSPushPermissionState.cpp
 JSPushSubscription.cpp
 JSPushSubscriptionChangeEvent.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -339,6 +339,7 @@ namespace WebCore {
     macro(PushEvent) \
     macro(PushManager) \
     macro(PushMessageData) \
+    macro(PushNotificationEvent) \
     macro(PushSubscription) \
     macro(PushSubscriptionChangeEvent) \
     macro(PushSubscriptionOptions) \

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -231,6 +231,7 @@ namespace WebCore {
     macro(processorerror) \
     macro(progress) \
     macro(push) \
+    macro(pushnotification) \
     macro(pushsubscriptionchange) \
     macro(qualitychange) \
     macro(ratechange) \

--- a/Source/WebCore/dom/EventNames.in
+++ b/Source/WebCore/dom/EventNames.in
@@ -43,6 +43,7 @@ PopStateEvent
 ProgressEvent
 PromiseRejectionEvent
 PushEvent conditional=SERVICE_WORKER
+PushNotificationEvent conditional=DECLARATIVE_WEB_PUSH
 PushSubscriptionChangeEvent conditional=SERVICE_WORKER
 SubmitEvent
 ToggleEvent

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -32,6 +32,7 @@
 #include "FetchRequest.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSFetchResponse.h"
+#include "NotificationPayload.h"
 #include "PushSubscription.h"
 #include "PushSubscriptionData.h"
 #include "SWContextManager.h"
@@ -76,7 +77,7 @@ void ServiceWorkerInternals::schedulePushEvent(const String& message, RefPtr<Def
         data = Vector<uint8_t> { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length()};
     }
     callOnMainThread([identifier = m_identifier, data = WTFMove(data), weakThis = WeakPtr { *this }, counter]() mutable {
-        SWContextManager::singleton().firePushEvent(identifier, WTFMove(data), [identifier, weakThis = WTFMove(weakThis), counter](bool result) mutable {
+        SWContextManager::singleton().firePushEvent(identifier, WTFMove(data), std::nullopt, [identifier, weakThis = WTFMove(weakThis), counter](bool result, std::optional<NotificationPayload>&&) mutable {
             if (auto* proxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier)) {
                 proxy->thread().runLoop().postTaskForMode([weakThis = WTFMove(weakThis), counter, result](auto&) {
                     if (!weakThis)

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -38,6 +38,7 @@
 #include "LocalFrameLoaderClient.h"
 #include "NotificationEvent.h"
 #include "PushEvent.h"
+#include "PushNotificationEvent.h"
 #include "SWContextManager.h"
 #include "SWServer.h"
 #include "ServiceWorker.h"
@@ -86,12 +87,33 @@ ServiceWorkerGlobalScope::~ServiceWorkerGlobalScope()
 
 void ServiceWorkerGlobalScope::dispatchPushEvent(PushEvent& pushEvent)
 {
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    ASSERT(!m_pushNotificationEvent && !m_pushEvent);
+#else
     ASSERT(!m_pushEvent);
+#endif
+
     m_pushEvent = &pushEvent;
     m_lastPushEventTime = MonotonicTime::now();
     dispatchEvent(pushEvent);
     m_pushEvent = nullptr;
 }
+
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+void ServiceWorkerGlobalScope::dispatchPushNotificationEvent(PushNotificationEvent& event)
+{
+    ASSERT(!m_pushNotificationEvent && !m_pushEvent);
+    m_pushNotificationEvent = &event;
+    m_lastPushEventTime = MonotonicTime::now();
+    dispatchEvent(event);
+}
+
+void ServiceWorkerGlobalScope::clearPushNotificationEvent()
+{
+    ASSERT(m_pushNotificationEvent);
+    m_pushNotificationEvent = nullptr;
+}
+#endif
 
 void ServiceWorkerGlobalScope::notifyServiceWorkerPageOfCreationIfNecessary()
 {

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -46,6 +46,10 @@ class ServiceWorkerClient;
 class ServiceWorkerClients;
 class ServiceWorkerThread;
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+class PushNotificationEvent;
+#endif
+
 enum class NotificationEventType : bool;
 
 struct ServiceWorkerClientData;
@@ -86,6 +90,12 @@ public:
     void dispatchPushEvent(PushEvent&);
     PushEvent* pushEvent() { return m_pushEvent.get(); }
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    void dispatchPushNotificationEvent(PushNotificationEvent&);
+    PushNotificationEvent* pushNotificationEvent() { return m_pushNotificationEvent.get(); }
+    void clearPushNotificationEvent();
+#endif
+
     bool hasPendingSilentPushEvent() const { return m_hasPendingSilentPushEvent; }
     void setHasPendingSilentPushEvent(bool value) { m_hasPendingSilentPushEvent = value; }
 
@@ -125,6 +135,9 @@ private:
     bool m_isProcessingUserGesture { false };
     Timer m_userGestureTimer;
     RefPtr<PushEvent> m_pushEvent;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    RefPtr<PushNotificationEvent> m_pushNotificationEvent;
+#endif
     MonotonicTime m_lastPushEventTime;
     bool m_consoleMessageReportingEnabled { false };
     RefPtr<CookieStore> m_cookieStore;

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -30,6 +30,7 @@
 #include "LocalFrameLoaderClient.h"
 #include "Logging.h"
 #include "MessageWithMessagePorts.h"
+#include "NotificationPayload.h"
 #include "ServiceWorkerGlobalScope.h"
 #include <wtf/WTFProcess.h>
 
@@ -120,16 +121,16 @@ void SWContextManager::fireActivateEvent(ServiceWorkerIdentifier identifier)
     serviceWorker->fireActivateEvent();
 }
 
-void SWContextManager::firePushEvent(ServiceWorkerIdentifier identifier, std::optional<Vector<uint8_t>>&& data, CompletionHandler<void(bool)>&& callback)
+void SWContextManager::firePushEvent(ServiceWorkerIdentifier identifier, std::optional<Vector<uint8_t>>&& data, std::optional<NotificationPayload>&& proposedPayload, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>&& callback)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
         RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::firePushEvent but service worker %" PRIu64 " not found", identifier.toUInt64());
-        callback(false);
+        callback(false, WTFMove(proposedPayload));
         return;
     }
 
-    serviceWorker->firePushEvent(WTFMove(data), WTFMove(callback));
+    serviceWorker->firePushEvent(WTFMove(data), WTFMove(proposedPayload), WTFMove(callback));
 }
 
 void SWContextManager::firePushSubscriptionChangeEvent(ServiceWorkerIdentifier identifier, std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData)

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -45,6 +45,8 @@ namespace WebCore {
 class SerializedScriptValue;
 class ServiceWorkerGlobalScope;
 
+struct NotificationPayload;
+
 class SWContextManager {
 public:
     WEBCORE_EXPORT static SWContextManager& singleton();
@@ -105,7 +107,7 @@ public:
     WEBCORE_EXPORT RefPtr<ServiceWorkerThreadProxy> serviceWorkerThreadProxyFromBackgroundThread(ServiceWorkerIdentifier) const;
     WEBCORE_EXPORT void fireInstallEvent(ServiceWorkerIdentifier);
     WEBCORE_EXPORT void fireActivateEvent(ServiceWorkerIdentifier);
-    WEBCORE_EXPORT void firePushEvent(ServiceWorkerIdentifier, std::optional<Vector<uint8_t>>&&, CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT void firePushEvent(ServiceWorkerIdentifier, std::optional<Vector<uint8_t>>&&, std::optional<NotificationPayload>&&, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>&&);
     WEBCORE_EXPORT void firePushSubscriptionChangeEvent(ServiceWorkerIdentifier, std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     WEBCORE_EXPORT void fireNotificationEvent(ServiceWorkerIdentifier, NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);
     WEBCORE_EXPORT void fireBackgroundFetchEvent(ServiceWorkerIdentifier, BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.h
@@ -50,6 +50,7 @@ class SerializedScriptValue;
 class WorkerObjectProxy;
 struct MessageWithMessagePorts;
 struct NotificationData;
+struct NotificationPayload;
 
 class ServiceWorkerThread : public WorkerThread, public CanMakeWeakPtr<ServiceWorkerThread, WeakPtrFactoryInitialization::Eager> {
 public:
@@ -72,7 +73,10 @@ public:
     void queueTaskToPostMessage(MessageWithMessagePorts&&, ServiceWorkerOrClientData&& sourceData);
     void queueTaskToFireInstallEvent();
     void queueTaskToFireActivateEvent();
-    void queueTaskToFirePushEvent(std::optional<Vector<uint8_t>>&&, Function<void(bool)>&&);
+    void queueTaskToFirePushEvent(std::optional<Vector<uint8_t>>&&, std::optional<NotificationPayload>&&, Function<void(bool, std::optional<NotificationPayload>&&)>&&);
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    void queueTaskToFirePushNotificationEvent(NotificationPayload&&, Function<void(bool, std::optional<NotificationPayload>&&)>&&);
+#endif
     void queueTaskToFirePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
 #if ENABLE(NOTIFICATION_EVENT)
     void queueTaskToFireNotificationEvent(NotificationData&&, NotificationEventType, Function<void(bool)>&&);
@@ -88,6 +92,8 @@ public:
     void stopFetchEventMonitoring() { m_isHandlingFetchEvent = false; }
     void startFunctionalEventMonitoring();
     void stopFunctionalEventMonitoring() { m_isHandlingFunctionalEvent = false; }
+    void startNotificationPayloadFunctionalEventMonitoring();
+    void stopNotificationPayloadFunctionalEventMonitoring() { m_isHandlingNotificationPayloadFunctionalEvent = false; }
 
 protected:
     Ref<WorkerGlobalScope> createWorkerGlobalScope(const WorkerParameters&, Ref<SecurityOrigin>&&, Ref<SecurityOrigin>&& topOrigin) final;
@@ -118,6 +124,7 @@ private:
 
     bool m_isHandlingFetchEvent { false };
     bool m_isHandlingFunctionalEvent { false };
+    bool m_isHandlingNotificationPayloadFunctionalEvent { false };
     uint64_t m_pushSubscriptionChangeEventCount { 0 };
     uint64_t m_messageEventCount { 0 };
     enum class State { Idle, Starting, Installing, Activating };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -360,28 +360,33 @@ void ServiceWorkerThreadProxy::didSaveScriptsToDisk(ScriptBuffer&& script, HashM
     });
 }
 
-void ServiceWorkerThreadProxy::firePushEvent(std::optional<Vector<uint8_t>>&& data, CompletionHandler<void(bool)>&& callback)
+void ServiceWorkerThreadProxy::firePushEvent(std::optional<Vector<uint8_t>>&& data, std::optional<NotificationPayload>&& proposedPayload, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>&& callback)
 {
     ASSERT(isMainThread());
 
-    if (m_ongoingFunctionalEventTasks.isEmpty())
-        thread().startFunctionalEventMonitoring();
+    if (m_ongoingNotificationPayloadFunctionalEventTasks.isEmpty())
+        thread().startNotificationPayloadFunctionalEventMonitoring();
 
     auto identifier = ++m_functionalEventTasksCounter;
-    ASSERT(!m_ongoingFunctionalEventTasks.contains(identifier));
-    m_ongoingFunctionalEventTasks.add(identifier, WTFMove(callback));
-    bool isPosted = postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, identifier, data = WTFMove(data)](auto&) mutable {
-        thread().queueTaskToFirePushEvent(WTFMove(data), [this, protectedThis = WTFMove(protectedThis), identifier](bool result) mutable {
-            callOnMainThread([this, protectedThis = WTFMove(protectedThis), identifier, result]() mutable {
-                if (auto callback = m_ongoingFunctionalEventTasks.take(identifier))
-                    callback(result);
-                if (m_ongoingFunctionalEventTasks.isEmpty())
-                    thread().stopFunctionalEventMonitoring();
+    ASSERT(!m_ongoingNotificationPayloadFunctionalEventTasks.contains(identifier));
+    m_ongoingNotificationPayloadFunctionalEventTasks.add(identifier, WTFMove(callback));
+
+    std::optional<NotificationPayload> payloadCopy;
+    if (proposedPayload)
+        payloadCopy = *proposedPayload;
+
+    bool isPosted = postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, identifier, data = crossThreadCopy(WTFMove(data)), proposedPayload = crossThreadCopy(WTFMove(proposedPayload))](auto&) mutable {
+        thread().queueTaskToFirePushEvent(WTFMove(data), WTFMove(proposedPayload), [this, protectedThis = WTFMove(protectedThis), identifier](bool result, std::optional<NotificationPayload> resultPayload) mutable {
+            callOnMainThread([this, protectedThis = WTFMove(protectedThis), identifier, result, resultPayload = crossThreadCopy(WTFMove(resultPayload))]() mutable {
+                if (auto callback = m_ongoingNotificationPayloadFunctionalEventTasks.take(identifier))
+                    callback(result, WTFMove(resultPayload));
+                if (m_ongoingNotificationPayloadFunctionalEventTasks.isEmpty())
+                    thread().stopNotificationPayloadFunctionalEventMonitoring();
             });
         });
     }, WorkerRunLoop::defaultMode());
     if (!isPosted)
-        m_ongoingFunctionalEventTasks.take(identifier)(false);
+        m_ongoingNotificationPayloadFunctionalEventTasks.take(identifier)(false, WTFMove(payloadCopy));
 }
 
 void ServiceWorkerThreadProxy::firePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData)

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -51,6 +51,7 @@ class FetchLoaderClient;
 class PageConfiguration;
 class NotificationClient;
 class ServiceWorkerInspectorProxy;
+struct NotificationPayload;
 struct ServiceWorkerContextData;
 enum class WorkerThreadMode : bool;
 
@@ -87,7 +88,7 @@ public:
 
     void fireInstallEvent();
     void fireActivateEvent();
-    void firePushEvent(std::optional<Vector<uint8_t>>&&, CompletionHandler<void(bool)>&&);
+    void firePushEvent(std::optional<Vector<uint8_t>>&&, std::optional<NotificationPayload>&&, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>&&);
     void firePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData);
     void fireNotificationEvent(NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);
     void fireBackgroundFetchEvent(BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
@@ -132,6 +133,7 @@ private:
     ServiceWorkerInspectorProxy m_inspectorProxy;
     uint64_t m_functionalEventTasksCounter { 0 };
     HashMap<uint64_t, CompletionHandler<void(bool)>> m_ongoingFunctionalEventTasks;
+    HashMap<uint64_t, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>> m_ongoingNotificationPayloadFunctionalEventTasks;
 
     // Accessed in worker thread.
     HashMap<std::pair<SWServerConnectionIdentifier, FetchIdentifier>, Ref<ServiceWorkerFetch::Client>> m_ongoingFetchTasks;

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -31,6 +31,7 @@
 #include "BackgroundFetchStore.h"
 #include "ClientOrigin.h"
 #include "ExceptionOr.h"
+#include "NotificationPayload.h"
 #include "PageIdentifier.h"
 #include "SWServerDelegate.h"
 #include "SWServerWorker.h"
@@ -252,7 +253,7 @@ public:
     LastNavigationWasAppInitiated clientIsAppInitiatedForRegistrableDomain(const RegistrableDomain&);
     bool shouldRunServiceWorkersOnMainThreadForTesting() const { return m_shouldRunServiceWorkersOnMainThreadForTesting; }
 
-    WEBCORE_EXPORT void processPushMessage(std::optional<Vector<uint8_t>>&&, URL&&, CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT void processPushMessage(std::optional<Vector<uint8_t>>&&, std::optional<NotificationPayload>&&, URL&&, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>&&);
     WEBCORE_EXPORT void processNotificationEvent(NotificationData&&, NotificationEventType, CompletionHandler<void(bool)>&&);
 
     enum class ShouldSkipEvent : bool { No, Yes };

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -49,6 +49,10 @@ struct ServiceWorkerContextData;
 struct ServiceWorkerJobDataIdentifier;
 enum class WorkerThreadMode : bool;
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+struct NotificationPayload;
+#endif
+
 class SWServerToContextConnection {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -69,7 +73,7 @@ public:
     virtual void terminateWorker(ServiceWorkerIdentifier) = 0;
     virtual void didSaveScriptsToDisk(ServiceWorkerIdentifier, const ScriptBuffer&, const MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>& importedScripts) = 0;
     virtual void matchAllCompleted(uint64_t requestIdentifier, const Vector<ServiceWorkerClientData>&) = 0;
-    virtual void firePushEvent(ServiceWorkerIdentifier, const std::optional<Vector<uint8_t>>&, CompletionHandler<void(bool)>&&) = 0;
+    virtual void firePushEvent(ServiceWorkerIdentifier, const std::optional<Vector<uint8_t>>&, std::optional<NotificationPayload>&&, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>&&) = 0;
     virtual void fireNotificationEvent(ServiceWorkerIdentifier, const NotificationData&, NotificationEventType, CompletionHandler<void(bool)>&&) = 0;
     virtual void fireBackgroundFetchEvent(ServiceWorkerIdentifier, const BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) = 0;
     virtual void fireBackgroundFetchClickEvent(ServiceWorkerIdentifier, const BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) = 0;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -396,7 +396,7 @@ public:
 
 #if ENABLE(SERVICE_WORKER)
     void getPendingPushMessages(PAL::SessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
-    void processPushMessage(PAL::SessionID, WebPushMessage&&, WebCore::PushPermissionState, CompletionHandler<void(bool)>&&);
+    void processPushMessage(PAL::SessionID, WebPushMessage&&, WebCore::PushPermissionState, CompletionHandler<void(bool, std::optional<WebCore::NotificationPayload>&&)>&&);
     void processNotificationEvent(WebCore::NotificationData&&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&);
 
     void getAllBackgroundFetchIdentifiers(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -227,7 +227,7 @@ messages -> NetworkProcess LegacyReceiver {
 
 #if ENABLE(SERVICE_WORKER)
     GetPendingPushMessages(PAL::SessionID sessionID) -> (Vector<WebKit::WebPushMessage> messages)
-    ProcessPushMessage(PAL::SessionID sessionID, struct WebKit::WebPushMessage pushMessage, enum:uint8_t WebCore::PushPermissionState pushPermissionState) -> (bool didSucceed)
+    ProcessPushMessage(PAL::SessionID sessionID, struct WebKit::WebPushMessage pushMessage, enum:uint8_t WebCore::PushPermissionState pushPermissionState) -> (bool didSucceed, std::optional<WebCore::NotificationPayload> displayPayload)
     ProcessNotificationEvent(struct WebCore::NotificationData data, enum:bool WebCore::NotificationEventType eventType) -> (bool didSucceed)
 
     GetAllBackgroundFetchIdentifiers(PAL::SessionID sessionID) -> (Vector<String> fetches);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -98,7 +98,7 @@ private:
     void terminateWorker(WebCore::ServiceWorkerIdentifier) final;
     void didSaveScriptsToDisk(WebCore::ServiceWorkerIdentifier, const WebCore::ScriptBuffer&, const MemoryCompactRobinHoodHashMap<URL, WebCore::ScriptBuffer>& importedScripts) final;
     void matchAllCompleted(uint64_t requestIdentifier, const Vector<WebCore::ServiceWorkerClientData>&) final;
-    void firePushEvent(WebCore::ServiceWorkerIdentifier, const std::optional<Vector<uint8_t>>&, CompletionHandler<void(bool)>&&) final;
+    void firePushEvent(WebCore::ServiceWorkerIdentifier, const std::optional<Vector<uint8_t>>&, std::optional<WebCore::NotificationPayload>&&, CompletionHandler<void(bool, std::optional<WebCore::NotificationPayload>&&)>&&) final;
     void fireNotificationEvent(WebCore::ServiceWorkerIdentifier, const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&) final;
     void fireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier, const WebCore::BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) final;
     void fireBackgroundFetchClickEvent(WebCore::ServiceWorkerIdentifier, const WebCore::BackgroundFetchInformation&, CompletionHandler<void(bool)>&&) final;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -401,6 +401,7 @@ def types_that_cannot_be_forward_declared():
         'WebCore::MediaAccessDenialReason',
         'WebCore::ModalContainerControlType',
         'WebCore::NativeImageReference',
+        'WebCore::NotificationPayload',
         'WebCore::PathArc',
         'WebCore::PathDataBezierCurve',
         'WebCore::PathDataLine',

--- a/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
@@ -69,7 +69,7 @@ std::optional<WebPushMessage> WebPushMessage::fromDictionary(NSDictionary *dicti
 
     WebPushMessage message { { }, String { pushPartition }, URL { url }, WTFMove(payload) };
 #else
-    WebPushMessage message { { }, String { pushPartition }, URL { url } };
+    WebPushMessage message { { }, String { pushPartition }, URL { url }, { } };
 #endif
 
     if (isData) {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5957,7 +5957,6 @@ struct WebCore::LinkDecorationFilteringData {
     String linkDecoration;
 };
 
-#if ENABLE(DECLARATIVE_WEB_PUSH)
 [WebKitPlatform] struct WebCore::NotificationPayload {
     URL defaultActionURL;
     String title;
@@ -5975,7 +5974,6 @@ struct WebCore::LinkDecorationFilteringData {
     String dataJSONString;
     std::optional<bool> silent;
 };
-#endif // ENABLE(DECLARATIVE_WEB_PUSH)
 
 class WebCore::NetworkLoadMetrics {
     MonotonicTime redirectStart;

--- a/Source/WebKit/Shared/WebPushMessage.h
+++ b/Source/WebKit/Shared/WebPushMessage.h
@@ -25,13 +25,11 @@
 
 #pragma once
 
+#include <WebCore/NotificationPayload.h>
 #include <optional>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 
-#if ENABLE(DECLARATIVE_WEB_PUSH)
-#include <WebCore/NotificationPayload.h>
-#endif
 
 OBJC_CLASS NSDictionary;
 
@@ -45,9 +43,9 @@ struct WebPushMessage {
     std::optional<Vector<uint8_t>> pushData;
     String pushPartitionString;
     URL registrationURL;
-#if ENABLE(DECLARATIVE_WEB_PUSH)
     std::optional<WebCore::NotificationPayload> notificationPayload;
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
     WebCore::NotificationData notificationPayloadToCoreData() const;
 #endif
 

--- a/Source/WebKit/Shared/WebPushMessage.serialization.in
+++ b/Source/WebKit/Shared/WebPushMessage.serialization.in
@@ -26,7 +26,5 @@ webkit_platform_headers: "ArgumentCoders.h" "WebPushMessage.h"
     std::optional<Vector<uint8_t>> pushData;
     String pushPartitionString;
     URL registrationURL;
-#if ENABLE(DECLARATIVE_WEB_PUSH)
     std::optional<WebCore::NotificationPayload> notificationPayload;
-#endif
 };

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1818,7 +1818,7 @@ void NetworkProcessProxy::getPendingPushMessages(PAL::SessionID sessionID, Compl
     sendWithAsyncReply(Messages::NetworkProcess::GetPendingPushMessages { sessionID }, WTFMove(completionHandler));
 }
 
-void NetworkProcessProxy::processPushMessage(PAL::SessionID sessionID, const WebPushMessage& pushMessage, CompletionHandler<void(bool wasProcessed)>&& callback)
+void NetworkProcessProxy::processPushMessage(PAL::SessionID sessionID, const WebPushMessage& pushMessage, CompletionHandler<void(bool wasProcessed, std::optional<WebCore::NotificationPayload>&&)>&& callback)
 {
     auto permission = PushPermissionState::Prompt;
     HashMap<String, bool> permissions;
@@ -1843,8 +1843,8 @@ void NetworkProcessProxy::processPushMessage(PAL::SessionID sessionID, const Web
     static constexpr Seconds pushEventTimeout = 20_s;
     assertionTimer->startOneShot(pushEventTimeout);
 
-    auto innerCallback = [callback = WTFMove(callback), assertionTimer = WTFMove(assertionTimer)] (bool wasProcessed) mutable {
-        callback(wasProcessed);
+    auto innerCallback = [callback = WTFMove(callback), assertionTimer = WTFMove(assertionTimer)] (bool wasProcessed, std::optional<WebCore::NotificationPayload>&& resultPayload) mutable {
+        callback(wasProcessed, WTFMove(resultPayload));
     };
     sendWithAsyncReply(Messages::NetworkProcess::ProcessPushMessage { sessionID, pushMessage, permission }, WTFMove(innerCallback));
 }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -72,13 +72,14 @@ class SharedBuffer;
 class ProtectionSpace;
 class ResourceRequest;
 class SecurityOrigin;
+class SecurityOriginData;
 enum class ShouldSample : bool;
 enum class StorageAccessPromptWasShown : bool;
 enum class StorageAccessWasGranted : bool;
 enum class StoredCredentialsPolicy : uint8_t;
 struct ClientOrigin;
 struct NotificationData;
-class SecurityOriginData;
+struct NotificationPayload;
 }
 
 namespace WebKit {
@@ -291,7 +292,7 @@ public:
 
 #if ENABLE(SERVICE_WORKER)
     void getPendingPushMessages(PAL::SessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
-    void processPushMessage(PAL::SessionID, const WebPushMessage&, CompletionHandler<void(bool wasProcessed)>&&);
+    void processPushMessage(PAL::SessionID, const WebPushMessage&, CompletionHandler<void(bool wasProcessed, std::optional<WebCore::NotificationPayload>&&)>&&);
     void processNotificationEvent(const WebCore::NotificationData&, WebCore::NotificationEventType, CompletionHandler<void(bool wasProcessed)>&&);
 
     void getAllBackgroundFetchIdentifiers(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -48,10 +48,13 @@ class FormDataReference;
 }
 
 namespace WebCore {
-struct FetchOptions;
 class ResourceRequest;
-struct ServiceWorkerContextData;
+
 enum class WorkerThreadMode : bool;
+
+struct FetchOptions;
+struct NotificationPayload;
+struct ServiceWorkerContextData;
 }
 
 namespace WebKit {
@@ -108,7 +111,7 @@ private:
     void postMessageToServiceWorker(WebCore::ServiceWorkerIdentifier destinationIdentifier, WebCore::MessageWithMessagePorts&&, WebCore::ServiceWorkerOrClientData&& sourceData);
     void fireInstallEvent(WebCore::ServiceWorkerIdentifier);
     void fireActivateEvent(WebCore::ServiceWorkerIdentifier);
-    void firePushEvent(WebCore::ServiceWorkerIdentifier, const std::optional<IPC::DataReference>&, CompletionHandler<void(bool)>&&);
+    void firePushEvent(WebCore::ServiceWorkerIdentifier, const std::optional<IPC::DataReference>&, std::optional<WebCore::NotificationPayload>&&, CompletionHandler<void(bool, std::optional<WebCore::NotificationPayload>&&)>&&);
     void fireNotificationEvent(WebCore::ServiceWorkerIdentifier, WebCore::NotificationData&&, WebCore::NotificationEventType, CompletionHandler<void(bool)>&&);
     void fireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier, WebCore::BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);
     void fireBackgroundFetchClickEvent(WebCore::ServiceWorkerIdentifier, WebCore::BackgroundFetchInformation&&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -31,7 +31,7 @@ messages -> WebSWContextManagerConnection {
     PostMessageToServiceWorker(WebCore::ServiceWorkerIdentifier destinationIdentifier, struct WebCore::MessageWithMessagePorts message, WebCore::ServiceWorkerOrClientData sourceData)
     FireInstallEvent(WebCore::ServiceWorkerIdentifier identifier)
     FireActivateEvent(WebCore::ServiceWorkerIdentifier identifier)
-    FirePushEvent(WebCore::ServiceWorkerIdentifier identifier, std::optional<IPC::DataReference> data) -> (bool result)
+    FirePushEvent(WebCore::ServiceWorkerIdentifier identifier, std::optional<IPC::DataReference> data, std::optional<WebCore::NotificationPayload> proposedPayload) -> (bool handled, std::optional<WebCore::NotificationPayload> resultPayload)
     FireNotificationEvent(WebCore::ServiceWorkerIdentifier identifier, struct WebCore::NotificationData data, enum:bool WebCore::NotificationEventType type) -> (bool result)
     FireBackgroundFetchEvent(WebCore::ServiceWorkerIdentifier identifier, struct WebCore::BackgroundFetchInformation info) -> (bool result)
     FireBackgroundFetchClickEvent(WebCore::ServiceWorkerIdentifier identifier, struct WebCore::BackgroundFetchInformation info) -> (bool result)

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -686,11 +686,7 @@ void PushService::didReceivePushMessage(NSString* topic, NSDictionary* userInfo,
         auto record = WTFMove(*recordResult);
 
         if (message.encoding == ContentEncoding::Empty) {
-#if ENABLE(DECLARATIVE_WEB_PUSH)
             m_incomingPushMessageHandler(record.subscriptionSetIdentifier, WebKit::WebPushMessage { { }, record.subscriptionSetIdentifier.pushPartition, URL { record.scope }, { } });
-#else
-            m_incomingPushMessageHandler(record.subscriptionSetIdentifier, WebKit::WebPushMessage { { }, record.subscriptionSetIdentifier.pushPartition, URL { record.scope } });
-#endif
             completionHandler();
             return;
         }
@@ -714,11 +710,7 @@ void PushService::didReceivePushMessage(NSString* topic, NSDictionary* userInfo,
 
         RELEASE_LOG(Push, "Decoded incoming push message for %{public}s %{sensitive}s", record.subscriptionSetIdentifier.debugDescription().utf8().data(), record.scope.utf8().data());
 
-#if ENABLE(DECLARATIVE_WEB_PUSH)
         m_incomingPushMessageHandler(record.subscriptionSetIdentifier, WebKit::WebPushMessage { WTFMove(*decryptedPayload), record.subscriptionSetIdentifier.pushPartition, URL { record.scope }, { } });
-#else
-        m_incomingPushMessageHandler(record.subscriptionSetIdentifier, WebKit::WebPushMessage { WTFMove(*decryptedPayload), record.subscriptionSetIdentifier.pushPartition, URL { record.scope } });
-#endif
         completionHandler();
     });
 }

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -298,12 +298,13 @@ void WebPushDaemon::injectPushMessageForTesting(PushClientConnection& connection
     }
 #endif // ENABLE(DECLARATIVE_WEB_PUSH)
 
-    connection.broadcastDebugMessage(makeString("Injected a test push message for ", message.targetAppCodeSigningIdentifier, " at ", message.registrationURL.string()));
-    connection.broadcastDebugMessage(message.payload);
-
     auto addResult = m_testingPushMessages.ensure(message.targetAppCodeSigningIdentifier, [] {
         return Deque<PushMessageForTesting> { };
     });
+
+    connection.broadcastDebugMessage(makeString("Injected a test push message for ", message.targetAppCodeSigningIdentifier, " at ", message.registrationURL.string(), ", there are now ", addResult.iterator->value.size() + 1, " pending messages"));
+    connection.broadcastDebugMessage(message.payload);
+
     addResult.iterator->value.append(WTFMove(message));
 
     notifyClientPushMessageIsAvailable(PushSubscriptionSetIdentifier { .bundleIdentifier = message.targetAppCodeSigningIdentifier, .pushPartition = message.pushPartitionString });
@@ -416,7 +417,7 @@ void WebPushDaemon::getPendingPushMessages(PushClientConnection& connection, Com
 #if ENABLE(DECLARATIVE_WEB_PUSH)
             resultMessages.append(WebKit::WebPushMessage { Vector<uint8_t> { reinterpret_cast<const uint8_t*>(data.data()), data.length() }, message.pushPartitionString, message.registrationURL, WTFMove(message.parsedPayload) });
 #else
-            resultMessages.append(WebKit::WebPushMessage { Vector<uint8_t> { reinterpret_cast<const uint8_t*>(data.data()), data.length() }, message.pushPartitionString, message.registrationURL });
+            resultMessages.append(WebKit::WebPushMessage { Vector<uint8_t> { reinterpret_cast<const uint8_t*>(data.data()), data.length() }, message.pushPartitionString, message.registrationURL, { } });
 #endif
         }
         m_testingPushMessages.remove(iterator);


### PR DESCRIPTION
#### 4b36aea360ae3875d94060a3c6705a7b3857b847
<pre>
Declarative Web Push: Support `pushnotification` event for declarative messages that are mutable
<a href="https://bugs.webkit.org/show_bug.cgi?id=261956">https://bugs.webkit.org/show_bug.cgi?id=261956</a>
rdar://114886688

Reviewed by Brent Fulgham and Chris Dumez.

When a declarative web push message arrives, and the sender has explicitly marked it &quot;mutable&quot;,
we fire a new `pushnotification` event at the Service Worker if there is one.

That event handler is given the proposed Notification described by the declarative message, and
has the opportunity to offer a new one instead.

It is also given the proposed AppBadge count described by the declarative message, and can modify
that as well.

If the event takes too long, or does *not* override the proposed Notification or AppBadge count,
then the originals described by the declarative message are used instead.

Implementation-wise, it&apos;s amazing how long of a chain of message handlers and completion handlers
exist to get a push message from the UI process to the point where an event can be dispatched
to the ServiceWorker.

This patch changes every single link in that chain to:
1 - Pass along the proposed NotificationPayload if one exists
2 - Change the CompletionHandlers to return the new NotificationPayload to be used.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::create):
(WebCore::Notification::Notification):
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/NotificationOptionsPayload.h:
(WebCore::NotificationOptionsPayload::isolatedCopy):
* Source/WebCore/Modules/notifications/NotificationPayload.cpp:
(WebCore::NotificationPayload::fromNotificationData):
* Source/WebCore/Modules/notifications/NotificationPayload.h:
(WebCore::NotificationPayload::isolatedCopy):
* Source/WebCore/Modules/push-api/PushNotificationEvent.cpp: Copied from Source/WebCore/Modules/notifications/NotificationPayload.cpp.
(WebCore::PushNotificationEvent::PushNotificationEvent):
(WebCore::PushNotificationEvent::~PushNotificationEvent):
(WebCore::PushNotificationEvent::create):
* Source/WebCore/Modules/push-api/PushNotificationEvent.h: Added.
* Source/WebCore/Modules/push-api/PushNotificationEvent.idl: Copied from Source/WebCore/Modules/notifications/NotificationOptionsPayload.h.
* Source/WebCore/Modules/push-api/PushNotificationEventInit.h: Copied from Source/WebCore/Modules/notifications/NotificationOptionsPayload.h.
* Source/WebCore/Modules/push-api/PushNotificationEventInit.idl: Copied from Source/WebCore/Modules/notifications/NotificationOptionsPayload.h.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventNames.h:
* Source/WebCore/dom/EventNames.in:
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::setAppBadge):
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::schedulePushEvent):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::dispatchPushEvent):
(WebCore::ServiceWorkerGlobalScope::dispatchPushNotificationEvent):
(WebCore::ServiceWorkerGlobalScope::clearPushNotificationEvent):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::showNotification):
* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::firePushEvent):
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFirePushEvent):
(WebCore::ServiceWorkerThread::queueTaskToFirePushNotificationEvent):
(WebCore::ServiceWorkerThread::startNotificationPayloadFunctionalEventMonitoring):
(WebCore::ServiceWorkerThread::heartBeatTimerFired):
* Source/WebCore/workers/service/context/ServiceWorkerThread.h:
(WebCore::ServiceWorkerThread::stopNotificationPayloadFunctionalEventMonitoring):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::firePushEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::processPushMessage):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::processPushMessage):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::firePushEvent):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm:
(WebKit::WebPushMessage::fromDictionary):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPushMessage.h:
* Source/WebKit/Shared/WebPushMessage.serialization.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::processPushMessage):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::processPushMessage):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::firePushEvent):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::didReceivePushMessage):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::injectPushMessageForTesting):
(WebPushD::WebPushDaemon::getPendingPushMessages):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(-[PushNotificationDelegate clearMostRecents]):

Canonical link: <a href="https://commits.webkit.org/268358@main">https://commits.webkit.org/268358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de03b84e804a1f9431228638fdafcdbf9fbc8844

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19437 "24 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19783 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22183 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19616 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23988 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21959 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15622 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17597 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4651 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->