### PR TITLE
Use more std::span<uint8_t> in IPC::Encoder

### DIFF
--- a/Source/WTF/wtf/Algorithms.h
+++ b/Source/WTF/wtf/Algorithms.h
@@ -58,6 +58,14 @@ bool allOf(ContainerType&& container, AllOfFunction allOfFunction)
     return true;
 }
 
+template<typename T, size_t extentT = std::dynamic_extent, typename U, size_t extentU = std::dynamic_extent>
+void memcpySpan(std::span<T, extentT> destination, std::span<U, extentU> source)
+{
+    RELEASE_ASSERT(destination.size() == source.size());
+    static_assert(sizeof(T) == sizeof(U));
+    memcpy(destination.data(), source.data(), destination.size() * sizeof(T));
+}
+
 template<typename T, typename U>
 std::span<T> spanReinterpretCast(std::span<U> span)
 {
@@ -68,5 +76,6 @@ std::span<T> spanReinterpretCast(std::span<U> span)
 
 } // namespace WTF
 
+using WTF::memcpySpan;
 using WTF::spanReinterpretCast;
 

--- a/Source/WebKit/Platform/IPC/DataReference.h
+++ b/Source/WebKit/Platform/IPC/DataReference.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,5 +30,6 @@
 namespace IPC {
 
 using DataReference = std::span<const uint8_t>;
+using MutableDataReference = std::span<uint8_t>;
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,10 +27,8 @@
 #include "Encoder.h"
 
 #include "ArgumentCoders.h"
-#include "DataReference.h"
 #include "MessageFlags.h"
 #include <algorithm>
-#include <wtf/OptionSet.h>
 #include <wtf/UniqueRef.h>
 
 #if OS(DARWIN)
@@ -72,8 +70,11 @@ Encoder::Encoder(MessageName messageName, uint64_t destinationID)
 
 Encoder::~Encoder()
 {
-    if (m_buffer != m_inlineBuffer)
-        freeBuffer(m_buffer, m_bufferCapacity);
+    if (m_buffer.data() != m_inlineBuffer) {
+        auto buffer = std::exchange(m_buffer, { });
+        freeBuffer(buffer.data(), buffer.size_bytes());
+        m_data = { };
+    }
     // FIXME: We need to dispose of the attachments in cases of failure.
 }
 
@@ -126,7 +127,7 @@ void Encoder::wrapForTesting(UniqueRef<Encoder>&& original)
 
     original->setShouldDispatchMessageWhenWaitingForSyncReply(ShouldDispatchWhenWaitingForSyncReply::Yes);
 
-    *this << DataReference(original->buffer(), original->bufferSize());
+    *this << original->data();
 
     Vector<Attachment> attachments = original->releaseAttachments();
     reserve(attachments.size());
@@ -141,24 +142,26 @@ static inline size_t roundUpToAlignment(size_t value, size_t alignment)
 
 void Encoder::reserve(size_t size)
 {
-    if (size <= m_bufferCapacity)
+    if (size <= m_buffer.size_bytes())
         return;
 
-    size_t newCapacity = roundUpToAlignment(m_bufferCapacity * 2, 4096);
+    size_t newCapacity = roundUpToAlignment(m_buffer.size_bytes() * 2, 4096);
     while (newCapacity < size)
         newCapacity *= 2;
 
-    uint8_t* newBuffer;
-    if (!allocBuffer(newBuffer, newCapacity))
+    uint8_t* newBufferPtr;
+    if (!allocBuffer(newBufferPtr, newCapacity))
         CRASH();
 
-    memcpy(newBuffer, m_buffer, m_bufferSize);
+    MutableDataReference newBuffer { newBufferPtr, newCapacity };
+    MutableDataReference newData = newBuffer.subspan(0, m_data.size());
+    memcpySpan(newData, m_data);
 
-    if (m_buffer != m_inlineBuffer)
-        freeBuffer(m_buffer, m_bufferCapacity);
+    if (m_buffer.data() != m_inlineBuffer)
+        freeBuffer(m_buffer.data(), m_buffer.size_bytes());
 
     m_buffer = newBuffer;
-    m_bufferCapacity = newCapacity;
+    m_data = newData;
 }
 
 void Encoder::encodeHeader()
@@ -172,25 +175,24 @@ OptionSet<MessageFlags>& Encoder::messageFlags()
 {
     // FIXME: We should probably pass an OptionSet<MessageFlags> into the Encoder constructor instead of encoding defaultMessageFlags then using this to change it later.
     static_assert(sizeof(OptionSet<MessageFlags>::StorageType) == 1, "Encoder uses the first byte of the buffer for message flags.");
-    return *reinterpret_cast<OptionSet<MessageFlags>*>(buffer());
+    return *spanReinterpretCast<OptionSet<MessageFlags>>(m_data.subspan(0, sizeof(OptionSet<MessageFlags>))).data();
 }
 
 const OptionSet<MessageFlags>& Encoder::messageFlags() const
 {
-    return *reinterpret_cast<OptionSet<MessageFlags>*>(buffer());
+    return *spanReinterpretCast<OptionSet<MessageFlags>>(m_data.subspan(0, sizeof(OptionSet<MessageFlags>))).data();
 }
 
-uint8_t* Encoder::grow(size_t alignment, size_t size)
+MutableDataReference Encoder::grow(size_t alignment, size_t size)
 {
-    size_t alignedSize = roundUpToAlignment(m_bufferSize, alignment);
+    size_t alignedSize = roundUpToAlignment(m_buffer.size_bytes(), alignment);
     reserve(alignedSize + size);
 
-    std::memset(m_buffer + m_bufferSize, 0, alignedSize - m_bufferSize);
+    std::memset(std::to_address(m_data.end()), 0, alignedSize - m_data.size_bytes());
 
-    m_bufferSize = alignedSize + size;
-    m_bufferPointer = m_buffer + alignedSize + size;
+    m_data = m_buffer.subspan(0, alignedSize + size);
 
-    return m_buffer + alignedSize;
+    return m_data.subspan(alignedSize, size);
 }
 
 void Encoder::addAttachment(Attachment&& attachment)

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,8 +26,10 @@
 #pragma once
 
 #include "Attachment.h"
+#include "DataReference.h"
 #include "MessageNames.h"
 #include <WebCore/SharedBuffer.h>
+#include <wtf/Algorithms.h>
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
@@ -79,8 +81,7 @@ public:
         return *this;
     }
 
-    uint8_t* buffer() const { return m_buffer; }
-    size_t bufferSize() const { return m_bufferSize; }
+    DataReference data() const { return m_data; }
 
     void addAttachment(Attachment&&);
     Vector<Attachment> releaseAttachments();
@@ -89,7 +90,7 @@ public:
     static constexpr bool isIPCEncoder = true;
 
 private:
-    uint8_t* grow(size_t alignment, size_t);
+    MutableDataReference grow(size_t alignment, size_t);
 
     bool hasAttachments() const;
 
@@ -102,11 +103,8 @@ private:
 
     uint8_t m_inlineBuffer[512];
 
-    uint8_t* m_buffer { m_inlineBuffer };
-    uint8_t* m_bufferPointer { m_inlineBuffer };
-    
-    size_t m_bufferSize { 0 };
-    size_t m_bufferCapacity { sizeof(m_inlineBuffer) };
+    MutableDataReference m_buffer { m_inlineBuffer, sizeof(m_inlineBuffer) / sizeof(m_inlineBuffer[0]) };
+    MutableDataReference m_data { m_buffer.subspan(0, 0) };
 
     Vector<Attachment> m_attachments;
 };
@@ -114,13 +112,11 @@ private:
 template<typename T, size_t Extent>
 inline void Encoder::encodeSpan(const std::span<T, Extent>& span)
 {
-    auto* data = reinterpret_cast<const uint8_t*>(span.data());
-    size_t size = span.size_bytes();
     constexpr size_t alignment = alignof(T);
-    ASSERT(!(reinterpret_cast<uintptr_t>(data) % alignment));
+    RELEASE_ASSERT(!(reinterpret_cast<uintptr_t>(span.data()) % alignment));
 
-    uint8_t* buffer = grow(alignment, size);
-    memcpy(buffer, data, size);
+    auto dataSubspan = grow(alignment, span.size_bytes());
+    memcpySpan(spanReinterpretCast<std::remove_const_t<T>>(dataSubspan), span);
 }
 
 template<typename T>

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -282,7 +282,7 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
     auto numberOfPortDescriptors = attachments.size();
 
     bool messageBodyIsOOL = false;
-    auto messageSize = MachMessage::messageSize(encoder->bufferSize(), numberOfPortDescriptors, messageBodyIsOOL);
+    auto messageSize = MachMessage::messageSize(encoder->data().size_bytes(), numberOfPortDescriptors, messageBodyIsOOL);
     if (UNLIKELY(messageSize.hasOverflowed()))
         return false;
 
@@ -307,6 +307,8 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
 
     auto* messageData = reinterpret_cast<uint8_t*>(header + 1);
 
+    auto encoderData = encoder->data();
+
     bool isComplex = numberOfPortDescriptors || messageBodyIsOOL;
     if (isComplex) {
         header->msgh_bits |= MACH_MSGH_BITS_COMPLEX;
@@ -328,8 +330,8 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
 
         if (messageBodyIsOOL) {
             auto* descriptor = getDescriptorAndAdvance(messageData, sizeof(mach_msg_ool_descriptor_t));
-            descriptor->out_of_line.address = encoder->buffer();
-            descriptor->out_of_line.size = encoder->bufferSize();
+            descriptor->out_of_line.address = const_cast<uint8_t*>(encoderData.data());
+            descriptor->out_of_line.size = encoderData.size_bytes();
             descriptor->out_of_line.copy = MACH_MSG_VIRTUAL_COPY;
             descriptor->out_of_line.deallocate = false;
             descriptor->out_of_line.type = MACH_MSG_OOL_DESCRIPTOR;
@@ -338,7 +340,7 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
 
     // Copy the data if it is not being sent out-of-line.
     if (!messageBodyIsOOL)
-        memcpy(messageData, encoder->buffer(), encoder->bufferSize());
+        memcpy(messageData, encoderData.data(), encoderData.size_bytes());
 
     return sendMessage(WTFMove(message));
 }

--- a/Source/WebKit/Platform/IPC/unix/UnixMessage.h
+++ b/Source/WebKit/Platform/IPC/unix/UnixMessage.h
@@ -81,8 +81,8 @@ class UnixMessage {
 public:
     UnixMessage(Encoder& encoder)
         : m_attachments(encoder.releaseAttachments())
-        , m_messageInfo(encoder.bufferSize(), m_attachments.size())
-        , m_body(encoder.buffer())
+        , m_messageInfo(encoder.data().size_bytes(), m_attachments.size())
+        , m_body(encoder.data().data())
     {
     }
 

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -288,7 +288,8 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
 
     // Write the outgoing message.
 
-    if (::WriteFile(m_connectionPipe, encoder->buffer(), encoder->bufferSize(), 0, &m_writeListener.state())) {
+    auto encoderData = encoder.data();
+    if (::WriteFile(m_connectionPipe, encoderData.data(), encoderData.size_bytes(), 0, &m_writeListener.state())) {
         // We successfully sent this message.
         return true;
     }

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
@@ -90,7 +90,8 @@ RetainPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&& vector)
 OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&& encoder)
 {
     __block auto blockEncoder = WTFMove(encoder);
-    auto dispatchData = adoptNS(dispatch_data_create(blockEncoder->buffer(), blockEncoder->bufferSize(), dispatch_get_main_queue(), ^{
+    auto encoderData = blockEncoder->data();
+    auto dispatchData = adoptNS(dispatch_data_create(encoderData.data(), encoderData.size_bytes(), dispatch_get_main_queue(), ^{
         // Explicitly clear out the encoder, destroying it.
         blockEncoder.moveToUniquePtr();
     }));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1142,7 +1142,7 @@ void ArgumentCoder<WebCore::FragmentedSharedBuffer>::encode(Encoder& encoder, co
         return;
 
     if (useUnixDomainSockets() || bufferSize < minimumPageSize) {
-        encoder.reserve(encoder.bufferSize() + bufferSize);
+        encoder.reserve(encoder.data().size_bytes() + bufferSize);
         // Do not use shared memory for FragmentedSharedBuffer encoding in Unix, because it's easy to reach the
         // maximum number of file descriptors open per process when sending large data in small chunks
         // over the IPC. ConnectionUnix.cpp already uses shared memory to send any IPC message that is

--- a/Source/WebKit/UIProcess/LegacySessionStateCodingNone.cpp
+++ b/Source/WebKit/UIProcess/LegacySessionStateCodingNone.cpp
@@ -43,7 +43,7 @@ RefPtr<API::Data> encodeLegacySessionState(const SessionState& sessionState)
     encoder << sessionState.backForwardListState;
     encoder << sessionState.renderTreeSize;
     encoder << sessionState.provisionalURL;
-    return API::Data::create(encoder.buffer(), encoder.bufferSize());
+    return API::Data::create(encoder.data());
 }
 
 bool decodeLegacySessionState(const uint8_t* data, size_t dataSize, SessionState& sessionState)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -521,9 +521,7 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
 bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
 {
     if (message.encoder->messageName() == IPC::MessageName::WebPage_LoadRequestWaitingForProcessLaunch) {
-        auto buffer = message.encoder->buffer();
-        auto bufferSize = message.encoder->bufferSize();
-        auto decoder = IPC::Decoder::create({ buffer, bufferSize }, { });
+        auto decoder = IPC::Decoder::create(message.encoder->data(), { });
         ASSERT(decoder);
         if (!decoder)
             return false;
@@ -541,9 +539,7 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
             ASSERT_NOT_REACHED();
         return false;
     } else if (message.encoder->messageName() == IPC::MessageName::WebPage_GoToBackForwardItemWaitingForProcessLaunch) {
-        auto buffer = message.encoder->buffer();
-        auto bufferSize = message.encoder->bufferSize();
-        auto decoder = IPC::Decoder::create({ buffer, bufferSize }, { });
+        auto decoder = IPC::Decoder::create(message.encoder->data(), { });
         ASSERT(decoder);
         if (!decoder)
             return false;

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2891,7 +2891,7 @@ void JSMessageListener::willSendMessage(const IPC::Encoder& encoder, OptionSet<I
     auto* globalObject = toJS(m_context);
     JSC::JSLockHolder lock(globalObject->vm());
 
-    auto decoder = IPC::Decoder::create({ encoder.buffer(), encoder.bufferSize() }, { });
+    auto decoder = IPC::Decoder::create(encoder.data(), { });
     auto* description = jsDescriptionFromDecoder(globalObject, *decoder);
 
     JSValueRef arguments[] = { description ? toRef(globalObject, description) : JSValueMakeUndefined(m_context) };

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -65,16 +65,16 @@ public:
     void SetUp() override
     {
         m_encoder = makeUnique<IPC::Encoder>(EncoderDecoderTest::name(), 0);
-        ASSERT_EQ(m_encoder->bufferSize(), headerSize());
+        ASSERT_EQ(m_encoder->data().size_bytes(), headerSize());
     }
 
     IPC::Encoder& encoder() const { return *m_encoder; }
     size_t headerSize() const { return 16; }
-    size_t encoderSize() const { return m_encoder->bufferSize(); }
+    size_t encoderSize() const { return m_encoder->data().size_bytes(); }
 
     std::unique_ptr<IPC::Decoder> createDecoder() const
     {
-        return IPC::Decoder::create({ m_encoder->buffer(), m_encoder->bufferSize() }, { });
+        return IPC::Decoder::create(m_encoder->data(), { });
     }
 
 private:

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -38,7 +38,7 @@ std::optional<T> copyViaEncoder(const T& o)
 {
     IPC::Encoder encoder(static_cast<IPC::MessageName>(78), 0);
     encoder << o;
-    auto decoder = IPC::Decoder::create({ encoder.buffer(), encoder.bufferSize() }, encoder.releaseAttachments());
+    auto decoder = IPC::Decoder::create(encoder.data(), encoder.releaseAttachments());
     return decoder->decode<T>();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -234,7 +234,8 @@ OSObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryFr
     xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, protocolVersion);
 
     __block auto blockEncoder = WTFMove(encoder);
-    auto dispatchData = adoptNS(dispatch_data_create(blockEncoder->buffer(), blockEncoder->bufferSize(), dispatch_get_main_queue(), ^{
+    auto blockEncoderData = blockEncoder->data();
+    auto dispatchData = adoptNS(dispatch_data_create(blockEncoderData.data(), blockEncoderData.size_bytes(), dispatch_get_main_queue(), ^{
         // Explicitly clear out the encoder, destroying it.
         blockEncoder.moveToUniquePtr();
     }));


### PR DESCRIPTION
#### 1f9180c6ccf1931e3491de1dfc8ac86e24e7d531
<pre>
Use more std::span&lt;uint8_t&gt; in IPC::Encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=262119">https://bugs.webkit.org/show_bug.cgi?id=262119</a>
&lt;rdar://116055966&gt;

Reviewed by NOBODY (OOPS!).

Switch IPC::Encoder to use MutableDataReference (std::span&lt;uint8_t&gt;).

The IPC::Encoder class tracks the backing buffer (m_buffer) and the
encoded data (m_data) in separate MutableDataReference objects.

* Source/WTF/wtf/Algorithms.h:
(WTF::memcpySpan): Add.
- Utility method written by Chris Dumez for another patch.  Updated to
  handle dynamic extents.

* Source/WebKit/Platform/IPC/DataReference.h:
(IPC::MutableDataReference): Add.
- Add new type definition for a mutable DataReference.

* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::~Encoder):
- Clear m_buffer and m_data in destructor.
(IPC::Encoder::wrapForTesting):
(IPC::Encoder::reserve):
(IPC::Encoder::messageFlags):
(IPC::Encoder::messageFlags const):
- Update messageFlags() methods to use subspans for bounds checking.
(IPC::Encoder::grow):
- Returns subspan that was just added to m_buffer since all callers want
  to populate that memory.
* Source/WebKit/Platform/IPC/Encoder.h:
(IPC::Encoder::buffer): Rename to data().
(IPC::Encoder::bufferSize): Delete.
(IPC::Encoder::data): Add.
(IPC::Encoder::encodeSpan):
- Change debug assert to release assert.
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::sendOutgoingMessage):
* Source/WebKit/Platform/IPC/unix/UnixMessage.h:
(IPC::UnixMessage::UnixMessage):
* Source/WebKit/Platform/IPC/win/ConnectionWin.cpp:
(IPC::Connection::sendOutgoingMessage):
* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::encoderToXPCData):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::FragmentedSharedBuffer&gt;::encode):
* Source/WebKit/UIProcess/LegacySessionStateCodingNone.cpp:
(WebKit::encodeLegacySessionState):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldSendPendingMessage):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSMessageListener::willSendMessage):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::Encoder&gt;::encoderSize const):
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::Encoder&gt;::createDecoder const):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
(TestWebKitAPI::copyViaEncoder):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f9180c6ccf1931e3491de1dfc8ac86e24e7d531

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20895 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21744 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18543 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20583 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/21744 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20073 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20057 "2 new passes 4 flakes 1 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17267 "6 api tests failed or timed out") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22599 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17224 "3 flakes 5 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18062 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/22599 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17259 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18300 "3258 api tests failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18248 "21 flakes 2 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/22599 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19219 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18826 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16142 "7 flakes 2 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23253 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17997 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22347 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24507 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18651 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5431 "Passed tests") | 
<!--EWS-Status-Bubble-End-->