### PR TITLE
REGRESSION(268343@main): Crash under WebCore::PositionedDescendantsMap::removeContainingBlock

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -154,7 +154,7 @@ public:
     void addDescendant(const RenderBlock& containingBlock, RenderBox& positionedDescendant)
     {
         // Protect against double insert where a descendant would end up with multiple containing blocks.
-        auto previousContainingBlock = m_containerMap.get(positionedDescendant);
+        auto previousContainingBlock = m_containerMap.get(&positionedDescendant);
         if (previousContainingBlock && previousContainingBlock != &containingBlock) {
             if (auto* descendants = m_descendantsMap.get(previousContainingBlock.get()))
                 descendants->remove(&positionedDescendant);
@@ -187,15 +187,15 @@ public:
         }
 
         if (!isNewEntry) {
-            ASSERT(m_containerMap.contains(positionedDescendant));
+            ASSERT(m_containerMap.contains(&positionedDescendant));
             return;
         }
-        m_containerMap.set(positionedDescendant, containingBlock);
+        m_containerMap.set(&positionedDescendant, containingBlock);
     }
 
     void removeDescendant(const RenderBox& positionedDescendant)
     {
-        auto containingBlock = m_containerMap.take(positionedDescendant);
+        auto containingBlock = m_containerMap.take(&positionedDescendant);
         if (!containingBlock)
             return;
 
@@ -219,7 +219,7 @@ public:
             return;
 
         for (auto* renderer : *descendants)
-            m_containerMap.remove(*renderer);
+            m_containerMap.remove(renderer);
     }
     
     TrackedRendererListHashSet* positionedRenderers(const RenderBlock& containingBlock) const
@@ -229,7 +229,7 @@ public:
 
 private:
     using DescendantsMap = HashMap<CheckedPtr<const RenderBlock>, std::unique_ptr<TrackedRendererListHashSet>>;
-    using ContainerMap = WeakHashMap<const RenderBox, WeakPtr<const RenderBlock>>;
+    using ContainerMap = HashMap<const RenderBox*, WeakPtr<const RenderBlock>>;
     
     DescendantsMap m_descendantsMap;
     ContainerMap m_containerMap;


### PR DESCRIPTION
#### e9f67fe4c9c1a5881942e18067772c28897f6399
<pre>
REGRESSION(268343@main): Crash under WebCore::PositionedDescendantsMap::removeContainingBlock
<a href="https://bugs.webkit.org/show_bug.cgi?id=261998">https://bugs.webkit.org/show_bug.cgi?id=261998</a>

Reviewed by Chris Dumez.

Some layout tests were crashing under
PositionedDescendantsMap::removeContainingBlock for WinCairo after
268343@main changed PositionedDescendantsMap::ContainerMap to
WeakHashMap. &apos;renderer&apos; in removeContainingBlock wasn&apos;t a live
RenderBox object in the cases. Previously it has no problem because it
just used a raw pointer as a key.

Changed the key of ContainerMap to const RenderBox*.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::PositionedDescendantsMap::addDescendant):
(WebCore::PositionedDescendantsMap::removeDescendant):
(WebCore::PositionedDescendantsMap::removeContainingBlock):

Canonical link: <a href="https://commits.webkit.org/268373@main">https://commits.webkit.org/268373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68a1cb482b8f3edb2037457ff629a96412044b3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18201 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19808 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22211 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24013 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15650 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17625 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4663 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/21981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->