### PR TITLE
Store fewer raw pointers in containers in Source/rendering/

### DIFF
--- a/Source/WebCore/rendering/FloatingObjects.cpp
+++ b/Source/WebCore/rendering/FloatingObjects.cpp
@@ -45,7 +45,7 @@ struct SameSizeAsFloatingObject {
 static_assert(sizeof(FloatingObject) == sizeof(SameSizeAsFloatingObject), "FloatingObject should stay small");
 #if !ASSERT_ENABLED
 static_assert(sizeof(WeakPtr<RenderBox>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
-static_assert(sizeof(WeakPtr<LegacyRootInlineBox>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
+static_assert(sizeof(CheckedPtr<LegacyRootInlineBox>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
 #endif
 
 FloatingObject::FloatingObject(RenderBox& renderer)

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -47,10 +47,12 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRootInlineBox);
 
-struct SameSizeAsLegacyRootInlineBox : public LegacyInlineFlowBox, public CanMakeWeakPtr<LegacyRootInlineBox> {
-    unsigned variables[7];
+struct SameSizeAsLegacyRootInlineBox : LegacyInlineFlowBox, CanMakeWeakPtr<LegacyRootInlineBox>, CanMakeCheckedPtr {
+    unsigned lineBreakPos;
     WeakPtr<RenderObject> lineBreakObj;
-    void* pointers[2];
+    void* lineBreakContext;
+    int layoutUnits[6];
+    void* floats;
 };
 
 static_assert(sizeof(LegacyRootInlineBox) == sizeof(SameSizeAsLegacyRootInlineBox), "LegacyRootInlineBox should stay small");

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -36,7 +36,7 @@ class RenderFragmentContainer;
 struct BidiStatus;
 struct GapRects;
 
-class LegacyRootInlineBox : public LegacyInlineFlowBox, public CanMakeWeakPtr<LegacyRootInlineBox> {
+class LegacyRootInlineBox : public LegacyInlineFlowBox, public CanMakeWeakPtr<LegacyRootInlineBox>, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(LegacyRootInlineBox);
 public:
     explicit LegacyRootInlineBox(RenderBlockFlow&);
@@ -199,6 +199,8 @@ private:
 
     LayoutUnit beforeAnnotationsAdjustment() const;
 
+    unsigned m_lineBreakPos { 0 };
+
     // Where this line ended. The exact object and the position within that object are stored so that
     // we can create an LegacyInlineIterator beginning just after the end of this line.
     WeakPtr<RenderObject> m_lineBreakObj;
@@ -216,8 +218,6 @@ private:
     // Floats hanging off the line are pushed into this vector during layout. It is only
     // good for as long as the line has not been marked dirty.
     std::unique_ptr<CleanLineFloatList> m_floats;
-
-    unsigned m_lineBreakPos { 0 };
 };
 
 inline LegacyRootInlineBox* LegacyRootInlineBox::nextRootBox() const

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -39,7 +39,7 @@ class RenderText;
 struct BidiRun;
 struct PaintInfo;
 
-typedef ListHashSet<RenderBox*> TrackedRendererListHashSet;
+using TrackedRendererListHashSet = ListHashSet<RenderBox*>;
 
 enum CaretType { CursorCaret, DragCaret };
 enum ContainingBlockState { NewContainingBlock, SameContainingBlock };
@@ -83,7 +83,7 @@ public:
     TrackedRendererListHashSet* positionedObjects() const;
     bool hasPositionedObjects() const
     {
-        TrackedRendererListHashSet* objects = positionedObjects();
+        auto* objects = positionedObjects();
         return objects && !objects->isEmpty();
     }
 
@@ -92,7 +92,7 @@ public:
     TrackedRendererListHashSet* percentHeightDescendants() const;
     bool hasPercentHeightDescendants() const
     {
-        TrackedRendererListHashSet* objects = percentHeightDescendants();
+        auto* objects = percentHeightDescendants();
         return objects && !objects->isEmpty();
     }
     static bool hasPercentHeightContainerMap();

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -199,7 +199,7 @@ void RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats()
     if (m_floatingObjects)
         m_floatingObjects->setHorizontalWritingMode(isHorizontalWritingMode());
 
-    HashSet<RenderBox*> oldIntrudingFloatSet;
+    HashSet<CheckedPtr<RenderBox>> oldIntrudingFloatSet;
     if (!childrenInline() && m_floatingObjects) {
         const FloatingObjectSet& floatingObjectSet = m_floatingObjects->set();
         auto end = floatingObjectSet.end();
@@ -937,7 +937,7 @@ void RenderBlockFlow::simplifiedNormalFlowLayout()
     }
 
     bool shouldUpdateOverflow = false;
-    ListHashSet<LegacyRootInlineBox*> lineBoxes;
+    ListHashSet<CheckedPtr<LegacyRootInlineBox>> lineBoxes;
     for (InlineWalker walker(*this); !walker.atEnd(); walker.advance()) {
         RenderObject& renderer = *walker.current();
         if (!renderer.isOutOfFlowPositioned() && (renderer.isReplacedOrInlineBlock() || renderer.isFloating())) {
@@ -959,8 +959,8 @@ void RenderBlockFlow::simplifiedNormalFlowLayout()
     }
 
     GlyphOverflowAndFallbackFontsMap textBoxDataMap;
-    for (auto it = lineBoxes.begin(), end = lineBoxes.end(); it != end; ++it) {
-        LegacyRootInlineBox* box = *it;
+    for (auto& lineBox : lineBoxes) {
+        auto* box = lineBox.get();
         box->computeOverflow(box->lineTop(), box->lineBottom(), textBoxDataMap);
     }
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2137,8 +2137,7 @@ bool RenderFlexibleBox::childHasPercentHeightDescendants(const RenderBox& render
     // addPercentHeightDescendant() is never called for them. This means that this method would always wrongly
     // return false for a child of a <button> with a percentage height.
     if (hasPercentHeightDescendants() && skipContainingBlockForPercentHeightCalculation(renderer, isHorizontalWritingMode() != renderer.isHorizontalWritingMode())) {
-        auto& descendants = *percentHeightDescendants();
-        for (auto* descendant : descendants) {
+        for (auto* descendant : *percentHeightDescendants()) {
             if (renderBlock.isContainingBlockAncestorFor(*descendant))
                 return true;
         }
@@ -2151,9 +2150,9 @@ bool RenderFlexibleBox::childHasPercentHeightDescendants(const RenderBox& render
     if (!percentHeightDescendants)
         return false;
 
-    for (auto it = percentHeightDescendants->begin(), end = percentHeightDescendants->end(); it != end; ++it) {
+    for (auto* descendant : *percentHeightDescendants) {
         bool hasOutOfFlowAncestor = false;
-        for (auto* ancestor = (*it)->containingBlock(); ancestor && ancestor != &renderBlock; ancestor = ancestor->containingBlock()) {
+        for (auto* ancestor = descendant->containingBlock(); ancestor && ancestor != &renderBlock; ancestor = ancestor->containingBlock()) {
             if (ancestor->isOutOfFlowPositioned()) {
                 hasOutOfFlowAncestor = true;
                 break;

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -1287,7 +1287,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
             // To make sure we properly repaint the section, we repaint all the overflowing cells that we collected.
             auto cells = copyToVector(m_overflowingCells);
 
-            HashSet<RenderTableCell*> spanningCells;
+            HashSet<CheckedPtr<RenderTableCell>> spanningCells;
 
             for (unsigned r = dirtiedRows.start; r < dirtiedRows.end; r++) {
                 RenderTableRow* row = m_grid[r].rowRenderer;


### PR DESCRIPTION
#### 18bfbbcf44443c95e8717df802e486f2254d1e3b
<pre>
Store fewer raw pointers in containers in Source/rendering/
<a href="https://bugs.webkit.org/show_bug.cgi?id=261545">https://bugs.webkit.org/show_bug.cgi?id=261545</a>
rdar://115506118

Reviewed by Brent Fulgham.

* Source/WebCore/rendering/FloatingObjects.cpp:
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
* Source/WebCore/rendering/LegacyRootInlineBox.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::PositionedDescendantsMap::addDescendant):
(WebCore::PositionedDescendantsMap::removeDescendant):
(WebCore::PositionedDescendantsMap::removeContainingBlock):
(WebCore::RenderBlock::addOverflowFromPositionedObjects):
(WebCore::RenderBlock::dirtyForLayoutFromPercentageHeightDescendants):
(WebCore::RenderBlock::layoutPositionedObjects):
(WebCore::RenderBlock::markPositionedObjectsForLayout):
(WebCore::RenderBlock::paintsContinuationOutline):
(WebCore::RenderBlock::paintContinuationOutlines):
(WebCore::clipOutPositionedObjects):
(WebCore::RenderBlock::removePositionedObjects):
* Source/WebCore/rendering/RenderBlock.h:
(WebCore::RenderBlock::hasPositionedObjects const):
(WebCore::RenderBlock::hasPercentHeightDescendants const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats):
(WebCore::RenderBlockFlow::simplifiedNormalFlowLayout):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::childHasPercentHeightDescendants const):
* Source/WebCore/rendering/RenderSelection.cpp:
(WebCore::RenderSelection::repaint const):
(WebCore::RenderSelection::apply):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::paintObject):

Canonical link: <a href="https://commits.webkit.org/268343@main">https://commits.webkit.org/268343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f889dd456fb97a2029058760fbc277088becb85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19918 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22130 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17631 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21923 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18394 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17532 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4641 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->