### PR TITLE
Move IPInt slow paths to a new file

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -979,6 +979,7 @@
 		52EED7942492B870008F4C93 /* FunctionAllowlist.h in Headers */ = {isa = PBXBuildFile; fileRef = 52EED7932492B868008F4C93 /* FunctionAllowlist.h */; };
 		52F6C35E1E71EB080081F4CC /* WebAssemblyWrapperFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F6C35C1E71EB080081F4CC /* WebAssemblyWrapperFunction.h */; };
 		52FDABC32788076B00C15B59 /* WasmIRGeneratorHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 52FDABC22788076900C15B59 /* WasmIRGeneratorHelpers.h */; };
+		53091F9A2ABE1F570076CBC4 /* WasmIPIntSlowPaths.h in Headers */ = {isa = PBXBuildFile; fileRef = 53091F982ABE1F570076CBC4 /* WasmIPIntSlowPaths.h */; };
 		530A66B91FA3E78B0026A545 /* UnifiedSource3-mm.mm in Sources */ = {isa = PBXBuildFile; fileRef = 530A66B11FA3E77A0026A545 /* UnifiedSource3-mm.mm */; };
 		530A66BA1FA3E78B0026A545 /* UnifiedSource4-mm.mm in Sources */ = {isa = PBXBuildFile; fileRef = 530A66B81FA3E77E0026A545 /* UnifiedSource4-mm.mm */; };
 		530A66BB1FA3E78B0026A545 /* UnifiedSource5-mm.mm in Sources */ = {isa = PBXBuildFile; fileRef = 530A66B51FA3E77D0026A545 /* UnifiedSource5-mm.mm */; };
@@ -3997,6 +3998,8 @@
 		52F6C35C1E71EB080081F4CC /* WebAssemblyWrapperFunction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAssemblyWrapperFunction.h; path = js/WebAssemblyWrapperFunction.h; sourceTree = "<group>"; };
 		52FDABC22788076900C15B59 /* WasmIRGeneratorHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmIRGeneratorHelpers.h; sourceTree = "<group>"; };
 		5300740C22DD6F6600B9ACB3 /* JSFinalizationRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSFinalizationRegistry.cpp; sourceTree = "<group>"; };
+		53091F972ABE1F570076CBC4 /* WasmIPIntSlowPaths.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmIPIntSlowPaths.cpp; sourceTree = "<group>"; };
+		53091F982ABE1F570076CBC4 /* WasmIPIntSlowPaths.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmIPIntSlowPaths.h; sourceTree = "<group>"; };
 		530A63401FA3E31C0026A545 /* SourcesCocoa.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SourcesCocoa.txt; sourceTree = "<group>"; };
 		530A63411FA3E31D0026A545 /* Sources.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Sources.txt; sourceTree = "<group>"; };
 		530A66AD1FA3E7770026A545 /* UnifiedSource144.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource144.cpp; path = "DerivedSources/JavaScriptCore/unified-sources/UnifiedSource144.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -7663,6 +7666,8 @@
 				F3D9C2352A426CB7006EE152 /* WasmIPIntGenerator.h */,
 				F3D9C2362A426CB7006EE152 /* WasmIPIntPlan.cpp */,
 				F3D9C2372A426CB7006EE152 /* WasmIPIntPlan.h */,
+				53091F972ABE1F570076CBC4 /* WasmIPIntSlowPaths.cpp */,
+				53091F982ABE1F570076CBC4 /* WasmIPIntSlowPaths.h */,
 				52FDABC22788076900C15B59 /* WasmIRGeneratorHelpers.h */,
 				AD5C36DC1F688B5F000BCAAF /* WasmJS.h */,
 				AD00659D1ECAC7FE000CA926 /* WasmLimits.h */,
@@ -11745,6 +11750,7 @@
 				AD5C36E21F699EC0000BCAAF /* WasmInstance.h in Headers */,
 				F3D9C2392A426CB8006EE152 /* WasmIPIntGenerator.h in Headers */,
 				F3D9C23B2A426CB8006EE152 /* WasmIPIntPlan.h in Headers */,
+				53091F9A2ABE1F570076CBC4 /* WasmIPIntSlowPaths.h in Headers */,
 				52FDABC32788076B00C15B59 /* WasmIRGeneratorHelpers.h in Headers */,
 				AD5C36DD1F688B65000BCAAF /* WasmJS.h in Headers */,
 				AD00659E1ECAC812000CA926 /* WasmLimits.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1126,6 +1126,7 @@ wasm/WasmInstance.cpp
 wasm/WasmInstance.h
 wasm/WasmIPIntGenerator.cpp
 wasm/WasmIPIntPlan.cpp
+wasm/WasmIPIntSlowPaths.cpp
 wasm/WasmLLIntGenerator.cpp
 wasm/WasmLLIntPlan.cpp
 wasm/WasmLLIntTierUpCounter.cpp

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1,0 +1,630 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WasmIPIntSlowPaths.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "BytecodeStructs.h"
+#include "FrameTracers.h"
+#include "JITExceptions.h"
+#include "JSWebAssemblyArray.h"
+#include "JSWebAssemblyException.h"
+#include "JSWebAssemblyInstance.h"
+#include "LLIntData.h"
+#include "WasmBBQPlan.h"
+#include "WasmCallee.h"
+#include "WasmCallingConvention.h"
+#include "WasmFunctionCodeBlockGenerator.h"
+#include "WasmInstance.h"
+#include "WasmLLIntBuiltin.h"
+#include "WasmLLIntGenerator.h"
+#include "WasmModuleInformation.h"
+#include "WasmOMGPlan.h"
+#include "WasmOSREntryPlan.h"
+#include "WasmOperationsInlines.h"
+#include "WasmTypeDefinitionInlines.h"
+#include "WasmWorklist.h"
+#include "WebAssemblyFunction.h"
+#include <bit>
+
+namespace JSC { namespace LLInt {
+
+#define WASM_RETURN_TWO(first, second) do { \
+        return encodeResult(first, second); \
+    } while (false)
+
+#define WASM_THROW(exceptionType) do { \
+        callFrame->setArgumentCountIncludingThis(static_cast<int>(exceptionType)); \
+        WASM_RETURN_TWO(LLInt::wasmExceptionInstructions(), 0); \
+    } while (false)
+
+#define WASM_CALL_RETURN(targetInstance, callTarget, callTargetTag) do { \
+        WASM_RETURN_TWO((retagCodePtr<callTargetTag, JSEntrySlowPathPtrTag>(callTarget)), targetInstance); \
+    } while (false)
+
+#define IPINT_CALLEE() \
+    static_cast<Wasm::IPIntCallee*>(callFrame->callee().asNativeCallee())
+
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+#if ENABLE(WEBASSEMBLY_OMGJIT)
+enum class RequiredWasmJIT { Any, OMG };
+
+inline bool shouldJIT(Wasm::IPIntCallee* callee, RequiredWasmJIT requiredJIT = RequiredWasmJIT::Any)
+{
+    if (requiredJIT == RequiredWasmJIT::OMG) {
+        if (!Options::useOMGJIT() || !Wasm::OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(callee->functionIndex()))
+            return false;
+    } else {
+        if (Options::wasmIPIntTiersUpToBBQ()
+            && (!Options::useBBQJIT() || !Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(callee->functionIndex())))
+            return false;
+        if (!Options::wasmIPIntTiersUpToOMG()
+            && (!Options::useOMGJIT() || !Wasm::OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(callee->functionIndex())))
+            return false;
+    }
+    if (!Options::wasmFunctionIndexRangeToCompile().isInRange(callee->functionIndex()))
+        return false;
+    return true;
+}
+
+inline bool jitCompileAndSetHeuristics(Wasm::IPIntCallee* callee, Wasm::Instance* instance)
+{
+    ASSERT(!instance->module().moduleInformation().usesSIMD(callee->functionIndex()));
+
+    Wasm::LLIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
+    if (!tierUpCounter.checkIfOptimizationThresholdReached()) {
+        dataLogLnIf(Options::verboseOSR(), "    JIT threshold should be lifted.");
+        return false;
+    }
+
+    if (callee->replacement(instance->memory()->mode()))  {
+        dataLogLnIf(Options::verboseOSR(), "    Code was already compiled.");
+        tierUpCounter.optimizeSoon();
+        return true;
+    }
+
+    bool compile = false;
+    {
+        Locker locker { tierUpCounter.m_lock };
+        switch (tierUpCounter.m_compilationStatus) {
+        case Wasm::LLIntTierUpCounter::CompilationStatus::NotCompiled:
+            compile = true;
+            tierUpCounter.m_compilationStatus = Wasm::LLIntTierUpCounter::CompilationStatus::Compiling;
+            break;
+        case Wasm::LLIntTierUpCounter::CompilationStatus::Compiling:
+            tierUpCounter.optimizeAfterWarmUp();
+            break;
+        case Wasm::LLIntTierUpCounter::CompilationStatus::Compiled:
+            break;
+        }
+    }
+
+    if (compile) {
+        uint32_t functionIndex = callee->functionIndex();
+        RefPtr<Wasm::Plan> plan;
+        if (Options::wasmIPIntTiersUpToBBQ() && Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex))
+            plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
+        else // No need to check OMG allow list: if we didn't want to compile this function, shouldJIT should have returned false.
+            plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), instance->memory()->mode(), Wasm::Plan::dontFinalize()));
+
+        Wasm::ensureWorklist().enqueue(*plan);
+        if (UNLIKELY(!Options::useConcurrentJIT()))
+            plan->waitForCompletion();
+        else
+            tierUpCounter.optimizeAfterWarmUp();
+    }
+
+    return !!callee->replacement(instance->memory()->mode());
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(prologue_osr, CallFrame* callFrame)
+{
+    Wasm::IPIntCallee* callee = IPINT_CALLEE();
+
+    if (!shouldJIT(callee)) {
+        callee->tierUpCounter().deferIndefinitely();
+        WASM_RETURN_TWO(nullptr, nullptr);
+    }
+
+    if (!Options::useWasmIPIntPrologueOSR())
+        WASM_RETURN_TWO(nullptr, nullptr);
+
+    dataLogLnIf(Options::verboseOSR(), *callee, ": Entered prologue_osr with tierUpCounter = ", callee->tierUpCounter());
+
+    if (!jitCompileAndSetHeuristics(callee, instance))
+        WASM_RETURN_TWO(nullptr, nullptr);
+    WASM_RETURN_TWO(callee->replacement(instance->memory()->mode())->entrypoint().taggedPtr(), nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t *pl)
+{
+    Wasm::IPIntCallee* callee = IPINT_CALLEE();
+    Wasm::LLIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
+
+    if (!Options::useWebAssemblyOSR() || !Options::useWasmIPIntLoopOSR() || !shouldJIT(callee, RequiredWasmJIT::OMG)) {
+        ipint_extern_prologue_osr(instance, callFrame);
+        WASM_RETURN_TWO(nullptr, nullptr);
+    }
+
+    dataLogLnIf(Options::verboseOSR(), *callee, ": Entered loop_osr with tierUpCounter = ", callee->tierUpCounter());
+
+    if (!tierUpCounter.checkIfOptimizationThresholdReached()) {
+        dataLogLnIf(Options::verboseOSR(), "    JIT threshold should be lifted.");
+        WASM_RETURN_TWO(nullptr, nullptr);
+    }
+
+    unsigned loopOSREntryBytecodeOffset = pc;
+    const auto& osrEntryData = tierUpCounter.osrEntryDataForLoop(loopOSREntryBytecodeOffset);
+
+    if (Options::wasmIPIntTiersUpToBBQ() && Options::useBBQJIT()) {
+        if (!jitCompileAndSetHeuristics(callee, instance))
+            WASM_RETURN_TWO(nullptr, nullptr);
+
+        Wasm::BBQCallee* bbqCallee;
+        {
+            Locker locker { instance->calleeGroup()->m_lock };
+            bbqCallee = instance->calleeGroup()->bbqCallee(locker, callee->functionIndex());
+        }
+        RELEASE_ASSERT(bbqCallee);
+
+        size_t osrEntryScratchBufferSize = bbqCallee->osrEntryScratchBufferSize();
+        RELEASE_ASSERT(osrEntryScratchBufferSize >= osrEntryData.values.size());
+
+        uint64_t* buffer = instance->vm().wasmContext.scratchBufferForSize(osrEntryScratchBufferSize);
+        if (!buffer)
+            WASM_RETURN_TWO(nullptr, nullptr);
+
+        uint32_t index = 0;
+        buffer[index++] = osrEntryData.loopIndex;
+        for (uint32_t i = 0; i < callee->m_numLocals; ++i)
+            buffer[index++] = pl[i];
+        while (index < osrEntryData.values.size()) {
+            pl -= 2; // each stack slot is 16B
+            buffer[index++] = *pl;
+        }
+
+        auto sharedLoopEntrypoint = bbqCallee->sharedLoopEntrypoint();
+        RELEASE_ASSERT(sharedLoopEntrypoint);
+        WASM_RETURN_TWO(buffer, sharedLoopEntrypoint->taggedPtr());
+    } else {
+        const auto doOSREntry = [&](Wasm::OSREntryCallee* osrEntryCallee) {
+            if (osrEntryCallee->loopIndex() != osrEntryData.loopIndex)
+                WASM_RETURN_TWO(nullptr, nullptr);
+
+            size_t osrEntryScratchBufferSize = osrEntryCallee->osrEntryScratchBufferSize();
+            RELEASE_ASSERT(osrEntryScratchBufferSize == osrEntryData.values.size());
+
+            uint64_t* buffer = instance->vm().wasmContext.scratchBufferForSize(osrEntryScratchBufferSize);
+            if (!buffer)
+                WASM_RETURN_TWO(nullptr, nullptr);
+
+            uint32_t index = 0;
+            for (uint32_t i = 0; i < callee->m_numLocals; ++i)
+                buffer[index++] = pl[i];
+            while (index < osrEntryData.values.size()) {
+                pl -= 2; // each stack slot is 16B
+                buffer[index++] = *pl;
+            }
+
+            WASM_RETURN_TWO(buffer, osrEntryCallee->entrypoint().taggedPtr());
+        };
+
+        if (auto* osrEntryCallee = callee->osrEntryCallee(instance->memory()->mode()))
+            return doOSREntry(osrEntryCallee);
+
+        bool compile = false;
+        {
+            Locker locker { tierUpCounter.m_lock };
+            switch (tierUpCounter.m_loopCompilationStatus) {
+            case Wasm::LLIntTierUpCounter::CompilationStatus::NotCompiled:
+                compile = true;
+                tierUpCounter.m_loopCompilationStatus = Wasm::LLIntTierUpCounter::CompilationStatus::Compiling;
+                break;
+            case Wasm::LLIntTierUpCounter::CompilationStatus::Compiling:
+                tierUpCounter.optimizeAfterWarmUp();
+                break;
+            case Wasm::LLIntTierUpCounter::CompilationStatus::Compiled:
+                break;
+            }
+        }
+
+        if (compile) {
+            Ref<Wasm::Plan> plan = adoptRef(*static_cast<Wasm::Plan*>(new Wasm::OSREntryPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), Ref<Wasm::Callee>(*callee), callee->functionIndex(), callee->hasExceptionHandlers(), osrEntryData.loopIndex, instance->memory()->mode(), Wasm::Plan::dontFinalize())));
+            Wasm::ensureWorklist().enqueue(plan.copyRef());
+            if (UNLIKELY(!Options::useConcurrentJIT()))
+                plan->waitForCompletion();
+            else
+                tierUpCounter.optimizeAfterWarmUp();
+        }
+
+        if (auto* osrEntryCallee = callee->osrEntryCallee(instance->memory()->mode()))
+            return doOSREntry(osrEntryCallee);
+
+        WASM_RETURN_TWO(nullptr, nullptr);
+    }
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(epilogue_osr, CallFrame* callFrame)
+{
+    Wasm::IPIntCallee* callee = IPINT_CALLEE();
+
+    if (!shouldJIT(callee)) {
+        callee->tierUpCounter().deferIndefinitely();
+        WASM_RETURN_TWO(nullptr, nullptr);
+    }
+    if (!Options::useWasmIPIntEpilogueOSR())
+        WASM_RETURN_TWO(nullptr, nullptr);
+
+    dataLogLnIf(Options::verboseOSR(), *callee, ": Entered epilogue_osr with tierUpCounter = ", callee->tierUpCounter());
+
+    jitCompileAndSetHeuristics(callee, instance);
+    WASM_RETURN_TWO(nullptr, nullptr);
+}
+#endif
+#endif
+
+
+WASM_IPINT_EXTERN_CPP_DECL(table_get, unsigned tableIndex, unsigned index)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    EncodedJSValue result = Wasm::tableGet(instance, tableIndex, index);
+    if (!result)
+        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
+    WASM_RETURN_TWO(bitwise_cast<void*>(result), 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(tableIndex);
+    UNUSED_PARAM(index);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARMv8 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    if (!Wasm::tableSet(instance, tableIndex, index, value))
+        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
+    WASM_RETURN_TWO(0, 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(tableIndex);
+    UNUSED_PARAM(index);
+    UNUSED_PARAM(value);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(table_init, uint32_t* metadata, uint32_t dest, uint64_t srcAndLength)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    uint32_t dstOffset = dest;
+    uint32_t srcOffset = srcAndLength >> 32;
+    uint32_t length = srcAndLength & 0xffffffff;
+    if (!Wasm::tableInit(instance, metadata[0], metadata[1], dstOffset, srcOffset, length))
+        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
+    WASM_RETURN_TWO(0, 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(metadata);
+    UNUSED_PARAM(dest);
+    UNUSED_PARAM(srcAndLength);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(table_fill, uint32_t tableIndex, EncodedJSValue fill, int64_t offsetAndSize)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    uint32_t offset = offsetAndSize >> 32;
+    uint32_t size = offsetAndSize & 0xffffffff;
+    if (!Wasm::tableFill(instance, tableIndex, offset, fill, size))
+        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
+    WASM_RETURN_TWO(0, 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(tableIndex);
+    UNUSED_PARAM(fill);
+    UNUSED_PARAM(offsetAndSize);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(table_grow, int32_t tableIndex, EncodedJSValue fill, uint32_t size)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    WASM_RETURN_TWO(bitwise_cast<void*>(Wasm::tableGrow(instance, tableIndex, fill, size)), 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(tableIndex);
+    UNUSED_PARAM(fill);
+    UNUSED_PARAM(size);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL_1P(current_memory)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    size_t size = instance->memory()->handle().size() >> 16;
+    WASM_RETURN_TWO(bitwise_cast<void*>(size), 0);
+#else
+    UNUSED_PARAM(instance);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_grow, int32_t delta)
+{
+    WASM_RETURN_TWO(reinterpret_cast<void*>(Wasm::growMemory(instance, delta)), 0);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_init, int32_t dataIndex, int32_t dst, int64_t srcAndLength)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    if (!Wasm::memoryInit(instance, dataIndex, dst, srcAndLength >> 32, srcAndLength & 0xffffffff))
+        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<int64_t>(Wasm::ExceptionType::OutOfBoundsMemoryAccess)));
+    WASM_RETURN_TWO(0, 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(dataIndex);
+    UNUSED_PARAM(dst);
+    UNUSED_PARAM(srcAndLength);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(data_drop, int32_t dataIndex)
+{
+    Wasm::dataDrop(instance, dataIndex);
+    WASM_RETURN_TWO(0, 0);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_copy, int32_t dst, int32_t src, int32_t count)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    if (!Wasm::memoryCopy(instance, dst, src, count))
+        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<int64_t>(Wasm::ExceptionType::OutOfBoundsMemoryAccess)));
+    WASM_RETURN_TWO(0, 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(dst);
+    UNUSED_PARAM(src);
+    UNUSED_PARAM(count);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_fill, int32_t dst, int32_t targetValue, int32_t count)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    if (!Wasm::memoryFill(instance, dst, targetValue, count))
+        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<int64_t>(Wasm::ExceptionType::OutOfBoundsMemoryAccess)));
+    WASM_RETURN_TWO(0, 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(dst);
+    UNUSED_PARAM(targetValue);
+    UNUSED_PARAM(count);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(elem_drop, int32_t dataIndex)
+{
+    Wasm::elemDrop(instance, dataIndex);
+    WASM_RETURN_TWO(0, 0);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(table_copy, int32_t* metadata, int32_t dst, int64_t srcAndCount)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    if (!Wasm::tableCopy(instance, metadata[0], metadata[1], dst, srcAndCount >> 32, srcAndCount & 0xffffffff))
+        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<int64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
+    WASM_RETURN_TWO(0, 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(metadata);
+    UNUSED_PARAM(dst);
+    UNUSED_PARAM(srcAndCount);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(table_size, int32_t tableIndex)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::tableSize(instance, tableIndex);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<EncodedJSValue>(result)), 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(tableIndex);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
+inline UGPRPair doWasmCall(Wasm::Instance* instance, unsigned functionIndex)
+{
+    uint32_t importFunctionCount = instance->module().moduleInformation().importFunctionCount();
+
+    CodePtr<WasmEntryPtrTag> codePtr;
+
+    if (functionIndex < importFunctionCount) {
+        Wasm::Instance::ImportFunctionInfo* functionInfo = instance->importFunctionInfo(functionIndex);
+        codePtr = functionInfo->importFunctionStub;
+    } else {
+        // Target is a wasm function within the same instance
+        codePtr = *instance->calleeGroup()->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
+    }
+
+    WASM_CALL_RETURN(instance, codePtr.taggedPtr(), WasmEntryPtrTag);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(call, unsigned functionIndex)
+{
+    return doWasmCall(instance, functionIndex);
+}
+
+inline UGPRPair doWasmCallIndirect(CallFrame* callFrame, Wasm::Instance* instance, unsigned functionIndex, unsigned tableIndex, unsigned typeIndex)
+{
+    Wasm::FuncRefTable* table = instance->table(tableIndex)->asFuncrefTable();
+
+    if (functionIndex >= table->length())
+        WASM_THROW(Wasm::ExceptionType::OutOfBoundsCallIndirect);
+
+    const Wasm::FuncRefTable::Function& function = table->function(functionIndex);
+
+    if (function.m_function.typeIndex == Wasm::TypeDefinition::invalidIndex)
+        WASM_THROW(Wasm::ExceptionType::NullTableEntry);
+
+    const auto& callSignature = IPINT_CALLEE()->signature(typeIndex);
+    if (callSignature.index() != function.m_function.typeIndex)
+        WASM_THROW(Wasm::ExceptionType::BadSignature);
+
+    WASM_CALL_RETURN(function.m_instance, function.m_function.entrypointLoadLocation->taggedPtr(), WasmEntryPtrTag);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(call_indirect, CallFrame* callFrame, unsigned functionIndex, unsigned* metadataEntry)
+{
+    unsigned tableIndex = metadataEntry[0];
+    unsigned typeIndex = metadataEntry[1];
+    Wasm::FuncRefTable* table = instance->table(tableIndex)->asFuncrefTable();
+
+    if (functionIndex >= table->length())
+        WASM_THROW(Wasm::ExceptionType::OutOfBoundsCallIndirect);
+
+    const Wasm::FuncRefTable::Function& function = table->function(functionIndex);
+
+    if (function.m_function.typeIndex == Wasm::TypeDefinition::invalidIndex)
+        WASM_THROW(Wasm::ExceptionType::NullTableEntry);
+
+    const auto& callSignature = static_cast<Wasm::IPIntCallee*>(callFrame->callee().asNativeCallee())->signature(typeIndex);
+    if (callSignature.index() != function.m_function.typeIndex)
+        WASM_THROW(Wasm::ExceptionType::BadSignature);
+
+    WASM_CALL_RETURN(function.m_instance, function.m_function.entrypointLoadLocation->taggedPtr(), WasmEntryPtrTag);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(set_global_ref, uint32_t globalIndex, JSValue value)
+{
+    instance->setGlobal(globalIndex, value);
+    WASM_RETURN_TWO(0, 0);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(set_global_64, unsigned index, uint64_t value)
+{
+    instance->setGlobal(index, value);
+    WASM_RETURN_TWO(0, 0);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(get_global_64, unsigned index)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    WASM_RETURN_TWO(bitwise_cast<void*>(instance->loadI64Global(index)), 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(index);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait32, uint64_t pointerWithOffset, uint32_t value, uint64_t timeout)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicWait32(instance, pointerWithOffset, value, timeout);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(pointerWithOffset);
+    UNUSED_PARAM(value);
+    UNUSED_PARAM(timeout);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait64, uint64_t pointerWithOffset, uint64_t value, uint64_t timeout)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicWait64(instance, pointerWithOffset, value, timeout);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(pointerWithOffset);
+    UNUSED_PARAM(value);
+    UNUSED_PARAM(timeout);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_notify, unsigned base, unsigned offset, int32_t count)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicNotify(instance, base, offset, count);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(base);
+    UNUSED_PARAM(offset);
+    UNUSED_PARAM(count);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(throw, CallFrame* callFrame, uint32_t exceptionIndex)
+{
+    SlowPathFrameTracer tracer(instance->vm(), callFrame);
+
+    JSGlobalObject* globalObject = instance->globalObject();
+    VM& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    const Wasm::Tag& tag = instance->tag(exceptionIndex);
+
+    FixedVector<uint64_t> values(tag.parameterCount());
+    JSWebAssemblyException* exception = JSWebAssemblyException::create(vm, globalObject->webAssemblyExceptionStructure(), tag, WTFMove(values));
+    throwException(globalObject, throwScope, exception);
+
+    genericUnwind(vm, callFrame);
+    ASSERT(!!vm.callFrameForCatch);
+    ASSERT(!!vm.targetMachinePCForThrow);
+    WASM_RETURN_TWO(vm.targetMachinePCForThrow, nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(ref_func, unsigned index)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    WASM_RETURN_TWO(bitwise_cast<void*>(Wasm::refFunc(instance, index)), 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(index);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
+} } // namespace JSC::LLInt
+
+#endif
+

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include "CommonSlowPaths.h"
+#include "WasmExceptionType.h"
+#include <wtf/StdLibExtras.h>
+
+namespace JSC {
+
+namespace Wasm {
+class Instance;
+}
+
+namespace LLInt {
+
+#define WASM_IPINT_EXTERN_CPP_DECL(name, ...) \
+    extern "C" UGPRPair ipint_extern_##name(Wasm::Instance* instance, __VA_ARGS__)
+
+#define WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(name, ...) \
+    WASM_IPINT_EXTERN_CPP_DECL(name, __VA_ARGS__) REFERENCED_FROM_ASM WTF_INTERNAL
+
+#define WASM_IPINT_EXTERN_CPP_DECL_1P(name) \
+    extern "C" UGPRPair ipint_extern_##name(Wasm::Instance* instance)
+
+#define WASM_IPINT_EXTERN_CPP_HIDDEN_DECL_1P(name) \
+    WASM_IPINT_EXTERN_CPP_DECL_1P(name) REFERENCED_FROM_ASM WTF_INTERNAL
+
+#if ENABLE(WEBASSEMBLY_OMGJIT)
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prologue_osr, CallFrame* callFrame);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t* pl);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(epilogue_osr, CallFrame* callFrame);
+#endif
+
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, unsigned);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_init, uint32_t* metadata, uint32_t dest, uint64_t srcAndLength);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_fill, uint32_t tableIndex, EncodedJSValue fill, int64_t offsetAndSize);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_grow, int32_t tableIndex, EncodedJSValue fill, uint32_t size);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL_1P(current_memory);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_grow, int32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_init, int32_t, int32_t, int64_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(data_drop, int32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_copy, int32_t, int32_t, int32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_fill, int32_t, int32_t, int32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(elem_drop, int32_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, int32_t*, int32_t, int64_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_size, int32_t);
+
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, CallFrame* callFrame, unsigned functionIndex, unsigned* metadataEntry);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, unsigned);
+
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_ref, uint32_t globalIndex, JSValue value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(get_global_64, unsigned);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_64, unsigned, uint64_t);
+
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, uint64_t, uint32_t, uint64_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, uint64_t, uint64_t, uint64_t);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, unsigned, unsigned, int32_t);
+
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw, CallFrame*, uint32_t);
+
+} } // namespace JSC::LLInt
+
+#endif

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -79,8 +79,6 @@ namespace JSC { namespace LLInt {
 
 #define CALLEE() \
     static_cast<Wasm::LLIntCallee*>(callFrame->callee().asNativeCallee())
-#define IPINT_CALLEE() \
-    static_cast<Wasm::IPIntCallee*>(callFrame->callee().asNativeCallee())
 
 #define READ(virtualRegister) \
     (virtualRegister.isConstant() \
@@ -98,7 +96,6 @@ extern "C" void wasm_log_crash(CallFrame*, Wasm::Instance* instance)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-// LLInt overload
 inline bool shouldJIT(Wasm::LLIntCallee* callee, RequiredWasmJIT requiredJIT = RequiredWasmJIT::Any)
 {
     if (requiredJIT == RequiredWasmJIT::OMG) {
@@ -117,26 +114,6 @@ inline bool shouldJIT(Wasm::LLIntCallee* callee, RequiredWasmJIT requiredJIT = R
     return true;
 }
 
-// IPInt overload
-inline bool shouldJIT(Wasm::IPIntCallee* callee, RequiredWasmJIT requiredJIT = RequiredWasmJIT::Any)
-{
-    if (requiredJIT == RequiredWasmJIT::OMG) {
-        if (!Options::useOMGJIT() || !Wasm::OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(callee->functionIndex()))
-            return false;
-    } else {
-        if (Options::wasmIPIntTiersUpToBBQ()
-            && (!Options::useBBQJIT() || !Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(callee->functionIndex())))
-            return false;
-        if (!Options::wasmIPIntTiersUpToOMG()
-            && (!Options::useOMGJIT() || !Wasm::OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(callee->functionIndex())))
-            return false;
-    }
-    if (!Options::wasmFunctionIndexRangeToCompile().isInRange(callee->functionIndex()))
-        return false;
-    return true;
-}
-
-// LLInt overload
 inline bool jitCompileAndSetHeuristics(Wasm::LLIntCallee* callee, Wasm::Instance* instance)
 {
     ASSERT(!instance->module().moduleInformation().usesSIMD(callee->functionIndex()));
@@ -173,57 +150,6 @@ inline bool jitCompileAndSetHeuristics(Wasm::LLIntCallee* callee, Wasm::Instance
         uint32_t functionIndex = callee->functionIndex();
         RefPtr<Wasm::Plan> plan;
         if (Options::wasmLLIntTiersUpToBBQ() && Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex))
-            plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
-        else // No need to check OMG allow list: if we didn't want to compile this function, shouldJIT should have returned false.
-            plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), instance->memory()->mode(), Wasm::Plan::dontFinalize()));
-
-        Wasm::ensureWorklist().enqueue(*plan);
-        if (UNLIKELY(!Options::useConcurrentJIT()))
-            plan->waitForCompletion();
-        else
-            tierUpCounter.optimizeAfterWarmUp();
-    }
-
-    return !!callee->replacement(instance->memory()->mode());
-}
-
-// IPInt overload
-inline bool jitCompileAndSetHeuristics(Wasm::IPIntCallee* callee, Wasm::Instance* instance)
-{
-    ASSERT(!instance->module().moduleInformation().usesSIMD(callee->functionIndex()));
-
-    Wasm::LLIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
-    if (!tierUpCounter.checkIfOptimizationThresholdReached()) {
-        dataLogLnIf(Options::verboseOSR(), "    JIT threshold should be lifted.");
-        return false;
-    }
-
-    if (callee->replacement(instance->memory()->mode()))  {
-        dataLogLnIf(Options::verboseOSR(), "    Code was already compiled.");
-        tierUpCounter.optimizeSoon();
-        return true;
-    }
-
-    bool compile = false;
-    {
-        Locker locker { tierUpCounter.m_lock };
-        switch (tierUpCounter.m_compilationStatus) {
-        case Wasm::LLIntTierUpCounter::CompilationStatus::NotCompiled:
-            compile = true;
-            tierUpCounter.m_compilationStatus = Wasm::LLIntTierUpCounter::CompilationStatus::Compiling;
-            break;
-        case Wasm::LLIntTierUpCounter::CompilationStatus::Compiling:
-            tierUpCounter.optimizeAfterWarmUp();
-            break;
-        case Wasm::LLIntTierUpCounter::CompilationStatus::Compiled:
-            break;
-        }
-    }
-
-    if (compile) {
-        uint32_t functionIndex = callee->functionIndex();
-        RefPtr<Wasm::Plan> plan;
-        if (Options::wasmIPIntTiersUpToBBQ() && Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex))
             plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
         else // No need to check OMG allow list: if we didn't want to compile this function, shouldJIT should have returned false.
             plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), instance->memory()->mode(), Wasm::Plan::dontFinalize()));
@@ -301,25 +227,6 @@ WASM_SLOW_PATH_DECL(prologue_osr)
     if (!jitCompileAndSetHeuristics(callee, instance))
         WASM_RETURN_TWO(nullptr, nullptr);
 
-    WASM_RETURN_TWO(callee->replacement(instance->memory()->mode())->entrypoint().taggedPtr(), nullptr);
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(prologue_osr, CallFrame* callFrame)
-{
-    Wasm::IPIntCallee* callee = IPINT_CALLEE();
-
-    if (!shouldJIT(callee)) {
-        callee->tierUpCounter().deferIndefinitely();
-        WASM_RETURN_TWO(nullptr, nullptr);
-    }
-
-    if (!Options::useWasmIPIntPrologueOSR())
-        WASM_RETURN_TWO(nullptr, nullptr);
-
-    dataLogLnIf(Options::verboseOSR(), *callee, ": Entered prologue_osr with tierUpCounter = ", callee->tierUpCounter());
-
-    if (!jitCompileAndSetHeuristics(callee, instance))
-        WASM_RETURN_TWO(nullptr, nullptr);
     WASM_RETURN_TWO(callee->replacement(instance->memory()->mode())->entrypoint().taggedPtr(), nullptr);
 }
 
@@ -422,114 +329,6 @@ WASM_SLOW_PATH_DECL(loop_osr)
     }
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t *pl)
-{
-    Wasm::IPIntCallee* callee = IPINT_CALLEE();
-    Wasm::LLIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
-
-    if (!Options::useWebAssemblyOSR() || !Options::useWasmIPIntLoopOSR() || !shouldJIT(callee, RequiredWasmJIT::OMG)) {
-        ipint_extern_prologue_osr(instance, callFrame);
-        WASM_RETURN_TWO(nullptr, nullptr);
-    }
-
-    dataLogLnIf(Options::verboseOSR(), *callee, ": Entered loop_osr with tierUpCounter = ", callee->tierUpCounter());
-
-    if (!tierUpCounter.checkIfOptimizationThresholdReached()) {
-        dataLogLnIf(Options::verboseOSR(), "    JIT threshold should be lifted.");
-        WASM_RETURN_TWO(nullptr, nullptr);
-    }
-
-    unsigned loopOSREntryBytecodeOffset = pc;
-    const auto& osrEntryData = tierUpCounter.osrEntryDataForLoop(loopOSREntryBytecodeOffset);
-
-    if (Options::wasmIPIntTiersUpToBBQ() && Options::useBBQJIT()) {
-        if (!jitCompileAndSetHeuristics(callee, instance))
-            WASM_RETURN_TWO(nullptr, nullptr);
-
-        Wasm::BBQCallee* bbqCallee;
-        {
-            Locker locker { instance->calleeGroup()->m_lock };
-            bbqCallee = instance->calleeGroup()->bbqCallee(locker, callee->functionIndex());
-        }
-        RELEASE_ASSERT(bbqCallee);
-
-        size_t osrEntryScratchBufferSize = bbqCallee->osrEntryScratchBufferSize();
-        RELEASE_ASSERT(osrEntryScratchBufferSize >= osrEntryData.values.size());
-
-        uint64_t* buffer = instance->vm().wasmContext.scratchBufferForSize(osrEntryScratchBufferSize);
-        if (!buffer)
-            WASM_RETURN_TWO(nullptr, nullptr);
-
-        uint32_t index = 0;
-        buffer[index++] = osrEntryData.loopIndex;
-        for (uint32_t i = 0; i < callee->m_numLocals; ++i)
-            buffer[index++] = pl[i];
-        while (index < osrEntryData.values.size()) {
-            pl -= 2; // each stack slot is 16B
-            buffer[index++] = *pl;
-        }
-
-        auto sharedLoopEntrypoint = bbqCallee->sharedLoopEntrypoint();
-        RELEASE_ASSERT(sharedLoopEntrypoint);
-        WASM_RETURN_TWO(buffer, sharedLoopEntrypoint->taggedPtr());
-    } else {
-        const auto doOSREntry = [&](Wasm::OSREntryCallee* osrEntryCallee) {
-            if (osrEntryCallee->loopIndex() != osrEntryData.loopIndex)
-                WASM_RETURN_TWO(nullptr, nullptr);
-
-            size_t osrEntryScratchBufferSize = osrEntryCallee->osrEntryScratchBufferSize();
-            RELEASE_ASSERT(osrEntryScratchBufferSize == osrEntryData.values.size());
-
-            uint64_t* buffer = instance->vm().wasmContext.scratchBufferForSize(osrEntryScratchBufferSize);
-            if (!buffer)
-                WASM_RETURN_TWO(nullptr, nullptr);
-
-            uint32_t index = 0;
-            for (uint32_t i = 0; i < callee->m_numLocals; ++i)
-                buffer[index++] = pl[i];
-            while (index < osrEntryData.values.size()) {
-                pl -= 2; // each stack slot is 16B
-                buffer[index++] = *pl;
-            }
-
-            WASM_RETURN_TWO(buffer, osrEntryCallee->entrypoint().taggedPtr());
-        };
-
-        if (auto* osrEntryCallee = callee->osrEntryCallee(instance->memory()->mode()))
-            return doOSREntry(osrEntryCallee);
-
-        bool compile = false;
-        {
-            Locker locker { tierUpCounter.m_lock };
-            switch (tierUpCounter.m_loopCompilationStatus) {
-            case Wasm::LLIntTierUpCounter::CompilationStatus::NotCompiled:
-                compile = true;
-                tierUpCounter.m_loopCompilationStatus = Wasm::LLIntTierUpCounter::CompilationStatus::Compiling;
-                break;
-            case Wasm::LLIntTierUpCounter::CompilationStatus::Compiling:
-                tierUpCounter.optimizeAfterWarmUp();
-                break;
-            case Wasm::LLIntTierUpCounter::CompilationStatus::Compiled:
-                break;
-            }
-        }
-
-        if (compile) {
-            Ref<Wasm::Plan> plan = adoptRef(*static_cast<Wasm::Plan*>(new Wasm::OSREntryPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), Ref<Wasm::Callee>(*callee), callee->functionIndex(), callee->hasExceptionHandlers(), osrEntryData.loopIndex, instance->memory()->mode(), Wasm::Plan::dontFinalize())));
-            Wasm::ensureWorklist().enqueue(plan.copyRef());
-            if (UNLIKELY(!Options::useConcurrentJIT()))
-                plan->waitForCompletion();
-            else
-                tierUpCounter.optimizeAfterWarmUp();
-        }
-
-        if (auto* osrEntryCallee = callee->osrEntryCallee(instance->memory()->mode()))
-            return doOSREntry(osrEntryCallee);
-
-        WASM_RETURN_TWO(nullptr, nullptr);
-    }
-}
-
 WASM_SLOW_PATH_DECL(epilogue_osr)
 {
     Wasm::LLIntCallee* callee = CALLEE();
@@ -545,23 +344,6 @@ WASM_SLOW_PATH_DECL(epilogue_osr)
 
     jitCompileAndSetHeuristics(callee, instance);
     WASM_END_IMPL();
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(epilogue_osr, CallFrame* callFrame)
-{
-    Wasm::IPIntCallee* callee = IPINT_CALLEE();
-
-    if (!shouldJIT(callee)) {
-        callee->tierUpCounter().deferIndefinitely();
-        WASM_RETURN_TWO(nullptr, nullptr);
-    }
-    if (!Options::useWasmIPIntEpilogueOSR())
-        WASM_RETURN_TWO(nullptr, nullptr);
-
-    dataLogLnIf(Options::verboseOSR(), *callee, ": Entered epilogue_osr with tierUpCounter = ", callee->tierUpCounter());
-
-    jitCompileAndSetHeuristics(callee, instance);
-    WASM_RETURN_TWO(nullptr, nullptr);
 }
 
 WASM_SLOW_PATH_DECL(simd_go_straight_to_bbq_osr)
@@ -619,17 +401,6 @@ WASM_SLOW_PATH_DECL(ref_func)
 {
     auto instruction = pc->as<WasmRefFunc>();
     WASM_RETURN(Wasm::refFunc(instance, instruction.m_functionIndex));
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(ref_func, unsigned index)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    WASM_RETURN_TWO(bitwise_cast<void*>(Wasm::refFunc(instance, index)), 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(index);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
-#endif
 }
 
 WASM_SLOW_PATH_DECL(array_new)
@@ -757,21 +528,6 @@ WASM_SLOW_PATH_DECL(table_get)
     WASM_RETURN(result);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_get, unsigned tableIndex, unsigned index)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    EncodedJSValue result = Wasm::tableGet(instance, tableIndex, index);
-    if (!result)
-        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
-    WASM_RETURN_TWO(bitwise_cast<void*>(result), 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(tableIndex);
-    UNUSED_PARAM(index);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARMv8 and X86_64 (for now)");
-#endif
-}
-
 WASM_SLOW_PATH_DECL(table_set)
 {
     auto instruction = pc->as<WasmTableSet>();
@@ -780,21 +536,6 @@ WASM_SLOW_PATH_DECL(table_set)
     if (!Wasm::tableSet(instance, instruction.m_tableIndex, index, value))
         WASM_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
     WASM_END();
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    if (!Wasm::tableSet(instance, tableIndex, index, value))
-        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
-    WASM_RETURN_TWO(0, 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(tableIndex);
-    UNUSED_PARAM(index);
-    UNUSED_PARAM(value);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
-#endif
 }
 
 WASM_SLOW_PATH_DECL(table_init)
@@ -808,24 +549,6 @@ WASM_SLOW_PATH_DECL(table_init)
     WASM_END();
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_init, uint32_t* metadata, uint32_t dest, uint64_t srcAndLength)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    uint32_t dstOffset = dest;
-    uint32_t srcOffset = srcAndLength >> 32;
-    uint32_t length = srcAndLength & 0xffffffff;
-    if (!Wasm::tableInit(instance, metadata[0], metadata[1], dstOffset, srcOffset, length))
-        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
-    WASM_RETURN_TWO(0, 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(metadata);
-    UNUSED_PARAM(dest);
-    UNUSED_PARAM(srcAndLength);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
-#endif
-}
-
 WASM_SLOW_PATH_DECL(table_fill)
 {
     auto instruction = pc->as<WasmTableFill>();
@@ -837,53 +560,12 @@ WASM_SLOW_PATH_DECL(table_fill)
     WASM_END();
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(table_fill, uint32_t tableIndex, EncodedJSValue fill, int64_t offsetAndSize)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    uint32_t offset = offsetAndSize >> 32;
-    uint32_t size = offsetAndSize & 0xffffffff;
-    if (!Wasm::tableFill(instance, tableIndex, offset, fill, size))
-        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
-    WASM_RETURN_TWO(0, 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(tableIndex);
-    UNUSED_PARAM(fill);
-    UNUSED_PARAM(offsetAndSize);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
-#endif
-}
-
 WASM_SLOW_PATH_DECL(table_grow)
 {
     auto instruction = pc->as<WasmTableGrow>();
     EncodedJSValue fill = READ(instruction.m_fill).encodedJSValue();
     uint32_t size = READ(instruction.m_size).unboxedUInt32();
     WASM_RETURN(Wasm::tableGrow(instance, instruction.m_tableIndex, fill, size));
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(table_grow, int32_t tableIndex, EncodedJSValue fill, uint32_t size)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    WASM_RETURN_TWO(bitwise_cast<void*>(Wasm::tableGrow(instance, tableIndex, fill, size)), 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(tableIndex);
-    UNUSED_PARAM(fill);
-    UNUSED_PARAM(size);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
-#endif
-}
-
-WASM_IPINT_EXTERN_CPP_DECL_1P(current_memory)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    size_t size = instance->memory()->handle().size() >> 16;
-    WASM_RETURN_TWO(bitwise_cast<void*>(size), 0);
-#else
-    UNUSED_PARAM(instance);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
-#endif
 }
 
 WASM_SLOW_PATH_DECL(grow_memory)
@@ -893,95 +575,6 @@ WASM_SLOW_PATH_DECL(grow_memory)
     auto instruction = pc->as<WasmGrowMemory>();
     int32_t delta = READ(instruction.m_delta).unboxedInt32();
     WASM_RETURN(Wasm::growMemory(instance, delta));
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(memory_grow, int32_t delta)
-{
-    WASM_RETURN_TWO(reinterpret_cast<void*>(Wasm::growMemory(instance, delta)), 0);
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(memory_init, int32_t dataIndex, int32_t dst, int64_t srcAndLength)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    if (!Wasm::memoryInit(instance, dataIndex, dst, srcAndLength >> 32, srcAndLength & 0xffffffff))
-        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<int64_t>(Wasm::ExceptionType::OutOfBoundsMemoryAccess)));
-    WASM_RETURN_TWO(0, 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(dataIndex);
-    UNUSED_PARAM(dst);
-    UNUSED_PARAM(srcAndLength);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
-#endif
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(data_drop, int32_t dataIndex)
-{
-    Wasm::dataDrop(instance, dataIndex);
-    WASM_RETURN_TWO(0, 0);
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(memory_copy, int32_t dst, int32_t src, int32_t count)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    if (!Wasm::memoryCopy(instance, dst, src, count))
-        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<int64_t>(Wasm::ExceptionType::OutOfBoundsMemoryAccess)));
-    WASM_RETURN_TWO(0, 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(dst);
-    UNUSED_PARAM(src);
-    UNUSED_PARAM(count);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
-#endif
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(memory_fill, int32_t dst, int32_t targetValue, int32_t count)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    if (!Wasm::memoryFill(instance, dst, targetValue, count))
-        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<int64_t>(Wasm::ExceptionType::OutOfBoundsMemoryAccess)));
-    WASM_RETURN_TWO(0, 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(dst);
-    UNUSED_PARAM(targetValue);
-    UNUSED_PARAM(count);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
-#endif
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(elem_drop, int32_t dataIndex)
-{
-    Wasm::elemDrop(instance, dataIndex);
-    WASM_RETURN_TWO(0, 0);
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(table_copy, int32_t* metadata, int32_t dst, int64_t srcAndCount)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    if (!Wasm::tableCopy(instance, metadata[0], metadata[1], dst, srcAndCount >> 32, srcAndCount & 0xffffffff))
-        WASM_RETURN_TWO(bitwise_cast<void*>(1L), bitwise_cast<void*>(static_cast<int64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
-    WASM_RETURN_TWO(0, 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(metadata);
-    UNUSED_PARAM(dst);
-    UNUSED_PARAM(srcAndCount);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
-#endif
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(table_size, int32_t tableIndex)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    int32_t result = Wasm::tableSize(instance, tableIndex);
-    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<EncodedJSValue>(result)), 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(tableIndex);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
-#endif
 }
 
 inline UGPRPair doWasmCall(Wasm::Instance* instance, unsigned functionIndex)
@@ -999,11 +592,6 @@ inline UGPRPair doWasmCall(Wasm::Instance* instance, unsigned functionIndex)
     }
 
     WASM_CALL_RETURN(instance, codePtr.taggedPtr(), WasmEntryPtrTag);
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(call, unsigned functionIndex)
-{
-    return doWasmCall(instance, functionIndex);
 }
 
 WASM_SLOW_PATH_DECL(call)
@@ -1027,27 +615,6 @@ inline UGPRPair doWasmCallIndirect(CallFrame* callFrame, Wasm::Instance* instanc
         WASM_THROW(Wasm::ExceptionType::NullTableEntry);
 
     const auto& callSignature = CALLEE()->signature(typeIndex);
-    if (callSignature.index() != function.m_function.typeIndex)
-        WASM_THROW(Wasm::ExceptionType::BadSignature);
-
-    WASM_CALL_RETURN(function.m_instance, function.m_function.entrypointLoadLocation->taggedPtr(), WasmEntryPtrTag);
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(call_indirect, CallFrame* callFrame, unsigned functionIndex, unsigned* metadataEntry)
-{
-    unsigned tableIndex = metadataEntry[0];
-    unsigned typeIndex = metadataEntry[1];
-    Wasm::FuncRefTable* table = instance->table(tableIndex)->asFuncrefTable();
-
-    if (functionIndex >= table->length())
-        WASM_THROW(Wasm::ExceptionType::OutOfBoundsCallIndirect);
-
-    const Wasm::FuncRefTable::Function& function = table->function(functionIndex);
-
-    if (function.m_function.typeIndex == Wasm::TypeDefinition::invalidIndex)
-        WASM_THROW(Wasm::ExceptionType::NullTableEntry);
-
-    const auto& callSignature = static_cast<Wasm::IPIntCallee*>(callFrame->callee().asNativeCallee())->signature(typeIndex);
     if (callSignature.index() != function.m_function.typeIndex)
         WASM_THROW(Wasm::ExceptionType::BadSignature);
 
@@ -1249,34 +816,11 @@ WASM_SLOW_PATH_DECL(call_builtin)
     WASM_END();
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(set_global_ref, uint32_t globalIndex, JSValue value)
-{
-    instance->setGlobal(globalIndex, value);
-    WASM_RETURN_TWO(0, 0);
-}
-
 WASM_SLOW_PATH_DECL(set_global_ref)
 {
     auto instruction = pc->as<WasmSetGlobalRef>();
     instance->setGlobal(instruction.m_globalIndex, READ(instruction.m_value).jsValue());
     WASM_END_IMPL();
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(get_global_64, unsigned index)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    WASM_RETURN_TWO(bitwise_cast<void*>(instance->loadI64Global(index)), 0);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(index);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
-#endif
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(set_global_64, unsigned index, uint64_t value)
-{
-    instance->setGlobal(index, value);
-    WASM_RETURN_TWO(0, 0);
 }
 
 WASM_SLOW_PATH_DECL(set_global_ref_portable_binding)
@@ -1299,21 +843,6 @@ WASM_SLOW_PATH_DECL(memory_atomic_wait32)
     WASM_RETURN(result);
 }
 
-
-WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait32, uint64_t pointerWithOffset, uint32_t value, uint64_t timeout)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    int32_t result = Wasm::memoryAtomicWait32(instance, pointerWithOffset, value, timeout);
-    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(pointerWithOffset);
-    UNUSED_PARAM(value);
-    UNUSED_PARAM(timeout);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
-#endif
-}
-
 WASM_SLOW_PATH_DECL(memory_atomic_wait64)
 {
     auto instruction = pc->as<WasmMemoryAtomicWait64>();
@@ -1327,20 +856,6 @@ WASM_SLOW_PATH_DECL(memory_atomic_wait64)
     WASM_RETURN(result);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait64, uint64_t pointerWithOffset, uint64_t value, uint64_t timeout)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    int32_t result = Wasm::memoryAtomicWait64(instance, pointerWithOffset, value, timeout);
-    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(pointerWithOffset);
-    UNUSED_PARAM(value);
-    UNUSED_PARAM(timeout);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
-#endif
-}
-
 WASM_SLOW_PATH_DECL(memory_atomic_notify)
 {
     auto instruction = pc->as<WasmMemoryAtomicNotify>();
@@ -1351,20 +866,6 @@ WASM_SLOW_PATH_DECL(memory_atomic_notify)
     if (result < 0)
         WASM_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
     WASM_RETURN(result);
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_notify, unsigned base, unsigned offset, int32_t count)
-{
-#if CPU(ARM64) || CPU(X86_64)
-    int32_t result = Wasm::memoryAtomicNotify(instance, base, offset, count);
-    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
-#else
-    UNUSED_PARAM(instance);
-    UNUSED_PARAM(base);
-    UNUSED_PARAM(offset);
-    UNUSED_PARAM(count);
-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
-#endif
 }
 
 WASM_SLOW_PATH_DECL(throw)
@@ -1382,26 +883,6 @@ WASM_SLOW_PATH_DECL(throw)
     for (unsigned i = 0; i < tag.parameterCount(); ++i)
         values[i] = READ((instruction.m_firstValue - i)).encodedJSValue();
 
-    JSWebAssemblyException* exception = JSWebAssemblyException::create(vm, globalObject->webAssemblyExceptionStructure(), tag, WTFMove(values));
-    throwException(globalObject, throwScope, exception);
-
-    genericUnwind(vm, callFrame);
-    ASSERT(!!vm.callFrameForCatch);
-    ASSERT(!!vm.targetMachinePCForThrow);
-    WASM_RETURN_TWO(vm.targetMachinePCForThrow, nullptr);
-}
-
-WASM_IPINT_EXTERN_CPP_DECL(throw, CallFrame* callFrame, uint32_t exceptionIndex)
-{
-    SlowPathFrameTracer tracer(instance->vm(), callFrame);
-
-    JSGlobalObject* globalObject = instance->globalObject();
-    VM& vm = globalObject->vm();
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
-
-    const Wasm::Tag& tag = instance->tag(exceptionIndex);
-
-    FixedVector<uint64_t> values(tag.parameterCount());
     JSWebAssemblyException* exception = JSWebAssemblyException::create(vm, globalObject->webAssemblyExceptionStructure(), tag, WTFMove(values));
     throwException(globalObject, throwScope, exception);
 

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.h
@@ -52,25 +52,10 @@ namespace LLInt {
 #define WASM_SLOW_PATH_HIDDEN_DECL(name) \
     WASM_SLOW_PATH_DECL(name) REFERENCED_FROM_ASM WTF_INTERNAL
 
-#define WASM_IPINT_EXTERN_CPP_DECL(name, ...) \
-    extern "C" UGPRPair ipint_extern_##name(Wasm::Instance* instance, __VA_ARGS__)
-
-#define WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(name, ...) \
-    WASM_IPINT_EXTERN_CPP_DECL(name, __VA_ARGS__) REFERENCED_FROM_ASM WTF_INTERNAL
-
-#define WASM_IPINT_EXTERN_CPP_DECL_1P(name) \
-    extern "C" UGPRPair ipint_extern_##name(Wasm::Instance* instance)
-
-#define WASM_IPINT_EXTERN_CPP_HIDDEN_DECL_1P(name) \
-    WASM_IPINT_EXTERN_CPP_DECL_1P(name) REFERENCED_FROM_ASM WTF_INTERNAL
-
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 WASM_SLOW_PATH_HIDDEN_DECL(prologue_osr);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(prologue_osr, CallFrame* callFrame);
 WASM_SLOW_PATH_HIDDEN_DECL(loop_osr);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t* pl);
 WASM_SLOW_PATH_HIDDEN_DECL(epilogue_osr);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(epilogue_osr, CallFrame* callFrame);
 WASM_SLOW_PATH_HIDDEN_DECL(simd_go_straight_to_bbq_osr);
 #endif
 
@@ -78,53 +63,27 @@ WASM_SLOW_PATH_HIDDEN_DECL(trace);
 WASM_SLOW_PATH_HIDDEN_DECL(out_of_line_jump_target);
 
 WASM_SLOW_PATH_HIDDEN_DECL(ref_func);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
 WASM_SLOW_PATH_HIDDEN_DECL(table_get);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, unsigned);
 WASM_SLOW_PATH_HIDDEN_DECL(table_set);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value);
 WASM_SLOW_PATH_HIDDEN_DECL(table_init);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_init, uint32_t* metadata, uint32_t dest, uint64_t srcAndLength);
 WASM_SLOW_PATH_HIDDEN_DECL(table_fill);
-WASM_IPINT_EXTERN_CPP_DECL(table_fill, uint32_t tableIndex, EncodedJSValue fill, int64_t offsetAndSize);
 WASM_SLOW_PATH_HIDDEN_DECL(table_grow);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_grow, int32_t tableIndex, EncodedJSValue fill, uint32_t size);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL_1P(current_memory);
 WASM_SLOW_PATH_HIDDEN_DECL(grow_memory);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_grow, int32_t);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_init);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_init, int32_t, int32_t, int64_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(data_drop, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_copy, int32_t, int32_t, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_fill, int32_t, int32_t, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(elem_drop, int32_t);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_copy, int32_t*, int32_t, int64_t);
-WASM_IPINT_EXTERN_CPP_DECL(table_size, int32_t);
 WASM_SLOW_PATH_HIDDEN_DECL(call);
 WASM_SLOW_PATH_HIDDEN_DECL(call_indirect);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, CallFrame* callFrame, unsigned functionIndex, unsigned* metadataEntry);
-
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, unsigned);
 
 WASM_SLOW_PATH_HIDDEN_DECL(call_ref);
 WASM_SLOW_PATH_HIDDEN_DECL(tail_call);
 WASM_SLOW_PATH_HIDDEN_DECL(tail_call_indirect);
 WASM_SLOW_PATH_HIDDEN_DECL(call_builtin);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_ref, uint32_t globalIndex, JSValue value);
 WASM_SLOW_PATH_HIDDEN_DECL(set_global_ref);
-
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(get_global_64, unsigned);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_64, unsigned, uint64_t);
 
 WASM_SLOW_PATH_HIDDEN_DECL(set_global_ref_portable_binding);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait32);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, uint64_t, uint32_t, uint64_t);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait64);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, uint64_t, uint64_t, uint64_t);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_notify);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, unsigned, unsigned, int32_t);
 WASM_SLOW_PATH_HIDDEN_DECL(throw);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw, CallFrame*, uint32_t);
 WASM_SLOW_PATH_HIDDEN_DECL(rethrow);
 WASM_SLOW_PATH_HIDDEN_DECL(retrieve_and_clear_exception);
 WASM_SLOW_PATH_HIDDEN_DECL(array_new);


### PR DESCRIPTION
#### 196a6557e7f4e12503fe4864e34c12fb06223658
<pre>
Move IPInt slow paths to a new file
<a href="https://bugs.webkit.org/show_bug.cgi?id=261963">https://bugs.webkit.org/show_bug.cgi?id=261963</a>

Reviewed by Yusuke Suzuki.

This is a simple code cleanliness improvement. No code should be changed
with the exception that `doWasmCallIndirect` used the wrong CALLEE macro
for IPInt before.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp: Added.
(JSC::LLInt::shouldJIT):
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL):
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL_1P):
(JSC::LLInt::doWasmCall):
(JSC::LLInt::doWasmCallIndirect):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h: Copied from Source/JavaScriptCore/wasm/WasmSlowPaths.h.
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL): Deleted.
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL_1P): Deleted.
* Source/JavaScriptCore/wasm/WasmSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/268516@main">https://commits.webkit.org/268516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dba9ecdab529df2da70f2d96e28e9bdaf5073083

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19374 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18121 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19744 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22128 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23951 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16817 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21920 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18703 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15576 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22766 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17530 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4768 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21889 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24017 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18712 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5365 "Passed tests") | 
<!--EWS-Status-Bubble-End-->