### PR TITLE
Auto-generate another handful of WebCore/platform coders

### DIFF
--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -66,6 +66,11 @@ enum class PlatformMediaSessionRemoteControlCommandType : uint8_t {
     EndScrubbingCommand,
 };
 
+struct PlatformMediaSessionRemoteCommandArgument {
+    std::optional<double> time;
+    std::optional<bool> fastSeek;
+};
+
 class PlatformMediaSession
     : public CanMakeWeakPtr<PlatformMediaSession>
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -137,14 +142,8 @@ public:
 
     virtual void suspendBuffering() { }
     virtual void resumeBuffering() { }
-    
-    struct RemoteCommandArgument {
-        std::optional<double> time;
-        std::optional<bool> fastSeek;
 
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<RemoteCommandArgument> decode(Decoder&);
-    };
+    using RemoteCommandArgument = PlatformMediaSessionRemoteCommandArgument;
 
     using RemoteControlCommandType = PlatformMediaSessionRemoteControlCommandType;
     bool canReceiveRemoteControlCommands() const;
@@ -293,27 +292,6 @@ protected:
 String convertEnumerationToString(PlatformMediaSession::State);
 String convertEnumerationToString(PlatformMediaSession::InterruptionType);
 WEBCORE_EXPORT String convertEnumerationToString(PlatformMediaSession::RemoteControlCommandType);
-
-template<class Encoder> inline void PlatformMediaSession::RemoteCommandArgument::encode(Encoder& encoder) const
-{
-    encoder << time << fastSeek;
-}
-
-template<class Decoder> inline std::optional<PlatformMediaSession::RemoteCommandArgument> PlatformMediaSession::RemoteCommandArgument::decode(Decoder& decoder)
-{
-#define DECODE(name, type) \
-    std::optional<std::optional<type>> name; \
-    decoder >> name; \
-    if (!name) \
-        return std::nullopt; \
-
-    DECODE(time, double);
-    DECODE(fastSeek, bool);
-
-#undef DECODE
-
-    return { { *time, *fastSeek } };
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/GraphicsStyle.h
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.h
@@ -52,9 +52,6 @@ struct GraphicsDropShadow {
     bool isVisible() const { return color.isVisible(); }
     bool isBlurred() const { return isVisible() && radius; }
     bool hasOutsets() const { return isBlurred() || (isVisible() && !offset.isZero()); }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<GraphicsDropShadow> decode(Decoder&);
 };
 
 inline bool operator==(const GraphicsDropShadow& a, const GraphicsDropShadow& b)
@@ -66,17 +63,12 @@ struct GraphicsGaussianBlur {
     FloatSize radius;
 
     friend bool operator==(const GraphicsGaussianBlur&, const GraphicsGaussianBlur&) = default;
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<GraphicsGaussianBlur> decode(Decoder&);
 };
 
 struct GraphicsColorMatrix {
     std::array<float, 20> values;
 
     friend bool operator==(const GraphicsColorMatrix&, const GraphicsColorMatrix&) = default;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<GraphicsColorMatrix> decode(Decoder&);
 };
 
 using GraphicsStyle = std::variant<
@@ -89,80 +81,5 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const GraphicsDropS
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const GraphicsGaussianBlur&);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const GraphicsColorMatrix&);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const GraphicsStyle&);
-
-template<class Encoder>
-void GraphicsDropShadow::encode(Encoder& encoder) const
-{
-    encoder << offset;
-    encoder << radius;
-    encoder << color;
-    encoder << radiusMode;
-    encoder << opacity;
-}
-
-template<class Decoder>
-std::optional<GraphicsDropShadow> GraphicsDropShadow::decode(Decoder& decoder)
-{
-    std::optional<FloatSize> offset;
-    decoder >> offset;
-    if (!offset)
-        return std::nullopt;
-
-    std::optional<float> radius;
-    decoder >> radius;
-    if (!radius)
-        return std::nullopt;
-
-    std::optional<Color> color;
-    decoder >> color;
-    if (!color)
-        return std::nullopt;
-
-    std::optional<ShadowRadiusMode> radiusMode;
-    decoder >> radiusMode;
-    if (!radius)
-        return std::nullopt;
-
-    std::optional<float> opacity;
-    decoder >> opacity;
-    if (!opacity)
-        return std::nullopt;
-
-    return GraphicsDropShadow { *offset, *radius, *color, *radiusMode, *opacity };
-}
-
-template<class Encoder>
-void GraphicsGaussianBlur::encode(Encoder& encoder) const
-{
-    encoder << radius;
-}
-
-template<class Decoder>
-std::optional<GraphicsGaussianBlur> GraphicsGaussianBlur::decode(Decoder& decoder)
-{
-    std::optional<FloatSize> radius;
-    decoder >> radius;
-    if (!radius)
-        return std::nullopt;
-
-    return GraphicsGaussianBlur { *radius };
-}
-
-template<class Encoder>
-void GraphicsColorMatrix::encode(Encoder& encoder) const
-{
-    encoder << values;
-}
-
-template<class Decoder>
-std::optional<GraphicsColorMatrix> GraphicsColorMatrix::decode(Decoder& decoder)
-{
-    std::optional<std::array<float, 20>> values;
-    decoder >> values;
-    if (!values)
-        return std::nullopt;
-
-    return GraphicsColorMatrix { WTFMove(*values) };
-}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -89,9 +89,6 @@ public:
     bool setOffset(ComponentTransferChannel, float);
     bool setTableValues(ComponentTransferChannel, Vector<float>&&);
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<Ref<FEComponentTransfer>> decode(Decoder&);
-
 private:
     FEComponentTransfer(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc);
     FEComponentTransfer(ComponentTransferFunctions&&);

--- a/Source/WebCore/platform/network/SocketStreamError.h
+++ b/Source/WebCore/platform/network/SocketStreamError.h
@@ -31,11 +31,14 @@
 
 #pragma once
 
+#include <wtf/ArgumentCoder.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class SocketStreamError {
+private:
+    friend struct IPC::ArgumentCoder<SocketStreamError, void>;
 public:
     SocketStreamError() = default;
 
@@ -45,11 +48,11 @@ public:
     {
     }
 
-    SocketStreamError(int errorCode, const String& failingURL, const String& localizedDescription)
+    SocketStreamError(int errorCode, const String& failingURL, const String& localizedDescription, bool isNull = false)
         : m_errorCode(errorCode)
         , m_failingURL(failingURL)
         , m_localizedDescription(localizedDescription)
-        , m_isNull(false)
+        , m_isNull(isNull)
     {
     }
 
@@ -58,41 +61,11 @@ public:
     const String& failingURL() const { return m_failingURL; }
     const String& localizedDescription() const { return m_localizedDescription; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, SocketStreamError&);
-
 private:
     int m_errorCode { 0 };
     String m_failingURL;
     String m_localizedDescription;
     bool m_isNull { true };
 };
-
-template<class Encoder>
-void SocketStreamError::encode(Encoder& encoder) const
-{
-    encoder << m_isNull;
-    if (m_isNull)
-        return;
-    encoder << m_errorCode;
-    encoder << m_failingURL;
-    encoder << m_localizedDescription;
-}
-
-template<class Decoder>
-bool SocketStreamError::decode(Decoder& decoder, SocketStreamError& error)
-{
-    if (!decoder.decode(error.m_isNull))
-        return false;
-    if (error.m_isNull)
-        return true;
-    if (!decoder.decode(error.m_errorCode))
-        return false;
-    if (!decoder.decode(error.m_failingURL))
-        return false;
-    if (!decoder.decode(error.m_localizedDescription))
-        return false;
-    return true;
-}
 
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4276,7 +4276,32 @@ header: <WebCore/GraphicsStyle.h>
     float radius;
     WebCore::Color color;
     WebCore::ShadowRadiusMode radiusMode;
+    float opacity;
 };
+
+header: <WebCore/GraphicsStyle.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::GraphicsGaussianBlur {
+    WebCore::FloatSize radius;
+};
+
+header: <WebCore/GraphicsStyle.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::GraphicsColorMatrix {
+    std::array<float, 20> values;
+};
+
+header: <WebCore/PlatformMediaSession.h>
+[CustomHeader] struct WebCore::PlatformMediaSessionRemoteCommandArgument {
+    std::optional<double> time;
+    std::optional<bool> fastSeek;
+}
+using WebCore::PlatformMediaSession::RemoteCommandArgument = WebCore::PlatformMediaSessionRemoteCommandArgument;
+
+class WebCore::SocketStreamError {
+    int m_errorCode;
+    String m_failingURL;
+    String m_localizedDescription;
+    bool m_isNull;
+}
 
 #if ENABLE(VIDEO)
 [Nested, AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::GenericCueData::Alignment : uint8_t {


### PR DESCRIPTION
#### e48bf086c1f3bf6811e7383d07c54a6f7bb664af
<pre>
Auto-generate another handful of WebCore/platform coders
<a href="https://bugs.webkit.org/show_bug.cgi?id=262075">https://bugs.webkit.org/show_bug.cgi?id=262075</a>
rdar://116017771

Reviewed by Alex Christensen.

* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WebCore::PlatformMediaSession::resumeBuffering):
(WebCore::PlatformMediaSession::RemoteCommandArgument::encode const): Deleted.
(WebCore::PlatformMediaSession::RemoteCommandArgument::decode): Deleted.
* Source/WebCore/platform/graphics/GraphicsStyle.h:
(WebCore::GraphicsDropShadow::hasOutsets const):
(WebCore::GraphicsDropShadow::encode const): Deleted.
(WebCore::GraphicsDropShadow::decode): Deleted.
(WebCore::GraphicsGaussianBlur::encode const): Deleted.
(WebCore::GraphicsGaussianBlur::decode): Deleted.
(WebCore::GraphicsColorMatrix::encode const): Deleted.
(WebCore::GraphicsColorMatrix::decode): Deleted.
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebCore/platform/network/SocketStreamError.h:
(WebCore::SocketStreamError::SocketStreamError):
(WebCore::SocketStreamError::encode const): Deleted.
(WebCore::SocketStreamError::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268430@main">https://commits.webkit.org/268430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/733d3c336c85123217273b2fba33a1268cada0e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20237 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/19976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22420 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24192 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22173 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15833 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17827 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->