### PR TITLE
[CSS Fonts] The `from-font` value for CSS `font-size-adjust` is not computed correctly

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3885,7 +3885,6 @@ webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/variations/fon
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/variations/font-slant-2a.html [ ImageOnlyFailure ]
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/variations/font-slant-2c.html [ ImageOnlyFailure ]
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/hiragana-katakana-kerning.html [ ImageOnlyFailure ]
-webkit.org/b/259551 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-014.html [ ImageOnlyFailure ]
 
 # Untriaged font-style/font-face @font-face descriptor bugs
 webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/font-face-style-auto-variable.html [ ImageOnlyFailure ]

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -358,7 +358,7 @@ static RefPtr<CSSValue> valueForNinePieceImage(CSSPropertyID propertyID, const N
 static Ref<CSSValue> fontSizeAdjustFromStyle(const RenderStyle& style)
 {
     auto fontSizeAdjust = style.fontSizeAdjust();
-    if (!fontSizeAdjust.value)
+    if (!fontSizeAdjust)
         return CSSPrimitiveValue::create(CSSValueNone);
 
     auto metric = fontSizeAdjust.metric;

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -120,7 +120,7 @@ struct FontDescriptionKey {
         auto variantAlternates = description.variantAlternates();
         auto fontPalette = description.fontPalette();
         auto fontSizeAdjust = description.fontSizeAdjust();
-        if (!featureSettings.isEmpty() || !variationSettings.isEmpty() || !variantAlternates.isNormal() || fontPalette.type != FontPalette::Type::Normal || fontSizeAdjust.value)
+        if (!featureSettings.isEmpty() || !variationSettings.isEmpty() || !variantAlternates.isNormal() || fontPalette.type != FontPalette::Type::Normal || fontSizeAdjust)
             m_rareData = FontDescriptionKeyRareData::create(WTFMove(featureSettings), WTFMove(variationSettings), WTFMove(variantAlternates), WTFMove(fontPalette), WTFMove(fontSizeAdjust));
     }
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -502,8 +502,15 @@ GlyphData FontCascadeFonts::glyphDataForCharacter(UChar32 c, const FontCascadeDe
     ASSERT(m_thread ? m_thread->ptr() == &Thread::current() : isMainThread());
     ASSERT(variant != AutoVariant);
 
+    FontCascadeDescription fontDescription(description);
+    auto fontSizeAdjust = description.fontSizeAdjust();
+    if (m_cachedPrimaryFont && fontSizeAdjust.isFromFont) {
+        auto aspectValue = fontSizeAdjust.resolve(description.computedSize(), m_cachedPrimaryFont->fontMetrics());
+        fontDescription.setFontSizeAdjust({ fontSizeAdjust.metric, fontSizeAdjust.isFromFont, aspectValue });
+    }
+
     if (variant != NormalVariant)
-        return glyphDataForVariant(c, description, variant, resolvedEmojiPolicy);
+        return glyphDataForVariant(c, fontDescription, variant, resolvedEmojiPolicy);
 
     const unsigned pageNumber = GlyphPage::pageNumberForCodePoint(c);
 
@@ -511,13 +518,13 @@ GlyphData FontCascadeFonts::glyphDataForCharacter(UChar32 c, const FontCascadeDe
 
     // Initialize cache with a full page of glyph mappings from a single font.
     if (cacheEntry.isNull())
-        cacheEntry.setSingleFontPage(glyphPageFromFontRanges(pageNumber, realizeFallbackRangesAt(description, 0)));
+        cacheEntry.setSingleFontPage(glyphPageFromFontRanges(pageNumber, realizeFallbackRangesAt(fontDescription, 0)));
 
     GlyphData glyphData = cacheEntry.glyphDataForCharacter(c);
     if (!glyphData.glyph) {
         // No glyph, resolve per-character.
         ASSERT(variant == NormalVariant);
-        glyphData = glyphDataForVariant(c, description, variant, resolvedEmojiPolicy);
+        glyphData = glyphDataForVariant(c, fontDescription, variant, resolvedEmojiPolicy);
         // Cache the results.
         cacheEntry.setGlyphDataForCharacter(c, glyphData);
     }

--- a/Source/WebCore/platform/graphics/FontSizeAdjust.h
+++ b/Source/WebCore/platform/graphics/FontSizeAdjust.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FontMetrics.h"
 #include <variant>
 #include <wtf/Markable.h>
 #include <wtf/text/TextStream.h>
@@ -45,6 +46,7 @@ struct FloatMarkableTraits {
 
 struct FontSizeAdjust {
     friend bool operator==(const FontSizeAdjust&, const FontSizeAdjust&) = default;
+    explicit operator bool() const { return value || isFromFont; }
 
     enum class Metric : uint8_t {
         ExHeight,
@@ -53,6 +55,36 @@ struct FontSizeAdjust {
         IcWidth,
         IcHeight
     };
+
+    std::optional<float> resolve(float computedSize, const FontMetrics& fontMetrics) const
+    {
+        std::optional<float> metricValue;
+        switch (metric) {
+        case FontSizeAdjust::Metric::CapHeight:
+            if (fontMetrics.hasCapHeight())
+                metricValue = fontMetrics.floatCapHeight();
+            break;
+        case FontSizeAdjust::Metric::ChWidth:
+            if (fontMetrics.zeroWidth())
+                metricValue = fontMetrics.zeroWidth();
+            break;
+        // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
+        case FontSizeAdjust::Metric::IcWidth:
+        case FontSizeAdjust::Metric::IcHeight:
+            if (fontMetrics.ideogramWidth() > 0)
+                metricValue = fontMetrics.ideogramWidth();
+            break;
+        case FontSizeAdjust::Metric::ExHeight:
+        default:
+            if (fontMetrics.hasXHeight())
+                metricValue = fontMetrics.xHeight();
+        }
+
+        return metricValue.has_value() && computedSize
+            ? std::make_optional(*metricValue / computedSize)
+            : std::nullopt;
+    }
+
     Metric metric { Metric::ExHeight };
     bool isFromFont { false };
     Markable<float, FloatMarkableTraits> value { };
@@ -60,7 +92,7 @@ struct FontSizeAdjust {
 
 inline void add(Hasher& hasher, const FontSizeAdjust& fontSizeAdjust)
 {
-    add(hasher, fontSizeAdjust.metric, *fontSizeAdjust.value);
+    add(hasher, fontSizeAdjust.metric, fontSizeAdjust.isFromFont, *fontSizeAdjust.value);
 }
 
 inline TextStream& operator<<(TextStream& ts, const FontSizeAdjust& fontSizeAdjust)
@@ -87,7 +119,7 @@ inline TextStream& operator<<(TextStream& ts, const FontSizeAdjust& fontSizeAdju
 
     if (fontSizeAdjust.isFromFont)
         return ts << " " << "from-font";
-    return ts << " " << fontSizeAdjust.value;
+    return ts << " " << *fontSizeAdjust.value;
 }
 
 }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -67,7 +67,6 @@
 #include "ScrollbarGutter.h"
 #include "Settings.h"
 #include "StyleBuilderState.h"
-#include "StyleFontSizeFunctions.h"
 #include "StyleReflection.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleTextBoxEdge.h"
@@ -1609,7 +1608,7 @@ inline FontVariationSettings BuilderConverter::convertFontVariationSettings(Buil
     return settings;
 }
 
-inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& builderState, const CSSValue& value)
+inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
@@ -1622,9 +1621,9 @@ inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& buil
             return { defaultMetric, false, primitiveValue.floatValue() };
 
         ASSERT(primitiveValue.valueID() == CSSValueFromFont);
-        // The primary font could be null in the current builder state where
-        // a fallback font is used. So, we use the parent style instead.
-        return { defaultMetric, true, aspectValueOfPrimaryFont(builderState.parentStyle(), defaultMetric) };
+        // As we cannot determine the primary font here, we defer resolving the
+        // aspect value for from-font to FontCascadeFonts::glyphDataForCharacter.
+        return { defaultMetric, true, std::nullopt };
     }
 
     ASSERT(value.isPair());
@@ -1636,7 +1635,7 @@ inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& buil
         return { metric, false, primitiveValue.floatValue() };
 
     ASSERT(primitiveValue.valueID() == CSSValueFromFont);
-    return { metric, true, aspectValueOfPrimaryFont(builderState.parentStyle(), metric) };
+    return { metric, true, std::nullopt };
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -214,36 +214,5 @@ float adjustedFontSize(float size, const FontSizeAdjust& sizeAdjust, const FontM
     ASSERT_NOT_REACHED();
 }
 
-std::optional<float> aspectValueOfPrimaryFont(const RenderStyle& style, FontSizeAdjust::Metric metric)
-{
-    const auto& metrics = style.metricsOfPrimaryFont();
-    std::optional<float> metricValue;
-    switch (metric) {
-    case FontSizeAdjust::Metric::CapHeight:
-        if (metrics.hasCapHeight())
-            metricValue = metrics.floatCapHeight();
-        break;
-    case FontSizeAdjust::Metric::ChWidth:
-        if (metrics.zeroWidth())
-            metricValue = metrics.zeroWidth();
-        break;
-    // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
-    case FontSizeAdjust::Metric::IcWidth:
-    case FontSizeAdjust::Metric::IcHeight:
-        if (metrics.ideogramWidth() > 0)
-            metricValue = metrics.ideogramWidth();
-        break;
-    case FontSizeAdjust::Metric::ExHeight:
-    default:
-        if (metrics.hasXHeight())
-            metricValue = metrics.xHeight();
-    }
-
-    float computedFontSize = style.computedFontSize();
-    return metricValue.has_value() && computedFontSize
-        ? std::make_optional(*metricValue / computedFontSize)
-        : std::nullopt;
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -43,7 +43,6 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
 float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle*, const Document&);
 float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
 float adjustedFontSize(float size, const FontSizeAdjust&, const FontMetrics&);
-std::optional<float> aspectValueOfPrimaryFont(const RenderStyle&, FontSizeAdjust::Metric);
 
 // Given a CSS keyword id in the range (CSSValueXxSmall to CSSValueXxxLarge), this function will return
 // the correct font size scaled relative to the user's default (medium).


### PR DESCRIPTION
#### 49f5188b5e8285f7c3b97cd7161b517ff0bd2886
<pre>
[CSS Fonts] The `from-font` value for CSS `font-size-adjust` is not computed correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=259551">https://bugs.webkit.org/show_bug.cgi?id=259551</a>

Reviewed by Myles C. Maxfield.

When resolving styles, we used the parent-style font to compute the aspect ratio
for font-size-adjust: from-font because the first available font could not be
determined at that moment. Unfortunately, this causes the failure of
font-size-adjust-014.html. To make the test happy, we should defer resolving
the aspect value after determining a primary font. Also, FontDescriptionKey
should consider if the font-size-adjust has from-font, not simply checking if
it has a valid value when looking up a proper FontCascadeFonts.

* LayoutTests/TestExpectations:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontSizeAdjustFromStyle):
* Source/WebCore/platform/graphics/FontCascadeCache.h:
(WebCore::FontDescriptionKey::FontDescriptionKey):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::glyphDataForCharacter):
* Source/WebCore/platform/graphics/FontSizeAdjust.h:
(WebCore::FontSizeAdjust::operator bool const):
(WebCore::FontSizeAdjust::resolve const):
(WebCore::add):
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertFontSizeAdjust):
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::aspectValueOfPrimaryFont): Deleted.
* Source/WebCore/style/StyleFontSizeFunctions.h:

Canonical link: <a href="https://commits.webkit.org/268550@main">https://commits.webkit.org/268550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6a51549b236fd8e070b6958729783bc0b100fe0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20569 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22740 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24445 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22434 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18945 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18126 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4795 "Failed to checkout and rebase branch from PR 18193") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->