### PR TITLE
REGRESSION(266828@main): Nested setTimeout not being throttled in the background

### DIFF
--- a/LayoutTests/fast/dom/timer-throttling-hidden-page-2-expected.txt
+++ b/LayoutTests/fast/dom/timer-throttling-hidden-page-2-expected.txt
@@ -1,0 +1,20 @@
+Tests that DOM timers gets throttled on hidden pages once they reach the max nesting level
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime < 100 is true
+PASS timerEndTime - timerStartTime > 100 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/timer-throttling-hidden-page-2.html
+++ b/LayoutTests/fast/dom/timer-throttling-hidden-page-2.html
@@ -1,0 +1,54 @@
+<html><!-- webkit-test-runner [ HiddenPageDOMTimerThrottlingEnabled=true ] -->
+<body>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        description('Tests that DOM timers gets throttled on hidden pages once they reach the max nesting level');
+        jsTestIsAsync = true;
+
+        let timerCount = 0;
+        const timeoutInterval = 10;
+        const maxNestingLevel = 10;
+        let timerHandle = 0;
+        let timerStartTime = 0;
+        let timerEndTime = 0;
+
+        function testTimer()
+        {
+            ++timerCount;
+
+            timerEndTime = performance.now();
+
+            timerHandle = setTimeout(testTimer, timeoutInterval);
+            if (timerCount > maxNestingLevel) {
+                shouldBeTrue('timerEndTime - timerStartTime > 100');
+                testRunner.resetPageVisibility();
+                clearTimeout(timerHandle);
+                finishJSTest();
+                return;
+            } else
+                shouldBeTrue('timerEndTime - timerStartTime < 100');
+            timerStartTime = timerEndTime;
+        }
+
+        function runTest()
+        {
+            if (!window.testRunner) {
+                debug('This test requires testRunner');
+                return;
+            }
+
+            timerStartTime = performance.now();
+            timerHandle = setTimeout(testTimer, timeoutInterval);
+        }
+        onload = function() {
+            document.onvisibilitychange = () => {
+                if (!document.hidden)
+                    return;
+                document.onvisibilitychange = null;
+                runTest();
+            };
+            testRunner.setPageVisibility("hidden");
+        };
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -376,6 +376,7 @@ fast/events/mouse-force-up.html [ Skip ]
 
 # testRunner.setPageVisibility is not implemented for iOS
 webkit.org/b/165799 fast/dom/timer-throttling-hidden-page.html [ Skip ]
+webkit.org/b/165799 fast/dom/timer-throttling-hidden-page-2.html [ Skip ]
 webkit.org/b/165799 fast/dom/timer-throttling-hidden-page-non-nested.html [ Skip ]
 webkit.org/b/165799 fast/events/page-visibility-onvisibilitychange.html [ Skip ]
 webkit.org/b/165799 media/media-playback-page-visibility.html [ Skip ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1093,6 +1093,7 @@ webkit.org/b/212144 http/tests/xmlhttprequest/on-network-timeout-error-during-pr
 
 # webkit.org/b/188506 fast/dom/timer-throttling-hidden-page.html [ Failure ]
 webkit.org/b/212350 fast/dom/timer-throttling-hidden-page.html [ Timeout ]
+webkit.org/b/212350 fast/dom/timer-throttling-hidden-page-2.html [ Timeout ]
 
 webkit.org/b/244480 webgl/max-active-contexts-webglcontextlost-prevent-default.html [ Timeout ]
 

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -188,9 +188,12 @@ void EventLoop::queueTask(std::unique_ptr<EventLoopTask>&& task)
     m_tasks.append(WTFMove(task));
 }
 
-EventLoopTimerHandle EventLoop::scheduleTask(Seconds timeout, std::unique_ptr<EventLoopTask>&& action)
+EventLoopTimerHandle EventLoop::scheduleTask(Seconds timeout, TimerAlignment* alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, std::unique_ptr<EventLoopTask>&& action)
 {
     auto timer = EventLoopTimer::create(EventLoopTimer::Type::OneShot, WTFMove(action));
+    if (alignment)
+        timer->setTimerAlignment(*alignment);
+    timer->setHasReachedMaxNestingLevel(hasReachedMaxNestingLevel == HasReachedMaxNestingLevel::Yes);
     timer->startOneShot(timeout);
     if (timer->group()->isSuspended())
         timer->suspend();
@@ -211,9 +214,12 @@ void EventLoop::removeScheduledTimer(EventLoopTimer& timer)
     invalidateNextTimerFireTimeCache();
 }
 
-EventLoopTimerHandle EventLoop::scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, std::unique_ptr<EventLoopTask>&& action)
+EventLoopTimerHandle EventLoop::scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment* alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, std::unique_ptr<EventLoopTask>&& action)
 {
     auto timer = EventLoopTimer::create(EventLoopTimer::Type::Repeating, WTFMove(action));
+    if (alignment)
+        timer->setTimerAlignment(*alignment);
+    timer->setHasReachedMaxNestingLevel(hasReachedMaxNestingLevel == HasReachedMaxNestingLevel::Yes);
     timer->startRepeating(nextTimeout, interval);
     if (timer->group()->isSuspended())
         timer->suspend();
@@ -482,7 +488,14 @@ EventLoopTimerHandle EventLoopTaskGroup::scheduleTask(Seconds timeout, TaskSourc
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return m_eventLoop->scheduleTask(timeout, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
+    return m_eventLoop->scheduleTask(timeout, nullptr, HasReachedMaxNestingLevel::No, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
+}
+
+EventLoopTimerHandle EventLoopTaskGroup::scheduleTask(Seconds timeout, TimerAlignment& alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, TaskSource source, EventLoop::TaskFunction&& function)
+{
+    if (m_state == State::Stopped || !m_eventLoop)
+        return { };
+    return m_eventLoop->scheduleTask(timeout, &alignment, hasReachedMaxNestingLevel, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
 }
 
 void EventLoopTaskGroup::removeScheduledTimer(EventLoopTimer& timer)
@@ -497,7 +510,14 @@ EventLoopTimerHandle EventLoopTaskGroup::scheduleRepeatingTask(Seconds nextTimeo
 {
     if (m_state == State::Stopped || !m_eventLoop)
         return { };
-    return m_eventLoop->scheduleRepeatingTask(nextTimeout, interval, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
+    return m_eventLoop->scheduleRepeatingTask(nextTimeout, interval, nullptr, HasReachedMaxNestingLevel::No, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
+}
+
+EventLoopTimerHandle EventLoopTaskGroup::scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment& alignment, HasReachedMaxNestingLevel hasReachedMaxNestingLevel, TaskSource source, EventLoop::TaskFunction&& function)
+{
+    if (m_state == State::Stopped || !m_eventLoop)
+        return { };
+    return m_eventLoop->scheduleRepeatingTask(nextTimeout, interval, &alignment, hasReachedMaxNestingLevel, makeUnique<EventLoopFunctionDispatchTask>(source, *this, WTFMove(function)));
 }
 
 void EventLoopTaskGroup::removeRepeatingTimer(EventLoopTimer& timer)
@@ -506,16 +526,6 @@ void EventLoopTaskGroup::removeRepeatingTimer(EventLoopTimer& timer)
     if (RefPtr eventLoop = m_eventLoop.get())
         eventLoop->removeRepeatingTimer(timer);
     m_timers.remove(timer);
-}
-
-void EventLoopTaskGroup::setTimerAlignment(EventLoopTimerHandle handle, TimerAlignment& timerAlignment)
-{
-    if (!handle.m_timer)
-        return;
-    ASSERT(m_timers.contains(*handle.m_timer));
-    handle.m_timer->setTimerAlignment(timerAlignment);
-    if (RefPtr eventLoop = m_eventLoop.get())
-        eventLoop->invalidateNextTimerFireTimeCache();
 }
 
 void EventLoopTaskGroup::didChangeTimerAlignmentInterval(EventLoopTimerHandle handle)

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -91,6 +91,8 @@ private:
     RefPtr<EventLoopTimer> m_timer;
 };
 
+enum class HasReachedMaxNestingLevel : bool { No, Yes };
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#event-loop
 class EventLoop : public RefCounted<EventLoop>, public CanMakeWeakPtr<EventLoop> {
 public:
@@ -99,10 +101,10 @@ public:
     typedef Function<void ()> TaskFunction;
     void queueTask(std::unique_ptr<EventLoopTask>&&);
 
-    EventLoopTimerHandle scheduleTask(Seconds timeout, std::unique_ptr<EventLoopTask>&&);
+    EventLoopTimerHandle scheduleTask(Seconds timeout, TimerAlignment*, HasReachedMaxNestingLevel, std::unique_ptr<EventLoopTask>&&);
     void removeScheduledTimer(EventLoopTimer&);
 
-    EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, std::unique_ptr<EventLoopTask>&&);
+    EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment*, HasReachedMaxNestingLevel, std::unique_ptr<EventLoopTask>&&);
     void removeRepeatingTimer(EventLoopTimer&);
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask
@@ -213,13 +215,14 @@ public:
     void runAtEndOfMicrotaskCheckpoint(EventLoop::TaskFunction&&);
 
     EventLoopTimerHandle scheduleTask(Seconds timeout, TaskSource, EventLoop::TaskFunction&&);
+    EventLoopTimerHandle scheduleTask(Seconds timeout, TimerAlignment&, HasReachedMaxNestingLevel, TaskSource, EventLoop::TaskFunction&&);
     void didExecuteScheduledTask(EventLoopTimer&);
     void removeScheduledTimer(EventLoopTimer&);
 
     EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TaskSource, EventLoop::TaskFunction&&);
+    EventLoopTimerHandle scheduleRepeatingTask(Seconds nextTimeout, Seconds interval, TimerAlignment&, HasReachedMaxNestingLevel, TaskSource, EventLoop::TaskFunction&&);
     void removeRepeatingTimer(EventLoopTimer&);
 
-    void setTimerAlignment(EventLoopTimerHandle, TimerAlignment&);
     void didChangeTimerAlignmentInterval(EventLoopTimerHandle);
     void setTimerHasReachedMaxNestingLevel(EventLoopTimerHandle, bool);
     void adjustTimerNextFireTime(EventLoopTimerHandle, Seconds delta);


### PR DESCRIPTION
#### e49305511b1aee7144154ad1530454b0970ac515
<pre>
REGRESSION(266828@main): Nested setTimeout not being throttled in the background
<a href="https://bugs.webkit.org/show_bug.cgi?id=262086">https://bugs.webkit.org/show_bug.cgi?id=262086</a>
&lt;rdar://115902836&gt;

Reviewed by Chris Dumez.

The bug was caused by TimerAlignment and hasReachedMaxNestingLevel state getting set after
the timer had already been scheduled. We need to update these states before we schedule it.

To do this, new variants of scheduleTask and scheduleRepeatingTask which takes TimerAlignment
and hasReachedMaxNestingLevel boolean as arguments are added and deployed them in DOMTimer.

* LayoutTests/fast/dom/timer-throttling-hidden-page-2-expected.txt: Added.
* LayoutTests/fast/dom/timer-throttling-hidden-page-2.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::scheduleTask):
(WebCore::EventLoop::scheduleRepeatingTask):
(WebCore::EventLoopTaskGroup::scheduleTask):
(WebCore::EventLoopTaskGroup::scheduleRepeatingTask):
(WebCore::EventLoopTaskGroup::setTimerAlignment): Deleted.
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::DOMTimer):

Canonical link: <a href="https://commits.webkit.org/268460@main">https://commits.webkit.org/268460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d01ec0982285434cafc335f51f6a266f15c87004

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21671 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20343 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22526 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17995 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22266 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15898 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17831 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22277 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2414 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->