### PR TITLE
[iOS] Only allow sandbox access to Web Inspector daemon in internal builds

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -930,9 +930,13 @@
             "com.apple.iphone.axserver-systemwide"
             "com.apple.mobileassetd.v2"
             "com.apple.mobilegestalt.xpc"
-            "com.apple.tccd"
-            "com.apple.webinspector"
-)))
+            "com.apple.tccd")))
+
+(allow mach-lookup
+    (require-all
+        (extension "com.apple.webkit.extension.mach")
+        (system-attribute apple-internal)
+        (global-name "com.apple.webinspector")))
 
 ;; Silence warnings about these connections if we have decided not to extend access to them:
 (deny mach-lookup (with no-report)


### PR DESCRIPTION
#### d1bbbb8f08252022bb4710482f8c6917c1a60dcf
<pre>
[iOS] Only allow sandbox access to Web Inspector daemon in internal builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=262042">https://bugs.webkit.org/show_bug.cgi?id=262042</a>
rdar://115993515

Reviewed by Chris Dumez.

Only allow access to Web Inspector daemon in internal builds in the WebContent process sandbox on iOS.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/268396@main">https://commits.webkit.org/268396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75b0a6a3969b591354efce9d5ebb2a832569d13b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20156 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22343 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17010 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22105 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15771 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17752 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4680 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->