### PR TITLE
REGRESSION (macOS Sonoma): Mouse clicks in Safari are sometimes vertically offset

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -87,7 +87,7 @@ public:
     WEBCORE_EXPORT virtual WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps> = { });
 
     bool isRubberBandInProgressForNode(ScrollingNodeID);
-    void setRubberBandingInProgressForNode(ScrollingNodeID, bool);
+    WEBCORE_EXPORT virtual void setRubberBandingInProgressForNode(ScrollingNodeID, bool);
 
     bool isUserScrollInProgressForNode(ScrollingNodeID);
     void setUserScrollInProgressForNode(ScrollingNodeID, bool);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -88,6 +88,7 @@ header: "RemoteScrollingUIState.h"
 [OptionSet] enum class WebKit::RemoteScrollingUIStateChanges : uint8_t {
     ScrollSnapNodes
     UserScrollNodes
+    RubberbandingNodes
 };
 
 [LegacyPopulateFromEmptyConstructor] class WebKit::RemoteLayerTreeTransaction {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
@@ -42,6 +42,7 @@ namespace WebKit {
 enum class RemoteScrollingUIStateChanges : uint8_t {
     ScrollSnapNodes     = 1 << 0,
     UserScrollNodes     = 1 << 1,
+    RubberbandingNodes  = 1 << 2,
 };
 
 class RemoteScrollingUIState {
@@ -66,10 +67,16 @@ public:
     void removeNodeWithActiveUserScroll(WebCore::ScrollingNodeID);
     void clearNodesWithActiveUserScroll();
 
+    const HashSet<WebCore::ScrollingNodeID>& nodesWithActiveRubberband() const { return m_nodesWithActiveRubberband; }
+    void addNodeWithActiveRubberband(WebCore::ScrollingNodeID);
+    void removeNodeWithActiveRubberband(WebCore::ScrollingNodeID);
+    void clearNodesWithActiveRubberband();
+
 private:
     OptionSet<RemoteScrollingUIStateChanges> m_changes;
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveScrollSnap;
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveUserScrolls;
+    HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveRubberband;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -123,6 +123,7 @@ public:
     virtual void clearNodesWithUserScrollInProgress() { }
     virtual void hasNodeWithAnimatedScrollChanged(bool) { }
     virtual void setRootNodeIsInUserScroll(bool) { }
+    virtual void setRubberBandingInProgressForNode(WebCore::ScrollingNodeID, bool isRubberBanding) { }
 
     virtual void scrollingTreeNodeDidBeginScrollSnapping(WebCore::ScrollingNodeID) { }
     virtual void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -49,6 +49,7 @@ private:
     bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
     bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&) override;
     void hasNodeWithAnimatedScrollChanged(bool) override;
+    void setRubberBandingInProgressForNode(WebCore::ScrollingNodeID, bool isRubberBanding) override;
 
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -117,6 +117,16 @@ void RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged(bool h
 #endif
 }
 
+void RemoteScrollingCoordinatorProxyMac::setRubberBandingInProgressForNode(ScrollingNodeID nodeID, bool isRubberBanding)
+{
+    if (isRubberBanding)
+        m_uiState.addNodeWithActiveRubberband(nodeID);
+    else
+        m_uiState.removeNodeWithActiveRubberband(nodeID);
+
+    sendUIStateChangedIfNecessary();
+}
+
 void RemoteScrollingCoordinatorProxyMac::clearNodesWithUserScrollInProgress()
 {
     m_uiState.clearNodesWithActiveUserScroll();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -78,6 +78,8 @@ private:
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
 
     void hasNodeWithAnimatedScrollChanged(bool) override;
+    void setRubberBandingInProgressForNode(WebCore::ScrollingNodeID, bool) override;
+
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
 
     void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -189,6 +189,16 @@ void RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAn
     });
 }
 
+void RemoteScrollingTreeMac::setRubberBandingInProgressForNode(ScrollingNodeID nodeID, bool isRubberBanding)
+{
+    ScrollingTree::setRubberBandingInProgressForNode(nodeID, isRubberBanding);
+
+    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, isRubberBanding] {
+        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+            scrollingCoordinatorProxy->setRubberBandingInProgressForNode(nodeID, isRubberBanding);
+    });
+}
+
 void RemoteScrollingTreeMac::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode& node, ScrollingLayerPositionAction action)
 {
     ScrollingTree::scrollingTreeNodeDidScroll(node, action);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -144,6 +144,9 @@ void RemoteScrollingCoordinator::scrollingStateInUIProcessChanged(const RemoteSc
 
     if (uiState.changes().contains(RemoteScrollingUIStateChanges::UserScrollNodes))
         m_nodesWithActiveUserScrolls = uiState.nodesWithActiveUserScrolls();
+
+    if (uiState.changes().contains(RemoteScrollingUIStateChanges::RubberbandingNodes))
+        m_nodesWithActiveRubberBanding = uiState.nodesWithActiveRubberband();
 }
 
 void RemoteScrollingCoordinator::addNodeWithActiveRubberBanding(ScrollingNodeID nodeID)


### PR DESCRIPTION
#### 0e58303d1704d1c10addc361f5b87270c9583854
<pre>
REGRESSION (macOS Sonoma): Mouse clicks in Safari are sometimes vertically offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=261992">https://bugs.webkit.org/show_bug.cgi?id=261992</a>
rdar://113335852

Reviewed by Richard Robinson.

Some combinations of user scrolling and programmatic scrolling can result in a state where the UI
process and web process end up with different notions of scroll position. That causes hover and
clicks to be offset from where they should be.

This change does not address the fundamental cause of the bug, but does address one common case,
which is a programmatic scroll triggered by a content size change; this occurs on sites that toggle
a header banner between fixed and non-fixed based on scroll position.

There was already code in `ScrollView::updateScrollbars()` to prevent scroll position clamping due
to size adjustment when rubberbanding, but on macOS with UI-side compositing,
`isRubberBandInProgress()` would always return false.

The fix is to maintain RemoteScrollingCoordinator&apos;s set of nodes with active rubberbands on macOS
like we do on iOS, since `isRubberBandInProgress()` consults this set. We follow
&quot;nodeWithActiveUserScroll&quot; in `RemoteScrollingUIState`, having
`RemoteScrollingCoordinatorProxyMac::setRubberBandingInProgressForNode()` update this state, which
is pushed to the web process as needed.

I tried to make a test, but this behavior is very timing dependent, and I failed to make a test
that was reliable.

* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.cpp:
(WebKit::RemoteScrollingUIState::encode const):
(WebKit::RemoteScrollingUIState::decode):
(WebKit::RemoteScrollingUIState::reset):
(WebKit::RemoteScrollingUIState::addNodeWithActiveRubberband):
(WebKit::RemoteScrollingUIState::removeNodeWithActiveRubberband):
(WebKit::RemoteScrollingUIState::clearNodesWithActiveRubberband):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h:
(WebKit::RemoteScrollingUIState::nodesWithActiveRubberband const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::setRubberBandingInProgressForNode):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::setRubberBandingInProgressForNode):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::setRubberBandingInProgressForNode):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::scrollingStateInUIProcessChanged):

Canonical link: <a href="https://commits.webkit.org/268363@main">https://commits.webkit.org/268363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df49cbfa3ef082a60eebde93d12c1cb424d3e78c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21320 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/19992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19778 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22177 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23983 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21954 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15617 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17592 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4655 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21946 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->