### PR TITLE
Make some RequestedScrollData logging a bit less verbose

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -344,7 +344,7 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
     else
         stateNode->setRequestedScrollData({ ScrollRequestType::PositionUpdate, scrollPosition, options.type, options.clamping, options.animated });
 
-    LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::requestScrollToPosition: " << (options.animated == ScrollIsAnimated::Yes ? "isAnimated" : "isntAnimated") << " currentScrollPosition: " << scrollableArea.scrollPosition() << " scrollTo:" << (options.animated == ScrollIsAnimated::Yes ? IntPoint(scrollPosition - scrollableArea.scrollPosition()) : scrollPosition) << " requestedScrollData: " << stateNode->requestedScrollData() << "options" << options);
+    LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::requestScrollToPosition " << scrollPosition << " for nodeID " << scrollingNodeID << " requestedScrollData " << stateNode->requestedScrollData());
 
     // FIXME: This should schedule a rendering update
     commitTreeStateIfNeeded();

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -126,7 +126,7 @@ TextStream& operator<<(TextStream& ts, ScrollingLayerPositionAction action)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, ScrollableAreaParameters scrollableAreaParameters)
+TextStream& operator<<(TextStream& ts, const ScrollableAreaParameters& scrollableAreaParameters)
 {
     ts.dumpProperty("horizontal scroll elasticity", scrollableAreaParameters.horizontalScrollElasticity);
     ts.dumpProperty("vertical scroll elasticity", scrollableAreaParameters.verticalScrollElasticity);
@@ -200,30 +200,40 @@ TextStream& operator<<(WTF::TextStream& ts, ScrollRequestType type)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, RequestedScrollData requestedScrollData)
+TextStream& operator<<(TextStream& ts, const RequestedScrollData& requestedScrollData)
 {
-    ts.dumpProperty("requested-type", requestedScrollData.requestType);
+    ts.dumpProperty("type", requestedScrollData.requestType);
 
-    if (requestedScrollData.requestType != ScrollRequestType::CancelAnimatedScroll) {
-        if (requestedScrollData.requestType == ScrollRequestType::DeltaUpdate)
-            ts.dumpProperty("requested-scroll-delta", std::get<FloatSize>(requestedScrollData.scrollPositionOrDelta));
+    if (requestedScrollData.requestType == ScrollRequestType::CancelAnimatedScroll)
+        return ts;
+
+    if (requestedScrollData.requestType == ScrollRequestType::DeltaUpdate)
+        ts.dumpProperty("scroll delta", std::get<FloatSize>(requestedScrollData.scrollPositionOrDelta));
+    else
+        ts.dumpProperty("position", std::get<FloatPoint>(requestedScrollData.scrollPositionOrDelta));
+
+    if (requestedScrollData.scrollType == ScrollType::Programmatic)
+        ts.dumpProperty("is programmatic", requestedScrollData.scrollType);
+
+    if (requestedScrollData.clamping == ScrollClamping::Clamped)
+        ts.dumpProperty("clamping", requestedScrollData.clamping);
+
+    if (requestedScrollData.animated == ScrollIsAnimated::Yes)
+        ts.dumpProperty("animated", requestedScrollData.animated == ScrollIsAnimated::Yes);
+
+    if (requestedScrollData.requestedDataBeforeAnimatedScroll) {
+        auto oldType = std::get<0>(*requestedScrollData.requestedDataBeforeAnimatedScroll);
+        ts.dumpProperty("before-animated scroll type", oldType);
+
+        if (oldType == ScrollRequestType::DeltaUpdate)
+            ts.dumpProperty("before-animated scroll delta", std::get<FloatSize>(std::get<1>(*requestedScrollData.requestedDataBeforeAnimatedScroll)));
         else
-            ts.dumpProperty("requested-scroll-position", std::get<FloatPoint>(requestedScrollData.scrollPositionOrDelta));
-        ts.dumpProperty("requested-scroll-position-is-programatic", requestedScrollData.scrollType);
-        ts.dumpProperty("requested-scroll-position-clamping", requestedScrollData.clamping);
-        ts.dumpProperty("requested-scroll-position-animated", requestedScrollData.animated == ScrollIsAnimated::Yes);
-        if (requestedScrollData.requestedDataBeforeAnimatedScroll) {
-            auto oldType = std::get<0>(*requestedScrollData.requestedDataBeforeAnimatedScroll);
-            ts.dumpProperty("requested-scroll-position-old-data-type", oldType);
+            ts.dumpProperty("before-animated scroll position", std::get<FloatPoint>(std::get<1>(*requestedScrollData.requestedDataBeforeAnimatedScroll)));
 
-            if (oldType == ScrollRequestType::DeltaUpdate)
-                ts.dumpProperty("requested-scroll-position-old-delta", std::get<FloatSize>(std::get<1>(*requestedScrollData.requestedDataBeforeAnimatedScroll)));
-            else
-                ts.dumpProperty("requested-scroll-position-old-position", std::get<FloatPoint>(std::get<1>(*requestedScrollData.requestedDataBeforeAnimatedScroll)));
-            ts.dumpProperty("requested-scroll-position-old-data-is-programatic", std::get<2>(*requestedScrollData.requestedDataBeforeAnimatedScroll));
-            ts.dumpProperty("requested-scroll-position-old-data-animated", std::get<3>(*requestedScrollData.requestedDataBeforeAnimatedScroll));
-        }
+        ts.dumpProperty("before-animated scroll programatic", std::get<2>(*requestedScrollData.requestedDataBeforeAnimatedScroll));
+        ts.dumpProperty("before-animated scroll animated", std::get<3>(*requestedScrollData.requestedDataBeforeAnimatedScroll));
     }
+
     return ts;
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -205,13 +205,13 @@ struct WheelEventHandlingResult {
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, SynchronousScrollingReason);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollingNodeType);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollingLayerPositionAction);
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollableAreaParameters);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const ScrollableAreaParameters&);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ViewportRectStability);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelEventHandlingResult);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WheelEventProcessingSteps);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollRequestType);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollUpdateType);
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, RequestedScrollData);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const RequestedScrollData&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -173,11 +173,11 @@ TextStream& operator<<(TextStream& ts, ScrollbarWidth width)
 
 TextStream& operator<<(TextStream& ts, ScrollPositionChangeOptions options)
 {
-    ts.dumpProperty("scroll-position-change-options-type", options.type);
-    ts.dumpProperty("scroll-position-change-options-clamping", options.clamping);
-    ts.dumpProperty("scroll-position-change-options-animated", (options.animated == ScrollIsAnimated::Yes ? "animated" : "not animated"));
-    ts.dumpProperty("scroll-position-change-options-snap-point-selection-method", options.snapPointSelectionMethod);
-    ts.dumpProperty("scroll-position-change-options-original-scroll-delta", options.originalScrollDelta ? *options.originalScrollDelta : FloatSize());
+    ts.dumpProperty("type", options.type);
+    ts.dumpProperty("clamping", options.clamping);
+    ts.dumpProperty("animated", options.animated == ScrollIsAnimated::Yes);
+    ts.dumpProperty("snap point selection method", options.snapPointSelectionMethod);
+    ts.dumpProperty("original scroll delta", options.originalScrollDelta ? *options.originalScrollDelta : FloatSize());
 
     return ts;
 }


### PR DESCRIPTION
#### 1776d3531ab287076a2e83b6495aabcd066f26ec
<pre>
Make some RequestedScrollData logging a bit less verbose
<a href="https://bugs.webkit.org/show_bug.cgi?id=261959">https://bugs.webkit.org/show_bug.cgi?id=261959</a>
rdar://115902118

Reviewed by Aditya Keerthi.

The verbosity of the &quot;requested-scroll-&quot; prefix on all the RequestedScrollData members hurt my eyes.
Also only dump things with non-default values, and pass some larger structs by reference.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/269881@main">https://commits.webkit.org/269881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de62ab8cca1b8ce8a03bd476a4a6a6c353d8afb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24410 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26652 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21580 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25610 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1284 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5723 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->