### PR TITLE
Rename WTF::Persistence::Coder encode/decode methods to set them apart from all other encode/decode methods

### DIFF
--- a/Source/WTF/wtf/persistence/PersistentCoders.cpp
+++ b/Source/WTF/wtf/persistence/PersistentCoders.cpp
@@ -32,14 +32,14 @@
 
 namespace WTF::Persistence {
 
-void Coder<AtomString>::encode(Encoder& encoder, const AtomString& atomString)
+void Coder<AtomString>::encodeForPersistence(Encoder& encoder, const AtomString& atomString)
 {
     encoder << atomString.string();
 }
 
 // FIXME: Constructing a String and then looking it up in the AtomStringTable is inefficient.
 // Ideally, we wouldn't need to allocate a String when it is already in the AtomStringTable.
-std::optional<AtomString> Coder<AtomString>::decode(Decoder& decoder)
+std::optional<AtomString> Coder<AtomString>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<String> string;
     decoder >> string;
@@ -49,7 +49,7 @@ std::optional<AtomString> Coder<AtomString>::decode(Decoder& decoder)
     return { AtomString { WTFMove(*string) } };
 }
 
-void Coder<CString>::encode(Encoder& encoder, const CString& string)
+void Coder<CString>::encodeForPersistence(Encoder& encoder, const CString& string)
 {
     // Special case the null string.
     if (string.isNull()) {
@@ -62,7 +62,7 @@ void Coder<CString>::encode(Encoder& encoder, const CString& string)
     encoder.encodeFixedLengthData({ string.dataAsUInt8Ptr(), length });
 }
 
-std::optional<CString> Coder<CString>::decode(Decoder& decoder)
+std::optional<CString> Coder<CString>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<uint32_t> length;
     decoder >> length;
@@ -86,7 +86,7 @@ std::optional<CString> Coder<CString>::decode(Decoder& decoder)
     return string;
 }
 
-void Coder<String>::encode(Encoder& encoder, const String& string)
+void Coder<String>::encodeForPersistence(Encoder& encoder, const String& string)
 {
     // Special case the null string.
     if (string.isNull()) {
@@ -120,7 +120,7 @@ static inline std::optional<String> decodeStringText(Decoder& decoder, uint32_t 
     return string;
 }
 
-std::optional<String> Coder<String>::decode(Decoder& decoder)
+std::optional<String> Coder<String>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<uint32_t> length;
     decoder >> length;
@@ -142,12 +142,12 @@ std::optional<String> Coder<String>::decode(Decoder& decoder)
     return decodeStringText<UChar>(decoder, *length);
 }
 
-void Coder<URL>::encode(Encoder& encoder, const URL& url)
+void Coder<URL>::encodeForPersistence(Encoder& encoder, const URL& url)
 {
     encoder << url.string();
 }
 
-std::optional<URL> Coder<URL>::decode(Decoder& decoder)
+std::optional<URL> Coder<URL>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<String> string;
     decoder >> string;
@@ -156,12 +156,12 @@ std::optional<URL> Coder<URL>::decode(Decoder& decoder)
     return URL(WTFMove(*string));
 }
 
-void Coder<SHA1::Digest>::encode(Encoder& encoder, const SHA1::Digest& digest)
+void Coder<SHA1::Digest>::encodeForPersistence(Encoder& encoder, const SHA1::Digest& digest)
 {
     encoder.encodeFixedLengthData({ digest.data(), sizeof(digest) });
 }
 
-std::optional<SHA1::Digest> Coder<SHA1::Digest>::decode(Decoder& decoder)
+std::optional<SHA1::Digest> Coder<SHA1::Digest>::decodeForPersistence(Decoder& decoder)
 {
     SHA1::Digest tmp;
     if (!decoder.decodeFixedLengthData({ tmp.data(), sizeof(tmp) }))
@@ -169,12 +169,12 @@ std::optional<SHA1::Digest> Coder<SHA1::Digest>::decode(Decoder& decoder)
     return tmp;
 }
 
-void Coder<WallTime>::encode(Encoder& encoder, const WallTime& time)
+void Coder<WallTime>::encodeForPersistence(Encoder& encoder, const WallTime& time)
 {
     encoder << time.secondsSinceEpoch().value();
 }
 
-std::optional<WallTime> Coder<WallTime>::decode(Decoder& decoder)
+std::optional<WallTime> Coder<WallTime>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<double> value;
     decoder >> value;
@@ -184,12 +184,12 @@ std::optional<WallTime> Coder<WallTime>::decode(Decoder& decoder)
     return WallTime::fromRawSeconds(*value);
 }
 
-void Coder<Seconds>::encode(Encoder& encoder, const Seconds& seconds)
+void Coder<Seconds>::encodeForPersistence(Encoder& encoder, const Seconds& seconds)
 {
     encoder << seconds.value();
 }
 
-std::optional<Seconds> Coder<Seconds>::decode(Decoder& decoder)
+std::optional<Seconds> Coder<Seconds>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<double> value;
     decoder >> value;

--- a/Source/WTF/wtf/persistence/PersistentCoders.h
+++ b/Source/WTF/wtf/persistence/PersistentCoders.h
@@ -42,13 +42,13 @@ class Encoder;
 
 template<typename T, typename U> struct Coder<std::pair<T, U>> {
     template<typename Encoder>
-    static void encode(Encoder& encoder, const std::pair<T, U>& pair)
+    static void encodeForPersistence(Encoder& encoder, const std::pair<T, U>& pair)
     {
         encoder << pair.first << pair.second;
     }
 
     template<typename Decoder>
-    static std::optional<std::pair<T, U>> decode(Decoder& decoder)
+    static std::optional<std::pair<T, U>> decodeForPersistence(Decoder& decoder)
     {
         std::optional<T> first;
         decoder >> first;
@@ -66,7 +66,7 @@ template<typename T, typename U> struct Coder<std::pair<T, U>> {
 
 template<typename T> struct Coder<std::optional<T>> {
     template<typename Encoder>
-    static void encode(Encoder& encoder, const std::optional<T>& optional)
+    static void encodeForPersistence(Encoder& encoder, const std::optional<T>& optional)
     {
         if (!optional) {
             encoder << false;
@@ -78,7 +78,7 @@ template<typename T> struct Coder<std::optional<T>> {
     }
     
     template<typename Decoder>
-    static std::optional<std::optional<T>> decode(Decoder& decoder)
+    static std::optional<std::optional<T>> decodeForPersistence(Decoder& decoder)
     {
         std::optional<bool> isEngaged;
         decoder >> isEngaged;
@@ -98,13 +98,13 @@ template<typename T> struct Coder<std::optional<T>> {
 
 template<typename KeyType, typename ValueType> struct Coder<WTF::KeyValuePair<KeyType, ValueType>> {
     template<typename Encoder>
-    static void encode(Encoder& encoder, const WTF::KeyValuePair<KeyType, ValueType>& pair)
+    static void encodeForPersistence(Encoder& encoder, const WTF::KeyValuePair<KeyType, ValueType>& pair)
     {
         encoder << pair.key << pair.value;
     }
 
     template<typename Decoder>
-    static std::optional<WTF::KeyValuePair<KeyType, ValueType>> decode(Decoder& decoder)
+    static std::optional<WTF::KeyValuePair<KeyType, ValueType>> decodeForPersistence(Decoder& decoder)
     {
         std::optional<KeyType> key;
         decoder >> key;
@@ -124,7 +124,7 @@ template<bool fixedSizeElements, typename T, size_t inlineCapacity> struct Vecto
 
 template<typename T, size_t inlineCapacity> struct VectorCoder<false, T, inlineCapacity> {
     template<typename Encoder>
-    static void encode(Encoder& encoder, const Vector<T, inlineCapacity>& vector)
+    static void encodeForPersistence(Encoder& encoder, const Vector<T, inlineCapacity>& vector)
     {
         encoder << static_cast<uint64_t>(vector.size());
         for (size_t i = 0; i < vector.size(); ++i)
@@ -132,7 +132,7 @@ template<typename T, size_t inlineCapacity> struct VectorCoder<false, T, inlineC
     }
 
     template<typename Decoder>
-    static std::optional<Vector<T, inlineCapacity>> decode(Decoder& decoder)
+    static std::optional<Vector<T, inlineCapacity>> decodeForPersistence(Decoder& decoder)
     {
         std::optional<uint64_t> size;
         decoder >> size;
@@ -155,14 +155,14 @@ template<typename T, size_t inlineCapacity> struct VectorCoder<false, T, inlineC
 
 template<typename T, size_t inlineCapacity> struct VectorCoder<true, T, inlineCapacity> {
     template<typename Encoder>
-    static void encode(Encoder& encoder, const Vector<T, inlineCapacity>& vector)
+    static void encodeForPersistence(Encoder& encoder, const Vector<T, inlineCapacity>& vector)
     {
         encoder << static_cast<uint64_t>(vector.size());
         encoder.encodeFixedLengthData({ reinterpret_cast<const uint8_t*>(vector.data()), vector.size() * sizeof(T) });
     }
     
     template<typename Decoder>
-    static std::optional<Vector<T, inlineCapacity>> decode(Decoder& decoder)
+    static std::optional<Vector<T, inlineCapacity>> decodeForPersistence(Decoder& decoder)
     {
         std::optional<uint64_t> decodedSize;
         decoder >> decodedSize;
@@ -196,7 +196,7 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
     typedef HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg> HashMapType;
 
     template<typename Encoder>
-    static void encode(Encoder& encoder, const HashMapType& hashMap)
+    static void encodeForPersistence(Encoder& encoder, const HashMapType& hashMap)
     {
         encoder << static_cast<uint64_t>(hashMap.size());
         for (typename HashMapType::const_iterator it = hashMap.begin(), end = hashMap.end(); it != end; ++it)
@@ -204,7 +204,7 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
     }
 
     template<typename Decoder>
-    static std::optional<HashMapType> decode(Decoder& decoder)
+    static std::optional<HashMapType> decodeForPersistence(Decoder& decoder)
     {
         std::optional<uint64_t> hashMapSize;
         decoder >> hashMapSize;
@@ -237,7 +237,7 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Coder<
     typedef HashSet<KeyArg, HashArg, KeyTraitsArg> HashSetType;
 
     template<typename Encoder>
-    static void encode(Encoder& encoder, const HashSetType& hashSet)
+    static void encodeForPersistence(Encoder& encoder, const HashSetType& hashSet)
     {
         encoder << static_cast<uint64_t>(hashSet.size());
         for (typename HashSetType::const_iterator it = hashSet.begin(), end = hashSet.end(); it != end; ++it)
@@ -245,7 +245,7 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Coder<
     }
 
     template<typename Decoder>
-    static std::optional<HashSetType> decode(Decoder& decoder)
+    static std::optional<HashSetType> decodeForPersistence(Decoder& decoder)
     {
         std::optional<uint64_t> hashSetSize;
         decoder >> hashSetSize;
@@ -271,8 +271,8 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Coder<
 
 #define DECLARE_CODER(class) \
 template<> struct Coder<class> { \
-    WTF_EXPORT_PRIVATE static void encode(Encoder&, const class&); \
-    WTF_EXPORT_PRIVATE static std::optional<class> decode(Decoder&); \
+    WTF_EXPORT_PRIVATE static void encodeForPersistence(Encoder&, const class&); \
+    WTF_EXPORT_PRIVATE static std::optional<class> decodeForPersistence(Decoder&); \
 }
 
 DECLARE_CODER(AtomString);

--- a/Source/WTF/wtf/persistence/PersistentDecoder.h
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.h
@@ -63,7 +63,7 @@ public:
     template<typename T, std::enable_if_t<!std::is_arithmetic<typename std::remove_const<T>>::value && !std::is_enum<T>::value>* = nullptr>
     Decoder& operator>>(std::optional<T>& result)
     {
-        result = Coder<T>::decode(*this);
+        result = Coder<T>::decodeForPersistence(*this);
         return *this;
     }
 

--- a/Source/WTF/wtf/persistence/PersistentEncoder.h
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.h
@@ -54,7 +54,7 @@ public:
     template<typename T, std::enable_if_t<!std::is_enum<T>::value && !std::is_arithmetic<typename std::remove_const<T>>::value>* = nullptr>
     Encoder& operator<<(const T& t)
     {
-        Coder<T>::encode(*this, t);
+        Coder<T>::encodeForPersistence(*this, t);
         return *this;
     }
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1049,7 +1049,7 @@ Protocol::ErrorStringOr<String> InspectorNetworkAgent::getSerializedCertificate(
         return makeUnexpected("Missing certificate of resource for given requestId"_s);
 
     WTF::Persistence::Encoder encoder;
-    WTF::Persistence::Coder<WebCore::CertificateInfo>::encode(encoder, certificate.value());
+    WTF::Persistence::Coder<WebCore::CertificateInfo>::encodeForPersistence(encoder, certificate.value());
     return base64EncodeToString(encoder.buffer(), encoder.bufferSize());
 }
 

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -48,7 +48,7 @@ namespace WTF::Persistence {
 
 #if ENABLE(APP_HIGHLIGHTS)
 template<> struct Coder<WebCore::AppHighlightRangeData::NodePathComponent> {
-    static void encode(Encoder& encoder, const WebCore::AppHighlightRangeData::NodePathComponent& instance)
+    static void encodeForPersistence(Encoder& encoder, const WebCore::AppHighlightRangeData::NodePathComponent& instance)
     {
         encoder << instance.identifier;
         encoder << instance.nodeName;
@@ -56,7 +56,7 @@ template<> struct Coder<WebCore::AppHighlightRangeData::NodePathComponent> {
         encoder << instance.pathIndex;
     }
 
-    static std::optional<WebCore::AppHighlightRangeData::NodePathComponent> decode(Decoder& decoder)
+    static std::optional<WebCore::AppHighlightRangeData::NodePathComponent> decodeForPersistence(Decoder& decoder)
     {
         std::optional<String> identifier;
         decoder >> identifier;
@@ -84,7 +84,7 @@ template<> struct Coder<WebCore::AppHighlightRangeData::NodePathComponent> {
 
 constexpr uint64_t highlightFileSignature = 0x4141504832303231; // File Signature  (A)pple(AP)plication(H)ighlights(2021)
 
-void Coder<WebCore::AppHighlightRangeData>::encode(Encoder& encoder, const WebCore::AppHighlightRangeData& instance)
+void Coder<WebCore::AppHighlightRangeData>::encodeForPersistence(Encoder& encoder, const WebCore::AppHighlightRangeData& instance)
 {
     constexpr uint64_t currentAppHighlightVersion = 1;
     
@@ -98,7 +98,7 @@ void Coder<WebCore::AppHighlightRangeData>::encode(Encoder& encoder, const WebCo
     encoder << instance.endOffset();
 }
 
-std::optional<WebCore::AppHighlightRangeData> Coder<WebCore::AppHighlightRangeData>::decode(Decoder& decoder)
+std::optional<WebCore::AppHighlightRangeData> Coder<WebCore::AppHighlightRangeData>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<uint64_t> version;
     
@@ -155,12 +155,12 @@ std::optional<WebCore::AppHighlightRangeData> Coder<WebCore::AppHighlightRangeDa
 #endif // ENABLE(APP_HIGHLIGHTS)
 
 #if ENABLE(SERVICE_WORKER)
-void Coder<WebCore::ImportedScriptAttributes>::encode(Encoder& encoder, const WebCore::ImportedScriptAttributes& instance)
+void Coder<WebCore::ImportedScriptAttributes>::encodeForPersistence(Encoder& encoder, const WebCore::ImportedScriptAttributes& instance)
 {
     encoder << instance.responseURL << instance.mimeType;
 }
 
-std::optional<WebCore::ImportedScriptAttributes> Coder<WebCore::ImportedScriptAttributes>::decode(Decoder& decoder)
+std::optional<WebCore::ImportedScriptAttributes> Coder<WebCore::ImportedScriptAttributes>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<URL> responseURL;
     decoder >> responseURL;
@@ -178,12 +178,12 @@ std::optional<WebCore::ImportedScriptAttributes> Coder<WebCore::ImportedScriptAt
     } };
 }
 
-void Coder<WebCore::ImageResource>::encode(Encoder& encoder, const WebCore::ImageResource& instance)
+void Coder<WebCore::ImageResource>::encodeForPersistence(Encoder& encoder, const WebCore::ImageResource& instance)
 {
     encoder << instance.src << instance.sizes << instance.type << instance.label;
 }
 
-std::optional<WebCore::ImageResource> Coder<WebCore::ImageResource>::decode(Decoder& decoder)
+std::optional<WebCore::ImageResource> Coder<WebCore::ImageResource>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<String> src;
     decoder >> src;
@@ -214,7 +214,7 @@ std::optional<WebCore::ImageResource> Coder<WebCore::ImageResource>::decode(Deco
 }
 #endif
 
-void Coder<WebCore::ResourceRequest>::encode(Encoder& encoder, const WebCore::ResourceRequest& instance)
+void Coder<WebCore::ResourceRequest>::encodeForPersistence(Encoder& encoder, const WebCore::ResourceRequest& instance)
 {
     ASSERT(!instance.httpBody());
     ASSERT(!instance.platformRequestUpdated());
@@ -233,7 +233,7 @@ void Coder<WebCore::ResourceRequest>::encode(Encoder& encoder, const WebCore::Re
     encoder << instance.isAppInitiated();
 }
 
-std::optional<WebCore::ResourceRequest> Coder<WebCore::ResourceRequest>::decode(Decoder& decoder)
+std::optional<WebCore::ResourceRequest> Coder<WebCore::ResourceRequest>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<URL> url;
     decoder >> url;
@@ -421,13 +421,13 @@ static std::optional<RetainPtr<CFArrayRef>> decodeCertificateChain(Decoder& deco
     return { WTFMove(array) };
 }
 
-void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::CertificateInfo& certificateInfo)
+void Coder<WebCore::CertificateInfo>::encodeForPersistence(Encoder& encoder, const WebCore::CertificateInfo& certificateInfo)
 {
     encoder << LegacyCertificateInfoType::Trust;
     encodeSecTrustRef(encoder, certificateInfo.trust().get());
 }
 
-std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(Decoder& decoder)
+std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<LegacyCertificateInfoType> certificateInfoType;
     decoder >> certificateInfoType;
@@ -456,7 +456,7 @@ std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(
 
 #elif USE(CURL)
 
-void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::CertificateInfo& certificateInfo)
+void Coder<WebCore::CertificateInfo>::encodeForPersistence(Encoder& encoder, const WebCore::CertificateInfo& certificateInfo)
 {
     auto& certificateChain = certificateInfo.certificateChain();
 
@@ -466,7 +466,7 @@ void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::Ce
         encoder << certificate;
 }
 
-std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(Decoder& decoder)
+std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<int> verificationError;
     decoder >> verificationError;
@@ -494,13 +494,13 @@ std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(
 #elif USE(SOUP)
 
 template<> struct Coder<GRefPtr<GByteArray>> {
-    static void encode(Encoder &encoder, const GRefPtr<GByteArray>& byteArray)
+    static void encodeForPersistence(Encoder &encoder, const GRefPtr<GByteArray>& byteArray)
     {
         encoder << static_cast<uint32_t>(byteArray->len);
         encoder.encodeFixedLengthData({ byteArray->data, byteArray->len });
     }
 
-    static std::optional<GRefPtr<GByteArray>> decode(Decoder& decoder)
+    static std::optional<GRefPtr<GByteArray>> decodeForPersistence(Decoder& decoder)
     {
         std::optional<uint32_t> size;
         decoder >> size;
@@ -553,7 +553,7 @@ static GRefPtr<GTlsCertificate> certificateFromCertificatesDataList(const Vector
     return certificate;
 }
 
-void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::CertificateInfo& certificateInfo)
+void Coder<WebCore::CertificateInfo>::encodeForPersistence(Encoder& encoder, const WebCore::CertificateInfo& certificateInfo)
 {
     auto certificatesDataList = certificatesDataListFromCertificateInfo(certificateInfo);
 
@@ -565,7 +565,7 @@ void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::Ce
     encoder << static_cast<uint32_t>(certificateInfo.tlsErrors());
 }
 
-std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(Decoder& decoder)
+std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<Vector<GRefPtr<GByteArray>>> certificatesDataList;
     decoder >> certificatesDataList;
@@ -592,11 +592,11 @@ std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(
 
 #elif PLATFORM(WIN)
 
-void Coder<WebCore::CertificateInfo>::encode(Encoder&, const WebCore::CertificateInfo&)
+void Coder<WebCore::CertificateInfo>::encodeForPersistence(Encoder&, const WebCore::CertificateInfo&)
 {
 }
 
-std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(Decoder&)
+std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decodeForPersistence(Decoder&)
 {
     return WebCore::CertificateInfo();
 }
@@ -605,13 +605,13 @@ std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(
 
 // FIXME: Move persistent coder implementations here and generate IPC coders for these structures.
 #if ENABLE(SERVICE_WORKER)
-void Coder<WebCore::NavigationPreloadState>::encode(Encoder& encoder, const WebCore::NavigationPreloadState& instance)
+void Coder<WebCore::NavigationPreloadState>::encodeForPersistence(Encoder& encoder, const WebCore::NavigationPreloadState& instance)
 {
     encoder << instance.enabled;
     encoder << instance.headerValue;
 }
 
-std::optional<WebCore::NavigationPreloadState> Coder<WebCore::NavigationPreloadState>::decode(Decoder& decoder)
+std::optional<WebCore::NavigationPreloadState> Coder<WebCore::NavigationPreloadState>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<bool> enabled;
     decoder >> enabled;
@@ -626,33 +626,33 @@ std::optional<WebCore::NavigationPreloadState> Coder<WebCore::NavigationPreloadS
 }
 #endif
 
-void Coder<WebCore::CrossOriginEmbedderPolicy>::encode(Encoder& encoder, const WebCore::CrossOriginEmbedderPolicy& instance)
+void Coder<WebCore::CrossOriginEmbedderPolicy>::encodeForPersistence(Encoder& encoder, const WebCore::CrossOriginEmbedderPolicy& instance)
 {
     instance.encode(encoder);
 }
 
-std::optional<WebCore::CrossOriginEmbedderPolicy> Coder<WebCore::CrossOriginEmbedderPolicy>::decode(Decoder& decoder)
+std::optional<WebCore::CrossOriginEmbedderPolicy> Coder<WebCore::CrossOriginEmbedderPolicy>::decodeForPersistence(Decoder& decoder)
 {
     return WebCore::CrossOriginEmbedderPolicy::decode(decoder);
 }
 
-void Coder<WebCore::ContentSecurityPolicyResponseHeaders>::encode(Encoder& encoder, const WebCore::ContentSecurityPolicyResponseHeaders& instance)
+void Coder<WebCore::ContentSecurityPolicyResponseHeaders>::encodeForPersistence(Encoder& encoder, const WebCore::ContentSecurityPolicyResponseHeaders& instance)
 {
     instance.encode(encoder);
 }
 
-std::optional<WebCore::ContentSecurityPolicyResponseHeaders> Coder<WebCore::ContentSecurityPolicyResponseHeaders>::decode(Decoder& decoder)
+std::optional<WebCore::ContentSecurityPolicyResponseHeaders> Coder<WebCore::ContentSecurityPolicyResponseHeaders>::decodeForPersistence(Decoder& decoder)
 {
     return WebCore::ContentSecurityPolicyResponseHeaders::decode(decoder);
 }
 
-void Coder<WebCore::ClientOrigin>::encode(Encoder& encoder, const WebCore::ClientOrigin& instance)
+void Coder<WebCore::ClientOrigin>::encodeForPersistence(Encoder& encoder, const WebCore::ClientOrigin& instance)
 {
     encoder << instance.topOrigin;
     encoder << instance.clientOrigin;
 }
 
-std::optional<WebCore::ClientOrigin> Coder<WebCore::ClientOrigin>::decode(Decoder& decoder)
+std::optional<WebCore::ClientOrigin> Coder<WebCore::ClientOrigin>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<WebCore::SecurityOriginData> topOrigin;
     std::optional<WebCore::SecurityOriginData> clientOrigin;
@@ -666,14 +666,14 @@ std::optional<WebCore::ClientOrigin> Coder<WebCore::ClientOrigin>::decode(Decode
     return WebCore::ClientOrigin { WTFMove(*topOrigin), WTFMove(*clientOrigin) };
 }
 
-void Coder<WebCore::SecurityOriginData>::encode(Encoder& encoder, const WebCore::SecurityOriginData& instance)
+void Coder<WebCore::SecurityOriginData>::encodeForPersistence(Encoder& encoder, const WebCore::SecurityOriginData& instance)
 {
     encoder << instance.protocol();
     encoder << instance.host();
     encoder << instance.port();
 }
 
-std::optional<WebCore::SecurityOriginData> Coder<WebCore::SecurityOriginData>::decode(Decoder& decoder)
+std::optional<WebCore::SecurityOriginData> Coder<WebCore::SecurityOriginData>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<String> protocol;
     decoder >> protocol;
@@ -697,12 +697,12 @@ std::optional<WebCore::SecurityOriginData> Coder<WebCore::SecurityOriginData>::d
     return data;
 }
 
-void Coder<WebCore::ResourceResponse>::encode(Encoder& encoder, const WebCore::ResourceResponse& instance)
+void Coder<WebCore::ResourceResponse>::encodeForPersistence(Encoder& encoder, const WebCore::ResourceResponse& instance)
 {
     instance.encode(encoder);
 }
 
-std::optional<WebCore::ResourceResponse> Coder<WebCore::ResourceResponse>::decode(Decoder& decoder)
+std::optional<WebCore::ResourceResponse> Coder<WebCore::ResourceResponse>::decodeForPersistence(Decoder& decoder)
 {
     WebCore::ResourceResponse response;
     if (!WebCore::ResourceResponseBase::decode(decoder, response))
@@ -710,12 +710,12 @@ std::optional<WebCore::ResourceResponse> Coder<WebCore::ResourceResponse>::decod
     return response;
 }
 
-void Coder<WebCore::FetchOptions>::encode(Encoder& encoder, const WebCore::FetchOptions& instance)
+void Coder<WebCore::FetchOptions>::encodeForPersistence(Encoder& encoder, const WebCore::FetchOptions& instance)
 {
     instance.encodePersistent(encoder);
 }
 
-std::optional<WebCore::FetchOptions> Coder<WebCore::FetchOptions>::decode(Decoder& decoder)
+std::optional<WebCore::FetchOptions> Coder<WebCore::FetchOptions>::decodeForPersistence(Decoder& decoder)
 {
     WebCore::FetchOptions options;
     if (!WebCore::FetchOptions::decodePersistent(decoder, options))
@@ -725,7 +725,7 @@ std::optional<WebCore::FetchOptions> Coder<WebCore::FetchOptions>::decode(Decode
 
 // Store common HTTP headers as strings instead of using their value in the HTTPHeaderName enumeration
 // so that the headers stored in the cache stays valid even after HTTPHeaderName.in gets updated.
-void Coder<WebCore::HTTPHeaderMap>::encode(Encoder& encoder, const WebCore::HTTPHeaderMap& headers)
+void Coder<WebCore::HTTPHeaderMap>::encodeForPersistence(Encoder& encoder, const WebCore::HTTPHeaderMap& headers)
 {
     encoder << static_cast<uint64_t>(headers.size());
     for (auto& keyValue : headers) {
@@ -734,7 +734,7 @@ void Coder<WebCore::HTTPHeaderMap>::encode(Encoder& encoder, const WebCore::HTTP
     }
 }
 
-std::optional<WebCore::HTTPHeaderMap> Coder<WebCore::HTTPHeaderMap>::decode(Decoder& decoder)
+std::optional<WebCore::HTTPHeaderMap> Coder<WebCore::HTTPHeaderMap>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<uint64_t> headersSize;
     decoder >> headersSize;

--- a/Source/WebCore/platform/WebCorePersistentCoders.h
+++ b/Source/WebCore/platform/WebCorePersistentCoders.h
@@ -56,8 +56,8 @@ class Encoder;
 
 #define DECLARE_CODER(class) \
 template<> struct Coder<class> { \
-    WEBCORE_EXPORT static void encode(Encoder&, const class&); \
-    WEBCORE_EXPORT static std::optional<class> decode(Decoder&); \
+    WEBCORE_EXPORT static void encodeForPersistence(Encoder&, const class&); \
+    WEBCORE_EXPORT static std::optional<class> decodeForPersistence(Decoder&); \
 }
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -910,7 +910,7 @@ std::optional<ResourceResponseBase::ResponseData> ResourceResponseBase::getRespo
 
 namespace WTF::Persistence {
 
-void Coder<WebCore::ResourceResponseBase::CrossThreadData>::encode(Encoder& encoder, const WebCore::ResourceResponseBase::CrossThreadData& data)
+void Coder<WebCore::ResourceResponseBase::CrossThreadData>::encodeForPersistence(Encoder& encoder, const WebCore::ResourceResponseBase::CrossThreadData& data)
 {
     encoder << data.url;
     encoder << data.mimeType;
@@ -930,7 +930,7 @@ void Coder<WebCore::ResourceResponseBase::CrossThreadData>::encode(Encoder& enco
     encoder << data.isRangeRequested;
 }
 
-std::optional<WebCore::ResourceResponseBase::CrossThreadData> Coder<WebCore::ResourceResponseBase::CrossThreadData>::decode(Decoder& decoder)
+std::optional<WebCore::ResourceResponseBase::CrossThreadData> Coder<WebCore::ResourceResponseBase::CrossThreadData>::decodeForPersistence(Decoder& decoder)
 {
     std::optional<URL> url;
     decoder >> url;

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -549,8 +549,8 @@ class Decoder;
 class Encoder;
 
 template<> struct Coder<WebCore::ResourceResponseBase::CrossThreadData> {
-    WEBCORE_EXPORT static void encode(Encoder&, const WebCore::ResourceResponseBase::CrossThreadData&);
-    WEBCORE_EXPORT static std::optional<WebCore::ResourceResponseBase::CrossThreadData> decode(Decoder&);
+    WEBCORE_EXPORT static void encodeForPersistence(Encoder&, const WebCore::ResourceResponseBase::CrossThreadData&);
+    WEBCORE_EXPORT static std::optional<WebCore::ResourceResponseBase::CrossThreadData> decodeForPersistence(Decoder&);
 };
 
 } // namespace Persistence

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp
@@ -32,7 +32,7 @@
 
 namespace WTF::Persistence {
 
-void Coder<WebKit::NetworkCache::Key>::encode(WTF::Persistence::Encoder& encoder, const WebKit::NetworkCache::Key& instance)
+void Coder<WebKit::NetworkCache::Key>::encodeForPersistence(WTF::Persistence::Encoder& encoder, const WebKit::NetworkCache::Key& instance)
 {
     encoder << instance.partition();
     encoder << instance.type();
@@ -42,7 +42,7 @@ void Coder<WebKit::NetworkCache::Key>::encode(WTF::Persistence::Encoder& encoder
     encoder << instance.partitionHash();
 }
 
-std::optional<WebKit::NetworkCache::Key> Coder<WebKit::NetworkCache::Key>::decode(WTF::Persistence::Decoder& decoder)
+std::optional<WebKit::NetworkCache::Key> Coder<WebKit::NetworkCache::Key>::decodeForPersistence(WTF::Persistence::Decoder& decoder)
 {
     WebKit::NetworkCache::Key key;
 
@@ -86,7 +86,7 @@ std::optional<WebKit::NetworkCache::Key> Coder<WebKit::NetworkCache::Key>::decod
 }
 
 #if ENABLE(NETWORK_CACHE_SPECULATIVE_REVALIDATION)
-void Coder<WebKit::NetworkCache::SubresourceInfo>::encode(WTF::Persistence::Encoder& encoder, const WebKit::NetworkCache::SubresourceInfo& instance)
+void Coder<WebKit::NetworkCache::SubresourceInfo>::encodeForPersistence(WTF::Persistence::Encoder& encoder, const WebKit::NetworkCache::SubresourceInfo& instance)
 {
     encoder << instance.key();
     encoder << instance.lastSeen();
@@ -104,7 +104,7 @@ void Coder<WebKit::NetworkCache::SubresourceInfo>::encode(WTF::Persistence::Enco
     encoder << instance.priority();
 }
 
-std::optional<WebKit::NetworkCache::SubresourceInfo> Coder<WebKit::NetworkCache::SubresourceInfo>::decode(WTF::Persistence::Decoder& decoder)
+std::optional<WebKit::NetworkCache::SubresourceInfo> Coder<WebKit::NetworkCache::SubresourceInfo>::decodeForPersistence(WTF::Persistence::Decoder& decoder)
 {
     std::optional<WebKit::NetworkCache::Key> key;
     decoder >> key;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.h
@@ -39,8 +39,8 @@ namespace WTF::Persistence {
 
 #define DECLARE_CODER(class) \
 template<> struct Coder<class> { \
-    static void encode(Encoder&, const class&); \
-    static std::optional<class> decode(Decoder&); \
+    static void encodeForPersistence(Encoder&, const class&); \
+    static std::optional<class> decodeForPersistence(Decoder&); \
 }
 
 DECLARE_CODER(WebKit::NetworkCache::Key);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h
@@ -40,12 +40,12 @@ struct DataKey {
     String type;
     SHA1::Digest identifier;
 
-    template <class Encoder> void encode(Encoder& encoder) const
+    template <class Encoder> void encodeForPersistence(Encoder& encoder) const
     {
         encoder << partition << type << identifier;
     }
 
-    template <class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder& decoder, DataKey& dataKey)
+    template <class Decoder> static WARN_UNUSED_RETURN bool decodeForPersistence(Decoder& decoder, DataKey& dataKey)
     {
         return decoder.decode(dataKey.partition) && decoder.decode(dataKey.type) && decoder.decode(dataKey.identifier);
     }


### PR DESCRIPTION
#### 0a6c03105aa25219198181e1fc052c653e5a4fb5
<pre>
Rename WTF::Persistence::Coder encode/decode methods to set them apart from all other encode/decode methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=261990">https://bugs.webkit.org/show_bug.cgi?id=261990</a>
rdar://115922979

Reviewed by Alex Christensen.

We want to eliminate manually written encode/decode methods used for IPC, and these more explicit method names
for Persistence Coders will help tools more easily find the IPC-specific ones in our code base.

* Source/WTF/wtf/persistence/PersistentCoders.cpp:
(WTF::Persistence::Coder&lt;AtomString&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;AtomString&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;CString&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;CString&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;String&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;String&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;URL&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;URL&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;SHA1::Digest&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;SHA1::Digest&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WallTime&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WallTime&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;Seconds&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;Seconds&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;AtomString&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;AtomString&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;CString&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;CString&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;String&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;String&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;URL&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;URL&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;SHA1::Digest&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;SHA1::Digest&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WallTime&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WallTime&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;Seconds&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;Seconds&gt;::decode): Deleted.
* Source/WTF/wtf/persistence/PersistentCoders.h:
(WTF::Persistence::Coder&lt;std::optional&lt;T&gt;&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;std::optional&lt;T&gt;&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;std::optional&lt;T&gt;&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;std::optional&lt;T&gt;&gt;::decode): Deleted.
* Source/WTF/wtf/persistence/PersistentDecoder.h:
(WTF::Persistence::Decoder::operator&gt;&gt;):
* Source/WTF/wtf/persistence/PersistentEncoder.h:
(WTF::Persistence::Encoder::operator&lt;&lt;):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::getSerializedCertificate):
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::AppHighlightRangeData::NodePathComponent&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::AppHighlightRangeData::NodePathComponent&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::AppHighlightRangeData&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::AppHighlightRangeData&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ImportedScriptAttributes&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ImportedScriptAttributes&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ImageResource&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ImageResource&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::CertificateInfo&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::CertificateInfo&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;GRefPtr&lt;GByteArray&gt;&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::NavigationPreloadState&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::NavigationPreloadState&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::CrossOriginEmbedderPolicy&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::CrossOriginEmbedderPolicy&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ContentSecurityPolicyResponseHeaders&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ContentSecurityPolicyResponseHeaders&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ClientOrigin&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ClientOrigin&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::SecurityOriginData&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::SecurityOriginData&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponse&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponse&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::FetchOptions&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::FetchOptions&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::HTTPHeaderMap&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::HTTPHeaderMap&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::AppHighlightRangeData::NodePathComponent&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::AppHighlightRangeData::NodePathComponent&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::AppHighlightRangeData&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::AppHighlightRangeData&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ImportedScriptAttributes&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ImportedScriptAttributes&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ImageResource&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ImageResource&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::CertificateInfo&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::CertificateInfo&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;GRefPtr&lt;GByteArray&gt;&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::NavigationPreloadState&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::NavigationPreloadState&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::CrossOriginEmbedderPolicy&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::CrossOriginEmbedderPolicy&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ContentSecurityPolicyResponseHeaders&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ContentSecurityPolicyResponseHeaders&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ClientOrigin&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ClientOrigin&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::SecurityOriginData&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::SecurityOriginData&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ResourceResponse&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ResourceResponse&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::FetchOptions&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::FetchOptions&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::HTTPHeaderMap&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::HTTPHeaderMap&gt;::decode): Deleted.
* Source/WebCore/platform/WebCorePersistentCoders.h:
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseBase::CrossThreadData&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseBase::CrossThreadData&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseBase::CrossThreadData&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebCore::ResourceResponseBase::CrossThreadData&gt;::decode): Deleted.
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.cpp:
(WTF::Persistence::Coder&lt;WebKit::NetworkCache::Key&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebKit::NetworkCache::Key&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebKit::NetworkCache::SubresourceInfo&gt;::encodeForPersistence):
(WTF::Persistence::Coder&lt;WebKit::NetworkCache::SubresourceInfo&gt;::decodeForPersistence):
(WTF::Persistence::Coder&lt;WebKit::NetworkCache::Key&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebKit::NetworkCache::Key&gt;::decode): Deleted.
(WTF::Persistence::Coder&lt;WebKit::NetworkCache::SubresourceInfo&gt;::encode): Deleted.
(WTF::Persistence::Coder&lt;WebKit::NetworkCache::SubresourceInfo&gt;::decode): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheCoders.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.h:
(WebKit::NetworkCache::DataKey::encodeForPersistence const):
(WebKit::NetworkCache::DataKey::decodeForPersistence):
(WebKit::NetworkCache::DataKey::encode const): Deleted.
(WebKit::NetworkCache::DataKey::decode): Deleted.

Canonical link: <a href="https://commits.webkit.org/268356@main">https://commits.webkit.org/268356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de2be5433d1264be1c6f42a9089f1d82f809304b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18168 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19993 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22178 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23984 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16876 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21955 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18770 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15618 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22825 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17593 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4648 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21948 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24077 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18277 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5374 "Passed tests") | 
<!--EWS-Status-Bubble-End-->