### PR TITLE
Add support for tabs.connect and runtime.connect in Web Extensions.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -387,6 +387,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIPermissions.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIPort.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIScripting.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -58,6 +58,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPermissions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPermissions.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPort.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIPort.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIRuntime.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIRuntime.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIScripting.h
@@ -141,6 +143,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PluginProcessProxyMessageReceiver.cp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PluginProcessProxyMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PluginProxyMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PluginProxyMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PushClientConnectionMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PushClientConnectionMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RTCDataChannelRemoteManagerMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RTCDataChannelRemoteManagerMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/RTCDataChannelRemoteManagerProxyMessageReceiver.cpp
@@ -468,8 +472,6 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebProcessPoolMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebProcessPoolMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebProcessProxyMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebProcessProxyMessages.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PushClientConnectionMessageReceiver.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/PushClientConnectionMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebRTCMonitorMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebRTCMonitorMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WebRTCResolverMessageReceiver.cpp
@@ -517,7 +519,4 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.webpushd.mac.sb
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.webpushd.relocatable.mac.sb
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebKit.webpushd.sb
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/com.apple.WebProcess.sb
-<<<<<<< ours
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/module.private.modulemap
-=======
->>>>>>> theirs

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -686,6 +686,7 @@ EXTENSION_INTERFACES = \
     WebExtensionAPILocalization \
     WebExtensionAPINamespace \
     WebExtensionAPIPermissions \
+    WebExtensionAPIPort \
     WebExtensionAPIRuntime \
     WebExtensionAPIScripting \
     WebExtensionAPITabs \

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -24,6 +24,7 @@
  */
 
 #import <wtf/HashSet.h>
+#import <wtf/OptionSet.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/UUID.h>
 #import <wtf/WallTime.h>
@@ -85,12 +86,18 @@ T *objectForKey(const RetainPtr<NSDictionary>& dictionary, id key, bool returnin
     return objectForKey<T>(dictionary.get(), key, returningNilIfEmpty, containingObjectsOfClass);
 }
 
-NSDictionary *parseJSON(NSString *, NSError ** = nullptr);
-NSDictionary *parseJSON(NSData *, NSError ** = nullptr);
-NSDictionary *parseJSON(API::Data&, NSError ** = nullptr);
+enum class JSONOptions {
+    FragmentsAllowed = 1 << 0, /// Allows for top-level scalar types, in addition to arrays and dictionaries.
+};
 
-NSString *encodeJSONString(NSDictionary *, NSError ** = nullptr);
-NSData *encodeJSONData(NSDictionary *, NSError ** = nullptr);
+using JSONOptionSet = OptionSet<JSONOptions>;
+
+id parseJSON(NSString *, JSONOptionSet = { }, NSError ** = nullptr);
+id parseJSON(NSData *, JSONOptionSet = { }, NSError ** = nullptr);
+id parseJSON(API::Data&, JSONOptionSet = { }, NSError ** = nullptr);
+
+NSString *encodeJSONString(id, JSONOptionSet = { }, NSError ** = nullptr);
+NSData *encodeJSONData(id, JSONOptionSet = { }, NSError ** = nullptr);
 
 NSDictionary *dictionaryWithLowercaseKeys(NSDictionary *);
 NSDictionary *mergeDictionaries(NSDictionary *, NSDictionary *);

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -364,6 +364,7 @@ def serialized_identifiers():
         'WebKit::WebExtensionContextIdentifier',
         'WebKit::WebExtensionControllerIdentifier',
         'WebKit::WebExtensionFrameIdentifier',
+        'WebKit::WebExtensionPortChannelIdentifier',
         'WebKit::WebExtensionTabIdentifier',
         'WebKit::WebExtensionWindowIdentifier',
         'WebKit::WebGPUIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -87,6 +87,7 @@
 #include "WebExtensionContextIdentifier.h"
 #include "WebExtensionControllerIdentifier.h"
 #include "WebExtensionFrameIdentifier.h"
+#include "WebExtensionPortChannelIdentifier.h"
 #include "WebExtensionTabIdentifier.h"
 #include "WebExtensionWindowIdentifier.h"
 #include "WebGPUIdentifier.h"
@@ -539,6 +540,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionContextIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionControllerIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionFrameIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionPortChannelIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionTabIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionWindowIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebGPUIdentifier));
@@ -644,6 +646,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebKit::WebExtensionContextIdentifier"_s,
         "WebKit::WebExtensionControllerIdentifier"_s,
         "WebKit::WebExtensionFrameIdentifier"_s,
+        "WebKit::WebExtensionPortChannelIdentifier"_s,
         "WebKit::WebExtensionTabIdentifier"_s,
         "WebKit::WebExtensionWindowIdentifier"_s,
         "WebKit::WebGPUIdentifier"_s,

--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h
@@ -27,12 +27,24 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include <wtf/text/WTFString.h>
+
 namespace WebKit {
 
-enum class WebExtensionContentWorldType : bool {
+enum class WebExtensionContentWorldType : uint8_t {
     Main,
     ContentScript,
 };
+
+inline String toDebugString(WebExtensionContentWorldType contentWorldType)
+{
+    switch (contentWorldType) {
+    case WebExtensionContentWorldType::Main:
+        return "main"_s;
+    case WebExtensionContentWorldType::ContentScript:
+        return "content script"_s;
+    }
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in
@@ -24,6 +24,9 @@
 
 headers: "WebExtensionContentWorldType.h"
 
-enum class WebKit::WebExtensionContentWorldType : bool;
+enum class WebKit::WebExtensionContentWorldType : uint8_t {
+    Main,
+    ContentScript,
+}
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionPortChannelIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionPortChannelIdentifier.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPIRuntime {
+#pragma once
 
-    [URL, ConvertNullStringTo=Null, RaisesException] DOMString getURL(DOMString resourcePath);
+#include <wtf/ObjectIdentifier.h>
 
-    [NSDictionary] any getManifest();
+namespace WebKit {
 
-    [ImplementedAs=runtimeIdentifier] readonly attribute DOMString id;
+struct WebExtensionPortChannelIdentifierType;
+using WebExtensionPortChannelIdentifier = ObjectIdentifier<WebExtensionPortChannelIdentifierType>;
 
-    [MainWorldOnly] void getPlatformInfo([Optional, CallbackHandler] function callback);
-
-    [MainWorldOnly] readonly attribute any lastError;
-
-    [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage([Optional] DOMString extensionID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect([Optional] DOMString extensionID, [Optional, NSDictionary] any options);
-
-    readonly attribute WebExtensionAPIEvent onConnect;
-    readonly attribute WebExtensionAPIEvent onMessage;
-
-};
+}

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in
@@ -40,7 +40,10 @@ struct WebKit::WebExtensionWindowParameters {
 
 [Nested] enum class WebKit::WebExtensionWindow::PopulateTabs : bool;
 
-[Nested] enum class WebKit::WebExtensionWindow::Type : bool;
+[Nested] enum class WebKit::WebExtensionWindow::Type : uint8_t {
+    Normal,
+    Popup,
+};
 
 [Nested, OptionSet] enum class WebKit::WebExtensionWindow::TypeFilter : uint8_t {
     None,

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "Logging.h"
+#import "WebExtensionContentWorldType.h"
+#import "WebExtensionContextProxyMessages.h"
+
+namespace WebKit {
+
+void WebExtensionContext::portPostMessage(WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, const String& messageJSON)
+{
+    if (!m_ports.contains({ targetContentWorldType, channelIdentifier })) {
+        // The port might not be open on the other end yet. Queue the message until it does open.
+        RELEASE_LOG_DEBUG(Extensions, "Enqueued message for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
+        auto& messages = m_portQueuedMessages.ensure({ targetContentWorldType, channelIdentifier }, [] {
+            return Vector<String> { };
+        }).iterator->value;
+        messages.append(messageJSON);
+        return;
+    }
+
+    RELEASE_LOG_DEBUG(Extensions, "Sending message to port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
+
+    constexpr auto type = WebExtensionEventListenerType::PortOnMessage;
+
+    switch (targetContentWorldType) {
+    case WebExtensionContentWorldType::Main:
+        wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+            sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortMessageEvent(channelIdentifier, messageJSON));
+        });
+
+        return;
+
+    case WebExtensionContentWorldType::ContentScript:
+        sendToContentScriptProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortMessageEvent(channelIdentifier, messageJSON));
+        return;
+    }
+}
+
+void WebExtensionContext::portDisconnect(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+{
+    RELEASE_LOG_DEBUG(Extensions, "Port for channel %{public}llu disconnected in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(sourceContentWorldType));
+
+    m_portQueuedMessages.remove({ sourceContentWorldType, channelIdentifier });
+    m_ports.remove({ sourceContentWorldType, channelIdentifier });
+
+    firePortDisconnectEventIfNeeded(sourceContentWorldType, targetContentWorldType, channelIdentifier);
+}
+
+void WebExtensionContext::addPorts(WebExtensionContentWorldType contentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, size_t totalPortObjects)
+{
+    ASSERT(totalPortObjects);
+
+    RELEASE_LOG_DEBUG(Extensions, "Added %{public}zu port(s) for channel %{public}llu in %{public}@ world", totalPortObjects, channelIdentifier.toUInt64(), (NSString *)toDebugString(contentWorldType));
+
+    for (size_t i = 0; i < totalPortObjects; ++i)
+        m_ports.add({ contentWorldType, channelIdentifier });
+}
+
+bool WebExtensionContext::isPortConnected(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+{
+    const auto sourceWorldCount = m_ports.count({ sourceContentWorldType, channelIdentifier });
+
+    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu has %{public}u port(s) open in %{public}@ world", channelIdentifier.toUInt64(), sourceWorldCount, (NSString *)toDebugString(sourceContentWorldType));
+
+    // When the worlds are the same, it is connected if there are 2 ports remaining.
+    if (sourceContentWorldType == targetContentWorldType)
+        return sourceWorldCount >= 2;
+
+    const auto targetWorldCount = m_ports.count({ targetContentWorldType, channelIdentifier });
+
+    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu has %{public}u port(s) open in %{public}@ world", channelIdentifier.toUInt64(), targetWorldCount, (NSString *)toDebugString(targetContentWorldType));
+
+    // When the worlds are different, it is connected if there is 1 port in each world remaining.
+    return sourceWorldCount && targetWorldCount;
+}
+
+void WebExtensionContext::fireQueuedPortMessageEventIfNeeded(WebProcessProxy& process, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+{
+    auto messages = m_portQueuedMessages.get({ targetContentWorldType, channelIdentifier });
+    if (messages.isEmpty())
+        return;
+
+    RELEASE_LOG_DEBUG(Extensions, "Sending %{public}zu queued message(s) to port channel %{public}llu in %{public}@ world", messages.size(), channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
+
+    for (auto& messageJSON : messages)
+        process.send(Messages::WebExtensionContextProxy::DispatchPortMessageEvent(channelIdentifier, messageJSON), identifier());
+}
+
+void WebExtensionContext::clearQueuedPortMessages(WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+{
+    m_portQueuedMessages.remove({ targetContentWorldType, channelIdentifier });
+}
+
+void WebExtensionContext::firePortDisconnectEventIfNeeded(WebExtensionContentWorldType sourceContentWorldType, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier)
+{
+    // Only fire the disconnect event if there are no ports connected on this channel.
+    if (isPortConnected(sourceContentWorldType, targetContentWorldType, channelIdentifier))
+        return;
+
+    RELEASE_LOG_DEBUG(Extensions, "Sending disconnect event for port channel %{public}llu in %{public}@ world", channelIdentifier.toUInt64(), (NSString *)toDebugString(targetContentWorldType));
+
+    constexpr auto type = WebExtensionEventListenerType::PortOnDisconnect;
+
+    switch (targetContentWorldType) {
+    case WebExtensionContentWorldType::Main:
+        wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+            sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortDisconnectEvent(channelIdentifier));
+        });
+
+        return;
+
+    case WebExtensionContentWorldType::ContentScript:
+        sendToContentScriptProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchPortDisconnectEvent(channelIdentifier));
+        return;
+    }
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -170,7 +170,7 @@ bool WebExtension::manifestParsedSuccessfully()
 bool WebExtension::parseManifest(NSData *manifestData)
 {
     NSError *parseError;
-    m_manifest = parseJSON(manifestData, &parseError);
+    m_manifest = parseJSON(manifestData, { }, &parseError);
     if (!m_manifest) {
         recordError(createError(Error::InvalidManifest, nil, parseError));
         return false;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -35,7 +35,7 @@ messages -> WebExtensionContext {
 
     // Event APIs
     AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType);
-    RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType);
+    RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType, size_t removedCount);
 
     // Permissions APIs
     PermissionsGetAll() -> (Vector<String> permissions, Vector<String> origins);
@@ -43,8 +43,13 @@ messages -> WebExtensionContext {
     PermissionsRequest(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
     PermissionsRemove(HashSet<String> permissions, HashSet<String> origins) -> (bool success);
 
+    // Port APIs
+    PortPostMessage(WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON);
+    PortDisconnect(WebKit::WebExtensionContentWorldType sourceContentWorldType, WebKit::WebExtensionContentWorldType targetContentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier);
+
     // Runtime APIs
     RuntimeSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON, std::optional<String> error);
+    RuntimeConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> error);
 
     // Tabs APIs
     TabsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
@@ -60,6 +65,7 @@ messages -> WebExtensionContext {
     TabsToggleReaderMode(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (WebKit::WebExtensionTab::Error error);
     TabsCaptureVisibleTab(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, WebKit::WebExtensionTab::ImageFormat imageFormat, uint8_t imageQuality) -> (std::optional<URL> imageDataURL, WebKit::WebExtensionTab::Error error);
     TabsSendMessage(WebKit::WebExtensionTabIdentifier tabIdentifier, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON, WebKit::WebExtensionTab::Error error);
+    TabsConnect(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (WebKit::WebExtensionTab::Error error);
     TabsGetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<double> zoomFactor, WebKit::WebExtensionTab::Error error);
     TabsSetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, double zoomFactor) -> (WebKit::WebExtensionTab::Error error);
     TabsRemove(Vector<WebKit::WebExtensionTabIdentifier> tabIdentifiers) -> (WebKit::WebExtensionWindow::Error error);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -58,7 +58,7 @@ public:
 
     explicit WebExtensionWindow(const WebExtensionContext&, _WKWebExtensionWindow*);
 
-    enum class Type : bool {
+    enum class Type : uint8_t {
         Normal,
         Popup,
     };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -493,6 +493,12 @@
 		1C8E293912761E5B00BC7BD0 /* WKInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E293712761E5B00BC7BD0 /* WKInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C8E2A351277852400BC7BD0 /* WebInspectorMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C8E2A311277852400BC7BD0 /* WebInspectorMessageReceiver.cpp */; };
 		1C8E2A361277852400BC7BD0 /* WebInspectorMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E2A321277852400BC7BD0 /* WebInspectorMessages.h */; };
+		1C9A15C82ABDEEB4002CC12A /* WebExtensionPortChannelIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C9A15C72ABDEEB4002CC12A /* WebExtensionPortChannelIdentifier.h */; };
+		1C9A15CA2ABDEF13002CC12A /* WebExtensionAPIPort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C9A15C92ABDEF13002CC12A /* WebExtensionAPIPort.h */; };
+		1C9A15CE2ABDF1E2002CC12A /* JSWebExtensionAPIPort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C9A15CC2ABDF1E1002CC12A /* JSWebExtensionAPIPort.h */; };
+		1C9A15CF2ABDF1E2002CC12A /* JSWebExtensionAPIPort.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C9A15CD2ABDF1E2002CC12A /* JSWebExtensionAPIPort.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C9A15D12ABDF335002CC12A /* WebExtensionAPIPortCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C9A15D02ABDF334002CC12A /* WebExtensionAPIPortCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C9A15D32ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C9A15D22ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1CA8B945127C882A00576C2B /* WebInspectorUIProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B943127C882A00576C2B /* WebInspectorUIProxyMessageReceiver.cpp */; };
 		1CA8B946127C882A00576C2B /* WebInspectorUIProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CA8B944127C882A00576C2B /* WebInspectorUIProxyMessages.h */; };
 		1CAB9B8628F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -3794,6 +3800,13 @@
 		1C98C0D627462682002CCB78 /* WebGPURenderPassColorAttachment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPURenderPassColorAttachment.cpp; sourceTree = "<group>"; };
 		1C98C0D727462682002CCB78 /* WebGPUDeviceDescriptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPUDeviceDescriptor.cpp; sourceTree = "<group>"; };
 		1C98C0D827462682002CCB78 /* WebGPUObjectDescriptorBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPUObjectDescriptorBase.cpp; sourceTree = "<group>"; };
+		1C9A15C72ABDEEB4002CC12A /* WebExtensionPortChannelIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionPortChannelIdentifier.h; sourceTree = "<group>"; };
+		1C9A15C92ABDEF13002CC12A /* WebExtensionAPIPort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIPort.h; sourceTree = "<group>"; };
+		1C9A15CB2ABDF10C002CC12A /* WebExtensionAPIPort.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIPort.idl; sourceTree = "<group>"; };
+		1C9A15CC2ABDF1E1002CC12A /* JSWebExtensionAPIPort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIPort.h; sourceTree = "<group>"; };
+		1C9A15CD2ABDF1E2002CC12A /* JSWebExtensionAPIPort.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIPort.mm; sourceTree = "<group>"; };
+		1C9A15D02ABDF334002CC12A /* WebExtensionAPIPortCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIPortCocoa.mm; sourceTree = "<group>"; };
+		1C9A15D22ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIPortCocoa.mm; sourceTree = "<group>"; };
 		1C9DD99028FA19A30093BDB0 /* WebExtensionAPIExtension.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIExtension.idl; sourceTree = "<group>"; };
 		1C9DD99C28FA19A30093BDB0 /* WebExtensionAPIRuntime.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIRuntime.idl; sourceTree = "<group>"; };
 		1C9DD9A428FA19A30093BDB0 /* WebExtensionAPINamespace.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPINamespace.idl; sourceTree = "<group>"; };
@@ -8761,6 +8774,7 @@
 				1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */,
 				B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */,
 				B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */,
+				1C9A15D22ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm */,
 				1C4A14C72ABBBA3900A1018C /* WebExtensionContextAPIRuntimeCocoa.mm */,
 				1C1D9C862AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm */,
 				1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */,
@@ -8791,6 +8805,7 @@
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
 				1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */,
 				B65DA1D1294BC25300DB503A /* WebExtensionAPIPermissions.h */,
+				1C9A15C92ABDEF13002CC12A /* WebExtensionAPIPort.h */,
 				1C5DC469290B239C0061EC62 /* WebExtensionAPIRuntime.h */,
 				B62FB8622AA9180C00E61418 /* WebExtensionAPIScripting.h */,
 				1C5ACFAD2A96F9D300C041C0 /* WebExtensionAPITabs.h */,
@@ -8812,6 +8827,7 @@
 				B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
 				B65DA1D2294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm */,
+				1C9A15D02ABDF334002CC12A /* WebExtensionAPIPortCocoa.mm */,
 				1C5DC464290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm */,
 				B6F6CA162AA91EC200DC14B5 /* WebExtensionAPIScriptingCocoa.mm */,
 				1C5ACFB52A96FA2800C041C0 /* WebExtensionAPITabsCocoa.mm */,
@@ -8960,6 +8976,7 @@
 				B6E5F2A3299C0FFB00DBCEA3 /* WebExtensionAPILocalization.idl */,
 				1C9DD9A428FA19A30093BDB0 /* WebExtensionAPINamespace.idl */,
 				B6544F76293560B000034EB0 /* WebExtensionAPIPermissions.idl */,
+				1C9A15CB2ABDF10C002CC12A /* WebExtensionAPIPort.idl */,
 				1C9DD99C28FA19A30093BDB0 /* WebExtensionAPIRuntime.idl */,
 				B6746A9C2AA8CC79002B244A /* WebExtensionAPIScripting.idl */,
 				1C5ACF9F2A96E15E00C041C0 /* WebExtensionAPITabs.idl */,
@@ -12199,6 +12216,7 @@
 				1C4A14C52ABB710E00A1018C /* WebExtensionFrameIdentifier.h */,
 				1C4EBD712ABA47610005868F /* WebExtensionMessageSenderParameters.h */,
 				1C4EBD732ABA481B0005868F /* WebExtensionMessageSenderParameters.serialization.in */,
+				1C9A15C72ABDEEB4002CC12A /* WebExtensionPortChannelIdentifier.h */,
 				1C4957A22A983E39007D0B64 /* WebExtensionTab.serialization.in */,
 				1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */,
 				1C4957A02A983E2B007D0B64 /* WebExtensionTabParameters.h */,
@@ -13608,6 +13626,8 @@
 				1C5DC4542908AC260061EC62 /* JSWebExtensionAPINamespace.mm */,
 				B61AFA4629510D0F008220B1 /* JSWebExtensionAPIPermissions.h */,
 				B61AFA4729510D0F008220B1 /* JSWebExtensionAPIPermissions.mm */,
+				1C9A15CC2ABDF1E1002CC12A /* JSWebExtensionAPIPort.h */,
+				1C9A15CD2ABDF1E2002CC12A /* JSWebExtensionAPIPort.mm */,
 				1C5DC461290B1C470061EC62 /* JSWebExtensionAPIRuntime.h */,
 				1C5DC463290B1C470061EC62 /* JSWebExtensionAPIRuntime.mm */,
 				B63E9A6C2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.h */,
@@ -14747,6 +14767,7 @@
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,
 				B61AFA4829510D0F008220B1 /* JSWebExtensionAPIPermissions.h in Headers */,
+				1C9A15CE2ABDF1E2002CC12A /* JSWebExtensionAPIPort.h in Headers */,
 				B63E9A6E2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.h in Headers */,
 				1C5ACFAC2A96F8D500C041C0 /* JSWebExtensionAPITabs.h in Headers */,
 				1C5ACFA52A96F8C400C041C0 /* JSWebExtensionAPIWindows.h in Headers */,
@@ -15215,6 +15236,7 @@
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,
 				1C5DC46B290B271E0061EC62 /* WebExtensionAPIObject.h in Headers */,
 				B61AFA392950DFB3008220B1 /* WebExtensionAPIPermissions.h in Headers */,
+				1C9A15CA2ABDEF13002CC12A /* WebExtensionAPIPort.h in Headers */,
 				1C5DC46A290B271A0061EC62 /* WebExtensionAPIRuntime.h in Headers */,
 				B62FB8632AA9180C00E61418 /* WebExtensionAPIScripting.h in Headers */,
 				1C5ACFAE2A96F9D300C041C0 /* WebExtensionAPITabs.h in Headers */,
@@ -15237,6 +15259,7 @@
 				B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */,
 				1C4A14C62ABB710E00A1018C /* WebExtensionFrameIdentifier.h in Headers */,
 				1C4EBD722ABA47610005868F /* WebExtensionMessageSenderParameters.h in Headers */,
+				1C9A15C82ABDEEB4002CC12A /* WebExtensionPortChannelIdentifier.h in Headers */,
 				1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */,
 				1C66BDDA2A8ADB8A009D4452 /* WebExtensionTabIdentifier.h in Headers */,
 				1C4957A12A983E2B007D0B64 /* WebExtensionTabParameters.h in Headers */,
@@ -17535,6 +17558,7 @@
 				B6CCAAB929A445E90092E846 /* JSWebExtensionAPILocalization.mm in Sources */,
 				1C5DC4552908AC900061EC62 /* JSWebExtensionAPINamespace.mm in Sources */,
 				B61AFA4929510D0F008220B1 /* JSWebExtensionAPIPermissions.mm in Sources */,
+				1C9A15CF2ABDF1E2002CC12A /* JSWebExtensionAPIPort.mm in Sources */,
 				1C5DC472290B33A60061EC62 /* JSWebExtensionAPIRuntime.mm in Sources */,
 				B63E9A6F2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.mm in Sources */,
 				1C5ACFAB2A96F8D500C041C0 /* JSWebExtensionAPITabs.mm in Sources */,
@@ -17864,6 +17888,7 @@
 				B6E5F2A7299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm in Sources */,
 				1C5DC4522908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm in Sources */,
 				B65DA1D3294BC26300DB503A /* WebExtensionAPIPermissionsCocoa.mm in Sources */,
+				1C9A15D12ABDF335002CC12A /* WebExtensionAPIPortCocoa.mm in Sources */,
 				1C5DC466290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm in Sources */,
 				B6F6CA172AA91EC300DC14B5 /* WebExtensionAPIScriptingCocoa.mm in Sources */,
 				1C5ACFB62A96FA2800C041C0 /* WebExtensionAPITabsCocoa.mm in Sources */,
@@ -17876,6 +17901,7 @@
 				1C2B4D3F2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm in Sources */,
 				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,
 				B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */,
+				1C9A15D32ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm in Sources */,
 				1C4A14C82ABBBA3900A1018C /* WebExtensionContextAPIRuntimeCocoa.mm in Sources */,
 				1C1D9C872AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm in Sources */,
 				1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */,
@@ -18072,6 +18098,7 @@
 			isa = PBXTargetDependency;
 			platformFilters = (
 				ios,
+				xros,
 			);
 			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
 			targetProxy = 5C400E6929DB8AB500446F6F /* PBXContainerItemProxy */;
@@ -18080,6 +18107,7 @@
 			isa = PBXTargetDependency;
 			platformFilters = (
 				ios,
+				xros,
 			);
 			target = 5C139D9429DB82D900D5117B /* WebContentCrashyExtension */;
 			targetProxy = 5C400E6B29DB8AB500446F6F /* PBXContainerItemProxy */;
@@ -18098,6 +18126,7 @@
 			isa = PBXTargetDependency;
 			platformFilters = (
 				ios,
+				xros,
 			);
 			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
 			targetProxy = 5CE4B60629CEBB760038F565 /* PBXContainerItemProxy */;
@@ -18106,6 +18135,7 @@
 			isa = PBXTargetDependency;
 			platformFilters = (
 				ios,
+				xros,
 			);
 			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
 			targetProxy = 5CE4B62229CF880B0038F565 /* PBXContainerItemProxy */;
@@ -18114,6 +18144,7 @@
 			isa = PBXTargetDependency;
 			platformFilters = (
 				ios,
+				xros,
 			);
 			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
 			targetProxy = 5CE4B62429CF880B0038F565 /* PBXContainerItemProxy */;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPIPort.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "Logging.h"
+#import "MessageSenderInlines.h"
+#import "WebExtensionAPIEvent.h"
+#import "WebExtensionAPINamespace.h"
+#import "WebExtensionAPIRuntime.h"
+#import "WebExtensionContextMessages.h"
+#import "WebExtensionUtilities.h"
+#import "WebProcess.h"
+
+namespace WebKit {
+
+using CheckedPortSet = HashSet<CheckedPtr<WebExtensionAPIPort>>;
+using PortChannelPortMap = HashMap<WebExtensionPortChannelIdentifier, CheckedPortSet>;
+
+static PortChannelPortMap& webExtensionPorts()
+{
+    static MainThreadNeverDestroyed<PortChannelPortMap> ports;
+    return ports;
+}
+
+WebExtensionAPIPort::PortSet WebExtensionAPIPort::get(WebExtensionPortChannelIdentifier identifier)
+{
+    PortSet result;
+
+    auto entry = webExtensionPorts().find(identifier);
+    if (entry == webExtensionPorts().end())
+        return result;
+
+    for (auto& port : entry->value)
+        result.add(*port);
+
+    return result;
+}
+
+void WebExtensionAPIPort::add()
+{
+    auto addResult = webExtensionPorts().ensure(channelIdentifier(), [&] {
+        return CheckedPortSet { };
+    });
+
+    addResult.iterator->value.add(this);
+
+    RELEASE_LOG_DEBUG(Extensions, "Added port for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+}
+
+void WebExtensionAPIPort::remove()
+{
+    auto entry = webExtensionPorts().find(channelIdentifier());
+    RELEASE_ASSERT(entry != webExtensionPorts().end());
+
+    entry->value.remove(this);
+
+    disconnect();
+
+    if (!entry->value.isEmpty())
+        return;
+
+    webExtensionPorts().remove(entry);
+}
+
+NSString *WebExtensionAPIPort::name()
+{
+    return m_name;
+}
+
+NSDictionary *WebExtensionAPIPort::sender()
+{
+    return toWebAPI(m_senderParameters);
+}
+
+JSValue *WebExtensionAPIPort::error()
+{
+    return m_error.get();
+}
+
+void WebExtensionAPIPort::setError(JSValue *error)
+{
+    m_error = error;
+}
+
+void WebExtensionAPIPort::postMessage(WebFrame *frame, NSString *message, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#postmessage
+
+    if (disconnected()) {
+        *outExceptionString = toErrorString(nil, nil, @"the port is disconnected");
+        return;
+    }
+
+    if (message.length > webExtensionMaxMessageLength) {
+        *outExceptionString = toErrorString(nil, @"message", @"it exceeded the maximum allowed length");
+        return;
+    }
+
+    RELEASE_LOG_DEBUG(Extensions, "Sent port message for channel %{public}llu from %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::PortPostMessage(targetContentWorldType(), channelIdentifier(), message), extensionContext().identifier());
+}
+
+void WebExtensionAPIPort::disconnect()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#disconnect
+
+    fireDisconnectEventIfNeeded();
+}
+
+void WebExtensionAPIPort::fireMessageEventIfNeeded(id message)
+{
+    if (disconnected() || !m_onMessage || m_onMessage->listeners().isEmpty())
+        return;
+
+    RELEASE_LOG_DEBUG(Extensions, "Fired port message event for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+
+    for (auto& listener : m_onMessage->listeners()) {
+        auto globalContext = listener->globalContext();
+        auto *port = toJSValue(globalContext, toJS(globalContext, this));
+
+        listener->call(message, port);
+    }
+}
+
+void WebExtensionAPIPort::fireDisconnectEventIfNeeded()
+{
+    if (disconnected())
+        return;
+
+    RELEASE_LOG_DEBUG(Extensions, "Port channel %{public}llu disconnected in %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+
+    m_disconnected = true;
+
+    if (m_onMessage)
+        m_onMessage->removeAllListeners();
+
+    remove();
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::PortDisconnect(contentWorldType(), targetContentWorldType(), channelIdentifier()), extensionContext().identifier());
+
+    if (!m_onDisconnect || m_onDisconnect->listeners().isEmpty())
+        return;
+
+    RELEASE_LOG_DEBUG(Extensions, "Fired port disconnect event for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), (NSString *)toDebugString(contentWorldType()));
+
+    for (auto& listener : m_onDisconnect->listeners()) {
+        auto globalContext = listener->globalContext();
+        auto *port = toJSValue(globalContext, toJS(globalContext, this));
+
+        listener->call(port);
+    }
+
+    m_onDisconnect->removeAllListeners();
+}
+
+WebExtensionAPIEvent& WebExtensionAPIPort::onMessage()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#onmessage
+
+    if (!m_onMessage)
+        m_onMessage = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PortOnMessage);
+
+    return *m_onMessage;
+}
+
+WebExtensionAPIEvent& WebExtensionAPIPort::onDisconnect()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#ondisconnect
+
+    if (!m_onDisconnect)
+        m_onDisconnect = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::PortOnDisconnect);
+
+    return *m_onDisconnect;
+}
+
+void WebExtensionContextProxy::dispatchPortMessageEvent(WebExtensionPortChannelIdentifier channelIdentifier, const String& messageJSON)
+{
+    auto ports = WebExtensionAPIPort::get(channelIdentifier);
+    if (ports.isEmpty())
+        return;
+
+    id message = parseJSON(messageJSON, { JSONOptions::FragmentsAllowed });
+
+    for (auto& port : ports)
+        port->fireMessageEventIfNeeded(message);
+}
+
+void WebExtensionContextProxy::dispatchPortDisconnectEvent(WebExtensionPortChannelIdentifier channelIdentifier)
+{
+    auto ports = WebExtensionAPIPort::get(channelIdentifier);
+    if (ports.isEmpty())
+        return;
+
+    for (auto& port : ports)
+        port->fireDisconnectEventIfNeeded();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
@@ -57,28 +57,35 @@ void WebExtensionAPIWindowsEvent::invokeListenersWithArgument(id argument, Windo
 
 void WebExtensionAPIWindowsEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, NSString **outExceptionString)
 {
+    ASSERT(page);
+
     OptionSet<WindowTypeFilter> windowTypeFilter;
     if (!WebExtensionAPIWindows::parseWindowTypesFilter(filter, windowTypeFilter, @"filters", outExceptionString))
         return;
 
+    m_pageProxyIdentifier = page->webPageProxyIdentifier();
     m_listeners.append({ listener, windowTypeFilter });
 
     if (!page)
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page->webPageProxyIdentifier(), m_type, contentWorldType()), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(m_pageProxyIdentifier, m_type, contentWorldType()), extensionContext().identifier());
 }
 
 void WebExtensionAPIWindowsEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
 {
-    m_listeners.removeAllMatching([&](auto& entry) {
+    ASSERT(page);
+
+    auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry.first->callbackFunction() == listener->callbackFunction();
     });
 
-    if (!page)
+    if (!removedCount)
         return;
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(page->webPageProxyIdentifier(), m_type, contentWorldType()), extensionContext().identifier());
+    ASSERT(page->webPageProxyIdentifier() == m_pageProxyIdentifier);
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }
 
 bool WebExtensionAPIWindowsEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)
@@ -86,6 +93,16 @@ bool WebExtensionAPIWindowsEvent::hasListener(RefPtr<WebExtensionCallbackHandler
     return m_listeners.containsIf([&](auto& entry) {
         return entry.first->callbackFunction() == listener->callbackFunction();
     });
+}
+
+void WebExtensionAPIWindowsEvent::removeAllListeners()
+{
+    if (m_listeners.isEmpty())
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), m_listeners.size()), extensionContext().identifier());
+
+    m_listeners.clear();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -54,13 +54,21 @@ public:
     void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
+    void removeAllListeners();
+
+    virtual ~WebExtensionAPIEvent()
+    {
+        removeAllListeners();
+    }
+
+private:
     explicit WebExtensionAPIEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
         : WebExtensionAPIObject(forMainWorld, runtime, context)
         , m_type(type)
     {
     }
 
-private:
+    WebPageProxyIdentifier m_pageProxyIdentifier;
     WebExtensionEventListenerType m_type;
     ListenerVector m_listeners;
 };

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -83,8 +83,6 @@ public: \
         return adoptRef(*new ImplClass(std::forward<Args>(args)...)); \
     } \
 \
-    virtual ~ImplClass() = default; \
-\
 private: \
     explicit ImplClass(ForMainWorld forMainWorld, WebExtensionContextProxy& context) \
         : WebExtensionAPIObject(forMainWorld, context) \

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "JSWebExtensionAPIPort.h"
+#include "WebExtensionAPIEvent.h"
+#include "WebExtensionAPIObject.h"
+#include "WebExtensionMessageSenderParameters.h"
+#include "WebExtensionPortChannelIdentifier.h"
+
+OBJC_CLASS NSDictionary;
+OBJC_CLASS NSObject;
+OBJC_CLASS NSString;
+
+namespace WebKit {
+
+class WebExtensionAPIPort : public WebExtensionAPIObject, public JSWebExtensionWrappable, public CanMakeCheckedPtr {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIPort, port);
+
+public:
+#if PLATFORM(COCOA)
+    using PortSet = HashSet<Ref<WebExtensionAPIPort>>;
+
+    static PortSet get(WebExtensionPortChannelIdentifier);
+
+    WebExtensionContentWorldType targetContentWorldType() const { return m_targetContentWorldType; }
+    WebExtensionPortChannelIdentifier channelIdentifier() const { return m_channelIdentifier; }
+
+    void postMessage(WebFrame*, NSString *, NSString **outExceptionString);
+    void disconnect();
+
+    bool disconnected() const { return m_disconnected; }
+
+    NSString *name();
+    NSDictionary *sender();
+
+    JSValue *error();
+    void setError(JSValue *);
+
+    WebExtensionAPIEvent& onMessage();
+    WebExtensionAPIEvent& onDisconnect();
+
+    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionContentWorldType targetContentWorldType, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
+        : WebExtensionAPIObject(forMainWorld, runtime, context)
+        , m_targetContentWorldType(targetContentWorldType)
+        , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
+        , m_name(name)
+        , m_senderParameters(senderParameters)
+    {
+        add();
+    }
+
+    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionContentWorldType targetContentWorldType, WebExtensionPortChannelIdentifier channelIdentifier, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
+        : WebExtensionAPIObject(forMainWorld, runtime, context)
+        , m_targetContentWorldType(targetContentWorldType)
+        , m_channelIdentifier(channelIdentifier)
+        , m_name(name)
+        , m_senderParameters(senderParameters)
+    {
+        add();
+    }
+
+    virtual ~WebExtensionAPIPort()
+    {
+        remove();
+    }
+
+private:
+    friend class WebExtensionContextProxy;
+
+    void add();
+    void remove();
+
+    void fireMessageEventIfNeeded(id message);
+    void fireDisconnectEventIfNeeded();
+
+    WebExtensionContentWorldType m_targetContentWorldType;
+    WebExtensionPortChannelIdentifier m_channelIdentifier;
+    bool m_disconnected { false };
+
+    String m_name;
+    RetainPtr<JSValue> m_error;
+    WebExtensionMessageSenderParameters m_senderParameters;
+
+    RefPtr<WebExtensionAPIEvent> m_onMessage;
+    RefPtr<WebExtensionAPIEvent> m_onDisconnect;
+#endif
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -37,11 +37,13 @@ OBJC_CLASS NSURL;
 
 namespace WebKit {
 
+class WebExtensionAPIPort;
 class WebExtensionAPIRuntime;
 
 class WebExtensionAPIRuntimeBase : public JSWebExtensionWrappable {
 public:
-    void reportErrorForCallbackHandler(WebExtensionCallbackHandler&, NSString *error, JSGlobalContextRef);
+    JSValue *reportError(NSString *errorMessage, JSGlobalContextRef, Function<void()>&& = nullptr);
+    JSValue *reportError(NSString *errorMessage, WebExtensionCallbackHandler&);
 
 private:
     friend class WebExtensionAPIRuntime;
@@ -66,16 +68,23 @@ public:
 
     NSString *runtimeIdentifier();
 
-    JSValueRef lastError();
+    JSValue *lastError();
 
     void sendMessage(WebFrame *, NSString *extensionID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebFrame*, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
 
+    WebExtensionAPIEvent& onConnect();
     WebExtensionAPIEvent& onMessage();
 
 private:
+    static bool parseConnectOptions(NSDictionary *, std::optional<String>& name, NSString *sourceKey, NSString **outExceptionString);
+
+    RefPtr<WebExtensionAPIEvent> m_onConnect;
     RefPtr<WebExtensionAPIEvent> m_onMessage;
 #endif
 };
+
+NSDictionary *toWebAPI(const WebExtensionMessageSenderParameters&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -36,8 +36,6 @@ OBJC_CLASS NSString;
 
 namespace WebKit {
 
-class WebExtensionAPIScripting;
-
 class WebExtensionAPIScripting : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIScripting, scripting);
 
@@ -56,7 +54,6 @@ private:
     bool validateScript(NSDictionary *, NSString **outExceptionString);
     bool validateTarget(NSDictionary *, NSString **outExceptionString);
     bool validateCSS(NSDictionary *, NSString **outExceptionString);
-
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -38,6 +38,7 @@ OBJC_CLASS NSString;
 
 namespace WebKit {
 
+class WebExtensionAPIPort;
 struct WebExtensionTabParameters;
 struct WebExtensionTabQueryParameters;
 
@@ -72,6 +73,7 @@ public:
     void captureVisibleTab(WebPage*, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void sendMessage(WebFrame*, double tabID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebFrame*, JSContextRef, double tabID, NSDictionary *options, NSString **outExceptionString);
 
     double tabIdentifierNone() const { return -1; }
 
@@ -92,6 +94,7 @@ private:
     static bool parseTabQueryOptions(NSDictionary *, WebExtensionTabQueryParameters&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseCaptureVisibleTabOptions(NSDictionary *, WebExtensionTab::ImageFormat&, uint8_t& imageQuality, NSString *sourceKey, NSString **outExceptionString);
     static bool parseSendMessageOptions(NSDictionary *, std::optional<WebExtensionFrameIdentifier>&, NSString *sourceKey, NSString **outExceptionString);
+    static bool parseConnectOptions(NSDictionary *, std::optional<String>& name, std::optional<WebExtensionFrameIdentifier>&, NSString *sourceKey, NSString **outExceptionString);
 
     RefPtr<WebExtensionAPIEvent> m_onActivated;
     RefPtr<WebExtensionAPIEvent> m_onAttached;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -56,6 +56,13 @@ public:
     void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
+    void removeAllListeners();
+
+    virtual ~WebExtensionAPIWebNavigationEvent()
+    {
+        removeAllListeners();
+    }
+
 private:
     explicit WebExtensionAPIWebNavigationEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
         : WebExtensionAPIObject(forMainWorld, runtime, context)
@@ -63,6 +70,7 @@ private:
     {
     }
 
+    WebPageProxyIdentifier m_pageProxyIdentifier;
     WebExtensionEventListenerType m_type;
     ListenerVector m_listeners;
 };

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -53,6 +53,13 @@ public:
     void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
+    void removeAllListeners();
+
+    virtual ~WebExtensionAPIWindowsEvent()
+    {
+        removeAllListeners();
+    }
+
 private:
     explicit WebExtensionAPIWindowsEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
         : WebExtensionAPIObject(forMainWorld, runtime, context)
@@ -60,6 +67,7 @@ private:
     {
     }
 
+    WebPageProxyIdentifier m_pageProxyIdentifier;
     WebExtensionEventListenerType m_type;
     ListenerVector m_listeners;
 };

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -102,7 +102,7 @@ void WebExtensionCallbackHandler::reportError(NSString *message)
         return;
 
     if (m_runtime) {
-        m_runtime->reportErrorForCallbackHandler(*this, message, m_globalContext.get());
+        m_runtime->reportError(message, *this);
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPort.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPort.idl
@@ -25,23 +25,16 @@
 
 [
     Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPIRuntime {
+] interface WebExtensionAPIPort {
 
-    [URL, ConvertNullStringTo=Null, RaisesException] DOMString getURL(DOMString resourcePath);
+    readonly attribute DOMString name;
+    readonly attribute any sender;
+    readonly attribute any error;
 
-    [NSDictionary] any getManifest();
+    [RaisesException, NeedsFrame] void postMessage([Serialization=JSON] any message);
+    void disconnect();
 
-    [ImplementedAs=runtimeIdentifier] readonly attribute DOMString id;
-
-    [MainWorldOnly] void getPlatformInfo([Optional, CallbackHandler] function callback);
-
-    [MainWorldOnly] readonly attribute any lastError;
-
-    [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage([Optional] DOMString extensionID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect([Optional] DOMString extensionID, [Optional, NSDictionary] any options);
-
-    readonly attribute WebExtensionAPIEvent onConnect;
+    readonly attribute WebExtensionAPIEvent onDisconnect;
     readonly attribute WebExtensionAPIEvent onMessage;
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -59,7 +59,7 @@
     // [RaisesException, Dynamic] void removeCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
 
     [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage(double tabID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
-    // [NeedsFrame] WebExtensionAPIPort connect(double tabID, [Optional, NSDictionary] any connectInfo);
+    [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect(double tabID, [Optional, NSDictionary] any options);
 
     [ImplementedAs=tabIdentifierNone] readonly attribute double TAB_ID_NONE;
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -30,11 +30,6 @@
 #include "MessageReceiver.h"
 #include "WebExtensionContext.h"
 #include "WebExtensionContextParameters.h"
-#include "WebExtensionEventListenerType.h"
-#include "WebExtensionFrameIdentifier.h"
-#include "WebExtensionTabIdentifier.h"
-#include "WebExtensionWindowIdentifier.h"
-#include "WebPageProxyIdentifier.h"
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
@@ -111,13 +106,18 @@ private:
     // Alarms
     void dispatchAlarmsEvent(const WebExtensionAlarmParameters&);
 
-    // Runtime
-    void dispatchRuntimeMessageEvent(WebCore::DOMWrapperWorld&, String messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
-    void dispatchRuntimeMainWorldMessageEvent(String, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
-    void dispatchRuntimeContentScriptMessageEvent(String, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
-
     // Permissions
     void dispatchPermissionsEvent(WebExtensionEventListenerType, HashSet<String> permissions, HashSet<String> origins);
+
+    // Port
+    void dispatchPortMessageEvent(WebExtensionPortChannelIdentifier, const String& messageJSON);
+    void dispatchPortDisconnectEvent(WebExtensionPortChannelIdentifier);
+
+    // Runtime
+    void internalDispatchRuntimeMessageEvent(WebCore::DOMWrapperWorld&, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
+    void internalDispatchRuntimeConnectEvent(WebCore::DOMWrapperWorld&, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
+    void dispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
+    void dispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
 
     // Tabs
     void dispatchTabsCreatedEvent(const WebExtensionTabParameters&);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -32,9 +32,13 @@ messages -> WebExtensionContextProxy {
     // Permissions
     DispatchPermissionsEvent(WebKit::WebExtensionEventListenerType type, HashSet<String> permissions, HashSet<String> origins)
 
+    // Ports
+    DispatchPortMessageEvent(WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String messageJSON)
+    DispatchPortDisconnectEvent(WebKit::WebExtensionPortChannelIdentifier channelIdentifier)
+
     // Runtime
-    DispatchRuntimeMainWorldMessageEvent(String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON)
-    DispatchRuntimeContentScriptMessageEvent(String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON)
+    DispatchRuntimeMessageEvent(WebKit::WebExtensionContentWorldType contentWorldType, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON)
+    DispatchRuntimeConnectEvent(WebKit::WebExtensionContentWorldType contentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (size_t firedEventCount)
 
     // Tabs Events
     DispatchTabsCreatedEvent(WebKit::WebExtensionTabParameters tabParameters)


### PR DESCRIPTION
#### c796edb0c90214638dc7865d5e078eb04ea735af
<pre>
Add support for tabs.connect and runtime.connect in Web Extensions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262022">https://bugs.webkit.org/show_bug.cgi?id=262022</a>
rdar://115967048

Reviewed by Brian Weinstein.

* Added support for tabs.connect, tabs.onConnect, runtime.connect and runtime.onConnect.
* Added the WebExtensionAPIPort interface and implementation with onMessage and onDisconnect.
* Added support for unregistering all listeners, which is needed for ports since they can be
  garbaged collected and otherwise the UIProcess would think there are still port listeners.
* Improved the logging for function calls in the generator to log the world type (main vs content).
* Fixed generated code for ports since there is no optional callback last argument, but a optional
  last options argument instead.
* Fixed runtime.sendMessage, tabs.sendMessage and port.postMessage so the message can be any JSON
  value, not just object types. This matches Chrome and Firefox. Safari has always had this bug.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::parseJSON):
(WebKit::encodeJSONString):
(WebKit::encodeJSONData):
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::toReadingImpl):
(WebKit::toWritingImpl):
(WebKit::parseJSON):
(WebKit::encodeJSONString):
(WebKit::encodeJSONData):
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h:
(WebKit::toDebugString):
* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionPortChannelIdentifier.h: Added.
* Source/WebKit/Shared/Extensions/WebExtensionWindow.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm: Added.
(WebKit::WebExtensionContext::portPostMessage):
(WebKit::WebExtensionContext::portDisconnect):
(WebKit::WebExtensionContext::addPorts):
(WebKit::WebExtensionContext::isPortConnected):
(WebKit::WebExtensionContext::fireQueuedPortMessageEventIfNeeded):
(WebKit::WebExtensionContext::clearQueuedPortMessages):
(WebKit::WebExtensionContext::firePortDisconnectEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeSendMessage):
(WebKit::WebExtensionContext::runtimeConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsSendMessage):
(WebKit::WebExtensionContext::tabsConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::parseManifest):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::addListener):
(WebKit::WebExtensionAPIEvent::removeListener):
(WebKit::WebExtensionAPIEvent::removeAllListeners):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm: Added.
(WebKit::webExtensionPorts):
(WebKit::WebExtensionAPIPort::get):
(WebKit::WebExtensionAPIPort::add):
(WebKit::WebExtensionAPIPort::remove):
(WebKit::WebExtensionAPIPort::name):
(WebKit::WebExtensionAPIPort::sender):
(WebKit::WebExtensionAPIPort::error):
(WebKit::WebExtensionAPIPort::setError):
(WebKit::WebExtensionAPIPort::postMessage):
(WebKit::WebExtensionAPIPort::disconnect):
(WebKit::WebExtensionAPIPort::fireMessageEventIfNeeded):
(WebKit::WebExtensionAPIPort::fireDisconnectEventIfNeeded):
(WebKit::WebExtensionAPIPort::onMessage):
(WebKit::WebExtensionAPIPort::onDisconnect):
(WebKit::WebExtensionContextProxy::dispatchPortMessageEvent):
(WebKit::WebExtensionContextProxy::dispatchPortDisconnectEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntimeBase::reportError):
(WebKit::WebExtensionAPIRuntime::parseConnectOptions):
(WebKit::WebExtensionAPIRuntime::lastError):
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::onConnect):
(WebKit::toWebAPI):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
(WebKit::WebExtensionContextProxy::dispatchRuntimeMessageEvent):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeConnectEvent):
(WebKit::WebExtensionContextProxy::dispatchRuntimeConnectEvent):
(WebKit::WebExtensionAPIRuntimeBase::reportErrorForCallbackHandler): Deleted.
(WebKit::WebExtensionContextProxy::dispatchRuntimeMainWorldMessageEvent): Deleted.
(WebKit::WebExtensionContextProxy::dispatchRuntimeContentScriptMessageEvent): Deleted.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::parseConnectOptions):
(WebKit::WebExtensionAPITabs::sendMessage):
(WebKit::WebExtensionAPITabs::connect):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm:
(WebKit::WebExtensionAPIWebNavigationEvent::addListener):
(WebKit::WebExtensionAPIWebNavigationEvent::removeListener):
(WebKit::WebExtensionAPIWebNavigationEvent::removeAllListeners):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm:
(WebKit::WebExtensionAPIWindowsEvent::addListener):
(WebKit::WebExtensionAPIWindowsEvent::removeListener):
(WebKit::WebExtensionAPIWindowsEvent::removeAllListeners):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
(WebKit::WebExtensionAPIEvent::~WebExtensionAPIEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h: Added.
(WebKit::WebExtensionAPIPort::targetContentWorldType const):
(WebKit::WebExtensionAPIPort::channelIdentifier const):
(WebKit::WebExtensionAPIPort::disconnected const):
(WebKit::WebExtensionAPIPort::WebExtensionAPIPort):
(WebKit::WebExtensionAPIPort::~WebExtensionAPIPort):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
(WebKit::WebExtensionAPIWebNavigationEvent::~WebExtensionAPIWebNavigationEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h:
(WebKit::WebExtensionAPIWindowsEvent::~WebExtensionAPIWindowsEvent):
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::WebExtensionCallbackHandler::reportError):
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_installAutomaticExceptions):
(_javaScriptTypeCondition):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIPort.idl: Copied from Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268403@main">https://commits.webkit.org/268403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8998b3ed2ee3228a3d7176b717d66a8cf75503cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20663 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/21523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19867 "Failed to checkout and rebase branch from PR 18142") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/23314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20193 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/21523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/19848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/23314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/22379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19811 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/23314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/22379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/23314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/22379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/17788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/22143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2395 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->