### PR TITLE
Add WebGPU enumerations and additional serialization updates

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
@@ -43,3 +43,325 @@ header: <WebCore/WebGPUMapMode.h>
     Read,
     Write,
 };
+
+using WebCore::WebGPU::Size64 = uint64_t;
+using WebCore::WebGPU::Size32 = uint32_t;
+using WebCore::WebGPU::BufferDynamicOffset = uint32_t;
+using WebCore::WebGPU::IntegerCoordinate = uint32_t;
+using WebCore::WebGPU::Index32 = uint32_t;
+using WebCore::WebGPU::StencilValue = uint32_t;
+using WebCore::WebGPU::SampleMask = uint32_t;
+using WebCore::WebGPU::DepthBias = int32_t;
+using WebCore::WebGPU::SignedOffset32 = int32_t;
+using WebCore::WebGPU::FlagsConstant = uint32_t;
+
+header: <WebCore/WebGPUBlendFactor.h>
+enum class WebCore::WebGPU::BlendFactor : uint8_t {
+    Zero,
+    One,
+    Src,
+    OneMinusSrc,
+    SrcAlpha,
+    OneMinusSrcAlpha,
+    Dst,
+    OneMinusDst,
+    DstAlpha,
+    OneMinusDstAlpha,
+    SrcAlphaSaturated,
+    Constant,
+    OneMinusConstant,
+};
+
+header: <WebCore/WebGPUTextureSampleType.h>
+enum class WebCore::WebGPU::TextureSampleType : uint8_t {
+    Float,
+    UnfilterableFloat,
+    Depth,
+    Sint,
+    Uint,
+};
+
+header: <WebCore/WebGPUBlendOperation.h>
+enum class WebCore::WebGPU::BlendOperation : uint8_t {
+    Add,
+    Subtract,
+    ReverseSubtract,
+    Min,
+    Max,
+};
+
+header: <WebCore/WebGPUCanvasAlphaMode.h>
+enum class WebCore::WebGPU::CanvasAlphaMode : uint8_t {
+    Opaque,
+    Premultiplied,
+};
+
+header: <WebCore/WebGPUQueryType.h>
+enum class WebCore::WebGPU::QueryType : uint8_t {
+    Occlusion,
+    Timestamp,
+};
+
+header: <WebCore/WebGPUCompareFunction.h>
+enum class WebCore::WebGPU::CompareFunction : uint8_t {
+    Never,
+    Less,
+    Equal,
+    LessEqual,
+    Greater,
+    NotEqual,
+    GreaterEqual,
+    Always,
+};
+
+header: <WebCore/WebGPUFilterMode.h>
+enum class WebCore::WebGPU::FilterMode : uint8_t {
+    Nearest,
+    Linear,
+};
+
+header: <WebCore/WebGPUFilterMode.h>
+enum class WebCore::WebGPU::MipmapFilterMode : uint8_t {
+    Nearest,
+    Linear,
+};
+
+header: <WebCore/WebGPUTextureDimension.h>
+enum class WebCore::WebGPU::TextureDimension : uint8_t {
+    _1d,
+    _2d,
+    _3d,
+};
+
+header: <WebCore/WebGPUVertexFormat.h>
+enum class WebCore::WebGPU::VertexFormat : uint8_t {
+    Uint8x2,
+    Uint8x4,
+    Sint8x2,
+    Sint8x4,
+    Unorm8x2,
+    Unorm8x4,
+    Snorm8x2,
+    Snorm8x4,
+    Uint16x2,
+    Uint16x4,
+    Sint16x2,
+    Sint16x4,
+    Unorm16x2,
+    Unorm16x4,
+    Snorm16x2,
+    Snorm16x4,
+    Float16x2,
+    Float16x4,
+    Float32,
+    Float32x2,
+    Float32x3,
+    Float32x4,
+    Uint32,
+    Uint32x2,
+    Uint32x3,
+    Uint32x4,
+    Sint32,
+    Sint32x2,
+    Sint32x3,
+    Sint32x4,
+};
+
+header: <WebCore/WebGPUShaderStage.h>
+enum class WebCore::WebGPU::ShaderStage : uint8_t {
+    Vertex,
+    Fragment,
+    Compute,
+};
+
+header: <WebCore/WebGPUShaderStage.h>
+[OptionSet] enum class WebCore::WebGPU::ShaderStage : uint8_t {
+    Vertex,
+    Fragment,
+    Compute,
+};
+
+using WebCore::WebGPU::ShaderStageFlags = OptionSet<WebCore::WebGPU::ShaderStage>;
+
+header: <WebCore/WebGPURenderPassTimestampLocation.h>
+enum class WebCore::WebGPU::RenderPassTimestampLocation : uint8_t {
+    Beginning,
+    End,
+};
+
+header: <WebCore/WebGPUCompilationMessageType.h>
+enum class WebCore::WebGPU::CompilationMessageType : uint8_t {
+    Error,
+    Warning,
+    Info,
+};
+
+header: <WebCore/WebGPUStencilOperation.h>
+enum class WebCore::WebGPU::StencilOperation : uint8_t {
+    Keep,
+    Zero,
+    Replace,
+    Invert,
+    IncrementClamp,
+    DecrementClamp,
+    IncrementWrap,
+    DecrementWrap,
+};
+
+header: <WebCore/WebGPUDeviceLostReason.h>
+enum class WebCore::WebGPU::DeviceLostReason : uint8_t {
+    Destroyed,
+    Unknown,
+};
+
+header: <WebCore/WebGPUComputePassTimestampLocation.h>
+enum class WebCore::WebGPU::ComputePassTimestampLocation : uint8_t {
+    Beginning,
+    End,
+};
+
+header: <WebCore/WebGPUAddressMode.h>
+enum class WebCore::WebGPU::AddressMode : uint8_t {
+    ClampToEdge,
+    Repeat,
+    MirrorRepeat,
+};
+
+header: <WebCore/WebGPUBufferBindingType.h>
+enum class WebCore::WebGPU::BufferBindingType : uint8_t {
+    Uniform,
+    Storage,
+    ReadOnlyStorage,
+};
+
+header: <WebCore/WebGPUStorageTextureAccess.h>
+enum class WebCore::WebGPU::StorageTextureAccess : uint8_t {
+    WriteOnly,
+};
+
+header: <WebCore/WebGPUFrontFace.h>
+enum class WebCore::WebGPU::FrontFace : uint8_t {
+    CCW,
+    CW,
+};
+
+header: <WebCore/WebGPUStoreOp.h>
+enum class WebCore::WebGPU::StoreOp : uint8_t {
+    Store,
+    Discard,
+};
+
+header: <WebCore/WebGPULoadOp.h>
+enum class WebCore::WebGPU::LoadOp : uint8_t {
+    Load,
+    Clear,
+};
+
+header: <WebCore/WebGPUColorWrite.h>
+enum class WebCore::WebGPU::ColorWrite : uint8_t {
+    Red,
+    Green,
+    Blue,
+    Alpha,
+    All,
+};
+
+header: <WebCore/WebGPUColorWrite.h>
+[OptionSet] enum class WebCore::WebGPU::ColorWrite : uint8_t {
+    Red,
+    Green,
+    Blue,
+    Alpha,
+    All,
+};
+
+using WebCore::WebGPU::ColorWriteFlags = OptionSet<WebCore::WebGPU::ColorWrite>;
+
+header: <WebCore/WebGPUSamplerBindingType.h>
+enum class WebCore::WebGPU::SamplerBindingType : uint8_t {
+    Filtering,
+    NonFiltering,
+    Comparison,
+};
+
+header: <WebCore/WebGPUPrimitiveTopology.h>
+enum class WebCore::WebGPU::PrimitiveTopology : uint8_t {
+    PointList,
+    LineList,
+    LineStrip,
+    TriangleList,
+    TriangleStrip,
+};
+
+header: <WebCore/WebGPUCullMode.h>
+enum class WebCore::WebGPU::CullMode : uint8_t {
+    None,
+    Front,
+    Back,
+};
+
+header: <WebCore/WebGPUTextureViewDimension.h>
+enum class WebCore::WebGPU::TextureViewDimension : uint8_t {
+    _1d,
+    _2d,
+    _2dArray,
+    Cube,
+    CubeArray,
+    _3d,
+};
+
+header: <WebCore/WebGPUVertexStepMode.h>
+enum class WebCore::WebGPU::VertexStepMode : uint8_t {
+    Vertex,
+    Instance,
+};
+
+header: <WebCore/WebGPUBufferUsage.h>
+enum class WebCore::WebGPU::BufferUsage : uint16_t {
+    MapRead,
+    MapWrite,
+    CopySource,
+    CopyDestination,
+    Index,
+    Vertex,
+    Uniform,
+    Storage,
+    Indirect,
+    QueryResolve,
+};
+
+header: <WebCore/WebGPUBufferUsage.h>
+[OptionSet] enum class WebCore::WebGPU::BufferUsage : uint16_t {
+    MapRead,
+    MapWrite,
+    CopySource,
+    CopyDestination,
+    Index,
+    Vertex,
+    Uniform,
+    Storage,
+    Indirect,
+    QueryResolve,
+};
+
+using WebCore::WebGPU::BufferUsageFlags = OptionSet<WebCore::WebGPU::BufferUsage>;
+
+header: <WebCore/WebGPUTextureUsage.h>
+enum class WebCore::WebGPU::TextureUsage : uint8_t {
+    CopySource,
+    CopyDestination,
+    TextureBinding,
+    StorageBinding,
+    RenderAttachment,
+};
+
+header: <WebCore/WebGPUTextureUsage.h>
+[OptionSet] enum class WebCore::WebGPU::TextureUsage : uint8_t {
+    CopySource,
+    CopyDestination,
+    TextureBinding,
+    StorageBinding,
+    RenderAttachment,
+};
+
+using WebCore::WebGPU::TextureUsageFlags = OptionSet<WebCore::WebGPU::TextureUsage>;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAddressMode.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAddressMode.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -37,16 +36,3 @@ enum class AddressMode : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::AddressMode> {
-    using values = EnumValues<
-        WebCore::WebGPU::AddressMode,
-        WebCore::WebGPU::AddressMode::ClampToEdge,
-        WebCore::WebGPU::AddressMode::Repeat,
-        WebCore::WebGPU::AddressMode::MirrorRepeat
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBlendFactor.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBlendFactor.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -47,26 +46,3 @@ enum class BlendFactor : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::BlendFactor> {
-    using values = EnumValues<
-        WebCore::WebGPU::BlendFactor,
-        WebCore::WebGPU::BlendFactor::Zero,
-        WebCore::WebGPU::BlendFactor::One,
-        WebCore::WebGPU::BlendFactor::Src,
-        WebCore::WebGPU::BlendFactor::OneMinusSrc,
-        WebCore::WebGPU::BlendFactor::SrcAlpha,
-        WebCore::WebGPU::BlendFactor::OneMinusSrcAlpha,
-        WebCore::WebGPU::BlendFactor::Dst,
-        WebCore::WebGPU::BlendFactor::OneMinusDst,
-        WebCore::WebGPU::BlendFactor::DstAlpha,
-        WebCore::WebGPU::BlendFactor::OneMinusDstAlpha,
-        WebCore::WebGPU::BlendFactor::SrcAlphaSaturated,
-        WebCore::WebGPU::BlendFactor::Constant,
-        WebCore::WebGPU::BlendFactor::OneMinusConstant
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBlendOperation.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBlendOperation.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -39,18 +38,3 @@ enum class BlendOperation : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::BlendOperation> {
-    using values = EnumValues<
-        WebCore::WebGPU::BlendOperation,
-        WebCore::WebGPU::BlendOperation::Add,
-        WebCore::WebGPU::BlendOperation::Subtract,
-        WebCore::WebGPU::BlendOperation::ReverseSubtract,
-        WebCore::WebGPU::BlendOperation::Min,
-        WebCore::WebGPU::BlendOperation::Max
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBindingType.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBindingType.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -37,16 +36,3 @@ enum class BufferBindingType : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::BufferBindingType> {
-    using values = EnumValues<
-        WebCore::WebGPU::BufferBindingType,
-        WebCore::WebGPU::BufferBindingType::Uniform,
-        WebCore::WebGPU::BufferBindingType::Storage,
-        WebCore::WebGPU::BufferBindingType::ReadOnlyStorage
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferUsage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferUsage.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore::WebGPU {
@@ -46,24 +45,3 @@ enum class BufferUsage : uint16_t {
 using BufferUsageFlags = OptionSet<BufferUsage>;
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::BufferUsage> {
-    using values = EnumValues<
-        WebCore::WebGPU::BufferUsage,
-        WebCore::WebGPU::BufferUsage::MapRead,
-        WebCore::WebGPU::BufferUsage::MapWrite,
-        WebCore::WebGPU::BufferUsage::CopySource,
-        WebCore::WebGPU::BufferUsage::CopyDestination,
-        WebCore::WebGPU::BufferUsage::Index,
-        WebCore::WebGPU::BufferUsage::Vertex,
-        WebCore::WebGPU::BufferUsage::Uniform,
-        WebCore::WebGPU::BufferUsage::Storage,
-        WebCore::WebGPU::BufferUsage::Indirect,
-        WebCore::WebGPU::BufferUsage::QueryResolve
-
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasAlphaMode.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasAlphaMode.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class CanvasAlphaMode : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::CanvasAlphaMode> {
-    using values = EnumValues<
-        WebCore::WebGPU::CanvasAlphaMode,
-        WebCore::WebGPU::CanvasAlphaMode::Opaque,
-        WebCore::WebGPU::CanvasAlphaMode::Premultiplied
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUColorWrite.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUColorWrite.h
@@ -29,7 +29,6 @@
 #include "WebGPUBlendOperation.h"
 #include "WebGPUIntegralTypes.h"
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore::WebGPU {
@@ -44,17 +43,3 @@ enum class ColorWrite : uint8_t {
 using ColorWriteFlags = OptionSet<ColorWrite>;
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::ColorWrite> {
-    using values = EnumValues<
-        WebCore::WebGPU::ColorWrite,
-        WebCore::WebGPU::ColorWrite::Red,
-        WebCore::WebGPU::ColorWrite::Green,
-        WebCore::WebGPU::ColorWrite::Blue,
-        WebCore::WebGPU::ColorWrite::Alpha
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompareFunction.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompareFunction.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -42,21 +41,3 @@ enum class CompareFunction : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::CompareFunction> {
-    using values = EnumValues<
-        WebCore::WebGPU::CompareFunction,
-        WebCore::WebGPU::CompareFunction::Never,
-        WebCore::WebGPU::CompareFunction::Less,
-        WebCore::WebGPU::CompareFunction::Equal,
-        WebCore::WebGPU::CompareFunction::LessEqual,
-        WebCore::WebGPU::CompareFunction::Greater,
-        WebCore::WebGPU::CompareFunction::NotEqual,
-        WebCore::WebGPU::CompareFunction::GreaterEqual,
-        WebCore::WebGPU::CompareFunction::Always
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompilationMessageType.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompilationMessageType.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -37,16 +36,3 @@ enum class CompilationMessageType : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::CompilationMessageType> {
-    using values = EnumValues<
-        WebCore::WebGPU::CompilationMessageType,
-        WebCore::WebGPU::CompilationMessageType::Error,
-        WebCore::WebGPU::CompilationMessageType::Warning,
-        WebCore::WebGPU::CompilationMessageType::Info
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampLocation.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampLocation.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class ComputePassTimestampLocation : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::ComputePassTimestampLocation> {
-    using values = EnumValues<
-        WebCore::WebGPU::ComputePassTimestampLocation,
-        WebCore::WebGPU::ComputePassTimestampLocation::Beginning,
-        WebCore::WebGPU::ComputePassTimestampLocation::End
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCullMode.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCullMode.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -37,16 +36,3 @@ enum class CullMode : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::CullMode> {
-    using values = EnumValues<
-        WebCore::WebGPU::CullMode,
-        WebCore::WebGPU::CullMode::None,
-        WebCore::WebGPU::CullMode::Front,
-        WebCore::WebGPU::CullMode::Back
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDeviceLostReason.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDeviceLostReason.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class DeviceLostReason : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::DeviceLostReason> {
-    using values = EnumValues<
-        WebCore::WebGPU::DeviceLostReason,
-        WebCore::WebGPU::DeviceLostReason::Destroyed,
-        WebCore::WebGPU::DeviceLostReason::Unknown
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFilterMode.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFilterMode.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -41,23 +40,3 @@ enum class MipmapFilterMode : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::FilterMode> {
-    using values = EnumValues<
-        WebCore::WebGPU::FilterMode,
-        WebCore::WebGPU::FilterMode::Nearest,
-        WebCore::WebGPU::FilterMode::Linear
-    >;
-};
-
-template<> struct EnumTraits<WebCore::WebGPU::MipmapFilterMode> {
-    using values = EnumValues<
-        WebCore::WebGPU::MipmapFilterMode,
-        WebCore::WebGPU::MipmapFilterMode::Nearest,
-        WebCore::WebGPU::MipmapFilterMode::Linear
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFrontFace.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFrontFace.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class FrontFace : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::FrontFace> {
-    using values = EnumValues<
-        WebCore::WebGPU::FrontFace,
-        WebCore::WebGPU::FrontFace::CCW,
-        WebCore::WebGPU::FrontFace::CW
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPULoadOp.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPULoadOp.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class LoadOp : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::LoadOp> {
-    using values = EnumValues<
-        WebCore::WebGPU::LoadOp,
-        WebCore::WebGPU::LoadOp::Load,
-        WebCore::WebGPU::LoadOp::Clear
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPrimitiveTopology.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPrimitiveTopology.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -39,18 +38,3 @@ enum class PrimitiveTopology : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::PrimitiveTopology> {
-    using values = EnumValues<
-        WebCore::WebGPU::PrimitiveTopology,
-        WebCore::WebGPU::PrimitiveTopology::PointList,
-        WebCore::WebGPU::PrimitiveTopology::LineList,
-        WebCore::WebGPU::PrimitiveTopology::LineStrip,
-        WebCore::WebGPU::PrimitiveTopology::TriangleList,
-        WebCore::WebGPU::PrimitiveTopology::TriangleStrip
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueryType.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueryType.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class QueryType : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::QueryType> {
-    using values = EnumValues<
-        WebCore::WebGPU::QueryType,
-        WebCore::WebGPU::QueryType::Occlusion,
-        WebCore::WebGPU::QueryType::Timestamp
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampLocation.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampLocation.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class RenderPassTimestampLocation : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::RenderPassTimestampLocation> {
-    using values = EnumValues<
-        WebCore::WebGPU::RenderPassTimestampLocation,
-        WebCore::WebGPU::RenderPassTimestampLocation::Beginning,
-        WebCore::WebGPU::RenderPassTimestampLocation::End
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSamplerBindingType.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSamplerBindingType.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -37,16 +36,3 @@ enum class SamplerBindingType : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::SamplerBindingType> {
-    using values = EnumValues<
-        WebCore::WebGPU::SamplerBindingType,
-        WebCore::WebGPU::SamplerBindingType::Filtering,
-        WebCore::WebGPU::SamplerBindingType::NonFiltering,
-        WebCore::WebGPU::SamplerBindingType::Comparison
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderStage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderStage.h
@@ -27,7 +27,6 @@
 
 #include "WebGPUIntegralTypes.h"
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore::WebGPU {
@@ -40,16 +39,3 @@ enum class ShaderStage : uint8_t {
 using ShaderStageFlags = OptionSet<ShaderStage>;
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::ShaderStage> {
-    using values = EnumValues<
-        WebCore::WebGPU::ShaderStage,
-        WebCore::WebGPU::ShaderStage::Vertex,
-        WebCore::WebGPU::ShaderStage::Fragment,
-        WebCore::WebGPU::ShaderStage::Compute
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStencilOperation.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStencilOperation.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -42,21 +41,3 @@ enum class StencilOperation : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::StencilOperation> {
-    using values = EnumValues<
-        WebCore::WebGPU::StencilOperation,
-        WebCore::WebGPU::StencilOperation::Keep,
-        WebCore::WebGPU::StencilOperation::Zero,
-        WebCore::WebGPU::StencilOperation::Replace,
-        WebCore::WebGPU::StencilOperation::Invert,
-        WebCore::WebGPU::StencilOperation::IncrementClamp,
-        WebCore::WebGPU::StencilOperation::DecrementClamp,
-        WebCore::WebGPU::StencilOperation::IncrementWrap,
-        WebCore::WebGPU::StencilOperation::DecrementWrap
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStorageTextureAccess.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStorageTextureAccess.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -35,14 +34,3 @@ enum class StorageTextureAccess : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::StorageTextureAccess> {
-    using values = EnumValues<
-        WebCore::WebGPU::StorageTextureAccess,
-        WebCore::WebGPU::StorageTextureAccess::WriteOnly
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStoreOp.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStoreOp.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class StoreOp : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::StoreOp> {
-    using values = EnumValues<
-        WebCore::WebGPU::StoreOp,
-        WebCore::WebGPU::StoreOp::Store,
-        WebCore::WebGPU::StoreOp::Discard
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureDimension.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureDimension.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -37,16 +36,3 @@ enum class TextureDimension : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::TextureDimension> {
-    using values = EnumValues<
-        WebCore::WebGPU::TextureDimension,
-        WebCore::WebGPU::TextureDimension::_1d,
-        WebCore::WebGPU::TextureDimension::_2d,
-        WebCore::WebGPU::TextureDimension::_3d
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureSampleType.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureSampleType.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -39,18 +38,3 @@ enum class TextureSampleType : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::TextureSampleType> {
-    using values = EnumValues<
-        WebCore::WebGPU::TextureSampleType,
-        WebCore::WebGPU::TextureSampleType::Float,
-        WebCore::WebGPU::TextureSampleType::UnfilterableFloat,
-        WebCore::WebGPU::TextureSampleType::Depth,
-        WebCore::WebGPU::TextureSampleType::Sint,
-        WebCore::WebGPU::TextureSampleType::Uint
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureUsage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureUsage.h
@@ -27,7 +27,6 @@
 
 #include "WebGPUIntegralTypes.h"
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore::WebGPU {
@@ -42,19 +41,3 @@ enum class TextureUsage : uint8_t {
 using TextureUsageFlags = OptionSet<TextureUsage>;
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::TextureUsage> {
-    using values = EnumValues<
-        WebCore::WebGPU::TextureUsage,
-        WebCore::WebGPU::TextureUsage::CopySource,
-        WebCore::WebGPU::TextureUsage::CopyDestination,
-        WebCore::WebGPU::TextureUsage::TextureBinding,
-        WebCore::WebGPU::TextureUsage::StorageBinding,
-        WebCore::WebGPU::TextureUsage::RenderAttachment
-    >;
-};
-
-} // namespace WTF
-

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureViewDimension.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureViewDimension.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -40,19 +39,3 @@ enum class TextureViewDimension : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::TextureViewDimension> {
-    using values = EnumValues<
-        WebCore::WebGPU::TextureViewDimension,
-        WebCore::WebGPU::TextureViewDimension::_1d,
-        WebCore::WebGPU::TextureViewDimension::_2d,
-        WebCore::WebGPU::TextureViewDimension::_2dArray,
-        WebCore::WebGPU::TextureViewDimension::Cube,
-        WebCore::WebGPU::TextureViewDimension::CubeArray,
-        WebCore::WebGPU::TextureViewDimension::_3d
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexFormat.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexFormat.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -64,43 +63,3 @@ enum class VertexFormat : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::VertexFormat> {
-    using values = EnumValues<
-        WebCore::WebGPU::VertexFormat,
-        WebCore::WebGPU::VertexFormat::Uint8x2,
-        WebCore::WebGPU::VertexFormat::Uint8x4,
-        WebCore::WebGPU::VertexFormat::Sint8x2,
-        WebCore::WebGPU::VertexFormat::Sint8x4,
-        WebCore::WebGPU::VertexFormat::Unorm8x2,
-        WebCore::WebGPU::VertexFormat::Unorm8x4,
-        WebCore::WebGPU::VertexFormat::Snorm8x2,
-        WebCore::WebGPU::VertexFormat::Snorm8x4,
-        WebCore::WebGPU::VertexFormat::Uint16x2,
-        WebCore::WebGPU::VertexFormat::Uint16x4,
-        WebCore::WebGPU::VertexFormat::Sint16x2,
-        WebCore::WebGPU::VertexFormat::Sint16x4,
-        WebCore::WebGPU::VertexFormat::Unorm16x2,
-        WebCore::WebGPU::VertexFormat::Unorm16x4,
-        WebCore::WebGPU::VertexFormat::Snorm16x2,
-        WebCore::WebGPU::VertexFormat::Snorm16x4,
-        WebCore::WebGPU::VertexFormat::Float16x2,
-        WebCore::WebGPU::VertexFormat::Float16x4,
-        WebCore::WebGPU::VertexFormat::Float32,
-        WebCore::WebGPU::VertexFormat::Float32x2,
-        WebCore::WebGPU::VertexFormat::Float32x3,
-        WebCore::WebGPU::VertexFormat::Float32x4,
-        WebCore::WebGPU::VertexFormat::Uint32,
-        WebCore::WebGPU::VertexFormat::Uint32x2,
-        WebCore::WebGPU::VertexFormat::Uint32x3,
-        WebCore::WebGPU::VertexFormat::Uint32x4,
-        WebCore::WebGPU::VertexFormat::Sint32,
-        WebCore::WebGPU::VertexFormat::Sint32x2,
-        WebCore::WebGPU::VertexFormat::Sint32x3,
-        WebCore::WebGPU::VertexFormat::Sint32x4
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexStepMode.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexStepMode.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 
@@ -36,15 +35,3 @@ enum class VertexStepMode : uint8_t {
 };
 
 } // namespace WebCore::WebGPU
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::WebGPU::VertexStepMode> {
-    using values = EnumValues<
-        WebCore::WebGPU::VertexStepMode,
-        WebCore::WebGPU::VertexStepMode::Vertex,
-        WebCore::WebGPU::VertexStepMode::Instance
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -88,7 +88,7 @@ ResourceResponseBase::ResourceResponseBase(std::optional<ResourceResponseBase::R
 {
 }
 
-ResourceResponseBase::CrossThreadData ResourceResponseBase::CrossThreadData::isolatedCopy() const
+ResourceResponseBaseCrossThreadData ResourceResponseBaseCrossThreadData::isolatedCopy() const
 {
     ResourceResponseBase::CrossThreadData result;
     result.url = url.isolatedCopy();

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -47,6 +47,7 @@ struct Result;
 }
 
 class ResourceResponse;
+struct ResourceResponseBaseCrossThreadData;
 
 bool isScriptAllowedByNosniff(const ResourceResponse&);
 
@@ -58,66 +59,24 @@ enum class WasPrivateRelayed : bool { No, Yes };
 static constexpr unsigned bitWidthOfWasPrivateRelayed = 1;
 static_assert(static_cast<unsigned>(WasPrivateRelayed::Yes) <= ((1U << bitWidthOfWasPrivateRelayed) - 1));
 
+enum class ResourceResponseBaseType : uint8_t { Basic, Cors, Default, Error, Opaque, Opaqueredirect };
+enum class ResourceResponseBaseTainting : uint8_t { Basic, Cors, Opaque, Opaqueredirect };
+enum class ResourceResponseBaseSource : uint8_t { Unknown, Network, DiskCache, DiskCacheAfterValidation, MemoryCache, MemoryCacheAfterValidation, ServiceWorker, ApplicationCache, DOMCache, InspectorOverride };
+
 // Do not use this class directly, use the class ResourceResponse instead
 class ResourceResponseBase {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    enum class Type : uint8_t { Basic, Cors, Default, Error, Opaque, Opaqueredirect };
+    using Type = ResourceResponseBaseType;
     static constexpr unsigned bitWidthOfType = 3;
-    enum class Tainting : uint8_t { Basic, Cors, Opaque, Opaqueredirect };
+    using Tainting = ResourceResponseBaseTainting;
     static constexpr unsigned bitWidthOfTainting = 2;
-    enum class Source : uint8_t { Unknown, Network, DiskCache, DiskCacheAfterValidation, MemoryCache, MemoryCacheAfterValidation, ServiceWorker, ApplicationCache, DOMCache, InspectorOverride };
+    using Source = ResourceResponseBaseSource;
     static constexpr unsigned bitWidthOfSource = 4;
 
     static bool isRedirectionStatusCode(int code) { return code == 301 || code == 302 || code == 303 || code == 307 || code == 308; }
 
-    struct CrossThreadData {
-        CrossThreadData(const CrossThreadData&) = delete;
-        CrossThreadData& operator=(const CrossThreadData&) = delete;
-        CrossThreadData() = default;
-        CrossThreadData(CrossThreadData&&) = default;
-        CrossThreadData& operator=(CrossThreadData&&) = default;
-        CrossThreadData(URL&& url, String&& mimeType, long long expectedContentLength, String&& textEncodingName, int httpStatusCode, String&& httpStatusText, String&& httpVersion, HTTPHeaderMap&& httpHeaderFields, std::optional<NetworkLoadMetrics>&& networkLoadMetrics, Source source, Type type, Tainting tainting, bool isRedirected, UsedLegacyTLS usedLegacyTLS, WasPrivateRelayed wasPrivateRelayed, bool isRangeRequested, std::optional<CertificateInfo> certificateInfo)
-            : url(WTFMove(url))
-            , mimeType(WTFMove(mimeType))
-            , expectedContentLength(expectedContentLength)
-            , textEncodingName(WTFMove(textEncodingName))
-            , httpStatusCode(httpStatusCode)
-            , httpStatusText(WTFMove(httpStatusText))
-            , httpVersion(WTFMove(httpVersion))
-            , httpHeaderFields(WTFMove(httpHeaderFields))
-            , networkLoadMetrics(WTFMove(networkLoadMetrics))
-            , source(source)
-            , type(type)
-            , tainting(tainting)
-            , isRedirected(isRedirected)
-            , usedLegacyTLS(usedLegacyTLS)
-            , wasPrivateRelayed(wasPrivateRelayed)
-            , isRangeRequested(isRangeRequested)
-            , certificateInfo(certificateInfo)
-        {
-        }
-
-        WEBCORE_EXPORT CrossThreadData isolatedCopy() const;
-
-        URL url;
-        String mimeType;
-        long long expectedContentLength;
-        String textEncodingName;
-        short httpStatusCode;
-        String httpStatusText;
-        String httpVersion;
-        HTTPHeaderMap httpHeaderFields;
-        std::optional<NetworkLoadMetrics> networkLoadMetrics;
-        Source source;
-        Type type;
-        Tainting tainting;
-        bool isRedirected;
-        UsedLegacyTLS usedLegacyTLS;
-        WasPrivateRelayed wasPrivateRelayed;
-        bool isRangeRequested;
-        std::optional<CertificateInfo> certificateInfo;
-    };
+    using CrossThreadData = ResourceResponseBaseCrossThreadData;
     
     struct ResponseData {
         URL m_url;
@@ -351,6 +310,54 @@ private:
     Tainting m_tainting : bitWidthOfTainting { Tainting::Basic };
     Source m_source : bitWidthOfSource { Source::Unknown };
     Type m_type : bitWidthOfType { Type::Default };
+};
+
+struct ResourceResponseBaseCrossThreadData {
+    ResourceResponseBaseCrossThreadData(const ResourceResponseBaseCrossThreadData&) = delete;
+    ResourceResponseBaseCrossThreadData& operator=(const ResourceResponseBaseCrossThreadData&) = delete;
+    ResourceResponseBaseCrossThreadData() = default;
+    ResourceResponseBaseCrossThreadData(ResourceResponseBaseCrossThreadData&&) = default;
+    ResourceResponseBaseCrossThreadData& operator=(ResourceResponseBaseCrossThreadData&&) = default;
+    ResourceResponseBaseCrossThreadData(URL&& url, String&& mimeType, long long expectedContentLength, String&& textEncodingName, int httpStatusCode, String&& httpStatusText, String&& httpVersion, HTTPHeaderMap&& httpHeaderFields, std::optional<NetworkLoadMetrics>&& networkLoadMetrics, ResourceResponseBaseSource source, ResourceResponseBaseType type, ResourceResponseBaseTainting tainting, bool isRedirected, UsedLegacyTLS usedLegacyTLS, WasPrivateRelayed wasPrivateRelayed, bool isRangeRequested, std::optional<CertificateInfo> certificateInfo)
+        : url(WTFMove(url))
+        , mimeType(WTFMove(mimeType))
+        , expectedContentLength(expectedContentLength)
+        , textEncodingName(WTFMove(textEncodingName))
+        , httpStatusCode(httpStatusCode)
+        , httpStatusText(WTFMove(httpStatusText))
+        , httpVersion(WTFMove(httpVersion))
+        , httpHeaderFields(WTFMove(httpHeaderFields))
+        , networkLoadMetrics(WTFMove(networkLoadMetrics))
+        , source(source)
+        , type(type)
+        , tainting(tainting)
+        , isRedirected(isRedirected)
+        , usedLegacyTLS(usedLegacyTLS)
+        , wasPrivateRelayed(wasPrivateRelayed)
+        , isRangeRequested(isRangeRequested)
+        , certificateInfo(certificateInfo)
+    {
+    }
+
+    WEBCORE_EXPORT ResourceResponseBaseCrossThreadData isolatedCopy() const;
+
+    URL url;
+    String mimeType;
+    long long expectedContentLength;
+    String textEncodingName;
+    short httpStatusCode;
+    String httpStatusText;
+    String httpVersion;
+    HTTPHeaderMap httpHeaderFields;
+    std::optional<NetworkLoadMetrics> networkLoadMetrics;
+    ResourceResponseBase::Source source;
+    ResourceResponseBase::Type type;
+    ResourceResponseBase::Tainting tainting;
+    bool isRedirected;
+    UsedLegacyTLS usedLegacyTLS;
+    WasPrivateRelayed wasPrivateRelayed;
+    bool isRangeRequested;
+    std::optional<CertificateInfo> certificateInfo;
 };
 
 template<class Encoder, typename>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2854,7 +2854,7 @@ enum class WebCore::ResourceLoadPriority : uint8_t {
     VeryHigh,
 };
 
-[Nested] enum class WebCore::ResourceResponseBase::Type : uint8_t {
+[Nested] enum class WebCore::ResourceResponseBaseType : uint8_t {
     Basic,
     Cors,
     Default,
@@ -2863,14 +2863,14 @@ enum class WebCore::ResourceLoadPriority : uint8_t {
     Opaqueredirect
 };
 
-[Nested] enum class WebCore::ResourceResponseBase::Tainting : uint8_t {
+[Nested] enum class WebCore::ResourceResponseBaseTainting : uint8_t {
     Basic,
     Cors,
     Opaque,
     Opaqueredirect
 };
 
-[Nested] enum class WebCore::ResourceResponseBase::Source : uint8_t {
+[Nested] enum class WebCore::ResourceResponseBaseSource : uint8_t {
     Unknown,
     Network,
     DiskCache,
@@ -2882,6 +2882,10 @@ enum class WebCore::ResourceLoadPriority : uint8_t {
     DOMCache,
     InspectorOverride
 };
+
+using WebCore::ResourceResponseBase::Type = WebCore::ResourceResponseBaseType;
+using WebCore::ResourceResponseBase::Tainting = WebCore::ResourceResponseBaseTainting;
+using WebCore::ResourceResponseBase::Source = WebCore::ResourceResponseBaseSource;
 
 [Nested] struct WebCore::ResourceResponseBase::ResponseData {
     URL m_url;
@@ -2914,7 +2918,7 @@ class WebCore::ResourceResponse : WebCore::ResourceResponseBase {
 }
 
 header: <WebCore/ResourceResponseBase.h>
-[Nested] struct WebCore::ResourceResponseBase::CrossThreadData {
+[CustomHeader] struct WebCore::ResourceResponseBaseCrossThreadData {
     URL url;
     String mimeType;
     long long expectedContentLength;
@@ -2933,6 +2937,8 @@ header: <WebCore/ResourceResponseBase.h>
     bool isRangeRequested;
     std::optional<WebCore::CertificateInfo> certificateInfo;
 };
+
+using WebCore::ResourceResponseBase::CrossThreadData = WebCore::ResourceResponseBaseCrossThreadData;
 
 enum class WebCore::ReferrerPolicy : uint8_t {
     EmptyString,
@@ -5922,6 +5928,7 @@ struct WebCore::PrewarmInformation {
 };
 
 using WebCore::PlatformLayerIdentifier = ProcessQualified<ObjectIdentifier<WebCore::PlatformLayerIdentifierType>>;
+using WebCore::ScriptExecutionContextIdentifier = ProcessQualified<WTF::UUID>;
 
 header: <WebCore/FontSelectionAlgorithm.h>
 using WebCore::FontSelectionValue::BackingType = int16_t;


### PR DESCRIPTION
#### f8aa338b7eb4b87fea71f58290729288bf2b4efb
<pre>
Add WebGPU enumerations and additional serialization updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=261962">https://bugs.webkit.org/show_bug.cgi?id=261962</a>
rdar://115904551

Reviewed by Alex Christensen.

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUAddressMode.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBlendFactor.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBlendOperation.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferBindingType.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBufferUsage.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCanvasAlphaMode.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUColorWrite.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompareFunction.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompilationMessageType.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUComputePassTimestampLocation.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCullMode.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUDeviceLostReason.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFilterMode.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFrontFace.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPULoadOp.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPrimitiveTopology.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueryType.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassTimestampLocation.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUSamplerBindingType.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUShaderStage.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStencilOperation.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStorageTextureAccess.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUStoreOp.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureDimension.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureSampleType.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureUsage.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureViewDimension.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexFormat.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUVertexStepMode.h:
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBaseCrossThreadData::isolatedCopy const):
(WebCore::ResourceResponseBase::CrossThreadData::isolatedCopy const): Deleted.
* Source/WebCore/platform/network/ResourceResponseBase.h:
(WebCore::ResourceResponseBaseCrossThreadData::ResourceResponseBaseCrossThreadData):
(WebCore::ResourceResponseBase::CrossThreadData::CrossThreadData): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268336@main">https://commits.webkit.org/268336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd4946c54f8da80e68648a29c8510a6a74d418cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19908 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19742 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22124 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23948 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21917 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15570 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17526 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4635 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->