### PR TITLE
[iOS] Adopt UIAsyncTextInput, UIKeyEvent and related APIs

### DIFF
--- a/Source/WebCore/platform/ios/WebEventPrivate.h
+++ b/Source/WebCore/platform/ios/WebEventPrivate.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <WebCore/WebEvent.h>
+
+#if HAVE(UI_ASYNC_TEXT_INPUT)
+
+@class UIKeyEvent;
+
+@interface WebEvent (UIAsyncTextInputSupport)
+
+- (instancetype)initWithUIKeyEvent:(UIKeyEvent *)event;
+@property (nonatomic, readonly) UIKeyEvent *originalUIKeyEvent;
+
+@end
+
+#endif // HAVE(UI_ASYNC_TEXT_INPUT)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -552,6 +552,9 @@ struct ImageAnalysisContextMenuActionData {
     WebCore::FloatRect _imageAnalysisInteractionBounds;
     std::optional<WebKit::RemoveBackgroundData> _removeBackgroundData;
 #endif
+#if HAVE(UI_ASYNC_TEXT_INPUT)
+    __weak id<UIAsyncTextInputDelegate> _asyncSystemInputDelegate;
+#endif
 }
 
 @end
@@ -575,6 +578,9 @@ struct ImageAnalysisContextMenuActionData {
 #endif
 #if HAVE(UI_ASYNC_DRAG_INTERACTION)
     , _UIAsyncDragInteractionDelegate
+#endif
+#if HAVE(UI_ASYNC_TEXT_INPUT)
+    , UIAsyncTextInput
 #endif
 >
 


### PR DESCRIPTION
#### bdc11864605dde11d84cec5713e3d92b1d4763cd
<pre>
[iOS] Adopt UIAsyncTextInput, UIKeyEvent and related APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=262017">https://bugs.webkit.org/show_bug.cgi?id=262017</a>
rdar://116319413

Reviewed by Tim Horton.

First pass at adopting new UIKit interfaces for dispatching key events asynchronously and deferring
key events to UIKit in the case where the default action was not prevented by the page. This work
aims to clean up existing architecture for propagating key events from UIKit to WebKit, which
currently requires UIKit to instantiate a `WebEvent` (from the WebCore framework) and hand it to
WebKit. In this new architecture, UIKit instead sends `UIKeyEvent`s to WebKit, which (for the time
being) are wrapped by `WebEvent`s within WebKit code.

This will eventually allow us to break UIKit out of the WebKit &quot;framework layering sandwich&quot;,
wherein WebKit links UIKit and UIKit currently links WebKitLegacy in order to call directly into the
WebCore framework.

See below for more details.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/ios/WebEvent.mm:
(webEventType):
(webEventModifierFlags):
(-[WebEvent initWithUIKeyEvent:]):
(-[WebEvent originalUIKeyEvent]):

Add an initializer to wrap a `UIKeyEvent` in a `WebEvent`, while keeping a pointer to the original
`UIKeyEvent` (accessible via a new property, `-originalUIKeyEvent`).

* Source/WebCore/platform/ios/WebEventPrivate.h: Added.

Put these new WebCore helpers in a new category on `WebEvent` in a separate private header,
`WebEventPrivate.h`. This separation from `WebEvent.h` allows us to use `HAVE(UI_ASYNC_TEXT_INPUT)`
consistently throughout WebKit, and avoid expanding the API surface exported through `WebEvent` to
system clients, such as UIKit or accessibility.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _interpretKeyEvent:isCharEvent:]):

Call back into UIKit via `-deferHandlingToSystemForKeyEvent:` when interpreting key events.

(-[WKContentView asyncSystemInputDelegate]):
(-[WKContentView setAsyncSystemInputDelegate:]):
(-[WKContentView handleAsyncKeyEvent:withCompletionHandler:]):

Wrap the given `UIKeyEvent` in a `WebEvent`, and just call into the existing `-handleKeyWebEvent:`
method.

(-[WKContentView textInputView]):

Canonical link: <a href="https://commits.webkit.org/269010@main">https://commits.webkit.org/269010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c9f5f7253d9da30cedb01575b44983e5631e219

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19757 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21850 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24010 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25636 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23475 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17031 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19307 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5101 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->