### PR TITLE
Ruby in WebVTT are not rendered correctly

### DIFF
--- a/LayoutTests/media/track/captions-webvtt/ruby.vtt
+++ b/LayoutTests/media/track/captions-webvtt/ruby.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:05.000 align:left
+This is a ruby <ruby>base<rt>ruby</rt></ruby>

--- a/LayoutTests/media/track/webvtt-ruby-expected.txt
+++ b/LayoutTests/media/track/webvtt-ruby-expected.txt
@@ -1,0 +1,12 @@
+
+EVENT(canplay)
+EVENT(addtrack)
+EXPECTED (video.textTracks.length == '1') OK
+RUN(video.textTracks[0].mode = 'showing')
+RUN(video.currentTime = 1)
+EVENT(seeked)
+EXPECTED (window.internals.shadowRoot(video).querySelector('rt') != 'null') OK
+EXPECTED (rubyText.offsetTop < rubyBase.offsetTop == 'true') OK
+EXPECTED (rubyBase.offsetTop == (rubyText.offsetTop + rubyText.offsetHeight) == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/track/webvtt-ruby.html
+++ b/LayoutTests/media/track/webvtt-ruby.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+    <head>
+        <title>WebVTTRubyText elements should appear above WebVTTRuby elements</title>
+        <script src=../../resources/js-test-pre.js></script>
+        <script src=../video-test.js></script>
+        <script src=../media-file.js></script>
+        <script>
+            async function runTest()
+            {
+                video = document.getElementById('video');
+                video.src = findMediaFile('video', '../content/test');
+                await waitFor(video, 'canplay');
+                let track = document.createElement('track');
+                track.src = 'captions-webvtt/ruby.vtt';
+                video.appendChild(track)
+
+                await waitFor(video.textTracks, 'addtrack');
+                testExpected("video.textTracks.length", 1);
+                run("video.textTracks[0].mode = 'showing'");
+
+                run("video.currentTime = 1");
+                await waitFor(video, 'seeked');
+
+                window.internals.ensureUserAgentShadowRoot(video);
+                await testExpectedEventually("window.internals.shadowRoot(video).querySelector('rt')", null, "!=", 1000);
+                rubyBase = window.internals.shadowRoot(video).querySelector('ruby');
+                rubyText = window.internals.shadowRoot(video).querySelector('rt');
+                await testExpected("rubyText.offsetTop < rubyBase.offsetTop", true);
+                await testExpected("rubyBase.offsetTop == (rubyText.offsetTop + rubyText.offsetHeight)", true);
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <video id="video" width="320px" height="240px" paused></video>
+    </body>
+</html>

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -206,6 +206,10 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVec
 #if ENABLE(VIDEO)
     if (is<WebVTTElement>(element))
         language = downcast<WebVTTElement>(element).language();
+    else if (is<WebVTTRubyElement>(element))
+        language = downcast<WebVTTRubyElement>(element).language();
+    else if (is<WebVTTRubyTextElement>(element))
+        language = downcast<WebVTTRubyTextElement>(element).language();
     else
 #endif
         language = element.effectiveLang();
@@ -469,12 +473,24 @@ ALWAYS_INLINE bool matchesPictureInPicturePseudoClass(const Element& element)
 
 ALWAYS_INLINE bool matchesFutureCuePseudoClass(const Element& element)
 {
-    return is<WebVTTElement>(element) && !downcast<WebVTTElement>(element).isPastNode();
+    if (auto* webVTTElement = dynamicDowncast<WebVTTElement>(element))
+        return !webVTTElement->isPastNode();
+    if (auto* webVTTRubyElement = dynamicDowncast<WebVTTRubyElement>(element))
+        return !webVTTRubyElement->isPastNode();
+    if (auto* webVTTRubyTextElement = dynamicDowncast<WebVTTRubyTextElement>(element))
+        return !webVTTRubyTextElement->isPastNode();
+    return false;
 }
 
 ALWAYS_INLINE bool matchesPastCuePseudoClass(const Element& element)
 {
-    return is<WebVTTElement>(element) && downcast<WebVTTElement>(element).isPastNode();
+    if (is<WebVTTElement>(element))
+        return downcast<WebVTTElement>(element).isPastNode();
+    if (is<WebVTTRubyElement>(element))
+        return downcast<WebVTTRubyElement>(element).isPastNode();
+    if (is<WebVTTRubyTextElement>(element))
+        return downcast<WebVTTRubyTextElement>(element).isPastNode();
+    return false;
 }
 
 ALWAYS_INLINE bool matchesPlayingPseudoClass(const Element& element)

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -220,6 +220,8 @@ public:
 
 #if ENABLE(VIDEO)
     virtual bool isWebVTTElement() const { return false; }
+    virtual bool isWebVTTRubyElement() const { return false; }
+    virtual bool isWebVTTRubyTextElement() const { return false; }
 #endif
     bool isStyledElement() const { return hasNodeFlag(NodeFlag::IsHTMLElement) || hasNodeFlag(NodeFlag::IsSVGElement) || hasNodeFlag(NodeFlag::IsMathMLElement); }
     virtual bool isAttributeNode() const { return false; }

--- a/Source/WebCore/html/RubyElement.h
+++ b/Source/WebCore/html/RubyElement.h
@@ -29,14 +29,16 @@
 
 namespace WebCore {
 
-class RubyElement final : public HTMLElement {
+class RubyElement : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(RubyElement);
 public:
     static Ref<RubyElement> create(Document&);
     static Ref<RubyElement> create(const QualifiedName&, Document&);
 
-private:
+protected:
     RubyElement(const QualifiedName&, Document&);
+
+private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 };
 

--- a/Source/WebCore/html/RubyTextElement.h
+++ b/Source/WebCore/html/RubyTextElement.h
@@ -29,14 +29,16 @@
 
 namespace WebCore {
 
-class RubyTextElement final : public HTMLElement {
+class RubyTextElement : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(RubyTextElement);
 public:
     static Ref<RubyTextElement> create(Document&);
     static Ref<RubyTextElement> create(const QualifiedName&, Document&);
 
-private:
+protected:
     RubyTextElement(const QualifiedName&, Document&);
+
+private:
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
 };
 

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -944,12 +944,16 @@ void VTTCue::markFutureAndPastNodes(ContainerNode* root, const MediaTime& previo
                 isPastNode = false;
         }
         
-        if (is<WebVTTElement>(*child)) {
+        if (is<WebVTTElement>(*child))
             downcast<WebVTTElement>(*child).setIsPastNode(isPastNode);
-            // Make an elemenet id match a cue id for style matching purposes.
-            if (!id().isEmpty())
-                downcast<WebVTTElement>(*child).setIdAttribute(id());
-        }
+        else if (is<WebVTTRubyElement>(*child))
+            downcast<WebVTTRubyElement>(*child).setIsPastNode(isPastNode);
+        else if (is<WebVTTRubyTextElement>(*child))
+            downcast<WebVTTRubyTextElement>(*child).setIsPastNode(isPastNode);
+
+        // Make an element id match a cue id for style matching purposes.
+        if (!id().isEmpty() && is<Element>(*child))
+            downcast<Element>(*child).setIdAttribute(id());
     }
 }
 

--- a/Source/WebCore/html/track/WebVTTElement.h
+++ b/Source/WebCore/html/track/WebVTTElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc.  All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,8 @@
 #if ENABLE(VIDEO)
 
 #include "HTMLElement.h"
+#include "RubyElement.h"
+#include "RubyTextElement.h"
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
@@ -44,13 +46,14 @@ enum WebVTTNodeType {
     WebVTTNodeTypeVoice
 };
 
-class WebVTTElement final : public Element {
-    WTF_MAKE_ISO_ALLOCATED(WebVTTElement);
+class WebVTTElement;
+
+class WebVTTElementImpl {
 public:
-    static Ref<WebVTTElement> create(const WebVTTNodeType, Document&);
+    static Ref<Element> create(const WebVTTNodeType, AtomString language, Document&);
     Ref<HTMLElement> createEquivalentHTMLElement(Document&);
 
-    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&) override;
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document&);
 
     void setWebVTTNodeType(WebVTTNodeType type) { m_webVTTNodeType = static_cast<unsigned>(type); }
     WebVTTNodeType webVTTNodeType() const { return static_cast<WebVTTNodeType>(m_webVTTNodeType); }
@@ -66,28 +69,89 @@ public:
         static NeverDestroyed<QualifiedName> voiceAttr(nullAtom(), "voice"_s, nullAtom());
         return voiceAttr;
     }
-    
+
     static const QualifiedName& langAttributeName()
     {
         static NeverDestroyed<QualifiedName> voiceAttr(nullAtom(), "lang"_s, nullAtom());
         return voiceAttr;
     }
 
-private:
-    WebVTTElement(WebVTTNodeType, Document&);
-
-    bool isWebVTTElement() const override { return true; }
+protected:
+    WebVTTElementImpl(WebVTTNodeType nodeType, AtomString language)
+        : m_isPastNode { false }
+        , m_webVTTNodeType { static_cast<unsigned>(nodeType) }
+        , m_language { language }
+    {
+    }
+    virtual ~WebVTTElementImpl() = default;
+    virtual Element& toElement() = 0;
 
     unsigned m_isPastNode : 1;
     unsigned m_webVTTNodeType : 4;
-    
+
     AtomString m_language;
 };
+
+class WebVTTElement final : public WebVTTElementImpl, public Element {
+    WTF_MAKE_ISO_ALLOCATED(WebVTTElement);
+public:
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document& document) final { return WebVTTElementImpl::cloneElementWithoutAttributesAndChildren(document); }
+
+private:
+    friend class WebVTTElementImpl;
+    WebVTTElement(WebVTTNodeType, AtomString language, Document&);
+
+    bool isWebVTTElement() const final { return true; }
+    Element& toElement() final { return *this; }
+};
+
+class WebVTTRubyElement final : public WebVTTElementImpl, public RubyElement {
+    WTF_MAKE_ISO_ALLOCATED(WebVTTRubyElement);
+public:
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document& document) final { return WebVTTElementImpl::cloneElementWithoutAttributesAndChildren(document); }
+
+private:
+    friend class WebVTTElementImpl;
+    WebVTTRubyElement(AtomString language, Document& document)
+        : WebVTTElementImpl(WebVTTNodeTypeRuby, language)
+        , RubyElement(HTMLNames::rubyTag, document)
+    {
+    }
+
+    bool isWebVTTRubyElement() const final { return true; }
+    Element& toElement() final { return *this; }
+};
+
+class WebVTTRubyTextElement final : public WebVTTElementImpl, public RubyTextElement {
+    WTF_MAKE_ISO_ALLOCATED(WebVTTRubyTextElement);
+public:
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document& document) final { return WebVTTElementImpl::cloneElementWithoutAttributesAndChildren(document); }
+
+private:
+    friend class WebVTTElementImpl;
+    WebVTTRubyTextElement(AtomString language, Document& document)
+        : WebVTTElementImpl(WebVTTNodeTypeRubyText, language)
+        , RubyTextElement(HTMLNames::rtTag, document)
+    {
+    }
+
+    bool isWebVTTRubyTextElement() const final { return true; }
+    Element& toElement() final { return *this; }
+};
+
 
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebVTTElement)
     static bool isType(const WebCore::Node& node) { return node.isWebVTTElement(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebVTTRubyElement)
+    static bool isType(const WebCore::Node& node) { return node.isWebVTTRubyElement(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebVTTRubyTextElement)
+    static bool isType(const WebCore::Node& node) { return node.isWebVTTRubyTextElement(); }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -509,7 +509,10 @@ public:
 private:
     void constructTreeFromToken(Document&);
 
+    WebVTTNodeType currentType() const { return m_typeStack.isEmpty() ? WebVTTNodeTypeNone : m_typeStack.last(); }
+
     WebVTTToken m_token;
+    Vector<WebVTTNodeType> m_typeStack;
     RefPtr<ContainerNode> m_currentNode;
     Vector<AtomString> m_languageStack;
     Document& m_document;
@@ -531,7 +534,7 @@ Ref<DocumentFragment> WebVTTTreeBuilder::buildFromString(const String& cueText)
 
     WebVTTTokenizer tokenizer(cueText);
     m_languageStack.clear();
-
+    m_typeStack.clear();
     while (tokenizer.nextToken(m_token))
         constructTreeFromToken(m_document);
     
@@ -694,12 +697,12 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
         if (nodeType == WebVTTNodeTypeNone)
             break;
 
-        WebVTTNodeType currentType = is<WebVTTElement>(*m_currentNode) ? downcast<WebVTTElement>(*m_currentNode).webVTTNodeType() : WebVTTNodeTypeNone;
         // <rt> is only allowed if the current node is <ruby>.
-        if (nodeType == WebVTTNodeTypeRubyText && currentType != WebVTTNodeTypeRuby)
+        if (nodeType == WebVTTNodeTypeRubyText && currentType() != WebVTTNodeTypeRuby)
             break;
 
-        auto child = WebVTTElement::create(nodeType, document);
+        auto language = !m_languageStack.isEmpty() ? m_languageStack.last() : emptyAtom();
+        auto child = WebVTTElementImpl::create(nodeType, language, document);
         if (!m_token.classes().isEmpty())
             child->setAttributeWithoutSynchronization(classAttr, m_token.classes());
 
@@ -709,10 +712,9 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
             m_languageStack.append(m_token.annotation());
             child->setAttributeWithoutSynchronization(WebVTTElement::langAttributeName(), m_languageStack.last());
         }
-        if (!m_languageStack.isEmpty())
-            child->setLanguage(m_languageStack.last());
         m_currentNode->parserAppendChild(child);
         m_currentNode = WTFMove(child);
+        m_typeStack.append(nodeType);
         break;
     }
     case WebVTTTokenTypes::EndTag: {
@@ -722,23 +724,26 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
         
         // The only non-VTTElement would be the DocumentFragment root. (Text
         // nodes and PIs will never appear as m_currentNode.)
-        if (!is<WebVTTElement>(*m_currentNode))
+        if (currentType() == WebVTTNodeTypeNone)
             break;
 
-        WebVTTNodeType currentType = downcast<WebVTTElement>(*m_currentNode).webVTTNodeType();
-        bool matchesCurrent = nodeType == currentType;
+        bool matchesCurrent = nodeType == currentType();
         if (!matchesCurrent) {
             // </ruby> auto-closes <rt>
-            if (currentType == WebVTTNodeTypeRubyText && nodeType == WebVTTNodeTypeRuby) {
-                if (m_currentNode->parentNode())
+            if (currentType() == WebVTTNodeTypeRubyText && nodeType == WebVTTNodeTypeRuby) {
+                if (m_currentNode->parentNode()) {
                     m_currentNode = m_currentNode->parentNode();
+                    m_typeStack.removeLast();
+                }
             } else
                 break;
         }
         if (nodeType == WebVTTNodeTypeLanguage)
             m_languageStack.removeLast();
-        if (m_currentNode->parentNode())
+        if (m_currentNode->parentNode()) {
             m_currentNode = m_currentNode->parentNode();
+            m_typeStack.removeLast();
+        }
         break;
     }
     case WebVTTTokenTypes::TimestampTag: {

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -590,9 +590,10 @@ String CaptionUserPreferencesMediaAF::captionsStyleSheetOverride() const
     String edgeStyle = captionsTextEdgeCSS();
     String fontName = captionsDefaultFontCSS();
     String background = captionsBackgroundCSS();
-    if (!background.isEmpty() || !captionsColor.isEmpty() || !edgeStyle.isEmpty() || !fontName.isEmpty())
+    if (!background.isEmpty() || !captionsColor.isEmpty() || !edgeStyle.isEmpty() || !fontName.isEmpty()) {
         captionsOverrideStyleSheet.append(" ::", ShadowPseudoIds::cue(), '{', background, captionsColor, edgeStyle, fontName, '}');
-
+        captionsOverrideStyleSheet.append(" ::", ShadowPseudoIds::cue(), "(rt) {", background, captionsColor, edgeStyle, fontName, '}');
+    }
     String windowColor = captionsWindowCSS();
     String windowCornerRadius = windowRoundedCornerRadiusCSS();
     if (!windowColor.isEmpty() || !windowCornerRadius.isEmpty())

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -395,7 +395,7 @@ void ElementRuleCollector::collectMatchingShadowPseudoElementRules(const MatchRe
     auto& rules = matchRequest.ruleSet;
 #if ENABLE(VIDEO)
     // FXIME: WebVTT should not be done by styling UA shadow trees like this.
-    if (element().isWebVTTElement())
+    if (element().isWebVTTElement() || element().isWebVTTRubyElement() || element().isWebVTTRubyTextElement())
         collectMatchingRulesForList(&rules.cuePseudoRules(), matchRequest);
 #endif
     auto& pseudoId = element().shadowPseudoId();


### PR DESCRIPTION
#### def69bfc9d9e2333a4c6bc5a254169754f0f4116
<pre>
Ruby in WebVTT are not rendered correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=262064">https://bugs.webkit.org/show_bug.cgi?id=262064</a>
rdar://116011365

Reviewed by Jer Noble and Eric Carlson.

This patch creates a new class WebVTTRubyElement, a subclass of WebVTTElementImpl
And RubyElement. Now, each ruby tag in a VTT is associated with a WebVTTRubyElement,
Which has access to RubyElement::createElementRenderer() to render it appropriately.

Added a layout test to check that ruby elements in WebVTT cues are positioned correctly.

* LayoutTests/media/track/captions-webvtt/ruby.vtt: Added.
* LayoutTests/media/track/webvtt-ruby.html: Added.
* LayoutTests/media/track/webvtt-ruby-expected.txt: Added.
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesLangPseudoClass):
(WebCore::matchesFutureCuePseudoClass):
(WebCore::matchesPastCuePseudoClass):
* Source/WebCore/dom/Node.h:
(WebCore::Node::isWebVTTRubyElement const):
(WebCore::Node::isWebVTTRubyTextElement const):
* Source/WebCore/html/RubyElement.h:
(): Deleted.
* Source/WebCore/html/RubyTextElement.h:
(): Deleted.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::markFutureAndPastNodes):
* Source/WebCore/html/track/WebVTTElement.cpp:
(WebCore::WebVTTElement::WebVTTElement):
(WebCore::WebVTTElementImpl::create):
(WebCore::WebVTTElementImpl::cloneElementWithoutAttributesAndChildren):
(WebCore::WebVTTElementImpl::createEquivalentHTMLElement):
(WebCore::WebVTTElement::create): Deleted.
(WebCore::WebVTTElement::cloneElementWithoutAttributesAndChildren): Deleted.
(WebCore::WebVTTElement::createEquivalentHTMLElement): Deleted.
* Source/WebCore/html/track/WebVTTElement.h:
(WebCore::WebVTTElementImpl::WebVTTElementImpl):
(isType):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTTreeBuilder::currentType const):
(WebCore::WebVTTTreeBuilder::buildFromString):
(WebCore::WebVTTTreeBuilder::constructTreeFromToken):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::captionsStyleSheetOverride const):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingShadowPseudoElementRules):

Canonical link: <a href="https://commits.webkit.org/268746@main">https://commits.webkit.org/268746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4b549de7afc0e4f9cbe8df68cca21583db882e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23274 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24935 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22874 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16492 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18628 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4934 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->