### PR TITLE
REGRESSION (iOS 17): PWA startup "FetchEvent.respondWith received an error TypeError: Internal error"

### DIFF
--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -50,6 +50,8 @@ public:
 
     virtual void reference(DOMCacheIdentifier /* cacheIdentifier */) = 0;
     virtual void dereference(DOMCacheIdentifier /* cacheIdentifier */) = 0;
+    virtual void lockStorage(const ClientOrigin&) = 0;
+    virtual void unlockStorage(const ClientOrigin&) = 0;
 
     uint64_t computeRecordBodySize(const FetchResponse&, const DOMCacheEngine::ResponseBody&);
 

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
@@ -62,6 +62,8 @@ private:
     void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&, DOMCacheEngine::RecordIdentifiersCallback&& callback)  final { callback(makeUnexpected(DOMCacheEngine::Error::Stopped)); }
     void reference(DOMCacheIdentifier)  final { }
     void dereference(DOMCacheIdentifier)  final { }
+    void lockStorage(const ClientOrigin&) final { }
+    void unlockStorage(const ClientOrigin&) final { }
 };
 
 static Ref<CacheStorageConnection> createMainThreadConnection(WorkerGlobalScope& scope)
@@ -226,6 +228,20 @@ void WorkerCacheStorageConnection::dereference(DOMCacheIdentifier cacheIdentifie
 {
     callOnMainThread([mainThreadConnection = m_mainThreadConnection, cacheIdentifier]() {
         mainThreadConnection->dereference(cacheIdentifier);
+    });
+}
+
+void WorkerCacheStorageConnection::lockStorage(const ClientOrigin& origin)
+{
+    callOnMainThread([mainThreadConnection = m_mainThreadConnection, origin = origin.isolatedCopy()]() {
+        mainThreadConnection->lockStorage(origin);
+    });
+}
+
+void WorkerCacheStorageConnection::unlockStorage(const ClientOrigin& origin)
+{
+    callOnMainThread([mainThreadConnection = m_mainThreadConnection, origin = origin.isolatedCopy()]() {
+        mainThreadConnection->unlockStorage(origin);
     });
 }
 

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h
@@ -56,6 +56,8 @@ private:
 
     void reference(DOMCacheIdentifier) final;
     void dereference(DOMCacheIdentifier) final;
+    void lockStorage(const ClientOrigin&) final;
+    void unlockStorage(const ClientOrigin&) final;
 
     void openCompleted(uint64_t requestIdentifier, const DOMCacheEngine::CacheIdentifierOrError&);
     void removeCompleted(uint64_t requestIdentifier, const DOMCacheEngine::RemoveCacheIdentifierOrError&);

--- a/Source/WebCore/page/CacheStorageProvider.h
+++ b/Source/WebCore/page/CacheStorageProvider.h
@@ -49,6 +49,8 @@ public:
         void batchPutOperation(DOMCacheIdentifier, Vector<DOMCacheEngine::CrossThreadRecord>&&, DOMCacheEngine::RecordIdentifiersCallback&&) final { }
         void reference(DOMCacheIdentifier) final { }
         void dereference(DOMCacheIdentifier) final { }
+        void lockStorage(const ClientOrigin&) final { }
+        void unlockStorage(const ClientOrigin&) final { }
     };
 
     static Ref<CacheStorageProvider> create() { return adoptRef(*new CacheStorageProvider); }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -431,8 +431,22 @@ void CacheStorageManager::dereference(IPC::Connection::UniqueID connection, WebC
     removeUnusedCache(cacheIdentifier);
 }
 
+void CacheStorageManager::lockStorage(IPC::Connection::UniqueID connection)
+{
+    ASSERT(!m_activeConnections.contains(connection));
+    m_activeConnections.add(connection);
+}
+
+void CacheStorageManager::unlockStorage(IPC::Connection::UniqueID connection)
+{
+    ASSERT(m_activeConnections.contains(connection));
+    m_activeConnections.remove(connection);
+}
+
 void CacheStorageManager::connectionClosed(IPC::Connection::UniqueID connection)
 {
+    m_activeConnections.remove(connection);
+
     HashSet<WebCore::DOMCacheIdentifier> unusedCacheIdentifiers;
     for (auto& [identifier, refConnections] : m_cacheRefConnections) {
         refConnections.removeAllMatching([&](auto refConnection) {
@@ -475,7 +489,7 @@ bool CacheStorageManager::hasDataInMemory()
 
 bool CacheStorageManager::isActive()
 {
-    return !m_cacheRefConnections.isEmpty();
+    return !m_cacheRefConnections.isEmpty() || !m_activeConnections.isEmpty();
 }
 
 String CacheStorageManager::representationString()

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -58,6 +58,8 @@ public:
     void allCaches(uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
     void reference(IPC::Connection::UniqueID, WebCore::DOMCacheIdentifier);
     void dereference(IPC::Connection::UniqueID, WebCore::DOMCacheIdentifier);
+    void lockStorage(IPC::Connection::UniqueID);
+    void unlockStorage(IPC::Connection::UniqueID);
 
     void connectionClosed(IPC::Connection::UniqueID);
     bool hasDataInMemory();
@@ -87,6 +89,7 @@ private:
     Vector<std::unique_ptr<CacheStorageCache>> m_caches;
     HashMap<WebCore::DOMCacheIdentifier, std::unique_ptr<CacheStorageCache>> m_removedCaches;
     HashMap<WebCore::DOMCacheIdentifier, Vector<IPC::Connection::UniqueID>> m_cacheRefConnections;
+    HashSet<IPC::Connection::UniqueID> m_activeConnections;
     Ref<WorkQueue> m_queue;
     Deque<std::pair<uint64_t, CompletionHandler<void(bool)>>> m_pendingSpaceRequests;
 };

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1631,6 +1631,16 @@ void NetworkStorageManager::cacheStorageDereference(IPC::Connection& connection,
     cacheStorageManager->dereference(connection.uniqueID(), cacheIdentifier);
 }
 
+void NetworkStorageManager::lockCacheStorage(IPC::Connection& connection, const WebCore::ClientOrigin& origin)
+{
+    originStorageManager(origin).cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()).lockStorage(connection.uniqueID());
+}
+
+void NetworkStorageManager::unlockCacheStorage(IPC::Connection& connection, const WebCore::ClientOrigin& origin)
+{
+    originStorageManager(origin).cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()).unlockStorage(connection.uniqueID());
+}
+
 void NetworkStorageManager::cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&& callback)
 {
     auto* cache = m_cacheStorageRegistry->cache(cacheIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -209,6 +209,8 @@ private:
     void cacheStorageAllCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
     void cacheStorageReference(IPC::Connection&, WebCore::DOMCacheIdentifier);
     void cacheStorageDereference(IPC::Connection&, WebCore::DOMCacheIdentifier);
+    void lockCacheStorage(IPC::Connection&, const WebCore::ClientOrigin&);
+    void unlockCacheStorage(IPC::Connection&, const WebCore::ClientOrigin&);
     void cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
     void cacheStorageRemoveRecords(WebCore::DOMCacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void cacheStoragePutRecords(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -83,6 +83,8 @@
     CacheStorageAllCaches(struct WebCore::ClientOrigin origin, uint64_t updateCounter) -> (WebCore::DOMCacheEngine::CacheInfosOrError result)
     CacheStorageReference(WebCore::DOMCacheIdentifier cacheIdentifier)
     CacheStorageDereference(WebCore::DOMCacheIdentifier cacheIdentifier)
+    LockCacheStorage(struct WebCore::ClientOrigin origin)
+    UnlockCacheStorage(struct WebCore::ClientOrigin origin)
     CacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (WebCore::DOMCacheEngine::CrossThreadRecordsOrError result)
     CacheStorageRemoveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest request, struct WebCore::CacheQueryOptions options) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
     CacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord> records) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -55,14 +55,7 @@ IPC::Connection& WebCacheStorageConnection::connection()
 
 void WebCacheStorageConnection::open(const WebCore::ClientOrigin& origin, const String& cacheName, WebCore::DOMCacheEngine::CacheIdentifierCallback&& callback)
 {
-    auto newCallback = [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& result) mutable {
-        if (weakThis && result) {
-            if (auto identifier = result.value().identifier)
-                weakThis->m_connectedIdentifiers.add(identifier);
-        }
-        callback(WTFMove(result));
-    };
-    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageOpenCache(origin, cacheName), WTFMove(newCallback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageOpenCache(origin, cacheName), WTFMove(callback));
 }
 
 void WebCacheStorageConnection::remove(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
@@ -92,18 +85,26 @@ void WebCacheStorageConnection::batchPutOperation(WebCore::DOMCacheIdentifier ca
 
 void WebCacheStorageConnection::reference(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
-    if (!m_connectedIdentifiers.contains(cacheIdentifier))
-        return;
-
-    connection().send(Messages::NetworkStorageManager::CacheStorageReference(cacheIdentifier), 0);
+    if (m_connectedIdentifierCounters.add(cacheIdentifier).isNewEntry)
+        connection().send(Messages::NetworkStorageManager::CacheStorageReference(cacheIdentifier), 0);
 }
 
 void WebCacheStorageConnection::dereference(WebCore::DOMCacheIdentifier cacheIdentifier)
 {
-    if (!m_connectedIdentifiers.contains(cacheIdentifier))
-        return;
+    if (m_connectedIdentifierCounters.remove(cacheIdentifier))
+        connection().send(Messages::NetworkStorageManager::CacheStorageDereference(cacheIdentifier), 0);
+}
 
-    connection().send(Messages::NetworkStorageManager::CacheStorageDereference(cacheIdentifier), 0);
+void WebCacheStorageConnection::lockStorage(const WebCore::ClientOrigin& origin)
+{
+    if (m_clientOriginLockRequestCounters.add(origin).isNewEntry)
+        connection().send(Messages::NetworkStorageManager::LockCacheStorage { origin }, 0);
+}
+
+void WebCacheStorageConnection::unlockStorage(const WebCore::ClientOrigin& origin)
+{
+    if (m_clientOriginLockRequestCounters.remove(origin))
+        connection().send(Messages::NetworkStorageManager::UnlockCacheStorage { origin }, 0);
 }
 
 void WebCacheStorageConnection::clearMemoryRepresentation(const WebCore::ClientOrigin& origin, CompletionCallback&& callback)
@@ -123,7 +124,8 @@ void WebCacheStorageConnection::updateQuotaBasedOnSpaceUsage(const WebCore::Clie
 
 void WebCacheStorageConnection::networkProcessConnectionClosed()
 {
-    m_connectedIdentifiers.clear();
+    m_connectedIdentifierCounters.clear();
+    m_clientOriginLockRequestCounters.clear();
 }
 
 }

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <WebCore/CacheStorageConnection.h>
+#include <WebCore/ClientOrigin.h>
+#include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
 
 namespace IPC {
@@ -63,13 +65,16 @@ private:
 
     void reference(WebCore::DOMCacheIdentifier) final;
     void dereference(WebCore::DOMCacheIdentifier) final;
+    void lockStorage(const WebCore::ClientOrigin&) final;
+    void unlockStorage(const WebCore::ClientOrigin&) final;
 
     void clearMemoryRepresentation(const WebCore::ClientOrigin&, WebCore::DOMCacheEngine::CompletionCallback&&) final;
     void engineRepresentation(CompletionHandler<void(const String&)>&&) final;
     void updateQuotaBasedOnSpaceUsage(const WebCore::ClientOrigin&) final;
 
     WebCacheStorageProvider& m_provider;
-    HashSet<WebCore::DOMCacheIdentifier> m_connectedIdentifiers;
+    HashCountedSet<WebCore::DOMCacheIdentifier> m_connectedIdentifierCounters;
+    HashCountedSet<WebCore::ClientOrigin> m_clientOriginLockRequestCounters;
 };
 
 }


### PR DESCRIPTION
#### dd68eb88a64ca414570729a171576e6a5571b5c4
<pre>
REGRESSION (iOS 17): PWA startup &quot;FetchEvent.respondWith received an error TypeError: Internal error&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=261767">https://bugs.webkit.org/show_bug.cgi?id=261767</a>
rdar://115747046

Reviewed by Chris Dumez and Sihui Liu.

We were skipping sending reference signals when creating caches previously created in other web pages.
This was allowing network process to clean up memory and we ended up not matching any resource from DOMCache.

Make sure to always send the reference message, but only send dereference message if there was a reference message before.

In addition, there is a potential race when network process sends DOMCache identifiers to the web process, but web process did not yet created the DOMCache objects
(aka WebProcess has not sent the reference message).
In that case, the OriginStorageManager can be removed, thus making the DOMCache identifiers useless.
To prevent this, we are now locking/unlocking cache storage from WebProcess when creating DOMCache objects.
This will prevent OriginStorageManager to be removed.

We are also handling reference/dereference counters directly in WebProcess since the new code path in networking process is not doing so anymore.
This is needed as the same DOMCache identifier may be used by different DOMCache objects (say one in a service worker and one in window).

Covered by API test.

* Source/WebCore/Modules/cache/CacheStorageConnection.h:
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::ConnectionStorageLock::ConnectionStorageLock):
(WebCore::ConnectionStorageLock::~ConnectionStorageLock):
(WebCore::DOMCacheStorage::retrieveCaches):
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::WorkerCacheStorageConnection::lockStorage):
(WebCore::WorkerCacheStorageConnection::unlockStorage):
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.h:
* Source/WebCore/page/CacheStorageProvider.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::CacheStorageManager::lockStorage):
(WebKit::CacheStorageManager::unlockStorage):
(WebKit::CacheStorageManager::connectionClosed):
(WebKit::CacheStorageManager::isActive):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::lockCacheStorage):
(WebKit::NetworkStorageManager::unlockCacheStorage):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::open):
(WebKit::WebCacheStorageConnection::reference):
(WebKit::WebCacheStorageConnection::dereference):
(WebKit::WebCacheStorageConnection::lockStorage):
(WebKit::WebCacheStorageConnection::unlockStorage):
(WebKit::WebCacheStorageConnection::networkProcessConnectionClosed):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:

Canonical link: <a href="https://commits.webkit.org/268565@main">https://commits.webkit.org/268565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcc5111be62315d1165adfca14ca132c8cf0e7e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19910 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18596 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20119 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22657 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24381 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22367 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16007 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18052 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4807 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->