### PR TITLE
[MediaStream] Reject when invalid required constraints are passed to getUserMedia

### DIFF
--- a/LayoutTests/fast/mediastream/reject-invalid-get-user-media-constraints-expected.txt
+++ b/LayoutTests/fast/mediastream/reject-invalid-get-user-media-constraints-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Call getUserMedia with a user gesture to remove the prompt from further calls
+PASS Deny getUserMedia call with required volume constraint
+PASS Deny getUserMedia call with required zoom constraint
+PASS Deny getUserMedia call with required whiteBalanceMode constraint
+

--- a/LayoutTests/fast/mediastream/reject-invalid-get-user-media-constraints.html
+++ b/LayoutTests/fast/mediastream/reject-invalid-get-user-media-constraints.html
@@ -1,0 +1,26 @@
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+
+promise_test(() => {
+    let promise;
+    internals.withUserGesture(() => {
+        promise = navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    });
+    return promise;
+}, "Call getUserMedia with a user gesture to remove the prompt from further calls");
+
+promise_test((test) => {
+    return promise_rejects_js(test, TypeError, navigator.mediaDevices.getUserMedia({ audio: { volume: { max: 1 } } }));
+}, "Deny getUserMedia call with required volume constraint");
+
+promise_test((test) => {
+    return promise_rejects_js(test, TypeError, navigator.mediaDevices.getUserMedia({ video: { zoom: { min: 1 } } }));
+}, "Deny getUserMedia call with required zoom constraint");
+
+promise_test((test) => {
+    return promise_rejects_js(test, TypeError, navigator.mediaDevices.getUserMedia({ video: { whiteBalanceMode: { exact: "continuous" } } }));
+}, "Deny getUserMedia call with required whiteBalanceMode constraint");
+
+</script>

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -121,6 +121,48 @@ bool MediaDevices::computeUserGesturePriviledge(GestureAllowedRequest requestTyp
     return isUserGesturePriviledged;
 }
 
+static std::optional<MediaConstraint> invalidRequiredConstraintForDeviceSelection(const MediaConstraints& constraints)
+{
+    // https://w3c.github.io/mediacapture-main/#dfn-allowed-required-constraints-for-device-selection
+    // The allowed required constraints for device selection contains the following constraint names:
+    // width, height, aspectRatio, frameRate, facingMode, resizeMode, sampleRate, sampleSize,
+    // echoCancellation, autoGainControl, noiseSuppression, latency, channelCount, deviceId, groupId.
+
+    std::optional<MediaConstraint> invalidConstraint;
+    constraints.mandatoryConstraints.filter([&invalidConstraint] (const MediaConstraint& constraint) mutable {
+        switch (constraint.constraintType()) {
+        case MediaConstraintType::Width:
+        case MediaConstraintType::Height:
+        case MediaConstraintType::AspectRatio:
+        case MediaConstraintType::FrameRate:
+        case MediaConstraintType::FacingMode:
+        case MediaConstraintType::SampleRate:
+        case MediaConstraintType::SampleSize:
+        case MediaConstraintType::EchoCancellation:
+        case MediaConstraintType::DeviceId:
+        case MediaConstraintType::GroupId:
+            break;
+
+        case MediaConstraintType::Volume:
+        case MediaConstraintType::FocusDistance:
+        case MediaConstraintType::Zoom:
+        case MediaConstraintType::WhiteBalanceMode:
+        case MediaConstraintType::Unknown:
+            invalidConstraint = { constraint };
+            break;
+
+        case MediaConstraintType::DisplaySurface:
+        case MediaConstraintType::LogicalSurface:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+
+        return invalidConstraint.has_value();
+    });
+
+    return invalidConstraint;
+}
+
 void MediaDevices::getUserMedia(StreamConstraints&& constraints, Promise&& promise)
 {
     auto audioConstraints = createMediaConstraints(constraints.audio);
@@ -152,10 +194,20 @@ void MediaDevices::getUserMedia(StreamConstraints&& constraints, Promise&& promi
     if (audioConstraints.isValid) {
         isUserGesturePriviledged |= computeUserGesturePriviledge(GestureAllowedRequest::Microphone);
         audioConstraints.setDefaultAudioConstraints();
+
+        if (auto invalidConstraint = invalidRequiredConstraintForDeviceSelection(audioConstraints)) {
+            promise.reject(Exception { TypeError, makeString("Invalid required constraint"_s, invalidConstraint->name()) });
+            return;
+        }
     }
     if (videoConstraints.isValid) {
         isUserGesturePriviledged |= computeUserGesturePriviledge(GestureAllowedRequest::Camera);
         videoConstraints.setDefaultVideoConstraints();
+
+        if (auto invalidConstraint = invalidRequiredConstraintForDeviceSelection(videoConstraints)) {
+            promise.reject(Exception { TypeError, makeString("Invalid required constraint"_s, invalidConstraint->name()) });
+            return;
+        }
     }
 
     auto request = UserMediaRequest::create(*document, { MediaStreamRequest::Type::UserMedia, WTFMove(audioConstraints), WTFMove(videoConstraints), isUserGesturePriviledged, *document->pageID() }, WTFMove(constraints.audio), WTFMove(constraints.video), WTFMove(promise));

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -597,7 +597,7 @@ void AVVideoCaptureSource::updateWhiteBalanceMode()
                 ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "error locking configuration ", error);
         }
     } @catch(NSException *exception) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "error setting white balance mode ", [[exception name] UTF8String], ", reason : ", exception.reason);
+        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "error setting white balance mode ", exception.name, ", reason : ", exception.reason);
     }
 
     [device unlockForConfiguration];


### PR DESCRIPTION
#### ab468d3da2c75d7d90289ba274ec158f4ce4c826
<pre>
[MediaStream] Reject when invalid required constraints are passed to getUserMedia
<a href="https://bugs.webkit.org/show_bug.cgi?id=262054">https://bugs.webkit.org/show_bug.cgi?id=262054</a>
rdar://116001840

Reviewed by NOBODY (OOPS!).

Immediately reject the getUserMedia promise if a required constraint is not in the allowed
list.

* LayoutTests/fast/mediastream/reject-invalid-get-user-media-constraints-expected.txt: Added.
* LayoutTests/fast/mediastream/reject-invalid-get-user-media-constraints.html: Added.

* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::invalidRequiredConstraintForDeviceSelection):
(WebCore::MediaDevices::getUserMedia):

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::updateWhiteBalanceMode): Drive-by - update logging to use
new `id` template specialization.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab468d3da2c75d7d90289ba274ec158f4ce4c826

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18350 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20181 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19836 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19854 "1 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17057 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22368 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17038 "8 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17848 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24161 "121 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18102 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18022 "1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22137 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18630 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15793 "1 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17683 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22132 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->