### PR TITLE
Declarative Web Push: Add "defaultAction" member to Notification and NotificationOptions

### DIFF
--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -72,6 +72,10 @@ public:
         RefPtr<SerializedScriptValue> serializedData;
         RefPtr<JSON::Value> jsonData;
         std::optional<bool> silent;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+        String defaultAction;
+        URL defaultActionURL;
+#endif
     };
     // For JS constructor only.
     static ExceptionOr<Ref<Notification>> create(ScriptExecutionContext&, String&& title, Options&&);
@@ -85,6 +89,9 @@ public:
     void show(CompletionHandler<void()>&& = [] { });
     void close();
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    const URL& defaultAction() const { return m_defaultActionURL; }
+#endif
     const String& title() const { return m_title; }
     Direction dir() const { return m_direction; }
     const String& body() const { return m_body; }
@@ -145,6 +152,9 @@ private:
 
     WTF::UUID m_identifier;
 
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    URL m_defaultActionURL;
+#endif
     String m_title;
     Direction m_direction;
     String m_lang;

--- a/Source/WebCore/Modules/notifications/Notification.idl
+++ b/Source/WebCore/Modules/notifications/Notification.idl
@@ -48,6 +48,7 @@
     attribute EventHandler onclick;
     attribute EventHandler onerror;
 
+    [Conditional=DECLARATIVE_WEB_PUSH, EnabledBySetting=DeclarativeWebPush] readonly attribute USVString defaultAction;
     readonly attribute DOMString title;
     readonly attribute NotificationDirection dir;
     readonly attribute DOMString lang;

--- a/Source/WebCore/Modules/notifications/NotificationOptions.idl
+++ b/Source/WebCore/Modules/notifications/NotificationOptions.idl
@@ -26,6 +26,7 @@
 [
     Conditional=NOTIFICATIONS
 ] dictionary NotificationOptions {
+    [Conditional=DECLARATIVE_WEB_PUSH, EnabledBySetting=DeclarativeWebPush] USVString defaultAction = "";
     NotificationDirection dir = "auto";
     DOMString lang = "";
     DOMString body = "";

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -319,6 +319,11 @@ void ServiceWorkerRegistration::showNotification(ScriptExecutionContext& context
 #if ENABLE(DECLARATIVE_WEB_PUSH)
         if (RefPtr pushNotificationEvent = serviceWorkerGlobalScope->pushNotificationEvent()) {
             auto notification = notificationResult.releaseReturnValue();
+            if (!notification->defaultAction().isValid()) {
+                promise->reject(Exception { TypeError, "Call to showNotification() while handling a `pushnotification` event did not include NotificationOptions that specify a valid defaultAction url"_s });
+                return;
+            }
+
             pushNotificationEvent->setUpdatedNotificationData(notification->data());
             return;
         }


### PR DESCRIPTION
#### 72258dba1b792f0c7f60bb30c81ecc2d8d4b4bfe
<pre>
Declarative Web Push: Add &quot;defaultAction&quot; member to Notification and NotificationOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=262004">https://bugs.webkit.org/show_bug.cgi?id=262004</a>
rdar://115938949

Reviewed by Dan Glastonbury.

When a declarative web push message comes in, it is required to have a default action URL.
This is so the user activating the notification can bypass service workers, as service workers are not required.

If the message is mutable, and a `pushnotification` event handler decides to show a different notification,
then that notification also needs a default action URL.

We put that as an option on NotificationOptions, add a Notification accessor for it, and enforce that
new notifications shown during `pushnotification` event handlers have one.

Then we test it.

* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::create):
(WebCore::Notification::Notification):
(WebCore::Notification::data const):
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/Notification.idl:
* Source/WebCore/Modules/notifications/NotificationOptions.idl:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::showNotification):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/268402@main">https://commits.webkit.org/268402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/992d91cf2e027d220100712448d1577cda6729d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19588 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18321 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19917 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22338 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24129 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22101 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15767 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17747 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4684 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->