### PR TITLE
Change the URL for contributors.json used for meeting registration

### DIFF
--- a/Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php
+++ b/Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php
@@ -17,7 +17,7 @@ class WebKit_Meeting_Registration {
     const MEETING_TAXONOMY = 'webkit_meeting';
     const CURRENT_MEETING_OPTION = 'current_webkit_meeting';
     const MEETING_REGISTRATION_STATE_SETTING = 'meeting-registration-state';
-    const CONTRIBUTORS_JSON = 'https://github.com/WebKit/WebKit/raw/main/metadata/contributors.json';
+    const CONTRIBUTORS_JSON = 'https://raw.githubusercontent.com/WebKit/WebKit/main/metadata/contributors.json';
     const EXTRA_FIELDS = [
         'slack'       => FILTER_SANITIZE_STRING,
         'affiliation' => FILTER_SANITIZE_STRING,


### PR DESCRIPTION
#### bfd235c3ba3e4db48c61df79d387bccb0a655998
<pre>
Change the URL for contributors.json used for meeting registration
<a href="https://bugs.webkit.org/show_bug.cgi?id=262063">https://bugs.webkit.org/show_bug.cgi?id=262063</a>
Reviewed by Tim Nguyen.

Uses raw.githubusercontent.com for access to the raw contributors.json file
used in the meeting registration process.

* Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php:

Canonical link: <a href="https://commits.webkit.org/268407@main">https://commits.webkit.org/268407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fae3470ac721dd12e42797520be3bb86447ac302

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20204 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19860 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22388 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/18121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18650 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22152 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2398 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->