### PR TITLE
imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-replaced.html is a perma-failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2157,7 +2157,4 @@ webkit.org/b/261344 requestidlecallback/requestidlecallback-does-not-block-timer
 
 webkit.org/b/261906 imported/w3c/web-platform-tests/editing/run/forwarddelete.html?6001-last [ Slow ]
 
-webkit.org/b/262019 imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-replaced.html [ Failure ]
-webkit.org/b/262020 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ ImageOnlyFailure ]
-
 webkit.org/b/262079 [ Ventura+ arm64 ] fast/gradients/alpha-premultiplied-representable-by-unpremultiplied.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -214,7 +214,8 @@ void MediaPlayerPrivateWebM::loadFailed(const ResourceError& error)
 void MediaPlayerPrivateWebM::loadFinished(const FragmentedSharedBuffer&)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    setNetworkState(MediaPlayer::NetworkState::Idle);
+    if (m_readyState >= MediaPlayer::ReadyState::HaveMetadata)
+        setNetworkState(MediaPlayer::NetworkState::Idle);
     m_loadFinished = true;
 }
 
@@ -512,10 +513,13 @@ void MediaPlayerPrivateWebM::setNaturalSize(FloatSize size)
         INFO_LOG(LOGIDENTIFIER, "was ", oldSize, ", is ", size);
         if (auto player = m_player.get())
             player->sizeChanged();
-        
-        if (m_readyState < MediaPlayer::ReadyState::HaveMetadata)
-            setReadyState(MediaPlayer::ReadyState::HaveMetadata);
     }
+
+    if (m_readyState < MediaPlayer::ReadyState::HaveMetadata)
+        setReadyState(MediaPlayer::ReadyState::HaveMetadata);
+
+    if (m_loadFinished)
+        setNetworkState(MediaPlayer::NetworkState::Idle);
 }
 
 void MediaPlayerPrivateWebM::setHasAudio(bool hasAudio)
@@ -1130,6 +1134,8 @@ void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObj
 void MediaPlayerPrivateWebM::append(SharedBuffer& buffer)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "data length = ", buffer.size());
+
+    setNetworkState(MediaPlayer::NetworkState::Loading);
 
     m_parser->setDidParseInitializationDataCallback([weakThis = WeakPtr { *this }, abortCalled = m_abortCalled.load()] (InitializationSegment&& segment) {
         if (!weakThis || abortCalled != weakThis->m_abortCalled)


### PR DESCRIPTION
#### 26d634c7747234e6438dc95115389287b23a5a65
<pre>
imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-replaced.html is a perma-failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=262019">https://bugs.webkit.org/show_bug.cgi?id=262019</a>
rdar://115966158

Reviewed by Youenn Fablet.

Delay moving networkState back to Idle until we have retrieved media&apos;s
metadata.

The MediaPlayerPrivateWebM currently load the entire file upfront to build
a sample table. This caused the networkState to move to Idle and stop
delaying the load. As such, the intrinsic dimensions of the video element
were incorrect when the test ran.

Fly-by fix: move the networkState to NETWORK_LOADING once we start receiving
buffers from the network as per <a href="https://html.spec.whatwg.org/multipage/media.html#concept-media-load-algorithm.">https://html.spec.whatwg.org/multipage/media.html#concept-media-load-algorithm.</a>

Covered by existing tests.

* LayoutTests/platform/mac-wk2/TestExpectations: Re-enable tests.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::loadFinished):
(WebCore::MediaPlayerPrivateWebM::setNaturalSize):
(WebCore::MediaPlayerPrivateWebM::append):

Canonical link: <a href="https://commits.webkit.org/268447@main">https://commits.webkit.org/268447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c1e16ad2ffa617fb1ae9416c3c27be3e3d1e571

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18451 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20312 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22494 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17971 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22249 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18734 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17896 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4719 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->