### PR TITLE
Treat huge 'repeatCount' values as invalid

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeatcount-numeric-limit.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeatcount-numeric-limit.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A huge 'repeatCount' (1e+309) is treated as unspecified
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeatcount-numeric-limit.tentative.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeatcount-numeric-limit.tentative.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>A huge 'repeatCount' (1e+309) is treated as unspecified</title>
+  <h:link rel="help" href="https://svgwg.org/specs/animations/#TimingAttributes"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+
+  <rect width="50" height="100" fill="blue">
+    <animate attributeName="fill" from="#007f00" to="green" dur="10ms" fill="freeze"
+             repeatCount="1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+  </rect>
+  <rect width="50" height="100" fill="blue" x="50">
+    <animate attributeName="fill" from="#007f00" to="green" dur="10ms" fill="freeze"
+             repeatCount="1e+309"/>
+  </rect>
+  <script>
+    promise_test(t => {
+      let watchers = Array.from(document.getElementsByTagName('animate')).map(element => {
+        let watcher = new EventWatcher(t, element, ['endEvent', 'repeatEvent']);
+        return watcher.wait_for('endEvent').then(() => {
+          assert_equals(getComputedStyle(element).fill, 'rgb(0, 128, 0)');
+        });
+      });
+      return Promise.all(watchers);
+    });
+  </script>
+</svg>

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2013-2017 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2021 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -719,7 +719,7 @@ SMILTime SVGSMILElement::repeatCount() const
         return SMILTime::indefinite();
     bool ok;
     double result = value.string().toDouble(&ok);
-    return m_cachedRepeatCount = ok && result > 0 ? result : SMILTime::unresolved();
+    return m_cachedRepeatCount = (ok && result > 0 && std::isfinite(result)) ? result : SMILTime::unresolved();
 }
 
 SMILTime SVGSMILElement::maxValue() const


### PR DESCRIPTION
#### 67ce0e5675816fce4f9989afe2ae1f2af709c16a
<pre>
Treat huge &apos;repeatCount&apos; values as invalid

<a href="https://bugs.webkit.org/show_bug.cgi?id=262046">https://bugs.webkit.org/show_bug.cgi?id=262046</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/8fcb33ec493a697c5973fed3fa3afaf77bf626db">https://chromium.googlesource.com/chromium/src/+/8fcb33ec493a697c5973fed3fa3afaf77bf626db</a>

String::toDouble() can return infinity. This value could either be
treated the same as the &apos;indefinite&apos; keyword or as invalid. Gecko
appears do the latter so follow suit. It is match Blink and Gecko.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(SVGSMILElement::repeatCount):
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeatcount-numeric-limit.tentative.svg: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeatcount-numeric-limit.tentative-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/268420@main">https://commits.webkit.org/268420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/414af4960d02135fce593daff33754bdd57f6cbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21492 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19925 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22349 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24137 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/17997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15777 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17758 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4691 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->