### PR TITLE
REGRESSION (268069@main): [iOS] Date picker fails to present after dismissing with Done button

### DIFF
--- a/LayoutTests/fast/forms/ios/show-and-dismiss-date-input-after-tapping-done-expected.txt
+++ b/LayoutTests/fast/forms/ios/show-and-dismiss-date-input-after-tapping-done-expected.txt
@@ -1,0 +1,11 @@
+Tests that repeatedly showing and dismissing a date picker on iOS using the Done button works as expected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Presented and dismissed date picker (1/2)
+PASS Presented and dismissed date picker (2/2)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/show-and-dismiss-date-input-after-tapping-done.html
+++ b/LayoutTests/fast/forms/ios/show-and-dismiss-date-input-after-tapping-done.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<input type="date" value="1976-04-01">
+<script>
+jsTestIsAsync = true;
+
+description("Tests that repeatedly showing and dismissing a date picker on iOS using the Done button works as expected.");
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    const input = document.querySelector("input");
+    const numberOfIterations = 2
+    for (let i = 1; i <= numberOfIterations; ++i) {
+        await UIHelper.activateElement(input);
+        await UIHelper.waitForContextMenuToShow();
+        await UIHelper.dismissFormAccessoryView();
+        await UIHelper.waitForContextMenuToHide();
+        testPassed(`Presented and dismissed date picker (${i}/${numberOfIterations})`);
+    }
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -151,7 +151,7 @@ static void dumpSeparatedLayerProperties(TextStream&, CALayer *) { }
 
 - (void)dismissFormAccessoryView
 {
-    [_contentView accessoryDone];
+    [_contentView dismissFormAccessoryView];
 }
 
 - (NSArray<NSString *> *)_filePickerAcceptedTypeIdentifiers

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -857,6 +857,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (BOOL)_allowAnimationControls;
 #endif
 
+- (void)dismissFormAccessoryView;
+
 #if ENABLE(DATALIST_ELEMENT)
 - (void)_selectDataListOption:(NSInteger)optionIndex;
 - (void)_setDataListSuggestionsControl:(WKDataListSuggestionsControl *)control;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12027,6 +12027,15 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
 }
 #endif
 
+- (void)dismissFormAccessoryView
+{
+#if !PLATFORM(WATCHOS)
+    if (auto dateInput = self.dateTimeInputControl; [dateInput dismissWithAnimation])
+        return;
+#endif
+    [self accessoryDone];
+}
+
 #if ENABLE(DATALIST_ELEMENT)
 - (void)_selectDataListOption:(NSInteger)optionIndex
 {

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h
@@ -39,6 +39,7 @@
 @interface WKDatePickerPopoverController : UIViewController
 - (instancetype)initWithDatePicker:(UIDatePicker *)datePicker delegate:(id<WKDatePickerPopoverControllerDelegate>)delegate;
 - (void)presentInView:(UIView *)view sourceRect:(CGRect)rect interactionBounds:(CGRect)interactionBounds completion:(void(^)())completion;
+- (void)dismissDatePicker;
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.h
@@ -38,6 +38,7 @@
 @property (nonatomic, readonly) double timePickerValueHour;
 @property (nonatomic, readonly) double timePickerValueMinute;
 - (void)setTimePickerHour:(NSInteger)hour minute:(NSInteger)minute;
+- (BOOL)dismissWithAnimation;
 @end
 
 #endif // PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -53,6 +53,7 @@
 
 - (instancetype)initWithView:(WKContentView *)view datePickerMode:(UIDatePickerMode)mode;
 
+@property (nonatomic, readonly) WKDatePickerPopoverController *datePickerController;
 @property (nonatomic, readonly) NSString *calendarType;
 @property (nonatomic, readonly) double hour;
 @property (nonatomic, readonly) double minute;
@@ -143,6 +144,11 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
         _datePickerController = nil;
         [_view.webView _didDismissContextMenu];
     }
+}
+
+- (WKDatePickerPopoverController *)datePickerController
+{
+    return _datePickerController.get();
 }
 
 - (void)showDateTimePicker
@@ -314,29 +320,38 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 
 - (void)setTimePickerHour:(NSInteger)hour minute:(NSInteger)minute
 {
-    if ([self.control isKindOfClass:WKDateTimePicker.class])
-        [(WKDateTimePicker *)self.control setHour:hour minute:minute];
+    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control))
+        [picker setHour:hour minute:minute];
 }
 
 - (NSString *)dateTimePickerCalendarType
 {
-    if ([self.control isKindOfClass:WKDateTimePicker.class])
-        return [(WKDateTimePicker *)self.control calendarType];
+    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control))
+        return picker.calendarType;
     return nil;
 }
 
 - (double)timePickerValueHour
 {
-    if ([self.control isKindOfClass:WKDateTimePicker.class])
-        return [(WKDateTimePicker *)self.control hour];
+    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control))
+        return picker.hour;
     return -1;
 }
 
 - (double)timePickerValueMinute
 {
-    if ([self.control isKindOfClass:WKDateTimePicker.class])
-        return [(WKDateTimePicker *)self.control minute];
+    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control))
+        return picker.minute;
     return -1;
+}
+
+- (BOOL)dismissWithAnimation
+{
+    if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control)) {
+        [picker.datePickerController dismissDatePicker];
+        return YES;
+    }
+    return NO;
 }
 
 @end


### PR DESCRIPTION
#### c9ac0cb7dfabcbf5aacdfecfde49b7b9f8936683
<pre>
REGRESSION (268069@main): [iOS] Date picker fails to present after dismissing with Done button
<a href="https://bugs.webkit.org/show_bug.cgi?id=262070">https://bugs.webkit.org/show_bug.cgi?id=262070</a>

Reviewed by Aditya Keerthi.

After the changes in 268069@main, tapping a datetime input after previously focusing and dismissing
it using the Done button silently fails to show the date picker popover a second time. This is
because we don&apos;t get a call to the `-presentationControllerDidDismiss:` delegate method in this case
where we&apos;re programmatically driving the dismissal of the popover; instead, we only get a call to
the completion handler of `-dismissViewControllerAnimated:completion:`.

I had actually caught (and prevented) this bug for Catalyst, which prompted me to add the call to
`-datePickerPopoverControllerDidDismiss:` in the completion handler specifically for Catalyst, but
for some reason didn&apos;t see that it also affected iOS as well. The fix here is simply:

1.  Remove the `PLATFORM(MACCATALYST)` in the completion handler of the dismissal animation, and...
2.  Make the logic around invoking `-datePickerPopoverControllerDidDismiss:` robust in the case
    where both the popover controller delegate method and completion block are invoked (which seems
    to be the case for month and time inputs, which use `UIDatePickerStyleWheels` instead of the
    inline style).

This was also almost caught by the existing test `fast/forms/ios/show-and-dismiss-date-input.html`,
but that test dismisses the date picker by tapping elsewhere on the screen, which narrowly avoids
this bug since we get a delegate call to `-presentationControllerDidDismiss:` in that case. We add
a new layout test that works similarly to this test, but instead simulates tapping the Done button
to dismiss the date picker.

* LayoutTests/fast/forms/ios/show-and-dismiss-date-input-after-tapping-done-expected.txt: Added.
* LayoutTests/fast/forms/ios/show-and-dismiss-date-input-after-tapping-done.html: Added.

Add a new layout test to exercise this fix.

* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView dismissFormAccessoryView]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView dismissFormAccessoryView]):

Augment existing test-only SPI to dismiss the date picker by simulating tapping the Done button when
a date picker popover is shown.

* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h:
* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverController dismissDatePicker]):
(-[WKDatePickerPopoverController presentInView:sourceRect:interactionBounds:completion:]):
(-[WKDatePickerPopoverController _dispatchPopoverControllerDidDismissIfNeeded]):
(-[WKDatePickerPopoverController presentationControllerDidDismiss:]):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.h:
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker datePickerController]):
(-[WKDateTimeInputControl setTimePickerHour:minute:]):
(-[WKDateTimeInputControl dateTimePickerCalendarType]):
(-[WKDateTimeInputControl timePickerValueHour]):
(-[WKDateTimeInputControl timePickerValueMinute]):
(-[WKDateTimeInputControl dismissWithAnimation]):

Canonical link: <a href="https://commits.webkit.org/268425@main">https://commits.webkit.org/268425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68577b448b99254d9cfe96d85cae40a7944f14aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20227 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22411 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17893 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24188 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18067 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22169 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18672 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17728 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4697 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->