### PR TITLE
[Win] Fix unused parameter warnings reported by clang-cl

### DIFF
--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -90,13 +90,13 @@ std::optional<uint64_t> fileSize(PlatformFileHandle fileHandle)
     return getFileSizeFromByHandleFileInformationStructure(fileInformation);
 }
 
-std::optional<PlatformFileID> fileID(PlatformFileHandle fileHandle)
+std::optional<PlatformFileID> fileID(PlatformFileHandle)
 {
     // FIXME (246118): Implement this function properly.
     return std::nullopt;
 }
 
-bool fileIDsAreEqual(std::optional<PlatformFileID> a, std::optional<PlatformFileID> b)
+bool fileIDsAreEqual(std::optional<PlatformFileID>, std::optional<PlatformFileID>)
 {
     // FIXME (246118): Implement this function properly.
     return true;
@@ -269,7 +269,7 @@ bool truncateFile(PlatformFileHandle handle, long long offset)
     return SetFileInformationByHandle(handle, FileEndOfFileInfo, &eofInfo, sizeof(FILE_END_OF_FILE_INFO));
 }
 
-bool flushFile(PlatformFileHandle handle)
+bool flushFile(PlatformFileHandle)
 {
     // Not implemented.
     return false;

--- a/Source/WTF/wtf/win/MemoryPressureHandlerWin.cpp
+++ b/Source/WTF/wtf/win/MemoryPressureHandlerWin.cpp
@@ -85,7 +85,7 @@ void MemoryPressureHandler::uninstall()
     m_installed = false;
 }
 
-void MemoryPressureHandler::holdOff(Seconds seconds)
+void MemoryPressureHandler::holdOff(Seconds)
 {
 }
 

--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -56,7 +56,7 @@ void* OSAllocator::reserveUncommitted(size_t bytes, Usage usage, bool writable, 
     return result;
 }
 
-void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, Usage usage, bool writable, bool executable, bool, bool)
+void* OSAllocator::tryReserveUncommittedAligned(size_t bytes, size_t alignment, Usage, bool writable, bool executable, bool, bool)
 {
     ASSERT(hasOneBitSet(alignment) && alignment >= pageSize());
 

--- a/Source/WebCore/accessibility/win/AccessibilityObjectWin.cpp
+++ b/Source/WebCore/accessibility/win/AccessibilityObjectWin.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-void AccessibilityObject::detachPlatformWrapper(AccessibilityDetachmentType detachmentType)
+void AccessibilityObject::detachPlatformWrapper(AccessibilityDetachmentType)
 {
     // On Windows, AccessibilityObjects are created when get_accChildCount is
     // called, but they are not wrapped until get_accChild is called, so this

--- a/Source/WebCore/platform/StaticPasteboard.cpp
+++ b/Source/WebCore/platform/StaticPasteboard.cpp
@@ -151,6 +151,8 @@ void StaticPasteboard::write(const PasteboardWebContent& content)
 #elif PLATFORM(GTK) || USE(LIBWPE)
     markup = content.markup;
     text = content.text;
+#else
+    UNUSED_PARAM(content);
 #endif
 
     if (!markup.isEmpty())

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -203,7 +203,7 @@ protected:
     static void fillWithSolidColor(GraphicsContext&, const FloatRect& dstRect, const Color&, CompositeOperator);
 
 #if PLATFORM(WIN)
-    virtual void drawFrameMatchingSourceSize(GraphicsContext&, const FloatRect& dstRect, const IntSize& srcSize, CompositeOperator) { }
+    virtual void drawFrameMatchingSourceSize(GraphicsContext&, const FloatRect&, const IntSize&, CompositeOperator) { }
 #endif
     virtual bool shouldDrawFromCachedSubimage(GraphicsContext&) const { return false; }
     virtual bool mustDrawFromCachedSubimage(GraphicsContext&) const { return false; }

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -65,7 +65,7 @@ IMLangFontLinkType* FontCache::getFontLinkInterface()
     return langFontLink;
 }
 
-static int CALLBACK metaFileEnumProc(HDC hdc, HANDLETABLE* table, CONST ENHMETARECORD* record, int tableEntries, LPARAM logFont)
+static int CALLBACK metaFileEnumProc(HDC, HANDLETABLE*, CONST ENHMETARECORD* record, int, LPARAM logFont)
 {
     if (record->iType == EMR_EXTCREATEFONTINDIRECTW) {
         const EMREXTCREATEFONTINDIRECTW* createFontRecord = reinterpret_cast<const EMREXTCREATEFONTINDIRECTW*>(record);
@@ -74,7 +74,7 @@ static int CALLBACK metaFileEnumProc(HDC hdc, HANDLETABLE* table, CONST ENHMETAR
     return true;
 }
 
-static int CALLBACK linkedFontEnumProc(CONST LOGFONT* logFont, CONST TEXTMETRIC* metrics, DWORD fontType, LPARAM hfont)
+static int CALLBACK linkedFontEnumProc(CONST LOGFONT* logFont, CONST TEXTMETRIC*, DWORD, LPARAM hfont)
 {
     *reinterpret_cast<HFONT*>(hfont) = CreateFontIndirect(logFont);
     return false;
@@ -463,7 +463,7 @@ struct MatchImprovingProcData {
     LOGFONT m_chosen;
 };
 
-static int CALLBACK matchImprovingEnumProc(CONST LOGFONT* candidate, CONST TEXTMETRIC* metrics, DWORD fontType, LPARAM lParam)
+static int CALLBACK matchImprovingEnumProc(CONST LOGFONT* candidate, CONST TEXTMETRIC*, DWORD, LPARAM lParam)
 {
     MatchImprovingProcData* matchData = reinterpret_cast<MatchImprovingProcData*>(lParam);
 
@@ -554,7 +554,7 @@ struct TraitsInFamilyProcData {
     Vector<FontSelectionCapabilities> m_capabilities;
 };
 
-static int CALLBACK traitsInFamilyEnumProc(CONST LOGFONT* logFont, CONST TEXTMETRIC* metrics, DWORD fontType, LPARAM lParam)
+static int CALLBACK traitsInFamilyEnumProc(CONST LOGFONT* logFont, CONST TEXTMETRIC*, DWORD, LPARAM lParam)
 {
     TraitsInFamilyProcData* procData = reinterpret_cast<TraitsInFamilyProcData*>(lParam);
 

--- a/Source/WebCore/platform/graphics/win/FontPlatformDataCairoWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontPlatformDataCairoWin.cpp
@@ -39,7 +39,7 @@
 
 namespace WebCore {
 
-void FontPlatformData::platformDataInit(HFONT font, float size, HDC hdc, WCHAR* faceName)
+void FontPlatformData::platformDataInit(HFONT font, float size, HDC, WCHAR* faceName)
 {
     cairo_font_face_t* fontFace = cairo_win32_font_face_create_for_hfont(font);
 

--- a/Source/WebCore/platform/graphics/win/GraphicsContextCairoWin.cpp
+++ b/Source/WebCore/platform/graphics/win/GraphicsContextCairoWin.cpp
@@ -37,7 +37,7 @@
 namespace WebCore {
 
 #if PLATFORM(WIN)
-static RefPtr<cairo_t> createCairoContextWithHDC(HDC hdc, bool hasAlpha)
+static RefPtr<cairo_t> createCairoContextWithHDC(HDC hdc)
 {
     // Put the HDC In advanced mode so it will honor affine transforms.
     SetGraphicsMode(hdc, GM_ADVANCED);
@@ -65,8 +65,8 @@ static RefPtr<cairo_t> createCairoContextWithHDC(HDC hdc, bool hasAlpha)
     return context;
 }
 
-GraphicsContextCairo::GraphicsContextCairo(HDC dc, bool hasAlpha)
-    : GraphicsContextCairo(createCairoContextWithHDC(dc, hasAlpha))
+GraphicsContextCairo::GraphicsContextCairo(HDC dc, bool)
+    : GraphicsContextCairo(createCairoContextWithHDC(dc))
 {
 }
 

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -87,7 +87,7 @@ public:
         return refCount;
     }
 
-    HRESULT STDMETHODCALLTYPE GetParameters(__RPC__out DWORD *pdwFlags, __RPC__out DWORD *pdwQueue) override
+    HRESULT STDMETHODCALLTYPE GetParameters(__RPC__out DWORD*, __RPC__out DWORD*) override
     {
         // Implementation of this method is optional. Returning E_NOTIMPL gives default values.
         return E_NOTIMPL;
@@ -979,7 +979,7 @@ ULONG MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::Release()
     return refCount;
 }
 
-HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockStart(MFTIME hnsSystemTime, LONGLONG llClockStartOffset)
+HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockStart(MFTIME, LONGLONG llClockStartOffset)
 {
     Locker locker { m_lock };
 
@@ -1002,7 +1002,7 @@ HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockStart(MF
     return S_OK;
 }
 
-HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockStop(MFTIME hnsSystemTime)
+HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockStop(MFTIME)
 {
     Locker locker { m_lock };
 
@@ -1018,7 +1018,7 @@ HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockStop(MFT
     return S_OK;
 }
 
-HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockPause(MFTIME hnsSystemTime)
+HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockPause(MFTIME)
 {
     Locker locker { m_lock };
 
@@ -1032,7 +1032,7 @@ HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockPause(MF
     return S_OK;
 }
 
-HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockRestart(MFTIME hnsSystemTime)
+HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockRestart(MFTIME)
 {
     Locker locker { m_lock };
 
@@ -1049,7 +1049,7 @@ HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockRestart(
     return S_OK;
 }
 
-HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockSetRate(MFTIME hnsSystemTime, float rate)
+HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockSetRate(MFTIME, float rate)
 {
     Locker locker { m_lock };
 
@@ -1064,7 +1064,7 @@ HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockSetRate(
     return S_OK;
 }
 
-HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::ProcessMessage(MFVP_MESSAGE_TYPE eMessage, ULONG_PTR ulParam)
+HRESULT MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::ProcessMessage(MFVP_MESSAGE_TYPE eMessage, ULONG_PTR)
 {
     Locker locker { m_lock };
 
@@ -2580,7 +2580,7 @@ MediaPlayerPrivateMediaFoundation::Direct3DPresenter::Direct3DPresenter()
 
 MediaPlayerPrivateMediaFoundation::Direct3DPresenter::~Direct3DPresenter() = default;
 
-HRESULT MediaPlayerPrivateMediaFoundation::Direct3DPresenter::getService(REFGUID guidService, REFIID riid, void** ppv)
+HRESULT MediaPlayerPrivateMediaFoundation::Direct3DPresenter::getService(REFGUID, REFIID riid, void** ppv)
 {
     ASSERT(ppv);
 
@@ -2742,7 +2742,7 @@ HRESULT MediaPlayerPrivateMediaFoundation::Direct3DPresenter::checkDeviceState(D
     return hr;
 }
 
-HRESULT MediaPlayerPrivateMediaFoundation::Direct3DPresenter::presentSample(IMFSample* sample, LONGLONG targetPresentationTime)
+HRESULT MediaPlayerPrivateMediaFoundation::Direct3DPresenter::presentSample(IMFSample* sample, LONGLONG)
 {
     HRESULT hr = S_OK;
 

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -349,58 +349,58 @@ private:
         HRESULT STDMETHODCALLTYPE ShutdownObject() override;
 
         // IMFAttributes
-        HRESULT STDMETHODCALLTYPE GetItem(__RPC__in REFGUID guidKey, __RPC__inout_opt PROPVARIANT *pValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetItemType(__RPC__in REFGUID guidKey, __RPC__out MF_ATTRIBUTE_TYPE *pType) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE CompareItem(__RPC__in REFGUID guidKey, __RPC__in REFPROPVARIANT Value, __RPC__out BOOL *pbResult) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE Compare(__RPC__in_opt IMFAttributes *pTheirs, MF_ATTRIBUTES_MATCH_TYPE MatchType, __RPC__out BOOL *pbResult) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetUINT32(__RPC__in REFGUID guidKey, __RPC__out UINT32 *punValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetUINT64(__RPC__in REFGUID guidKey, __RPC__out UINT64 *punValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetDouble(__RPC__in REFGUID guidKey, __RPC__out double *pfValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetGUID(__RPC__in REFGUID guidKey, __RPC__out GUID *pguidValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetStringLength(__RPC__in REFGUID guidKey, __RPC__out UINT32 *pcchLength) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetString(__RPC__in REFGUID guidKey, __RPC__out_ecount_full(cchBufSize) LPWSTR pwszValue, UINT32 cchBufSize, __RPC__inout_opt UINT32 *pcchLength) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetAllocatedString(__RPC__in REFGUID guidKey, __RPC__deref_out_ecount_full_opt((*pcchLength + 1)) LPWSTR *ppwszValue, __RPC__out UINT32 *pcchLength) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetBlobSize(__RPC__in REFGUID guidKey, __RPC__out UINT32 *pcbBlobSize) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetBlob(__RPC__in REFGUID guidKey, __RPC__out_ecount_full(cbBufSize) UINT8 *pBuf, UINT32 cbBufSize, __RPC__inout_opt UINT32 *pcbBlobSize) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetAllocatedBlob(__RPC__in REFGUID guidKey, __RPC__deref_out_ecount_full_opt(*pcbSize) UINT8 **ppBuf, __RPC__out UINT32 *pcbSize) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetUnknown(__RPC__in REFGUID guidKey, __RPC__in REFIID riid, __RPC__deref_out_opt LPVOID *ppv) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetItem(__RPC__in REFGUID guidKey, __RPC__in REFPROPVARIANT Value) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE DeleteItem(__RPC__in REFGUID guidKey) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetItem(__RPC__in REFGUID, __RPC__inout_opt PROPVARIANT*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetItemType(__RPC__in REFGUID, __RPC__out MF_ATTRIBUTE_TYPE*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE CompareItem(__RPC__in REFGUID, __RPC__in REFPROPVARIANT, __RPC__out BOOL*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE Compare(__RPC__in_opt IMFAttributes*, MF_ATTRIBUTES_MATCH_TYPE, __RPC__out BOOL*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetUINT32(__RPC__in REFGUID, __RPC__out UINT32*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetUINT64(__RPC__in REFGUID, __RPC__out UINT64*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetDouble(__RPC__in REFGUID, __RPC__out double*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetGUID(__RPC__in REFGUID, __RPC__out GUID*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetStringLength(__RPC__in REFGUID, __RPC__out UINT32*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetString(__RPC__in REFGUID, __RPC__out_ecount_full(cchBufSize) LPWSTR, UINT32, __RPC__inout_opt UINT32*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetAllocatedString(__RPC__in REFGUID, __RPC__deref_out_ecount_full_opt((*pcchLength + 1)) LPWSTR*, __RPC__out UINT32*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetBlobSize(__RPC__in REFGUID, __RPC__out UINT32*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetBlob(__RPC__in REFGUID, __RPC__out_ecount_full(cbBufSize) UINT8*, UINT32, __RPC__inout_opt UINT32*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetAllocatedBlob(__RPC__in REFGUID, __RPC__deref_out_ecount_full_opt(*pcbSize) UINT8**, __RPC__out UINT32*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetUnknown(__RPC__in REFGUID, __RPC__in REFIID, __RPC__deref_out_opt LPVOID*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetItem(__RPC__in REFGUID, __RPC__in REFPROPVARIANT) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE DeleteItem(__RPC__in REFGUID) override { return E_NOTIMPL; }
         HRESULT STDMETHODCALLTYPE DeleteAllItems(void) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetUINT32(__RPC__in REFGUID guidKey, UINT32 unValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetUINT64(__RPC__in REFGUID guidKey, UINT64 unValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetDouble(__RPC__in REFGUID guidKey, double fValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetGUID(__RPC__in REFGUID guidKey, __RPC__in REFGUID guidValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetString(__RPC__in REFGUID guidKey, __RPC__in_string LPCWSTR wszValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetBlob(__RPC__in REFGUID guidKey, __RPC__in_ecount_full(cbBufSize) const UINT8 *pBuf, UINT32 cbBufSize) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetUnknown(__RPC__in REFGUID guidKey, __RPC__in_opt IUnknown *pUnknown) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetUINT32(__RPC__in REFGUID, UINT32) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetUINT64(__RPC__in REFGUID, UINT64) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetDouble(__RPC__in REFGUID, double) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetGUID(__RPC__in REFGUID, __RPC__in REFGUID) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetString(__RPC__in REFGUID, __RPC__in_string LPCWSTR) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetBlob(__RPC__in REFGUID, __RPC__in_ecount_full(cbBufSize) const UINT8*, UINT32) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetUnknown(__RPC__in REFGUID, __RPC__in_opt IUnknown*) override { return E_NOTIMPL; }
         HRESULT STDMETHODCALLTYPE LockStore(void) override { return E_NOTIMPL; }
         HRESULT STDMETHODCALLTYPE UnlockStore(void) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetCount(__RPC__out UINT32 *pcItems) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetItemByIndex(UINT32 unIndex, __RPC__out GUID *pguidKey, __RPC__inout_opt PROPVARIANT *pValue) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE CopyAllItems(__RPC__in_opt IMFAttributes *pDest) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetCount(__RPC__out UINT32*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetItemByIndex(UINT32, __RPC__out GUID*, __RPC__inout_opt PROPVARIANT*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE CopyAllItems(__RPC__in_opt IMFAttributes*) override { return E_NOTIMPL; }
 
         // IMFVideoDisplayControl
-        HRESULT STDMETHODCALLTYPE GetNativeVideoSize(SIZE* pszVideo, SIZE* pszARVideo) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetIdealVideoSize(SIZE* pszMin, SIZE* pszMax) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetNativeVideoSize(SIZE*, SIZE*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetIdealVideoSize(SIZE*, SIZE*) override { return E_NOTIMPL; }
         HRESULT STDMETHODCALLTYPE SetVideoPosition(const MFVideoNormalizedRect* pnrcSource, const LPRECT prcDest) override;
         HRESULT STDMETHODCALLTYPE GetVideoPosition(MFVideoNormalizedRect* pnrcSource, LPRECT prcDest) override;
-        HRESULT STDMETHODCALLTYPE SetAspectRatioMode(DWORD dwAspectRatioMode) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetAspectRatioMode(DWORD* pdwAspectRatioMode) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetAspectRatioMode(DWORD) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetAspectRatioMode(DWORD*) override { return E_NOTIMPL; }
         HRESULT STDMETHODCALLTYPE SetVideoWindow(HWND hwndVideo) override;
         HRESULT STDMETHODCALLTYPE GetVideoWindow(HWND* phwndVideo) override;
         HRESULT STDMETHODCALLTYPE RepaintVideo() override;
-        HRESULT STDMETHODCALLTYPE GetCurrentImage(BITMAPINFOHEADER* pBih, BYTE** pDib, DWORD* pcbDib, LONGLONG* pTimeStamp) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetBorderColor(COLORREF Clr) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetBorderColor(COLORREF* pClr) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetRenderingPrefs(DWORD dwRenderFlags) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetRenderingPrefs(DWORD* pdwRenderFlags) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE SetFullscreen(BOOL bFullscreen) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE GetFullscreen(BOOL* pbFullscreen) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetCurrentImage(BITMAPINFOHEADER*, BYTE**, DWORD*, LONGLONG*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetBorderColor(COLORREF) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetBorderColor(COLORREF*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetRenderingPrefs(DWORD) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetRenderingPrefs(DWORD*) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE SetFullscreen(BOOL) override { return E_NOTIMPL; }
+        HRESULT STDMETHODCALLTYPE GetFullscreen(BOOL*) override { return E_NOTIMPL; }
 
         // IMFAsyncCallback methods
         HRESULT STDMETHODCALLTYPE GetParameters(DWORD*, DWORD*) override { return E_NOTIMPL; }
-        HRESULT STDMETHODCALLTYPE Invoke(IMFAsyncResult* pAsyncResult) override;
+        HRESULT STDMETHODCALLTYPE Invoke(IMFAsyncResult*) override;
 
         // MediaPlayerListener
         void onMediaPlayerDeleted() override;

--- a/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
@@ -51,7 +51,7 @@ void Font::platformDestroy()
     ScriptFreeCache(&m_scriptCache);
 }
 
-RefPtr<Font> Font::platformCreateScaledFont(const FontDescription& fontDescription, float scaleFactor) const
+RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleFactor) const
 {
     float scaledSize = scaleFactor * m_platformData.size();
     if (origin() == Origin::Remote)

--- a/Source/WebCore/platform/network/win/NetworkStateNotifierWin.cpp
+++ b/Source/WebCore/platform/network/win/NetworkStateNotifierWin.cpp
@@ -56,7 +56,7 @@ void NetworkStateNotifier::updateStateWithoutNotifying()
     m_isOnLine = false;
 }
 
-void CALLBACK NetworkStateNotifier::addressChangeCallback(void*, BOOLEAN timedOut)
+void CALLBACK NetworkStateNotifier::addressChangeCallback(void*, BOOLEAN)
 {
     callOnMainThread([] {
         // NotifyAddrChange only notifies us of a single address change. Now that we've been notified,

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -540,7 +540,7 @@ void Pasteboard::writeSelection(const SimpleRange& selectedRange, bool canSmartC
     writeRangeToDataObject(selectedRange, frame);
 }
 
-void Pasteboard::writePlainTextToDataObject(const String& text, SmartReplaceOption smartReplaceOption)
+void Pasteboard::writePlainTextToDataObject(const String& text, SmartReplaceOption)
 {
     if (!m_writableDataObject)
         return;

--- a/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
+++ b/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 
 #define HIGH_BIT_MASK_SHORT 0x8000
 
-static IntPoint positionForEvent(HWND hWnd, LPARAM lParam)
+static IntPoint positionForEvent(HWND, LPARAM lParam)
 {
     IntPoint point(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
     return point;

--- a/Source/WebCore/platform/win/WidgetWin.cpp
+++ b/Source/WebCore/platform/win/WidgetWin.cpp
@@ -73,7 +73,7 @@ void Widget::paint(GraphicsContext&, const IntRect&, SecurityOriginPaintPolicy, 
 {
 }
 
-void Widget::setFocus(bool focused)
+void Widget::setFocus(bool)
 {
 }
 

--- a/Source/WebDriver/win/WebDriverServiceWin.cpp
+++ b/Source/WebDriver/win/WebDriverServiceWin.cpp
@@ -43,12 +43,12 @@ Capabilities WebDriverService::platformCapabilities()
     return capabilities;
 }
 
-bool WebDriverService::platformCompareBrowserVersions(const String& requiredVersion, const String& proposedVersion)
+bool WebDriverService::platformCompareBrowserVersions(const String&, const String&)
 {
     return true;
 }
 
-bool WebDriverService::platformValidateCapability(const String& name, const Ref<JSON::Value>& value) const
+bool WebDriverService::platformValidateCapability(const String&, const Ref<JSON::Value>&) const
 {
     return true;
 }

--- a/Tools/MiniBrowser/win/DialogHelper.h
+++ b/Tools/MiniBrowser/win/DialogHelper.h
@@ -82,7 +82,7 @@ protected:
     virtual void update() { updateOkButton(validate()); }
     virtual bool validate() { return true; }
     virtual void updateOkButton(bool isValid) { setEnabled(IDOK, isValid); }
-    virtual bool command(int wmId) { return false; }
+    virtual bool command(int) { return false; }
     virtual void ok() { }
     virtual void cancel() { }
 

--- a/Tools/MiniBrowser/win/InjectedBundle.cpp
+++ b/Tools/MiniBrowser/win/InjectedBundle.cpp
@@ -31,7 +31,7 @@
 #include <WebKit/WKBundlePage.h>
 #include <WebKit/WKBundlePrivate.h>
 
-void didReceiveMessageToPage(WKBundleRef bundle, WKBundlePageRef page, WKStringRef messageName, WKTypeRef messageBody, const void* clientInfo)
+void didReceiveMessageToPage(WKBundleRef, WKBundlePageRef page, WKStringRef messageName, WKTypeRef, const void*)
 {
     if (WKStringIsEqualToUTF8CString(messageName, "DumpLayerTree")) {
         auto frame = WKBundlePageGetMainFrame(page);

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
@@ -305,7 +305,7 @@ void WebKitBrowserWindow::navigateForwardOrBackward(bool forward)
         WKPageGoBack(page);
 }
 
-void WebKitBrowserWindow::navigateToHistory(UINT menuID)
+void WebKitBrowserWindow::navigateToHistory(UINT)
 {
     // Not implemented
 }
@@ -385,7 +385,7 @@ void WebKitBrowserWindow::showLayerTree()
     WKPagePostMessageToInjectedBundle(page, name.get(), nullptr);
 }
 
-void WebKitBrowserWindow::updateStatistics(HWND hDlg)
+void WebKitBrowserWindow::updateStatistics(HWND)
 {
     // Not implemented
 }
@@ -498,7 +498,7 @@ void WebKitBrowserWindow::didChangeActiveURL(const void* clientInfo)
     thisWindow.m_client.activeURLChanged(createString(url.get()));
 }
 
-void WebKitBrowserWindow::decidePolicyForNavigationResponse(WKPageRef page, WKNavigationResponseRef navigationResponse, WKFramePolicyListenerRef listener, WKTypeRef userData, const void* clientInfo)
+void WebKitBrowserWindow::decidePolicyForNavigationResponse(WKPageRef, WKNavigationResponseRef navigationResponse, WKFramePolicyListenerRef listener, WKTypeRef, const void* clientInfo)
 {
     auto& thisWindow = toWebKitBrowserWindow(clientInfo);
     auto response = adoptWK(WKNavigationResponseCopyResponse(navigationResponse));
@@ -529,7 +529,7 @@ void WebKitBrowserWindow::decidePolicyForNavigationResponse(WKPageRef page, WKNa
     }
 }
 
-void WebKitBrowserWindow::didFailProvisionalNavigation(WKPageRef page, WKNavigationRef navigation, WKErrorRef error, WKTypeRef userData, const void* clientInfo)
+void WebKitBrowserWindow::didFailProvisionalNavigation(WKPageRef, WKNavigationRef, WKErrorRef error, WKTypeRef, const void* clientInfo)
 {
     auto& thisWindow = toWebKitBrowserWindow(clientInfo);
     std::wstringstream text;
@@ -540,7 +540,7 @@ void WebKitBrowserWindow::didFailProvisionalNavigation(WKPageRef page, WKNavigat
     MessageBox(thisWindow.m_hMainWnd, text.str().c_str(), L"Provisional Navigation Failure", MB_OK | MB_ICONWARNING);
 }
 
-void WebKitBrowserWindow::didReceiveAuthenticationChallenge(WKPageRef page, WKAuthenticationChallengeRef challenge, const void* clientInfo)
+void WebKitBrowserWindow::didReceiveAuthenticationChallenge(WKPageRef, WKAuthenticationChallengeRef challenge, const void* clientInfo)
 {
     auto& thisWindow = toWebKitBrowserWindow(clientInfo);
     auto protectionSpace = WKAuthenticationChallengeGetProtectionSpace(challenge);
@@ -657,7 +657,7 @@ void WebKitBrowserWindow::downloadDidFailWithError(WKDownloadRef, WKErrorRef err
     MessageBox(thisWindow.hwnd(), text.str().c_str(), L"Download Failure", MB_OK | MB_ICONWARNING);
 }
 
-WKPageRef WebKitBrowserWindow::createNewPage(WKPageRef page, WKPageConfigurationRef pageConf, WKNavigationActionRef navigationAction, WKWindowFeaturesRef windowFeatures, const void *clientInfo)
+WKPageRef WebKitBrowserWindow::createNewPage(WKPageRef, WKPageConfigurationRef pageConf, WKNavigationActionRef, WKWindowFeaturesRef, const void*)
 {
     auto& newWindow = MainWindow::create().leakRef();
     auto factory = [pageConf](BrowserWindowClient& client, HWND mainWnd, bool) -> auto {
@@ -678,7 +678,7 @@ void WebKitBrowserWindow::didNotHandleKeyEvent(WKPageRef, WKNativeEventPtr event
     PostMessage(thisWindow.m_hMainWnd, event->message, event->wParam, event->lParam);
 }
 
-void WebKitBrowserWindow::runJavaScriptAlert(WKPageRef page, WKStringRef alertText, WKFrameRef frame, WKSecurityOriginRef securityOrigin, WKPageRunJavaScriptAlertResultListenerRef listener, const void *clientInfo)
+void WebKitBrowserWindow::runJavaScriptAlert(WKPageRef, WKStringRef alertText, WKFrameRef, WKSecurityOriginRef securityOrigin, WKPageRunJavaScriptAlertResultListenerRef listener, const void* clientInfo)
 {
     auto& thisWindow = toWebKitBrowserWindow(clientInfo);
     std::wstring title = L"Alert: ";
@@ -688,7 +688,7 @@ void WebKitBrowserWindow::runJavaScriptAlert(WKPageRef page, WKStringRef alertTe
     WKPageRunJavaScriptAlertResultListenerCall(listener);
 }
 
-void WebKitBrowserWindow::runJavaScriptConfirm(WKPageRef page, WKStringRef message, WKFrameRef frame, WKSecurityOriginRef securityOrigin, WKPageRunJavaScriptConfirmResultListenerRef listener, const void *clientInfo)
+void WebKitBrowserWindow::runJavaScriptConfirm(WKPageRef, WKStringRef message, WKFrameRef, WKSecurityOriginRef securityOrigin, WKPageRunJavaScriptConfirmResultListenerRef listener, const void* clientInfo)
 {
     auto& thisWindow = toWebKitBrowserWindow(clientInfo);
     std::wstring title = L"Confirm: ";
@@ -698,7 +698,7 @@ void WebKitBrowserWindow::runJavaScriptConfirm(WKPageRef page, WKStringRef messa
     WKPageRunJavaScriptConfirmResultListenerCall(listener, result);
 }
 
-void WebKitBrowserWindow::runJavaScriptPrompt(WKPageRef page, WKStringRef message, WKStringRef defaultValue, WKFrameRef frame, WKSecurityOriginRef securityOrigin, WKPageRunJavaScriptPromptResultListenerRef listener, const void *clientInfo)
+void WebKitBrowserWindow::runJavaScriptPrompt(WKPageRef, WKStringRef message, WKStringRef defaultValue, WKFrameRef, WKSecurityOriginRef securityOrigin, WKPageRunJavaScriptPromptResultListenerRef listener, const void* clientInfo)
 {
     auto& thisWindow = toWebKitBrowserWindow(clientInfo);
     std::wstring title = L"Prompt: ";

--- a/Tools/MiniBrowser/win/WinMain.cpp
+++ b/Tools/MiniBrowser/win/WinMain.cpp
@@ -37,7 +37,7 @@
 SOFT_LINK_LIBRARY(user32);
 SOFT_LINK_OPTIONAL(user32, SetProcessDpiAwarenessContext, BOOL, STDAPICALLTYPE, (DPI_AWARENESS_CONTEXT));
 
-int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPWSTR lpstrCmdLine, _In_ int nCmdShow)
+int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int nCmdShow)
 {
     hInst = hInstance;
 #ifdef _CRTDBG_MAP_ALLOC


### PR DESCRIPTION
#### 6cc3f85ca0cf2ead6c93a48cf5b0511876180a0d
<pre>
[Win] Fix unused parameter warnings reported by clang-cl
<a href="https://bugs.webkit.org/show_bug.cgi?id=262098">https://bugs.webkit.org/show_bug.cgi?id=262098</a>

Reviewed by Ross Kirsling.

clang-cl reported a lot of unused parameter warnings like the following.

&gt; Source\WebCore\platform/StaticPasteboard.cpp(143,58): error: unused parameter &apos;content&apos; [-Werror,-Wunused-parameter]

* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::fileID):
(WTF::FileSystemImpl::fileIDsAreEqual):
(WTF::FileSystemImpl::flushFile):
* Source/WTF/wtf/win/MemoryPressureHandlerWin.cpp:
(WTF::MemoryPressureHandler::holdOff):
* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::tryReserveUncommittedAligned):
* Source/WebCore/accessibility/win/AccessibilityObjectWin.cpp:
(WebCore::AccessibilityObject::detachPlatformWrapper):
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::drawFrameMatchingSourceSize):
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
(WebCore::metaFileEnumProc):
(WebCore::linkedFontEnumProc):
(WebCore::matchImprovingEnumProc):
(WebCore::traitsInFamilyEnumProc):
* Source/WebCore/platform/graphics/win/FontPlatformDataCairoWin.cpp:
(WebCore::FontPlatformData::platformDataInit):
* Source/WebCore/platform/graphics/win/GraphicsContextCairoWin.cpp:
(WebCore::createCairoContextWithHDC):
(WebCore::GraphicsContextCairo::GraphicsContextCairo):
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
(WebCore::MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockStart):
(WebCore::MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockStop):
(WebCore::MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockPause):
(WebCore::MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockRestart):
(WebCore::MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::OnClockSetRate):
(WebCore::MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::ProcessMessage):
(WebCore::MediaPlayerPrivateMediaFoundation::Direct3DPresenter::getService):
(WebCore::MediaPlayerPrivateMediaFoundation::Direct3DPresenter::presentSample):
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:
* Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp:
(WebCore::Font::platformCreateScaledFont const):
* Source/WebCore/platform/network/win/NetworkStateNotifierWin.cpp:
(WebCore::NetworkStateNotifier::addressChangeCallback):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::Pasteboard::writePlainTextToDataObject):
* Source/WebCore/platform/win/PlatformMouseEventWin.cpp:
(WebCore::positionForEvent):
* Source/WebCore/platform/win/WidgetWin.cpp:
(WebCore::Widget::setFocus):
* Source/WebDriver/win/WebDriverServiceWin.cpp:
(WebDriver::WebDriverService::platformCompareBrowserVersions):
(WebDriver::WebDriverService::platformValidateCapability const):
* Tools/MiniBrowser/win/DialogHelper.h:
(Dialog::command):
* Tools/MiniBrowser/win/InjectedBundle.cpp:
(didReceiveMessageToPage):
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
(WebKitBrowserWindow::navigateToHistory):
(WebKitBrowserWindow::updateStatistics):
(WebKitBrowserWindow::decidePolicyForNavigationResponse):
(WebKitBrowserWindow::didFailProvisionalNavigation):
(WebKitBrowserWindow::didReceiveAuthenticationChallenge):
(WebKitBrowserWindow::createNewPage):
(WebKitBrowserWindow::runJavaScriptAlert):
(WebKitBrowserWindow::runJavaScriptConfirm):
(WebKitBrowserWindow::runJavaScriptPrompt):
* Tools/MiniBrowser/win/WinMain.cpp:
(wWinMain):

Canonical link: <a href="https://commits.webkit.org/268434@main">https://commits.webkit.org/268434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6ec9b9944ce07c116cc53945aee58d47d112327

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21626 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/19967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20297 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19951 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/19954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22480 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/17956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/17155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/18202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/19103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23130 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/17882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/22233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24383 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2410 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5405 "Passed tests") | 
<!--EWS-Status-Bubble-End-->