### PR TITLE
REGRESSION(249828@main) ASSERTION FAILED: willBeComposited == needsToBeComposited in https://www.playstation.com/

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1182,7 +1182,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
 
             // If we have to make a layer for this child, make one now so we can have a contents layer
             // (since we need to ensure that the -ve z-order child renders underneath our contents).
-            if (!willBeComposited && currentState.subtreeIsCompositing) {
+            if (!willBeComposited && currentState.subtreeIsCompositing && canBeComposited(layer)) {
                 layer.setIndirectCompositingReason(IndirectCompositingReason::BackgroundLayer);
                 layerWillComposite();
                 overlapMap.confirmSpeculativeCompositingContainer();
@@ -1192,7 +1192,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
         if (didSpeculativelyPushOverlapContainer) {
             if (overlapMap.maybePopSpeculativeCompositingContainer())
                 didPushOverlapContainer = false;
-            else if (!willBeComposited) {
+            else if (!willBeComposited && canBeComposited(layer)) {
                 layer.setIndirectCompositingReason(IndirectCompositingReason::BackgroundLayer);
                 layerWillComposite();
             }


### PR DESCRIPTION
#### c3b81b7792b99ad6ec78fe53d44dbe7d71284b9d
<pre>
REGRESSION(249828@main) ASSERTION FAILED: willBeComposited == needsToBeComposited in <a href="https://www.playstation.com/">https://www.playstation.com/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=262107">https://bugs.webkit.org/show_bug.cgi?id=262107</a>

Reviewed by NOBODY (OOPS!).

Some websites trigger layer composition even when the accelerated compositing is turned off.
&quot;willBeComposited = true&quot; must be blocked by &quot;canBeComposited&quot; to avoid it.

* Source/WebCore/rendering/RenderLayerCompositor.cpp: Add &quot;canBeComposited&quot; around layerWillComposite call.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b81b7792b99ad6ec78fe53d44dbe7d71284b9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/19991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20024 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22504 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24261 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22247 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15884 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17906 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->