### PR TITLE
Add support for Web Extension native messaging via delegate methods.

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2169,6 +2169,16 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionMessagePort {
+    header "_WKWebExtensionMessagePort.h"
+    export *
+  }
+
+  explicit module _WKWebExtensionMessagePortPrivate {
+    header "_WKWebExtensionMessagePortPrivate.h"
+    export *
+  }
+
   explicit module _WKWebExtensionPermission {
     header "_WKWebExtensionPermission.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3071,6 +3071,16 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionMessagePort {
+    header "_WKWebExtensionMessagePort.h"
+    export *
+  }
+
+  explicit module _WKWebExtensionMessagePortPrivate {
+    header "_WKWebExtensionMessagePortPrivate.h"
+    export *
+  }
+
   explicit module _WKWebExtensionPermission {
     header "_WKWebExtensionPermission.h"
     export *

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -92,6 +92,8 @@ enum class JSONOptions {
 
 using JSONOptionSet = OptionSet<JSONOptions>;
 
+bool isValidJSONObject(id, JSONOptionSet = { });
+
 id parseJSON(NSString *, JSONOptionSet = { }, NSError ** = nullptr);
 id parseJSON(NSData *, JSONOptionSet = { }, NSError ** = nullptr);
 id parseJSON(API::Data&, JSONOptionSet = { }, NSError ** = nullptr);

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -208,6 +208,18 @@ static inline NSJSONWritingOptions toWritingImpl(JSONOptionSet options)
     return result;
 }
 
+bool isValidJSONObject(id object, JSONOptionSet options)
+{
+    if (!object)
+        return false;
+
+    if (options.contains(JSONOptions::FragmentsAllowed))
+        return [object isKindOfClass:NSString.class] || [object isKindOfClass:NSNumber.class] || [object isKindOfClass:NSNull.class] || [NSJSONSerialization isValidJSONObject:object];
+
+    // NSJSONSerialization allows top-level arrays, but we only support dictionaries when not using FragmentsAllowed.
+    return [object isKindOfClass:NSDictionary.class] && [NSJSONSerialization isValidJSONObject:object];
+}
+
 id parseJSON(NSData *json, JSONOptionSet options, NSError **error)
 {
     if (!json)
@@ -242,7 +254,7 @@ NSData *encodeJSONData(id object, JSONOptionSet options, NSError **error)
     if (!object)
         return nil;
 
-    ASSERT([NSJSONSerialization isValidJSONObject:object]);
+    ASSERT(isValidJSONObject(object, options));
 
     if (!options.contains(JSONOptions::FragmentsAllowed) && ![object isKindOfClass:NSDictionary.class])
         return nil;

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -180,6 +180,7 @@ public:
         WebExtensionController,
         WebExtensionControllerConfiguration,
         WebExtensionMatchPattern,
+        WebExtensionMessagePort,
 #endif
         WebResourceLoadStatisticsManager,
         WebsiteDataRecord,
@@ -440,6 +441,7 @@ template<> struct EnumTraits<API::Object::Type> {
         API::Object::Type::WebExtensionController,
         API::Object::Type::WebExtensionControllerConfiguration,
         API::Object::Type::WebExtensionMatchPattern,
+        API::Object::Type::WebExtensionMessagePort,
 #endif
         API::Object::Type::WebResourceLoadStatisticsManager,
         API::Object::Type::WebsiteDataRecord,

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -109,6 +109,7 @@
 #import "_WKWebExtensionControllerInternal.h"
 #import "_WKWebExtensionInternal.h"
 #import "_WKWebExtensionMatchPatternInternal.h"
+#import "_WKWebExtensionMessagePortInternal.h"
 #endif
 
 static const size_t minimumObjectAlignment = alignof(std::aligned_storage<std::numeric_limits<size_t>::max()>::type);
@@ -413,6 +414,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     case Type::WebExtensionMatchPattern:
         wrapper = [_WKWebExtensionMatchPattern alloc];
+        break;
+
+    case Type::WebExtensionMessagePort:
+        wrapper = [_WKWebExtensionMessagePort alloc];
         break;
 #endif
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in
@@ -27,6 +27,7 @@ headers: "WebExtensionContentWorldType.h"
 enum class WebKit::WebExtensionContentWorldType : uint8_t {
     Main,
     ContentScript,
+    Native,
 }
 
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
@@ -32,6 +32,7 @@
 @class _WKWebExtensionContext;
 @class _WKWebExtensionController;
 @class _WKWebExtensionMatchPattern;
+@class _WKWebExtensionMessagePort;
 @class _WKWebExtensionTabCreationOptions;
 @class _WKWebExtensionWindowCreationOptions;
 @protocol _WKWebExtensionTab;
@@ -135,6 +136,34 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  the request is assumed to have been denied.
  */
 - (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionMatchPatterns:in:for:completionHandler:));
+
+/*!
+ @abstract Called when an extension context wants to send a one-time message to an application.
+ @param controller The web extension controller that is managing the extension.
+ @param message The message to be sent.
+ @param applicationIdentifier The unique identifier for the application, or \c nil if none was specified.
+ @param extensionContext The context in which the web extension is running.
+ @param replyHandler A block to be called with a JSON-serializable reply message or an error.
+ @discussion This method should be implemented by the app to handle one-off messages to applications.
+ If not implemented, the default behavior is to pass the message to the app extension handler within the extension's bundle,
+ if the extension was loaded from an app extension bundle; otherwise, no action is performed if not implemented.
+ */
+- (void)webExtensionController:(_WKWebExtensionController *)controller sendMessage:(id)message toApplicationIdentifier:(nullable NSString *)applicationIdentifier forExtensionContext:(_WKWebExtensionContext *)extensionContext replyHandler:(void (^)(id _Nullable replyMessage, NSError * _Nullable error))replyHandler WK_SWIFT_ASYNC(5) NS_SWIFT_NAME(webExtensionController(_:sendMessage:to:for:replyHandler:));
+
+/*!
+ @abstract Called when an extension context wants to establish a persistent connection to an application.
+ @param controller The web extension controller that is managing the extension.
+ @param extensionContext The context in which the web extension is running.
+ @param port A port object for handling the message exchange.
+ @param completionHandler A block to be called when the connection is ready to use, taking an optional error object
+ as a parameter. If the connection is successfully established, the error parameter should be \c nil.
+ @discussion This method should be implemented by the app to handle establishing connections to applications.
+ The provided `WKWebExtensionPort` object can be used to handle message sending, receiving, and disconnection.
+ You should retain the port object for as long as the connection remains active. Releasing the port will disconnect it.
+ If not implemented, the default behavior is to pass the messages to the app extension handler within the extension's bundle,
+ if the extension was loaded from an app extension bundle; otherwise, no action is performed if not implemented.
+ */
+- (void)webExtensionController:(_WKWebExtensionController *)controller connectUsingMessagePort:(_WKWebExtensionMessagePort *)port forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError * _Nullable error))replyHandler NS_SWIFT_NAME(webExtensionController(_:connectUsingMessagePort:for:completionHandler:));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @abstract Indicates a `_WKWebExtensionMessagePort` error. */
+WK_EXTERN NSErrorDomain const _WKWebExtensionMessagePortErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*!
+ @abstract Constants used by NSError to indicate errors in the `_WKWebExtensionMessagePort` domain.
+ @constant WKWebExtensionMessagePortErrorUnknown  Indicates that an unknown error occurred.
+ @constant WKWebExtensionMessagePortErrorNotConnected  Indicates that the message port is disconnected.
+ */
+typedef NS_ERROR_ENUM(_WKWebExtensionMessagePortErrorDomain, _WKWebExtensionMessagePortError) {
+    _WKWebExtensionMessagePortErrorUnknown,
+    _WKWebExtensionMessagePortErrorNotConnected,
+} NS_SWIFT_NAME(_WKWebExtensionMessagePort.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*!
+ @abstract A `WKWebExtensionMessagePort` object manages message-based communication with a web extension.
+ @discussion Contains properties and methods to handle message exchanges with a web extension.
+*/
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+NS_SWIFT_NAME(_WKWebExtension.MessagePort)
+@interface _WKWebExtensionMessagePort : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+/*!
+ @abstract The unique identifier for the app to which this port should be connected.
+ @discussion This identifier is provided by the web extension and may or may not be used by the app.
+ It's up to the app to decide how to interpret this identifier.
+ */
+@property (nonatomic, readonly, nullable) NSString *applicationIdentifier;
+
+/*!
+ @abstract The block to be executed when a message is received from the web extension.
+ @discussion The block takes two parameters: the message and an optional error object in case of an error.
+ */
+@property (nonatomic, copy, nullable) void (^messageHandler)(id _Nullable message, NSError * _Nullable error);
+
+/*!
+ @abstract The block to be executed when the port disconnects.
+ @discussion This block has one parameter: an optional error object in case an error caused the disconnection.
+ */
+@property (nonatomic, copy, nullable) void (^disconnectHandler)(NSError * _Nullable error);
+
+/*! @abstract Indicates whether the message port is disconnected. */
+@property (nonatomic, readonly, getter=isDisconnected) BOOL disconnected;
+
+/*!
+ @abstract Sends a message to the connected web extension.
+ @param message The message that needs to be sent, which must be JSON-serializable.
+ @param completionHandler A block to be invoked after the message is sent, taking a boolean and an optional error object as parameters.
+ */
+- (void)sendMessage:(id)message completionHandler:(void (^)(BOOL success, NSError * _Nullable error))completionHandler;
+
+/*!
+ @abstract Disconnects the port, terminating all further messages.
+ @param error An optional error object indicating the reason for disconnection.
+ */
+- (void)disconnectWithError:(nullable NSError *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionMessagePortInternal.h"
+
+#import "WebExtensionMessagePort.h"
+#import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/CompletionHandler.h>
+
+NSErrorDomain const _WKWebExtensionMessagePortErrorDomain = @"_WKWebExtensionMessagePortErrorDomain";
+
+@implementation _WKWebExtensionMessagePort
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionMessagePort.class, self))
+        return;
+
+    _webExtensionMessagePort->~WebExtensionMessagePort();
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+        return YES;
+
+    auto *other = dynamic_objc_cast<_WKWebExtensionMessagePort>(object);
+    if (!other)
+        return NO;
+
+    return *_webExtensionMessagePort == *other->_webExtensionMessagePort;
+}
+
+- (NSString *)applicationIdentifier
+{
+    if (auto& applicationIdentifier = _webExtensionMessagePort->applicationIdentifier(); !applicationIdentifier.isNull())
+        return applicationIdentifier;
+    return nil;
+}
+
+- (BOOL)isDisconnected
+{
+    return _webExtensionMessagePort->isDisconnected();
+}
+
+- (void)sendMessage:(id)message completionHandler:(void (^)(BOOL success, NSError *))completionHandler
+{
+    NSParameterAssert(message);
+
+    _webExtensionMessagePort->sendMessage(message, [completionHandler = makeBlockPtr(completionHandler)] (WebKit::WebExtensionMessagePort::Error error) {
+        if (error) {
+            completionHandler(NO, toAPI(error.value()));
+            return;
+        }
+
+        completionHandler(YES, nil);
+    });
+}
+
+- (void)disconnectWithError:(NSError *)error
+{
+    _webExtensionMessagePort->disconnect(WebKit::toWebExtensionMessagePortError(error));
+}
+
+#pragma mark WKObject protocol implementation
+
+- (API::Object&)_apiObject
+{
+    return *_webExtensionMessagePort;
+}
+
+- (WebKit::WebExtensionMessagePort&)_webExtensionMessagePort
+{
+    return *_webExtensionMessagePort;
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS)
+
+- (NSString *)applicationIdentifier
+{
+    return nil;
+}
+
+- (BOOL)isDisconnected
+{
+    return NO;
+}
+
+- (void)sendMessage:(id)message completionHandler:(void (^)(BOOL success, NSError *))completionHandler
+{
+}
+
+- (void)disconnectWithError:(NSError *)error
+{
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePortInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePortInternal.h
@@ -23,39 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import "_WKWebExtensionMessagePortPrivate.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include <wtf/text/WTFString.h>
+#import "WKObject.h"
+#import "WebExtensionMessagePort.h"
 
 namespace WebKit {
-
-enum class WebExtensionContentWorldType : uint8_t {
-    Main,
-    ContentScript,
-    Native,
+template<> struct WrapperTraits<WebExtensionMessagePort> {
+    using WrapperClass = _WKWebExtensionMessagePort;
 };
-
-inline String toDebugString(WebExtensionContentWorldType contentWorldType)
-{
-    switch (contentWorldType) {
-    case WebExtensionContentWorldType::Main:
-        return "main"_s;
-    case WebExtensionContentWorldType::ContentScript:
-        return "content script"_s;
-    case WebExtensionContentWorldType::Native:
-        return "native"_s;
-    }
 }
 
-} // namespace WebKit
+@interface _WKWebExtensionMessagePort () <WKObject> {
+@package
+    API::ObjectStorage<WebKit::WebExtensionMessagePort> _webExtensionMessagePort;
+}
 
-namespace WTF {
+@property (nonatomic, readonly) WebKit::WebExtensionMessagePort& _webExtensionMessagePort;
 
-template<> struct DefaultHash<WebKit::WebExtensionContentWorldType> : IntHash<WebKit::WebExtensionContentWorldType> { };
-template<> struct HashTraits<WebKit::WebExtensionContentWorldType> : StrongEnumHashTraits<WebKit::WebExtensionContentWorldType> { };
-
-} // namespace WTF
+@end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePortPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePortPrivate.h
@@ -23,39 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import <WebKit/_WKWebExtensionMessagePort.h>
 
-#if ENABLE(WK_WEB_EXTENSIONS)
+@interface _WKWebExtensionMessagePort ()
 
-#include <wtf/text/WTFString.h>
-
-namespace WebKit {
-
-enum class WebExtensionContentWorldType : uint8_t {
-    Main,
-    ContentScript,
-    Native,
-};
-
-inline String toDebugString(WebExtensionContentWorldType contentWorldType)
-{
-    switch (contentWorldType) {
-    case WebExtensionContentWorldType::Main:
-        return "main"_s;
-    case WebExtensionContentWorldType::ContentScript:
-        return "content script"_s;
-    case WebExtensionContentWorldType::Native:
-        return "native"_s;
-    }
-}
-
-} // namespace WebKit
-
-namespace WTF {
-
-template<> struct DefaultHash<WebKit::WebExtensionContentWorldType> : IntHash<WebKit::WebExtensionContentWorldType> { };
-template<> struct HashTraits<WebKit::WebExtensionContentWorldType> : StrongEnumHashTraits<WebKit::WebExtensionContentWorldType> { };
-
-} // namespace WTF
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)
+@end

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
@@ -40,7 +40,7 @@
 #import "WebExtensionMatchPattern.h"
 #import "_WKWebExtensionControllerInternal.h"
 #import <WebKit/_WKWebExtensionContext.h>
-#import <WebKit/_WKWebExtensionControllerDelegate.h>
+#import <WebKit/_WKWebExtensionControllerDelegatePrivate.h>
 #import <WebKit/_WKWebExtensionMatchPattern.h>
 #import <WebKit/_WKWebExtensionPermission.h>
 
@@ -93,7 +93,7 @@ void WebExtensionContext::permissionsRequest(HashSet<String> permissions, HashSe
 
     __block MatchPatternSet grantedPatterns;
     __block PermissionsSet grantedPermissions = permissions;
-    auto delegate = extensionController()->wrapper().delegate;
+    auto delegate = extensionController()->delegate();
 
     auto originsCompletionHandler = ^(NSSet<_WKWebExtensionMatchPattern *> *allowedOrigins) {
         // No granted origins were sent back, but origins were requested.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -469,7 +469,7 @@ void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, W
 
     process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, frameIdentifier, senderParameters), [=, protectedThis = Ref { *this }](size_t firedEventCount) mutable {
         protectedThis->addPorts(targetContentWorldType, channelIdentifier, firedEventCount);
-        protectedThis->fireQueuedPortMessageEventIfNeeded(*process, targetContentWorldType, channelIdentifier);
+        protectedThis->fireQueuedPortMessageEventsIfNeeded(*process, targetContentWorldType, channelIdentifier);
         protectedThis->firePortDisconnectEventIfNeeded(sourceContentWorldType, targetContentWorldType, channelIdentifier);
         protectedThis->clearQueuedPortMessages(targetContentWorldType, channelIdentifier);
     }, identifier());

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionMessagePort.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WebExtensionContext.h"
+#import "_WKWebExtensionMessagePortInternal.h"
+#import <wtf/BlockPtr.h>
+
+namespace WebKit {
+
+NSError *toAPI(WebExtensionMessagePort::Error error)
+{
+    if (!error)
+        return nil;
+
+    _WKWebExtensionMessagePortError errorCode;
+    NSString *message;
+
+    switch (error.value().first) {
+    case WebKit::WebExtensionMessagePort::ErrorType::Unknown:
+        errorCode = _WKWebExtensionMessagePortErrorUnknown;
+        message = (NSString *)error.value().second.value_or("An unknown error occurred."_s);
+        break;
+
+    case WebKit::WebExtensionMessagePort::ErrorType::NotConnected:
+        errorCode = _WKWebExtensionMessagePortErrorNotConnected;
+        message = (NSString *)error.value().second.value_or("Message port is not connected and cannot send messages."_s);
+        break;
+    }
+
+    return [NSError errorWithDomain:_WKWebExtensionMessagePortErrorDomain code:errorCode userInfo:@{ NSDebugDescriptionErrorKey: message }];
+}
+
+WebExtensionMessagePort::Error toWebExtensionMessagePortError(NSError *error)
+{
+    if (!error)
+        return std::nullopt;
+    return { { WebExtensionMessagePort::ErrorType::Unknown, error.localizedDescription } };
+}
+
+WebExtensionMessagePort::WebExtensionMessagePort(WebExtensionContext& extensionContext, String applicationIdentifier, WebExtensionPortChannelIdentifier channelIdentifier)
+    : m_extensionContext(extensionContext)
+    , m_applicationIdentifier(applicationIdentifier)
+    , m_channelIdentifier(channelIdentifier)
+{
+}
+
+bool WebExtensionMessagePort::operator==(const WebExtensionMessagePort& other) const
+{
+    return this == &other || (m_extensionContext == other.m_extensionContext && m_applicationIdentifier == other.m_applicationIdentifier && m_channelIdentifier == other.m_channelIdentifier);
+}
+
+WebExtensionContext* WebExtensionMessagePort::extensionContext() const
+{
+    return m_extensionContext.get();
+}
+
+bool WebExtensionMessagePort::isDisconnected() const
+{
+    return !m_extensionContext;
+}
+
+void WebExtensionMessagePort::disconnect(Error error)
+{
+    if (isDisconnected())
+        return;
+
+    m_extensionContext->portDisconnect(WebExtensionContentWorldType::Native, WebExtensionContentWorldType::Main, m_channelIdentifier);
+
+    remove();
+}
+
+void WebExtensionMessagePort::reportDisconnection(Error error)
+{
+    ASSERT(!isDisconnected());
+
+    remove();
+
+    if (auto disconnectHandler = wrapper().disconnectHandler)
+        disconnectHandler(toAPI(error));
+}
+
+void WebExtensionMessagePort::remove()
+{
+    if (isDisconnected())
+        return;
+
+    m_extensionContext->removeNativePort(*this);
+    m_extensionContext = nullptr;
+}
+
+void WebExtensionMessagePort::sendMessage(id message, CompletionHandler<void(Error error)>&& completionHandler)
+{
+    if (isDisconnected()) {
+        completionHandler({ { ErrorType::NotConnected, std::nullopt } });
+        return;
+    }
+
+    THROW_UNLESS(isValidJSONObject(message, { JSONOptions::FragmentsAllowed }), @"Message object is not JSON-serializable");
+
+    m_extensionContext->portPostMessage(WebExtensionContentWorldType::Main, m_channelIdentifier, encodeJSONString(message, { JSONOptions::FragmentsAllowed }) );
+
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionMessagePort::receiveMessage(id message, Error error)
+{
+    ASSERT(!isDisconnected());
+
+    if (auto messageHandler = wrapper().messageHandler)
+        messageHandler(message, toAPI(error));
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -50,6 +50,8 @@ messages -> WebExtensionContext {
     // Runtime APIs
     RuntimeSendMessage(String extensionID, String messageJSON, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON, std::optional<String> error);
     RuntimeConnect(String extensionID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> error);
+    RuntimeSendNativeMessage(String applicationID, String messageJSON) -> (std::optional<String> replyJSON, std::optional<String> error);
+    RuntimeConnectNative(String applicationID, WebKit::WebExtensionPortChannelIdentifier channelIdentifier) -> (std::optional<String> error);
 
     // Tabs APIs
     TabsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "APIObject.h"
+#include "WebExtensionPortChannelIdentifier.h"
+#include <wtf/Forward.h>
+
+OBJC_CLASS NSError;
+OBJC_CLASS _WKWebExtensionMessagePort;
+
+namespace WebKit {
+
+class WebExtensionContext;
+
+class WebExtensionMessagePort : public API::ObjectImpl<API::Object::Type::WebExtensionMessagePort> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionMessagePort);
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionMessagePort> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionMessagePort(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionMessagePort(WebExtensionContext&, String applicationIdentifier, WebExtensionPortChannelIdentifier);
+
+    ~WebExtensionMessagePort()
+    {
+        remove();
+    }
+
+    enum class ErrorType : uint8_t {
+        Unknown,
+        NotConnected,
+    };
+
+    using Error = std::optional<std::pair<ErrorType, std::optional<String>>>;
+
+    bool operator==(const WebExtensionMessagePort&) const;
+
+    const String& applicationIdentifier() const { return m_applicationIdentifier; }
+    WebExtensionPortChannelIdentifier channelIdentifier() const { return m_channelIdentifier; }
+    WebExtensionContext* extensionContext() const;
+
+    void disconnect(Error);
+    void reportDisconnection(Error);
+    bool isDisconnected() const;
+
+    void sendMessage(id message, CompletionHandler<void(Error)>&&);
+    void receiveMessage(id message, Error);
+
+#ifdef __OBJC__
+    _WKWebExtensionMessagePort *wrapper() const { return (_WKWebExtensionMessagePort *)API::ObjectImpl<API::Object::Type::WebExtensionMessagePort>::wrapper(); }
+#endif
+
+private:
+    void remove();
+
+    WeakPtr<WebExtensionContext> m_extensionContext;
+    String m_applicationIdentifier;
+    WebExtensionPortChannelIdentifier m_channelIdentifier;
+};
+
+NSError *toAPI(WebExtensionMessagePort::Error);
+WebExtensionMessagePort::Error toWebExtensionMessagePortError(NSError *);
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -486,6 +486,12 @@
 		1C66BDDE2A8AEADE009D4452 /* WebExtensionWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C66BDDD2A8AEADD009D4452 /* WebExtensionWindow.h */; };
 		1C66BDE12A8C2830009D4452 /* WebExtensionWindowCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C66BDDF2A8C282F009D4452 /* WebExtensionWindowCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C66BDE22A8C2830009D4452 /* WebExtensionTabCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C7316732AC1D647007FADA4 /* _WKWebExtensionMessagePort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7316722AC1D647007FADA4 /* _WKWebExtensionMessagePort.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C7316752AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C7316742AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C7316772AC1DFDF007FADA4 /* _WKWebExtensionMessagePortInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7316762AC1DFDF007FADA4 /* _WKWebExtensionMessagePortInternal.h */; };
+		1C7316792AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7316782AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1C73167B2AC1E676007FADA4 /* WebExtensionMessagePort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C73167A2AC1E676007FADA4 /* WebExtensionMessagePort.h */; };
+		1C73167F2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C73167E2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C891D6619B124FF00BA79DD /* WebInspectorUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C891D6319B124FF00BA79DD /* WebInspectorUI.h */; };
 		1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C8E28201275D15400BC7BD0 /* WebInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E281E1275D15400BC7BD0 /* WebInspector.h */; };
@@ -3647,6 +3653,12 @@
 		1C66BDDD2A8AEADD009D4452 /* WebExtensionWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionWindow.h; sourceTree = "<group>"; };
 		1C66BDDF2A8C282F009D4452 /* WebExtensionWindowCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionWindowCocoa.mm; sourceTree = "<group>"; };
 		1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionTabCocoa.mm; sourceTree = "<group>"; };
+		1C7316722AC1D647007FADA4 /* _WKWebExtensionMessagePort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMessagePort.h; sourceTree = "<group>"; };
+		1C7316742AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionMessagePort.mm; sourceTree = "<group>"; };
+		1C7316762AC1DFDF007FADA4 /* _WKWebExtensionMessagePortInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMessagePortInternal.h; sourceTree = "<group>"; };
+		1C7316782AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMessagePortPrivate.h; sourceTree = "<group>"; };
+		1C73167A2AC1E676007FADA4 /* WebExtensionMessagePort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionMessagePort.h; sourceTree = "<group>"; };
+		1C73167E2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionMessagePortCocoa.mm; sourceTree = "<group>"; };
 		1C739E852347BCF600C621EC /* CoreTextHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreTextHelpers.mm; sourceTree = "<group>"; };
 		1C739E872347BD0F00C621EC /* CoreTextHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreTextHelpers.h; sourceTree = "<group>"; };
 		1C77C1951288A872006A742F /* WebInspectorUIProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebInspectorUIProxy.messages.in; sourceTree = "<group>"; };
@@ -8894,6 +8906,7 @@
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
 				1C1549D129381B9F001B9E5B /* WebExtensionControllerConfiguration.mm */,
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
+				1C73167E2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm */,
 				1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */,
 				1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */,
 				1C66BDDF2A8C282F009D4452 /* WebExtensionWindowCocoa.mm */,
@@ -9317,6 +9330,7 @@
 				1C1549CF293817FE001B9E5B /* WebExtensionControllerConfiguration.cpp */,
 				1C1549CE293812F8001B9E5B /* WebExtensionControllerConfiguration.h */,
 				1C1CE96A288DF31E0098D3A1 /* WebExtensionMatchPattern.h */,
+				1C73167A2AC1E676007FADA4 /* WebExtensionMessagePort.h */,
 				1C66BDD72A8AD957009D4452 /* WebExtensionTab.h */,
 				1CAB9B8428F7427F00E6C77E /* WebExtensionURLSchemeHandler.h */,
 				1C66BDDD2A8AEADD009D4452 /* WebExtensionWindow.h */,
@@ -10358,6 +10372,10 @@
 				1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */,
 				1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */,
 				1C1CE970288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h */,
+				1C7316722AC1D647007FADA4 /* _WKWebExtensionMessagePort.h */,
+				1C7316742AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm */,
+				1C7316762AC1DFDF007FADA4 /* _WKWebExtensionMessagePortInternal.h */,
+				1C7316782AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h */,
 				1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */,
 				1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */,
 				1C3BEB6F288883E300E66E38 /* _WKWebExtensionPrivate.h */,
@@ -14521,6 +14539,9 @@
 				1C1CE975288DF5030098D3A1 /* _WKWebExtensionMatchPattern.h in Headers */,
 				1C1CE973288DF5030098D3A1 /* _WKWebExtensionMatchPatternInternal.h in Headers */,
 				1C1CE974288DF5030098D3A1 /* _WKWebExtensionMatchPatternPrivate.h in Headers */,
+				1C7316732AC1D647007FADA4 /* _WKWebExtensionMessagePort.h in Headers */,
+				1C7316772AC1DFDF007FADA4 /* _WKWebExtensionMessagePortInternal.h in Headers */,
+				1C7316792AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h in Headers */,
 				1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */,
 				1C3BEB712888842A00E66E38 /* _WKWebExtensionPrivate.h in Headers */,
 				1C049840289AFF9B0010308B /* _WKWebExtensionTab.h in Headers */,
@@ -15298,6 +15319,7 @@
 				1C3BEB512887492F00E66E38 /* WebExtensionControllerProxyMessages.h in Headers */,
 				B6114A8C293AE06800380B1B /* WebExtensionEventListenerType.h in Headers */,
 				1C4A14C62ABB710E00A1018C /* WebExtensionFrameIdentifier.h in Headers */,
+				1C73167B2AC1E676007FADA4 /* WebExtensionMessagePort.h in Headers */,
 				1C4EBD722ABA47610005868F /* WebExtensionMessageSenderParameters.h in Headers */,
 				1C9A15C82ABDEEB4002CC12A /* WebExtensionPortChannelIdentifier.h in Headers */,
 				1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */,
@@ -17554,6 +17576,7 @@
 				1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */,
 				B62C01BC2A8E7AF600D6A941 /* _WKWebExtensionLocalization.mm in Sources */,
 				1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */,
+				1C7316752AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm in Sources */,
 				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
 				1C5ACF902A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.mm in Sources */,
 				337822432947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm in Sources */,
@@ -17956,6 +17979,7 @@
 				1C3D0AC1291AE6210093F67E /* WebExtensionControllerProxyCocoa.mm in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,
 				1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */,
+				1C73167F2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm in Sources */,
 				1C66BDE22A8C2830009D4452 /* WebExtensionTabCocoa.mm in Sources */,
 				1CAB9B8628F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm in Sources */,
 				337822482947FBA5002106BB /* WebExtensionUtilities.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -100,7 +100,7 @@ NSString *WebExtensionAPIPort::name()
 
 NSDictionary *WebExtensionAPIPort::sender()
 {
-    return toWebAPI(m_senderParameters);
+    return m_senderParameters ? toWebAPI(m_senderParameters.value()) : nil;
 }
 
 JSValue *WebExtensionAPIPort::error()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -110,6 +110,18 @@ bool WebExtensionAPIRuntime::parseConnectOptions(NSDictionary *options, std::opt
     return true;
 }
 
+bool WebExtensionAPIRuntime::isPropertyAllowed(ASCIILiteral name, WebPage*)
+{
+    if (name == "connectNative"_s || name == "sendNativeMessage"_s) {
+        // FIXME: https://webkit.org/b/259914 This should be a hasPermission: call to extensionContext() and updated with actually granted permissions from the UI process.
+        auto *permissions = objectForKey<NSArray>(extensionContext().manifest(), @"permissions", true, NSString.class);
+        return [permissions containsObject:@"nativeMessaging"];
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 NSURL *WebExtensionAPIRuntime::getURL(NSString *resourcePath, NSString **errorString)
 {
     URL baseURL = extensionContext().baseURL();
@@ -159,11 +171,11 @@ JSValue *WebExtensionAPIRuntime::lastError()
     return m_lastError.get();
 }
 
-void WebExtensionAPIRuntime::sendMessage(WebFrame *frame, NSString *extensionID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIRuntime::sendMessage(WebFrame *frame, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 
-    if (message.length > webExtensionMaxMessageLength) {
+    if (messageJSON.length > webExtensionMaxMessageLength) {
         *outExceptionString = toErrorString(nil, @"message", @"it exceeded the maximum allowed length");
         return;
     }
@@ -179,7 +191,7 @@ void WebExtensionAPIRuntime::sendMessage(WebFrame *frame, NSString *extensionID,
         frame->url(),
     };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeSendMessage(extensionID, message, sender), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, std::optional<String> error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeSendMessage(extensionID, messageJSON, sender), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, std::optional<String> error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -216,6 +228,42 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connect(WebFrame* frame, JSC
     auto port = WebExtensionAPIPort::create(forMainWorld(), runtime(), extensionContext(), WebExtensionContentWorldType::Main, resolvedName, sender);
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeConnect(extensionID, port->channelIdentifier(), resolvedName, sender), [=, globalContext = JSRetainPtr { JSContextGetGlobalContext(context) }, protectedThis = Ref { *this }](WebExtensionTab::Error error) {
+        if (!error)
+            return;
+
+        port->setError(protectedThis->runtime().reportError(error.value(), globalContext.get()));
+        port->disconnect();
+    }, extensionContext().identifier());
+
+    return port;
+}
+
+void WebExtensionAPIRuntime::sendNativeMessage(WebFrame* frame, NSString *applicationID, NSString *messageJSON, Ref<WebExtensionCallbackHandler>&& callback)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeSendNativeMessage(applicationID, messageJSON), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        if (!replyJSON) {
+            callback->call();
+            return;
+        }
+
+        callback->call(parseJSON(replyJSON.value(), { JSONOptions::FragmentsAllowed }));
+    }, extensionContext().identifier());
+}
+
+RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connectNative(WebFrame* frame, JSContextRef context, NSString *applicationID)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connectNative
+
+    auto port = WebExtensionAPIPort::create(forMainWorld(), runtime(), extensionContext(), WebExtensionContentWorldType::Native, applicationID);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeConnectNative(applicationID, port->channelIdentifier()), [=, globalContext = JSRetainPtr { JSContextGetGlobalContext(context) }, protectedThis = Ref { *this }](WebExtensionTab::Error error) {
         if (!error)
             return;
 
@@ -342,6 +390,10 @@ void WebExtensionContextProxy::dispatchRuntimeMessageEvent(WebExtensionContentWo
     case WebExtensionContentWorldType::ContentScript:
         internalDispatchRuntimeMessageEvent(contentScriptWorld(), messageJSON, frameIdentifier, senderParameters, WTFMove(completionHandler));
         return;
+
+    case WebExtensionContentWorldType::Native:
+        ASSERT_NOT_REACHED();
+        return;
     }
 }
 
@@ -385,6 +437,10 @@ void WebExtensionContextProxy::dispatchRuntimeConnectEvent(WebExtensionContentWo
 
     case WebExtensionContentWorldType::ContentScript:
         internalDispatchRuntimeConnectEvent(contentScriptWorld(), channelIdentifier, name, frameIdentifier, senderParameters, WTFMove(completionHandler));
+        return;
+
+    case WebExtensionContentWorldType::Native:
+        ASSERT_NOT_REACHED();
         return;
     }
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -883,7 +883,7 @@ void WebExtensionAPITabs::captureVisibleTab(WebPage* page, double windowID, NSDi
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::sendMessage(WebFrame *frame, double tabID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::sendMessage(WebFrame *frame, double tabID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage
 
@@ -891,7 +891,7 @@ void WebExtensionAPITabs::sendMessage(WebFrame *frame, double tabID, NSString *m
     if (!isValid(tabIdentifer, outExceptionString))
         return;
 
-    if (message.length > webExtensionMaxMessageLength) {
+    if (messageJSON.length > webExtensionMaxMessageLength) {
         *outExceptionString = toErrorString(nil, @"message", @"it exceeded the maximum allowed length");
         return;
     }
@@ -909,7 +909,7 @@ void WebExtensionAPITabs::sendMessage(WebFrame *frame, double tabID, NSString *m
         frame->url(),
     };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSendMessage(tabIdentifer.value(), message, targetFrameIdentifier, sender), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSendMessage(tabIdentifer.value(), messageJSON, targetFrameIdentifier, sender), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -65,6 +65,15 @@ public:
     WebExtensionAPIEvent& onMessage();
     WebExtensionAPIEvent& onDisconnect();
 
+    explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionContentWorldType targetContentWorldType, const String& name)
+        : WebExtensionAPIObject(forMainWorld, runtime, context)
+        , m_targetContentWorldType(targetContentWorldType)
+        , m_channelIdentifier(WebExtensionPortChannelIdentifier::generate())
+        , m_name(name)
+    {
+        add();
+    }
+
     explicit WebExtensionAPIPort(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionContentWorldType targetContentWorldType, const String& name, const WebExtensionMessageSenderParameters& senderParameters)
         : WebExtensionAPIObject(forMainWorld, runtime, context)
         , m_targetContentWorldType(targetContentWorldType)
@@ -105,7 +114,7 @@ private:
 
     String m_name;
     RetainPtr<JSValue> m_error;
-    WebExtensionMessageSenderParameters m_senderParameters;
+    std::optional<WebExtensionMessageSenderParameters> m_senderParameters;
 
     RefPtr<WebExtensionAPIEvent> m_onMessage;
     RefPtr<WebExtensionAPIEvent> m_onDisconnect;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -62,6 +62,8 @@ public:
     WebExtensionAPIRuntime& runtime() final { return *this; }
 
 #if PLATFORM(COCOA)
+    bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
+
     NSURL *getURL(NSString *resourcePath, NSString **outExceptionString);
     NSDictionary *getManifest();
     void getPlatformInfo(Ref<WebExtensionCallbackHandler>&&);
@@ -70,8 +72,11 @@ public:
 
     JSValue *lastError();
 
-    void sendMessage(WebFrame *, NSString *extensionID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void sendMessage(WebFrame*, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     RefPtr<WebExtensionAPIPort> connect(WebFrame*, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
+
+    void sendNativeMessage(WebFrame*, NSString *applicationID, NSString *messageJSON, Ref<WebExtensionCallbackHandler>&&);
+    RefPtr<WebExtensionAPIPort> connectNative(WebFrame*, JSContextRef, NSString *applicationID);
 
     WebExtensionAPIEvent& onConnect();
     WebExtensionAPIEvent& onMessage();

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
@@ -41,6 +41,9 @@
     [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage([Optional] DOMString extensionID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
     [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect([Optional] DOMString extensionID, [Optional, NSDictionary] any options);
 
+    [MainWorldOnly, Dynamic, NeedsFrame] void sendNativeMessage([Optional] DOMString applicationID, [Serialization=JSON] any message, [Optional, CallbackHandler] function callback);
+    [MainWorldOnly, Dynamic, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connectNative([Optional] DOMString applicationID);
+
     readonly attribute WebExtensionAPIEvent onConnect;
     readonly attribute WebExtensionAPIEvent onMessage;
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -29,6 +29,7 @@
 
 #import <WebKit/_WKWebExtensionControllerDelegate.h>
 #import <WebKit/_WKWebExtensionMatchPattern.h>
+#import <WebKit/_WKWebExtensionMessagePort.h>
 #import <WebKit/_WKWebExtensionPermission.h>
 #import <WebKit/_WKWebExtensionTab.h>
 
@@ -42,6 +43,9 @@
 
 @property (nonatomic, copy) void (^promptForPermissions)(id <_WKWebExtensionTab>, NSSet<NSString *> *, void (^)(NSSet<_WKWebExtensionPermission> *));
 @property (nonatomic, copy) void (^promptForPermissionMatchPatterns)(id <_WKWebExtensionTab>, NSSet<_WKWebExtensionMatchPattern *> *, void (^)(NSSet<_WKWebExtensionMatchPattern *> *));
+
+@property (nonatomic, copy) void (^sendMessage)(id message, NSString *applicationIdentifier, void (^)(id replyMessage, NSError *));
+@property (nonatomic, copy) void (^connectUsingMessagePort)(_WKWebExtensionMessagePort *);
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -96,6 +96,23 @@
         completionHandler(matchPatterns);
 }
 
+- (void)webExtensionController:(_WKWebExtensionController *)controller sendMessage:(id)message toApplicationIdentifier:(NSString *)applicationIdentifier forExtensionContext:(_WKWebExtensionContext *)extensionContext replyHandler:(void (^)(id, NSError *))replyHandler
+{
+    if (_sendMessage)
+        _sendMessage(message, applicationIdentifier, replyHandler);
+    else
+        replyHandler(nil, [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.sendNativeMessage() not implemneted" }]);
+}
+
+- (void)webExtensionController:(_WKWebExtensionController *)controller connectUsingMessagePort:(_WKWebExtensionMessagePort *)port forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError *error))completionHandler
+{
+    if (_connectUsingMessagePort) {
+        _connectUsingMessagePort(port);
+        completionHandler(nil);
+    } else
+        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.connectNative() not implemneted" }]);
+}
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 9ea15e2119dff2b6faf4f5862973b5a88eb37574
<pre>
Add support for Web Extension native messaging via delegate methods.
<a href="https://webkit.org/b/262082">https://webkit.org/b/262082</a>
rdar://problem/116022790

Reviewed by Brady Eidson.

Introduces two new _WKWebExtensionControllerDelegate methods for native messaging.
The first is for single message sending via runtime.sendNativeMessage(), and the other
is for persistent messaging vis runtime.connectNative(), which also introduces the
_WKWebExtensionMessagePort class for handling the port based messaging.

The ultimate plan is to have native messaging work by default internally via NSExtension,
which is tracked by <a href="https://webkit.org/b/262081.">https://webkit.org/b/262081.</a> These delegate methods will still be
useful for testing or for clients that want alternative native messaging.

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::isValidJSONObject):
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::isValidJSONObject):
(WebKit::encodeJSONData):
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.h:
(WebKit::toDebugString):
* Source/WebKit/Shared/Extensions/WebExtensionContentWorldType.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h: Added.
(NS_ERROR_ENUM):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm: Added.
(-[_WKWebExtensionMessagePort dealloc]):
(-[_WKWebExtensionMessagePort isEqual:]):
(-[_WKWebExtensionMessagePort applicationIdentifier]):
(-[_WKWebExtensionMessagePort isDisconnected]):
(-[_WKWebExtensionMessagePort sendMessage:completionHandler:]):
(-[_WKWebExtensionMessagePort disconnectWithError:]):
(-[_WKWebExtensionMessagePort _apiObject]):
(-[_WKWebExtensionMessagePort _webExtensionMessagePort]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePortInternal.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePortPrivate.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::permissionsRequest):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPortCocoa.mm:
(WebKit::WebExtensionContext::portPostMessage):
(WebKit::WebExtensionContext::portDisconnect):
(WebKit::WebExtensionContext::removePort):
(WebKit::WebExtensionContext::addNativePort):
(WebKit::WebExtensionContext::removeNativePort):
(WebKit::WebExtensionContext::fireQueuedPortMessageEventsIfNeeded):
(WebKit::WebExtensionContext::sendQueuedNativePortMessagesIfNeeded):
(WebKit::WebExtensionContext::firePortDisconnectEventIfNeeded):
(WebKit::WebExtensionContext::fireQueuedPortMessageEventIfNeeded): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeConnect):
(WebKit::WebExtensionContext::runtimeSendNativeMessage):
(WebKit::WebExtensionContext::runtimeConnectNative):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm: Added.
(WebKit::toAPI):
(WebKit::toWebExtensionMessagePortError):
(WebKit::WebExtensionMessagePort::WebExtensionMessagePort):
(WebKit::WebExtensionMessagePort::operator== const):
(WebKit::WebExtensionMessagePort::extensionContext const):
(WebKit::WebExtensionMessagePort::isDisconnected const):
(WebKit::WebExtensionMessagePort::disconnect):
(WebKit::WebExtensionMessagePort::reportDisconnection):
(WebKit::WebExtensionMessagePort::remove):
(WebKit::WebExtensionMessagePort::sendMessage):
(WebKit::WebExtensionMessagePort::receiveMessage):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::create):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h: Added.
(WebKit::WebExtensionMessagePort::create):
(WebKit::WebExtensionMessagePort::~WebExtensionMessagePort):
(WebKit::WebExtensionMessagePort::applicationIdentifier const):
(WebKit::WebExtensionMessagePort::channelIdentifier const):
(WebKit::WebExtensionMessagePort::wrapper const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::sender):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::isPropertyAllowed):
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::sendNativeMessage):
(WebKit::WebExtensionAPIRuntime::connectNative):
(WebKit::WebExtensionContextProxy::dispatchRuntimeMessageEvent):
(WebKit::WebExtensionContextProxy::dispatchRuntimeConnectEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::sendMessage):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
(WebKit::WebExtensionAPIPort::WebExtensionAPIPort):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate webExtensionController:sendMessage:toApplicationIdentifier:forExtensionContext:replyHandler:]):
(-[TestWebExtensionsDelegate webExtensionController:connectUsingMessagePort:forExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/268468@main">https://commits.webkit.org/268468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fab30b5b8dce51d507ca56720cf447b0a0b36cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19763 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18469 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20330 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22513 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24276 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22258 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15890 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22265 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2418 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->