### PR TITLE
Use more smart pointers in markup.cpp

### DIFF
--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -795,7 +795,7 @@ void ApplyStyleCommand::applyInlineStyleToNodeRange(EditingStyle& style, Node& s
             continue;
         }
         
-        if (isBlock(node.get()))
+        if (isBlock(*node))
             continue;
         
         if (node->hasChildNodes()) {
@@ -810,7 +810,7 @@ void ApplyStyleCommand::applyInlineStyleToNodeRange(EditingStyle& style, Node& s
         auto runStart = node;
         auto runEnd = node;
         RefPtr sibling { node->nextSibling() };
-        while (sibling && sibling != pastEndNode && !sibling->contains(pastEndNode) && (!isBlock(sibling.get()) || sibling->hasTagName(brTag)) && !containsNonEditableRegion(*sibling)) {
+        while (sibling && sibling != pastEndNode && !sibling->contains(pastEndNode) && (!isBlock(*sibling) || sibling->hasTagName(brTag)) && !containsNonEditableRegion(*sibling)) {
             runEnd = sibling;
             sibling = runEnd->nextSibling();
         }

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1228,7 +1228,7 @@ RefPtr<Node> CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary(co
         return nullptr;
 
     // Perform some checks to see if we need to perform work in this function.
-    if (isBlock(upstreamStart.deprecatedNode())) {
+    if (upstreamStart.deprecatedNode() && isBlock(*upstreamStart.deprecatedNode())) {
         // If the block is the root editable element, always move content to a new block,
         // since it is illegal to modify attributes on the root editable element for editing.
         if (upstreamStart.deprecatedNode() == editableRootForPosition(upstreamStart)) {
@@ -1236,7 +1236,7 @@ RefPtr<Node> CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary(co
             // block but don't try and move content into it, since there's nothing for moveParagraphs to move.
             if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(downcast<RenderElement>(*upstreamStart.deprecatedNode()->renderer())))
                 return insertNewDefaultParagraphElementAt(upstreamStart);
-        } else if (isBlock(upstreamEnd.deprecatedNode())) {
+        } else if (upstreamEnd.deprecatedNode() && isBlock(*upstreamEnd.deprecatedNode())) {
             if (!upstreamEnd.deprecatedNode()->isDescendantOf(upstreamStart.deprecatedNode())) {
                 // If the paragraph end is a descendant of paragraph start, then we need to run
                 // the rest of this function. If not, we can bail here.
@@ -1369,7 +1369,7 @@ void CompositeEditCommand::cleanupAfterDeletion(VisiblePosition destination)
         // doesn't require a placeholder to prop itself open (like a bordered
         // div or an li), remove it during the move (the list removal code
         // expects this behavior).
-        else if (isBlock(node.get())) {
+        else if (isBlock(*node)) {
             // If caret position after deletion and destination position coincides,
             // node should not be removed.
             if (!position.rendersInDifferentPosition(destination.deepEquivalent())) {
@@ -1628,9 +1628,9 @@ bool CompositeEditCommand::breakOutOfEmptyListItem()
 
     RefPtr<Node> previousListNode = emptyListItem->isElementNode() ? ElementTraversal::previousSibling(*emptyListItem): emptyListItem->previousSibling();
     RefPtr<Node> nextListNode = emptyListItem->isElementNode() ? ElementTraversal::nextSibling(*emptyListItem): emptyListItem->nextSibling();
-    if (isListItem(nextListNode.get()) || isListHTMLElement(nextListNode.get())) {
+    if ((nextListNode && isListItem(*nextListNode)) || isListHTMLElement(nextListNode.get())) {
         // If emptyListItem follows another list item or nested list, split the list node.
-        if (isListItem(previousListNode.get()) || isListHTMLElement(previousListNode.get()))
+        if (previousListNode && (isListItem(*previousListNode) || isListHTMLElement(previousListNode.get())))
             splitElement(downcast<Element>(*listNode), *emptyListItem);
 
         // If emptyListItem is followed by other list item or nested list, then insert newBlock before the list node.
@@ -1642,7 +1642,7 @@ bool CompositeEditCommand::breakOutOfEmptyListItem()
         // When emptyListItem does not follow any list item or nested list, insert newBlock after the enclosing list node.
         // Remove the enclosing node if emptyListItem is the only child; otherwise just remove emptyListItem.
         insertNodeAfter(*newBlock, *listNode);
-        removeNode(isListItem(previousListNode.get()) || isListHTMLElement(previousListNode.get()) ? *emptyListItem : *listNode);
+        removeNode((previousListNode && (isListItem(*previousListNode) || isListHTMLElement(previousListNode.get()))) ? *emptyListItem : *listNode);
     }
 
     appendBlockPlaceholder(*newBlock);
@@ -1663,7 +1663,7 @@ bool CompositeEditCommand::breakOutOfEmptyMailBlockquotedParagraph()
         return false;
         
     VisiblePosition caret(endingSelection().visibleStart());
-    RefPtr highestBlockquote { highestEnclosingNodeOfType(caret.deepEquivalent(), &isMailBlockquote) };
+    RefPtr highestBlockquote = highestEnclosingNodeOfType(caret.deepEquivalent(), &isMailBlockquote);
     if (!highestBlockquote)
         return false;
 
@@ -1727,7 +1727,7 @@ Position CompositeEditCommand::positionAvoidingSpecialElementBoundary(const Posi
         return result;
 
     // Don't avoid block level anchors, because that would insert content into the wrong paragraph.
-    if (enclosingAnchor && !isBlock(enclosingAnchor.get())) {
+    if (enclosingAnchor && !isBlock(*enclosingAnchor)) {
         VisiblePosition firstInAnchor(firstPositionInNode(enclosingAnchor.get()));
         VisiblePosition lastInAnchor(lastPositionInNode(enclosingAnchor.get()));
         // If visually just after the anchor, insert *inside* the anchor unless it's the last

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -54,24 +54,24 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static bool isTableRow(const Node* node)
+static bool isTableRow(const Node& node)
 {
-    return node && node->hasTagName(trTag);
+    return node.hasTagName(trTag);
 }
 
-static bool isTableCellEmpty(Node* cell)
+static bool isTableCellEmpty(Node& cell)
 {
     ASSERT(isTableCell(cell));
-    return VisiblePosition(firstPositionInNode(cell)) == VisiblePosition(lastPositionInNode(cell));
+    return VisiblePosition(firstPositionInNode(&cell)) == VisiblePosition(lastPositionInNode(&cell));
 }
 
-static bool isTableRowEmpty(Node* row)
+static bool isTableRowEmpty(const Node& row)
 {
     if (!isTableRow(row))
         return false;
 
-    for (RefPtr child = row->firstChild(); child; child = child->nextSibling()) {
-        if (isTableCell(child.get()) && !isTableCellEmpty(child.get()))
+    for (RefPtr child = row.firstChild(); child; child = child->nextSibling()) {
+        if (isTableCell(*child) && !isTableCellEmpty(*child))
             return false;
     }
 
@@ -518,7 +518,7 @@ void DeleteSelectionCommand::removeNodeUpdatingStates(Node& node, ShouldAssumeCo
     
 static inline bool shouldRemoveContentOnly(const Node& node)
 {
-    return isTableStructureNode(&node) || node.isRootEditableElement();
+    return isTableStructureNode(node) || node.isRootEditableElement();
 }
 
 void DeleteSelectionCommand::removeNode(Node& node, ShouldAssumeContentIsAlwaysEditable shouldAssumeContentIsAlwaysEditable)
@@ -866,7 +866,7 @@ void DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows()
         RefPtr row { m_endTableRow->previousSibling() };
         while (row && row != m_startTableRow) {
             RefPtr previousRow { row->previousSibling() };
-            if (isTableRowEmpty(row.get()))
+            if (isTableRowEmpty(*row))
                 removeNodeUpdatingStates(*row, DoNotAssumeContentIsAlwaysEditable);
             row = WTFMove(previousRow);
         }
@@ -877,14 +877,14 @@ void DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows()
         RefPtr row { m_startTableRow->nextSibling() };
         while (row && row != m_endTableRow) {
             RefPtr nextRow { row->nextSibling() };
-            if (isTableRowEmpty(row.get()))
+            if (isTableRowEmpty(*row))
                 removeNodeUpdatingStates(*row, DoNotAssumeContentIsAlwaysEditable);
             row = WTFMove(nextRow);
         }
     }
 
     if (m_endTableRow && m_endTableRow->isConnected() && m_endTableRow != m_startTableRow) {
-        if (isTableRowEmpty(m_endTableRow.get())) {
+        if (isTableRowEmpty(*m_endTableRow)) {
             // Don't remove m_endTableRow if it's where we're putting the ending selection.
             if (!m_endingPosition.deprecatedNode()->isDescendantOf(*m_endTableRow)) {
                 // FIXME: We probably shouldn't remove m_endTableRow unless it's fully selected, even if it is empty.

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -50,7 +50,7 @@ struct SimpleRange;
 
 RefPtr<ContainerNode> highestEditableRoot(const Position&, EditableType = ContentIsEditable);
 
-Node* highestEnclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node*), EditingBoundaryCrossingRule = CannotCrossEditingBoundary, Node* stayWithin = nullptr);
+RefPtr<Node> highestEnclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node&), EditingBoundaryCrossingRule = CannotCrossEditingBoundary, Node* stayWithin = nullptr);
 Node* highestNodeToRemoveInPruning(Node*);
 Element* lowestEditableAncestor(Node*);
 
@@ -60,7 +60,7 @@ RefPtr<Element> enclosingTableCell(const Position&);
 Node* enclosingEmptyListItem(const VisiblePosition&);
 Element* enclosingAnchorElement(const Position&);
 Element* enclosingElementWithTag(const Position&, const QualifiedName&);
-RefPtr<Node> enclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node*), EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
+RefPtr<Node> enclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node&), EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
 HTMLSpanElement* tabSpanNode(const Node*);
 Element* isLastPositionBeforeTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
 Element* isFirstPositionAfterTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
@@ -85,18 +85,18 @@ bool editingIgnoresContent(const Node&);
 bool canHaveChildrenForEditing(const Node&);
 bool isAtomicNode(const Node*);
 
-bool isBlock(const Node*);
+bool isBlock(const Node&);
 bool isBlockFlowElement(const Node&);
-bool isInline(const Node*);
+bool isInline(const Node&);
 bool isTabSpanNode(const Node*);
 bool isTabSpanTextNode(const Node*);
-bool isMailBlockquote(const Node*);
+bool isMailBlockquote(const Node&);
 bool isRenderedTable(const Node*);
-bool isTableCell(const Node*);
+bool isTableCell(const Node&);
 bool isEmptyTableCell(const Node*);
-bool isTableStructureNode(const Node*);
+bool isTableStructureNode(const Node&);
 bool isListHTMLElement(Node*);
-bool isListItem(const Node*);
+bool isListItem(const Node&);
 bool isNodeRendered(const Node&);
 bool isRenderedAsNonInlineTableImageOrHR(const Node*);
 bool isNonTableCellHTMLBlockElement(const Node*);

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1287,8 +1287,8 @@ Ref<EditingStyle> EditingStyle::wrappingStyleForSerialization(Node& context, boo
     auto wrappingStyle = EditingStyle::create();
 
     // When not annotating for interchange, we only preserve inline style declarations.
-    for (Node* node = &context; node && !node->isDocumentNode(); node = node->parentNode()) {
-        if (is<StyledElement>(*node) && !isMailBlockquote(node))
+    for (RefPtr node = &context; node && !node->isDocumentNode(); node = node->parentNode()) {
+        if (is<StyledElement>(*node) && !isMailBlockquote(*node))
             wrappingStyle->mergeInlineAndImplicitStyleOfElement(downcast<StyledElement>(*node), DoNotOverrideValues, EditingPropertiesInEffect, standardFontFamilySerializationMode);
     }
 

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -44,9 +44,9 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static bool isListOrIndentBlockquote(const Node* node)
+static bool isListOrIndentBlockquote(const Node& node)
 {
-    return node && (node->hasTagName(ulTag) || node->hasTagName(olTag) || node->hasTagName(blockquoteTag));
+    return node.hasTagName(ulTag) || node.hasTagName(olTag) || node.hasTagName(blockquoteTag);
 }
 
 IndentOutdentCommand::IndentOutdentCommand(Ref<Document>&& document, EIndentType typeOfAction)

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -396,13 +396,16 @@ RefPtr<HTMLElement> InsertListCommand::listifyParagraph(const VisiblePosition& o
         listElement = createHTMLElement(document(), listTag);
         appendNode(WTFMove(listItemElement), *listElement);
 
-        if (start == end && isBlock(start.deepEquivalent().deprecatedNode())) {
-            // Inserting the list into an empty paragraph that isn't held open 
-            // by a br or a '\n', will invalidate start and end.  Insert 
-            // a placeholder and then recompute start and end.
-            auto blockPlaceholder = insertBlockPlaceholder(start.deepEquivalent());
-            start = positionBeforeNode(blockPlaceholder.get());
-            end = start;
+        if (start == end) {
+            RefPtr node = start.deepEquivalent().deprecatedNode();
+            if (node && isBlock(*node)) {
+                // Inserting the list into an empty paragraph that isn't held open
+                // by a br or a '\n', will invalidate start and end. Insert
+                // a placeholder and then recompute start and end.
+                auto blockPlaceholder = insertBlockPlaceholder(start.deepEquivalent());
+                start = positionBeforeNode(blockPlaceholder.get());
+                end = start;
+            }
         }
 
         // Insert the list at a position visually equivalent to start of the

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -147,12 +147,12 @@ Ref<Element> InsertParagraphSeparatorCommand::cloneHierarchyUnderNewBlock(const 
     return parent.releaseNonNull();
 }
 
-static bool isPhrasingContent(const Node* node)
+static bool isPhrasingContent(const Node& node)
 {
-    if (!node || !is<Element>(*node))
+    if (!is<Element>(node))
         return false;
 
-    switch (downcast<Element>(*node).elementName()) {
+    switch (downcast<Element>(node).elementName()) {
     case ElementNames::HTML::a:
     case ElementNames::HTML::abbr:
     case ElementNames::HTML::area:
@@ -247,7 +247,7 @@ void InsertParagraphSeparatorCommand::doApply()
         || !startBlock->nonShadowBoundaryParentNode()
         || isEditableRootPhrasingContent(insertionPosition)
         || isRenderedTable(startBlock.get())
-        || isTableCell(startBlock.get())
+        || isTableCell(*startBlock)
         || is<HTMLFormElement>(*startBlock)
         // FIXME: If the node is hidden, we don't have a canonical position so we will do the wrong thing for tables and <hr>. https://bugs.webkit.org/show_bug.cgi?id=40342
         || (!canonicalPos.isNull() && canonicalPos.deprecatedNode()->renderer() && canonicalPos.deprecatedNode()->renderer()->isTable())
@@ -316,8 +316,8 @@ void InsertParagraphSeparatorCommand::doApply()
             // We can get here if we pasted a copied portion of a blockquote with a newline at the end and are trying to paste it
             // into an unquoted area. We then don't want the newline within the blockquote or else it will also be quoted.
             if (m_pasteBlockqutoeIntoUnquotedArea) {
-                if (Node* highestBlockquote = highestEnclosingNodeOfType(canonicalPos, &isMailBlockquote))
-                    startBlock = downcast<Element>(highestBlockquote);
+                if (RefPtr highestBlockquote = highestEnclosingNodeOfType(canonicalPos, &isMailBlockquote))
+                    startBlock = downcast<Element>(WTFMove(highestBlockquote));
             }
 
             // Most of the time we want to stay at the nesting level of the startBlock (e.g., when nesting within lists).  However,

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -185,7 +185,7 @@ void MarkupAccumulator::appendCharactersReplacingEntities(StringBuilder& result,
         appendCharactersReplacingEntitiesInternal<UChar>(result, source, offset, length, entityMask);
 }
 
-MarkupAccumulator::MarkupAccumulator(Vector<Node*>* nodes, ResolveURLs resolveURLs, SerializationSyntax serializationSyntax)
+MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializationSyntax serializationSyntax)
     : m_nodes(nodes)
     , m_resolveURLs(resolveURLs)
     , m_serializationSyntax(serializationSyntax)
@@ -278,7 +278,7 @@ void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespa
         appendNonElementNode(m_markup, node, namespaces);
 
     if (m_nodes)
-        m_nodes->append(const_cast<Node*>(&node));
+        m_nodes->append(const_cast<Node&>(node));
 }
 
 void MarkupAccumulator::appendEndTag(StringBuilder& result, const Element& element)

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -64,7 +64,7 @@ constexpr auto EntityMaskInHTMLAttributeValue = { EntityMask::Amp, EntityMask::Q
 class MarkupAccumulator {
     WTF_MAKE_NONCOPYABLE(MarkupAccumulator);
 public:
-    MarkupAccumulator(Vector<Node*>*, ResolveURLs, SerializationSyntax);
+    MarkupAccumulator(Vector<Ref<Node>>*, ResolveURLs, SerializationSyntax);
     virtual ~MarkupAccumulator();
 
     String serializeNodes(Node& targetNode, SerializedNodes, Vector<QualifiedName>* tagNamesToSkip = nullptr);
@@ -97,7 +97,7 @@ protected:
 
     OptionSet<EntityMask> entityMaskForText(const Text&) const;
 
-    Vector<Node*>* const m_nodes;
+    Vector<Ref<Node>>* const m_nodes;
 
 private:
     void appendNamespace(StringBuilder&, const AtomString& prefix, const AtomString& namespaceURI, Namespaces&, bool allowEmptyDefaultNS = false);

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -819,7 +819,7 @@ static bool shouldEmitTabBeforeNode(Node& node)
     auto* renderer = node.renderer();
     
     // Table cells are delimited by tabs.
-    if (!renderer || !isTableCell(&node))
+    if (!renderer || !isTableCell(node))
         return false;
     
     // Want a tab before every cell other than the first one.
@@ -880,7 +880,7 @@ static bool shouldEmitNewlinesBeforeAndAfterNode(Node& node)
     
     // Need to make an exception for table cells, because they are blocks, but we
     // want them tab-delimited rather than having newlines before and after.
-    if (isTableCell(&node))
+    if (isTableCell(node))
         return false;
     
     // Need to make an exception for table row elements, because they are neither

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -302,7 +302,7 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
                 if (auto* table = isFirstPositionAfterTable(end)) {
                     // The paragraph break after the last paragraph in the last cell of a block table ends
                     // at the start of the paragraph after the table.
-                    if (isBlock(table))
+                    if (isBlock(*table))
                         end = end.next(CannotCrossEditingBoundary);
                     else
                         end = wordEnd;
@@ -355,7 +355,7 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
             if (Node* table = isFirstPositionAfterTable(end)) {
                 // The paragraph break after the last paragraph in the last cell of a block table ends
                 // at the start of the paragraph after the table, not at the position just after the table.
-                if (isBlock(table))
+                if (isBlock(*table))
                     end = end.next(CannotCrossEditingBoundary);
                 // There is no parargraph break after the last paragraph in the last cell of an inline table.
                 else

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -1139,7 +1139,7 @@ Node* findStartOfParagraph(Node* startNode, Node* highestRoot, Node* startBlock,
             continue;
         }
         
-        if (r->isBR() || isBlock(n))
+        if (r->isBR() || isBlock(*n))
             break;
 
         if (is<RenderText>(*r) && downcast<RenderText>(*r).hasRenderedText()) {
@@ -1199,7 +1199,7 @@ Node* findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayInsideBlo
         }
         
         // FIXME: This is wrong when startNode is a block. We should return a position after the block.
-        if (r->isBR() || is<HTMLBRElement>(n) || isBlock(n))
+        if (r->isBR() || is<HTMLBRElement>(*n) || isBlock(*n))
             break;
 
         // FIXME: We avoid returning a position where the renderer can't accept the caret.

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -92,13 +92,13 @@ ExceptionOr<void> replaceChildrenWithFragment(ContainerNode&, Ref<DocumentFragme
 enum class ConvertBlocksToInlines : bool { No, Yes };
 enum class SerializeComposedTree : bool { No, Yes };
 enum class IgnoreUserSelectNone : bool { No, Yes };
-WEBCORE_EXPORT String serializePreservingVisualAppearance(const SimpleRange&, Vector<Node*>* = nullptr, AnnotateForInterchange = AnnotateForInterchange::No, ConvertBlocksToInlines = ConvertBlocksToInlines::No, ResolveURLs = ResolveURLs::No);
+WEBCORE_EXPORT String serializePreservingVisualAppearance(const SimpleRange&, Vector<Ref<Node>>* = nullptr, AnnotateForInterchange = AnnotateForInterchange::No, ConvertBlocksToInlines = ConvertBlocksToInlines::No, ResolveURLs = ResolveURLs::No);
 String serializePreservingVisualAppearance(const VisibleSelection&, ResolveURLs = ResolveURLs::No, SerializeComposedTree = SerializeComposedTree::No,
-    IgnoreUserSelectNone = IgnoreUserSelectNone::Yes, Vector<Node*>* = nullptr);
+    IgnoreUserSelectNone = IgnoreUserSelectNone::Yes, Vector<Ref<Node>>* = nullptr);
 
 enum class SerializedNodes : uint8_t { SubtreeIncludingNode, SubtreesOfChildren };
 enum class SerializationSyntax : uint8_t { HTML, XML };
-WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Node*>* = nullptr, ResolveURLs = ResolveURLs::No, Vector<QualifiedName>* tagNamesToSkip = nullptr, std::optional<SerializationSyntax> = std::nullopt);
+WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, Vector<QualifiedName>* tagNamesToSkip = nullptr, std::optional<SerializationSyntax> = std::nullopt);
 
 String urlToMarkup(const URL&, const String& title);
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -61,7 +61,7 @@ private:
 
     enum MainResourceStatus { Subresource, MainResource };
 
-    static RefPtr<LegacyWebArchive> create(const String& markupString, LocalFrame&, const Vector<Node*>& nodes, Function<bool(LocalFrame&)>&& frameFilter);
+    static RefPtr<LegacyWebArchive> create(const String& markupString, LocalFrame&, Vector<Ref<Node>>&& nodes, Function<bool(LocalFrame&)>&& frameFilter);
     static RefPtr<ArchiveResource> createResource(CFDictionaryRef);
     static ResourceResponse createResourceResponseFromMacArchivedData(CFDataRef);
     static ResourceResponse createResourceResponseFromPropertyListData(CFDataRef, CFStringRef responseDataType);


### PR DESCRIPTION
#### 96524b1516c8f6575ef510d38ca9d739f14a34a6
<pre>
Use more smart pointers in markup.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=261979">https://bugs.webkit.org/show_bug.cgi?id=261979</a>

Reviewed by Darin Adler.

* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyInlineStyleToNodeRange):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary):
(WebCore::CompositeEditCommand::cleanupAfterDeletion):
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::isTableRow):
(WebCore::isTableCellEmpty):
(WebCore::isTableRowEmpty):
(WebCore::shouldRemoveContentOnly):
(WebCore::DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows):
* Source/WebCore/editing/Editing.cpp:
(WebCore::isBlock):
(WebCore::isInline):
(WebCore::isTableStructureNode):
(WebCore::isListItem):
(WebCore::enclosingNodeOfType):
(WebCore::highestEnclosingNodeOfType):
(WebCore::enclosingListChild):
(WebCore::isTableCell):
(WebCore::numEnclosingMailBlockquotes):
(WebCore::isMailBlockquote):
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::wrappingStyleForSerialization):
* Source/WebCore/editing/FormatBlockCommand.cpp:
(WebCore::FormatBlockCommand::formatRange):
(WebCore::enclosingBlockToSplitTreeTo):
* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::isListOrIndentBlockquote):
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::InsertListCommand::listifyParagraph):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::isPhrasingContent):
(WebCore::InsertParagraphSeparatorCommand::doApply):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::MarkupAccumulator):
(WebCore::MarkupAccumulator::startAppendingNode):
* Source/WebCore/editing/MarkupAccumulator.h:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::removeUnrenderedNodes):
(WebCore::isMailPasteAsQuotationNode):
(WebCore::isHeaderElement):
(WebCore::ReplaceSelectionCommand::shouldMerge):
(WebCore::ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline):
(WebCore::ReplaceSelectionCommand::makeInsertedContentRoundTrippableWithHTMLTreeBuilder):
(WebCore::handleStyleSpansBeforeInsertion):
(WebCore::ReplaceSelectionCommand::handleStyleSpans):
(WebCore::isInlineNodeWithStyle):
(WebCore::nodeToSplitToAvoidPastingIntoInlineNodesWithStyle):
(WebCore::ReplaceSelectionCommand::doApply):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::shouldEmitTabBeforeNode):
(WebCore::shouldEmitNewlinesBeforeAndAfterNode):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::adjustSelectionRespectingGranularity):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::findStartOfParagraph):
(WebCore::findEndOfParagraph):
* Source/WebCore/editing/markup.cpp:
(WebCore::AttributeChange::AttributeChange):
(WebCore::completeURLs):
(WebCore::replaceSubresourceURLs):
(WebCore::removeSubresourceURLAttributes):
(WebCore::createPageForSanitizingWebContent):
(WebCore::sanitizeMarkup):
(WebCore::UserSelectNoneStateCache::computeState):
(WebCore::StyledMarkupAccumulator::StyledMarkupAccumulator):
(WebCore::StyledMarkupAccumulator::wrapWithNode):
(WebCore::StyledMarkupAccumulator::appendText):
(WebCore::StyledMarkupAccumulator::appendCustomAttributes):
(WebCore::StyledMarkupAccumulator::serializeNodes):
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):
(WebCore::StyledMarkupAccumulator::appendNodeToPreserveMSOList):
(WebCore::needInterchangeNewlineAfter):
(WebCore::isElementPresentational):
(WebCore::highestAncestorToWrapMarkup):
(WebCore::serializePreservingVisualAppearanceInternal):
(WebCore::serializePreservingVisualAppearance):
(WebCore::serializeFragment):
(WebCore::fillContainerFromString):
(WebCore::isPlainTextMarkup):
(WebCore::contextPreservesNewline):
(WebCore::createFragmentFromText):
(WebCore::documentTypeString):
(WebCore::removeElementFromFragmentPreservingChildren):
(WebCore::canUseSetDataOptimization):
(WebCore::replaceChildrenWithFragment):
* Source/WebCore/editing/markup.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
(WebCore::addSubresourcesForAttachmentElementsIfNecessary):
(WebCore::LegacyWebArchive::createFromSelection):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::SerializerMarkupAccumulator::SerializerMarkupAccumulator):
(WebCore::PageSerializer::serializeFrame):

Canonical link: <a href="https://commits.webkit.org/268378@main">https://commits.webkit.org/268378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91f05bdfa7be6865c6c62d97e228a2d70aff3243

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20081 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22266 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16946 "7 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17752 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22035 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18536 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17680 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4668 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->