### PR TITLE
[motion-path] circle() and ellipse() should use non-offset starting position

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-008-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-008-expected.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;basic-shape&gt; circle() path with offset-position</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  transform: translate(250px, 350px) rotate(180deg);
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-008.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;basic-shape&gt; circle() path offset-position</title>
+<meta name="fuzzy" content="maxDifference=0-150; totalPixels=0-300">
+<link rel="match" href="offset-path-shape-circle-001-ref.html">
+<link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  top: 100px;
+  left: 200px;
+  background-color: green;
+  position: relative;
+  offset-path: circle();
+  offset-position: 300px 200px;
+  offset-distance: 25%;
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-007-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-007-expected.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test reference: &lt;basic-shape&gt; ellipse() path with offset-path</title>
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  background-color: green;
+  transform: translate(250px, 350px) rotate(180deg);
+  border-radius: 50% 50% 0 0;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-007.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Motion Path test: &lt;basic-shape&gt; ellipse() path offset-position</title>
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-401">
+<link rel="match" href="offset-path-shape-ellipse-001-ref.html">
+<link rel="help" href="https://drafts.fxtf.org/motion/#valdef-offset-path-basic-shape">
+
+<style>
+#outer {
+  top: 100px;
+  left: 100px;
+  position: relative;
+  width: 600px;
+  height: 400px;
+}
+#box {
+  top: 100px;
+  left: 200px;
+  background-color: green;
+  position: relative;
+  offset-path: ellipse();
+  offset-distance: 25%;
+  border-radius: 50% 50% 0 0;
+  offset-position: 300px 200px;
+  width: 100px;
+  height: 100px;
+}
+</style>
+
+<div id="outer">
+  <div id="box"></div>
+</div>

--- a/Source/WebCore/rendering/MotionPath.cpp
+++ b/Source/WebCore/rendering/MotionPath.cpp
@@ -224,7 +224,7 @@ std::optional<Path> MotionPath::computePathForShape(const ShapePathOperation& pa
         if (is<BasicShapeCircleOrEllipse>(shape)) {
             auto& centerCoordShape = downcast<BasicShapeCircleOrEllipse>(shape);
             if (centerCoordShape.positionWasOmitted())
-                return centerCoordShape.pathForCenterCoordinate(containingBlockRect, currentOffsetForData(*motionPathData));
+                return centerCoordShape.pathForCenterCoordinate(containingBlockRect, motionPathData->usedStartingPosition);
         }
         return pathOperation.pathForReferenceRect(containingBlockRect);
     }


### PR DESCRIPTION
#### eddbc5df03c84c7da6b202923cad6ae71ecc1b0e
<pre>
[motion-path] circle() and ellipse() should use non-offset starting position
<a href="https://bugs.webkit.org/show_bug.cgi?id=262014">https://bugs.webkit.org/show_bug.cgi?id=262014</a>
rdar://115962433

Reviewed by Tim Nguyen.

circle() and ellipse() should use non-offset starting position. We don&apos;t want to use the offset starting
position as this would make the calculation of the radius size incorrect for circle/ellipse. The one wpt
for circle()/ellipse() do not actually test this properly (they use a 0,0 starting position).

* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-008-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-circle-008.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-007-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-shape-ellipse-007.html: Added.
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::computePathForShape):

Canonical link: <a href="https://commits.webkit.org/268400@main">https://commits.webkit.org/268400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe27222a21d18a0dad96efed78c49dc97604eb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19886 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22297 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24095 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22067 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15733 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17617 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22066 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2393 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->