### PR TITLE
Block MobileGestalt Mach sandbox extension

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/MobileGestaltSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/MobileGestaltSPI.h
@@ -95,6 +95,8 @@ SInt32 MGGetSInt32Answer(CFStringRef question, SInt32 defaultValue);
 Float32 MGGetFloat32Answer(CFStringRef question, Float32 defaultValue);
 #endif
 
+int MGSetAnswer(CFStringRef question, CFTypeRef answer);
+
 bool _MGCacheValid();
 
 WTF_EXTERN_C_END

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -195,6 +195,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCData.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCDate.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/InsertTextOptions.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/MobileGestaltParameters.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
 $(PROJECT_DIR)/Shared/Databases/IndexedDB/WebIDBResult.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -542,6 +542,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCDate.serialization.in \
 	Shared/Cocoa/DataDetectionResult.serialization.in \
 	Shared/Cocoa/InsertTextOptions.serialization.in \
+	Shared/Cocoa/MobileGestaltParameters.serialization.in \
 	Shared/Cocoa/RevealItem.serialization.in \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \
 	Shared/CallbackID.serialization.in \

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -257,9 +257,8 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
 #if PLATFORM(IOS_FAMILY)
     SandboxExtension::consumePermanently(parameters.compilerServiceExtensionHandles);
     SandboxExtension::consumePermanently(parameters.dynamicIOKitExtensionHandles);
+    parameters.mobileGestaltParameters.populate();
 #endif
-
-    populateMobileGestaltCache(WTFMove(parameters.mobileGestaltExtensionHandle));
 
 #if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
     SandboxExtension::consumePermanently(parameters.gpuToolsExtensionHandles);

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GPUProcessCreationParameters.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#include "ArgumentCoders.h"
+#include "WebCoreArgumentCoders.h"
+
+#if PLATFORM(COCOA)
+#include "ArgumentCodersCF.h"
+#endif
+
+namespace WebKit {
+
+GPUProcessCreationParameters::GPUProcessCreationParameters() = default;
+
+void GPUProcessCreationParameters::encode(IPC::Encoder& encoder) const
+{
+    encoder << auxiliaryProcessParameters;
+#if ENABLE(MEDIA_STREAM)
+    encoder << useMockCaptureDevices;
+#if PLATFORM(MAC)
+    encoder << microphoneSandboxExtensionHandle;
+    encoder << launchServicesExtensionHandle;
+#endif
+#endif
+#if HAVE(AVCONTENTKEYSPECIFIER)
+    encoder << sampleBufferContentKeySessionSupportEnabled;
+#endif
+    encoder << parentPID;
+
+#if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
+    encoder << containerCachesDirectoryExtensionHandle;
+    encoder << containerTemporaryDirectoryExtensionHandle;
+#endif
+#if PLATFORM(IOS_FAMILY)
+    encoder << compilerServiceExtensionHandles;
+    encoder << dynamicIOKitExtensionHandles;
+    encoder << mobileGestaltParameters;
+#endif
+#if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
+    encoder << gpuToolsExtensionHandles;
+#endif
+
+    encoder << applicationVisibleName;
+#if PLATFORM(COCOA)
+    encoder << strictSecureDecodingForAllObjCEnabled;
+#endif
+
+#if USE(GBM)
+    encoder << renderDeviceFile;
+#endif
+
+    encoder << overrideLanguages;
+}
+
+bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreationParameters& result)
+{
+    if (!decoder.decode(result.auxiliaryProcessParameters))
+        return false;
+#if ENABLE(MEDIA_STREAM)
+    if (!decoder.decode(result.useMockCaptureDevices))
+        return false;
+#if PLATFORM(MAC)
+    if (!decoder.decode(result.microphoneSandboxExtensionHandle))
+        return false;
+    if (!decoder.decode(result.launchServicesExtensionHandle))
+        return false;
+#endif
+#endif
+#if HAVE(AVCONTENTKEYSPECIFIER)
+    if (!decoder.decode(result.sampleBufferContentKeySessionSupportEnabled))
+        return false;
+#endif
+
+    if (!decoder.decode(result.parentPID))
+        return false;
+
+#if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
+    std::optional<SandboxExtension::Handle> containerCachesDirectoryExtensionHandle;
+    decoder >> containerCachesDirectoryExtensionHandle;
+    if (!containerCachesDirectoryExtensionHandle)
+        return false;
+    result.containerCachesDirectoryExtensionHandle = WTFMove(*containerCachesDirectoryExtensionHandle);
+
+    std::optional<SandboxExtension::Handle> containerTemporaryDirectoryExtensionHandle;
+    decoder >> containerTemporaryDirectoryExtensionHandle;
+    if (!containerTemporaryDirectoryExtensionHandle)
+        return false;
+    result.containerTemporaryDirectoryExtensionHandle = WTFMove(*containerTemporaryDirectoryExtensionHandle);
+#endif
+#if PLATFORM(IOS_FAMILY)
+    std::optional<Vector<SandboxExtension::Handle>> compilerServiceExtensionHandles;
+    decoder >> compilerServiceExtensionHandles;
+    if (!compilerServiceExtensionHandles)
+        return false;
+    result.compilerServiceExtensionHandles = WTFMove(*compilerServiceExtensionHandles);
+
+    std::optional<Vector<SandboxExtension::Handle>> dynamicIOKitExtensionHandles;
+    decoder >> dynamicIOKitExtensionHandles;
+    if (!dynamicIOKitExtensionHandles)
+        return false;
+    result.dynamicIOKitExtensionHandles = WTFMove(*dynamicIOKitExtensionHandles);
+
+    std::optional<MobileGestaltParameters> mobileGestaltParameters;
+    decoder >> mobileGestaltParameters;
+    if (!mobileGestaltParameters)
+        return false;
+    result.mobileGestaltParameters = WTFMove(*mobileGestaltParameters);
+#endif
+
+#if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
+    std::optional<Vector<SandboxExtension::Handle>> gpuToolsExtensionHandles;
+    decoder >> gpuToolsExtensionHandles;
+    if (!gpuToolsExtensionHandles)
+        return false;
+    result.gpuToolsExtensionHandles = WTFMove(*gpuToolsExtensionHandles);
+#endif
+
+    if (!decoder.decode(result.applicationVisibleName))
+        return false;
+
+#if PLATFORM(COCOA)
+    if (!decoder.decode(result.strictSecureDecodingForAllObjCEnabled))
+        return false;
+#endif
+
+#if USE(GBM)
+    std::optional<String> renderDeviceFile;
+    decoder >> renderDeviceFile;
+    if (!renderDeviceFile)
+        return false;
+    result.renderDeviceFile = WTFMove(*renderDeviceFile);
+#endif
+
+    std::optional<Vector<String>> overrideLanguages;
+    decoder >> overrideLanguages;
+    if (!overrideLanguages)
+        return false;
+    result.overrideLanguages = WTFMove(*overrideLanguages);
+
+    return true;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -31,6 +31,10 @@
 #include "SandboxExtension.h"
 #include <wtf/ProcessID.h>
 
+#if PLATFORM(IOS_FAMILY)
+#include "MobileGestaltParameters.h"
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -59,8 +63,8 @@ struct GPUProcessCreationParameters {
 #if PLATFORM(IOS_FAMILY)
     Vector<SandboxExtension::Handle> compilerServiceExtensionHandles;
     Vector<SandboxExtension::Handle> dynamicIOKitExtensionHandles;
+    MobileGestaltParameters mobileGestaltParameters;
 #endif
-    std::optional<SandboxExtension::Handle> mobileGestaltExtensionHandle;
 #if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
     Vector<SandboxExtension::Handle> gpuToolsExtensionHandles;
 #endif

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -935,8 +935,7 @@
         (extension "com.apple.webkit.extension.mach")
         (global-name
             "com.apple.frontboard.systemappservices"
-            "com.apple.mobileassetd.v2"
-            "com.apple.mobilegestalt.xpc")))
+            "com.apple.mobileassetd.v2")))
 
 (allow mach-lookup
     (require-all

--- a/Source/WebKit/Shared/Cocoa/MobileGestaltParameters.cpp
+++ b/Source/WebKit/Shared/Cocoa/MobileGestaltParameters.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MobileGestaltParameters.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#include "Logging.h"
+#include <pal/spi/ios/MobileGestaltSPI.h>
+
+namespace WebKit {
+
+void MobileGestaltParameters::initialize()
+{
+    mainScreenScale = MGGetFloat32Answer(kMGQMainScreenScale, 0);
+    mainScreenPitch = MGGetSInt32Answer(kMGQMainScreenPitch, 0);
+    mainScreenClass = MGGetSInt32Answer(kMGQMainScreenClass, MGScreenClassPad2);
+    appleInternalInstallCapability = MGGetBoolAnswer(kMGQAppleInternalInstallCapability);
+    iPadCapability = MGGetBoolAnswer(kMGQiPadCapability);
+    deviceName = adoptCF(static_cast<CFStringRef>(MGCopyAnswer(kMGQDeviceName, nullptr))).get();
+    deviceClassNumber = MGGetSInt32Answer(kMGQDeviceClassNumber, MGDeviceClassInvalid);
+    hasExtendedColorDisplay = MGGetBoolAnswer(kMGQHasExtendedColorDisplay);
+    deviceCornerRadius = MGGetFloat32Answer(kMGQDeviceCornerRadius, 0);
+    supportsForceTouch = MGGetBoolAnswer(kMGQSupportsForceTouch);
+    bluetoothCapability = MGGetBoolAnswer(kMGQBluetoothCapability);
+    deviceProximityCapability = MGGetBoolAnswer(kMGQDeviceProximityCapability);
+    deviceSupportsARKit = MGGetBoolAnswer(kMGQDeviceSupportsARKit);
+    timeSyncCapability = MGGetBoolAnswer(kMGQTimeSyncCapability);
+    wAPICapability = MGGetBoolAnswer(kMGQWAPICapability);
+    mainDisplayRotation = MGGetSInt32Answer(kMGQMainDisplayRotation, 0);
+}
+
+void MobileGestaltParameters::populate()
+{
+    if (MGSetAnswer(kMGQMainScreenScale, adoptCF(CFNumberCreate(nullptr, kCFNumberFloatType, &mainScreenScale)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQMainScreenScale");
+    if (MGSetAnswer(kMGQMainScreenPitch, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt32Type, &mainScreenPitch)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQMainScreenPitch");
+    if (MGSetAnswer(kMGQMainScreenClass, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt32Type, &mainScreenClass)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQMainScreenClass");
+    if (MGSetAnswer(kMGQAppleInternalInstallCapability, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &appleInternalInstallCapability)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQAppleInternalInstallCapability");
+    if (MGSetAnswer(kMGQiPadCapability, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &iPadCapability)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQiPadCapability");
+    if (MGSetAnswer(kMGQDeviceName, deviceName.createCFString().get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQDeviceName");
+    if (MGSetAnswer(kMGQDeviceClassNumber, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt32Type, &deviceClassNumber)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQDeviceClassNumber");
+    if (MGSetAnswer(kMGQHasExtendedColorDisplay, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &hasExtendedColorDisplay)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQHasExtendedColorDisplay");
+    if (MGSetAnswer(kMGQDeviceCornerRadius, adoptCF(CFNumberCreate(nullptr, kCFNumberFloatType, &deviceCornerRadius)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQDeviceCornerRadius");
+    if (MGSetAnswer(kMGQSupportsForceTouch, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &supportsForceTouch)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQSupportsForceTouch");
+    if (MGSetAnswer(kMGQBluetoothCapability, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &bluetoothCapability)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQBluetoothCapability");
+    if (MGSetAnswer(kMGQDeviceProximityCapability, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &deviceProximityCapability)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQDeviceProximityCapability");
+    if (MGSetAnswer(kMGQDeviceSupportsARKit, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &deviceSupportsARKit)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQDeviceSupportsARKit");
+    if (MGSetAnswer(kMGQTimeSyncCapability, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &timeSyncCapability)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQTimeSyncCapability");
+    if (MGSetAnswer(kMGQWAPICapability, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt8Type, &wAPICapability)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQWAPICapability");
+    if (MGSetAnswer(kMGQMainDisplayRotation, adoptCF(CFNumberCreate(nullptr, kCFNumberSInt32Type, &mainDisplayRotation)).get()))
+        RELEASE_LOG_ERROR(Process, "Could not set kMGQMainDisplayRotation");
+}
+
+}
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/Cocoa/MobileGestaltParameters.h
+++ b/Source/WebKit/Shared/Cocoa/MobileGestaltParameters.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+struct MobileGestaltParameters {
+    float mainScreenScale;
+    int mainScreenPitch;
+    int mainScreenClass;
+    bool appleInternalInstallCapability;
+    bool iPadCapability;
+    String deviceName;
+    int deviceClassNumber;
+    bool hasExtendedColorDisplay;
+    float deviceCornerRadius;
+    bool supportsForceTouch;
+    bool bluetoothCapability;
+    bool deviceProximityCapability;
+    bool deviceSupportsARKit;
+    bool timeSyncCapability;
+    bool wAPICapability;
+    int mainDisplayRotation;
+
+    void initialize();
+    void populate();
+};
+
+}

--- a/Source/WebKit/Shared/Cocoa/MobileGestaltParameters.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/MobileGestaltParameters.serialization.in
@@ -20,47 +20,23 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE(GPU_PROCESS)
+header: "MobileGestaltParameters.h"
 
-[RValue] struct WebKit::GPUProcessCreationParameters {
-    WebKit::AuxiliaryProcessCreationParameters auxiliaryProcessParameters;
-
-#if ENABLE(MEDIA_STREAM)
-    bool useMockCaptureDevices;
-#if PLATFORM(MAC)
-    WebKit::SandboxExtension::Handle microphoneSandboxExtensionHandle;
-    WebKit::SandboxExtension::Handle launchServicesExtensionHandle;
-#endif
-#endif
-
-#if HAVE(AVCONTENTKEYSPECIFIER)
-    bool sampleBufferContentKeySessionSupportEnabled;
-#endif
-
-    ProcessID parentPID;
-
-#if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
-    WebKit::SandboxExtension::Handle containerCachesDirectoryExtensionHandle;
-    WebKit::SandboxExtension::Handle containerTemporaryDirectoryExtensionHandle;
-#endif
-
-#if PLATFORM(IOS_FAMILY)
-    Vector<WebKit::SandboxExtension::Handle> compilerServiceExtensionHandles;
-    Vector<WebKit::SandboxExtension::Handle> dynamicIOKitExtensionHandles;
-    WebKit::MobileGestaltParameters mobileGestaltParameters;
-#endif
-
-#if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
-    Vector<WebKit::SandboxExtension::Handle> gpuToolsExtensionHandles;
-#endif
-
-    String applicationVisibleName;
-
-#if USE(GBM)
-    String renderDeviceFile;
-#endif
-
-    Vector<String> overrideLanguages;
+struct WebKit::MobileGestaltParameters {
+    float mainScreenScale;
+    int mainScreenPitch;
+    int mainScreenClass;
+    bool appleInternalInstallCapability;
+    bool iPadCapability;
+    String deviceName;
+    int deviceClassNumber;
+    bool hasExtendedColorDisplay;
+    float deviceCornerRadius;
+    bool supportsForceTouch;
+    bool bluetoothCapability;
+    bool deviceProximityCapability;
+    bool deviceSupportsARKit;
+    bool timeSyncCapability;
+    bool wAPICapability;
+    int mainDisplayRotation;
 };
-
-#endif

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -52,6 +52,7 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+#include "MobileGestaltParameters.h"
 #include <WebCore/RenderThemeIOS.h>
 #include <pal/system/ios/UserInterfaceIdiom.h>
 #endif
@@ -193,7 +194,6 @@ struct WebProcessCreationParameters {
     Vector<SandboxExtension::Handle> compilerServiceExtensionHandles;
 #endif
 
-    std::optional<SandboxExtension::Handle> mobileGestaltExtensionHandle;
     std::optional<SandboxExtension::Handle> launchServicesExtensionHandle;
 #if HAVE(VIDEO_RESTRICTED_DECODING)
 #if PLATFORM(MAC)
@@ -204,6 +204,7 @@ struct WebProcessCreationParameters {
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+    MobileGestaltParameters mobileGestaltParameters;
     Vector<SandboxExtension::Handle> dynamicIOKitExtensionHandles;
 #endif
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -142,7 +142,6 @@
     Vector<WebKit::SandboxExtension::Handle> compilerServiceExtensionHandles;
 #endif
 
-    std::optional<WebKit::SandboxExtension::Handle> mobileGestaltExtensionHandle;
     std::optional<WebKit::SandboxExtension::Handle> launchServicesExtensionHandle;
 #if PLATFORM(MAC) && HAVE(VIDEO_RESTRICTED_DECODING)
     WebKit::SandboxExtension::Handle trustdExtensionHandle;
@@ -153,6 +152,7 @@
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+    WebKit::MobileGestaltParameters mobileGestaltParameters;
     Vector<WebKit::SandboxExtension::Handle> dynamicIOKitExtensionHandles;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -45,7 +45,9 @@ namespace WebKit {
 
 void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationParameters& parameters)
 {
-    parameters.mobileGestaltExtensionHandle = createMobileGestaltSandboxExtensionIfNeeded();
+#if PLATFORM(IOS_FAMILY)
+    parameters.mobileGestaltParameters.initialize();
+#endif
     parameters.gpuToolsExtensionHandles = createGPUToolsSandboxExtensionHandlesIfNeeded();
     parameters.applicationVisibleName = applicationVisibleName();
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -439,9 +439,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     parameters.focusRingColor = RenderThemeIOS::systemFocusRingColor();
     parameters.localizedDeviceModel = localizedDeviceModel();
     parameters.contentSizeCategory = contentSizeCategory();
+    parameters.mobileGestaltParameters.initialize();
 #endif
-
-    parameters.mobileGestaltExtensionHandle = process.createMobileGestaltSandboxExtensionIfNeeded();
 
 #if PLATFORM(MAC)
     if (auto launchServicesExtensionHandle = SandboxExtension::createHandleForMachLookup("com.apple.coreservices.launchservicesd"_s, std::nullopt))

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2200,6 +2200,7 @@
 		E31586D32AD610F30062ED2A /* ExtensionEventHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = E31586CC2AD610F30062ED2A /* ExtensionEventHandler.mm */; };
 		E31586D42AD610F30062ED2A /* ExtensionEventHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = E31586CC2AD610F30062ED2A /* ExtensionEventHandler.mm */; };
 		E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */; };
+		E3308CFC2AC237D400D8FBBF /* MobileGestaltParameters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3308CFB2AC237D400D8FBBF /* MobileGestaltParameters.cpp */; };
 		E36A00E329CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */; };
 		E36FF00327F36FBD004BE21A /* SandboxStateVariables.h in Headers */ = {isa = PBXBuildFile; fileRef = E36FF00127F36FBD004BE21A /* SandboxStateVariables.h */; };
 		E3816B3D27E2463A005EAFC0 /* WebMockContentFilterManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3816B3B27E24639005EAFC0 /* WebMockContentFilterManager.cpp */; };
@@ -7305,6 +7306,9 @@
 		E31586CB2AD610F30062ED2A /* ExtensionEventHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExtensionEventHandler.h; path = Cocoa/ExtensionEventHandler.h; sourceTree = "<group>"; };
 		E31586CC2AD610F30062ED2A /* ExtensionEventHandler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ExtensionEventHandler.mm; path = Cocoa/ExtensionEventHandler.mm; sourceTree = "<group>"; };
 		E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AuxiliaryProcessProxyCocoa.mm; sourceTree = "<group>"; };
+		E3308CFA2AC2309F00D8FBBF /* MobileGestaltParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = MobileGestaltParameters.serialization.in; sourceTree = "<group>"; };
+		E3308CFB2AC237D400D8FBBF /* MobileGestaltParameters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MobileGestaltParameters.cpp; sourceTree = "<group>"; };
+		E33D8A952AC21C5B001D641D /* MobileGestaltParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MobileGestaltParameters.h; sourceTree = "<group>"; };
 		E3439B632345463A0011DE0B /* NetworkProcessConnectionInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkProcessConnectionInfo.h; path = Network/NetworkProcessConnectionInfo.h; sourceTree = "<group>"; };
 		E34B110C27C46BC6006D2F2E /* libWebCoreTestShim.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libWebCoreTestShim.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		E34B110F27C46D09006D2F2E /* libWebCoreTestSupport.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libWebCoreTestSupport.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -10639,6 +10643,9 @@
 				86E0787C2ACE0AE400B8FADC /* InsertTextOptions.serialization.in */,
 				C1663E5A24AEA74200C6A3B2 /* LaunchServicesDatabaseXPCConstants.h */,
 				2D1087621D2C641B00B85F82 /* LoadParametersCocoa.mm */,
+				E3308CFB2AC237D400D8FBBF /* MobileGestaltParameters.cpp */,
+				E33D8A952AC21C5B001D641D /* MobileGestaltParameters.h */,
+				E3308CFA2AC2309F00D8FBBF /* MobileGestaltParameters.serialization.in */,
 				2D440B8325EF235E00A98D87 /* PDFKitSoftLink.h */,
 				2D440B8225EF235E00A98D87 /* PDFKitSoftLink.mm */,
 				442E7BEA27B4581300C69AC1 /* RevealItem.h */,
@@ -17717,6 +17724,7 @@
 				07E19EFB23D401F10094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp in Sources */,
 				1DF29E64257F37A3003C28AF /* MediaSourcePrivateRemoteMessageReceiver.cpp in Sources */,
 				9B4790912531563200EC11AB /* MessageArgumentDescriptions.cpp in Sources */,
+				E3308CFC2AC237D400D8FBBF /* MobileGestaltParameters.cpp in Sources */,
 				EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */,
 				57B826452304F14000B72EB0 /* NearFieldSoftLink.mm in Sources */,
 				C1C1B30F2540F50D00D9100B /* NetworkConnectionToWebProcessMac.mm in Sources */,

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -332,8 +332,6 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     }
 #endif
 
-    populateMobileGestaltCache(WTFMove(parameters.mobileGestaltExtensionHandle));
-
     m_uiProcessBundleIdentifier = parameters.uiProcessBundleIdentifier;
 
     WebCore::setPresentingApplicationBundleIdentifier(parameters.presentingApplicationBundleIdentifier);
@@ -502,6 +500,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 #endif
 
 #if PLATFORM(IOS_FAMILY)
+    parameters.mobileGestaltParameters.populate();
     SandboxExtension::consumePermanently(parameters.dynamicIOKitExtensionHandles);
 #endif
 


### PR DESCRIPTION
#### f46a5d13b993ad444ac5802fca3d8a083287f3ca
<pre>
Block MobileGestalt Mach sandbox extension
<a href="https://bugs.webkit.org/show_bug.cgi?id=262116">https://bugs.webkit.org/show_bug.cgi?id=262116</a>
<a href="https://rdar.apple.com/problem/116054248">rdar://problem/116054248</a>

Reviewed by NOBODY (OOPS!).

Block MobileGestalt Mach sandbox extension in the WebContent process on iOS.

* Source/WebCore/PAL/pal/spi/ios/MobileGestaltSPI.h:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp:
(WebKit::GPUProcessCreationParameters::encode const):
(WebKit::GPUProcessCreationParameters::decode):
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Shared/Cocoa/MobileGestaltParameters.cpp: Added.
(WebKit::MobileGestaltParameters::initialize):
(WebKit::MobileGestaltParameters::populate):
* Source/WebKit/Shared/Cocoa/MobileGestaltParameters.h: Added.
* Source/WebKit/Shared/Cocoa/MobileGestaltParameters.serialization.in: Added.
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::platformInitializeGPUProcessParameters):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f46a5d13b993ad444ac5802fca3d8a083287f3ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23583 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28256 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29089 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26928 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/992 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->