### PR TITLE
link@rel=stylesheet: Don’t load if bad MIME type, even if resource is empty

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css
@@ -1,0 +1,3 @@
+body {
+    background-color: green;
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css' because non CSS MIME types are not allowed in strict mode.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://localhost:8800/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css' because non CSS MIME types are not allowed in strict mode.
+
+PASS 'load' event does not fire at link@rel=stylesheet having non-empty resource with bad MIME type
+PASS 'load' event does not fire at link@rel=stylesheet having empty resource with bad MIME type
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>stylesheets served with bad MIME types</title>
+<link rel="author" title="Michael[tm] Smith" href="mailto:mike@w3.org">
+<link rel="help" href="https://html.spec.whatwg.org/#link-type-stylesheet:process-the-linked-resource">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  async_test((t) => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "resources/stylesheet-bad-mime-type.css";
+    link.onload = t.unreached_func();
+    link.onerror = t.step_func_done();
+    document.head.append(link);
+  }, "'load' event does not fire at link@rel=stylesheet having non-empty resource with bad MIME type");
+  async_test((t) => {
+    t.step_timeout(() => {
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = "resources/stylesheet-bad-mime-type-empty.css";
+      link.onload = t.unreached_func();
+      link.onerror = t.step_func_done();
+      document.head.append(link);
+    }, 2000);
+  }, "'load' event does not fire at link@rel=stylesheet having empty resource with bad MIME type");
+</script>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://web-platform.test:8800/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css' because non CSS MIME types are not allowed in strict mode.
+CONSOLE MESSAGE: Did not parse stylesheet at 'http://web-platform.test:8800/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css' because non CSS MIME types are not allowed in strict mode.
+
+PASS 'load' event does not fire at link@rel=stylesheet having non-empty resource with bad MIME type
+PASS 'load' event does not fire at link@rel=stylesheet having empty resource with bad MIME type
+

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -75,7 +75,10 @@ String CachedCSSStyleSheet::encoding() const
 
 const String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint, bool* hasValidMIMEType) const
 {
-    if (!m_data || m_data->isEmpty() || !canUseSheet(mimeTypeCheckHint, hasValidMIMEType))
+    // Ensure hasValidMIMEType always gets set (even if m_data is null or empty) — which in
+    // turn ensures that if the MIME type isn't text/css, we never load the resource.
+    // https://html.spec.whatwg.org/#link-type-stylesheet:process-the-linked-resource
+    if (!canUseSheet(mimeTypeCheckHint, hasValidMIMEType) || !m_data || m_data->isEmpty())
         return String();
 
     if (!m_decodedSheetText.isNull())


### PR DESCRIPTION
#### c31f4e6a298d56fd8fee979fbef060b001c7674e
<pre>
link@rel=stylesheet: Don’t load if bad MIME type, even if resource is empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=261811">https://bugs.webkit.org/show_bug.cgi?id=261811</a>

Reviewed by Chris Dumez.

When a resource from a &lt;link rel=stylesheet&gt; element has a non-CSS MIME
type and is also empty (has no body/data), this change ensures that
WebKit fully conforms to the requirement in the HTML standard at
<a href="https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet">https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet</a>
that no “load” event is fired at the element.

The change also ensures that a “Did not parse stylesheet… because non
CSS MIME types are not allowed in strict mode” error is logged to the
Web Inspector console.

Otherwise, without this change, WebKit fires a “load” event in this case —
and so, doesn’t conform to the relevant requirement in the HTML standard —
and also logs no error to the Web Inspector console.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type-empty.css.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css: Added.
(body):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/resources/stylesheet-bad-mime-type.css.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type.html: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/document-metadata/the-link-element/stylesheet-bad-mime-type-expected.txt: Added.
Changed expectations to have <a href="http://web-platform.test">http://web-platform.test</a>:8800 URL in console message, rather than <a href="http://localhost">http://localhost</a>:8800
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::sheetText const):

Canonical link: <a href="https://commits.webkit.org/268535@main">https://commits.webkit.org/268535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35a19683bf38f585e2662391154401767a87b579

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20551 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22721 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24425 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22414 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18000 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4778 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22460 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->