### PR TITLE
[iOS] Only allow access to the TCC daemon when the GPU process is not enabled

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -929,8 +929,7 @@
             "com.apple.frontboard.systemappservices"
             "com.apple.iphone.axserver-systemwide"
             "com.apple.mobileassetd.v2"
-            "com.apple.mobilegestalt.xpc"
-            "com.apple.tccd")))
+            "com.apple.mobilegestalt.xpc")))
 
 (allow mach-lookup
     (require-all

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -196,13 +196,6 @@ function mac_process_webcontent_shared_entitlements()
 {
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
-        if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 101400 ))
-        then
-            plistbuddy Add :com.apple.tcc.delegated-services array
-            plistbuddy Add :com.apple.tcc.delegated-services:1 string kTCCServiceMicrophone
-            plistbuddy Add :com.apple.tcc.delegated-services:0 string kTCCServiceCamera
-        fi
-
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
@@ -374,9 +367,6 @@ function ios_family_process_webcontent_shared_entitlements()
     plistbuddy Add :com.apple.private.webinspector.proxy-application bool YES
     plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
     plistbuddy Add :com.apple.runningboard.assertions.webkit bool YES
-    plistbuddy Add :com.apple.tcc.delegated-services array
-    plistbuddy Add :com.apple.tcc.delegated-services:0 string kTCCServiceCamera
-    plistbuddy Add :com.apple.tcc.delegated-services:1 string kTCCServiceMicrophone
     plistbuddy Add :com.apple.private.sandbox.profile string com.apple.WebKit.WebContent
     webcontent_sandbox_entitlements
 }

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -45,22 +45,6 @@ void SpeechRecognitionRemoteRealtimeMediaSourceManager::addSource(SpeechRecognit
     ASSERT(!m_sources.contains(identifier));
     m_sources.add(identifier, source);
 
-#if ENABLE(SANDBOX_EXTENSIONS)
-    if (!captureDevice.isMockDevice()) {
-        m_sourcesNeedingSandboxExtension.add(identifier);
-        if (m_sourcesNeedingSandboxExtension.size() == 1) {
-            auto machBootstrapHandle = SandboxExtension::createHandleForMachBootstrapExtension();
-            SandboxExtension::Handle handleForTCCD;
-            if (auto handle = SandboxExtension::createHandleForMachLookup("com.apple.tccd"_s, m_connection->getAuditToken()))
-                handleForTCCD = WTFMove(*handle);
-            SandboxExtension::Handle handleForMicrophone;
-            if (auto handle = SandboxExtension::createHandleForGenericExtension("com.apple.webkit.microphone"_s))
-                handleForMicrophone = WTFMove(*handle);
-            send(Messages::SpeechRecognitionRealtimeMediaSourceManager::GrantSandboxExtensions(machBootstrapHandle, handleForTCCD, handleForMicrophone));
-        }
-    }
-#endif
-
     send(Messages::SpeechRecognitionRealtimeMediaSourceManager::CreateSource(identifier, captureDevice, source.pageIdentifier()));
 }
 
@@ -69,13 +53,6 @@ void SpeechRecognitionRemoteRealtimeMediaSourceManager::removeSource(SpeechRecog
     auto identifier = source.identifier();
     ASSERT(!m_sources.get(identifier).get().get() || m_sources.get(identifier).get().get() == &source);
     m_sources.remove(identifier);
-
-#if ENABLE(SANDBOX_EXTENSIONS)
-    if (m_sourcesNeedingSandboxExtension.remove(identifier)) {
-        if (m_sourcesNeedingSandboxExtension.isEmpty())
-            send(Messages::SpeechRecognitionRealtimeMediaSourceManager::RevokeSandboxExtensions());
-    }
-#endif
 
     send(Messages::SpeechRecognitionRealtimeMediaSourceManager::DeleteSource(identifier));
 }

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -72,7 +72,6 @@ private:
 
     Ref<IPC::Connection> m_connection;
     HashMap<WebCore::RealtimeMediaSourceIdentifier, ThreadSafeWeakPtr<SpeechRecognitionRemoteRealtimeMediaSource>> m_sources;
-    HashSet<WebCore::RealtimeMediaSourceIdentifier> m_sourcesNeedingSandboxExtension;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -150,49 +150,6 @@ SpeechRecognitionRealtimeMediaSourceManager::~SpeechRecognitionRealtimeMediaSour
     WebProcess::singleton().removeMessageReceiver(*this);
 }
 
-#if ENABLE(SANDBOX_EXTENSIONS)
-
-void SpeechRecognitionRealtimeMediaSourceManager::grantSandboxExtensions(SandboxExtension::Handle&& machBootstrapHandle,  SandboxExtension::Handle&& sandboxHandleForTCCD, SandboxExtension::Handle&& sandboxHandleForMicrophone)
-{
-    m_machBootstrapExtension = SandboxExtension::create(WTFMove(machBootstrapHandle));
-    if (!m_machBootstrapExtension)
-        RELEASE_LOG_ERROR(Media, "Failed to create Mach bootstrap sandbox extension");
-    else
-        m_machBootstrapExtension->consume();
-
-    m_sandboxExtensionForTCCD = SandboxExtension::create(WTFMove(sandboxHandleForTCCD));
-    if (!m_sandboxExtensionForTCCD)
-        RELEASE_LOG_ERROR(Media, "Failed to create sandbox extension for tccd");
-    else
-        m_sandboxExtensionForTCCD->consume();
-
-    m_sandboxExtensionForMicrophone = SandboxExtension::create(WTFMove(sandboxHandleForMicrophone));
-    if (!m_sandboxExtensionForMicrophone)
-        RELEASE_LOG_ERROR(Media, "Failed to create sandbox extension for microphone");
-    else
-        m_sandboxExtensionForMicrophone->consume();
-}
-
-void SpeechRecognitionRealtimeMediaSourceManager::revokeSandboxExtensions()
-{
-    if (m_sandboxExtensionForTCCD) {
-        m_sandboxExtensionForTCCD->revoke();
-        m_sandboxExtensionForTCCD = nullptr;
-    }
-
-    if (m_sandboxExtensionForMicrophone) {
-        m_sandboxExtensionForMicrophone->revoke();
-        m_sandboxExtensionForMicrophone = nullptr;
-    }
-
-    if (m_machBootstrapExtension) {
-        m_machBootstrapExtension->revoke();
-        m_machBootstrapExtension = nullptr;
-    }
-}
-
-#endif
-
 void SpeechRecognitionRealtimeMediaSourceManager::createSource(RealtimeMediaSourceIdentifier identifier, const CaptureDevice& device, PageIdentifier pageIdentifier)
 {
     auto result = SpeechRecognitionCaptureSource::createRealtimeMediaSource(device, pageIdentifier);

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -51,10 +51,6 @@ private:
     void deleteSource(WebCore::RealtimeMediaSourceIdentifier);
     void start(WebCore::RealtimeMediaSourceIdentifier);
     void stop(WebCore::RealtimeMediaSourceIdentifier);
-#if ENABLE(SANDBOX_EXTENSIONS)
-    void grantSandboxExtensions(SandboxExtension::Handle&&, SandboxExtension::Handle&&, SandboxExtension::Handle&&);
-    void revokeSandboxExtensions();
-#endif
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in
@@ -28,11 +28,6 @@ messages -> SpeechRecognitionRealtimeMediaSourceManager NotRefCounted {
     DeleteSource(WebCore::RealtimeMediaSourceIdentifier identifier)
     Start(WebCore::RealtimeMediaSourceIdentifier identifier);
     Stop(WebCore::RealtimeMediaSourceIdentifier identifier);
-
-#if ENABLE(SANDBOX_EXTENSIONS)
-    GrantSandboxExtensions(WebKit::SandboxExtension::Handle bootstrapHandle, WebKit::SandboxExtension::Handle sandboxExtensionHandleForTCCD, WebKit::SandboxExtension::Handle sandboxExtensionHandleForMicrophone)
-    RevokeSandboxExtensions()
-#endif
 }
 
 #endif

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1754,11 +1754,7 @@
             "com.apple.webinspector"
             "com.apple.coreservices.launchservicesd"
             "com.apple.iconservices"
-            "com.apple.iconservices.store"
-            "com.apple.tccd"
-        )
-    )
-)
+            "com.apple.iconservices.store")))
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < 110000
 (allow mach-lookup


### PR DESCRIPTION
#### ac5c0d67aaf4040d236090f77d11a04bcdff7865
<pre>
[iOS] Only allow access to the TCC daemon when the GPU process is not enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=262049">https://bugs.webkit.org/show_bug.cgi?id=262049</a>
rdar://115996579

Reviewed by Youenn Fablet.

Block access to the TCC daemon in the WebContent process on iOS when the GPU process is enabled.
When the GPU process is enabled, the code that requires access to TCCD will be running in the
GPU process. There is no longer any need to grant this sandbox extension to the WebContent
process.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::addSource):
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::removeSource):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::grantSandboxExtensions): Deleted.
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::revokeSandboxExtensions): Deleted.
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.messages.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/268586@main">https://commits.webkit.org/268586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b57e42ba8f6a89cbc91ab25a81804a3c0c57ae6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18671 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20171 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22739 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20178 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17328 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24437 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22426 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16071 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18125 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22476 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2468 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->