### PR TITLE
Declarative Web Push: Flatten the JSON structure, removing the `options` sub-object

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -1581,153 +1581,119 @@ static constexpr ASCIILiteral json15 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "dir": 0
-    }
+    "dir": 0
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json16 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "dir": "auto"
-    }
+    "dir": "auto"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json17 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "dir": "ltr"
-    }
+    "dir": "ltr"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json18 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "dir": "rtl"
-    }
+    "dir": "rtl"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json19 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "dir": "nonsense"
-    }
+    "dir": "nonsense"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json20 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "lang": { }
-    }
+    "lang": { }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json21 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "lang": "language"
-    }
+    "lang": "language"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json22 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "body": { }
-    }
+    "body": { }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json23 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "body": "world"
-    }
+    "body": "world"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json24 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "tag": { }
-    }
+    "tag": { }
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json25 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "tag": "world"
-    }
+    "tag": "world"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json26 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "icon": 0
-    }
+    "icon": 0
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json27 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "icon": "world"
-    }
+    "icon": "world"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json28 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "icon": "https://example.com/icon.png"
-    }
+    "icon": "https://example.com/icon.png"
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json29 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "silent": 0
-    }
+    "silent": 0
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json30 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "silent": true
-    }
+    "silent": true
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json31 = R"JSONRESOURCE(
 {
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
-    "options": {
-        "silent": false
-    }
+    "silent": false
 }
 )JSONRESOURCE"_s;
 static constexpr ASCIILiteral json32 = R"JSONRESOURCE(
@@ -1792,9 +1758,7 @@ static constexpr ASCIILiteral json40 = R"JSONRESOURCE(
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
     "mutable": true,
-    "options": {
-        "tag": "title Gotcha!"
-    },
+    "tag": "title Gotcha!",
     "app_badge": "12"
 }
 )JSONRESOURCE"_s;
@@ -1803,9 +1767,7 @@ static constexpr ASCIILiteral json41 = R"JSONRESOURCE(
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
     "mutable": true,
-    "options": {
-        "tag": "badge 1024"
-    },
+    "tag": "badge 1024",
     "app_badge": "12"
 }
 )JSONRESOURCE"_s;
@@ -1814,9 +1776,7 @@ static constexpr ASCIILiteral json42 = R"JSONRESOURCE(
     "default_action_url": "https://example.com/",
     "title": "Hello world!",
     "mutable": true,
-    "options": {
-        "tag": "titleandbadge ThisRules 4096"
-    },
+    "tag": "titleandbadge ThisRules 4096",
     "app_badge": "12"
 }
 )JSONRESOURCE"_s;
@@ -1825,10 +1785,8 @@ static constexpr ASCIILiteral json43 = R"JSONRESOURCE(
     "default_action_url": "https://example.com/",
     "title": "Test the data object",
     "mutable": true,
-    "options": {
-        "tag": "datatotitle",
-        "data": "Raw string"
-    },
+    "tag": "datatotitle",
+    "data": "Raw string",
     "app_badge": "12"
 }
 )JSONRESOURCE"_s;
@@ -1837,10 +1795,8 @@ static constexpr ASCIILiteral json44 = R"JSONRESOURCE(
     "default_action_url": "https://example.com/",
     "title": "Test the data object",
     "mutable": true,
-    "options": {
-        "tag": "datatotitle",
-        "data": { "key": "value" }
-    },
+    "tag": "datatotitle",
+    "data": { "key": "value" },
     "app_badge": "12"
 }
 )JSONRESOURCE"_s;
@@ -1875,16 +1831,16 @@ static constexpr ASCIILiteral errors[] = {
     "'title' member is specified but is not a string"_s,
     "'app_badge' member is specified as a string that did not parse to to an unsigned long long"_s,
     "'app_badge' member is specified as an number but is not a valid unsigned long long"_s,
-    "'options' member is specified but is not an object"_s,
+    "<intentionally left blank>"_s,
     "'app_badge' member is specified but is not a string or a number"_s,
-    "'options' JSON is not valid: 'dir' member is specified but is not a valid NotificationDirection"_s,
-    "'options' JSON is not valid: 'dir' member is specified but is not a string"_s,
-    "'options' JSON is not valid: 'lang' member is specified but is not a string"_s,
-    "'options' JSON is not valid: 'body' member is specified but is not a string"_s,
-    "'options' JSON is not valid: 'tag' member is specified but is not a string"_s,
-    "'options' JSON is not valid: 'icon' member is specified but is not a string"_s,
-    "'options' JSON is not valid: 'icon' member is specified but does not represent a valid URL"_s,
-    "'options' JSON is not valid: 'silent' member is specified but is not a boolean"_s,
+    "'dir' member is specified but is not a valid NotificationDirection"_s,
+    "'dir' member is specified but is not a string"_s,
+    "'lang' member is specified but is not a string"_s,
+    "'body' member is specified but is not a string"_s,
+    "'tag' member is specified but is not a string"_s,
+    "'icon' member is specified but is not a string"_s,
+    "'icon' member is specified but does not represent a valid URL"_s,
+    "'silent' member is specified but is not a boolean"_s,
     "'app_badge' member is specified as a string that did not parse to a valid unsigned long long"_s,
     "'mutable' member is specified but is not a boolean"_s
 };
@@ -1903,7 +1859,7 @@ static std::pair<ASCIILiteral, ASCIILiteral> jsonAndErrors[] = {
     { json10, errors[6] },
     { json11, errors[8] },
     { json12, { " "_s } },
-    { json13, errors[7] },
+    { json13, { " "_s } },
     { json14, { " "_s } },
     { json15, errors[10] },
     { json16, { " "_s } },
@@ -2098,6 +2054,10 @@ public:
     {
         NSString *recentTitle = webViews().first()->mostRecentNotification().userInfo[@"WebNotificationTitleKey"];
         EXPECT_TRUE([recentTitle isEqualToString:title]);
+
+        if (![recentTitle isEqualToString:title])
+            NSLog(@"Most recent title: %@\nExpected title: %@", recentTitle, title);
+
     }
 
     void checkLastNotificationDefaultActionURL(NSString *actionURL)
@@ -2110,6 +2070,10 @@ public:
     {
         NSURL *recentActionURL = webViews().first()->mostRecentActionURL();
         EXPECT_TRUE([url isEqualToString:recentActionURL.absoluteString]);
+
+        if (![url isEqualToString:recentActionURL.absoluteString])
+            NSLog(@"Lact action URL: %@\nExpected URL: %@", recentActionURL, url);
+
     }
 
     void checkLastAppBadge(std::optional<uint64_t> badge)


### PR DESCRIPTION
#### d3f529899e76b9a2e64ea39fee114fcbfb776f52
<pre>
Declarative Web Push: Flatten the JSON structure, removing the `options` sub-object
<a href="https://bugs.webkit.org/show_bug.cgi?id=262055">https://bugs.webkit.org/show_bug.cgi?id=262055</a>
rdar://116003373

Reviewed by Alex Christensen.

This helps to reconcile the non-optional &quot;default action URL&quot; JSON member with the
completely optional &quot;default action URL&quot; NotificationOptions dictionary member.

Makes describing the JSON simpler, as well as making future additions easier.

* Source/WebCore/Modules/notifications/NotificationJSONParser.cpp:
(WebCore::NotificationJSONParser::parseNotificationPayload):
(WebCore::optionsKey): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/268408@main">https://commits.webkit.org/268408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fbcfdf1791951dbadc5abb2e9f8ade3eed551c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20189 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22376 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17855 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22138 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18638 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17785 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4687 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->