### PR TITLE
REGRESSION(268243@main) ~9/21: MotionMark Images 15% on multiple models

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
@@ -85,18 +85,6 @@ std::optional<ImageBufferBackendHandle> ImageBufferShareableMappedIOSurfaceBacke
     return ImageBufferBackendHandle(m_surface->createSendRight());
 }
 
-RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBackend::copyNativeImage()
-{
-    auto currentSeed = m_surface->seed();
-
-    // Invalidate the cached image before getting a new one because GPUProcess might
-    // have drawn something to the IOSurface since last time this function was called.
-    if (std::exchange(m_lastSeedWhenCopyingImage, currentSeed) != currentSeed)
-        invalidateCachedNativeImage();
-
-    return ImageBufferIOSurfaceBackend::copyNativeImage();
-}
-
 String ImageBufferShareableMappedIOSurfaceBackend::debugDescription() const
 {
     TextStream stream;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
@@ -52,11 +52,7 @@ private:
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
 
-    RefPtr<WebCore::NativeImage> copyNativeImage() final;
-
     String debugDescription() const final;
-
-    WebCore::IOSurfaceSeed m_lastSeedWhenCopyingImage { 0 };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### de7538e40c42ca6292df250a984e8737ca9baec6
<pre>
REGRESSION(268243@main) ~9/21: MotionMark Images 15% on multiple models
<a href="https://bugs.webkit.org/show_bug.cgi?id=262032">https://bugs.webkit.org/show_bug.cgi?id=262032</a>
rdar://115907669

Reviewed by Matt Woodrow.

Before 268243@main, call ImageBuffer::copyImageForDrawing() would do the work:
  if (can use ref)
    &lt;do the work of create native image reference&gt;
  else
    &lt;do the work of copy native image&gt;

After 268243@main, the invocation was moved to GraphicsContext::nativeImageForDrawing():
  if (can use ref)
     imageBuffer-&gt;createNativeImageReference();
  else
     imageBuffer-&gt;copyNativeImage();

ImageBufferShareableMappedIOSurfaceBackend happened to have an
copyNativeImage() override that caused a difference in behavior.

Remove this code altogether, it was a leftover from eariler days
working around the issues of backbuffer reading from WP and updating
from GPUP. This code was not needed anymore. It is not correct, as
IOSurface seed cannot be used to determine read cache invalidation
accurately. The seed is updated during HW rasterization, which happens
at undefined time. The drawing commands might be on their way from WP
-&gt; GPUP or from GPUP -&gt; CG, and not yet issued at the HW rasterization
level.

The read cache is cleared when the drawing context, e.g.
RemoteDisplayListRecorderProxy detects the first modification after a
copyNativeImage() call.
RemoteImageBufferProxy::backingStoreWillChange() notification will
invalidate the read caches.

* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp:

Canonical link: <a href="https://commits.webkit.org/268438@main">https://commits.webkit.org/268438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/458ac6a2a5047e994a1ab9aa3c50295b4239ac5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18300 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19897 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22315 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16990 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24107 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22079 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15749 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17725 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4711 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->