### PR TITLE
[webkitglib/2.42] GPUExternalTextureDescriptor: fix compilation without video support

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
@@ -45,6 +45,7 @@ using GPUVideoSource = RefPtr<HTMLVideoElement>;
 
 struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
 
+#if ENABLE(VIDEO)
     static WebGPU::VideoSourceIdentifier mediaIdentifierForSource(const GPUVideoSource& videoSource, CVPixelBufferRef& outPixelBuffer)
     {
 #if ENABLE(WEB_CODECS)
@@ -72,11 +73,16 @@ struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
         return WebGPU::HTMLVideoElementIdentifier { playerIdentifier ? playerIdentifier->toUInt64() : 0 };
 #endif
     }
+#endif
 
     WebGPU::ExternalTextureDescriptor convertToBacking() const
     {
         CVPixelBufferRef pixelBuffer = nullptr;
+#if ENABLE(VIDEO)
         auto mediaIdentifier = mediaIdentifierForSource(source, pixelBuffer);
+#else
+        auto mediaIdentifier = WebGPU::HTMLVideoElementIdentifier { 0 };
+#endif
         return {
             { label },
             mediaIdentifier,
@@ -85,7 +91,9 @@ struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
         };
     }
 
+#if ENABLE(VIDEO)
     GPUVideoSource source;
+#endif
     GPUPredefinedColorSpace colorSpace { GPUPredefinedColorSpace::SRGB };
 };
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=262039

Reviewed by NOBODY (OOPS!).

GPUVideoSource is only copmiled if ENABLE(VIDEO),
so we can't have a member variable for it.

The static mediaIdentifierForSource function calls playerIdentifier which is also not present
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e9e84c254d72a787375ce79473db7eaa87582ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19591 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21484 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18324 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19927 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22341 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17020 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17826 "9 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24138 "2 flakes 90 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22110 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18604 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17750 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4731 "") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->