### PR TITLE
Reimport WPT tests up to 5e3b0aa

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/META.yml
@@ -1,1 +1,5 @@
 spec: https://w3c.github.io/webcodecs/
+suggested_reviewers:
+  - Djuffin
+  - sandersdan
+  - youennf

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
@@ -21,24 +21,12 @@ PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Ambiguou
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Codec with MIME type
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future opus codec string
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future aac codec string
-FAIL Test that AudioDecoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Video codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Ambiguous codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Codec with MIME type assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Possible future opus codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Possible future aac codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that AudioDecoder.configure() doesn't support config: Unrecognized codec
+PASS Test that AudioDecoder.configure() doesn't support config: Video codec
+PASS Test that AudioDecoder.configure() doesn't support config: Ambiguous codec
+PASS Test that AudioDecoder.configure() doesn't support config: Codec with MIME type
+PASS Test that AudioDecoder.configure() doesn't support config: Possible future opus codec string
+PASS Test that AudioDecoder.configure() doesn't support config: Possible future aac codec string
 PASS Test AudioDecoder construction
 PASS Verify unconfigured AudioDecoder operations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js
@@ -137,11 +137,22 @@ validButUnsupportedConfigs.forEach(entry => {
 validButUnsupportedConfigs.forEach(entry => {
   async_test(
       t => {
-        let codec = new AudioDecoder(getDefaultCodecInit(t));
-        assert_throws_dom('NotSupportedError', () => {
-          codec.configure(entry.config);
+        let codec = new AudioDecoder({
+          output: t.unreached_func('unexpected output'),
+          error: t.step_func_done(e => {
+            assert_true(e instanceof DOMException);
+            assert_equals(e.name, 'NotSupportedError');
+            assert_equals(codec.state, 'closed', 'state');
+          })
         });
-        t.done();
+        codec.configure(entry.config);
+        codec.flush()
+            .then(t.unreached_func('flush succeeded unexpectedly'))
+            .catch(t.step_func(e => {
+              assert_true(e instanceof DOMException);
+              assert_equals(e.name, 'InvalidStateError');
+              assert_equals(codec.state, 'closed', 'state');
+            }));
       },
       'Test that AudioDecoder.configure() doesn\'t support config: ' +
           entry.comment);

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
@@ -21,24 +21,12 @@ PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Ambiguou
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Codec with MIME type
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future opus codec string
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future aac codec string
-FAIL Test that AudioDecoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Video codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Ambiguous codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Codec with MIME type assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Possible future opus codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() doesn't support config: Possible future aac codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that AudioDecoder.configure() doesn't support config: Unrecognized codec
+PASS Test that AudioDecoder.configure() doesn't support config: Video codec
+PASS Test that AudioDecoder.configure() doesn't support config: Ambiguous codec
+PASS Test that AudioDecoder.configure() doesn't support config: Codec with MIME type
+PASS Test that AudioDecoder.configure() doesn't support config: Possible future opus codec string
+PASS Test that AudioDecoder.configure() doesn't support config: Possible future aac codec string
 PASS Test AudioDecoder construction
 PASS Verify unconfigured AudioDecoder operations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any-expected.txt
@@ -1,3 +1,5 @@
 
 PASS Test the Opus DTX flag works.
+FAIL Test the Opus bitrateMode flag works. assert_less_than: expected a number less than 40330 but got 80660
+PASS Test the AAC bitrateMode flag works.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.js
@@ -96,3 +96,185 @@ promise_test(async t => {
   // We expect a significant reduction in the number of packets, over ~10s of silence.
   assert_less_than(dtx_outputs.length, (normal_outputs.length / 2));
 }, 'Test the Opus DTX flag works.');
+
+
+// The Opus bitrateMode enum chooses whether we use a constant or variable bitrate.
+// This test ensures that VBR/CBR is respected properly by encoding almost 10s of
+// silence and comparing the size of the encoded variable or constant bitrates.
+promise_test(async t => {
+  let sample_rate = 48000;
+  let total_duration_s = 10;
+  let data_count = 100;
+  let vbr_outputs = [];
+  let cbr_outputs = [];
+
+  let cbr_encoder = new AudioEncoder({
+    error: e => {
+      assert_unreached('error: ' + e);
+    },
+    output: chunk => {
+      cbr_outputs.push(chunk);
+    }
+  });
+
+  let vbr_encoder = new AudioEncoder({
+    error: e => {
+      assert_unreached('error: ' + e);
+    },
+    output: chunk => {
+      vbr_outputs.push(chunk);
+    }
+  });
+
+  let config = {
+    codec: 'opus',
+    sampleRate: sample_rate,
+    numberOfChannels: 2,
+    bitrate: 256000,  // 256kbit
+  };
+
+  let cbr_config = { ...config, bitrateMode: "constant" };
+  let vbr_config = { ...config, bitrateMode: "variable" };
+
+  let cbr_config_support = await AudioEncoder.isConfigSupported(cbr_config);
+  assert_implements_optional(cbr_config_support.supported, "Opus CBR not supported");
+
+  let vbr_config_support = await AudioEncoder.isConfigSupported(vbr_config);
+  assert_implements_optional(vbr_config_support.supported, "Opus VBR not supported");
+
+  // Configure one encoder with VBR and one CBR.
+  cbr_encoder.configure(cbr_config);
+  vbr_encoder.configure(vbr_config);
+
+  let timestamp_us = 0;
+  let data_duration_s = total_duration_s / data_count;
+  let data_length = data_duration_s * config.sampleRate;
+  for (let i = 0; i < data_count; i++) {
+    let data;
+
+    if (i == 0 || i == (data_count - 1)) {
+      // Send real data for the first and last 100ms.
+      data = make_audio_data(
+        timestamp_us, config.numberOfChannels, config.sampleRate,
+        data_length);
+
+    } else {
+      // Send silence for the rest of the 10s.
+      data = make_silent_audio_data(
+        timestamp_us, config.numberOfChannels, config.sampleRate,
+        data_length);
+    }
+
+    vbr_encoder.encode(data);
+    cbr_encoder.encode(data);
+    data.close();
+
+    timestamp_us += data_duration_s * 1_000_000;
+  }
+
+  await Promise.all([cbr_encoder.flush(), vbr_encoder.flush()])
+
+  cbr_encoder.close();
+  vbr_encoder.close();
+
+  let vbr_total_bytes = 0;
+  vbr_outputs.forEach(chunk => vbr_total_bytes += chunk.byteLength)
+
+  let cbr_total_bytes = 0;
+  cbr_outputs.forEach(chunk => cbr_total_bytes += chunk.byteLength)
+
+  // We expect a significant reduction in the size of the packets, over ~10s of silence.
+  assert_less_than(vbr_total_bytes, (cbr_total_bytes / 2));
+}, 'Test the Opus bitrateMode flag works.');
+
+
+// The AAC bitrateMode enum chooses whether we use a constant or variable bitrate.
+// This test exercises the VBR/CBR paths. Some platforms don't support VBR for AAC,
+// and still emit a constant bitrate.
+promise_test(async t => {
+  let sample_rate = 48000;
+  let total_duration_s = 10;
+  let data_count = 100;
+  let vbr_outputs = [];
+  let cbr_outputs = [];
+
+  let cbr_encoder = new AudioEncoder({
+    error: e => {
+      assert_unreached('error: ' + e);
+    },
+    output: chunk => {
+      cbr_outputs.push(chunk);
+    }
+  });
+
+  let vbr_encoder = new AudioEncoder({
+    error: e => {
+      assert_unreached('error: ' + e);
+    },
+    output: chunk => {
+      vbr_outputs.push(chunk);
+    }
+  });
+
+  let config = {
+    codec: 'mp4a.40.2',
+    sampleRate: sample_rate,
+    numberOfChannels: 2,
+    bitrate: 192000,  // 256kbit
+  };
+
+  let cbr_config = { ...config, bitrateMode: "constant" };
+  let vbr_config = { ...config, bitrateMode: "variable" };
+
+  let cbr_config_support = await AudioEncoder.isConfigSupported(cbr_config);
+  assert_implements_optional(cbr_config_support.supported, "AAC CBR not supported");
+
+  let vbr_config_support = await AudioEncoder.isConfigSupported(vbr_config);
+  assert_implements_optional(vbr_config_support.supported, "AAC VBR not supported");
+
+  // Configure one encoder with VBR and one CBR.
+  cbr_encoder.configure(cbr_config);
+  vbr_encoder.configure(vbr_config);
+
+  let timestamp_us = 0;
+  let data_duration_s = total_duration_s / data_count;
+  let data_length = data_duration_s * config.sampleRate;
+  for (let i = 0; i < data_count; i++) {
+    let data;
+
+    if (i == 0 || i == (data_count - 1)) {
+      // Send real data for the first and last 100ms.
+      data = make_audio_data(
+        timestamp_us, config.numberOfChannels, config.sampleRate,
+        data_length);
+
+    } else {
+      // Send silence for the rest of the 10s.
+      data = make_silent_audio_data(
+        timestamp_us, config.numberOfChannels, config.sampleRate,
+        data_length);
+    }
+
+    vbr_encoder.encode(data);
+    cbr_encoder.encode(data);
+    data.close();
+
+    timestamp_us += data_duration_s * 1_000_000;
+  }
+
+  await Promise.all([cbr_encoder.flush(), vbr_encoder.flush()])
+
+  cbr_encoder.close();
+  vbr_encoder.close();
+
+  let vbr_total_bytes = 0;
+  vbr_outputs.forEach(chunk => vbr_total_bytes += chunk.byteLength)
+
+  let cbr_total_bytes = 0;
+  cbr_outputs.forEach(chunk => cbr_total_bytes += chunk.byteLength)
+
+  // We'd like to confirm that the encoded size using VBR is less than CBR, but
+  // platforms without VBR support will silently revert to CBR (which is
+  // technically a subset of VBR).
+  assert_less_than_equal(vbr_total_bytes, cbr_total_bytes);
+}, 'Test the AAC bitrateMode flag works.');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
@@ -40,30 +40,17 @@ FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample r
 FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Way too many channels assert_false: expected false got true
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future opus codec string
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future aac codec string
-FAIL Test that AudioEncoder.configure() doesn't support config: Bitrate is too low assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too small assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Way too many channels assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Possible future opus codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Possible future aac codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+FAIL Test that AudioEncoder.configure() doesn't support config: Bitrate is too low assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Unrecognized codec
+FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too small assert_unreached: flush succeeded unexpectedly Reached unreachable code
+FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too large assert_unreached: flush succeeded unexpectedly Reached unreachable code
+FAIL Test that AudioEncoder.configure() doesn't support config: Way too many channels assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Possible future opus codec string
+PASS Test that AudioEncoder.configure() doesn't support config: Possible future aac codec string
 PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":8000,"numberOfChannels":1}
 PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bogus":123}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"constant","bogus":123}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"variable","bogus":123}
 PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"complexity":5,"frameDuration":20000,"packetlossperc":10,"useinbandfec":true}}
 PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"format":"opus","complexity":10,"frameDuration":60000,"packetlossperc":20,"usedtx":true,"bogus":456}}
 FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{}} assert_true: expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js
@@ -215,11 +215,22 @@ validButUnsupportedConfigs.forEach(entry => {
 validButUnsupportedConfigs.forEach(entry => {
   async_test(
       t => {
-        let codec = new AudioEncoder(getDefaultCodecInit(t));
-        assert_throws_dom('NotSupportedError', () => {
-          codec.configure(entry.config);
+        let codec = new AudioEncoder({
+          output: t.unreached_func('unexpected output'),
+          error: t.step_func_done(e => {
+            assert_true(e instanceof DOMException);
+            assert_equals(e.name, 'NotSupportedError');
+            assert_equals(codec.state, 'closed', 'state');
+          })
         });
-        t.done();
+        codec.configure(entry.config);
+        codec.flush()
+            .then(t.unreached_func('flush succeeded unexpectedly'))
+            .catch(t.step_func(e => {
+              assert_true(e instanceof DOMException);
+              assert_equals(e.name, 'InvalidStateError');
+              assert_equals(codec.state, 'closed', 'state');
+            }));
       },
       'Test that AudioEncoder.configure() doesn\'t support config: ' +
           entry.comment);
@@ -241,6 +252,15 @@ const validConfigs = [
     sampleRate: 48000,
     numberOfChannels: 2,
     bitrate: 128000,
+    bitrateMode: "constant",
+    bogus: 123
+  },
+  {
+    codec: 'opus',
+    sampleRate: 48000,
+    numberOfChannels: 2,
+    bitrate: 128000,
+    bitrateMode: "variable",
     bogus: 123
   },
   {

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
@@ -40,30 +40,17 @@ FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample r
 FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Way too many channels assert_false: expected false got true
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future opus codec string
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future aac codec string
-FAIL Test that AudioEncoder.configure() doesn't support config: Bitrate is too low assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too small assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Way too many channels assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Possible future opus codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() doesn't support config: Possible future aac codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+FAIL Test that AudioEncoder.configure() doesn't support config: Bitrate is too low assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Unrecognized codec
+FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too small assert_unreached: flush succeeded unexpectedly Reached unreachable code
+FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too large assert_unreached: flush succeeded unexpectedly Reached unreachable code
+FAIL Test that AudioEncoder.configure() doesn't support config: Way too many channels assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Possible future opus codec string
+PASS Test that AudioEncoder.configure() doesn't support config: Possible future aac codec string
 PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":8000,"numberOfChannels":1}
 PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bogus":123}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"constant","bogus":123}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"variable","bogus":123}
 PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"complexity":5,"frameDuration":20000,"packetlossperc":10,"useinbandfec":true}}
 PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"format":"opus","complexity":10,"frameDuration":60000,"packetlossperc":20,"usedtx":true,"bogus":456}}
 FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{}} assert_true: expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any-expected.txt
@@ -1,18 +1,19 @@
 
 PASS Simple audio encoding
+PASS Test reset during flush
 PASS Encode audio with negative timestamp
-PASS Channel number variation: 1
-PASS Channel number variation: 2
-PASS Sample rate variation: 3000
-PASS Sample rate variation: 13000
-PASS Sample rate variation: 23000
-PASS Sample rate variation: 33000
-PASS Sample rate variation: 43000
-PASS Sample rate variation: 53000
-PASS Sample rate variation: 63000
-PASS Sample rate variation: 73000
-PASS Sample rate variation: 83000
-PASS Sample rate variation: 93000
+FAIL Channel number variation: 1 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Channel number variation: 2 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 3000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 13000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 23000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 33000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 43000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 53000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 63000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 73000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 83000 assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Sample rate variation: 93000 assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Encoding and decoding assert_true: expected true got false
 PASS Emit decoder config and extra data.
 PASS encodeQueueSize test

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.js
@@ -123,6 +123,51 @@ promise_test(async t => {
 }, 'Simple audio encoding');
 
 promise_test(async t => {
+  let outputs = 0;
+  let init = getDefaultCodecInit(t);
+  let firstOutput = new Promise(resolve => {
+    init.output = (chunk, metadata) => {
+      outputs++;
+      assert_equals(outputs, 1, 'outputs');
+      encoder.reset();
+      resolve();
+    };
+  });
+
+  let encoder = new AudioEncoder(init);
+  let config = {
+    codec: 'opus',
+    sampleRate: 48000,
+    numberOfChannels: 2,
+    bitrate: 256000  // 256kbit
+  };
+  encoder.configure(config);
+
+  let frame_count = 1024;
+  let frame1 = make_audio_data(
+      0, config.numberOfChannels, config.sampleRate, frame_count);
+  let frame2 = make_audio_data(
+      frame_count / config.sampleRate, config.numberOfChannels,
+      config.sampleRate, frame_count);
+  t.add_cleanup(() => {
+    frame1.close();
+    frame2.close();
+  });
+
+  encoder.encode(frame1);
+  encoder.encode(frame2);
+  const flushDone = encoder.flush();
+
+  // Wait for the first output, then reset.
+  await firstOutput;
+
+  // Flush should have been synchronously rejected.
+  await promise_rejects_dom(t, 'AbortError', flushDone);
+
+  assert_equals(outputs, 1, 'outputs');
+}, 'Test reset during flush');
+
+promise_test(async t => {
   let sample_rate = 48000;
   let total_duration_s = 1;
   let data_count = 10;
@@ -163,24 +208,24 @@ promise_test(async t => {
   }
 }, 'Encode audio with negative timestamp');
 
-async function checkEncodingError(config, good_data, bad_data) {
-  let error = null;
-  let outputs = 0;
-  let init = {
-    error: e => {
-      error = e;
-    },
-    output: chunk => {
-      outputs++;
-    }
-  };
-  let encoder = new AudioEncoder(init);
-
-
+async function checkEncodingError(t, config, good_data, bad_data) {
   let support = await AudioEncoder.isConfigSupported(config);
   assert_true(support.supported)
   config = support.config;
 
+  const callbacks = {};
+  let errors = 0;
+  let gotError = new Promise(resolve => callbacks.error = e => {
+    errors++;
+    resolve(e);
+  });
+
+  let outputs = 0;
+  callbacks.output = chunk => {
+    outputs++;
+  };
+
+  let encoder = new AudioEncoder(callbacks);
   encoder.configure(config);
   for (let data of good_data) {
     encoder.encode(data);
@@ -190,11 +235,21 @@ async function checkEncodingError(config, good_data, bad_data) {
 
   let txt_config = "sampleRate: " + config.sampleRate
                  + " numberOfChannels: " + config.numberOfChannels;
-  assert_equals(error, null, txt_config);
+  assert_equals(errors, 0, txt_config);
   assert_greater_than(outputs, 0);
+  outputs = 0;
+
   encoder.encode(bad_data);
-  await encoder.flush().catch(() => {});
-  assert_not_equals(error, null, txt_config);
+  await promise_rejects_dom(t, 'EncodingError', encoder.flush().catch((e) => {
+    assert_equals(errors, 0);
+    throw e;
+  }));
+
+  assert_equals(outputs, 0);
+  let e = await gotError;
+  assert_true(e instanceof DOMException);
+  assert_equals(e.name, 'EncodingError');
+  assert_equals(encoder.state, 'closed', 'state');
 }
 
 function channelNumberVariationTests() {
@@ -216,9 +271,9 @@ function channelNumberVariationTests() {
     ts += Math.floor(data2.duration / 1000000);
 
     let bad_data = make_audio_data(ts, channels + 1, sample_rate, length);
-    promise_test(async t =>
-      checkEncodingError(config, [data1, data2], bad_data),
-      "Channel number variation: " + channels);
+    promise_test(
+        async t => checkEncodingError(t, config, [data1, data2], bad_data),
+        'Channel number variation: ' + channels);
   }
 }
 channelNumberVariationTests();
@@ -242,9 +297,9 @@ function sampleRateVariationTests() {
     ts += Math.floor(data2.duration / 1000000);
 
     let bad_data = make_audio_data(ts, channels, sample_rate + 333, length);
-    promise_test(async t =>
-      checkEncodingError(config, [data1, data2], bad_data),
-      "Sample rate variation: " + sample_rate);
+    promise_test(
+        async t => checkEncodingError(t, config, [data1, data2], bad_data),
+        'Sample rate variation: ' + sample_rate);
   }
 }
 sampleRateVariationTests();
@@ -569,4 +624,4 @@ testOpusEncoderConfigs.forEach(entry => {
     assert_greater_than_equal(
         total_encoded_duration, total_duration_s * 1_000_000);
   }, 'Test encoding Opus with additional parameters: ' + entry.comment);
-})
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
@@ -19,8 +19,8 @@ PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
 PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
-PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
-PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string
+FAIL Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future AV1 codec string
 PASS Test VideoDecoder construction

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -22,40 +22,18 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
-FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264 assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode
+PASS Test that VideoEncoder.configure() doesn't support config: Unrecognized codec
+PASS Test that VideoEncoder.configure() doesn't support config: Codec with bad casing
+FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}}
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
@@ -191,11 +191,22 @@ validButUnsupportedConfigs.forEach(entry => {
 validButUnsupportedConfigs.forEach(entry => {
   async_test(
       t => {
-        let codec = new VideoEncoder(getDefaultCodecInit(t));
-        assert_throws_dom('NotSupportedError', () => {
-          codec.configure(entry.config);
+        let codec = new VideoEncoder({
+          output: t.unreached_func('unexpected output'),
+          error: t.step_func_done(e => {
+            assert_true(e instanceof DOMException);
+            assert_equals(e.name, 'NotSupportedError');
+            assert_equals(codec.state, 'closed', 'state');
+          })
         });
-        t.done();
+        codec.configure(entry.config);
+        codec.flush()
+            .then(t.unreached_func('flush succeeded unexpectedly'))
+            .catch(t.step_func(e => {
+              assert_true(e instanceof DOMException);
+              assert_equals(e.name, 'InvalidStateError');
+              assert_equals(codec.state, 'closed', 'state');
+            }));
       },
       'Test that VideoEncoder.configure() doesn\'t support config: ' +
           entry.comment);
@@ -259,12 +270,7 @@ validConfigs.forEach(config => {
       assert_equals(new_config.latencyMode, config.latencyMode);
     if (config.alpha)
       assert_equals(new_config.alpha, config.alpha);
-    if (config.codec.startsWith('avc')) {
-      if (config.avc) {
-        assert_equals(new_config.avc.format, config.avc.format);
-      }
-    } else {
-      assert_equals(new_config.avc, undefined);
-    }
+    if (config.avc)
+      assert_equals(new_config.avc.format, config.avc.format);
   }, "VideoEncoder.isConfigSupported() supports:" + JSON.stringify(config));
 });

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -22,40 +22,18 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
-FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264 assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode
+PASS Test that VideoEncoder.configure() doesn't support config: Unrecognized codec
+PASS Test that VideoEncoder.configure() doesn't support config: Codec with bad casing
+FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}}
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test reset during flush
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.js
@@ -1,0 +1,47 @@
+// META: global=window,dedicatedworker
+// META: script=/common/media.js
+// META: script=/webcodecs/utils.js
+// META: script=/webcodecs/video-encoder-utils.js
+
+promise_test(async t => {
+  let codecInit = getDefaultCodecInit(t);
+  let encoderConfig = {
+    codec: 'vp8',
+    width: 640,
+    height: 480,
+    displayWidth: 800,
+    displayHeight: 600,
+  };
+
+  let outputs = 0;
+  let firstOutput = new Promise(resolve => {
+    codecInit.output = (chunk, metadata) => {
+      outputs++;
+      assert_equals(outputs, 1, 'outputs');
+      encoder.reset();
+      resolve();
+    };
+  });
+
+  let encoder = new VideoEncoder(codecInit);
+  encoder.configure(encoderConfig);
+
+  let frame1 = createFrame(640, 480, 0);
+  let frame2 = createFrame(640, 480, 33333);
+  t.add_cleanup(() => {
+    frame1.close();
+    frame2.close();
+  });
+
+  encoder.encode(frame1);
+  encoder.encode(frame2);
+  const flushDone = encoder.flush();
+
+  // Wait for the first output, then reset.
+  await firstOutput;
+
+  // Flush should have been synchronously rejected.
+  await promise_rejects_dom(t, 'AbortError', flushDone);
+
+  assert_equals(outputs, 1, 'outputs');
+}, 'Test reset during flush');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test reset during flush
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
@@ -1,12 +1,9 @@
 
 PASS Test VideoEncoder construction
-FAIL Test VideoEncoder.configure() assert_throws_dom: bogus function "() => {
-      codec.configure(config);
-    }" did not throw
 PASS Test successful configure(), encode(), and flush()
 PASS encodeQueueSize test
 PASS Test successful reset() and re-confiugre()
-FAIL Test successful encode() after re-configure(). assert_throws_dom: function "() => encoder.configure(badConfig)" did not throw
+PASS Test successful encode() after re-configure().
 PASS Verify closed VideoEncoder operations
 PASS Verify unconfigured VideoEncoder operations
 PASS Verify encoding closed frames throws.

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt
@@ -1,12 +1,9 @@
 
 PASS Test VideoEncoder construction
-FAIL Test VideoEncoder.configure() assert_throws_dom: bogus function "() => {
-      codec.configure(config);
-    }" did not throw
 PASS Test successful configure(), encode(), and flush()
 PASS encodeQueueSize test
 PASS Test successful reset() and re-confiugre()
-FAIL Test successful encode() after re-configure(). assert_throws_dom: function "() => encoder.configure(badConfig)" did not throw
+PASS Test successful encode() after re-configure().
 PASS Verify closed VideoEncoder operations
 PASS Verify unconfigured VideoEncoder operations
 PASS Verify encoding closed frames throws.

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js
@@ -568,7 +568,6 @@ promise_test(async t => {
   });
 }, 'Test low-latency decoding');
 
-
 promise_test(async t => {
   await checkImplements();
   const callbacks = {};

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.js
@@ -404,16 +404,8 @@ test(t => {
       'invalid coded height');
   assert_throws_js(
       TypeError,
-      () => constructFrame({timestamp: 1234, codedWidth: 4, codedHeight: 1}),
-      'odd coded height');
-  assert_throws_js(
-      TypeError,
       () => constructFrame({timestamp: 1234, codedWidth: 0, codedHeight: 4}),
       'invalid coded width');
-  assert_throws_js(
-      TypeError,
-      () => constructFrame({timestamp: 1234, codedWidth: 3, codedHeight: 2}),
-      'odd coded width');
   assert_throws_js(
       TypeError, () => constructFrame({
                    timestamp: 1234,

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt
@@ -14,7 +14,6 @@ PASS Test invalid stride.
 PASS Test address overflow.
 PASS Test codedRect.
 PASS Test empty rect.
-PASS Test unaligned rect.
 PASS Test left crop.
 PASS Test invalid rect.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.js
@@ -281,16 +281,6 @@ promise_test(async t => {
 promise_test(async t => {
   const frame = makeI420_4x2();
   const options = {
-      rect: {x: 0, y: 0, width: 4, height: 1},
-  };
-  assert_throws_js(TypeError, () => frame.allocationSize(options));
-  const data = new Uint8Array(12);
-  await promise_rejects_js(t, TypeError, frame.copyTo(data, options));
-}, 'Test unaligned rect.');
-
-promise_test(async t => {
-  const frame = makeI420_4x2();
-  const options = {
       rect: {x: 2, y: 0, width: 2, height: 2},
   };
   const expectedLayout = [

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt
@@ -14,7 +14,6 @@ PASS Test invalid stride.
 PASS Test address overflow.
 PASS Test codedRect.
 PASS Test empty rect.
-PASS Test unaligned rect.
 PASS Test left crop.
 PASS Test invalid rect.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Test I420 VideoFrame construction with odd coded size coded width or height is odd
+FAIL Test I420 copyTo with odd coded size. promise_test: Unhandled rejection with value: object "TypeError: coded width or height is odd"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.js
@@ -1,0 +1,50 @@
+// META: global=window,dedicatedworker
+// META: script=/webcodecs/videoFrame-utils.js
+
+test(t => {
+  let fmt = 'I420';
+  let vfInit = {
+    format: fmt,
+    timestamp: 1234,
+    codedWidth: 3,
+    codedHeight: 3,
+    visibleRect: {x: 0, y: 0, width: 3, height: 3},
+  };
+  let data = new Uint8Array([
+    1, 2, 3, 4, 5, 6, 7, 8, 9,  // y
+    1, 2, 3, 4,                 // u
+    1, 2, 3, 4,                 // v
+  ]);
+  let frame = new VideoFrame(data, vfInit);
+  assert_equals(frame.format, fmt, 'format');
+  assert_equals(frame.visibleRect.x, 0, 'visibleRect.x');
+  assert_equals(frame.visibleRect.y, 0, 'visibleRect.y');
+  assert_equals(frame.visibleRect.width, 3, 'visibleRect.width');
+  assert_equals(frame.visibleRect.height, 3, 'visibleRect.height');
+  frame.close();
+}, 'Test I420 VideoFrame construction with odd coded size');
+
+promise_test(async t => {
+  const init = {
+    format: 'I420',
+    timestamp: 0,
+    codedWidth: 3,
+    codedHeight: 3,
+  };
+  const buf = new Uint8Array([
+    1, 2, 3, 4, 5, 6, 7, 8, 9,  // y
+    10, 11, 12, 13,             // u
+    14, 15, 16, 17,             // v
+  ]);
+  const expectedLayout = [
+    {offset: 0, stride: 3},
+    {offset: 9, stride: 2},
+    {offset: 13, stride: 2},
+  ];
+  const frame = new VideoFrame(buf, init);
+  assert_equals(frame.allocationSize(), buf.length, 'allocationSize()');
+  const data = new Uint8Array(buf.length);
+  const layout = await frame.copyTo(data);
+  assert_layout_equals(layout, expectedLayout);
+  assert_buffer_equals(data, buf);
+}, 'Test I420 copyTo with odd coded size.');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL Test I420 VideoFrame construction with odd coded size coded width or height is odd
+FAIL Test I420 copyTo with odd coded size. promise_test: Unhandled rejection with value: object "TypeError: coded width or height is odd"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/w3c-import.log
@@ -79,6 +79,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.crossOriginIsolated.https.any.js.headers
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-flush.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-h264.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-utils.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.js
@@ -98,8 +99,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.js
+/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-odd-size.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.helper.html
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html
+/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.https.html
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-utils.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/vp8.webm

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
@@ -19,8 +19,8 @@ PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
 PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
-FAIL Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future AV1 codec string
 PASS Test VideoDecoder construction

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
@@ -19,8 +19,8 @@ PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
 PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
-FAIL Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future AV1 codec string
 PASS Test VideoDecoder construction

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -22,40 +22,18 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
-FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264 assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode
+PASS Test that VideoEncoder.configure() doesn't support config: Unrecognized codec
+PASS Test that VideoEncoder.configure() doesn't support config: Codec with bad casing
+FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}}
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -22,40 +22,18 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible future AV1 codec string
-FAIL Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Unrecognized codec assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Codec with bad casing assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264 assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string assert_throws_dom: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode
+PASS Test that VideoEncoder.configure() doesn't support config: Unrecognized codec
+PASS Test that VideoEncoder.configure() doesn't support config: Codec with bad casing
+FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
-FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}}
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}
 


### PR DESCRIPTION
#### abb7c5d5bd0783f04b8c8411c3f862c004f487a3
<pre>
Reimport WPT tests up to 5e3b0aa
<a href="https://bugs.webkit.org/show_bug.cgi?id=262040">https://bugs.webkit.org/show_bug.cgi?id=262040</a>
rdar://115992997

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/: Resynced.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:

Canonical link: <a href="https://commits.webkit.org/268505@main">https://commits.webkit.org/268505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6fd135d9fff44f3e9f0b6ad810d5c71d3345329

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21789 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18582 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20109 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22643 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24368 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22354 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15992 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4756 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->