### PR TITLE
check-webkit-style: false positive calling std::span::begin() in initializer

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2529,13 +2529,14 @@ def check_namespace_indentation(clean_lines, line_number, file_extension, file_s
     looking_for_semicolon = False
     line_offset = 0
     in_preprocessor_directive = False
+    initializer_re = re.compile(r'^\s+[:,] m_[a-zA-Z][a-zA-Z0-9_]* { .+ }$')
     for current_line in clean_lines.elided[line_number + 1:]:
         line_offset += 1
         if not current_line.strip():
             continue
         if not current_indentation_level:
             if not (in_preprocessor_directive or looking_for_semicolon):
-                if not match(r'\S', current_line) and not file_state.did_inside_namespace_indent_warning():
+                if not match(r'\S', current_line) and not initializer_re.match(current_line) and not file_state.did_inside_namespace_indent_warning():
                     file_state.set_did_inside_namespace_indent_warning()
                     error(line_number + line_offset, 'whitespace/indent', 4,
                           'Code inside a namespace should not be indented.')

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -4785,6 +4785,16 @@ class WebKitStyleTest(CppStyleTestBase):
             '  [whitespace/indent] [4]',
             'foo.cpp')
         self.assert_multi_line_lint(
+            'namespace IPC {\n'
+            'Decoder::Decoder(DataReference buffer, BufferDeallocator&& bufferDeallocator, Vector<Attachment>&& attachments)\n'
+            '    : m_buffer { buffer }\n'
+            '    , m_bufferPosition { m_buffer.begin() }\n'
+            '    , m_bufferDeallocator { WTFMove(bufferDeallocator) }\n'
+            '    , m_attachments { WTFMove(attachments) }\n'
+            '{ }',
+            '',
+            'Decoder.cpp')
+        self.assert_multi_line_lint(
             'namespace WebCore {\n'
             '#define abc(x) x; \\\n'
             '    x\n'
@@ -6551,12 +6561,13 @@ class WebKitStyleTest(CppStyleTestBase):
         'Should be indented on a separate line, with the colon or comma first on that line.'
         '  [whitespace/indent] [4]')
 
-        self.assert_multi_line_lint((
+        self.assert_multi_line_lint(
             'MyClass::MyClass(Document* doc)\n'
             '    : m_myMember(b ? bar() : baz())\n'
             '    , MySuperClass()\n'
             '    , m_doc(0)\n'
-            '{ }'), '')
+            '{ }',
+            '')
 
         self.assert_multi_line_lint('''\
         MyClass::MyClass(Document* doc) : MySuperClass()


### PR DESCRIPTION
#### 2a9cd8313d475a3217d18c3b76d87806472fb8b6
<pre>
check-webkit-style: false positive calling std::span::begin() in initializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=262071">https://bugs.webkit.org/show_bug.cgi?id=262071</a>
&lt;rdar://116015290&gt;

Reviewed by Jonathan Bedard.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_namespace_indentation):
- Skip check on class initializer lines.

* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_indentation):
- Add test case.
(WebKitStyleTest.test_member_initialization_list):
- Drive-by fix to remove extra parenthesis.

Canonical link: <a href="https://commits.webkit.org/268413@main">https://commits.webkit.org/268413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a3b70f0c13ad19958361f7aa3e52df1a3d23be4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20209 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22393 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/19828 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17876 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/18127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18655 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22157 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2401 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->