### PR TITLE
WebProcess.h: fix PlatformDisplay is not a member of WebCore

### DIFF
--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -70,7 +70,7 @@
 #include <wtf/MachSendRight.h>
 #endif
 
-#if PLATFORM(GTK) && USE(EGL)
+#if PLATFORM(GTK)
 #include <WebCore/PlatformDisplay.h>
 #endif
 


### PR DESCRIPTION
#### 8d923e34615738e5b8ffd7b3971a14544b61f429
<pre>
WebProcess.h: fix PlatformDisplay is not a member of WebCore

<a href="https://bugs.webkit.org/show_bug.cgi?id=262108">https://bugs.webkit.org/show_bug.cgi?id=262108</a>

Reviewed by Michael Catanzaro.

It&apos;s safe to include PlatformDisplay if no EGL, so drop this check.

Signed-off-by: Thomas Devoogdt &lt;thomas.devoogdt@barco.com&gt;
Canonical link: <a href="https://commits.webkit.org/266719.67@bugfix/WebProcess-2.42.0">https://commits.webkit.org/266719.67@bugfix/WebProcess-2.42.0</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/854b20e44d941d883ad8319fb4c5796ffdf7661e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19754 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21649 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18460 "The change is no longer eligible for processing.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23437 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/20396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20023 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22510 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17149 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24274 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22256 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18743 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15885 "Exiting early after 60 failures. 66537 tests run. 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17905 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4729 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->