### PR TITLE
[JSC] Implement Annex B block-level function hoisting for global scope

### DIFF
--- a/JSTests/mozilla/ecma_3/Function/scope-001.js
+++ b/JSTests/mozilla/ecma_3/Function/scope-001.js
@@ -79,8 +79,7 @@ with (obj)
   }
   actual = f();
 }
-// Mozilla result, which contradicts IE and the ECMA spec: expect = 2;
-expect = 1;
+expect = 2;
 addThis();
 
 
@@ -99,8 +98,7 @@ with (obj)
   }
 }
 actual = f();
-// Mozilla result, which contradicts IE and the ECMA spec: expect = 2;
-expect = 1;
+expect = 2;
 addThis();
 
 
@@ -121,8 +119,7 @@ with (obj)
   }
 }
 actual = f();
-// Mozilla result, which contradicts IE and the ECMA spec: expect = 3;
-expect = 1;
+expect = 3;
 addThis();
 
 
@@ -142,8 +139,7 @@ with (obj)
 }
 delete obj;
 actual = f();
-// Mozilla result, which contradicts IE and the ECMA spec: expect = 2;
-expect = 1;
+expect = 2;
 addThis();
 
 
@@ -167,8 +163,7 @@ with (obj)
 {
   actual = f();
 }
-// Mozilla result, which contradicts IE and the ECMA spec: expect = 2;  // NOT 3 !!!
-expect = 1;
+expect = 2;
 addThis();
 
 

--- a/JSTests/mozilla/js1_5/Scope/regress-184107.js
+++ b/JSTests/mozilla/js1_5/Scope/regress-184107.js
@@ -78,8 +78,7 @@ addThis();
 
 status = inSection(2);
 actual = f();
-// Mozilla result, which contradicts IE and the ECMA spec: expect = obj.y;
-expect = y;
+expect = obj.y;
 addThis();
 
 status = inSection(3);

--- a/JSTests/mozilla/mozilla-tests.yaml
+++ b/JSTests/mozilla/mozilla-tests.yaml
@@ -1617,7 +1617,7 @@
 - path: ecma_3/FunExpr/fe-001-n.js
   cmd: defaultRunMozillaTest :negative, "../shell.js"
 - path: ecma_3/FunExpr/fe-001.js
-  cmd: defaultRunMozillaTest :fail, "../shell.js"
+  cmd: defaultRunMozillaTest :normal, "../shell.js"
 - path: ecma_3/FunExpr/fe-002.js
   cmd: defaultRunMozillaTest :normal, "../shell.js"
 - path: ecma_3/Number/15.7.4.5-1.js

--- a/JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-eval.js
+++ b/JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-eval.js
@@ -8,12 +8,12 @@ Object.defineProperty(globalThis, "foo", { get() {}, set() { fooSetCalls++; }, e
 
 let didThrow = false;
 try {
-    $262.evalScript(`
-        function foo() {}
-
+    eval(`
         if (true) {
             function bar() {}
         }
+
+        function foo() {}
     `);
 } catch (err) {
     didThrow = true;

--- a/JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-global.js
+++ b/JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-global.js
@@ -1,0 +1,25 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+let barSetCalls = 0;
+Object.defineProperty(globalThis, "bar", { writable: false, enumerable: true, configurable: false });
+
+let didThrow = false;
+try {
+    $262.evalScript(`
+        if (true) {
+            function foo() {}
+        }
+
+        function bar() {}
+    `);
+} catch (err) {
+    didThrow = true;
+    assert(err.toString() === "TypeError: Can't declare global function 'bar': property must be either configurable or both writable and enumerable");
+}
+
+assert(didThrow);
+assert(barSetCalls === 0);
+assert(!globalThis.hasOwnProperty("foo"));

--- a/JSTests/stress/can-declare-global-var-invoked-before-any-func-decl-is-hoisted-global.js
+++ b/JSTests/stress/can-declare-global-var-invoked-before-any-func-decl-is-hoisted-global.js
@@ -3,22 +3,22 @@ function assert(x) {
         throw new Error("Bad assertion!");
 }
 
-globalThis.foo = 1;
+globalThis.bar = 1;
 Object.preventExtensions(globalThis);
 
 let didThrow = false;
 try {
-    eval(`
+    $262.evalScript(`
         if (true) {
-            function foo() {}
+            function bar() {}
         }
 
-        var bar;
+        var foo;
     `);
 } catch (err) {
     didThrow = true;
-    assert(err.toString() === "TypeError: Can't declare global variable 'bar': global object must be extensible");
+    assert(err.toString() === "TypeError: Can't declare global variable 'foo': global object must be extensible");
 }
 
 assert(didThrow);
-assert(foo === 1);
+assert(bar === 1);

--- a/JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-eval.js
+++ b/JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-eval.js
@@ -3,7 +3,8 @@ function assert(x) {
         throw new Error("Bad assertion!");
 }
 
-globalThis.bar = 1;
+let barSetterValue;
+Object.defineProperty(globalThis, "bar", { get() {}, set(val) { barSetterValue = val; }, enumerable: true, configurable: false });
 Object.preventExtensions(globalThis);
 
 eval(`{
@@ -12,4 +13,5 @@ eval(`{
 }`);
 
 assert(typeof foo === "undefined");
-assert(typeof bar === "function");
+assert(typeof barSetterValue === "function");
+assert(!globalThis.hasOwnProperty("foo"));

--- a/JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-global.js
+++ b/JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-global.js
@@ -1,0 +1,17 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+let fooSetterValue;
+Object.defineProperty(globalThis, "foo", { get() {}, set(val) { fooSetterValue = val; }, enumerable: false, configurable: false });
+Object.preventExtensions(globalThis);
+
+$262.evalScript(`{
+    function foo() {}
+    function bar() {}
+}`);
+
+assert(typeof fooSetterValue === "function");
+assert(typeof bar === "undefined");
+assert(!globalThis.hasOwnProperty("bar"));

--- a/JSTests/stress/sloppy-mode-function-hoisting-global-code-2.js
+++ b/JSTests/stress/sloppy-mode-function-hoisting-global-code-2.js
@@ -1,0 +1,39 @@
+//@ runBytecodeCacheNoAssertion
+
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+
+try {
+    $262.evalScript(`try {} catch ({foo2}) { function foo2() {} }`);
+    throw new Error("evalScript() didn't throw()!");
+} catch (err) {
+    assert(err.toString() === "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'foo2'.");
+}
+assert(!globalThis.hasOwnProperty("foo2"));
+
+
+let foo9 = 9;
+$262.evalScript(`{ function foo9() {} }`);
+assert(foo9 === 9);
+assert(!globalThis.hasOwnProperty("foo9"));
+
+
+try {
+    $262.evalScript(`try {} catch (foo19) { function foo19() {} }`);
+    throw new Error("evalScript() didn't throw()!");
+} catch (err) {
+    assert(err.toString() === "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'foo19'.");
+}
+assert(!globalThis.hasOwnProperty("foo19"));
+
+
+try {
+    $262.evalScript(`"use strict"; { function foo20() {} function foo20() {} }`);
+    throw new Error("evalScript() didn't throw()!");
+} catch (err) {
+    assert(err.toString() === "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'foo20'.");
+}
+assert(!globalThis.hasOwnProperty("foo19"));

--- a/JSTests/stress/sloppy-mode-function-hoisting-global-code.js
+++ b/JSTests/stress/sloppy-mode-function-hoisting-global-code.js
@@ -1,0 +1,163 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+
+{
+  const MY_CONST = 1e6;
+  function foo1() { return MY_CONST; }
+  assert(foo1() === MY_CONST);
+}
+assert(foo1() === 1e6);
+
+
+try {
+    throw new Error();
+} catch ({foo3}) {
+    { function foo3() {} }
+}
+assert(!globalThis.hasOwnProperty("foo3"));
+
+
+with ({foo4: 4}) {
+  function foo5() { return foo4; }
+  assert(foo5() === 4);
+}
+assert(foo5() === 4);
+
+
+with({}) {
+  let foo6 = 6;
+  function foo7() { return foo6; }
+  assert(foo7() === foo6);
+}
+assert(foo7() === 6);
+
+
+let foo8 = 8;
+{ function foo8 () {} }
+assert(foo8 === 8);
+assert(!globalThis.hasOwnProperty("foo8"));
+
+
+assert(foo10 === undefined);
+{
+    assert(foo10() === 1);
+    function foo10() { return 1; }
+    assert(foo10() === 1);
+}
+assert(foo10() === 1);
+{
+    let foo10 = 1;
+
+    {
+        assert(foo10() === 2);
+        function foo10() { return 2; }
+        assert(foo10() === 2);
+    }
+}
+assert(foo10() === 1);
+
+
+assert(foo11 === undefined);
+{
+    assert(foo11() === 1);
+    function foo11() { return 1; }
+    assert(foo11() === 1);
+}
+assert(foo11() === 1);
+{
+    {{{
+        assert(foo11() === 2);
+        function foo11() { return 2; }
+        assert(foo11() === 2);
+    }}}
+    let foo11 = 1;
+}
+assert(foo11() === 1);
+
+
+assert(foo12 === undefined);
+const err12 = new Error();
+try {
+    assert(foo12() === 1);
+    function foo12() { return 1; }
+    throw err12;
+} catch (foo12) {
+    assert(foo12 === err12);
+    {
+        assert(foo12() === 2);
+        function foo12() { return 2; }
+        assert(foo12() === 2);
+    }
+    assert(foo12 === err12);
+}
+assert(foo12() === 2);
+
+
+assert(foo13 === undefined);
+const err13 = new Error();
+err13.foo13 = err13;
+try {
+    assert(foo13() === 1);
+    function foo13() { return 1; }
+    throw err13;
+} catch ({foo13}) {
+    assert(foo13 === err13);
+    {
+        assert(foo13() === 2);
+        function foo13() { return 2; }
+        assert(foo13() === 2);
+    }
+    assert(foo13 === err13);
+}
+assert(foo13() === 1);
+
+
+assert(foo14 === undefined);
+const err14 = new Error();
+err14.foo14 = err14;
+try {
+    assert(foo14() === 1);
+    function foo14() { return 1; }
+    throw err14;
+} catch (foo14) {
+    assert(foo14 === err14);
+    {
+        {{
+            assert(foo14() === 2);
+            function foo14() { return 2; }
+            assert(foo14() === 2);
+        }}
+        const foo14 = 1;
+    }
+    assert(foo14 === err14);
+}
+assert(foo14() === 1);
+
+
+if (true) { { function foo15() {} } } let foo15 = 15;
+assert(foo15 === 15);
+
+
+if (true) { function foo16() {} } let foo16 = 16;
+assert(foo16 === 16);
+
+
+{ if (true) function foo17() {} } let foo17 = 17;
+assert(foo17 === 17);
+
+
+assert(foo18 === undefined);
+{
+    assert(foo18() === 1);
+    function foo18() { return 1; }
+    assert(foo18() === 1);
+    {
+        assert(foo18() === 2);
+        function foo18() { return 2; }
+        assert(foo18() === 2);
+    }
+}
+assert(foo18() === 1);

--- a/JSTests/stress/sloppy-mode-function-hoisting.js
+++ b/JSTests/stress/sloppy-mode-function-hoisting.js
@@ -711,7 +711,8 @@ test(function() {
 });
 
 for (let i = 0; i < 500; i++)
-    assert(foo() === 25);
+    assert(foo() === 20);
+
 function foo() { return 20; }
 
 {
@@ -721,7 +722,7 @@ function foo() { return 20; }
 assert(foo() === 25);
 
 for (let i = 0; i < 500; i++)
-    assert(bar() === "bar2");
+    assert(bar() === "bar1");
 function bar() { return "bar1"; }
 if (falsey()) {
     {
@@ -730,14 +731,14 @@ if (falsey()) {
         }
     }
 }
-assert(bar() === "bar2");
+assert(bar() === "bar1");
 
 for (let i = 0; i < 500; i++)
-    assert(baz() === "baz2");
+    assert(baz() === "baz1");
 function baz() { return "baz1"; }
 while (falsey()) {
     if (falsey()) {
         function baz() { return "baz2"; }
     }
 }
-assert(baz() === "baz2");
+assert(baz() === "baz1");

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -7,214 +7,6 @@ test/annexB/built-ins/Function/createdynfn-html-open-comment-params.js:
   strict mode: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
 test/annexB/language/function-code/block-decl-func-skip-arguments.js:
   default: 'Test262Error: Expected SameValue(«function arguments() {}», «[object Arguments]») to be true'
-test/annexB/language/global-code/block-decl-global-block-scoping.js:
-  default: "TypeError: f is not a function. (In 'f()', 'f' is 123)"
-test/annexB/language/global-code/block-decl-global-existing-block-fn-no-init.js:
-  default: 'Test262Error: Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/block-decl-global-existing-fn-update.js:
-  default: 'Test262Error: Expected SameValue(«outer declaration», «inner declaration») to be true'
-test/annexB/language/global-code/block-decl-global-existing-non-enumerable-global-init.js:
-  default: 'Test262Error: descriptor should not be enumerable; descriptor should be configurable'
-test/annexB/language/global-code/block-decl-global-init.js:
-  default: 'Test262Error: binding is initialized to `undefined` Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/block-decl-global-no-skip-try.js:
-  default: 'Test262Error: Initialized binding created prior to evaluation Expected SameValue(«function f() { return 123; }», «undefined») to be true'
-test/annexB/language/global-code/block-decl-global-skip-early-err-block.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/block-decl-global-skip-early-err-for-in.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/block-decl-global-skip-early-err-for-of.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/block-decl-global-skip-early-err-for.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/block-decl-global-skip-early-err-switch.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/block-decl-global-skip-early-err-try.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/block-decl-global-skip-early-err.js:
-  default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
-test/annexB/language/global-code/if-decl-else-decl-a-global-block-scoping.js:
-  default: "TypeError: f is not a function. (In 'f()', 'f' is 123)"
-test/annexB/language/global-code/if-decl-else-decl-a-global-existing-block-fn-no-init.js:
-  default: 'Test262Error: Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-decl-a-global-existing-fn-update.js:
-  default: 'Test262Error: Expected SameValue(«outer declaration», «inner declaration») to be true'
-test/annexB/language/global-code/if-decl-else-decl-a-global-existing-non-enumerable-global-init.js:
-  default: 'Test262Error: descriptor should not be enumerable; descriptor should be configurable'
-test/annexB/language/global-code/if-decl-else-decl-a-global-init.js:
-  default: 'Test262Error: binding is initialized to `undefined` Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-decl-a-global-no-skip-try.js:
-  default: 'Test262Error: Initialized binding created prior to evaluation Expected SameValue(«function f() { return 123; }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-block.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-in.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for-of.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-for.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-switch.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err-try.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-a-global-skip-early-err.js:
-  default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
-test/annexB/language/global-code/if-decl-else-decl-b-global-block-scoping.js:
-  default: "TypeError: f is not a function. (In 'f()', 'f' is 123)"
-test/annexB/language/global-code/if-decl-else-decl-b-global-existing-block-fn-no-init.js:
-  default: 'Test262Error: Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-decl-b-global-existing-fn-update.js:
-  default: 'Test262Error: Expected SameValue(«outer declaration», «inner declaration») to be true'
-test/annexB/language/global-code/if-decl-else-decl-b-global-existing-non-enumerable-global-init.js:
-  default: 'Test262Error: descriptor should not be enumerable; descriptor should be configurable'
-test/annexB/language/global-code/if-decl-else-decl-b-global-init.js:
-  default: 'Test262Error: binding is initialized to `undefined` Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-decl-b-global-no-skip-try.js:
-  default: 'Test262Error: Initialized binding created prior to evaluation Expected SameValue(«function f() { return 123; }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-block.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-in.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for-of.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-for.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-switch.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err-try.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-decl-b-global-skip-early-err.js:
-  default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
-test/annexB/language/global-code/if-decl-else-stmt-global-block-scoping.js:
-  default: "TypeError: f is not a function. (In 'f()', 'f' is 123)"
-test/annexB/language/global-code/if-decl-else-stmt-global-existing-block-fn-no-init.js:
-  default: 'Test262Error: Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-stmt-global-existing-fn-update.js:
-  default: 'Test262Error: Expected SameValue(«outer declaration», «inner declaration») to be true'
-test/annexB/language/global-code/if-decl-else-stmt-global-existing-non-enumerable-global-init.js:
-  default: 'Test262Error: descriptor should not be enumerable; descriptor should be configurable'
-test/annexB/language/global-code/if-decl-else-stmt-global-init.js:
-  default: 'Test262Error: binding is initialized to `undefined` Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-stmt-global-no-skip-try.js:
-  default: 'Test262Error: Initialized binding created prior to evaluation Expected SameValue(«function f() { return 123; }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-block.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-in.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for-of.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-for.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-switch.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err-try.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-else-stmt-global-skip-early-err.js:
-  default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
-test/annexB/language/global-code/if-decl-no-else-global-block-scoping.js:
-  default: "TypeError: f is not a function. (In 'f()', 'f' is 123)"
-test/annexB/language/global-code/if-decl-no-else-global-existing-block-fn-no-init.js:
-  default: 'Test262Error: Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-no-else-global-existing-fn-update.js:
-  default: 'Test262Error: Expected SameValue(«outer declaration», «inner declaration») to be true'
-test/annexB/language/global-code/if-decl-no-else-global-existing-non-enumerable-global-init.js:
-  default: 'Test262Error: descriptor should not be enumerable; descriptor should be configurable'
-test/annexB/language/global-code/if-decl-no-else-global-init.js:
-  default: 'Test262Error: binding is initialized to `undefined` Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-no-else-global-no-skip-try.js:
-  default: 'Test262Error: Initialized binding created prior to evaluation Expected SameValue(«function f() { return 123; }», «undefined») to be true'
-test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-block.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-in.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for-of.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-for.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-switch.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-no-else-global-skip-early-err-try.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-decl-no-else-global-skip-early-err.js:
-  default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
-test/annexB/language/global-code/if-stmt-else-decl-global-block-scoping.js:
-  default: "TypeError: f is not a function. (In 'f()', 'f' is 123)"
-test/annexB/language/global-code/if-stmt-else-decl-global-existing-block-fn-no-init.js:
-  default: 'Test262Error: Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-stmt-else-decl-global-existing-fn-update.js:
-  default: 'Test262Error: Expected SameValue(«outer declaration», «inner declaration») to be true'
-test/annexB/language/global-code/if-stmt-else-decl-global-existing-non-enumerable-global-init.js:
-  default: 'Test262Error: descriptor should not be enumerable; descriptor should be configurable'
-test/annexB/language/global-code/if-stmt-else-decl-global-init.js:
-  default: 'Test262Error: binding is initialized to `undefined` Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/if-stmt-else-decl-global-no-skip-try.js:
-  default: 'Test262Error: Initialized binding created prior to evaluation Expected SameValue(«function f() { return 123; }», «undefined») to be true'
-test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-block.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-in.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for-of.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-for.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-switch.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err-try.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/if-stmt-else-decl-global-skip-early-err.js:
-  default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
-test/annexB/language/global-code/switch-case-global-block-scoping.js:
-  default: "TypeError: f is not a function. (In 'f()', 'f' is 123)"
-test/annexB/language/global-code/switch-case-global-existing-block-fn-no-init.js:
-  default: 'Test262Error: Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/switch-case-global-existing-fn-update.js:
-  default: 'Test262Error: Expected SameValue(«outer declaration», «inner declaration») to be true'
-test/annexB/language/global-code/switch-case-global-existing-non-enumerable-global-init.js:
-  default: 'Test262Error: descriptor should not be enumerable; descriptor should be configurable'
-test/annexB/language/global-code/switch-case-global-init.js:
-  default: 'Test262Error: binding is initialized to `undefined` Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/switch-case-global-no-skip-try.js:
-  default: 'Test262Error: Initialized binding created prior to evaluation Expected SameValue(«function f() { return 123; }», «undefined») to be true'
-test/annexB/language/global-code/switch-case-global-skip-early-err-block.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-case-global-skip-early-err-for-in.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-case-global-skip-early-err-for-of.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-case-global-skip-early-err-for.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-case-global-skip-early-err-switch.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-case-global-skip-early-err-try.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-case-global-skip-early-err.js:
-  default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
-test/annexB/language/global-code/switch-dflt-global-block-scoping.js:
-  default: "TypeError: f is not a function. (In 'f()', 'f' is 123)"
-test/annexB/language/global-code/switch-dflt-global-existing-block-fn-no-init.js:
-  default: 'Test262Error: Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/switch-dflt-global-existing-fn-update.js:
-  default: 'Test262Error: Expected SameValue(«outer declaration», «inner declaration») to be true'
-test/annexB/language/global-code/switch-dflt-global-existing-non-enumerable-global-init.js:
-  default: 'Test262Error: descriptor should not be enumerable; descriptor should be configurable'
-test/annexB/language/global-code/switch-dflt-global-init.js:
-  default: 'Test262Error: binding is initialized to `undefined` Expected SameValue(«function f() {  }», «undefined») to be true'
-test/annexB/language/global-code/switch-dflt-global-no-skip-try.js:
-  default: 'Test262Error: Initialized binding created prior to evaluation Expected SameValue(«function f() { return 123; }», «undefined») to be true'
-test/annexB/language/global-code/switch-dflt-global-skip-early-err-block.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-dflt-global-skip-early-err-for-in.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-dflt-global-skip-early-err-for-of.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-dflt-global-skip-early-err-for.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-dflt-global-skip-early-err-switch.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-dflt-global-skip-early-err-try.js:
-  default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/global-code/switch-dflt-global-skip-early-err.js:
-  default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
 test/built-ins/ArrayBuffer/prototype/detached/detached-buffer-resizable.js:
   default: 'Test262Error: Resizable ArrayBuffer with maxByteLength of 0 is not detached Expected SameValue(«undefined», «false») to be true'
   strict mode: 'Test262Error: Resizable ArrayBuffer with maxByteLength of 0 is not detached Expected SameValue(«undefined», «false») to be true'
@@ -1374,79 +1166,31 @@ test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-let.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-var.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-const.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-let.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-var.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/const-name-redeclaration-attempt-with-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/const-name-redeclaration-attempt-with-generator.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-class.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-const.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-let.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-var.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
@@ -1460,22 +1204,6 @@ test/language/block-scope/syntax/redeclaration/inner-block-var-name-redeclaratio
 test/language/block-scope/syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js:
   default: 'Test262: This statement should not be evaluated.'
   strict mode: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/inner-block-var-redeclaration-attempt-after-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/inner-block-var-redeclaration-attempt-after-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/inner-block-var-redeclaration-attempt-after-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/let-name-redeclaration-attempt-with-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/let-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
   strict mode: 'Test262: This statement should not be evaluated.'
@@ -1488,14 +1216,6 @@ test/language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-wi
 test/language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js:
   default: 'Test262: This statement should not be evaluated.'
   strict mode: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/var-redeclaration-attempt-after-async-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/var-redeclaration-attempt-after-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/var-redeclaration-attempt-after-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/block-scope/syntax/redeclaration/var-redeclaration-attempt-after-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
 test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js:
@@ -2010,105 +1730,41 @@ test/language/statements/labeled/decl-async-generator.js:
   strict mode: 'Test262: This statement should not be evaluated.'
 test/language/statements/labeled/let-array-with-newline.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/statements/let/block-local-closure-set-before-initialization.js:
-  default: 'Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all'
 test/language/statements/let/dstr/ary-init-iter-get-err-array-prototype.js:
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
 test/language/statements/let/dstr/ary-ptrn-elem-id-iter-val-array-prototype.js:
   default: 'Test262Error: Expected SameValue(«3», «42») to be true'
   strict mode: 'Test262Error: Expected SameValue(«3», «42») to be true'
-test/language/statements/switch/scope-lex-async-function.js:
-  default: Expected uncaught exception with name 'ReferenceError' but none was thrown
-test/language/statements/switch/scope-lex-async-generator.js:
-  default: Expected uncaught exception with name 'ReferenceError' but none was thrown
-test/language/statements/switch/scope-lex-generator.js:
-  default: Expected uncaught exception with name 'ReferenceError' but none was thrown
 test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-let.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-var.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-const.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-let.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-var.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/const-name-redeclaration-attempt-with-async-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/const-name-redeclaration-attempt-with-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/const-name-redeclaration-attempt-with-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/const-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-class.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-const.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-let.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-var.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-const.js:
-  default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-let.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-var.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/let-name-redeclaration-attempt-with-async-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/let-name-redeclaration-attempt-with-async-generator.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/let-name-redeclaration-attempt-with-function.js:
-  default: 'Test262: This statement should not be evaluated.'
-test/language/statements/switch/syntax/redeclaration/let-name-redeclaration-attempt-with-generator.js:
   default: 'Test262: This statement should not be evaluated.'
 test/language/statements/switch/syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js:
   default: 'Test262: This statement should not be evaluated.'

--- a/LayoutTests/accessibility/insert-children-assert.html
+++ b/LayoutTests/accessibility/insert-children-assert.html
@@ -54,21 +54,21 @@ body {
         shouldBe("valueOccuranceInElementTree(content, value)", "1");
         if (window.eventSender)
             eventSender.keyDown('a');
-    
-        function valueOccuranceInElementTree(element, value) {
-            if (!element) {
-                return 0;
-            }
-            var count = 0;
-            if (element.stringValue == value)
-                count++;
-            var childrenCount = element.childrenCount;
-            for (var k = 0; k < childrenCount; k++)
-                count += valueOccuranceInElementTree(element.childAtIndex(k), value);
-            return count;
-        }
     }
     successfullyParsed = true;
+
+    function valueOccuranceInElementTree(element, value) {
+        if (!element) {
+            return 0;
+        }
+        var count = 0;
+        if (element.stringValue == value)
+            count++;
+        var childrenCount = element.childrenCount;
+        for (var k = 0; k < childrenCount; k++)
+            count += valueOccuranceInElementTree(element.childAtIndex(k), value);
+        return count;
+    }
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/dom/MutationObserver/disconnect-observer-while-mutation-records-are-enqueued-crash.html
+++ b/LayoutTests/fast/dom/MutationObserver/disconnect-observer-while-mutation-records-are-enqueued-crash.html
@@ -19,18 +19,16 @@ else {
     observer.observe(div, {childList: true});
 
     var script = document.createElement('script');
-    script.textContent = 'disconnectObserver()';
-
-    var child = document.createElement('div');
-    child.appendChild(script);
-    div.appendChild(child);
-
-    function disconnectObserver() {
+    script.textContent = `
         observer.disconnect();
         observer = null;
         GCController.collect();
         observer = new MutationObserver(function() {});
-    }
+    `;
+
+    var child = document.createElement('div');
+    child.appendChild(script);
+    div.appendChild(child);
 
     window.onload = () => {
         testPassed('WebKit did not crash');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-with-hints.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-with-hints.tentative-expected.txt
@@ -1,9 +1,11 @@
+HintAsyncAsync
+Hint anchored to popover
 Hint Nested hint
 Hint
 
-FAIL manuals do not close popovers Can't find variable: auto
-FAIL autos close hints but not manuals Can't find variable: auto
-FAIL hint is not closed by pre-existing auto Can't find variable: popover1
+PASS manuals do not close popovers
+FAIL autos close hints but not manuals assert_equals: hint open state is incorrect expected false but got true
+FAIL hint is not closed by pre-existing auto assert_equals: popover3 open state is incorrect expected false but got true
 FAIL If a popover=hint is shown, it should hide any other open popover=hint popovers, including ancestral popovers. (You can't nest popover=hint) assert_false: expected false got true
 FAIL If a popover=auto is shown, it should hide any open popover=hint, including if the popover=hint is an ancestral popover of the popover=auto. (You can't nest a popover=auto inside a popover=hint) assert_false: expected false got true
 FAIL If you: a) show a popover=auto (call it D), then b) show a descendent popover=hint of D (call it T), then c) hide D, then T should be hidden. (A popover=hint can be nested inside a popover=auto) assert_false: expected false got true


### PR DESCRIPTION
#### a4c5231dbae7cb9180fc5c02f8438bcce3f2cd52
<pre>
[JSC] Implement Annex B block-level function hoisting for global scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=163209">https://bugs.webkit.org/show_bug.cgi?id=163209</a>
&lt;rdar://problem/53234438&gt;

Reviewed by Yusuke Suzuki.

This change expands existing (and recently revamped) block-level function hoisting infrastructure
to global scope code, removing the extremely troublesome hack that used to unconditionally set the
scope of a block-level function declaration in global code to the top-level `var` scope instead of
lexical, which caused plenty of bug reports.

GlobalDeclarationInstantiation [1] implementation was tweaked to properly handle all the &quot;phantom&quot;
isSloppyModeHoistedFunction() variables, which are used merely to compute used / captured variables,
and not treat them like `var`s to avoid throwing spec-noncompliant errors.

Since there is no way to account for lexical declarations from another &lt;script&gt; in the parser [2],
nor for non-extensible global object, emitResolveScopeForHoistingFuncDeclInEval() for global code
has to emit same unresolved scope check as for declarations in eval().

Aligns JSC with the spec, V8, and SpiderMonkey.

[1]: <a href="https://tc39.es/ecma262/#sec-globaldeclarationinstantiation">https://tc39.es/ecma262/#sec-globaldeclarationinstantiation</a>
[2]: <a href="https://tc39.es/ecma262/#sec-web-compat-globaldeclarationinstantiation">https://tc39.es/ecma262/#sec-web-compat-globaldeclarationinstantiation</a> (step 12.b.ii.2.a)

* JSTests/mozilla/ecma_3/Function/scope-001.js:
* JSTests/mozilla/js1_5/Scope/regress-184107.js:
* JSTests/mozilla/mozilla-tests.yaml:
* JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-eval.js:
* JSTests/stress/can-declare-global-function-invoked-before-any-func-decl-is-hoisted-global.js: Added.
* JSTests/stress/can-declare-global-var-invoked-before-any-func-decl-is-hoisted-eval.js:
* JSTests/stress/can-declare-global-var-invoked-before-any-func-decl-is-hoisted-global.js: Added.
* JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-eval.js:
* JSTests/stress/can-declare-global-var-invoked-during-func-decl-hoisting-global.js: Added.
* JSTests/stress/sloppy-mode-function-hoisting-global-code.js: Added.
* JSTests/stress/sloppy-mode-function-hoisting-global-code-2.js: Added.
Separate file is necessary to skip bytecode cache assertion for scripts that throw SyntaxError.
See <a href="https://commits.webkit.org/r244241.">https://commits.webkit.org/r244241.</a>

* JSTests/stress/sloppy-mode-function-hoisting.js:
* JSTests/test262/expectations.yaml: Mark 172 tests as passing.
* LayoutTests/accessibility/insert-children-assert.html:
Adjust test that relied on previous incorrect behavior of block-level function declaration being
hoisted to top-level `var` scope before FunctionDeclaration is evaluated.

* LayoutTests/fast/dom/MutationObserver/disconnect-observer-while-mutation-records-are-enqueued-crash.html: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-types-with-hints.tentative-expected.txt:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::hoistSloppyModeFunctionIfNecessary):
(JSC::BytecodeGenerator::emitResolveScopeForHoistingFuncDeclInEval): Hoist the common logic between FunctionCode and EvalCode.
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseFunctionDeclarationStatement):
(JSC::Parser&lt;LexerType&gt;::parseFunctionDeclaration):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Parser::declareFunction):
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):

Canonical link: <a href="https://commits.webkit.org/268553@main">https://commits.webkit.org/268553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/872b1efd76633d7abd9ac4fc0561c682bf590ee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18656 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20552 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20163 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17370 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22722 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24428 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17376 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22417 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19347 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16060 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23378 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18112 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18002 "Passed tests") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22461 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24634 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2460 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18757 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5449 "Passed tests") | 
<!--EWS-Status-Bubble-End-->