### PR TITLE
Add a quirk for accounts.google.com for the third party IP cookie expiry capping heuristic

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include "NetworkDataTask.h"
-#include <WebCore/FrameIdentifier.h>
-#include <WebCore/PageIdentifier.h>
-#include <WebCore/ResourceRequest.h>
-#include <WebCore/ResourceResponse.h>
-#include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
+#import "NetworkDataTask.h"
+#import <WebCore/FrameIdentifier.h>
+#import <WebCore/PageIdentifier.h>
+#import <WebCore/ResourceRequest.h>
+#import <WebCore/ResourceResponse.h>
+#import <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
 
 OBJC_CLASS NSArray;
 OBJC_CLASS NSString;


### PR DESCRIPTION
#### f7bf40970a7b23b55231eb2632e5536177d83ec6
<pre>
Add a quirk for accounts.google.com for the third party IP cookie expiry capping heuristic
<a href="https://bugs.webkit.org/show_bug.cgi?id=262062">https://bugs.webkit.org/show_bug.cgi?id=262062</a>
rdar://115081644

Reviewed by John Wilander and Charlie Wolfe.

This patch:

1.  Adds a quirk to avoid treating requests to `accounts.google.com` as being from a third party IP
    *only under google.com*, for the purposes of applying 7-day expiry restrictions on incoming
    cookies.

2.  Contains various cleanup around the `NetworkTaskCocoa.mm` file:

    -   Add a missing `namespace WebKit` around the implementation file, and moves the existing
        `using namespace WebCore` behind the WebKit namespace.

    -   Add missing source includes (which are currently not necessary, due to unified sources).

    -   Consistently use `#import` throughout this Cocoa-specific header and implementation file.

* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::applyCookiePolicyForThirdPartyCloaking):

Add the quirk; note that we only need to check the host of the requested URL here, because we only
get to this codepath in the case where the request is already a first party subdomain of google.com.

(computeIsAlwaysOnLoggingAllowed): Deleted.
(NetworkTaskCocoa::NetworkTaskCocoa): Deleted.
(shouldCapCookieExpiryForThirdPartyIPAddress): Deleted.
(NetworkTaskCocoa::shouldApplyCookiePolicyForThirdPartyCloaking const): Deleted.
(NetworkTaskCocoa::statelessCookieStorage): Deleted.
(NetworkTaskCocoa::lastRemoteIPAddress): Deleted.
(NetworkTaskCocoa::lastCNAMEDomain): Deleted.
(NetworkTaskCocoa::needsFirstPartyCookieBlockingLatchModeQuirk const): Deleted.
(NetworkTaskCocoa::applyCookiePolicyForThirdPartyCloaking): Deleted.
(NetworkTaskCocoa::blockCookies): Deleted.
(NetworkTaskCocoa::unblockCookies): Deleted.
(NetworkTaskCocoa::updateTaskWithFirstPartyForSameSiteCookies): Deleted.
(NetworkTaskCocoa::willPerformHTTPRedirection): Deleted.

Canonical link: <a href="https://commits.webkit.org/268423@main">https://commits.webkit.org/268423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5350ae96812740091a3e4384ef48855a9850baef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18383 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20220 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22404 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17069 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24180 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22161 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18665 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17812 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4696 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->