### PR TITLE
[Filters] Do not clip the destination context when compositing the filter style transparency layers

### DIFF
--- a/LayoutTests/css3/filters/drop-shadow-child-clipped-expected.html
+++ b/LayoutTests/css3/filters/drop-shadow-child-clipped-expected.html
@@ -1,0 +1,28 @@
+<style>
+    .container {
+        width: 135px;
+        height: 100px;
+        border: gray 1px solid;
+        overflow: hidden;                
+    }
+    .box {
+        width: 45px;
+        height: 100px;
+        position: relative;
+    }
+    .blue-background {
+        left: 0;
+        background: MediumBlue;
+    }
+    .red-background {
+        left: 90px;
+        top: -100px;
+        background: crimson;
+    }
+</style>
+<body>
+    <div class="container">
+        <div class="box blue-background"></div>
+        <div class="box red-background"></div>
+    </div>
+</body>

--- a/LayoutTests/css3/filters/drop-shadow-child-clipped.html
+++ b/LayoutTests/css3/filters/drop-shadow-child-clipped.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ GraphicsContextFiltersEnabled=true ] -->
+<style>
+    .container {
+        width: 135px;
+        height: 100px;
+        border: gray 1px solid;
+        overflow: hidden;                
+    }
+    .box {
+        width: 45px;
+        height: 100px;
+        position: relative;
+        left: 90px;
+        background: crimson;
+        filter: drop-shadow(-90px 0 0 MediumBlue);
+    }
+</style>
+<body>
+    <div class="container">
+        <div class="box"></div>
+    </div>
+</body>

--- a/LayoutTests/fast/filter-image/clipped-filter.html
+++ b/LayoutTests/fast/filter-image/clipped-filter.html
@@ -46,7 +46,7 @@
 <svg>
     <defs>
         <clipPath id="clipPath">
-            <path d="M18,38 v200 h90 a150,150 0 0,1 300,0 h50 v-200 z"
+            <path d="M18,38 v200 h90 a150,150 0 0,1 300,0 h50 v-200 z">
         </clipPath>
     </defs>
 </svg>

--- a/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,8 @@ public:
 
 private:
     GraphicsContext* drawingContext(GraphicsContext& destinationContext) const override;
+
+    bool hasSourceImage() const override { return m_sourceImage; }
 
     void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect) override;
     void endClipAndDrawSourceImage(GraphicsContext& destinationContext) override;

--- a/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,8 +36,6 @@ public:
     FilterStyleTargetSwitcher(Filter&, const FloatRect &sourceImageRect);
 
 private:
-    bool needsRedrawSourceImage() const override { return true; }
-
     void beginDrawSourceImage(GraphicsContext& destinationContext) override;
     void endDrawSourceImage(GraphicsContext& destinationContext) override;
 

--- a/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,7 +44,7 @@ public:
 
     virtual GraphicsContext* drawingContext(GraphicsContext& destinationContext) const { return &destinationContext; }
 
-    virtual bool needsRedrawSourceImage() const { return false; }
+    virtual bool hasSourceImage() const { return false; }
 
     virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&) { beginDrawSourceImage(destinationContext); }
     virtual void endClipAndDrawSourceImage(GraphicsContext& destinationContext) { endDrawSourceImage(destinationContext); }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3162,13 +3162,18 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
 
 void RenderLayer::applyFilters(GraphicsContext& originalContext, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> behavior, const LayerFragments& layerFragments)
 {
-    // FIXME: Handle more than one fragment.
-    ClipRect backgroundRect = layerFragments.isEmpty() ? ClipRect() : layerFragments[0].backgroundRect;
-
     GraphicsContextStateSaver stateSaver(originalContext, false);
-    RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
+    bool needsClipping = m_filters->hasSourceImage();
 
-    clipToRect(originalContext, stateSaver, regionContextStateSaver, paintingInfo, behavior, backgroundRect);
+    if (needsClipping) {
+        // FIXME: Handle more than one fragment.
+        ClipRect backgroundRect = layerFragments.isEmpty() ? ClipRect() : layerFragments[0].backgroundRect;
+
+        RegionContextStateSaver regionContextStateSaver(paintingInfo.regionContext);
+
+        clipToRect(originalContext, stateSaver, regionContextStateSaver, paintingInfo, behavior, backgroundRect);
+    }
+
     m_filters->applyFilterEffect(originalContext);
 }
 

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -62,9 +62,9 @@ bool RenderLayerFilters::hasFilterThatShouldBeRestrictedBySecurityOrigin() const
     return m_filter && m_filter->hasFilterThatShouldBeRestrictedBySecurityOrigin();
 }
 
-bool RenderLayerFilters::needsRedrawSourceImage() const
+bool RenderLayerFilters::hasSourceImage() const
 {
-    return m_targetSwitcher && m_targetSwitcher->needsRedrawSourceImage();
+    return m_targetSwitcher && m_targetSwitcher->hasSourceImage();
 }
 
 void RenderLayerFilters::notifyFinished(CachedResource&, const NetworkLoadMetrics&)
@@ -178,7 +178,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
 
     if (!filter.hasFilterThatMovesPixels())
         m_repaintRect = dirtyRect;
-    else if (hasUpdatedBackingStore || needsRedrawSourceImage())
+    else if (hasUpdatedBackingStore || !hasSourceImage())
         m_repaintRect = filterRegion;
     else {
         m_repaintRect = dirtyRect;

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,6 +56,7 @@ public:
     
     bool hasFilterThatMovesPixels() const;
     bool hasFilterThatShouldBeRestrictedBySecurityOrigin() const;
+    bool hasSourceImage() const;
 
     void updateReferenceFilterClients(const FilterOperations&);
     void removeReferenceFilterClients();
@@ -73,8 +74,6 @@ public:
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:
-    bool needsRedrawSourceImage() const;
-
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
     void resetDirtySourceRect() { m_dirtySourceRect = LayoutRect(); }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -94,7 +94,7 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
         }
         
         ASSERT(filterData->targetSwitcher);
-        if (!filterData->targetSwitcher->needsRedrawSourceImage())
+        if (filterData->targetSwitcher->hasSourceImage())
             return false;
 
         filterData->targetSwitcher->beginDrawSourceImage(*context);


### PR DESCRIPTION
#### a73cf0548cd6e04f725ac36102b13cb4890781da
<pre>
[Filters] Do not clip the destination context when compositing the filter style transparency layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=261926">https://bugs.webkit.org/show_bug.cgi?id=261926</a>
rdar://115901634

Reviewed by Simon Fraser.

Clipping is not needed at that time because it has to be applied to the filter
style transparency layers before drawing the target element.

If this unneeded clipping is applied, removing this clipping will overlap with
ending the transparency layers. This will end up calling GraphicsContext::restore()
with the wrong purpose.

Rename FilterTargetSwitcher::needsRedrawSourceImage() to hasSourceImage() and
flip its meaning. This will make differentiating software filters from style
filters clearer. When hasSourceImage() is true, this means the target element is
drawn to an ImageBuffer.

* LayoutTests/css3/filters/drop-shadow-child-clipped-expected.html: Added.
* LayoutTests/css3/filters/drop-shadow-child-clipped.html: Added.
* LayoutTests/fast/filter-image/clipped-filter.html:
* Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h:
* Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h:
(): Deleted.
* Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h:
(WebCore::FilterTargetSwitcher::hasSourceImage const):
(WebCore::FilterTargetSwitcher::needsRedrawSourceImage const): Deleted.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::applyFilters):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::hasSourceImage const):
(WebCore::RenderLayerFilters::beginFilterEffect):
(WebCore::RenderLayerFilters::needsRedrawSourceImage const): Deleted.
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::applyResource):

Canonical link: <a href="https://commits.webkit.org/268341@main">https://commits.webkit.org/268341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/755fef0088a8443ceeeebb7a39bdb34f84e69298

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21264 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19917 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22129 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17632 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21921 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4637 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->