### PR TITLE
[iOS] [WK2] Adopt _UIAsyncDragInteraction and _UIAsyncDragInteractionDelegate

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6851,6 +6851,20 @@ UseARKitForModel:
     WebKit:
       default: true
 
+UseAsyncUIKitInteractions:
+  type: bool
+  status: internal
+  humanReadableName: "Async UIKit Interactions"
+  humanReadableDescription: "Use Async UIKit Interactions"
+  condition: PLATFORM(IOS_FAMILY)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 UseCGDisplayListImageCache:
   type: bool
   status: internal

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -124,6 +124,11 @@
 #import <UIKit/_UITextDragCaretView.h>
 #endif
 
+#if HAVE(UI_ASYNC_DRAG_INTERACTION)
+#import <UIKit/UIDragInteraction_AsyncSupport.h>
+#import <UIKit/_UIAsyncDragInteraction.h>
+#endif
+
 #if HAVE(UIFINDINTERACTION)
 #import <UIKit/UIFindSession_Private.h>
 #import <UIKit/_UIFindInteraction.h>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -579,6 +579,9 @@ struct ImageAnalysisContextMenuActionData {
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)
     , WKMouseInteractionDelegate
 #endif
+#if HAVE(UI_ASYNC_DRAG_INTERACTION)
+    , _UIAsyncDragInteractionDelegate
+#endif
 >
 
 @property (nonatomic, readonly) CGPoint lastInteractionLocation;


### PR DESCRIPTION
#### 196398d09011b84ec6081ec5fb5ff932c0de2622
<pre>
[iOS] [WK2] Adopt _UIAsyncDragInteraction and _UIAsyncDragInteractionDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=262006">https://bugs.webkit.org/show_bug.cgi?id=262006</a>
rdar://114331777

Reviewed by Tim Horton.

As a part of cleaning up asynchronous `UIInteraction` integration in WebKit, adopt a new
`_UIAsyncDragInteraction` subclass that encapsulates the delegate methods for both (1) starting a
drag session asynchronously, and (2) adding items to an existing drag session asynchronously.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Add a runtime feature flag as well, to guard adoption of these new async `UIInteraction`s in UIKit.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _dragInteractionClass]):

Add a helper method to return the drag interaction class to instantiate, based on runtime and build-
time flags.

(-[WKContentView setUpDragAndDropInteractions]):
(-[WKContentView asyncDragInteraction:prepareDragSession:completion:]):
(-[WKContentView asyncDragInteraction:itemsForAddingToSession:withTouchAtPoint:completion:]):

Implement the new `_UIAsyncDragInteractionDelegate` methods here.

Canonical link: <a href="https://commits.webkit.org/268470@main">https://commits.webkit.org/268470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26f6a71fdd08eb3f45468b3daa732f2b45249fab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18199 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19809 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22209 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24016 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/16906 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21987 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/18816 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15648 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/22856 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17623 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4733 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21979 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24108 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18307 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5378 "Found 1 jsc stress test failure: microbenchmarks/array-from-object.js.lockdown") | 
<!--EWS-Status-Bubble-End-->