### PR TITLE
REGRESSION (?): CrashTracer: [USER] com.apple.WebKit.GPU.Development at com.apple.WebCore: WebCore::SourceBufferParserWebM::SourceBufferParserWebM

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -182,8 +182,10 @@ bool AudioFileReader::isMaybeWebM(const uint8_t* data, size_t dataSize) const
 
 std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(const uint8_t* data, size_t dataSize) const
 {
+    auto parser = SourceBufferParserWebM::create();
+    if (!parser)
+        return nullptr;
     auto buffer = SharedBuffer::create(data, dataSize);
-    auto parser = adoptRef(new SourceBufferParserWebM());
     bool error = false;
     std::optional<uint64_t> audioTrackId;
     MediaTime duration;
@@ -218,7 +220,7 @@ std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(const ui
     });
     SourceBufferParser::Segment segment(Ref { buffer.get() });
     parser->appendData(WTFMove(segment));
-    if (!track)
+    if (!track || error)
         return nullptr;
     parser->flushPendingAudioSamples();
     return makeUnique<AudioFileReaderWebMData>(AudioFileReaderWebMData { WTFMove(buffer), track.releaseNonNull(), WTFMove(duration), WTFMove(samples) });

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -86,7 +86,7 @@ static const MediaTime discontinuityTolerance = MediaTime(1, 1);
 MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer* player)
     : m_player(player)
     , m_synchronizer(adoptNS([PAL::allocAVSampleBufferRenderSynchronizerInstance() init]))
-    , m_parser(adoptRef(*new SourceBufferParserWebM()))
+    , m_parser(SourceBufferParserWebM::create().releaseNonNull())
     , m_appendQueue(WorkQueue::create("MediaPlayerPrivateWebM data parser queue"))
     , m_logger(player->mediaPlayerLogger())
     , m_logIdentifier(player->mediaPlayerLogIdentifier())
@@ -1563,7 +1563,8 @@ void MediaPlayerPrivateWebM::registerMediaEngine(MediaEngineRegistrar registrar)
 
 bool MediaPlayerPrivateWebM::isAvailable()
 {
-    return PAL::isAVFoundationFrameworkAvailable()
+    return SourceBufferParserWebM::isAvailable()
+        && PAL::isAVFoundationFrameworkAvailable()
         && PAL::isCoreMediaFrameworkAvailable()
         && PAL::getAVSampleBufferAudioRendererClass()
         && PAL::getAVSampleBufferRenderSynchronizerClass()

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp
@@ -50,7 +50,7 @@ MediaPlayerEnums::SupportsType SourceBufferParser::isContentTypeSupported(const 
 RefPtr<SourceBufferParser> SourceBufferParser::create(const ContentType& type, bool webMParserEnabled)
 {
     if (SourceBufferParserWebM::isContentTypeSupported(type) != MediaPlayerEnums::SupportsType::IsNotSupported && webMParserEnabled)
-        return adoptRef(new SourceBufferParserWebM());
+        return SourceBufferParserWebM::create();
 
     if (SourceBufferParserAVFObjC::isContentTypeSupported(type) != MediaPlayerEnums::SupportsType::IsNotSupported)
         return adoptRef(new SourceBufferParserAVFObjC());

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1437,11 +1437,14 @@ MediaPlayerEnums::SupportsType SourceBufferParserWebM::isContentTypeSupported(co
 #endif // ENABLE(VP9) || ENABLE(VORBIS) || ENABLE(OPUS)
 }
 
-RefPtr<SourceBufferParserWebM> SourceBufferParserWebM::create(const ContentType& type)
+bool SourceBufferParserWebM::isAvailable()
 {
-    if (isContentTypeSupported(type) != MediaPlayerEnums::SupportsType::IsNotSupported)
-        return adoptRef(new SourceBufferParserWebM());
-    return nullptr;
+    return isWebmParserAvailable();
+}
+
+RefPtr<SourceBufferParserWebM> SourceBufferParserWebM::create()
+{
+    return isAvailable() ? adoptRef(new SourceBufferParserWebM()) : nullptr;
 }
 
 void WebMParser::provideMediaData(MediaSamplesBlock&& samples)

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -318,9 +318,8 @@ public:
     static bool isWebMFormatReaderAvailable();
     static MediaPlayerEnums::SupportsType isContentTypeSupported(const ContentType&);
     static std::span<const ASCIILiteral> supportedMIMETypes();
-    WEBCORE_EXPORT static RefPtr<SourceBufferParserWebM> create(const ContentType&);
+    WEBCORE_EXPORT static RefPtr<SourceBufferParserWebM> create();
 
-    SourceBufferParserWebM();
     ~SourceBufferParserWebM();
 
     static bool isAvailable();
@@ -345,6 +344,7 @@ public:
     WEBCORE_EXPORT void setLogger(const Logger&, const void* identifier) final;
 
 private:
+    SourceBufferParserWebM();
     // WebMParser::Callback
     void parsedInitializationData(SourceBufferParser::InitializationSegment&&) final;
     void parsedMediaData(MediaSamplesBlock&&) final;


### PR DESCRIPTION
#### 7371609179cbbbe1c4ad33bbcbb90bd7e2b5c80d
<pre>
REGRESSION (?): CrashTracer: [USER] com.apple.WebKit.GPU.Development at com.apple.WebCore: WebCore::SourceBufferParserWebM::SourceBufferParserWebM
<a href="https://bugs.webkit.org/show_bug.cgi?id=262105">https://bugs.webkit.org/show_bug.cgi?id=262105</a>
rdar://116032608

Reviewed by Youenn Fablet.

libwebm was weak-linked, the SourceBufferParserWebM was being constructed
without checking if libwebm was available (which would have automatically
loaded the symbols).
As such, in the vtable of SourceBufferParserWebM the pointer to the libwebm
base class was null, giving us this very puzzling crash trace.

We make SourceBufferParserWebM constructor private and make a static
create() method instead that will check for libwebm support which incidentally
will link the library as needed.

* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::demuxWebMData const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::registerMediaEngine):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParser.cpp:
(WebCore::SourceBufferParser::create):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::SourceBufferParserWebM::isAvailable):
(WebCore::SourceBufferParserWebM::create):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:

Canonical link: <a href="https://commits.webkit.org/268448@main">https://commits.webkit.org/268448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bdc9fd8751e91c9676de62b2bc134712372e8c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18453 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20314 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22496 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24247 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22240 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17898 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4720 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22249 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18561 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->