### PR TITLE
Sync and add missing 'readonly' in [Audio|Video|Text]Track.idl as per web specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -249,13 +249,9 @@ PASS AudioTrack interface: existence and properties of interface prototype objec
 PASS AudioTrack interface: existence and properties of interface prototype object's "constructor" property
 PASS AudioTrack interface: existence and properties of interface prototype object's @@unscopables property
 PASS AudioTrack interface: attribute id
-FAIL AudioTrack interface: attribute kind assert_equals: setter must be undefined for readonly attributes expected (undefined) undefined but got (function) function "function kind() {
-    [native code]
-}"
+PASS AudioTrack interface: attribute kind
 PASS AudioTrack interface: attribute label
-FAIL AudioTrack interface: attribute language assert_equals: setter must be undefined for readonly attributes expected (undefined) undefined but got (function) function "function language() {
-    [native code]
-}"
+PASS AudioTrack interface: attribute language
 PASS AudioTrack interface: attribute enabled
 PASS VideoTrackList interface: existence and properties of interface object
 PASS VideoTrackList interface object length
@@ -276,13 +272,9 @@ PASS VideoTrack interface: existence and properties of interface prototype objec
 PASS VideoTrack interface: existence and properties of interface prototype object's "constructor" property
 PASS VideoTrack interface: existence and properties of interface prototype object's @@unscopables property
 PASS VideoTrack interface: attribute id
-FAIL VideoTrack interface: attribute kind assert_equals: setter must be undefined for readonly attributes expected (undefined) undefined but got (function) function "function kind() {
-    [native code]
-}"
+PASS VideoTrack interface: attribute kind
 PASS VideoTrack interface: attribute label
-FAIL VideoTrack interface: attribute language assert_equals: setter must be undefined for readonly attributes expected (undefined) undefined but got (function) function "function language() {
-    [native code]
-}"
+PASS VideoTrack interface: attribute language
 PASS VideoTrack interface: attribute selected
 PASS TextTrackList interface: existence and properties of interface object
 PASS TextTrackList interface object length
@@ -309,13 +301,9 @@ PASS TextTrack interface object name
 PASS TextTrack interface: existence and properties of interface prototype object
 PASS TextTrack interface: existence and properties of interface prototype object's "constructor" property
 PASS TextTrack interface: existence and properties of interface prototype object's @@unscopables property
-FAIL TextTrack interface: attribute kind assert_equals: setter must be undefined for readonly attributes expected (undefined) undefined but got (function) function "function kind() {
-    [native code]
-}"
+PASS TextTrack interface: attribute kind
 PASS TextTrack interface: attribute label
-FAIL TextTrack interface: attribute language assert_equals: setter must be undefined for readonly attributes expected (undefined) undefined but got (function) function "function language() {
-    [native code]
-}"
+PASS TextTrack interface: attribute language
 PASS TextTrack interface: attribute id
 PASS TextTrack interface: attribute inBandMetadataTrackDispatchType
 PASS TextTrack interface: attribute mode

--- a/LayoutTests/media/media-source/only-bcp47-language-tags-accepted-as-valid-expected.txt
+++ b/LayoutTests/media/media-source/only-bcp47-language-tags-accepted-as-valid-expected.txt
@@ -1,47 +1,17 @@
 CONSOLE MESSAGE: The language 'a' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'a' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'a' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language '1' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language '1' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language '1' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'ab-abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'ab-abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'ab-abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language '1a' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language '1a' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language '1a' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language '-a' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language '-a' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language '-a' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'a-' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'a-' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'a-' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'a1' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'a1' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'a1' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'aa1' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'aa1' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'aa1' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'aaaa' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'aaaa' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'aaaa' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'aaa1' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'aaa1' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'aaa1' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'inv-alid-char space' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-char space' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-char space' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-charâ€“longDash' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-charâ€“longDash' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'inv-alid-charâ€“longDash' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'inv-alid-char-PÃ¥lska' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-char-PÃ¥lska' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-char-PÃ¥lska' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'inv-alid-char-*' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-char-*' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-char-*' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-char-ï£¿' is not a valid BCP 47 language tag.
-CONSOLE MESSAGE: The language 'inv-alid-char-ï£¿' is not a valid BCP 47 language tag.
 CONSOLE MESSAGE: The language 'inv-alid-char-ï£¿' is not a valid BCP 47 language tag.
 Test that only BCP47 language tags are accepted as valid but still reflected.
 
@@ -55,248 +25,86 @@ EVENT(update)
 Append a partial media segment.
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0).slice(0, loader.mediaSegment(0).byteLength / 2)))
 EVENT(update)
-EXPECTED (videoTrack.language == 'en-GB-oed') OK
 EXPECTED (textTrack.track.language == 'en-GB-oed') OK
-EXPECTED (audioTrack.language == 'en-GB-oed') OK
-EXPECTED (videoTrack.language == 'i-ami') OK
 EXPECTED (textTrack.track.language == 'i-ami') OK
-EXPECTED (audioTrack.language == 'i-ami') OK
-EXPECTED (videoTrack.language == 'i-bnn') OK
 EXPECTED (textTrack.track.language == 'i-bnn') OK
-EXPECTED (audioTrack.language == 'i-bnn') OK
-EXPECTED (videoTrack.language == 'i-default') OK
 EXPECTED (textTrack.track.language == 'i-default') OK
-EXPECTED (audioTrack.language == 'i-default') OK
-EXPECTED (videoTrack.language == 'i-enochian') OK
 EXPECTED (textTrack.track.language == 'i-enochian') OK
-EXPECTED (audioTrack.language == 'i-enochian') OK
-EXPECTED (videoTrack.language == 'i-hak') OK
 EXPECTED (textTrack.track.language == 'i-hak') OK
-EXPECTED (audioTrack.language == 'i-hak') OK
-EXPECTED (videoTrack.language == 'i-klingon') OK
 EXPECTED (textTrack.track.language == 'i-klingon') OK
-EXPECTED (audioTrack.language == 'i-klingon') OK
-EXPECTED (videoTrack.language == 'i-lux') OK
 EXPECTED (textTrack.track.language == 'i-lux') OK
-EXPECTED (audioTrack.language == 'i-lux') OK
-EXPECTED (videoTrack.language == 'i-mingo') OK
 EXPECTED (textTrack.track.language == 'i-mingo') OK
-EXPECTED (audioTrack.language == 'i-mingo') OK
-EXPECTED (videoTrack.language == 'i-navajo') OK
 EXPECTED (textTrack.track.language == 'i-navajo') OK
-EXPECTED (audioTrack.language == 'i-navajo') OK
-EXPECTED (videoTrack.language == 'i-pwn') OK
 EXPECTED (textTrack.track.language == 'i-pwn') OK
-EXPECTED (audioTrack.language == 'i-pwn') OK
-EXPECTED (videoTrack.language == 'i-tao') OK
 EXPECTED (textTrack.track.language == 'i-tao') OK
-EXPECTED (audioTrack.language == 'i-tao') OK
-EXPECTED (videoTrack.language == 'i-tay') OK
 EXPECTED (textTrack.track.language == 'i-tay') OK
-EXPECTED (audioTrack.language == 'i-tay') OK
-EXPECTED (videoTrack.language == 'i-tsu') OK
 EXPECTED (textTrack.track.language == 'i-tsu') OK
-EXPECTED (audioTrack.language == 'i-tsu') OK
-EXPECTED (videoTrack.language == 'sgn-BE-FR') OK
 EXPECTED (textTrack.track.language == 'sgn-BE-FR') OK
-EXPECTED (audioTrack.language == 'sgn-BE-FR') OK
-EXPECTED (videoTrack.language == 'sgn-BE-NL') OK
 EXPECTED (textTrack.track.language == 'sgn-BE-NL') OK
-EXPECTED (audioTrack.language == 'sgn-BE-NL') OK
-EXPECTED (videoTrack.language == 'sgn-CH-DE') OK
 EXPECTED (textTrack.track.language == 'sgn-CH-DE') OK
-EXPECTED (audioTrack.language == 'sgn-CH-DE') OK
-EXPECTED (videoTrack.language == 'art-lojban') OK
 EXPECTED (textTrack.track.language == 'art-lojban') OK
-EXPECTED (audioTrack.language == 'art-lojban') OK
-EXPECTED (videoTrack.language == 'cel-gaulish') OK
 EXPECTED (textTrack.track.language == 'cel-gaulish') OK
-EXPECTED (audioTrack.language == 'cel-gaulish') OK
-EXPECTED (videoTrack.language == 'no-bok') OK
 EXPECTED (textTrack.track.language == 'no-bok') OK
-EXPECTED (audioTrack.language == 'no-bok') OK
-EXPECTED (videoTrack.language == 'no-nyn') OK
 EXPECTED (textTrack.track.language == 'no-nyn') OK
-EXPECTED (audioTrack.language == 'no-nyn') OK
-EXPECTED (videoTrack.language == 'zh-guoyu') OK
 EXPECTED (textTrack.track.language == 'zh-guoyu') OK
-EXPECTED (audioTrack.language == 'zh-guoyu') OK
-EXPECTED (videoTrack.language == 'zh-hakka') OK
 EXPECTED (textTrack.track.language == 'zh-hakka') OK
-EXPECTED (audioTrack.language == 'zh-hakka') OK
-EXPECTED (videoTrack.language == 'zh-min') OK
 EXPECTED (textTrack.track.language == 'zh-min') OK
-EXPECTED (audioTrack.language == 'zh-min') OK
-EXPECTED (videoTrack.language == 'zh-min-nan') OK
 EXPECTED (textTrack.track.language == 'zh-min-nan') OK
-EXPECTED (audioTrack.language == 'zh-min-nan') OK
-EXPECTED (videoTrack.language == 'zh-xiang') OK
 EXPECTED (textTrack.track.language == 'zh-xiang') OK
-EXPECTED (audioTrack.language == 'zh-xiang') OK
-EXPECTED (videoTrack.language == 'de') OK
 EXPECTED (textTrack.track.language == 'de') OK
-EXPECTED (audioTrack.language == 'de') OK
-EXPECTED (videoTrack.language == 'fr') OK
 EXPECTED (textTrack.track.language == 'fr') OK
-EXPECTED (audioTrack.language == 'fr') OK
-EXPECTED (videoTrack.language == 'ja') OK
 EXPECTED (textTrack.track.language == 'ja') OK
-EXPECTED (audioTrack.language == 'ja') OK
-EXPECTED (videoTrack.language == 'zh-Hant') OK
 EXPECTED (textTrack.track.language == 'zh-Hant') OK
-EXPECTED (audioTrack.language == 'zh-Hant') OK
-EXPECTED (videoTrack.language == 'zh-Han') OK
 EXPECTED (textTrack.track.language == 'zh-Han') OK
-EXPECTED (audioTrack.language == 'zh-Han') OK
-EXPECTED (videoTrack.language == 'sr-Cyrl') OK
 EXPECTED (textTrack.track.language == 'sr-Cyrl') OK
-EXPECTED (audioTrack.language == 'sr-Cyrl') OK
-EXPECTED (videoTrack.language == 'sr-Latn') OK
 EXPECTED (textTrack.track.language == 'sr-Latn') OK
-EXPECTED (audioTrack.language == 'sr-Latn') OK
-EXPECTED (videoTrack.language == 'zh-cmn-Hans-CN') OK
 EXPECTED (textTrack.track.language == 'zh-cmn-Hans-CN') OK
-EXPECTED (audioTrack.language == 'zh-cmn-Hans-CN') OK
-EXPECTED (videoTrack.language == 'cmn-Hans-CN') OK
 EXPECTED (textTrack.track.language == 'cmn-Hans-CN') OK
-EXPECTED (audioTrack.language == 'cmn-Hans-CN') OK
-EXPECTED (videoTrack.language == 'zh-yue-HK') OK
 EXPECTED (textTrack.track.language == 'zh-yue-HK') OK
-EXPECTED (audioTrack.language == 'zh-yue-HK') OK
-EXPECTED (videoTrack.language == 'yue-HK') OK
 EXPECTED (textTrack.track.language == 'yue-HK') OK
-EXPECTED (audioTrack.language == 'yue-HK') OK
-EXPECTED (videoTrack.language == 'zh-Hans-CN') OK
 EXPECTED (textTrack.track.language == 'zh-Hans-CN') OK
-EXPECTED (audioTrack.language == 'zh-Hans-CN') OK
-EXPECTED (videoTrack.language == 'sr-Latn-RS') OK
 EXPECTED (textTrack.track.language == 'sr-Latn-RS') OK
-EXPECTED (audioTrack.language == 'sr-Latn-RS') OK
-EXPECTED (videoTrack.language == 'sl-rozaj') OK
 EXPECTED (textTrack.track.language == 'sl-rozaj') OK
-EXPECTED (audioTrack.language == 'sl-rozaj') OK
-EXPECTED (videoTrack.language == 'sl-rozaj-biske') OK
 EXPECTED (textTrack.track.language == 'sl-rozaj-biske') OK
-EXPECTED (audioTrack.language == 'sl-rozaj-biske') OK
-EXPECTED (videoTrack.language == 'sl-nedis') OK
 EXPECTED (textTrack.track.language == 'sl-nedis') OK
-EXPECTED (audioTrack.language == 'sl-nedis') OK
-EXPECTED (videoTrack.language == 'de-CH-1901') OK
 EXPECTED (textTrack.track.language == 'de-CH-1901') OK
-EXPECTED (audioTrack.language == 'de-CH-1901') OK
-EXPECTED (videoTrack.language == 'sl-IT-nedis') OK
 EXPECTED (textTrack.track.language == 'sl-IT-nedis') OK
-EXPECTED (audioTrack.language == 'sl-IT-nedis') OK
-EXPECTED (videoTrack.language == 'hy-Latn-IT-arevela') OK
 EXPECTED (textTrack.track.language == 'hy-Latn-IT-arevela') OK
-EXPECTED (audioTrack.language == 'hy-Latn-IT-arevela') OK
-EXPECTED (videoTrack.language == 'en-US') OK
 EXPECTED (textTrack.track.language == 'en-US') OK
-EXPECTED (audioTrack.language == 'en-US') OK
-EXPECTED (videoTrack.language == 'es-419') OK
 EXPECTED (textTrack.track.language == 'es-419') OK
-EXPECTED (audioTrack.language == 'es-419') OK
-EXPECTED (videoTrack.language == 'de-CH-x-phonebk') OK
 EXPECTED (textTrack.track.language == 'de-CH-x-phonebk') OK
-EXPECTED (audioTrack.language == 'de-CH-x-phonebk') OK
-EXPECTED (videoTrack.language == 'az-Arab-x-AZE-derbend') OK
 EXPECTED (textTrack.track.language == 'az-Arab-x-AZE-derbend') OK
-EXPECTED (audioTrack.language == 'az-Arab-x-AZE-derbend') OK
-EXPECTED (videoTrack.language == 'x-whatever') OK
 EXPECTED (textTrack.track.language == 'x-whatever') OK
-EXPECTED (audioTrack.language == 'x-whatever') OK
-EXPECTED (videoTrack.language == 'qaa-Qaaa-QM-x-southern') OK
 EXPECTED (textTrack.track.language == 'qaa-Qaaa-QM-x-southern') OK
-EXPECTED (audioTrack.language == 'qaa-Qaaa-QM-x-southern') OK
-EXPECTED (videoTrack.language == 'de-Qaaa') OK
 EXPECTED (textTrack.track.language == 'de-Qaaa') OK
-EXPECTED (audioTrack.language == 'de-Qaaa') OK
-EXPECTED (videoTrack.language == 'sr-Latn-QM') OK
 EXPECTED (textTrack.track.language == 'sr-Latn-QM') OK
-EXPECTED (audioTrack.language == 'sr-Latn-QM') OK
-EXPECTED (videoTrack.language == 'sr-Qaaa-RS') OK
 EXPECTED (textTrack.track.language == 'sr-Qaaa-RS') OK
-EXPECTED (audioTrack.language == 'sr-Qaaa-RS') OK
-EXPECTED (videoTrack.language == 'zh-Hant-CN-x-private1-private2') OK
 EXPECTED (textTrack.track.language == 'zh-Hant-CN-x-private1-private2') OK
-EXPECTED (audioTrack.language == 'zh-Hant-CN-x-private1-private2') OK
-EXPECTED (videoTrack.language == 'de-DE') OK
 EXPECTED (textTrack.track.language == 'de-DE') OK
-EXPECTED (audioTrack.language == 'de-DE') OK
-EXPECTED (videoTrack.language == 'de-de') OK
 EXPECTED (textTrack.track.language == 'de-de') OK
-EXPECTED (audioTrack.language == 'de-de') OK
-EXPECTED (videoTrack.language == 'de-Latn-DE') OK
 EXPECTED (textTrack.track.language == 'de-Latn-DE') OK
-EXPECTED (audioTrack.language == 'de-Latn-DE') OK
-EXPECTED (videoTrack.language == 'de-Latf-DE') OK
 EXPECTED (textTrack.track.language == 'de-Latf-DE') OK
-EXPECTED (audioTrack.language == 'de-Latf-DE') OK
-EXPECTED (videoTrack.language == 'de-DE-x-goethe') OK
 EXPECTED (textTrack.track.language == 'de-DE-x-goethe') OK
-EXPECTED (audioTrack.language == 'de-DE-x-goethe') OK
-EXPECTED (videoTrack.language == 'de-Latn-DE-1996') OK
 EXPECTED (textTrack.track.language == 'de-Latn-DE-1996') OK
-EXPECTED (audioTrack.language == 'de-Latn-DE-1996') OK
-EXPECTED (videoTrack.language == 'de-Deva-DE') OK
 EXPECTED (textTrack.track.language == 'de-Deva-DE') OK
-EXPECTED (audioTrack.language == 'de-Deva-DE') OK
-EXPECTED (videoTrack.language == 'en-US-u-islamcal') OK
 EXPECTED (textTrack.track.language == 'en-US-u-islamcal') OK
-EXPECTED (audioTrack.language == 'en-US-u-islamcal') OK
-EXPECTED (videoTrack.language == 'zh-CN-a-myext-x-private') OK
 EXPECTED (textTrack.track.language == 'zh-CN-a-myext-x-private') OK
-EXPECTED (audioTrack.language == 'zh-CN-a-myext-x-private') OK
-EXPECTED (videoTrack.language == 'en-a-myext-b-another') OK
 EXPECTED (textTrack.track.language == 'en-a-myext-b-another') OK
-EXPECTED (audioTrack.language == 'en-a-myext-b-another') OK
-EXPECTED (videoTrack.language == 'zh-Latn-CN-variant1-a-extend1-x-wadegile-private1') OK
 EXPECTED (textTrack.track.language == 'zh-Latn-CN-variant1-a-extend1-x-wadegile-private1') OK
-EXPECTED (audioTrack.language == 'zh-Latn-CN-variant1-a-extend1-x-wadegile-private1') OK
-EXPECTED (videoTrack.language == 'a') OK
 EXPECTED (textTrack.track.language == 'a') OK
-EXPECTED (audioTrack.language == 'a') OK
-EXPECTED (videoTrack.language == '1') OK
 EXPECTED (textTrack.track.language == '1') OK
-EXPECTED (audioTrack.language == '1') OK
-EXPECTED (videoTrack.language == 'ab-abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij') OK
 EXPECTED (textTrack.track.language == 'ab-abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij') OK
-EXPECTED (audioTrack.language == 'ab-abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij') OK
-EXPECTED (videoTrack.language == '1a') OK
 EXPECTED (textTrack.track.language == '1a') OK
-EXPECTED (audioTrack.language == '1a') OK
-EXPECTED (videoTrack.language == '-a') OK
 EXPECTED (textTrack.track.language == '-a') OK
-EXPECTED (audioTrack.language == '-a') OK
-EXPECTED (videoTrack.language == 'a-') OK
 EXPECTED (textTrack.track.language == 'a-') OK
-EXPECTED (audioTrack.language == 'a-') OK
-EXPECTED (videoTrack.language == 'a1') OK
 EXPECTED (textTrack.track.language == 'a1') OK
-EXPECTED (audioTrack.language == 'a1') OK
-EXPECTED (videoTrack.language == 'aa1') OK
 EXPECTED (textTrack.track.language == 'aa1') OK
-EXPECTED (audioTrack.language == 'aa1') OK
-EXPECTED (videoTrack.language == 'aaaa') OK
 EXPECTED (textTrack.track.language == 'aaaa') OK
-EXPECTED (audioTrack.language == 'aaaa') OK
-EXPECTED (videoTrack.language == 'aaa1') OK
 EXPECTED (textTrack.track.language == 'aaa1') OK
-EXPECTED (audioTrack.language == 'aaa1') OK
-EXPECTED (videoTrack.language == 'inv-alid-char space') OK
 EXPECTED (textTrack.track.language == 'inv-alid-char space') OK
-EXPECTED (audioTrack.language == 'inv-alid-char space') OK
-EXPECTED (videoTrack.language == 'inv-alid-charâ€“longDash') OK
 EXPECTED (textTrack.track.language == 'inv-alid-charâ€“longDash') OK
-EXPECTED (audioTrack.language == 'inv-alid-charâ€“longDash') OK
-EXPECTED (videoTrack.language == 'inv-alid-char-PÃ¥lska') OK
 EXPECTED (textTrack.track.language == 'inv-alid-char-PÃ¥lska') OK
-EXPECTED (audioTrack.language == 'inv-alid-char-PÃ¥lska') OK
-EXPECTED (videoTrack.language == 'inv-alid-char-*') OK
 EXPECTED (textTrack.track.language == 'inv-alid-char-*') OK
-EXPECTED (audioTrack.language == 'inv-alid-char-*') OK
-EXPECTED (videoTrack.language == 'inv-alid-char-ï£¿') OK
 EXPECTED (textTrack.track.language == 'inv-alid-char-ï£¿') OK
-EXPECTED (audioTrack.language == 'inv-alid-char-ï£¿') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/only-bcp47-language-tags-accepted-as-valid.html
+++ b/LayoutTests/media/media-source/only-bcp47-language-tags-accepted-as-valid.html
@@ -77,32 +77,20 @@
                 "inv-alid-char-*", "inv-alid-char-"
             ];
 
-            var videoTrack;
-            var audioTrack;
             var textTrack;
             function startBCP74Test () {
-                videoTrack = video.videoTracks[0];
-                audioTrack = video.audioTracks[0];
                 // Access text track language through the element's srclang attribute
                 // since the DOM property is read-only.
                 textTrack = document.getElementById("textTrack");
                 for (var i = 0; i < validLanguageTags.length; i++) {
-                    videoTrack.language = validLanguageTags[i];
-                    testExpected("videoTrack.language", validLanguageTags[i]);
                     textTrack.setAttribute("srclang", validLanguageTags[i]);
                     testExpected("textTrack.track.language", validLanguageTags[i]);
-                    audioTrack.language = validLanguageTags[i];
-                    testExpected("audioTrack.language", validLanguageTags[i]);
                 }
                 var notOverwritten = "not-overwritten";
                 for (var i = 0; i < invalidLanguageTags.length; i++) {
                     // These are accepted in the web page layer but will produce console warnings
-                    videoTrack.language = invalidLanguageTags[i];
-                    testExpected("videoTrack.language", invalidLanguageTags[i]);
                     textTrack.setAttribute("srclang", invalidLanguageTags[i]);
                     testExpected("textTrack.track.language", invalidLanguageTags[i]);
-                    audioTrack.language = invalidLanguageTags[i];
-                    testExpected("audioTrack.language", invalidLanguageTags[i]);
                 }
                 endTest();
             }

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -301,9 +301,7 @@ PASS TextTrack interface object name
 PASS TextTrack interface: existence and properties of interface prototype object
 PASS TextTrack interface: existence and properties of interface prototype object's "constructor" property
 PASS TextTrack interface: existence and properties of interface prototype object's @@unscopables property
-FAIL TextTrack interface: attribute kind assert_equals: setter must be undefined for readonly attributes expected (undefined) undefined but got (function) function "function kind() {
-    [native code]
-}"
+PASS TextTrack interface: attribute kind
 PASS TextTrack interface: attribute label
 PASS TextTrack interface: attribute language
 PASS TextTrack interface: attribute id

--- a/Source/WebCore/html/track/AudioTrack.idl
+++ b/Source/WebCore/html/track/AudioTrack.idl
@@ -32,9 +32,9 @@
     Exposed=Window
 ] interface AudioTrack {
     readonly attribute DOMString id;
-    [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString kind;
+    readonly attribute [AtomString] DOMString kind;
     readonly attribute DOMString label;
-    [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString language;
+    readonly attribute [AtomString] DOMString language;
     attribute boolean enabled;
 
     [EnabledBySetting=TrackConfigurationEnabled] readonly attribute AudioTrackConfiguration configuration;

--- a/Source/WebCore/html/track/TextTrack.idl
+++ b/Source/WebCore/html/track/TextTrack.idl
@@ -37,9 +37,9 @@ enum TextTrackKind { "subtitles", "captions", "descriptions", "chapters", "metad
     SkipVTableValidation,
     Exposed=Window
 ] interface TextTrack : EventTarget {
-    [ImplementedAs=kindForBindings] attribute TextTrackKind kind;
+    [ImplementedAs=kindForBindings] readonly attribute TextTrackKind kind;
     readonly attribute DOMString label;
-    [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString language;
+    readonly attribute [AtomString] DOMString language;
 
     readonly attribute DOMString id;
     readonly attribute DOMString inBandMetadataTrackDispatchType;

--- a/Source/WebCore/html/track/VideoTrack.idl
+++ b/Source/WebCore/html/track/VideoTrack.idl
@@ -31,9 +31,9 @@
     Exposed=Window
 ] interface VideoTrack {
     readonly attribute DOMString id;
-    [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString kind;
+    readonly attribute [AtomString] DOMString kind;
     readonly attribute DOMString label;
-    [EnabledConditionallyReadWriteBySetting=MediaSourceEnabled] attribute [AtomString] DOMString language;
+    readonly attribute [AtomString] DOMString language;
     attribute boolean selected;
 
     [EnabledBySetting=TrackConfigurationEnabled] readonly attribute VideoTrackConfiguration configuration;


### PR DESCRIPTION
#### 93d70016b8882ffa3490fa3117ea60eb6f5ce8b3
<pre>
Sync and add missing &apos;readonly&apos; in [Audio|Video|Text]Track.idl as per web specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=262060">https://bugs.webkit.org/show_bug.cgi?id=262060</a>

Reviewed by Chris Dumez and Eric Carlson.

This PR adds missing `readonly` for &apos;kind&apos; and &apos;language&apos; as
required by web specification [1], [2], [3], it was missed
unintentionally.

[1] <a href="https://html.spec.whatwg.org/#texttrack">https://html.spec.whatwg.org/#texttrack</a>
[2] <a href="https://html.spec.whatwg.org/#audiotrack">https://html.spec.whatwg.org/#audiotrack</a>
[3] <a href="https://html.spec.whatwg.org/#videotrack">https://html.spec.whatwg.org/#videotrack</a>

* Source/WebCore/html/track/TextTrack.idl:
* Source/WebCore/html/track/VideoTrack.idl:
* Source/WebCore/html/track/AudioTrack.idl:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt: Rebaselined
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt: Rebaselined
* LayoutTests/media/media-source/only-bcp47-language-tags-accepted-as-valid.html: Rebaselined
* LayoutTests/media/media-source/only-bcp47-language-tags-accepted-as-valid-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/268580@main">https://commits.webkit.org/268580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08fac4350c61cf4323a2f20c3b9ccc1524103bbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18736 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20219 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22820 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24497 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22487 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16140 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18081 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4817 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->