### PR TITLE
Fix painting of RenderListBox in vertical writing mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS select[multiple][style="writing-mode: horizontal-tb"] has visually correct option order
+FAIL select[multiple][style="writing-mode: vertical-lr"] has visually correct option order assert_equals: options are in visually incorrect order expected "Option 1" but got "Option 3"
+FAIL select[multiple][style="writing-mode: vertical-rl"] has visually correct option order assert_equals: options are in visually incorrect order expected "Option 4" but got "Option 3"
+FAIL select[multiple][style="writing-mode: sideways-lr"] has visually correct option order assert_equals: options are in visually incorrect order expected "Option 1" but got "Option 3"
+FAIL select[multiple][style="writing-mode: sideways-rl"] has visually correct option order assert_equals: options are in visually incorrect order expected "Option 4" but got "Option 3"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test &lt;select&gt; multiple attribute options visual order</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<select multiple size="4"></select>
+<script>
+const select = document.querySelector("select");
+for (let i = 0; i < 4; i++) {
+    const option = document.createElement("option");
+    option.textContent = `Option ${i + 1}`;
+    select.appendChild(option);
+}
+
+for (const writingMode of ["horizontal-tb", "vertical-lr", "vertical-rl", "sideways-lr", "sideways-rl"]) {
+    if (!CSS.supports(`writing-mode: ${writingMode}`))
+        continue;
+
+    const isHorizontal = writingMode === "horizontal-tb";
+    const isReversedBlockFlowDirection = writingMode.endsWith("-rl");
+
+    promise_test(async function() {
+        select.style.writingMode = writingMode;
+        this.add_cleanup(() => {
+            select.removeAttribute("style");
+        });
+
+        const elementBox = select.getBoundingClientRect();
+        const computedStyle = getComputedStyle(select);
+
+        const borderAndPaddingTop = parseFloat(computedStyle.borderTopWidth) + parseFloat(computedStyle.paddingTop);
+        const borderAndPaddingRight = parseFloat(computedStyle.borderRightWidth) + parseFloat(computedStyle.paddingRight);
+        const borderAndPaddingBottom = parseFloat(computedStyle.borderBottomWidth) + parseFloat(computedStyle.paddingBottom);
+        const borderAndPaddingLeft = parseFloat(computedStyle.borderLeftWidth) + parseFloat(computedStyle.paddingLeft);
+
+        const contentX = elementBox.x + borderAndPaddingLeft;
+        const contentY = elementBox.y + borderAndPaddingTop;
+        const contentWidth = elementBox.width - borderAndPaddingLeft - borderAndPaddingRight;
+        const contentHeight = elementBox.height - borderAndPaddingTop - borderAndPaddingBottom;
+
+        const logicalOptionHeight = (isHorizontal ? contentHeight : contentWidth) / select.size;
+
+        let currentX = contentX + (isHorizontal ? contentWidth : logicalOptionHeight) / 2;
+        let currentY = contentY + (isHorizontal ? logicalOptionHeight : contentHeight) / 2;
+
+        for (let i = 0; i < select.size; i++) {
+            await new test_driver.Actions()
+                .pointerMove(Math.round(currentX), Math.round(currentY))
+                .pointerDown()
+                .pointerUp()
+                .send();
+
+            assert_equals(
+                select.value,
+                select.options[isReversedBlockFlowDirection ? (select.size - i - 1) : i].value,
+                "options are in visually incorrect order"
+            );
+
+            if (isHorizontal) {
+                currentY += logicalOptionHeight;
+            } else {
+                currentX += logicalOptionHeight;
+            }
+        }
+    }, `select[multiple][style="writing-mode: ${writingMode}"] has visually correct option order`);
+};
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3941,6 +3941,7 @@ imported/w3c/web-platform-tests/css/css-writing-modes/forms/color-input-appearan
 # <select> are always menulists on iOS, regardless of multiple/size attributes, these tests assume the listbox appearance that desktop platforms have.
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order.html [ Failure ]
 fast/forms/select/multiselect-in-listbox-mouse-release-outside.html [ Skip ]
 
 # To investigate: might need to relax the tests, or adapt native thumb appearance.

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -157,20 +157,20 @@ private:
     void setHasVerticalScrollbar(bool hasScrollbar);
     Ref<Scrollbar> createScrollbar();
     void destroyScrollbar();
-    
-    int maximumNumberOfItemsThatFitInPaddingBottomArea() const;
 
-    int numberOfVisibleItemsInPaddingTop() const;
-    int numberOfVisibleItemsInPaddingBottom() const;
+    int maximumNumberOfItemsThatFitInPaddingAfterArea() const;
 
-    void computeFirstIndexesVisibleInPaddingTopBottomAreas();
+    int numberOfVisibleItemsInPaddingBefore() const;
+    int numberOfVisibleItemsInPaddingAfter() const;
 
-    LayoutUnit itemHeight() const;
+    void computeFirstIndexesVisibleInPaddingBeforeAfterAreas();
+
+    LayoutUnit itemLogicalHeight() const;
 
     enum class ConsiderPadding : bool { No, Yes };
     int numVisibleItems(ConsiderPadding = ConsiderPadding::No) const;
     int numItems() const;
-    LayoutUnit listHeight() const;
+    LayoutUnit listLogicalHeight() const;
 
     std::optional<int> optionRowIndex(const HTMLOptionElement&) const;
 
@@ -188,15 +188,15 @@ private:
     bool m_optionsChanged { true };
     bool m_scrollToRevealSelectionAfterLayout { false };
     bool m_inAutoscroll { false };
-    int m_optionsWidth { 0 };
+    int m_optionsLogicalWidth { 0 };
 
     RefPtr<Scrollbar> m_vBar;
 
     // Note: This is based on item index rather than a pixel offset.
     ScrollPosition m_scrollPosition;
 
-    std::optional<int> m_indexOfFirstVisibleItemInsidePaddingTopArea;
-    std::optional<int> m_indexOfFirstVisibleItemInsidePaddingBottomArea;
+    std::optional<int> m_indexOfFirstVisibleItemInsidePaddingBeforeArea;
+    std::optional<int> m_indexOfFirstVisibleItemInsidePaddingAfterArea;
 
 };
 


### PR DESCRIPTION
#### c7a54f98d7217bc27161357670a5b7549a231959
<pre>
Fix painting of RenderListBox in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=261802">https://bugs.webkit.org/show_bug.cgi?id=261802</a>
rdar://115766419

Reviewed by Tim Nguyen.

Ensure option items are painted following the block direction. This patch
also renames variables refer to logical values where necessary.

Subsequent patches will add support for horizontal scrolling and keyboard
navigation.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order-expected.txt: Added.

The newly added tests is a failures for now, since `&lt;select&gt;` is still forced
to `writing-mode: horizontal-tb`. Once `RenderListBox` fully supports vertical
writing mode, and is enabled under the setting, these tests will pass.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order.html: Added.
* LayoutTests/platform/ios/TestExpectations:

`RenderListBox` is not used on iOS.

* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::updateFromElement):
(WebCore::RenderListBox::layout):
(WebCore::RenderListBox::computeIntrinsicLogicalWidths const):
(WebCore::RenderListBox::computePreferredLogicalWidths):
(WebCore::RenderListBox::numVisibleItems const):
(WebCore::RenderListBox::listLogicalHeight const):
(WebCore::RenderListBox::computeLogicalHeight const):
(WebCore::RenderListBox::itemBoundingBoxRect const):
(WebCore::RenderListBox::paintItem):
(WebCore::itemOffsetForAlignment):
(WebCore::RenderListBox::paintItemForeground):
(WebCore::RenderListBox::listIndexAtOffset const):
(WebCore::RenderListBox::panScroll):
(WebCore::RenderListBox::listIndexIsVisible):
(WebCore::RenderListBox::maximumNumberOfItemsThatFitInPaddingAfterArea const):
(WebCore::RenderListBox::numberOfVisibleItemsInPaddingBefore const):
(WebCore::RenderListBox::numberOfVisibleItemsInPaddingAfter const):
(WebCore::RenderListBox::computeFirstIndexesVisibleInPaddingBeforeAfterAreas):
(WebCore::RenderListBox::scrollTo):
(WebCore::RenderListBox::itemLogicalHeight const):
(WebCore::RenderListBox::scrollHeight const):
(WebCore::RenderListBox::scrollTop const):
(WebCore::RenderListBox::setScrollTop):
(WebCore::RenderListBox::listHeight const): Deleted.
(WebCore::RenderListBox::maximumNumberOfItemsThatFitInPaddingBottomArea const): Deleted.
(WebCore::RenderListBox::numberOfVisibleItemsInPaddingTop const): Deleted.
(WebCore::RenderListBox::numberOfVisibleItemsInPaddingBottom const): Deleted.
(WebCore::RenderListBox::computeFirstIndexesVisibleInPaddingTopBottomAreas): Deleted.
(WebCore::RenderListBox::itemHeight const): Deleted.
* Source/WebCore/rendering/RenderListBox.h:

Canonical link: <a href="https://commits.webkit.org/268594@main">https://commits.webkit.org/268594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a00788ecd65f2691cb3db6c1443bd3840596e417

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18710 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20199 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22791 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24472 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22462 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18984 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16104 "5 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18051 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4827 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->