### PR TITLE
REGRESSION(266896@main): [ Debug wk2 ] fast/mediastream/captureStream/canvas3d.html is a constant failure.

### DIFF
--- a/LayoutTests/fast/mediastream/captureStream/canvas3d.html
+++ b/LayoutTests/fast/mediastream/captureStream/canvas3d.html
@@ -42,6 +42,8 @@ promise_test(async test => {
     var stream = canvas1.captureStream();
     video1.srcObject = stream;
 
+    await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+
     const promise = new Promise((resolve, reject) => {
         const identifier = video1.requestVideoFrameCallback((now, metadata) => {
             resolve(new VideoFrame(video1));
@@ -70,6 +72,8 @@ promise_test(async test => {
 promise_test(async test => {
     var stream = canvas2.captureStream();
     video2.srcObject = stream;
+
+    await new Promise(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
 
     const promise = new Promise((resolve, reject) => {
         const identifier = video2.requestVideoFrameCallback((now, metadata) => {

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -883,6 +883,4 @@ webkit.org/b/260834 imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasI
 
 webkit.org/b/260926 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click.html [ Pass Failure ]
 
-webkit.org/b/261314 [ Debug ] fast/mediastream/captureStream/canvas3d.html [ Failure ]
-
 webkit.org/b/261920 fast/mediastream/video-srcObject-set-twice.html [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 777397b2e4c0a9268e9ca242ce89119dd255da04
<pre>
REGRESSION(266896@main): [ Debug wk2 ] fast/mediastream/captureStream/canvas3d.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261314">https://bugs.webkit.org/show_bug.cgi?id=261314</a>

Reviewed by Eric Carlson.

Align the start of each test case with 0s timer after rAF to make the execution order between
requestVideoFrameCallback callback and timers consistent.

* LayoutTests/fast/mediastream/captureStream/canvas3d.html:
* LayoutTests/platform/wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/268416@main">https://commits.webkit.org/268416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0b4e940d933ee6514a854bd7467e5d556e3c19e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21510 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18349 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20180 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22367 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17037 "10 flakes 5 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24154 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22144 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15792 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17682 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22131 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2405 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->