### PR TITLE
[JSC] Generator functions should not be Annex B hoisting candidates

### DIFF
--- a/JSTests/stress/generator-function-declaration-isnt-sloppy-mode-hoisting-candidate.js
+++ b/JSTests/stress/generator-function-declaration-isnt-sloppy-mode-hoisting-candidate.js
@@ -1,0 +1,30 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+(function() {
+    {
+        function* foo() {}
+
+        if (true) {
+            function* bar() {}
+        }
+    }
+
+    assert(typeof foo === "undefined");
+    assert(typeof bar === "undefined");
+})();
+
+eval(`
+    if (true) {
+        function* foo1() {}
+    }
+
+    {
+        function* bar1() {}
+    }
+`);
+
+assert(!globalThis.hasOwnProperty("foo1"));
+assert(!globalThis.hasOwnProperty("bar1"));

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -2837,7 +2837,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseFunctionDecla
         functionDeclaration.second->appendFunction(metadata);
         // FIXME: This convoluted condition is only temporary until Annex B hoisting for global scope is implemented.
         // https://bugs.webkit.org/show_bug.cgi?id=163209
-        bool isSloppyModeHoistingCandidate = m_statementDepth != 1 && !strictMode() && (currentScope()->isFunction() || closestParentOrdinaryFunctionNonLexicalScope()->isEvalContext());
+        bool isSloppyModeHoistingCandidate = m_statementDepth != 1 && !strictMode() && m_parseMode == SourceParseMode::NormalFunctionMode && (currentScope()->isFunction() || closestParentOrdinaryFunctionNonLexicalScope()->isEvalContext());
         if (isSloppyModeHoistingCandidate)
             functionDeclaration.second->addSloppyModeFunctionHoistingCandidate<Scope::NeedsDuplicateDeclarationCheck::No>(metadata);
     }


### PR DESCRIPTION
#### b215cab40b67971fcdd8680eefe775b1ad42b919
<pre>
[JSC] Generator functions should not be Annex B hoisting candidates
<a href="https://bugs.webkit.org/show_bug.cgi?id=260485">https://bugs.webkit.org/show_bug.cgi?id=260485</a>
&lt;rdar://problem/114213642&gt;

Reviewed by Justin Michaud.

Per Annex B [1], only functions defined using a FunctionDeclaration are candidates for legacy
block-level declaration hoisting. Generator functions are defined using a different parse node [2].

Aligns JSC with V8 and SpiderMonkey.

[1]: <a href="https://tc39.es/ecma262/#sec-web-compat-functiondeclarationinstantiation">https://tc39.es/ecma262/#sec-web-compat-functiondeclarationinstantiation</a> (step 29.a)
[2]: <a href="https://tc39.es/ecma262/#prod-GeneratorDeclaration">https://tc39.es/ecma262/#prod-GeneratorDeclaration</a>

* JSTests/stress/generator-function-declaration-isnt-sloppy-mode-hoisting-candidate.js: Added.
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseFunctionDeclaration):

Canonical link: <a href="https://commits.webkit.org/268352@main">https://commits.webkit.org/268352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fda1cbfd99c4a2b0b3570963f54b074bc53384a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18144 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19945 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22153 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17654 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/23965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16850 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21935 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18739 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15601 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22799 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17559 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21916 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24051 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2382 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18247 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5367 "Passed tests") | 
<!--EWS-Status-Bubble-End-->