### PR TITLE
Pausing MediaRecorder still continues to call ondataavailable at every timeslice event

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/pause-recording-timeSlice-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/pause-recording-timeSlice-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Pausing and resuming the recording should pause dataavailable event
+

--- a/LayoutTests/http/wpt/mediarecorder/pause-recording-timeSlice.html
+++ b/LayoutTests/http/wpt/mediarecorder/pause-recording-timeSlice.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <script>
+function waitFor(duration)
+{
+    return new Promise((resolve) => setTimeout(resolve, duration));
+}
+
+promise_test(async (test) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+
+    const recorder = new MediaRecorder(stream);
+
+    let counter = 0;
+    recorder.ondataavailable = (e) => { counter++; }
+
+    const startPromise = new Promise(resolve => recorder.onstart = resolve);
+    recorder.start(100);
+    await startPromise;
+
+    setTimeout(() => recorder.pause(), 50);
+    setTimeout(() => recorder.resume(), 1550);
+
+    await waitFor(500);
+    const pausedCounter = counter;
+
+    await waitFor(500);
+    assert_equals(counter, pausedCounter);
+
+    return new Promise(resolve => recorder.ondataavailable = resolve);
+}, "Pausing and resuming the recording should pause dataavailable event");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -138,6 +138,8 @@ private:
 
     unsigned m_audioBitsPerSecond { 0 };
     unsigned m_videoBitsPerSecond { 0 };
+
+    std::optional<Seconds> m_nextFireInterval;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 849a8db626632e2045a3a5349b5b362dbc870981
<pre>
Pausing MediaRecorder still continues to call ondataavailable at every timeslice event
<a href="https://bugs.webkit.org/show_bug.cgi?id=261964">https://bugs.webkit.org/show_bug.cgi?id=261964</a>
rdar://115979604

Reviewed by Eric Carlson.

Before the patch, we were firing dataavailable events with zero data in case recorder is using timeSlice but is paused.
We are now stopping the timer to stop fetching data when pausing.
When resuming, we restart the timer with the delay left at pause time.

* LayoutTests/http/wpt/mediarecorder/pause-recording-timeSlice-expected.txt: Added.
* LayoutTests/http/wpt/mediarecorder/pause-recording-timeSlice.html: Added.
* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::requestData):
(WebCore::MediaRecorder::pauseRecording):
(WebCore::MediaRecorder::resumeRecording):
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:

Canonical link: <a href="https://commits.webkit.org/268433@main">https://commits.webkit.org/268433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75c91bf5ebbd155a1497fbe611454c1caabea716

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19801 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19898 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22314 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24108 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22080 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15748 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17630 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4706 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->