### PR TITLE
Use `->` directly instead of `.get()->` when possible

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRHand.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRHand.cpp
@@ -86,7 +86,7 @@ WebXRSession* WebXRHand::session()
     if (!m_inputSource)
         return nullptr;
 
-    return m_inputSource.get()->session();
+    return m_inputSource->session();
 }
 
 void WebXRHand::updateFromInputSource(const PlatformXR::Device::FrameData::InputSource& inputSource)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8749,7 +8749,7 @@ void Document::updateMainArticleElementAfterLayout()
     float secondTallestArticleHeight = 0;
 
     for (auto& article : m_articleElements) {
-        auto* box = article.get()->renderBox();
+        auto* box = article->renderBox();
         float height = box ? box->height().toFloat() : 0;
         if (height >= tallestArticleHeight) {
             secondTallestArticleHeight = tallestArticleHeight;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6088,7 +6088,7 @@ void LocalFrameView::updateWidgetPositionsTimerFired()
 void LocalFrameView::notifyWidgets(WidgetNotification notification)
 {
     for (auto& widget : collectAndProtectWidgets(m_widgetsInRenderTree))
-        widget.get()->notifyWidget(notification);
+        widget->notifyWidget(notification);
 }
 
 void LocalFrameView::setViewExposedRect(std::optional<FloatRect> viewExposedRect)

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -251,7 +251,7 @@ static void networkStateChanged(bool isOnLine)
 
     // Get all the frames of all the pages in all the page groups
     for (auto& page : allPages()) {
-        for (auto* frame = &page.get()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        for (auto* frame = &page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
@@ -477,7 +477,7 @@ void Page::firstTimeInitialization()
 void Page::clearPreviousItemFromAllPages(HistoryItem* item)
 {
     for (auto& page : allPages()) {
-        auto* localMainFrame = dynamicDowncast<LocalFrame>(page.get()->mainFrame());
+        auto* localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
         if (!localMainFrame)
             return;
 
@@ -757,7 +757,7 @@ void Page::updateStyleAfterChangeInEnvironment()
 void Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment()
 {
     for (auto& page : allPages())
-        page.get()->updateStyleAfterChangeInEnvironment();
+        page->updateStyleAfterChangeInEnvironment();
 }
 
 void Page::setNeedsRecalcStyleInAllFrames()
@@ -773,7 +773,7 @@ void Page::refreshPlugins(bool reload)
     HashSet<PluginInfoProvider*> pluginInfoProviders;
 
     for (auto& page : allPages())
-        pluginInfoProviders.add(&page.get()->pluginInfoProvider());
+        pluginInfoProviders.add(&page->pluginInfoProvider());
 
     for (auto& pluginInfoProvider : pluginInfoProviders)
         pluginInfoProvider->refresh(reload);

--- a/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm
@@ -55,7 +55,7 @@ void platformReleaseMemory(Critical)
     LocaleCocoa::releaseMemory();
 
     for (auto& pool : LayerPool::allLayerPools())
-        pool.get()->drain();
+        pool->drain();
 
 #if PLATFORM(IOS_FAMILY)
     LegacyTileCache::drainLayerPool();

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -460,7 +460,7 @@ bool ContentSecurityPolicy::shouldPerformEarlyCSPCheck() const
     // We perform checks early if strict-dynamic is included in the CSP policy because
     // we have access to necessary information about the script that we do not have later on.
     for (auto& policy : m_policies) {
-        if (policy.get()->strictDynamicIncluded())
+        if (policy->strictDynamicIncluded())
             return true;
     }
     return false;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -170,7 +170,7 @@ ContentSecurityPolicySourceListDirective* ContentSecurityPolicyDirectiveList::op
     }
 
     if (m_childSrc.get()) {
-        m_childSrc.get()->setNameForReporting(nameForReporting);
+        m_childSrc->setNameForReporting(nameForReporting);
         return m_childSrc.get();
     }
 
@@ -185,7 +185,7 @@ ContentSecurityPolicySourceListDirective* ContentSecurityPolicyDirectiveList::op
     }
 
     if (m_defaultSrc.get())
-        m_defaultSrc.get()->setNameForReporting(nameForReporting);
+        m_defaultSrc->setNameForReporting(nameForReporting);
 
     return m_defaultSrc.get();
 }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -61,7 +61,7 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
     if (m_mediaElement == mediaElement) {
         if (m_mediaElement) {
             for (auto& client : m_clients)
-                client.get()->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
+                client->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
         }
         return;
     }
@@ -109,14 +109,14 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
     updateForEventName(eventNameAll());
 
     for (auto& client : m_clients)
-        client.get()->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
+        client->isPictureInPictureSupportedChanged(isPictureInPictureSupported());
 }
 
 void PlaybackSessionModelMediaElement::mediaEngineChanged()
 {
     bool wirelessVideoPlaybackDisabled = this->wirelessVideoPlaybackDisabled();
     for (auto& client : m_clients)
-        client.get()->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
+        client->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
 }
 
 void PlaybackSessionModelMediaElement::handleEvent(WebCore::ScriptExecutionContext&, WebCore::Event& event)
@@ -135,19 +135,19 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
         || eventName == eventNames().durationchangeEvent) {
         double duration = this->duration();
         for (auto& client : m_clients)
-            client.get()->durationChanged(duration);
+            client->durationChanged(duration);
         // These is no standard event for minFastReverseRateChange; duration change is a reasonable proxy for it.
         // It happens every time a new item becomes ready to play.
         bool canPlayFastReverse = this->canPlayFastReverse();
         for (auto& client : m_clients)
-            client.get()->canPlayFastReverseChanged(canPlayFastReverse);
+            client->canPlayFastReverseChanged(canPlayFastReverse);
     }
 
     if (all
         || eventName == eventNames().playEvent
         || eventName == eventNames().playingEvent) {
         for (auto& client : m_clients)
-            client.get()->playbackStartedTimeChanged(playbackStartedTime());
+            client->playbackStartedTimeChanged(playbackStartedTime());
     }
 
     if (all
@@ -165,7 +165,7 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
         double playbackRate =  this->playbackRate();
         double defaultPlaybackRate = this->defaultPlaybackRate();
         for (auto& client : m_clients)
-            client.get()->rateChanged(playbackState, playbackRate, defaultPlaybackRate);
+            client->rateChanged(playbackState, playbackRate, defaultPlaybackRate);
     }
 
     if (all
@@ -173,7 +173,7 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
         auto currentTime = this->currentTime();
         auto anchorTime = [[NSProcessInfo processInfo] systemUptime];
         for (auto& client : m_clients)
-            client.get()->currentTimeChanged(currentTime, anchorTime);
+            client->currentTimeChanged(currentTime, anchorTime);
     }
 
     if (all
@@ -183,8 +183,8 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
         auto seekableTimeRangesLastModifiedTime = this->seekableTimeRangesLastModifiedTime();
         auto liveUpdateInterval = this->liveUpdateInterval();
         for (auto& client : m_clients) {
-            client.get()->bufferedTimeChanged(bufferedTime);
-            client.get()->seekableRangesChanged(seekableRanges, seekableTimeRangesLastModifiedTime, liveUpdateInterval);
+            client->bufferedTimeChanged(bufferedTime);
+            client->seekableRangesChanged(seekableRanges, seekableTimeRangesLastModifiedTime, liveUpdateInterval);
         }
     }
 
@@ -202,8 +202,8 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
         bool wirelessVideoPlaybackDisabled = this->wirelessVideoPlaybackDisabled();
 
         for (auto& client : m_clients) {
-            client.get()->externalPlaybackChanged(enabled, targetType, localizedDeviceName);
-            client.get()->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
+            client->externalPlaybackChanged(enabled, targetType, localizedDeviceName);
+            client->wirelessVideoPlaybackDisabledChanged(wirelessVideoPlaybackDisabled);
         }
     }
 
@@ -212,7 +212,7 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
         bool isPictureInPictureActive = this->isPictureInPictureActive();
 
         for (auto& client : m_clients)
-            client.get()->pictureInPictureActiveChanged(isPictureInPictureActive);
+            client->pictureInPictureActiveChanged(isPictureInPictureActive);
     }
 
 
@@ -224,8 +224,8 @@ void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString&
     if (all
         || eventName == eventNames().volumechangeEvent) {
         for (auto& client : m_clients) {
-            client.get()->mutedChanged(isMuted());
-            client.get()->volumeChanged(volume());
+            client->mutedChanged(isMuted());
+            client->volumeChanged(volume());
         }
     }
 }
@@ -407,8 +407,8 @@ void PlaybackSessionModelMediaElement::updateMediaSelectionOptions()
     auto legibleIndex = legibleMediaSelectedIndex();
 
     for (auto& client : m_clients) {
-        client.get()->audioMediaSelectionOptionsChanged(audioOptions, audioIndex);
-        client.get()->legibleMediaSelectionOptionsChanged(legibleOptions, legibleIndex);
+        client->audioMediaSelectionOptionsChanged(audioOptions, audioIndex);
+        client->legibleMediaSelectionOptionsChanged(legibleOptions, legibleIndex);
     }
 }
 
@@ -418,8 +418,8 @@ void PlaybackSessionModelMediaElement::updateMediaSelectionIndices()
     auto legibleIndex = legibleMediaSelectedIndex();
 
     for (auto& client : m_clients) {
-        client.get()->audioMediaSelectionIndexChanged(audioIndex);
-        client.get()->legibleMediaSelectionIndexChanged(legibleIndex);
+        client->audioMediaSelectionIndexChanged(audioIndex);
+        client->legibleMediaSelectionIndexChanged(legibleIndex);
     }
 }
 

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
@@ -281,7 +281,7 @@ void VideoFullscreenModelVideoElement::setHasVideo(bool hasVideo)
     m_hasVideo = hasVideo;
 
     for (auto& client : copyToVector(m_clients))
-        client.get()->hasVideoChanged(m_hasVideo);
+        client->hasVideoChanged(m_hasVideo);
 }
 
 void VideoFullscreenModelVideoElement::setVideoDimensions(const FloatSize& videoDimensions)
@@ -293,7 +293,7 @@ void VideoFullscreenModelVideoElement::setVideoDimensions(const FloatSize& video
     m_videoDimensions = videoDimensions;
 
     for (auto& client : copyToVector(m_clients))
-        client.get()->videoDimensionsChanged(m_videoDimensions);
+        client->videoDimensionsChanged(m_videoDimensions);
 }
 
 void VideoFullscreenModelVideoElement::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
@@ -304,42 +304,42 @@ void VideoFullscreenModelVideoElement::setPlayerIdentifier(std::optional<MediaPl
     m_playerIdentifier = identifier;
 
     for (auto& client : copyToVector(m_clients))
-        client.get()->setPlayerIdentifier(identifier);
+        client->setPlayerIdentifier(identifier);
 }
 
 void VideoFullscreenModelVideoElement::willEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client.get()->willEnterPictureInPicture();
+        client->willEnterPictureInPicture();
 }
 
 void VideoFullscreenModelVideoElement::didEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client.get()->didEnterPictureInPicture();
+        client->didEnterPictureInPicture();
 }
 
 void VideoFullscreenModelVideoElement::failedToEnterPictureInPicture()
 {
     ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client.get()->failedToEnterPictureInPicture();
+        client->failedToEnterPictureInPicture();
 }
 
 void VideoFullscreenModelVideoElement::willExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client.get()->willExitPictureInPicture();
+        client->willExitPictureInPicture();
 }
 
 void VideoFullscreenModelVideoElement::didExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
-        client.get()->didExitPictureInPicture();
+        client->didExitPictureInPicture();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp
@@ -115,7 +115,7 @@ std::optional<FramesPerSecond> DisplayRefreshMonitor::maximumClientPreferredFram
 {
     std::optional<FramesPerSecond> maxFramesPerSecond;
     for (auto& client : m_clients)
-        maxFramesPerSecond = std::max<FramesPerSecond>(maxFramesPerSecond.value_or(0), client.get()->preferredFramesPerSecond());
+        maxFramesPerSecond = std::max<FramesPerSecond>(maxFramesPerSecond.value_or(0), client->preferredFramesPerSecond());
 
     return maxFramesPerSecond;
 }
@@ -207,7 +207,7 @@ void DisplayRefreshMonitor::displayDidRefresh(const DisplayUpdate& displayUpdate
     m_clientsToBeNotified = &clientsToBeNotified;
     while (!clientsToBeNotified.isEmpty()) {
         auto client = clientsToBeNotified.takeAny();
-        client.get()->fireDisplayRefreshIfNeeded(displayUpdate);
+        client->fireDisplayRefreshIfNeeded(displayUpdate);
 
         // This checks if this function was reentered. In that case, stop iterating
         // since it's not safe to use the set any more.

--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -48,7 +48,7 @@ public:
         if (!hasValidRenderingResourceIdentifier())
             return;
         for (auto& observer : m_observers)
-            observer.get()->releaseRenderingResource(renderingResourceIdentifier());
+            observer->releaseRenderingResource(renderingResourceIdentifier());
     }
 
     virtual bool isNativeImage() const { return false; }

--- a/Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.cpp
+++ b/Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.cpp
@@ -50,7 +50,7 @@ unsigned TileControllerMemoryHandler::totalUnparentedTiledLayers() const
 {
     unsigned totalUnparentedLayers = 0;
     for (auto& tileController : m_tileControllers)
-        totalUnparentedLayers += tileController.get()->numberOfUnparentedTiles();
+        totalUnparentedLayers += tileController->numberOfUnparentedTiles();
     return totalUnparentedLayers;
 }
 
@@ -73,7 +73,7 @@ void TileControllerMemoryHandler::tileControllerGainedUnparentedTiles(TileContro
 void TileControllerMemoryHandler::trimUnparentedTilesToTarget(int target)
 {
     while (!m_tileControllers.isEmpty()) {
-        m_tileControllers.first().get()->removeUnparentedTilesNow();
+        m_tileControllers.first()->removeUnparentedTilesNow();
         m_tileControllers.removeFirst();
 
         if (target > 0 && totalUnparentedTiledLayers() < static_cast<unsigned>(target))

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -434,7 +434,7 @@ void VideoFullscreenControllerContext::hasVideoChanged(bool hasVideo)
     }
 
     for (auto& client : m_fullscreenClients)
-        client.get()->hasVideoChanged(hasVideo);
+        client->hasVideoChanged(hasVideo);
 }
 
 void VideoFullscreenControllerContext::videoDimensionsChanged(const FloatSize& videoDimensions)
@@ -447,7 +447,7 @@ void VideoFullscreenControllerContext::videoDimensionsChanged(const FloatSize& v
     }
 
     for (auto& client : m_fullscreenClients)
-        client.get()->videoDimensionsChanged(videoDimensions);
+        client->videoDimensionsChanged(videoDimensions);
 }
 
 void VideoFullscreenControllerContext::seekableRangesChanged(const TimeRanges& timeRanges, double lastModifiedTime, double liveUpdateInterval)
@@ -650,35 +650,35 @@ void VideoFullscreenControllerContext::willEnterPictureInPicture()
 {
     ASSERT(isUIThread());
     for (auto& client : m_fullscreenClients)
-        client.get()->willEnterPictureInPicture();
+        client->willEnterPictureInPicture();
 }
 
 void VideoFullscreenControllerContext::didEnterPictureInPicture()
 {
     ASSERT(isUIThread());
     for (auto& client : m_fullscreenClients)
-        client.get()->didEnterPictureInPicture();
+        client->didEnterPictureInPicture();
 }
 
 void VideoFullscreenControllerContext::failedToEnterPictureInPicture()
 {
     ASSERT(isUIThread());
     for (auto& client : m_fullscreenClients)
-        client.get()->failedToEnterPictureInPicture();
+        client->failedToEnterPictureInPicture();
 }
 
 void VideoFullscreenControllerContext::willExitPictureInPicture()
 {
     ASSERT(isUIThread());
     for (auto& client : m_fullscreenClients)
-        client.get()->willExitPictureInPicture();
+        client->willExitPictureInPicture();
 }
 
 void VideoFullscreenControllerContext::didExitPictureInPicture()
 {
     ASSERT(isUIThread());
     for (auto& client : m_fullscreenClients)
-        client.get()->didExitPictureInPicture();
+        client->didExitPictureInPicture();
 }
 
 FloatSize VideoFullscreenControllerContext::videoDimensions() const

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -365,7 +365,7 @@ void RealtimeMediaSource::audioSamplesAvailable(const MediaTime& time, const Pla
 
     Locker locker { m_audioSampleObserversLock };
     for (auto& observer : m_audioSampleObservers)
-        observer.get()->audioSamplesAvailable(time, audioData, description, numberOfFrames);
+        observer->audioSamplesAvailable(time, audioData, description, numberOfFrames);
 }
 
 void RealtimeMediaSource::start()

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -295,8 +295,8 @@ void BaseAudioSharedUnit::audioSamplesAvailable(const MediaTime& time, const Pla
     ForbidMallocUseForCurrentThreadScope forbidMallocUse;
 
     for (auto& client : m_audioThreadClients) {
-        if (client.get()->isProducingData())
-            client.get()->audioSamplesAvailable(time, data, description, numberOfFrames);
+        if (client->isProducingData())
+            client->audioSamplesAvailable(time, data, description, numberOfFrames);
     }
 }
 

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -736,7 +736,7 @@ void NetworkStorageSession::registerCookieChangeListenersIfNecessary()
         if (cookies.isEmpty())
             return;
         for (auto& observer : it->value)
-            observer.get()->cookiesAdded(host, cookies);
+            observer->cookiesAdded(host, cookies);
     }).get() onQueue:dispatch_get_main_queue()];
 
     [nsCookieStorage() _setCookiesRemovedHandler:makeBlockPtr([this, weakThis = WeakPtr { *this }](NSArray<NSHTTPCookie *> *removedCookies, NSString *domainForRemovedCookies, bool removeAllCookies) {
@@ -745,7 +745,7 @@ void NetworkStorageSession::registerCookieChangeListenersIfNecessary()
         if (removeAllCookies) {
             for (auto& observers : m_cookieChangeObservers.values()) {
                 for (auto& observer : observers)
-                    observer.get()->allCookiesDeleted();
+                    observer->allCookiesDeleted();
             }
             return;
         }
@@ -759,7 +759,7 @@ void NetworkStorageSession::registerCookieChangeListenersIfNecessary()
         if (cookies.isEmpty())
             return;
         for (auto& observer : it->value)
-            observer.get()->cookiesDeleted(host, cookies);
+            observer->cookiesDeleted(host, cookies);
     }).get() onQueue:dispatch_get_main_queue()];
 }
 

--- a/Source/WebCore/rendering/RenderSelection.cpp
+++ b/Source/WebCore/rendering/RenderSelection.cpp
@@ -219,7 +219,7 @@ void RenderSelection::apply(const RenderRange& newSelection, RepaintMode blockRe
     auto oldSelectionData = collectSelectionData(m_renderRange, blockRepaintMode == RepaintMode::NewXOROld);
     // Remove current selection.
     for (auto& renderer : oldSelectionData.renderers.keys())
-        renderer.get()->setSelectionStateIfNeeded(RenderObject::HighlightState::None);
+        renderer->setSelectionStateIfNeeded(RenderObject::HighlightState::None);
     m_renderRange = newSelection;
     auto* selectionStart = m_renderRange.start();
     // Update the selection status of all objects between selectionStart and selectionEnd

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1043,7 +1043,7 @@ RenderView::RepaintRegionAccumulator::~RepaintRegionAccumulator()
         return;
     if (!m_rootView)
         return;
-    m_rootView.get()->flushAccumulatedRepaintRegion();
+    m_rootView->flushAccumulatedRepaintRegion();
 }
 
 unsigned RenderView::pageNumberForBlockProgressionOffset(int offset) const

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -304,7 +304,7 @@ bool NetworkLoadChecker::isAllowedByContentSecurityPolicy(const ResourceRequest&
         contentSecurityPolicy->setClient(nullptr);
     });
 
-    auto preRedirectURL = m_networkResourceLoader ? m_networkResourceLoader.get()->originalRequest().url() : URL();
+    auto preRedirectURL = m_networkResourceLoader ? m_networkResourceLoader->originalRequest().url() : URL();
     auto redirectResponseReceived = isRedirected() ? ContentSecurityPolicy::RedirectResponseReceived::Yes : ContentSecurityPolicy::RedirectResponseReceived::No;
     switch (m_options.destination) {
     case FetchOptions::Destination::Audioworklet:

--- a/Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm
@@ -163,7 +163,7 @@
             WTFLogAlways("Could not init user defaults instance for domain %s", String(domain).utf8().data());
             continue;
         }
-        userDefaults.get()->m_observer = self;
+        userDefaults->m_observer = self;
         // Start observing a dummy key in order to make the preference daemon become aware of our NSUserDefaults instance.
         // This is to make sure we receive KVO notifications. We cannot use normal KVO techniques here, since we are looking
         // for _any_ changes in a preference domain. For normal KVO techniques to work, we need to provide the specific

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -121,7 +121,7 @@ ViewGestureController* ViewGestureController::controllerForGesture(WebPageProxyI
     auto gestureControllerIter = viewGestureControllersForAllPages().find(pageID);
     if (gestureControllerIter == viewGestureControllersForAllPages().end())
         return nullptr;
-    if (gestureControllerIter->value.get()->m_currentGestureID != gestureID)
+    if (gestureControllerIter->value->m_currentGestureID != gestureID)
         return nullptr;
     return gestureControllerIter->value.get();
 }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -247,7 +247,7 @@ bool WebsiteDataStore::defaultDataStoreExists()
 RefPtr<WebsiteDataStore> WebsiteDataStore::existingDataStoreForIdentifier(const WTF::UUID& identifier)
 {
     for (auto& dataStore : allDataStores().values()) {
-        if (dataStore && dataStore.get()->configuration().identifier() == identifier)
+        if (dataStore && dataStore->configuration().identifier() == identifier)
             return dataStore.get();
     }
 
@@ -261,7 +261,7 @@ Ref<WebsiteDataStore> WebsiteDataStore::dataStoreForIdentifier(const WTF::UUID& 
 
     InitializeWebKit2();
     for (auto& dataStore : allDataStores().values()) {
-        if (dataStore && dataStore.get()->configuration().identifier() == uuid)
+        if (dataStore && dataStore->configuration().identifier() == uuid)
             return Ref { *dataStore };
     }
 
@@ -298,8 +298,8 @@ static Ref<NetworkProcessProxy> networkProcessForSession(PAL::SessionID sessionI
     if (sessionID.isEphemeral()) {
         // Reuse a previous persistent session network process for ephemeral sessions.
         for (auto& dataStore : allDataStores().values()) {
-            if (dataStore.get()->isPersistent())
-                return dataStore.get()->networkProcess();
+            if (dataStore->isPersistent())
+                return dataStore->networkProcess();
         }
     }
     return NetworkProcessProxy::create();
@@ -1831,7 +1831,7 @@ void WebsiteDataStore::setCacheModelSynchronouslyForTesting(CacheModel cacheMode
 Vector<WebsiteDataStoreParameters> WebsiteDataStore::parametersFromEachWebsiteDataStore()
 {
     return WTF::map(allDataStores(), [](auto& entry) {
-        return entry.value.get()->parameters();
+        return entry.value->parameters();
     });
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -75,7 +75,7 @@ Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::getOrCreate(DOMWrapper
 InjectedBundleScriptWorld* InjectedBundleScriptWorld::find(const String& name)
 {
     for (auto& world : allWorlds().values()) {
-        if (world.get()->name() == name)
+        if (world->name() == name)
             return world.get();
     }
     return nullptr;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
@@ -143,7 +143,7 @@ void LibWebRTCSocketFactory::forSocketInGroup(ScriptExecutionContextIdentifier c
 {
     ASSERT(!WTF::isMainRunLoop());
     for (auto& socket : m_sockets.values()) {
-        if (socket.get()->contextIdentifier() == contextIdentifier)
+        if (socket->contextIdentifier() == contextIdentifier)
             callback(*socket);
     }
 }


### PR DESCRIPTION
#### 02f5d90ce162696c0dfbe851f1d485e86ed537e1
<pre>
Use `-&gt;` directly instead of `.get()-&gt;` when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=262058">https://bugs.webkit.org/show_bug.cgi?id=262058</a>

Reviewed by Aditya Keerthi.

* Source/WebCore/Modules/webxr/WebXRHand.cpp:
(WebCore::WebXRHand::session):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateMainArticleElementAfterLayout):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::notifyWidgets):
* Source/WebCore/page/Page.cpp:
(WebCore::networkStateChanged):
(WebCore::Page::clearPreviousItemFromAllPages):
(WebCore::Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment):
(WebCore::Page::refreshPlugins):
* Source/WebCore/page/cocoa/MemoryReleaseCocoa.mm:
(WebCore::platformReleaseMemory):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::shouldPerformEarlyCSPCheck const):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::operativeDirectiveForWorkerSrc const):
(WebCore::ContentSecurityPolicyDirectiveList::operativeDirective const):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::setMediaElement):
(WebCore::PlaybackSessionModelMediaElement::mediaEngineChanged):
(WebCore::PlaybackSessionModelMediaElement::updateForEventName):
(WebCore::PlaybackSessionModelMediaElement::updateMediaSelectionOptions):
(WebCore::PlaybackSessionModelMediaElement::updateMediaSelectionIndices):
* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm:
(WebCore::VideoFullscreenModelVideoElement::setHasVideo):
(WebCore::VideoFullscreenModelVideoElement::setVideoDimensions):
(WebCore::VideoFullscreenModelVideoElement::setPlayerIdentifier):
(WebCore::VideoFullscreenModelVideoElement::willEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::didEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::failedToEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::willExitPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::didExitPictureInPicture):
* Source/WebCore/platform/graphics/DisplayRefreshMonitor.cpp:
(WebCore::DisplayRefreshMonitor::maximumClientPreferredFramesPerSecond const):
(WebCore::DisplayRefreshMonitor::displayDidRefresh):
* Source/WebCore/platform/graphics/RenderingResource.h:
(WebCore::RenderingResource::~RenderingResource):
* Source/WebCore/platform/ios/TileControllerMemoryHandlerIOS.cpp:
(WebCore::TileControllerMemoryHandler::totalUnparentedTiledLayers const):
(WebCore::TileControllerMemoryHandler::trimUnparentedTilesToTarget):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::hasVideoChanged):
(VideoFullscreenControllerContext::videoDimensionsChanged):
(VideoFullscreenControllerContext::willEnterPictureInPicture):
(VideoFullscreenControllerContext::didEnterPictureInPicture):
(VideoFullscreenControllerContext::failedToEnterPictureInPicture):
(VideoFullscreenControllerContext::willExitPictureInPicture):
(VideoFullscreenControllerContext::didExitPictureInPicture):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::audioSamplesAvailable):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::audioSamplesAvailable):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::registerCookieChangeListenersIfNecessary):
* Source/WebCore/rendering/RenderSelection.cpp:
(WebCore::RenderSelection::apply):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::RepaintRegionAccumulator::~RepaintRegionAccumulator):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::isAllowedByContentSecurityPolicy):
* Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm:
(-[WKPreferenceObserver init]):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::controllerForGesture):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::existingDataStoreForIdentifier):
(WebKit::WebsiteDataStore::dataStoreForIdentifier):
(WebKit::networkProcessForSession):
(WebKit::WebsiteDataStore::parametersFromEachWebsiteDataStore):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::find):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp:
(WebKit::LibWebRTCSocketFactory::forSocketInGroup):

Canonical link: <a href="https://commits.webkit.org/268415@main">https://commits.webkit.org/268415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/643e7bab9a7676b45bd67d86a141083f4ef563b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21516 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20186 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22373 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24166 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15797 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17782 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22137 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2404 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->