### PR TITLE
Introduce UnifiedPDFPlugin

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -29,6 +29,7 @@
 #import <wtf/HashSet.h>
 #import <wtf/Noncopyable.h>
 #import <wtf/OptionSet.h>
+#import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -54,6 +54,10 @@
 #include <WebCore/AcceleratedEffectValues.h>
 #endif
 
+#if ENABLE(MODEL_ELEMENT)
+#include <WebCore/Model.h>
+#endif
+
 namespace WebKit {
 
 struct LayerProperties;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -668,6 +668,7 @@ WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 
 WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
 WebProcess/WebCoreSupport/WebValidationMessageClient.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3111,6 +3111,8 @@
 		0FF7CE892901FDA500EA62D6 /* RemoteScrollingTreeIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingTreeIOS.h; sourceTree = "<group>"; };
 		0FF7CE8A2901FDAC00EA62D6 /* RemoteScrollingTreeMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingTreeMac.h; sourceTree = "<group>"; };
 		0FF7CE8B2901FDAD00EA62D6 /* RemoteScrollingTreeMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteScrollingTreeMac.mm; sourceTree = "<group>"; };
+		0FFACF032AC2453300ED8DB6 /* UnifiedPDFPlugin.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UnifiedPDFPlugin.mm; sourceTree = "<group>"; };
+		0FFACF042AC2453300ED8DB6 /* UnifiedPDFPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnifiedPDFPlugin.h; sourceTree = "<group>"; };
 		0FFED98C23A3200400EEF459 /* WKWebViewIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebViewIOS.h; sourceTree = "<group>"; };
 		0FFED98D23A3200500EEF459 /* WKWebViewIOS.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewIOS.mm; sourceTree = "<group>"; };
 		0FFED98F23A3203700EEF459 /* WKWebViewMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewMac.mm; sourceTree = "<group>"; };
@@ -7982,6 +7984,16 @@
 				0F45A330239D89A100294ABF /* WKWebViewTestingIOS.mm */,
 			);
 			path = ios;
+			sourceTree = "<group>";
+		};
+		0FFACF022AC2453300ED8DB6 /* UnifiedPDF */ = {
+			isa = PBXGroup;
+			children = (
+				0FFACF042AC2453300ED8DB6 /* UnifiedPDFPlugin.h */,
+				0FFACF032AC2453300ED8DB6 /* UnifiedPDFPlugin.mm */,
+			);
+			name = UnifiedPDF;
+			path = PDF/UnifiedPDF;
 			sourceTree = "<group>";
 		};
 		1058C7B0FEA5585E11CA2CBB /* Linked Frameworks */ = {
@@ -14195,6 +14207,7 @@
 		E199875B142BF9CF00BB2DE7 /* PDF */ = {
 			isa = PBXGroup;
 			children = (
+				0FFACF022AC2453300ED8DB6 /* UnifiedPDF */,
 				3574B37F1665932C00859BB7 /* PDFAnnotationTextWidgetDetails.h */,
 				2D2ADF0C16363DEC00197E47 /* PDFLayerControllerSPI.h */,
 				2D0035221BC7414800DA8716 /* PDFPlugin.h */,

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_PDF)
+
+#include "PDFPluginBase.h"
+
+namespace WebKit {
+
+class WebFrame;
+
+class UnifiedPDFPlugin final : public PDFPluginBase {
+public:
+    static Ref<UnifiedPDFPlugin> create(WebCore::HTMLPlugInElement&);
+
+private:
+    explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
+    bool isUnifiedPDFPlugin() const override { return true; }
+
+    void teardown() override;
+
+    CGFloat scaleFactor() const override;
+
+    RetainPtr<PDFDocument> pdfDocumentForPrinting() const override;
+    WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
+
+    void streamDidReceiveResponse(const WebCore::ResourceResponse&) override;
+    void streamDidReceiveData(const WebCore::SharedBuffer&) override;
+    void streamDidFinishLoading() override;
+    void streamDidFail() override;
+    RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
+
+    bool handleMouseEvent(const WebMouseEvent&) override;
+    bool handleWheelEvent(const WebWheelEvent&) override;
+    bool handleMouseEnterEvent(const WebMouseEvent&) override;
+    bool handleMouseLeaveEvent(const WebMouseEvent&) override;
+    bool handleContextMenuEvent(const WebMouseEvent&) override;
+    bool handleKeyboardEvent(const WebKeyboardEvent&) override;
+    bool handleEditingCommand(StringView commandName) override;
+    bool isEditingCommandEnabled(StringView commandName) override;
+
+    String getSelectionString() const override;
+    bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const override;
+    WebCore::FloatRect rectForSelectionInRootView(PDFSelection *) const override;
+    unsigned countFindMatches(const String& target, WebCore::FindOptions, unsigned maxMatchCount) override;
+    bool findString(const String& target, WebCore::FindOptions, unsigned maxMatchCount) override;
+    bool performDictionaryLookupAtLocation(const WebCore::FloatPoint&) override;
+    std::tuple<String, PDFSelection *, NSDictionary *> lookupTextAtLocation(const WebCore::FloatPoint&, WebHitTestResultData&) const override;
+
+    RefPtr<ShareableBitmap> snapshot() override;
+
+    id accessibilityHitTest(const WebCore::IntPoint&) const override;
+    id accessibilityObject() const override;
+    id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
+};
+
+} // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::UnifiedPDFPlugin)
+    static bool isType(const WebKit::PDFPluginBase& plugin) { return plugin.isUnifiedPDFPlugin(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "UnifiedPDFPlugin.h"
+
+#if ENABLE(UNIFIED_PDF)
+
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<UnifiedPDFPlugin> UnifiedPDFPlugin::create(WebCore::HTMLPlugInElement& pluginElement)
+{
+    return adoptRef(*new UnifiedPDFPlugin(pluginElement));
+}
+
+UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
+    : PDFPluginBase(element)
+{
+}
+
+void UnifiedPDFPlugin::teardown()
+{
+
+}
+
+CGFloat UnifiedPDFPlugin::scaleFactor() const
+{
+    return 1;
+}
+
+RetainPtr<PDFDocument> UnifiedPDFPlugin::pdfDocumentForPrinting() const
+{
+    return nil;
+}
+
+WebCore::FloatSize UnifiedPDFPlugin::pdfDocumentSizeForPrinting() const
+{
+    return { };
+}
+
+void UnifiedPDFPlugin::streamDidReceiveResponse(const WebCore::ResourceResponse&)
+{
+
+}
+
+void UnifiedPDFPlugin::streamDidReceiveData(const WebCore::SharedBuffer&)
+{
+
+}
+
+void UnifiedPDFPlugin::streamDidFinishLoading()
+{
+
+}
+
+void UnifiedPDFPlugin::streamDidFail()
+{
+
+}
+
+RefPtr<FragmentedSharedBuffer> UnifiedPDFPlugin::liveResourceData() const
+{
+    return nullptr;
+}
+
+bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent&)
+{
+    return false;
+}
+
+bool UnifiedPDFPlugin::handleWheelEvent(const WebWheelEvent&)
+{
+    return false;
+}
+
+bool UnifiedPDFPlugin::handleMouseEnterEvent(const WebMouseEvent&)
+{
+    return false;
+}
+
+bool UnifiedPDFPlugin::handleMouseLeaveEvent(const WebMouseEvent&)
+{
+    return false;
+}
+
+bool UnifiedPDFPlugin::handleContextMenuEvent(const WebMouseEvent&)
+{
+    return false;
+}
+
+bool UnifiedPDFPlugin::handleKeyboardEvent(const WebKeyboardEvent&)
+{
+    return false;
+}
+
+bool UnifiedPDFPlugin::handleEditingCommand(StringView commandName)
+{
+    return false;
+}
+
+bool UnifiedPDFPlugin::isEditingCommandEnabled(StringView commandName)
+{
+    return false;
+}
+
+String UnifiedPDFPlugin::getSelectionString() const
+{
+    return emptyString();
+}
+
+bool UnifiedPDFPlugin::existingSelectionContainsPoint(const WebCore::FloatPoint&) const
+{
+    return false;
+}
+
+WebCore::FloatRect UnifiedPDFPlugin::rectForSelectionInRootView(PDFSelection *) const
+{
+    return { };
+}
+
+unsigned UnifiedPDFPlugin::countFindMatches(const String& target, WebCore::FindOptions, unsigned maxMatchCount)
+{
+    return 0;
+}
+
+bool UnifiedPDFPlugin::findString(const String& target, WebCore::FindOptions, unsigned maxMatchCount)
+{
+    return false;
+}
+
+bool UnifiedPDFPlugin::performDictionaryLookupAtLocation(const WebCore::FloatPoint&)
+{
+    return false;
+}
+
+std::tuple<String, PDFSelection *, NSDictionary *> UnifiedPDFPlugin::lookupTextAtLocation(const WebCore::FloatPoint&, WebHitTestResultData&) const
+{
+    return { };
+}
+
+RefPtr<ShareableBitmap> UnifiedPDFPlugin::snapshot()
+{
+    return nullptr;
+}
+
+id UnifiedPDFPlugin::accessibilityHitTest(const WebCore::IntPoint&) const
+{
+    return nil;
+}
+
+id UnifiedPDFPlugin::accessibilityObject() const
+{
+    return nil;
+}
+
+id UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement(WebCore::Element*) const
+{
+    return nil;
+}
+
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -46,7 +46,7 @@ class LocalFrame;
 
 namespace WebKit {
 
-class PDFPlugin;
+class PDFPluginBase;
 class ShareableBitmap;
 class WebPage;
 
@@ -144,7 +144,7 @@ private:
     void clipRectChanged() final;
 
     Ref<WebCore::HTMLPlugInElement> m_pluginElement;
-    Ref<PDFPlugin> m_plugin;
+    Ref<PDFPluginBase> m_plugin;
     WeakPtr<WebPage> m_webPage;
     URL m_mainResourceURL;
     String m_mainResourceContentType;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -35,7 +35,9 @@
 #import "VideoFullscreenManager.h"
 #import "WebFrame.h"
 #import "WebPage.h"
+#import "WebProcess.h"
 #import <WebCore/HTMLMediaElementIdentifier.h>
+#import <WebCore/HTMLVideoElement.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/Page.h>


### PR DESCRIPTION
#### b7c083b8e5ef3f450f1ae580f43cdd97fbeb80f1
<pre>
Introduce UnifiedPDFPlugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=262095">https://bugs.webkit.org/show_bug.cgi?id=262095</a>
rdar://116029997

Reviewed by Tim Horton.

Flesh out the interface of PDFPluginBase, which is a pure virtual base class for the
old PDFPlugin and the new UnifiedPDFPlugin. These may get renamed later.

Move code which we are sure to share to PDFPluginBase, and add stubs in UnifiedPDFPlugin.
This is all mechanical, other than some minor cleanup the the `destroy()` function.

PDFPlugin inherits `deviceScaleFactor()` from ScrollableArea, and since UnifiedPDFPlugin
may not end up being a ScrollableArea we can avoid multiple inheritance issues by just
changing code in PluginView to avoid calling it on the plugin.

PluginView creates a UnifiedPDFPlugin based on the runtime flag now.

Fix Unified sources fallout.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
(isType):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::PDFPlugin):
(WebKit::PDFPlugin::setView):
(WebKit::PDFPlugin::teardown):
(WebKit::PDFPlugin::destroy): Deleted.
(WebKit::PDFPlugin::isFullFramePlugin const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::isUnifiedPDFPlugin const):
(WebKit::PDFPluginBase::isLegacyPDFPlugin const):
(WebKit::PDFPluginBase::willDetachRenderer):
(WebKit::PDFPluginBase::isComposited const):
(WebKit::PDFPluginBase::geometryDidChange):
(WebKit::PDFPluginBase::visibilityDidChange):
(WebKit::PDFPluginBase::contentsScaleFactorChanged):
(WebKit::PDFPluginBase::updateControlTints):
(WebKit::PDFPluginBase::wantsWheelEvents const):
(WebKit::PDFPluginBase::isBeingDestroyed const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::setView):
(WebKit::PDFPluginBase::destroy):
(WebKit::PDFPluginBase::isFullFramePlugin const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h: Added.
(isType):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm: Added.
(WebKit::UnifiedPDFPlugin::create):
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::scaleFactor const):
(WebKit::UnifiedPDFPlugin::pdfDocumentForPrinting const):
(WebKit::UnifiedPDFPlugin::pdfDocumentSizeForPrinting const):
(WebKit::UnifiedPDFPlugin::streamDidReceiveResponse):
(WebKit::UnifiedPDFPlugin::streamDidReceiveData):
(WebKit::UnifiedPDFPlugin::streamDidFinishLoading):
(WebKit::UnifiedPDFPlugin::streamDidFail):
(WebKit::UnifiedPDFPlugin::liveResourceData const):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::handleWheelEvent):
(WebKit::UnifiedPDFPlugin::handleMouseEnterEvent):
(WebKit::UnifiedPDFPlugin::handleMouseLeaveEvent):
(WebKit::UnifiedPDFPlugin::handleContextMenuEvent):
(WebKit::UnifiedPDFPlugin::handleKeyboardEvent):
(WebKit::UnifiedPDFPlugin::handleEditingCommand):
(WebKit::UnifiedPDFPlugin::isEditingCommandEnabled):
(WebKit::UnifiedPDFPlugin::getSelectionString const):
(WebKit::UnifiedPDFPlugin::existingSelectionContainsPoint const):
(WebKit::UnifiedPDFPlugin::rectForSelectionInRootView const):
(WebKit::UnifiedPDFPlugin::countFindMatches):
(WebKit::UnifiedPDFPlugin::findString):
(WebKit::UnifiedPDFPlugin::performDictionaryLookupAtLocation):
(WebKit:: const):
(WebKit::UnifiedPDFPlugin::snapshot):
(WebKit::UnifiedPDFPlugin::accessibilityHitTest const):
(WebKit::UnifiedPDFPlugin::accessibilityObject const):
(WebKit::UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement const):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::createPlugin):
(WebKit::PluginView::PluginView):
(WebKit::PluginView::initializePlugin):
(WebKit::PluginView::platformLayer const):
(WebKit::PluginView::scroll):
(WebKit::PluginView::scrollPositionForTesting const):
(WebKit::PluginView::horizontalScrollbar):
(WebKit::PluginView::verticalScrollbar):
(WebKit::PluginView::wantsWheelEvents):
(WebKit::PluginView::paint):
(WebKit::PluginView::invalidateRect):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:

Canonical link: <a href="https://commits.webkit.org/268476@main">https://commits.webkit.org/268476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c24b1266b73fc774ab55454d039b696c6f4431d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21681 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18492 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20355 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22536 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17172 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24288 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22270 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15908 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17936 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4737 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18600 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->