### PR TITLE
Fix inconsistent test results for webvtt/paring tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align-expected.txt
@@ -1,4 +1,4 @@
 
 PASS VTTCue.align, script-created cue
-FAIL VTTCue.align, parsed cue null is not an object (evaluating 't.track.cues[0]')
+PASS VTTCue.align, parsed cue
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ captionDisplayMode=automatic ] -->
 <title>VTTCue.align</title>
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-align">
 <script src=/resources/testharness.js></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line-expected.txt
@@ -1,4 +1,4 @@
 
 PASS VTTCue.line, script-created cue
-FAIL VTTCue.line, parsed cue null is not an object (evaluating 't.track.cues[0]')
+PASS VTTCue.line, parsed cue
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ captionDisplayMode=automatic ] -->
 <title>VTTCue.line</title>
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-line">
 <script src=/resources/testharness.js></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt
@@ -1,4 +1,4 @@
 
 PASS VTTCue.snapToLines, script-created cue
-FAIL VTTCue.snapToLines, parsed cue null is not an object (evaluating 't.track.cues[0]')
+FAIL VTTCue.snapToLines, parsed cue assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ captionDisplayMode=automatic ] -->
 <title>VTTCue.snapToLines</title>
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-snaptolines">
 <script src=/resources/testharness.js></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text-expected.txt
@@ -1,4 +1,4 @@
 
 PASS VTTCue.text, script-created cue
-FAIL VTTCue.text, parsed cue null is not an object (evaluating 'c[0]')
+PASS VTTCue.text, parsed cue
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ captionDisplayMode=automatic ] -->
 <title>VTTCue.text</title>
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-text">
 <script src=/resources/testharness.js></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical-expected.txt
@@ -1,4 +1,4 @@
 
 PASS VTTCue.vertical, script-created cue
-FAIL VTTCue.vertical, parsed cue null is not an object (evaluating 't.track.cues[0]')
+PASS VTTCue.vertical, parsed cue
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ captionDisplayMode=automatic ] -->
 <title>VTTCue.vertical</title>
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-vertical">
 <script src=/resources/testharness.js></script>


### PR DESCRIPTION
#### 4fd46adb8769322fc06e7d39b8d9cea72f6d01b6
<pre>
Fix inconsistent test results for webvtt/paring tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=262010">https://bugs.webkit.org/show_bug.cgi?id=262010</a>

Reviewed by Dan Glastonbury.

Even though these tests have succeeded, they are labeled as failures
due to the default setting not displaying the caption. To fix this issue,
we should set the caption mode to `automatic` by the captionDisplayMode option.

* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/align.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/line.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/text.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/vertical.html:

Canonical link: <a href="https://commits.webkit.org/268638@main">https://commits.webkit.org/268638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9152885c49d83bcf2e8f0eed9dc244eba0f7f575

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21395 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18241 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19845 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22251 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24051 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22022 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15972 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17574 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4858 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->