### PR TITLE
[macOS] Block IOKit related mig syscalls when IOKit is blocked

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2147,11 +2147,6 @@
     thread_suspend))
 
 (define (kernel-mig-routines-possibly-in-use) (kernel-mig-routine
-    io_connect_add_client
-    io_connect_async_method
-    io_connect_method
-    io_connect_method_var_output
-    io_connect_set_notification_port_64
     io_registry_entry_get_property_bytes
     mach_exception_raise
     mach_port_extract_right
@@ -2159,6 +2154,11 @@
     mach_vm_region))
 
 (define (kernel-mig-routines-iokit-service) (kernel-mig-routine
+    io_connect_add_client
+    io_connect_async_method
+    io_connect_method
+    io_connect_method_var_output
+    io_connect_set_notification_port_64
     io_service_add_interest_notification_64
     io_service_add_notification_bin_64
     io_service_get_matching_service_bin
@@ -2201,7 +2201,12 @@
 #endif
 
             (allow mach-message-send (kernel-mig-routines-in-use))
+#if HAVE(SANDBOX_STATE_FLAGS)
+            (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+                (allow mach-message-send (kernel-mig-routines-iokit-service)))
+#else
             (allow mach-message-send (kernel-mig-routines-iokit-service))
+#endif
             (allow mach-message-send (with report) (with telemetry) (kernel-mig-routines-possibly-in-use))
                 
 #if HAVE(SANDBOX_STATE_FLAGS) && HAVE(MACH_RANGE_CREATE)


### PR DESCRIPTION
#### 5334f66e6e1fe541a0af10350d3def69c2244ad4
<pre>
[macOS] Block IOKit related mig syscalls when IOKit is blocked
<a href="https://bugs.webkit.org/show_bug.cgi?id=262052">https://bugs.webkit.org/show_bug.cgi?id=262052</a>
rdar://116000694

Reviewed by Brent Fulgham.

Block IOKit related mig syscalls in the WebContent process sandbox on macOS when IOKit is blocked.
We believe these syscalls are not required in this case, since all access to IOKit services and
clients is blocked in the sandbox already.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/268417@main">https://commits.webkit.org/268417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3695cc8e1856248f1bc8df2de17640b50a86d878

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20177 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22364 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17031 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24148 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22124 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15790 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17773 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4690 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->