### PR TITLE
[WebGPU] fragmentWriteGBuffers.wgsl does not compile

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -41,6 +41,7 @@ enum class StructureRole : uint8_t {
     BindGroup,
     UserDefinedResource,
     PackedResource,
+    FragmentOutput,
 };
 
 class Structure final : public Declaration {

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -314,7 +314,7 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
                 addPadding(finalSize - size);
         }
 
-        if (structDecl.role() == AST::StructureRole::VertexOutput) {
+        if (structDecl.role() == AST::StructureRole::VertexOutput || structDecl.role() == AST::StructureRole::FragmentOutput) {
             m_stringBuilder.append("\n");
             m_stringBuilder.append(m_indent, "template<typename T>\n");
             m_stringBuilder.append(m_indent, structDecl.name(), "(const thread T& other)\n");
@@ -532,6 +532,9 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         case AST::StructureRole::ComputeInput:
         case AST::StructureRole::UserDefinedResource:
         case AST::StructureRole::PackedResource:
+            return;
+        case AST::StructureRole::FragmentOutput:
+            m_stringBuilder.append("[[color(", *AST::extractInteger(location.location()), ")]]");
             return;
         case AST::StructureRole::VertexInput:
             m_stringBuilder.append("[[attribute(", *AST::extractInteger(location.location()), ")]]");

--- a/Source/WebGPU/WGSL/tests/valid/fragment-output.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/fragment-output.wgsl
@@ -1,0 +1,15 @@
+// RUN: %metal-compile main
+struct S {
+  @location(0) x : vec3<f32>,
+  @location(1) y : vec4<f32>,
+}
+
+@group(0) @binding(0) var<storage> s: S;
+
+@fragment
+fn main() -> S {
+  var output : S;
+  output.x = vec3f(0);
+  output.y = vec4f(1);
+  return output;
+}


### PR DESCRIPTION
#### 255232f837a9a41c63d7d6b167cf66df9b8180af
<pre>
[WebGPU] fragmentWriteGBuffers.wgsl does not compile
<a href="https://bugs.webkit.org/show_bug.cgi?id=261890">https://bugs.webkit.org/show_bug.cgi?id=261890</a>
rdar://115849432

Reviewed by Mike Wyrzykowski.

When a fragment entrypoint returns a struct, the generated code requires different
annotations for the struct fields, similar to how we generate VertexOutput structs.
We replicate the same process of cloning the struct with a different role, FragmentOutput,
and use it to generate the correct code without breaking other uses of the user-defined
struct.

* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::checkReturnType):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/fragment-output.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/268436@main">https://commits.webkit.org/268436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e20b06ebd19cc9ac715dddc2e539191604078678

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18325 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19919 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22342 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17009 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24131 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22103 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18605 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15769 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17751 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4707 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22108 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->