### PR TITLE
Avoid forced layouts because of scrollTo(0,0) if the element hasn't scrolled

### DIFF
--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -629,8 +629,8 @@ public:
     inline bool hasName() const;
     inline const SpaceSplitString& classNames() const;
 
-    IntPoint savedLayerScrollPosition() const;
-    void setSavedLayerScrollPosition(const IntPoint&);
+    ScrollPosition savedLayerScrollPosition() const;
+    void setSavedLayerScrollPosition(const ScrollPosition&);
 
     enum class EventIsDefaultPrevented : bool { No, Yes };
     enum class EventIsDispatched : bool { No, Yes };
@@ -846,7 +846,7 @@ private:
     void addAttributeInternal(const QualifiedName&, const AtomString& value, InSynchronizationOfLazyAttribute);
     void removeAttributeInternal(unsigned index, InSynchronizationOfLazyAttribute);
 
-    void setSavedLayerScrollPositionSlow(const IntPoint&);
+    void setSavedLayerScrollPositionSlow(const ScrollPosition&);
     void clearBeforePseudoElementSlow();
     void clearAfterPseudoElementSlow();
 
@@ -913,13 +913,16 @@ private:
     bool hasLanguageAttribute() const { return hasLangAttr() || hasXMLLangAttr(); }
     bool hasLangAttrKnownToMatchDocumentElement() const { return hasLanguageAttribute() && effectiveLangKnownToMatchDocumentElement(); }
 
+    bool hasEverHadSmoothScroll() const { return hasEventTargetFlag(EventTargetFlag::EverHadSmoothScroll); }
+    void setHasEverHadSmoothScroll(bool value) { return setEventTargetFlag(EventTargetFlag::EverHadSmoothScroll, value); }
+
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.
 
     QualifiedName m_tagName;
     RefPtr<ElementData> m_elementData;
 };
 
-inline void Element::setSavedLayerScrollPosition(const IntPoint& position)
+inline void Element::setSavedLayerScrollPosition(const ScrollPosition& position)
 {
     if (position.isZero() && !hasRareData())
         return;

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -107,8 +107,8 @@ public:
     DatasetDOMStringMap* dataset() const { return m_dataset.get(); }
     void setDataset(std::unique_ptr<DatasetDOMStringMap>&& dataset) { m_dataset = WTFMove(dataset); }
 
-    IntPoint savedLayerScrollPosition() const { return m_savedLayerScrollPosition; }
-    void setSavedLayerScrollPosition(IntPoint position) { m_savedLayerScrollPosition = position; }
+    ScrollPosition savedLayerScrollPosition() const { return m_savedLayerScrollPosition; }
+    void setSavedLayerScrollPosition(ScrollPosition position) { m_savedLayerScrollPosition = position; }
 
     ElementAnimationRareData* animationRareData(PseudoId) const;
     ElementAnimationRareData& ensureAnimationRareData(PseudoId);
@@ -215,8 +215,8 @@ private:
     int m_unusualTabIndex { 0 }; // Keep on top for better bit packing with NodeRareData.
 
     std::optional<OptionSet<ContentRelevancy>> m_contentRelevancy;
+    ScrollPosition m_savedLayerScrollPosition;
 
-    IntPoint m_savedLayerScrollPosition;
     std::unique_ptr<RenderStyle> m_computedStyle;
     std::unique_ptr<RenderStyle> m_displayContentsStyle;
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -162,13 +162,14 @@ protected:
     WEBCORE_EXPORT virtual ~EventTarget();
 
     enum class EventTargetFlag : uint16_t {
-        HasEventTargetData = 1 << 0,
-        IsNode = 1 << 1,
+        HasEventTargetData                          = 1 << 0,
+        IsNode                                      = 1 << 1,
         // Element bits
-        HasDuplicateAttribute = 1 << 2,
-        HasLangAttr = 1 << 3,
-        HasXMLLangAttr = 1 << 4,
-        EffectiveLangKnownToMatchDocumentElement = 1 << 5,
+        HasDuplicateAttribute                       = 1 << 2,
+        HasLangAttr                                 = 1 << 3,
+        HasXMLLangAttr                              = 1 << 4,
+        EffectiveLangKnownToMatchDocumentElement    = 1 << 5,
+        EverHadSmoothScroll                         = 1 << 6,
     };
 
     EventTargetData& ensureEventTargetData()

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "ScrollTypes.h"
 
+#include "ScrollBehavior.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -68,6 +69,16 @@ TextStream& operator<<(TextStream& ts, ScrollBehaviorForFixedElements behavior)
     case ScrollBehaviorForFixedElements::StickToViewportBounds:
         ts << 1;
         break;
+    }
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, ScrollBehavior behavior)
+{
+    switch (behavior) {
+    case ScrollBehavior::Auto: ts << "auto"; break;
+    case ScrollBehavior::Instant: ts << "instant"; break;
+    case ScrollBehavior::Smooth: ts << "smooth"; break;
     }
     return ts;
 }

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -38,6 +38,8 @@ namespace WebCore {
 
 class IntPoint;
 
+enum class ScrollBehavior : uint8_t;
+
 // scrollPosition is in content coordinates (0,0 is at scrollOrigin), so may have negative components.
 using ScrollPosition = IntPoint;
 // scrollOffset() is the value used by scrollbars (min is 0,0), and should never have negative components.
@@ -376,6 +378,7 @@ struct ScrollPositionChangeOptions {
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollType);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollClamping);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollBehaviorForFixedElements);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollBehavior);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollElasticity);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarMode);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, OverflowAnchor);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -107,7 +107,7 @@ void RenderLayerScrollableArea::clear()
 #if ENABLE(IOS_TOUCH_EVENTS)
     unregisterAsTouchEventListenerForScrolling();
 #endif
-    if (Element* element = renderer.element())
+    if (auto* element = renderer.element())
         element->setSavedLayerScrollPosition(m_scrollPosition);
 
     destroyScrollbar(ScrollbarOrientation::Horizontal);
@@ -133,7 +133,7 @@ void RenderLayerScrollableArea::restoreScrollPosition()
             scrollAnimator().setCurrentPosition(m_scrollPosition);
     }
 
-    element->setSavedLayerScrollPosition(IntPoint());
+    element->setSavedLayerScrollPosition({ });
 }
 
 bool RenderLayerScrollableArea::shouldPlaceVerticalScrollbarOnLeft() const
@@ -351,6 +351,9 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     m_scrollPosition = newPosition;
 
     auto& renderer = m_layer.renderer();
+    if (auto* element = renderer.element())
+        element->setSavedLayerScrollPosition(m_scrollPosition);
+
     RenderView& view = renderer.view();
 
     // Update the positions of our child layers (if needed as only fixed layers should be impacted by a scroll).


### PR DESCRIPTION
#### 13f0d241c7f2d817c79ec142f33b54b35597b42b
<pre>
Avoid forced layouts because of scrollTo(0,0) if the element hasn&apos;t scrolled
<a href="https://bugs.webkit.org/show_bug.cgi?id=262012">https://bugs.webkit.org/show_bug.cgi?id=262012</a>
<a href="https://rdar.apple.com/115732977">rdar://115732977</a>

Reviewed by Ryosuke Niwa.

We force a layout in `Element::scrollTo()` to ensure that style is up-to-date for checking
`document().scrollingElement()`, and to layout so that scrollHeight etc is computed.

But we can avoid this layout if the scrollTo() is to 0,0, and if this element&apos;s scroll
position was already 0,0. Do this by updating `Element::savedLayerScrollPosition()` on
every scroll (instead of just when a RenderLayer is torn down), and check this, and some
other conditions, before short-circuiting the scrollTo.

We have to store a bit in EventTargetFlags to say if this element has ever had a smooth scroll because
`scrollTo(0, 500, { behavior: smooth})` immediately followed by scrollTo(0, 0)` needs
to not short-circuit in order to cancel the animated scroll (tested by
imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html).

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollTo):
(WebCore::Element::setScrollLeft):
(WebCore::Element::setScrollTop):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::setSavedLayerScrollPositionSlow):
* Source/WebCore/dom/Element.h:
(WebCore::Element::hasEverHadSmoothScroll const):
(WebCore::Element::setHasEverHadSmoothScroll):
(WebCore::Element::setSavedLayerScrollPosition):
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::savedLayerScrollPosition const):
(WebCore::ElementRareData::setSavedLayerScrollPosition):
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::clear):
(WebCore::RenderLayerScrollableArea::restoreScrollPosition):
(WebCore::RenderLayerScrollableArea::scrollTo):

Canonical link: <a href="https://commits.webkit.org/271943@main">https://commits.webkit.org/271943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/765317ff321a209e7b09422058e4df0df968bcc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32543 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27189 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32571 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30371 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8079 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7133 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->