### PR TITLE
Refactor RenderListBox to use ScrollPosition

### DIFF
--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -66,11 +66,6 @@ public:
     int size() const;
 
     bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr, RenderBox* startBox = nullptr, const IntPoint& wheelEventAbsolutePoint = IntPoint()) override;
-
-    bool scrolledToTop() const final;
-    bool scrolledToBottom() const final;
-    bool scrolledToLeft() const final;
-    bool scrolledToRight() const final;
     
 private:
     bool isVisibleToHitTesting() const final;
@@ -154,7 +149,7 @@ private:
     void didStartScrollAnimation() final;
 
     // NOTE: This should only be called by the overridden setScrollOffset from ScrollableArea.
-    void scrollTo(int newOffset);
+    void scrollTo(const ScrollPosition&);
 
     using PaintFunction = Function<void(PaintInfo&, const LayoutPoint&, int listItemIndex)>;
     void paintItem(PaintInfo&, const LayoutPoint&, const PaintFunction&);
@@ -188,6 +183,8 @@ private:
 
     bool shouldPlaceVerticalScrollbarOnLeft() const final { return RenderBlockFlow::shouldPlaceVerticalScrollbarOnLeft(); }
 
+    int indexOffset() const;
+
     bool m_optionsChanged { true };
     bool m_scrollToRevealSelectionAfterLayout { false };
     bool m_inAutoscroll { false };
@@ -195,7 +192,8 @@ private:
 
     RefPtr<Scrollbar> m_vBar;
 
-    int m_indexOffset { 0 };
+    // Note: This is based on item index rather than a pixel offset.
+    ScrollPosition m_scrollPosition;
 
     std::optional<int> m_indexOfFirstVisibleItemInsidePaddingTopArea;
     std::optional<int> m_indexOfFirstVisibleItemInsidePaddingBottomArea;


### PR DESCRIPTION
#### 9aea0cafc6c84113c0dd547ea5a3cab42a19ce2f
<pre>
Refactor RenderListBox to use ScrollPosition
<a href="https://bugs.webkit.org/show_bug.cgi?id=262018">https://bugs.webkit.org/show_bug.cgi?id=262018</a>
rdar://115965535

Reviewed by Simon Fraser.

The use of `ScrollPosition` is necessary in order to support vertical writing
modes and flipped block directions. Eventually, `RenderListBox` will no longer
assume single-axis scrolling, and a scroll origin of (0, 0).

No behavior change. Subsequent patches will add support and tests for vertical
writing modes.

* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::layout):
(WebCore::RenderListBox::itemBoundingBoxRect const):
(WebCore::RenderListBox::paintItem):
(WebCore::RenderListBox::listIndexAtOffset const):
(WebCore::RenderListBox::scrollToward):
(WebCore::RenderListBox::scrollToRevealElementAtListIndex):
(WebCore::RenderListBox::listIndexIsVisible):
(WebCore::RenderListBox::indexOffset const):
(WebCore::RenderListBox::scrollPosition const):
(WebCore::RenderListBox::minimumScrollPosition const):
(WebCore::RenderListBox::maximumScrollPosition const):
(WebCore::RenderListBox::setScrollOffset):
(WebCore::RenderListBox::numberOfVisibleItemsInPaddingTop const):
(WebCore::RenderListBox::numberOfVisibleItemsInPaddingBottom const):
(WebCore::RenderListBox::computeFirstIndexesVisibleInPaddingTopBottomAreas):
(WebCore::RenderListBox::scrollTo):
(WebCore::RenderListBox::scrollTop const):
(WebCore::RenderListBox::setScrollTop):
(WebCore::RenderListBox::scrolledToTop const): Deleted.
(WebCore::RenderListBox::scrolledToBottom const): Deleted.
(WebCore::RenderListBox::scrolledToLeft const): Deleted.
(WebCore::RenderListBox::scrolledToRight const): Deleted.
* Source/WebCore/rendering/RenderListBox.h:

Canonical link: <a href="https://commits.webkit.org/268414@main">https://commits.webkit.org/268414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9e5d7561a157973354a000814c2d64ab6fd04ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18378 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20215 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19870 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22399 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/18130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18660 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22162 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2403 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->