### PR TITLE
REGRESSION(268312@main): std::nullopt de-ref in `checkRelevancyOfContentVisibilityElement`

### DIFF
--- a/Source/WebCore/dom/ContentVisibilityDocumentState.h
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.h
@@ -34,6 +34,7 @@ class Document;
 class Element;
 
 enum class DidUpdateAnyContentRelevancy : bool { No, Yes };
+enum class IsSkippedContent : bool { No, Yes };
 // https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
 enum class ViewportProximity : bool { Far, Near };
 
@@ -54,7 +55,7 @@ public:
 
     void updateViewportProximity(const Element&, ViewportProximity);
 
-    static void skippedContentStateDidChange(const Element&, bool wasSkipped, bool becameUnskipped);
+    static void updateAnimations(const Element&, IsSkippedContent wasSkipped, IsSkippedContent becomesSkipped);
 
 private:
     bool checkRelevancyOfContentVisibilityElement(Element&, OptionSet<ContentRelevancy>) const;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -814,7 +814,9 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
         if (contentVisibilityChanged) {
             if (oldStyle->contentVisibility() == ContentVisibility::Auto)
                 ContentVisibilityDocumentState::unobserve(*element());
-            ContentVisibilityDocumentState::skippedContentStateDidChange(*element(), oldStyle->contentVisibility() == ContentVisibility::Hidden, newStyle.contentVisibility() == ContentVisibility::Visible);
+            auto wasSkippedContent = oldStyle->contentVisibility() == ContentVisibility::Hidden ? IsSkippedContent::Yes : IsSkippedContent::No;
+            auto isSkippedContent = newStyle.contentVisibility() == ContentVisibility::Hidden ? IsSkippedContent::Yes : IsSkippedContent::No;
+            ContentVisibilityDocumentState::updateAnimations(*element(), wasSkippedContent, isSkippedContent);
         }
         if ((contentVisibilityChanged || !oldStyle) && newStyle.contentVisibility() == ContentVisibility::Auto)
             ContentVisibilityDocumentState::observe(*element());


### PR DESCRIPTION
#### 88a90c5d94439c6ef027a7daf26a0048f44f8df1
<pre>
REGRESSION(268312@main): std::nullopt de-ref in `checkRelevancyOfContentVisibilityElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=262021">https://bugs.webkit.org/show_bug.cgi?id=262021</a>
rdar://115966527

Reviewed by Cameron McCormack.

Fix a crash on builds that use a newer compiler, that affects many of the content-visibility tests.

The crash was happening because we were trying to access `oldRelevancy-&gt;isEmpty()` without checking if `oldRelevancy` isn&apos;t `std::nullopt`.
To resolve this, we use the `isRelevantToUser()` function which includes that check.

Also renamed skippedContentStateDidChange to updateAnimations for clarity, and switched the boolean arguments to an enum class for clarity.

* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement const):
(WebCore::ContentVisibilityDocumentState::updateAnimations):
(WebCore::ContentVisibilityDocumentState::skippedContentStateDidChange): Deleted.
* Source/WebCore/dom/ContentVisibilityDocumentState.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange):

Canonical link: <a href="https://commits.webkit.org/268382@main">https://commits.webkit.org/268382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93edbaf839e17105237d2cfd97d3af35ddff41ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20099 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22284 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17770 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22054 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15720 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17697 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4670 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->