### PR TITLE
Support buttons in vertical writing mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-compressible-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-compressible-002-expected.txt
@@ -37,19 +37,19 @@ FAIL .flexbox 3 assert_equals:
       <div class="spacer"></div>
       <input type="button" value="XXXXXXX" class="test1" data-expected-height="140">
     </div>
-height expected 140 but got 100
+height expected 140 but got 40
 FAIL .flexbox 4 assert_equals:
 <div class="flexbox">
       <div class="spacer"></div>
       <input type="submit" value="XXXXXXX" class="test1" data-expected-height="140">
     </div>
-height expected 140 but got 100
+height expected 140 but got 40
 FAIL .flexbox 5 assert_equals:
 <div class="flexbox">
       <div class="spacer"></div>
       <input type="reset" value="XXXXXXX" class="test1" data-expected-height="140">
     </div>
-height expected 140 but got 100
+height expected 140 but got 40
 FAIL .flexbox 6 assert_equals:
 <div class="flexbox">
       <div class="spacer"></div>
@@ -67,19 +67,19 @@ FAIL .flexbox 8 assert_equals:
       <div class="spacer"></div>
       <input type="button" value="XXXXXXX" class="test2" data-expected-height="140">
     </div>
-height expected 140 but got 100
+height expected 140 but got 40
 FAIL .flexbox 9 assert_equals:
 <div class="flexbox">
       <div class="spacer"></div>
       <input type="submit" value="XXXXXXX" class="test2" data-expected-height="140">
     </div>
-height expected 140 but got 100
+height expected 140 but got 40
 FAIL .flexbox 10 assert_equals:
 <div class="flexbox">
       <div class="spacer"></div>
       <input type="reset" value="XXXXXXX" class="test2" data-expected-height="140">
     </div>
-height expected 140 but got 100
+height expected 140 but got 40
 FAIL .flexbox 11 assert_equals:
 <div class="flexbox">
       <div class="spacer"></div>
@@ -92,22 +92,7 @@ FAIL .flexbox 12 assert_equals:
       <input type="range" class="test3" data-expected-height="140">
     </div>
 height expected 140 but got 129
-FAIL .flexbox 13 assert_equals:
-<div class="flexbox">
-      <div class="spacer"></div>
-      <input type="button" value="XXXXXXX" class="test3" data-expected-height="140">
-    </div>
-height expected 140 but got 100
-FAIL .flexbox 14 assert_equals:
-<div class="flexbox">
-      <div class="spacer"></div>
-      <input type="submit" value="XXXXXXX" class="test3" data-expected-height="140">
-    </div>
-height expected 140 but got 100
-FAIL .flexbox 15 assert_equals:
-<div class="flexbox">
-      <div class="spacer"></div>
-      <input type="reset" value="XXXXXXX" class="test3" data-expected-height="140">
-    </div>
-height expected 140 but got 100
+PASS .flexbox 13
+PASS .flexbox 14
+PASS .flexbox 15
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/button-appearance-native-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/button-appearance-native-computed-style-expected.txt
@@ -1,0 +1,24 @@
+あいなき あいなき あいなき あいなき
+あいなき     あいなき あいなき あいなき あいなき あいなき あいなき
+あいなき あいなき あいなき
+あいなき
+
+PASS horizontal-button block size should match height and inline size should match width
+PASS horizontal-button's height is less than its multi-line counterpart, but width is identical.
+PASS horizontal-button-multiline block size should match height and inline size should match width
+PASS horizontal-input block size should match height and inline size should match width
+PASS horizontal-input's height is less than its multi-line counterpart, but width is identical.
+PASS horizontal-input-multiline block size should match height and inline size should match width
+PASS vertical-lr-button block size should match width and inline size should match height
+PASS vertical-lr-button's width is less than its multi-line counterpart, but height is identical.
+PASS vertical-rl-button block size should match width and inline size should match height
+PASS vertical-rl-button's width is less than its multi-line counterpart, but height is identical.
+PASS vertical-lr-button-multiline block size should match width and inline size should match height
+PASS vertical-rl-button-multiline block size should match width and inline size should match height
+PASS vertical-lr-input block size should match width and inline size should match height
+PASS vertical-lr-input's width is less than its multi-line counterpart, but height is identical.
+PASS vertical-rl-input block size should match width and inline size should match height
+PASS vertical-rl-input's width is less than its multi-line counterpart, but height is identical.
+PASS vertical-lr-input-multiline block size should match width and inline size should match height
+PASS vertical-rl-input-multiline block size should match width and inline size should match height
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/button-appearance-native-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/button-appearance-native-computed-style.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow">
+<title>Button appearance native writing mode computed style</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<button id="horizontal-button">あいなき あいなき</button>
+<button id="horizontal-button-multiline">あいなき あいなき<br>あいなき</button>
+
+<input type="button" id="horizontal-input" value="あいなき あいなき">
+<input type="button" id="horizontal-input-multiline" value="あいなき あいなき&#10;あいなき">
+
+<button id="vertical-lr-button" style="writing-mode: vertical-lr">あいなき あいなき</button>
+<button id="vertical-rl-button" style="writing-mode: vertical-rl">あいなき あいなき</button>
+<button id="vertical-lr-button-multiline" style="writing-mode: vertical-lr">あいなき あいなき<br>あいなき</button>
+<button id="vertical-rl-button-multiline" style="writing-mode: vertical-rl">あいなき あいなき<br>あいなき</button>
+
+<input type="button" id="vertical-lr-input" style="writing-mode: vertical-lr" value="あいなき あいなき">
+<input type="button" id="vertical-rl-input" style="writing-mode: vertical-rl" value="あいなき あいなき">
+<input type="button" id="vertical-lr-input-multiline" style="writing-mode: vertical-lr" value="あいなき あいなき&#10;あいなき">
+<input type="button" id="vertical-rl-input-multiline" style="writing-mode: vertical-rl" value="あいなき あいなき&#10;あいなき">
+
+<script>
+for (const element of document.querySelectorAll("[id^='horizontal-']")) {
+    test(() => {
+        const style = getComputedStyle(element);
+        const blockSize = parseInt(style.blockSize, 10);
+        const inlineSize = parseInt(style.inlineSize, 10);
+        assert_not_equals(blockSize, 0);
+        assert_not_equals(inlineSize, 0);
+        assert_greater_than(inlineSize, blockSize);
+        assert_equals(style.blockSize, style.height);
+        assert_equals(style.inlineSize, style.width);
+    }, `${element.id} block size should match height and inline size should match width`);
+    if (!element.matches("[id$='-multiline']")) {
+        test(() => {
+            const multiline = document.querySelector(`#${element.id}-multiline`);
+            const style = getComputedStyle(element);
+            const multilineStyle = getComputedStyle(multiline);
+            assert_greater_than(parseInt(multilineStyle.height, 10), parseInt(style.height, 10));
+            assert_equals(multilineStyle.width, style.width);
+        }, `${element.id}'s height is less than its multi-line counterpart, but width is identical.`);
+    }
+}
+
+for (const element of document.querySelectorAll("[id^='vertical-']")) {
+    test(() => {
+        const style = getComputedStyle(element);
+        const blockSize = parseInt(style.blockSize, 10);
+        const inlineSize = parseInt(style.inlineSize, 10);
+        assert_not_equals(blockSize, 0);
+        assert_not_equals(inlineSize, 0);
+        assert_greater_than(inlineSize, blockSize);
+        assert_equals(style.blockSize, style.width);
+        assert_equals(style.inlineSize, style.height);
+    }, `${element.id} block size should match width and inline size should match height`);
+
+    if (!element.matches("[id$='-multiline']")) {
+        test(() => {
+            const multiline = document.querySelector(`#${element.id}-multiline`);
+            const style = getComputedStyle(element);
+            const multilineStyle = getComputedStyle(multiline);
+            assert_greater_than(parseInt(multilineStyle.width, 10), parseInt(style.width, 10));
+            assert_equals(multilineStyle.height, style.height);
+        }, `${element.id}'s width is less than its multi-line counterpart, but height is identical.`);
+    }
+}
+</script>

--- a/Source/WebCore/css/horizontalFormControls.css
+++ b/Source/WebCore/css/horizontalFormControls.css
@@ -25,6 +25,6 @@
 @namespace "http://www.w3.org/1999/xhtml";
 
 /* Every time a new control is supported in vertical writing mode, it should be added here and removed from the html.css rule */
-textarea, progress, meter, input:not([type="button"], [type="submit"], [type="reset"], [type="file"]) {
+button, textarea, progress, meter, input:not([type="file"]) {
     writing-mode: horizontal-tb !important;
 }

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -400,7 +400,7 @@ button {
 }
 
 /* Every time a new control is supported in vertical writing mode, it should be removed from here and added in the horizontalFormControls.css rule */
-select, button, input:is([type="button"], [type="submit"], [type="reset"], [type="file"]) {
+select, input[type="file"] {
     writing-mode: horizontal-tb !important;
 }
 
@@ -860,11 +860,13 @@ input:is([type="button"], [type="submit"], [type="reset"]), input[type="file"]::
     cursor: default;
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
     color: ButtonText;
-    padding: 2px 6px 3px 6px;
+    padding-block: 2px 3px;
+    padding-inline: 6px;
     border: 2px outset ButtonFace;
     background-color: ButtonFace;
 #else
-    padding: 0 1.0em;
+    padding-block: 0;
+    padding-inline: 1em;
     border: 1px solid -webkit-control-background;
     font: 11px system-ui;
     color: -apple-system-blue;

--- a/Source/WebCore/rendering/RenderButton.cpp
+++ b/Source/WebCore/rendering/RenderButton.cpp
@@ -78,12 +78,19 @@ void RenderButton::setInnerRenderer(RenderBlock& innerRenderer)
 void RenderButton::updateAnonymousChildStyle(RenderStyle& childStyle) const
 {
     childStyle.setFlexGrow(1.0f);
-    // min-width: 0; is needed for correct shrinking.
-    childStyle.setMinWidth(Length(0, LengthType::Fixed));
-    // Use margin:auto instead of align-items:center to get safe centering, i.e.
+
+    // min-inline-size: 0; is needed for correct shrinking.
+    // Use margin-block:auto instead of align-items:center to get safe centering, i.e.
     // when the content overflows, treat it the same as align-items: flex-start.
-    childStyle.setMarginTop(Length());
-    childStyle.setMarginBottom(Length());
+    if (isHorizontalWritingMode()) {
+        childStyle.setMinWidth(Length(0, LengthType::Fixed));
+        childStyle.setMarginTop(Length());
+        childStyle.setMarginBottom(Length());
+    } else {
+        childStyle.setMinHeight(Length(0, LengthType::Fixed));
+        childStyle.setMarginLeft(Length());
+        childStyle.setMarginRight(Length());
+    }
     childStyle.setFlexDirection(style().flexDirection());
     childStyle.setJustifyContent(style().justifyContent());
     childStyle.setFlexWrap(style().flexWrap());

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -231,6 +231,17 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
         // Border
         LengthBox borderBox(style.borderTopWidth(), style.borderRightWidth(), style.borderBottomWidth(), style.borderLeftWidth());
         borderBox = Theme::singleton().controlBorder(appearance, style.fontCascade(), borderBox, style.effectiveZoom());
+
+        auto supportsVerticalWritingMode = [](StyleAppearance appearance) {
+            return appearance == StyleAppearance::Button
+                || appearance == StyleAppearance::DefaultButton
+                || appearance == StyleAppearance::SquareButton
+                || appearance == StyleAppearance::PushButton;
+        };
+        // Transpose for vertical writing mode:
+        if (!style.isHorizontalWritingMode() && supportsVerticalWritingMode(appearance))
+            borderBox = LengthBox(borderBox.left().value(), borderBox.top().value(), borderBox.right().value(), borderBox.bottom().value());
+
         if (borderBox.top().value() != static_cast<int>(style.borderTopWidth())) {
             if (borderBox.top().value())
                 style.setBorderTopWidth(borderBox.top().value());


### PR DESCRIPTION
#### 75c116236d3fb405a955fd1cf05feb7fffd45bbb
<pre>
Support buttons in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=117231">https://bugs.webkit.org/show_bug.cgi?id=117231</a>
rdar://102651654

Reviewed by Aditya Keerthi.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-compressible-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/button-appearance-native-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/button-appearance-native-computed-style.html: Added.
* Source/WebCore/css/horizontalFormControls.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
* Source/WebCore/css/html.css:
(select, input[type=&quot;file&quot;]):
(input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;]), input[type=&quot;file&quot;]::file-selector-button, button):
(select, button, input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;], [type=&quot;file&quot;])): Deleted.
* Source/WebCore/rendering/RenderButton.cpp:
(WebCore::RenderButton::updateAnonymousChildStyle const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):

Canonical link: <a href="https://commits.webkit.org/268370@main">https://commits.webkit.org/268370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1bd83da5b572d958f983a4d73c1d9b0e016f5a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20056 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19836 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22241 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16924 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24041 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22012 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18511 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17567 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4661 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->