### PR TITLE
[LBSE] Errorous/unnecessary repainting when viewBox is used on <svg> elements

### DIFF
--- a/LayoutTests/platform/ios/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints-expected.txt
+++ b/LayoutTests/platform/ios/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints-expected.txt
@@ -1,0 +1,40 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 851.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 851.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 784.00 784.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 784.00 784.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=100 height=100)
+                  (position 100.00 100.00)
+                  (anchor -1.00 -1.00)
+                  (bounds 100.00 100.00)
+                  (contentsVisible 0)
+                  (transform [2.61 0.00 0.00 0.00] [0.00 2.61 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                      (transform [0.71 0.71 0.00 0.00] [-0.71 0.71 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-wk1/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt
+++ b/LayoutTests/platform/mac-wk1/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt
@@ -1,0 +1,42 @@
+ (repaint rects
+  (rect 19 19 180 180)
+  (rect 19 19 180 180)
+  (rect 8 8 502 302)
+  (rect 19 19 180 180)
+  (rect 0 0 800 600)
+  (rect 0 0 800 327)
+)
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 502.00 302.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 500.00 300.00)
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (anchor 1.33 0.78)
+                  (bounds 180.00 180.00)
+                  (drawsContent 1)
+                  (transform [0.71 0.71 0.00 0.00] [-0.71 0.71 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-wk1/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt
+++ b/LayoutTests/platform/mac-wk1/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt
@@ -1,0 +1,50 @@
+ (repaint rects
+  (rect 124 24 270 270)
+  (rect 124 24 270 270)
+  (rect 124 24 270 270)
+  (rect 8 8 502 302)
+  (rect 0 0 800 600)
+  (rect 0 0 800 327)
+)
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 502.00 302.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 500.00 300.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (transform [1.50 0.00 0.00 0.00] [0.00 1.50 0.00 0.00] [0.00 0.00 1.00 0.00] [100.00 0.00 0.00 1.00])
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 180.00 180.00)
+                      (drawsContent 1)
+                      (transform [0.71 0.71 0.00 0.00] [-0.71 0.71 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints-expected.txt
+++ b/LayoutTests/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints-expected.txt
@@ -1,0 +1,41 @@
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 837.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 837.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (anchor 0.50 0.50)
+          (bounds 769.00 769.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 769.00 769.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=100 height=100)
+                  (position 100.00 100.00)
+                  (anchor -1.00 -1.00)
+                  (bounds 100.00 100.00)
+                  (contentsVisible 0)
+                  (transform [2.56 0.00 0.00 0.00] [0.00 2.56 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (drawsContent 1)
+                      (transform [0.71 0.71 0.00 0.00] [-0.71 0.71 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints.html
+++ b/LayoutTests/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+    <style type="text/css">
+    rect {
+        transform-origin: 50% 50%;
+        transform-box: fill-box;
+        transform: rotate(45deg) translateZ(0);
+    }
+    </style>
+    <script type="text/javascript">
+        if (window.testRunner && window.internals) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            requestAnimationFrame(() => {
+                document.getElementById('out').textContent = internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            });
+        }
+    </script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
+    <rect x="100" y="100" width="100" height="100" fill="green"/>
+</svg>
+<pre id="out"/>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-expected.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-expected.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+    <title>Tests that SVG documents without viewBox don't trigger unnecessary repaints during animations.</title>
+    <style>
+        svg { border: 1px solid black; }
+
+        .animating1 {
+            transform-origin: 50% 50%;
+            transform-box: border-box;
+            transform: translateZ(0);
+	}
+
+        .animating2 {
+            transform-origin: 50% 50%;
+            transform-box: border-box;
+            transform: rotate(25deg) translateZ(0);
+	}
+
+        .animating3 {
+            transform-origin: 50% 50%;
+            transform-box: border-box;
+	    transform: rotate(45deg) translateZ(0);
+            fill: green;
+        }
+    </style>
+    <script type="text/javascript">
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        if (window.internals) {
+            internals.settings.setShowRepaintCounter(true);
+            internals.settings.setShowDebugBorders(true);
+        }
+
+        window.addEventListener('load', () => {
+            requestAnimationFrame(() => {
+                document.getElementById('rect').setAttribute("class", "animating2");
+		requestAnimationFrame(() => {
+                    document.getElementById('rect').setAttribute("class", "animating3");
+                    if (window.testRunner)
+			testRunner.notifyDone();
+		    });
+		});
+	    }, false);
+    </script>
+</head>
+<body>
+    <svg xmlns="http://www.w3.org/2000/svg" width="500" height="300">
+        <rect id="rect" class="animating1" x="10" y="10" width="180" height="180" fill="red"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt
+++ b/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt
@@ -1,0 +1,40 @@
+ (repaint rects
+  (rect 19 19 180 180)
+  (rect 19 19 180 180)
+  (rect 8 8 502 302)
+  (rect 19 19 180 180)
+)
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 502.00 302.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 500.00 300.00)
+              (children 1
+                (GraphicsLayer
+                  (position 10.00 10.00)
+                  (anchor 1.33 0.78)
+                  (bounds 180.00 180.00)
+                  (drawsContent 1)
+                  (transform [0.71 0.71 0.00 0.00] [-0.71 0.71 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+
+<html>
+<head>
+    <style>
+        svg { border: 1px solid black; }
+
+        .rotate {
+	    transform-origin: 50% 50%;
+            transform: rotate(45deg) translateZ(0);
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', () => {
+            requestAnimationFrame(() => {
+                document.body.offsetTop;
+                if (window.internals)
+                    window.internals.startTrackingRepaints();
+
+                document.getElementById('rect').setAttribute('class', 'rotate');
+
+                if (window.internals)
+                    document.getElementById('repaintRects').textContent = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+
+                if (window.testRunner)
+                    testRunner.notifyDone();
+	    });
+	}, false);
+    </script>
+</head>
+<body>
+    <svg xmlns="http://www.w3.org/2000/svg" width="500" height="300">
+        <rect id="rect" x="10" y="10" width="180" height="180" fill="green"/>
+    </svg>
+    <pre id="repaintRects"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-no-viewBox.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=26; totalPixels=4" />
+    <title>Tests that SVG documents without viewBox don't trigger unnecessary repaints during animations.</title>
+    <style>
+        svg { border: 1px solid black; }
+
+        #animating {
+            transform-origin: 50% 50%;
+            transform-box: border-box;
+	    transform: translateZ(0);
+
+            animation: rotation 1s 1s;
+	    animation-fill-mode: forwards;
+        }
+
+        @keyframes rotation {
+            from { transform: rotate(0deg) translateZ(0); }
+            to   { transform: rotate(45deg) translateZ(0); }
+        }
+        
+        #result {
+            display: none;
+        }
+    </style>
+    <script src="../../animations/resources/animation-test-helpers.js" type="text/javascript"></script>
+    <script type="text/javascript">
+        const expectedValues = [
+            // [animation-name, time, element-id, property, expected-value, tolerance]
+            ["rotation", 1.5, "animating", "webkitTransform", "matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)", 0],
+        ];
+
+        if (window.internals) {
+            internals.settings.setShowRepaintCounter(true);
+            internals.settings.setShowDebugBorders(true);
+        }
+
+        var doPixelTest = true;
+        var disablePauseAPI = true;
+        runAnimationTest(expectedValues, null, undefined, disablePauseAPI, doPixelTest);
+    </script>
+</head>
+<body>
+    <svg xmlns="http://www.w3.org/2000/svg" width="500" height="300">
+        <rect id="animating" x="10" y="10" width="180" height="180" fill="green"/>
+    </svg>
+    <div id="result"/>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/transform-change-repainting-viewBox-expected.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-viewBox-expected.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+    <title>Tests that SVG documents with viewBox don't trigger unnecessary repaints during animations.</title>
+    <style>
+        svg { border: 1px solid black; }
+
+        .animating1 {
+            transform-origin: 50% 50%;
+            transform-box: border-box;
+            transform: translateZ(0);
+	}
+
+        .animating2 {
+            transform-origin: 50% 50%;
+            transform-box: border-box;
+            transform: rotate(25deg) translateZ(0);
+	}
+
+        .animating3 {
+            transform-origin: 50% 50%;
+            transform-box: border-box;
+	    transform: rotate(45deg) translateZ(0);
+            fill: green;
+        }
+    </style>
+    <script type="text/javascript">
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        if (window.internals) {
+            internals.settings.setShowRepaintCounter(true);
+            internals.settings.setShowDebugBorders(true);
+        }
+
+        window.addEventListener('load', () => {
+            requestAnimationFrame(() => {
+                document.getElementById('rect').setAttribute("class", "animating2");
+		requestAnimationFrame(() => {
+                    document.getElementById('rect').setAttribute("class", "animating3");
+                    if (window.testRunner)
+			testRunner.notifyDone();
+		    });
+		});
+	    }, false);
+    </script>
+</head>
+<body>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="500" height="300">
+        <rect id="rect" class="animating1" x="10" y="10" width="180" height="180" fill="red"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt
+++ b/LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt
@@ -1,0 +1,48 @@
+ (repaint rects
+  (rect 124 24 270 270)
+  (rect 124 24 270 270)
+  (rect 124 24 270 270)
+  (rect 8 8 502 302)
+)
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 502.00 302.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 500.00 300.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=10 height=10)
+                  (position 10.00 10.00)
+                  (anchor -0.06 -0.06)
+                  (bounds 180.00 180.00)
+                  (contentsVisible 0)
+                  (transform [1.50 0.00 0.00 0.00] [0.00 1.50 0.00 0.00] [0.00 0.00 1.00 0.00] [100.00 0.00 0.00 1.00])
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 180.00 180.00)
+                      (drawsContent 1)
+                      (transform [0.71 0.71 0.00 0.00] [-0.71 0.71 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+
+<html>
+<head>
+    <style>
+        svg { border: 1px solid black; }
+
+        .rotate {
+	    transform-origin: 50% 50%;
+            transform: rotate(45deg) translateZ(0);
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', () => {
+            requestAnimationFrame(() => {
+                document.body.offsetTop;
+                if (window.internals)
+                    window.internals.startTrackingRepaints();
+
+                document.getElementById('rect').setAttribute('class', 'rotate');
+
+                if (window.internals)
+                    document.getElementById('repaintRects').textContent = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+
+                if (window.testRunner)
+                    testRunner.notifyDone();
+	    });
+	}, false);
+    </script>
+</head>
+<body>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="500" height="300">
+        <rect id="rect" x="10" y="10" width="180" height="180" fill="green"/>
+    </svg>
+    <pre id="repaintRects"></pre>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/transform-change-repainting-viewBox.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-viewBox.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+    <meta name="fuzzy" content="maxDifference=35; totalPixels=11" />
+    <title>Tests that SVG documents with viewBox don't trigger unnecessary repaints during animations.</title>
+    <style>
+        svg { border: 1px solid black; }
+
+        #animating {
+            transform-origin: 50% 50%;
+            transform-box: border-box;
+	    transform: translateZ(0);
+
+            animation: rotation 1s 1s;
+	    animation-fill-mode: forwards;
+        }
+
+        @keyframes rotation {
+            from { transform: rotate(0deg) translateZ(0); }
+            to   { transform: rotate(45deg) translateZ(0); }
+        }
+        
+        #result {
+            display: none;
+        }
+    </style>
+    <script src="../../animations/resources/animation-test-helpers.js" type="text/javascript"></script>
+    <script type="text/javascript">
+        const expectedValues = [
+            // [animation-name, time, element-id, property, expected-value, tolerance]
+            ["rotation", 1.5, "animating", "webkitTransform", "matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)", 0],
+        ];
+
+        if (window.internals) {
+            internals.settings.setShowRepaintCounter(true);
+            internals.settings.setShowDebugBorders(true);
+        }
+
+        var doPixelTest = true;
+        var disablePauseAPI = true;
+        runAnimationTest(expectedValues, null, undefined, disablePauseAPI, doPixelTest);
+    </script>
+</head>
+<body>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="500" height="300">    
+        <rect id="animating" x="10" y="10" width="180" height="180" fill="green"/>
+    </svg>
+    <div id="result"/>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -119,6 +119,7 @@
 #include "RenderSVGModelObject.h"
 #include "RenderSVGRoot.h"
 #include "RenderSVGText.h"
+#include "RenderSVGViewportContainer.h"
 #include "RenderScrollbar.h"
 #include "RenderScrollbarPart.h"
 #include "RenderStyleSetters.h"
@@ -1667,6 +1668,8 @@ bool RenderLayer::computeHasVisibleContent() const
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     // FIXME: [LBSE] Eventually cache if we're part of a RenderSVGHiddenContainer subtree to avoid tree walks.
     if (renderer().document().settings().layerBasedSVGEngineEnabled() && lineageOfType<RenderSVGHiddenContainer>(renderer()).first())
+        return false;
+    if (renderer().isAnonymous() && is<RenderSVGViewportContainer>(renderer()))
         return false;
 #endif
     if (m_isHiddenByOverflowTruncation)


### PR DESCRIPTION
#### af30a9bb6eef26b7e5f32b8311ecc0d9ac7df8c1
<pre>
[LBSE] Errorous/unnecessary repainting when viewBox is used on &lt;svg&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=258351">https://bugs.webkit.org/show_bug.cgi?id=258351</a>

Reviewed by Rob Buis.

The anonymous RenderSVGViewportContainer, that encloses the entire SVG render tree,
caused errorous repaints whenever the outermost &lt;svg&gt; specified a viewBox attribute.

RenderLayerBacking::isSimpleContainerCompositingLayer() returned &apos;false&apos; for the
anyonmous RenderSVGViewportContainer, as it advertized itself as &apos;paintsContents()=true&apos;,
which is incorrect, since it does not paint on its own.

Alter RenderLayer::computeHasVisibleContent() to return false for the anonymous
RenderSVGViewportContainer, similar to the existing condition, that prevents
repaints for layers that have a &apos;RenderSVGHiddenContainer&apos; ancestor in the render
tree hierarchy.

Covered by new tests (graphics layer tree dump will showed &apos;drawsContent 1&apos; before and
&apos;contentsVisible 0&apos; after this change for the anonymous RenderSVGViewportContainer layer).

* LayoutTests/platform/ios/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints-expected.txt: Added.
  Taken from iOS 16 Simulator EWS build -- scrollbars on iOS influence the GraphicsLayer tree dump, so this needs
  a platform specific result.
* LayoutTests/platform/mac-wk1/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt: Added.
* LayoutTests/platform/mac-wk1/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt: Added.
  Legacy WK1 exposes individual repainting bugs -- add an exception instead of skipping to document this.
* LayoutTests/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints-expected.txt: Added.
* LayoutTests/svg/compositing/anonymous-RenderSVGViewportContainer-no-repaints.html: Added.
* LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-expected.html: Added.
* LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects-expected.txt: Added.
* LayoutTests/svg/compositing/transform-change-repainting-no-viewBox-repaintRects.html: Added.
* LayoutTests/svg/compositing/transform-change-repainting-no-viewBox.html: Added.
* LayoutTests/svg/compositing/transform-change-repainting-viewBox-expected.html: Added.
* LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects-expected.txt: Added.
* LayoutTests/svg/compositing/transform-change-repainting-viewBox-repaintRects.html: Added.
* LayoutTests/svg/compositing/transform-change-repainting-viewBox.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::computeHasVisibleContent const):

Canonical link: <a href="https://commits.webkit.org/269034@main">https://commits.webkit.org/269034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29f443b90c66873bc54d7d91f17915a75d4c0ef2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19775 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20988 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24037 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25658 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23499 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17050 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19147 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5115 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23587 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->