### PR TITLE
[WGSL] GlobalVariableRewriter doesn't distinguish between multiple globals with the same binding

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -848,6 +848,8 @@ void RewriteGlobalVariables::insertStructs(const UsedResources& usedResources)
         for (auto [binding, globalName] : bindingGlobalMap) {
             if (!usedBindings.contains(binding))
                 continue;
+            if (!m_reads.contains(globalName))
+                continue;
 
             auto it = m_globals.find(globalName);
             RELEASE_ASSERT(it != m_globals.end());

--- a/Source/WebGPU/WGSL/tests/valid/global-same-binding.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-same-binding.wgsl
@@ -1,0 +1,9 @@
+// RUN: %metal-compile main
+
+@binding(0) @group(0) var<uniform> x : vec4<f32>;
+@binding(0) @group(0) var<uniform> y : vec4<f32>;
+
+@compute @workgroup_size(1)
+fn main() {
+    _ = x;
+}


### PR DESCRIPTION
#### d83c118fb83b8b9d192dc37a05462975854bf4cd
<pre>
[WGSL] GlobalVariableRewriter doesn&apos;t distinguish between multiple globals with the same binding
<a href="https://bugs.webkit.org/show_bug.cgi?id=262045">https://bugs.webkit.org/show_bug.cgi?id=262045</a>
rdar://115994053

Reviewed by Dan Glastonbury.

When GlobalVariableRewriter determines which globals are used by each entrypoint, it
uses a pair of (group, binding) to determine which globals are used. However, it is
valid to have multiple globals with the same (group, binding) pair, so long as they are
not used by the same entrypoint. In those cases, we ended up marking all such variables
as used, which resulted in invalid code since we had multiple struct fields with the same
[[id]]. The fix is trivial, since we already keep track of the names of all the variables
used, all we need to do is add an extra check to see if the variable is used according
to its name.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/tests/valid/global-same-binding.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/268435@main">https://commits.webkit.org/268435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cd1dc9633794f7bc112c31817d19f2825fca6cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18333 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19926 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22350 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17019 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24139 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18080 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22111 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15779 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17759 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4709 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->