### PR TITLE
[Multicol][IFC] Enable absolute positioned content in multicolumn

### DIFF
--- a/LayoutTests/fast/multicol/content-bounding-box-rtl.html
+++ b/LayoutTests/fast/multicol/content-bounding-box-rtl.html
@@ -42,7 +42,7 @@
                             {"top":0,"left":233.34375,"width":150,"height":30},
                             {"top":30,"left":203.34375,"width":180,"height":30},
                             {"top":0,"left":16.6875,"width":150,"height":30},
-                            {"top":150,"left":450,"width":150,"height":30}];
+                            {"top":120,"left":300,"width":150,"height":30}];
 
         var errorString = null;
         for (var i = 0; i < boxes.length; i++) {

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
@@ -44,7 +44,6 @@ enum class AvoidanceReason : uint64_t {
     FlowHasLineAlignEdges                        = 1LLU  << 20,
     FlowHasLineSnap                              = 1LLU  << 21,
     FeatureIsDisabled                            = 1LLU  << 41,
-    MultiColumnFlowHasOutOfFlowChild             = 1LLU  << 50,
     ContentIsSVG                                 = 1LLU  << 56,
     EndOfReasons                                 = 1LLU  << 62
 };


### PR DESCRIPTION
#### b70eda7d68835d7dfa22e86463fbb90263b0e619
<pre>
[Multicol][IFC] Enable absolute positioned content in multicolumn
<a href="https://bugs.webkit.org/show_bug.cgi?id=262031">https://bugs.webkit.org/show_bug.cgi?id=262031</a>
rdar://problem/115982927

Reviewed by Alan Baradlay.

While ideally absolute positioned object with static position would stick to its line when paginated
(it does in Chrome) we don&apos;t implement this in legacy either. As a result there is nothing to here.

* LayoutTests/fast/multicol/content-bounding-box-rtl.html:

The new expected result here is logically more correct (or equally wrong in practice) compared to legacy.

* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::printReason):
(WebCore::LayoutIntegration::canUseForChild):
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.h:

Canonical link: <a href="https://commits.webkit.org/268394@main">https://commits.webkit.org/268394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da78e9cac8e2488a59d21186c8598f866c9b88df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/19992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21464 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19808 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19902 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22321 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24111 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22083 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15755 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4679 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->