### PR TITLE
Move off of UIKit SPI: -[UIScrollView _is(Vertical|Horizontal)Bouncing]

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -455,8 +455,6 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 - (double)_verticalVelocity;
 - (void)_flashScrollIndicatorsForAxes:(UIAxis)axes persistingPreviousFlashes:(BOOL)persisting;
 @property (nonatomic, getter=isZoomEnabled) BOOL zoomEnabled;
-@property (nonatomic, readonly, getter=_isVerticalBouncing) BOOL isVerticalBouncing;
-@property (nonatomic, readonly, getter=_isHorizontalBouncing) BOOL isHorizontalBouncing;
 @property (nonatomic, readonly, getter=_isAnimatingZoom) BOOL isAnimatingZoom;
 @property (nonatomic, readonly, getter=_isAnimatingScroll) BOOL isAnimatingScroll;
 @property (nonatomic, getter=_contentScrollInset, setter=_setContentScrollInset:) UIEdgeInsets contentScrollInset;

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -37,6 +37,22 @@
     return self.decelerating && self.tracking;
 }
 
+- (BOOL)_wk_isScrolledBeyondExtents
+{
+    auto contentOffset = self.contentOffset;
+    auto inset = self.adjustedContentInset;
+    if (contentOffset.x < -inset.left || contentOffset.y < -inset.top)
+        return YES;
+
+    auto contentSize = self.contentSize;
+    auto boundsSize = self.bounds.size;
+    auto maxScrollExtent = CGPointMake(
+        contentSize.width + inset.right - std::min<CGFloat>(boundsSize.width, contentSize.width + inset.left + inset.right),
+        contentSize.height + inset.bottom - std::min<CGFloat>(boundsSize.height, contentSize.height + inset.top + inset.bottom)
+    );
+    return contentOffset.x > maxScrollExtent.x || contentOffset.y > maxScrollExtent.y;
+}
+
 @end
 
 @implementation UIView (WebKitInternal)

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -30,6 +30,7 @@
 
 #import "Logging.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "WKDeferringGestureRecognizer.h"
 #import "WKWebViewIOS.h"
 #import "WebPage.h"
@@ -415,8 +416,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 - (void)_setContentSizePreservingContentOffsetDuringRubberband:(CGSize)contentSize
 {
     CGSize currentContentSize = [self contentSize];
-
-    BOOL mightBeRubberbanding = self.isDragging || self.isVerticalBouncing || self.isHorizontalBouncing || self.refreshControl;
+    BOOL mightBeRubberbanding = self.isDragging || (self.scrollEnabled && self._wk_isScrolledBeyondExtents) || self.refreshControl;
     if (!mightBeRubberbanding || CGSizeEqualToSize(currentContentSize, CGSizeZero) || CGSizeEqualToSize(currentContentSize, contentSize) || ((self.zoomScale < self.minimumZoomScale) && !WebKit::scalesAreEssentiallyEqual(self.zoomScale, self.minimumZoomScale))) {
         // FIXME: rdar://problem/65277759 Find out why iOS Mail needs this call even when the contentSize has not changed.
         [self setContentSize:contentSize];

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		F44A531821B899E500DBB99C /* InstanceMethodSwizzler.mm in Sources */ = {isa = PBXBuildFile; fileRef = F44A531621B899DA00DBB99C /* InstanceMethodSwizzler.mm */; };
 		F46240B1217013E500917B16 /* UIScriptControllerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = F46240AF2170128300917B16 /* UIScriptControllerCocoa.mm */; };
 		F4C3578C20E8444600FA0748 /* LayoutTestSpellChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4C3578A20E8444000FA0748 /* LayoutTestSpellChecker.mm */; };
+		F4C80D4E2ABFBCB500DEB820 /* UIKitSPIForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = F4C80D4D2ABFBCB500DEB820 /* UIKitSPIForTesting.h */; };
 		F4FED324235823A3003C139C /* NSPasteboardAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4FED3222358215E003C139C /* NSPasteboardAdditions.mm */; };
 /* End PBXBuildFile section */
 
@@ -450,6 +451,7 @@
 		F46240AF2170128300917B16 /* UIScriptControllerCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UIScriptControllerCocoa.mm; sourceTree = "<group>"; };
 		F4C3578A20E8444000FA0748 /* LayoutTestSpellChecker.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = LayoutTestSpellChecker.mm; path = ../TestRunnerShared/cocoa/LayoutTestSpellChecker.mm; sourceTree = "<group>"; };
 		F4C3578B20E8444000FA0748 /* LayoutTestSpellChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LayoutTestSpellChecker.h; path = ../TestRunnerShared/cocoa/LayoutTestSpellChecker.h; sourceTree = "<group>"; };
+		F4C80D4D2ABFBCB500DEB820 /* UIKitSPIForTesting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIKitSPIForTesting.h; sourceTree = "<group>"; };
 		F4FED3212358215E003C139C /* NSPasteboardAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NSPasteboardAdditions.h; path = ../TestRunnerShared/mac/NSPasteboardAdditions.h; sourceTree = "<group>"; };
 		F4FED3222358215E003C139C /* NSPasteboardAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = NSPasteboardAdditions.mm; path = ../TestRunnerShared/mac/NSPasteboardAdditions.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -756,6 +758,7 @@
 				0FEBF8591BB61DF20028722D /* HIDEventGenerator.mm */,
 				2EE52D131890A9FB0010ED21 /* PlatformWebViewIOS.mm */,
 				2EE52D141890A9FB0010ED21 /* TestControllerIOS.mm */,
+				F4C80D4D2ABFBCB500DEB820 /* UIKitSPIForTesting.h */,
 				F415C22A27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h */,
 				F415C22B27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.mm */,
 				2D0BEE1722EAD1360092B738 /* UIScriptControllerIOS.h */,
@@ -1002,6 +1005,7 @@
 				0F73B5521BA78968004B3EF4 /* JSUIScriptController.h in Headers */,
 				2DFA98481D7F70CF00AFF2C9 /* SharedEventStreamsMac.h in Headers */,
 				2904FA1E265CC5D900A7EBC9 /* StringFunctionsCocoa.h in Headers */,
+				F4C80D4E2ABFBCB500DEB820 /* UIKitSPIForTesting.h in Headers */,
 				F415C22C27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h in Headers */,
 				2D058E0922E2EE2200E4C145 /* UIScriptControllerCocoa.h in Headers */,
 				2D058E0B22E2EF6D00E4C145 /* UIScriptControllerMac.h in Headers */,

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -37,6 +37,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 #import "UIKitSPI.h"
+#import "UIKitSPIForTesting.h"
 #import <WebKit/WKWebViewPrivate.h>
 
 @interface WKWebView ()

--- a/Tools/WebKitTestRunner/ios/UIKitSPIForTesting.h
+++ b/Tools/WebKitTestRunner/ios/UIKitSPIForTesting.h
@@ -28,22 +28,18 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <UIKit/UIKit.h>
-#import <wtf/RetainPtr.h>
 
-@interface UIScrollView (WebKitInternal)
-@property (readonly, nonatomic) BOOL _wk_isInterruptingDeceleration;
-@property (readonly, nonatomic) BOOL _wk_isScrolledBeyondExtents;
+#if USE(APPLE_INTERNAL_SDK)
+
+#import <UIKit/UIScrollView_Private.h>
+
+#else
+
+@interface UIScrollView ()
+@property (nonatomic, readonly, getter=_isVerticalBouncing) BOOL isVerticalBouncing;
+@property (nonatomic, readonly, getter=_isHorizontalBouncing) BOOL isHorizontalBouncing;
 @end
 
-@interface UIView (WebKitInternal)
-@property (nonatomic, readonly) UIViewController *_wk_viewControllerForFullScreenPresentation;
-@end
-
-namespace WebKit {
-
-RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message);
-UIScrollView *scrollViewForTouches(NSSet<UITouch *> *);
-
-} // namespace WebKit
+#endif
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 2f74816e605d1c2539f2613ca928bda62dd21c3c
<pre>
Move off of UIKit SPI: -[UIScrollView _is(Vertical|Horizontal)Bouncing]
<a href="https://bugs.webkit.org/show_bug.cgi?id=262013">https://bugs.webkit.org/show_bug.cgi?id=262013</a>
rdar://112473874

Reviewed by Aditya Keerthi.

Stop using `-_isVerticalBouncing` and `-_isHorizontalBouncing` on `UIScrollView`; as an alternative,
add a new category helper method, `-[UIScrollView _wk_isScrolledBeyondExtents]`, that returns
whether or not the current content offset is scrolled beyond the minimum or maximum extents of the
scroll view, taking the `-adjustedContentInset` into account.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIScrollView _wk_isScrolledBeyondExtents]):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _setContentSizePreservingContentOffsetDuringRubberband:]):
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
* Tools/WebKitTestRunner/ios/UIKitSPIForTesting.h: Copied from Source/WebKit/UIProcess/ios/UIKitUtilities.h.

Continue using `-_isVerticalBouncing` and `-_isHorizontalBouncing` in WebKitTestRunner harness logic
to determine when scrolling/zooming animations are complete. We also add an SPI header, specific to
WebKitTestRunner for now, to house these new forward declarations and SPI include points. I&apos;ll move
various existing testing-only declarations and includes in UIKitSPI.h into this header in a
subsequent patch.

Canonical link: <a href="https://commits.webkit.org/268376@main">https://commits.webkit.org/268376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cead75a7ee66d5280dfbe615704cdff35ea4151d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19854 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22261 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24058 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22031 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18531 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15700 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17675 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4667 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->