### PR TITLE
PointerEvent.button should be -1 when mouse buttons are in released state

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_hoverable_pointers_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_hoverable_pointers_mouse-expected.txt
@@ -15,7 +15,7 @@ Harness Error (TIMEOUT), message = null
 
 NOTRUN mouse pointerevent attributes
 PASS mouse pointerover.type should be pointerover
-FAIL mouse pointerover.button is -1 when mouse buttons are in released state. assert_equals: expected -1 but got 0
+PASS mouse pointerover.button is -1 when mouse buttons are in released state.
 PASS mouse pointerover.buttons is 0 when mouse buttons are in released state.
 PASS mouse pointerover.clientX and .clientY attributes are correct.
 PASS mouse pointerover.pointerType is correct.
@@ -30,7 +30,7 @@ PASS mouse pointerover.pressure value is valid
 PASS mouse pointerover properties for pointerType = mouse
 PASS mouse pointerover.isPrimary attribute is true.
 PASS mouse pointerenter.type should be pointerenter
-FAIL mouse pointerenter.button is -1 when mouse buttons are in released state. assert_equals: expected -1 but got 0
+PASS mouse pointerenter.button is -1 when mouse buttons are in released state.
 PASS mouse pointerenter.buttons is 0 when mouse buttons are in released state.
 PASS mouse pointerenter.clientX and .clientY attributes are correct.
 PASS mouse pointerenter.pointerType is correct.
@@ -95,7 +95,7 @@ PASS mouse pointerup properties for pointerup
 PASS mouse pointerup.isPrimary attribute is true.
 PASS mouse pointerup.pointerId should be the same as previous pointer events for this active pointer.
 PASS mouse pointerout.type should be pointerout
-FAIL mouse pointerout.button is -1 when mouse buttons are in released state. assert_equals: expected -1 but got 0
+PASS mouse pointerout.button is -1 when mouse buttons are in released state.
 PASS mouse pointerout.buttons is 0 when mouse buttons are in released state.
 PASS mouse pointerout.clientX and .clientY attributes are correct.
 PASS mouse pointerout.pointerType is correct.
@@ -111,7 +111,7 @@ PASS mouse pointerout properties for pointerType = mouse
 PASS mouse pointerout.isPrimary attribute is true.
 PASS mouse pointerout.pointerId should be the same as previous pointer events for this active pointer.
 PASS mouse pointerleave.type should be pointerleave
-FAIL mouse pointerleave.button is -1 when mouse buttons are in released state. assert_equals: expected -1 but got 0
+PASS mouse pointerleave.button is -1 when mouse buttons are in released state.
 PASS mouse pointerleave.buttons is 0 when mouse buttons are in released state.
 PASS mouse pointerleave.clientX and .clientY attributes are correct.
 PASS mouse pointerleave.pointerType is correct.

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -183,7 +183,7 @@ bool MouseEvent::canTriggerActivationBehavior(const Event& event)
 
 MouseButton MouseEvent::button() const
 {
-    static constexpr std::array mouseButtonCases { MouseButton::None, MouseButton::PointerMove, MouseButton::Left, MouseButton::Middle, MouseButton::Right };
+    static constexpr std::array mouseButtonCases { MouseButton::None, MouseButton::PointerHasNotChanged, MouseButton::Left, MouseButton::Middle, MouseButton::Right };
     const auto isKnownButton = WTF::anyOf(mouseButtonCases, [buttonValue = this->m_button](MouseButton button) {
         return buttonValue == enumToUnderlyingType(button);
     });

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -102,7 +102,7 @@ PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const Mou
 }
 
 PointerEvent::PointerEvent(const AtomString& type, PointerID pointerId, const String& pointerType, IsPrimary isPrimary)
-    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, 0, 0, { }, MouseButton::Left, 0, SyntheticClickType::NoTap, nullptr)
+    : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, 0, 0, { }, buttonForType(type), 0, SyntheticClickType::NoTap, nullptr)
     , m_pointerId(pointerId)
     , m_pointerType(pointerType)
     , m_isPrimary(isPrimary == IsPrimary::Yes)

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -114,6 +114,8 @@ public:
     RefPtr<Node> fromElement() const final { return nullptr; }
 
     EventInterface eventInterface() const override;
+    static bool typeIsUpOrDown(const AtomString& type);
+    static MouseButton buttonForType(const AtomString& type) { return !typeIsUpOrDown(type) ? MouseButton::PointerHasNotChanged : MouseButton::Left; }
 
 private:
     static bool typeIsEnterOrLeave(const AtomString& type);
@@ -121,7 +123,6 @@ private:
     static IsCancelable typeIsCancelable(const AtomString& type) { return typeIsEnterOrLeave(type) ? IsCancelable::No : IsCancelable::Yes; }
     static IsComposed typeIsComposed(const AtomString& type) { return typeIsEnterOrLeave(type) ? IsComposed::No : IsComposed::Yes; }
 #if PLATFORM(WPE)
-    static MouseButton buttonForType(const AtomString& type) { return type == eventNames().pointermoveEvent ? MouseButton::PointerMove : MouseButton::Left; }
     static unsigned short buttonsForType(const AtomString& type)
     {
         // We have contact with the touch surface for most events except when we've released the touch or canceled it.
@@ -154,6 +155,12 @@ inline bool PointerEvent::typeIsEnterOrLeave(const AtomString& type)
 {
     auto& eventNames = WebCore::eventNames();
     return type == eventNames.pointerenterEvent || type == eventNames.pointerleaveEvent;
+}
+
+inline bool PointerEvent::typeIsUpOrDown(const AtomString& type)
+{
+    auto& eventNames = WebCore::eventNames();
+    return type == eventNames.pointerupEvent || type == eventNames.pointerdownEvent;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ios/PointerEventIOS.cpp
+++ b/Source/WebCore/dom/ios/PointerEventIOS.cpp
@@ -51,11 +51,6 @@ static const AtomString& pointerEventType(PlatformTouchPoint::TouchPhaseType pha
     return nullAtom();
 }
 
-static MouseButton buttonForType(const AtomString& type)
-{
-    return type == eventNames().pointermoveEvent ? MouseButton::PointerMove : MouseButton::Left;
-}
-
 static unsigned short buttonsForType(const AtomString& type)
 {
     // We have contact with the touch surface for most events except when we've released the touch or canceled it.

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -312,6 +312,27 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
 }
 #endif
 
+static AtomString pointerEventType(const AtomString& mouseEventType)
+{
+    auto& names = eventNames();
+    if (mouseEventType == names.mousedownEvent)
+        return names.pointerdownEvent;
+    if (mouseEventType == names.mouseoverEvent)
+        return names.pointeroverEvent;
+    if (mouseEventType == names.mouseenterEvent)
+        return names.pointerenterEvent;
+    if (mouseEventType == names.mousemoveEvent)
+        return names.pointermoveEvent;
+    if (mouseEventType == names.mouseleaveEvent)
+        return names.pointerleaveEvent;
+    if (mouseEventType == names.mouseoutEvent)
+        return names.pointeroutEvent;
+    if (mouseEventType == names.mouseupEvent)
+        return names.pointerupEvent;
+
+    return nullAtom();
+}
+
 RefPtr<PointerEvent> PointerCaptureController::pointerEventForMouseEvent(const MouseEvent& mouseEvent, PointerID pointerId, const String& pointerType)
 {
     // If we already have known touches then we cannot dispatch a mouse event,
@@ -328,8 +349,12 @@ RefPtr<PointerEvent> PointerCaptureController::pointerEventForMouseEvent(const M
     bool pointerIsPressed = capturingData ? capturingData->pointerIsPressed : false;
 
     MouseButton newButton = mouseEvent.button();
-    MouseButton previousMouseButton = capturingData ? capturingData->previousMouseButton : MouseButton::PointerMove;
-    MouseButton button = (type == names.mousemoveEvent && newButton == previousMouseButton) ? MouseButton::PointerMove : newButton;
+    MouseButton previousMouseButton = capturingData ? capturingData->previousMouseButton : MouseButton::PointerHasNotChanged;
+    MouseButton button = [newButton, previousMouseButton, type = pointerEventType(type)] {
+        if (newButton == previousMouseButton)
+            return PointerEvent::buttonForType(type);
+        return PointerEvent::typeIsUpOrDown(type) ? newButton : MouseButton::PointerHasNotChanged;
+    }();
 
     // https://w3c.github.io/pointerevents/#chorded-button-interactions
     // Some pointer devices, such as mouse or pen, support multiple buttons. In the Mouse Event model, each button

--- a/Source/WebCore/page/PointerCaptureController.h
+++ b/Source/WebCore/page/PointerCaptureController.h
@@ -98,7 +98,7 @@ private:
         bool isPrimary { false };
         bool preventsCompatibilityMouseEvents { false };
         bool pointerIsPressed { false };
-        MouseButton previousMouseButton { MouseButton::PointerMove };
+        MouseButton previousMouseButton { MouseButton::PointerHasNotChanged };
 
     private:
         CapturingData(const String& pointerType)

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -37,11 +37,11 @@ const double ForceAtClick = 1;
 const double ForceAtForceClick = 2;
 
 // These button numbers match the ones used in the DOM API, 0 through 2, except for None and Other which aren't specified.
-// We reserve -2 for the former and -1 to represent pointermove events that indicate that the pressed mouse button hasn't
+// We reserve -2 for the former and -1 to represent pointer events that indicate that the pressed mouse button hasn't
 // changed since the last event, as specified in the DOM API for Pointer Events.
 // https://w3c.github.io/uievents/#dom-mouseevent-button
 // https://w3c.github.io/pointerevents/#the-button-property
-enum class MouseButton : int8_t { None = -2, PointerMove, Left, Middle, Right, Other };
+enum class MouseButton : int8_t { None = -2, PointerHasNotChanged, Left, Middle, Right, Other };
 enum class SyntheticClickType : uint8_t { NoTap, OneFingerTap, TwoFingerTap };
 
 class PlatformMouseEvent : public PlatformEvent {


### PR DESCRIPTION
#### 18348e5bdfbb903ccb30c1f0b1aff70b5ec81a82
<pre>
PointerEvent.button should be -1 when mouse buttons are in released state
<a href="https://bugs.webkit.org/show_bug.cgi?id=262089">https://bugs.webkit.org/show_bug.cgi?id=262089</a>
rdar://116027480

Reviewed by Wenson Hsieh.

This commit fixes part of the failure in the
pointerevent_attributes_hoverable_pointers.html?mouse WPT, where the
failure mode suggests we&apos;re returning 0 for the button attribute of a
pointer event instead of -1.

This failure reflects an inconformity with the Pointer Events W3C spec
in our implementation of the button proprerty. As specified, an event&apos;s
button property should be -1 when &quot;Neither buttons nor touch/pen contact
changed since last event&quot;, but it does _not_ suggest limiting this
behavior to pointermove events only, which is what we were doing.

To be better aligned with other browser vendors (and the spec), we make
our button property heuristic less restrictive and applicable for all
pointer event types (barring pointerup/pointerdown, since they represent
button change). In doing so, we also take the liberty to rename
MouseEvent::PointerMove to MouseEvent::PointerHasNotChanged, since the
latter case better reflects the meaning of the `-1` button value.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_hoverable_pointers_mouse-expected.txt:
* Source/WebCore/dom/MouseEvent.cpp:
(WebCore::MouseEvent::button const):

* Source/WebCore/dom/PointerEvent.cpp:
(WebCore::PointerEvent::PointerEvent):
Do not unconditionally assign MouseButton::Left (0) to the button
property.

* Source/WebCore/dom/PointerEvent.h:
(WebCore::PointerEvent::typeIsUpOrDown):

Make `buttonForType` platform agnostic (and public), making it a more
useful utility and reducing code duplication.

* Source/WebCore/dom/ios/PointerEventIOS.cpp:
(WebCore::buttonForType): Deleted.
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::pointerEventType):
(WebCore::PointerCaptureController::pointerEventForMouseEvent):
* Source/WebCore/page/PointerCaptureController.h:
* Source/WebCore/platform/PlatformMouseEvent.h:

Rename MouseButton::PointerMove to MouseButton::PointerHasNotChanged.

Canonical link: <a href="https://commits.webkit.org/268459@main">https://commits.webkit.org/268459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/101999b527dd150c060fb1997d49de54adefd339

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19989 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22442 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24206 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22189 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15846 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17844 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4725 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->