### PR TITLE
[WGSL] Add code generation for textureNumLevels

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -841,6 +841,161 @@ static void visitArguments(FunctionDefinitionWriter* writer, AST::CallExpression
     writer->stringBuilder().append(")");
 }
 
+static void emitTextureDimensions(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    const auto& get = [&](const char* property) {
+        writer->visit(call.arguments()[0]);
+        writer->stringBuilder().append(".get_", property, "(");
+        if (call.arguments().size() > 1)
+            writer->visit(call.arguments()[1]);
+        writer->stringBuilder().append(")");
+    };
+
+    const auto* vector = std::get_if<Types::Vector>(call.inferredType());
+    if (!vector) {
+        get("width");
+        return;
+    }
+
+    auto size = vector->size;
+    ASSERT(size >= 2 && size <= 3);
+    writer->stringBuilder().append("uint", String::number(size), "(");
+    get("width");
+    writer->stringBuilder().append(", ");
+    get("height");
+    if (size > 2) {
+        writer->stringBuilder().append(", ");
+        get("depth");
+    }
+    writer->stringBuilder().append(")");
+}
+
+static void emitTextureLoad(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    auto& texture = call.arguments()[0];
+    auto* textureType = texture.inferredType();
+
+    // FIXME: this should become isPrimitiveReference once PR#14299 lands
+    auto* primitive = std::get_if<Types::Primitive>(textureType);
+    bool isExternalTexture = primitive && primitive->kind == Types::Primitive::TextureExternal;
+    if (!isExternalTexture) {
+        writer->visit(call.arguments()[0]);
+        writer->stringBuilder().append(".read");
+        bool first = true;
+        writer->stringBuilder().append("(");
+        const char* cast = "uint";
+        if (const auto* vector = std::get_if<Types::Vector>(call.arguments()[1].inferredType())) {
+            switch (vector->size) {
+            case 2:
+                cast = "uint2";
+                break;
+            case 3:
+                cast = "uint3";
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        }
+        for (unsigned i = 1; i < call.arguments().size(); ++i) {
+            if (first) {
+                writer->stringBuilder().append(cast, "(");
+                writer->visit(call.arguments()[i]);
+                writer->stringBuilder().append(")");
+            } else {
+                writer->stringBuilder().append(", ");
+                writer->visit(call.arguments()[i]);
+            }
+            first = false;
+        }
+        writer->stringBuilder().append(")");
+        return;
+    }
+
+    auto& coordinates = call.arguments()[1];
+    writer->stringBuilder().append("({\n");
+    {
+        IndentationScope scope(writer->indent());
+        {
+            writer->stringBuilder().append(writer->indent(), "auto __coords = uint2((");
+            writer->visit(texture);
+            writer->stringBuilder().append(".UVRemapMatrix * float3(float2(");
+            writer->visit(coordinates);
+            writer->stringBuilder().append("), 1)).xy);\n");
+        }
+        {
+            writer->stringBuilder().append(writer->indent(), "auto __y = float(");
+            writer->visit(texture);
+            writer->stringBuilder().append(".FirstPlane.read(__coords).r);\n");
+        }
+        {
+            writer->stringBuilder().append(writer->indent(), "auto __cbcr = float2(");
+            writer->visit(texture);
+            writer->stringBuilder().append(".SecondPlane.read(__coords).rg);\n");
+        }
+        writer->stringBuilder().append(writer->indent(), "auto __ycbcr = float3(__y, __cbcr);\n");
+        {
+            writer->stringBuilder().append(writer->indent(), "float4(");
+            writer->visit(texture);
+            writer->stringBuilder().append(".ColorSpaceConversionMatrix * float4(__ycbcr, 1), 1);\n");
+        }
+    }
+    writer->stringBuilder().append(writer->indent(), "})");
+}
+
+static void emitTextureSample(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    ASSERT(call.arguments().size() > 1);
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append(".sample");
+    visitArguments(writer, call, 1);
+}
+
+static void emitTextureSampleClampToEdge(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    // FIXME: we need to handle `texture2d<T>` here too, not only `texture_external`
+    auto& texture = call.arguments()[0];
+    auto& sampler = call.arguments()[1];
+    auto& coordinates = call.arguments()[2];
+    writer->stringBuilder().append("({\n");
+    {
+        IndentationScope scope(writer->indent());
+        {
+            writer->stringBuilder().append(writer->indent(), "auto __coords = (");
+            writer->visit(texture);
+            writer->stringBuilder().append(".UVRemapMatrix * float3(");
+            writer->visit(coordinates);
+            writer->stringBuilder().append(", 1)).xy;\n");
+        }
+        {
+            writer->stringBuilder().append(writer->indent(), "auto __y = float(");
+            writer->visit(texture);
+            writer->stringBuilder().append(".FirstPlane.sample(");
+            writer->visit(sampler);
+            writer->stringBuilder().append(", __coords).r);\n");
+        }
+        {
+            writer->stringBuilder().append(writer->indent(), "auto __cbcr = float2(");
+            writer->visit(texture);
+            writer->stringBuilder().append(".SecondPlane.sample(");
+            writer->visit(sampler);
+            writer->stringBuilder().append(", __coords).rg);\n");
+        }
+        writer->stringBuilder().append(writer->indent(), "auto __ycbcr = float3(__y, __cbcr);\n");
+        {
+            writer->stringBuilder().append(writer->indent(), "float4(");
+            writer->visit(texture);
+            writer->stringBuilder().append(".ColorSpaceConversionMatrix * float4(__ycbcr, 1), 1);\n");
+        }
+    }
+    writer->stringBuilder().append(writer->indent(), "})");
+}
+
+static void emitTextureNumLevels(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append(".get_num_mip_levels()");
+}
+
 void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call)
 {
     auto isArray = is<AST::ArrayTypeExpression>(call.target());
@@ -854,19 +1009,15 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
         if (isArray)
             arrayElementType = std::get<Types::Array>(*type).element;
 
-        const auto& visitArgument = [&](auto& argument) {
-            if (isStruct)
-                visit(argument);
-            else
-                visit(arrayElementType, argument);
-        };
-
         m_stringBuilder.append("{\n");
         {
             IndentationScope scope(m_indent);
             for (auto& argument : call.arguments()) {
                 m_stringBuilder.append(m_indent);
-                visitArgument(argument);
+                if (isStruct)
+                    visit(argument);
+                else
+                    visit(arrayElementType, argument);
                 m_stringBuilder.append(",\n");
             }
         }
@@ -876,147 +1027,11 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
 
     if (is<AST::IdentifierExpression>(call.target())) {
         static constexpr std::pair<ComparableASCIILiteral, void(*)(FunctionDefinitionWriter*, AST::CallExpression&)> builtinMappings[] {
-            { "textureDimensions", [](FunctionDefinitionWriter* writer, AST::CallExpression& call) {
-                const auto& get = [&](const char* property) {
-                    writer->visit(call.arguments()[0]);
-                    writer->stringBuilder().append(".get_", property, "(");
-                    if (call.arguments().size() > 1)
-                        writer->visit(call.arguments()[1]);
-                    writer->stringBuilder().append(")");
-                };
-
-                const auto* vector = std::get_if<Types::Vector>(call.inferredType());
-                if (!vector) {
-                    get("width");
-                    return;
-                }
-
-                auto size = vector->size;
-                ASSERT(size >= 2 && size <= 3);
-                writer->stringBuilder().append("uint", String::number(size), "(");
-                get("width");
-                writer->stringBuilder().append(", ");
-                get("height");
-                if (size > 2) {
-                    writer->stringBuilder().append(", ");
-                    get("depth");
-                }
-                writer->stringBuilder().append(")");
-            } },
-            { "textureLoad", [](FunctionDefinitionWriter* writer, AST::CallExpression& call) {
-                auto& texture = call.arguments()[0];
-                auto* textureType = texture.inferredType();
-
-                // FIXME: this should become isPrimitiveReference once PR#14299 lands
-                auto* primitive = std::get_if<Types::Primitive>(textureType);
-                bool isExternalTexture = primitive && primitive->kind == Types::Primitive::TextureExternal;
-                if (!isExternalTexture) {
-                    writer->visit(call.arguments()[0]);
-                    writer->stringBuilder().append(".read");
-                    bool first = true;
-                    writer->stringBuilder().append("(");
-                    const char* cast = "uint";
-                    if (const auto* vector = std::get_if<Types::Vector>(call.arguments()[1].inferredType())) {
-                        switch (vector->size) {
-                        case 2:
-                            cast = "uint2";
-                            break;
-                        case 3:
-                            cast = "uint3";
-                            break;
-                        default:
-                            RELEASE_ASSERT_NOT_REACHED();
-                        }
-                    }
-                    for (unsigned i = 1; i < call.arguments().size(); ++i) {
-                        if (first) {
-                            writer->stringBuilder().append(cast, "(");
-                            writer->visit(call.arguments()[i]);
-                            writer->stringBuilder().append(")");
-                        } else {
-                            writer->stringBuilder().append(", ");
-                            writer->visit(call.arguments()[i]);
-                        }
-                        first = false;
-                    }
-                    writer->stringBuilder().append(")");
-                    return;
-                }
-
-                auto& coordinates = call.arguments()[1];
-                writer->stringBuilder().append("({\n");
-                {
-                    IndentationScope scope(writer->indent());
-                    {
-                        writer->stringBuilder().append(writer->indent(), "auto __coords = uint2((");
-                        writer->visit(texture);
-                        writer->stringBuilder().append(".UVRemapMatrix * float3(float2(");
-                        writer->visit(coordinates);
-                        writer->stringBuilder().append("), 1)).xy);\n");
-                    }
-                    {
-                        writer->stringBuilder().append(writer->indent(), "auto __y = float(");
-                        writer->visit(texture);
-                        writer->stringBuilder().append(".FirstPlane.read(__coords).r);\n");
-                    }
-                    {
-                        writer->stringBuilder().append(writer->indent(), "auto __cbcr = float2(");
-                        writer->visit(texture);
-                        writer->stringBuilder().append(".SecondPlane.read(__coords).rg);\n");
-                    }
-                    writer->stringBuilder().append(writer->indent(), "auto __ycbcr = float3(__y, __cbcr);\n");
-                    {
-                        writer->stringBuilder().append(writer->indent(), "float4(");
-                        writer->visit(texture);
-                        writer->stringBuilder().append(".ColorSpaceConversionMatrix * float4(__ycbcr, 1), 1);\n");
-                    }
-                }
-                writer->stringBuilder().append(writer->indent(), "})");
-            } },
-            { "textureSample", [](FunctionDefinitionWriter* writer, AST::CallExpression& call) {
-                ASSERT(call.arguments().size() > 1);
-                writer->visit(call.arguments()[0]);
-                writer->stringBuilder().append(".sample");
-                visitArguments(writer, call, 1);
-            } },
-            { "textureSampleBaseClampToEdge", [](FunctionDefinitionWriter* writer, AST::CallExpression& call) {
-                // FIXME: we need to handle `texture2d<T>` here too, not only `texture_external`
-                auto& texture = call.arguments()[0];
-                auto& sampler = call.arguments()[1];
-                auto& coordinates = call.arguments()[2];
-                writer->stringBuilder().append("({\n");
-                {
-                    IndentationScope scope(writer->indent());
-                    {
-                        writer->stringBuilder().append(writer->indent(), "auto __coords = (");
-                        writer->visit(texture);
-                        writer->stringBuilder().append(".UVRemapMatrix * float3(");
-                        writer->visit(coordinates);
-                        writer->stringBuilder().append(", 1)).xy;\n");
-                    }
-                    {
-                        writer->stringBuilder().append(writer->indent(), "auto __y = float(");
-                        writer->visit(texture);
-                        writer->stringBuilder().append(".FirstPlane.sample(");
-                        writer->visit(sampler);
-                        writer->stringBuilder().append(", __coords).r);\n");
-                    }
-                    {
-                        writer->stringBuilder().append(writer->indent(), "auto __cbcr = float2(");
-                        writer->visit(texture);
-                        writer->stringBuilder().append(".SecondPlane.sample(");
-                        writer->visit(sampler);
-                        writer->stringBuilder().append(", __coords).rg);\n");
-                    }
-                    writer->stringBuilder().append(writer->indent(), "auto __ycbcr = float3(__y, __cbcr);\n");
-                    {
-                        writer->stringBuilder().append(writer->indent(), "float4(");
-                        writer->visit(texture);
-                        writer->stringBuilder().append(".ColorSpaceConversionMatrix * float4(__ycbcr, 1), 1);\n");
-                    }
-                }
-                writer->stringBuilder().append(writer->indent(), "})");
-            } },
+            { "textureDimensions", emitTextureDimensions },
+            { "textureLoad", emitTextureLoad },
+            { "textureNumLevels", emitTextureNumLevels },
+            { "textureSample", emitTextureSample },
+            { "textureSampleBaseClampToEdge", emitTextureSampleClampToEdge },
         };
         static constexpr SortedArrayMap builtins { builtinMappings };
         const auto& targetName = downcast<AST::IdentifierExpression>(call.target()).identifier().id();

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2312,6 +2312,8 @@ fn testTextureNumLayers()
 }
 
 // 16.7.6
+// RUN: %metal-compile testTextureNumLevels
+@compute @workgroup_size(1)
 fn testTextureNumLevels()
 {
     // [S < Concrete32BitNumber].(Texture[S, Texture1d]) => U32,


### PR DESCRIPTION
#### 518faba7204dd1a114f54a8734a382741b78e1a0
<pre>
[WGSL] Add code generation for textureNumLevels
<a href="https://bugs.webkit.org/show_bug.cgi?id=262047">https://bugs.webkit.org/show_bug.cgi?id=262047</a>
rdar://115996263

Reviewed by Dan Glastonbury.

Generate Metal code for `textureNumLevels(t)` calls by transforming it into
`t.get_num_mip_levels()` calls. I also moved all the helpers that emit code for
built-ins into their own static functions, as it was becoming quite messy to
have so many lambdas in the same method.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitTextureDimensions):
(WGSL::Metal::emitTextureLoad):
(WGSL::Metal::emitTextureSample):
(WGSL::Metal::emitTextureSampleClampToEdge):
(WGSL::Metal::emitTextureNumLevels):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268442@main">https://commits.webkit.org/268442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/761d9ceea8f51bdeb08a67edb9007d11f63b582b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18334 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19929 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22351 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17021 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24140 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22112 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15783 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17760 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4714 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->