### PR TITLE
[WebGPU] https://webgpu.github.io/webgpu-samples/samples/renderBundles does not load

### DIFF
--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -252,7 +252,10 @@ void ConstantRewriter::materialize(Node& expression, const ConstantValue& value)
     evaluated(expression, value);
 
     const auto& replace = [&]<typename Literal, typename Value>() {
-        auto& node =  m_shaderModule.astBuilder().construct<Literal>(SourceSpan::empty(), std::get<Value>(value));
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=262068
+        auto* maybeValue = std::get_if<Value>(&value);
+        Value valueOrDefault = maybeValue ? *maybeValue : (Value)0;
+        auto& node = m_shaderModule.astBuilder().construct<Literal>(SourceSpan::empty(), valueOrDefault);
         node.m_inferredType = expression.inferredType();
         m_shaderModule.replace(expression, node);
     };

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -507,7 +507,8 @@ void FunctionDefinitionWriter::visit(AST::GroupAttribute& group)
 {
     unsigned bufferIndex = *AST::extractInteger(group.group());
     if (m_entryPointStage.has_value() && *m_entryPointStage == AST::StageAttribute::Stage::Vertex) {
-        auto max = m_callGraph.ast().configuration().maxBuffersPlusVertexBuffersForVertexStage;
+        ASSERT(m_callGraph.ast().configuration().maxBuffersPlusVertexBuffersForVertexStage > 0);
+        auto max = m_callGraph.ast().configuration().maxBuffersPlusVertexBuffersForVertexStage - 1;
         bufferIndex = vertexBufferIndexForBindGroup(bufferIndex, max);
     }
     m_stringBuilder.append("[[buffer(", bufferIndex, ")]]");

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -122,7 +122,7 @@ public:
     bool hasUnifiedMemory() const { return m_device.hasUnifiedMemory; }
 
     uint32_t maxBuffersPlusVertexBuffersForVertexStage() const;
-    uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex, uint32_t maxIndex = 0) const;
+    uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex) const;
 
 private:
     Device(id<MTLDevice>, id<MTLCommandQueue> defaultQueue, HardwareCapabilities&&, Adapter&);

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -307,14 +307,13 @@ void Device::generateAnInternalError(String&& message)
 
 uint32_t Device::maxBuffersPlusVertexBuffersForVertexStage() const
 {
-    // FIXME: use value in HardwareCapabilities from https://github.com/gpuweb/gpuweb/issues/2749
-    return 8;
+    return m_capabilities.limits.maxBindGroupsPlusVertexBuffers;
 }
 
-uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex, uint32_t maxIndex) const
+uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex) const
 {
-    maxIndex = maxIndex ?: maxBuffersPlusVertexBuffersForVertexStage();
-    return WGSL::vertexBufferIndexForBindGroup(groupIndex, maxIndex);
+    ASSERT(maxBuffersPlusVertexBuffersForVertexStage() > 0);
+    return WGSL::vertexBufferIndexForBindGroup(groupIndex, maxBuffersPlusVertexBuffersForVertexStage() - 1);
 }
 
 void Device::captureFrameIfNeeded() const

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -28,13 +28,52 @@
 
 #import "APIConversions.h"
 
+@implementation ResourceUsageAndRenderStage
+- (instancetype)initWithUsage:(MTLResourceUsage)usage renderStages:(MTLRenderStages)renderStages
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _usage = usage;
+    _renderStages = renderStages;
+
+    return self;
+}
+@end
+
 namespace WebGPU {
 
-RenderBundle::RenderBundle(id<MTLIndirectCommandBuffer> indirectCommandBuffer, Vector<BindableResources>&& resources, Device& device)
+RenderBundle::RenderBundle(id<MTLIndirectCommandBuffer> indirectCommandBuffer, RenderBundle::ResourcesContainer* resources, id<MTLRenderPipelineState> renderPipelineState, id<MTLDepthStencilState> depthStencilState, MTLCullMode cullMode, MTLWinding frontFace, MTLDepthClipMode clipMode, Device& device)
     : m_indirectCommandBuffer(indirectCommandBuffer)
     , m_device(device)
-    , m_resources(WTFMove(resources))
+    , m_currentPipelineState(renderPipelineState)
+    , m_depthStencilState(depthStencilState)
+    , m_cullMode(cullMode)
+    , m_frontFace(frontFace)
+    , m_depthClipMode(clipMode)
 {
+    constexpr auto maxResourceUsageValue = MTLResourceUsageRead | MTLResourceUsageWrite;
+    constexpr auto maxStageValue = MTLRenderStageVertex | MTLRenderStageFragment;
+    static_assert(maxResourceUsageValue == 3 && maxStageValue == 3, "Code path assumes MTLResourceUsageRead | MTLResourceUsageWrite == 3 and MTLRenderStageVertex | MTLRenderStageFragment == 3");
+    Vector<id<MTLResource>> stageResources[maxStageValue][maxResourceUsageValue];
+
+    for (id<MTLResource> r : resources) {
+        ResourceUsageAndRenderStage *usageAndStage = [resources objectForKey:r];
+        stageResources[usageAndStage.renderStages - 1][usageAndStage.renderStages - 1].append(r);
+    }
+
+    for (size_t stage = 0; stage < maxStageValue; ++stage) {
+        for (size_t i = 0; i < maxResourceUsageValue; ++i) {
+            Vector<id<MTLResource>> &v = stageResources[stage][i];
+            if (v.size()) {
+                m_resources.append(BindableResources {
+                    .mtlResources = WTFMove(v),
+                    .usage = static_cast<MTLResourceUsage>(i + 1),
+                    .renderStages = static_cast<MTLRenderStages>(stage + 1)
+                });
+            }
+        }
+    }
 }
 
 RenderBundle::RenderBundle(Device& device)
@@ -47,6 +86,31 @@ RenderBundle::~RenderBundle() = default;
 void RenderBundle::setLabel(String&& label)
 {
     m_indirectCommandBuffer.label = label;
+}
+
+id<MTLRenderPipelineState> RenderBundle::currentPipelineState() const
+{
+    return m_currentPipelineState;
+}
+
+id<MTLDepthStencilState> RenderBundle::depthStencilState() const
+{
+    return m_depthStencilState;
+}
+
+MTLCullMode RenderBundle::cullMode() const
+{
+    return m_cullMode;
+}
+
+MTLWinding RenderBundle::frontFace() const
+{
+    return m_frontFace;
+}
+
+MTLDepthClipMode RenderBundle::depthClipMode() const
+{
+    return m_depthClipMode;
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -85,6 +85,7 @@ private:
     id<MTLIndirectRenderCommand> currentRenderCommand();
 
     void makeInvalid() { m_indirectCommandBuffer = nil; }
+    void executePreDrawCommands();
 
     id<MTLIndirectCommandBuffer> m_indirectCommandBuffer { nil };
     MTLIndirectCommandBufferDescriptor *m_icbDescriptor { nil };
@@ -93,11 +94,22 @@ private:
     uint64_t m_currentCommandIndex { 0 };
     id<MTLBuffer> m_indexBuffer { nil };
     id<MTLRenderPipelineState> m_currentPipelineState { nil };
+    id<MTLDepthStencilState> m_depthStencilState { nil };
+    MTLCullMode m_cullMode { MTLCullModeNone };
+    MTLWinding m_frontFace { MTLWindingClockwise };
+    MTLDepthClipMode m_depthClipMode { MTLDepthClipModeClip };
+
     MTLPrimitiveType m_primitiveType { MTLPrimitiveTypeTriangle };
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };
     Vector<WTF::Function<void(void)>> m_recordedCommands;
-    Vector<BindableResources> m_resources;
+    NSMapTable<id<MTLResource>, ResourceUsageAndRenderStage*>* m_resources;
+    struct BufferAndOffset {
+        id<MTLBuffer> buffer { nil };
+        uint64_t offset { 0 };
+    };
+    Vector<BufferAndOffset> m_vertexBuffers;
+    Vector<BufferAndOffset> m_fragmentBuffers;
     const Ref<Device> m_device;
 };
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -137,6 +137,14 @@ void RenderPassEncoder::executeBundles(Vector<std::reference_wrapper<const Rende
 {
     for (auto& bundle : bundles) {
         const auto& renderBundle = bundle.get();
+        if (renderBundle.currentPipelineState())
+            [m_renderCommandEncoder setRenderPipelineState:renderBundle.currentPipelineState()];
+        if (renderBundle.depthStencilState())
+            [m_renderCommandEncoder setDepthStencilState:renderBundle.depthStencilState()];
+        [m_renderCommandEncoder setCullMode:renderBundle.cullMode()];
+        [m_renderCommandEncoder setFrontFacingWinding:renderBundle.frontFace()];
+        [m_renderCommandEncoder setDepthClipMode:renderBundle.depthClipMode()];
+
         for (const auto& resource : renderBundle.resources())
             [m_renderCommandEncoder useResources:&resource.mtlResources[0] count:resource.mtlResources.size() usage:resource.usage stages:resource.renderStages];
 


### PR DESCRIPTION
#### 0b7d33831395826f3fdba7417d104da2e50059b3
<pre>
[WebGPU] <a href="https://webgpu.github.io/webgpu-samples/samples/renderBundles">https://webgpu.github.io/webgpu-samples/samples/renderBundles</a> does not load
<a href="https://bugs.webkit.org/show_bug.cgi?id=261852">https://bugs.webkit.org/show_bug.cgi?id=261852</a>
&lt;radar://115810432&gt;

Reviewed by Tadeu Zagallo.

Fixup RenderBundle implementation to the point where
<a href="https://webgpu.github.io/webgpu-samples/samples/renderBundles">https://webgpu.github.io/webgpu-samples/samples/renderBundles</a>
works as expected.

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::materialize):
Add FIXME to workaround variant not containing the expected value.

* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::maxBuffersPlusVertexBuffersForVertexStage const):
(WebGPU::Device::vertexBufferIndexForBindGroup const):
Return the actual count of buffers.

* Source/WebGPU/WebGPU/RenderBundle.h:
(WebGPU::RenderBundle::create):
(WebGPU::RenderBundle::resources const):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(-[ResourceUsageAndRenderStage initWithUsage:renderStages:]):
(WebGPU::RenderBundle::RenderBundle):
(WebGPU::RenderBundle::currentPipelineState const):
(WebGPU::RenderBundle::depthStencilState const):
(WebGPU::RenderBundle::cullMode const):
(WebGPU::RenderBundle::frontFace const):
(WebGPU::RenderBundle::depthClipMode const):
Save various state which is part of RenderBundle but not Metal&apos;s ICBs.

* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::Device::createRenderBundleEncoder):
(WebGPU::RenderBundleEncoder::RenderBundleEncoder):
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::draw):
(WebGPU::RenderBundleEncoder::drawIndexed):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::finish):
(WebGPU::addResource):
(WebGPU::RenderBundleEncoder::setBindGroup):
(WebGPU::RenderBundleEncoder::setIndexBuffer):
(WebGPU::RenderBundleEncoder::setPipeline):
(WebGPU::RenderBundleEncoder::setVertexBuffer):
RenderBundleEncoder needs to restore previously set buffers on
earlier ICB commands.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):
Set state which is needed but not part of the ICBs.

Canonical link: <a href="https://commits.webkit.org/268454@main">https://commits.webkit.org/268454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/890912c497c3cc0908482fa3e8f6a4d450496538

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18430 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19999 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22466 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17116 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24224 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22211 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15856 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17868 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4723 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22221 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->