### PR TITLE
Reland Atomics in IPInt

### DIFF
--- a/JSTests/wasm/stress/non-canonical-extended-ops.js
+++ b/JSTests/wasm/stress/non-canonical-extended-ops.js
@@ -1,0 +1,120 @@
+load("../spec-harness.js", "caller relative");
+
+instance = (() => {
+  let builder = new WasmModuleBuilder();
+  builder.addFunction('I32TruncSatF32S_2', makeSig([kWasmF32], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x80, 0x00])
+    .exportFunc();
+  builder.addFunction('I32TruncSatF32S_3', makeSig([kWasmF32], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x80, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I32TruncSatF32U_2', makeSig([kWasmF32], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x81, 0x00])
+    .exportFunc();
+  builder.addFunction('I32TruncSatF32U_3', makeSig([kWasmF32], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x81, 0x80, 0x00])
+    .exportFunc();
+
+
+  builder.addFunction('I32TruncSatF64S_2', makeSig([kWasmF64], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x82, 0x00])
+    .exportFunc();
+  builder.addFunction('I32TruncSatF64S_3', makeSig([kWasmF64], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x82, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I32TruncSatF64U_2', makeSig([kWasmF64], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x83, 0x00])
+    .exportFunc();
+  builder.addFunction('I32TruncSatF64U_3', makeSig([kWasmF64], [kWasmI32]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x83, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I64TruncSatF32S_2', makeSig([kWasmF32], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x84, 0x00])
+    .exportFunc();
+  builder.addFunction('I64TruncSatF32S_3', makeSig([kWasmF32], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x84, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I64TruncSatF32U_2', makeSig([kWasmF32], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x85, 0x00])
+    .exportFunc();
+  builder.addFunction('I64TruncSatF32U_3', makeSig([kWasmF32], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x85, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I64TruncSatF64S_2', makeSig([kWasmF64], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x86, 0x00])
+    .exportFunc();
+  builder.addFunction('I64TruncSatF64S_3', makeSig([kWasmF64], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x86, 0x80, 0x00])
+    .exportFunc();
+
+  builder.addFunction('I64TruncSatF64U_2', makeSig([kWasmF64], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x87, 0x00])
+    .exportFunc();
+  builder.addFunction('I64TruncSatF64U_3', makeSig([kWasmF64], [kWasmI64]))
+    .addBody([
+      kExprGetLocal, 0,
+      0xfc /* Misc ops prefix */, 0x87, 0x80, 0x00])
+    .exportFunc();
+
+  return builder.instantiate({});
+})();
+
+assert.eq(instance.exports.I32TruncSatF32S_2(1), 1);
+assert.eq(instance.exports.I32TruncSatF32S_3(1), 1);
+
+assert.eq(instance.exports.I32TruncSatF32U_2(1), 1);
+assert.eq(instance.exports.I32TruncSatF32U_3(1), 1);
+
+assert.eq(instance.exports.I32TruncSatF64S_2(1), 1);
+assert.eq(instance.exports.I32TruncSatF64S_3(1), 1);
+
+assert.eq(instance.exports.I32TruncSatF64U_2(1), 1);
+assert.eq(instance.exports.I32TruncSatF64U_3(1), 1);
+
+assert.eq(instance.exports.I64TruncSatF32S_2(1), 1n);
+assert.eq(instance.exports.I64TruncSatF32S_3(1), 1n);
+
+assert.eq(instance.exports.I64TruncSatF32U_2(1), 1n);
+assert.eq(instance.exports.I64TruncSatF32U_3(1), 1n);
+
+assert.eq(instance.exports.I64TruncSatF64S_2(1), 1n);
+assert.eq(instance.exports.I64TruncSatF64S_3(1), 1n);
+
+assert.eq(instance.exports.I64TruncSatF64U_2(1), 1n);
+assert.eq(instance.exports.I64TruncSatF64U_3(1), 1n);
+

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -66,12 +66,22 @@ do { \
     RELEASE_ASSERT((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256); \
 } while (false);
 
+#define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(ipint_memory_atomic_notify_validate); \
+    void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    RELEASE_ASSERT((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256); \
+} while (false);
+
 void initialize()
 {
 #if !ENABLE(C_LOOP) && CPU(ADDRESS64) && (CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS)))
     FOR_EACH_IPINT_OPCODE(VALIDATE_IPINT_OPCODE);
     FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(VALIDATE_IPINT_0xFC_OPCODE);
     FOR_EACH_IPINT_SIMD_OPCODE(VALIDATE_IPINT_SIMD_OPCODE);
+    FOR_EACH_IPINT_ATOMIC_OPCODE(VALIDATE_IPINT_ATOMIC_OPCODE);
 #else
     RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now).");
 #endif

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -218,7 +218,8 @@ extern "C" void ipint_entry_simd();
     m(0xd1, ref_is_null) \
     m(0xd2, ref_func) \
     m(0xfc, fc_block) \
-    m(0xfd, simd)
+    m(0xfd, simd) \
+    m(0xfe, atomic)
 
 #define FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(m) \
     m(0x00, i32_trunc_sat_f32_s) \
@@ -478,11 +479,81 @@ extern "C" void ipint_entry_simd();
     m(0xfe, simd_f64x2_convert_low_i32x4_s) \
     m(0xff, simd_f64x2_convert_low_i32x4_u)
 
+#define FOR_EACH_IPINT_ATOMIC_OPCODE(m) \
+    m(0x00, memory_atomic_notify) \
+    m(0x01, memory_atomic_wait32) \
+    m(0x02, memory_atomic_wait64) \
+    m(0x03, atomic_fence) \
+    m(0x10, i32_atomic_load) \
+    m(0x11, i64_atomic_load) \
+    m(0x12, i32_atomic_load8_u) \
+    m(0x13, i32_atomic_load16_u) \
+    m(0x14, i64_atomic_load8_u) \
+    m(0x15, i64_atomic_load16_u) \
+    m(0x16, i64_atomic_load32_u) \
+    m(0x17, i32_atomic_store) \
+    m(0x18, i64_atomic_store) \
+    m(0x19, i32_atomic_store8_u) \
+    m(0x1a, i32_atomic_store16_u) \
+    m(0x1b, i64_atomic_store8_u) \
+    m(0x1c, i64_atomic_store16_u) \
+    m(0x1d, i64_atomic_store32_u) \
+    m(0x1e, i32_atomic_rmw_add) \
+    m(0x1f, i64_atomic_rmw_add) \
+    m(0x20, i32_atomic_rmw8_add_u) \
+    m(0x21, i32_atomic_rmw16_add_u) \
+    m(0x22, i64_atomic_rmw8_add_u) \
+    m(0x23, i64_atomic_rmw16_add_u) \
+    m(0x24, i64_atomic_rmw32_add_u) \
+    m(0x25, i32_atomic_rmw_sub) \
+    m(0x26, i64_atomic_rmw_sub) \
+    m(0x27, i32_atomic_rmw8_sub_u) \
+    m(0x28, i32_atomic_rmw16_sub_u) \
+    m(0x29, i64_atomic_rmw8_sub_u) \
+    m(0x2a, i64_atomic_rmw16_sub_u) \
+    m(0x2b, i64_atomic_rmw32_sub_u) \
+    m(0x2c, i32_atomic_rmw_and) \
+    m(0x2d, i64_atomic_rmw_and) \
+    m(0x2e, i32_atomic_rmw8_and_u) \
+    m(0x2f, i32_atomic_rmw16_and_u) \
+    m(0x30, i64_atomic_rmw8_and_u) \
+    m(0x31, i64_atomic_rmw16_and_u) \
+    m(0x32, i64_atomic_rmw32_and_u) \
+    m(0x33, i32_atomic_rmw_or) \
+    m(0x34, i64_atomic_rmw_or) \
+    m(0x35, i32_atomic_rmw8_or_u) \
+    m(0x36, i32_atomic_rmw16_or_u) \
+    m(0x37, i64_atomic_rmw8_or_u) \
+    m(0x38, i64_atomic_rmw16_or_u) \
+    m(0x39, i64_atomic_rmw32_or_u) \
+    m(0x3a, i32_atomic_rmw_xor) \
+    m(0x3b, i64_atomic_rmw_xor) \
+    m(0x3c, i32_atomic_rmw8_xor_u) \
+    m(0x3d, i32_atomic_rmw16_xor_u) \
+    m(0x3e, i64_atomic_rmw8_xor_u) \
+    m(0x3f, i64_atomic_rmw16_xor_u) \
+    m(0x40, i64_atomic_rmw32_xor_u) \
+    m(0x41, i32_atomic_rmw_xchg) \
+    m(0x42, i64_atomic_rmw_xchg) \
+    m(0x43, i32_atomic_rmw8_xchg_u) \
+    m(0x44, i32_atomic_rmw16_xchg_u) \
+    m(0x45, i64_atomic_rmw8_xchg_u) \
+    m(0x46, i64_atomic_rmw16_xchg_u) \
+    m(0x47, i64_atomic_rmw32_xchg_u) \
+    m(0x48, i32_atomic_rmw_cmpxchg) \
+    m(0x49, i64_atomic_rmw_cmpxchg) \
+    m(0x4a, i32_atomic_rmw8_cmpxchg_u) \
+    m(0x4b, i32_atomic_rmw16_cmpxchg_u) \
+    m(0x4c, i64_atomic_rmw8_cmpxchg_u) \
+    m(0x4d, i64_atomic_rmw16_cmpxchg_u) \
+    m(0x4e, i64_atomic_rmw32_cmpxchg_u) \
+
+
 #if !ENABLE(C_LOOP) && CPU(ADDRESS64) && (CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_SIMD_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-
+FOR_EACH_IPINT_ATOMIC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 #endif
 
 namespace JSC { namespace IPInt {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -562,6 +562,12 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
     v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
     v(Unsigned, thresholdForStringReplaceCache, 0x1000, Normal, nullptr) \
+    v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt.") \
+    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues") \
+    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations") \
+    v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues") \
+    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ") \
+    v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG") \
     \
     /* Feature Flags */\
     \
@@ -586,12 +592,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWebAssemblyRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec.") \
     v(Bool, useWebAssemblyTailCalls, false, Normal, "Allow the new instructions from the wasm tail calls spec.") \
     v(Bool, useWebAssemblyExtendedConstantExpressions, false, Normal, "Allow the use of global, element, and data init expressions from the extended constant expressions proposal.") \
-    v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt.") \
-    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues") \
-    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations") \
-    v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues") \
-    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ") \
-    v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG")
+
 
 
 enum OptionEquivalence {

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -54,6 +54,13 @@ void FunctionIPIntMetadataGenerator::addRawValue(uint64_t value)
     WRITE_TO_METADATA(m_metadata.data() + size, value, uint64_t);
 }
 
+void FunctionIPIntMetadataGenerator::addLength(uint32_t length)
+{
+    size_t size = m_metadata.size();
+    m_metadata.resize(size + 1);
+    WRITE_TO_METADATA(m_metadata.data() + size, length, uint8_t);
+}
+
 void FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length)
 {
     size_t size = m_metadata.size();

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -88,6 +88,7 @@ private:
 
     void addBlankSpace(uint32_t size);
     void addRawValue(uint64_t value);
+    void addLength(uint32_t length);
     void addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length);
     void addCondensedLocalIndexAndLength(uint32_t index, uint32_t length);
     void addLEB128ConstantAndLengthForType(Type, uint64_t value, uint32_t length);

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -508,7 +508,7 @@ auto FunctionParser<Context>::truncSaturated(Ext1OpType op, Type returnType, Typ
     TypedExpression value;
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "unary");
 
-    WASM_VALIDATOR_FAIL_IF(value.type() != operandType, "trunc-saturated value type mismatch");
+    WASM_VALIDATOR_FAIL_IF(value.type() != operandType, "trunc-saturated value type mismatch. Expected: ", operandType, " but expression stack has ", value.type());
 
     ExpressionType result;
     WASM_TRY_ADD_TO_CONTEXT(truncSaturated(op, value, result, returnType, operandType));

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -54,6 +54,8 @@
  * through many bytes to find their target, constants are stored in LEB128, and a myriad of other reasons.
  * For IPInt, we design metadata to act as "supporting information" for the interpreter, allowing it to quickly
  * find important values such as constants, indices, and branch targets.
+ *
+ * FIXME: We should consider not aligning on Apple ARM64 cores since they don't typically have a penatly for unaligned loads/stores.
  * 
  * 2. Metadata Structure
  * ---------------------
@@ -712,7 +714,7 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::setGlobal(uint32_t index, Expre
 
 // Loads and Stores
 
-// Implementation status: UNIMPLEMENTED
+// Implementation status: DONE.
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::load(LoadOpType, ExpressionType, ExpressionType&, uint32_t offset)
 {
@@ -727,12 +729,20 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::store(StoreOpType, ExpressionTy
 
 // Memories
 
-// Implementation status: UNIMPLEMENTED
+// Implementation status: DONE.
 
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addGrowMemory(ExpressionType, ExpressionType&) { return { }; }
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addCurrentMemory(ExpressionType&) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryFill(ExpressionType, ExpressionType, ExpressionType) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryCopy(ExpressionType, ExpressionType, ExpressionType) { return { }; }
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryFill(ExpressionType, ExpressionType, ExpressionType)
+{
+    m_metadata->addLength(getCurrentInstructionLength());
+    return { };
+}
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryCopy(ExpressionType, ExpressionType, ExpressionType)
+{
+    m_metadata->addLength(getCurrentInstructionLength());
+    return { };
+}
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addMemoryInit(unsigned dataIndex, ExpressionType, ExpressionType, ExpressionType)
 {
     m_metadata->addLEB128ConstantInt32AndLength(dataIndex, getCurrentInstructionLength());
@@ -746,15 +756,49 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addDataDrop(unsigned dataIndex)
 
 // Atomics
 
-// Implementation status: UNIMPLEMENTED
+// Implementation status: DONE.
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t) { return { }; }
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t) { return { }; }
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicLoad(ExtAtomicOpType, Type, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicStore(ExtAtomicOpType, Type, ExpressionType, ExpressionType, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicBinaryRMW(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicCompareExchange(ExtAtomicOpType, Type, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicWait(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicNotify(ExtAtomicOpType, ExpressionType, ExpressionType, ExpressionType&, uint32_t offset)
+{
+    m_metadata->addLEB128ConstantInt32AndLength(offset, getCurrentInstructionLength());
+    return { };
+}
+
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::atomicFence(ExtAtomicOpType, uint8_t)
+{
+    m_metadata->addLength(getCurrentInstructionLength());
+    return { };
+}
 
 // GC
 
@@ -935,7 +979,11 @@ PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncSF32(ExpressionType,
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncUF64(ExpressionType, ExpressionType&) { return { }; }
 PartialResult WARN_UNUSED_RETURN IPIntGenerator::addI64TruncUF32(ExpressionType, ExpressionType&) { return { }; }
 
-PartialResult WARN_UNUSED_RETURN IPIntGenerator::truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type) { return { }; }
+PartialResult WARN_UNUSED_RETURN IPIntGenerator::truncSaturated(Ext1OpType, ExpressionType, ExpressionType&, Type, Type)
+{
+    m_metadata->addLength(getCurrentInstructionLength());
+    return { };
+}
 
 // Conversions
 

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -571,10 +571,9 @@ static inline int32_t waitImpl(VM& vm, ValueType* pointer, ValueType expectedVal
     return static_cast<int32_t>(WaiterListManager::singleton().waitSync(vm, pointer, expectedValue, timeout));
 }
 
-inline int32_t memoryAtomicWait32(Instance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeoutInNanoseconds)
+inline int32_t memoryAtomicWait32(Instance* instance, uint64_t offsetInMemory, int32_t value, int64_t timeoutInNanoseconds)
 {
     VM& vm = instance->vm();
-    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
     if (offsetInMemory & (0x4 - 1))
         return -1;
     if (!instance->memory())
@@ -589,10 +588,14 @@ inline int32_t memoryAtomicWait32(Instance* instance, unsigned base, unsigned of
     return waitImpl<int32_t>(vm, pointer, value, timeoutInNanoseconds);
 }
 
-inline int32_t memoryAtomicWait64(Instance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeoutInNanoseconds)
+inline int32_t memoryAtomicWait32(Instance* instance, unsigned base, unsigned offset, int32_t value, int64_t timeoutInNanoseconds)
+{
+    return memoryAtomicWait32(instance, static_cast<uint64_t>(base) + offset, value, timeoutInNanoseconds);
+}
+
+inline int32_t memoryAtomicWait64(Instance* instance, uint64_t offsetInMemory, int64_t value, int64_t timeoutInNanoseconds)
 {
     VM& vm = instance->vm();
-    uint64_t offsetInMemory = static_cast<uint64_t>(base) + offset;
     if (offsetInMemory & (0x8 - 1))
         return -1;
     if (!instance->memory())
@@ -605,6 +608,11 @@ inline int32_t memoryAtomicWait64(Instance* instance, unsigned base, unsigned of
         return -1;
     int64_t* pointer = bitwise_cast<int64_t*>(bitwise_cast<uint8_t*>(instance->memory()->basePointer()) + offsetInMemory);
     return waitImpl<int64_t>(vm, pointer, value, timeoutInNanoseconds);
+}
+
+inline int32_t memoryAtomicWait64(Instance* instance, unsigned base, unsigned offset, int64_t value, int64_t timeoutInNanoseconds)
+{
+    return memoryAtomicWait64(instance, static_cast<uint64_t>(base) + offset, value, timeoutInNanoseconds);
 }
 
 inline int32_t memoryAtomicNotify(Instance* instance, unsigned base, unsigned offset, int32_t countValue)

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -1299,6 +1299,21 @@ WASM_SLOW_PATH_DECL(memory_atomic_wait32)
     WASM_RETURN(result);
 }
 
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait32, uint64_t pointerWithOffset, uint32_t value, uint64_t timeout)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicWait32(instance, pointerWithOffset, value, timeout);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(pointerWithOffset);
+    UNUSED_PARAM(value);
+    UNUSED_PARAM(timeout);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
 WASM_SLOW_PATH_DECL(memory_atomic_wait64)
 {
     auto instruction = pc->as<WasmMemoryAtomicWait64>();
@@ -1312,6 +1327,20 @@ WASM_SLOW_PATH_DECL(memory_atomic_wait64)
     WASM_RETURN(result);
 }
 
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_wait64, uint64_t pointerWithOffset, uint64_t value, uint64_t timeout)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicWait64(instance, pointerWithOffset, value, timeout);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(pointerWithOffset);
+    UNUSED_PARAM(value);
+    UNUSED_PARAM(timeout);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
+}
+
 WASM_SLOW_PATH_DECL(memory_atomic_notify)
 {
     auto instruction = pc->as<WasmMemoryAtomicNotify>();
@@ -1322,6 +1351,20 @@ WASM_SLOW_PATH_DECL(memory_atomic_notify)
     if (result < 0)
         WASM_THROW(Wasm::ExceptionType::OutOfBoundsMemoryAccess);
     WASM_RETURN(result);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(memory_atomic_notify, unsigned base, unsigned offset, int32_t count)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    int32_t result = Wasm::memoryAtomicNotify(instance, base, offset, count);
+    WASM_RETURN_TWO(bitwise_cast<void*>(static_cast<intptr_t>(result)), nullptr);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(base);
+    UNUSED_PARAM(offset);
+    UNUSED_PARAM(count);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
 }
 
 WASM_SLOW_PATH_DECL(throw)

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.h
@@ -118,8 +118,11 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_64, unsigned, uint64_t);
 
 WASM_SLOW_PATH_HIDDEN_DECL(set_global_ref_portable_binding);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait32);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, uint64_t, uint32_t, uint64_t);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait64);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, uint64_t, uint64_t, uint64_t);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_notify);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, unsigned, unsigned, int32_t);
 WASM_SLOW_PATH_HIDDEN_DECL(throw);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw, CallFrame*, uint32_t);
 WASM_SLOW_PATH_HIDDEN_DECL(rethrow);


### PR DESCRIPTION
#### 9a3d986518bcc657eebf7f246604f4b0be78a79e
<pre>
Reland Atomics in IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=262118">https://bugs.webkit.org/show_bug.cgi?id=262118</a>

Reviewed by Yusuke Suzuki.

This is a fixed patch for 268300@main and 268252@main. Before there was an issue that
we were using the `unimplementedInstruction` macro instead of the `reservedOpcode`
macro for the holes in the Atomic instruction set. The `unimplementedInstruction`
macro emits a global label, which on iOS would get stripped. I think this is happening
as the definition of the label is not in the same translation unit as the declaration,
which has the attribute, so the attribute doesn&apos;t get merged into the definition. Right
now it seems the only thing preserving the IPInt labels is the `IPInt::initialize()` function
and that function did not have any references to the Atomic intruction gaps.

* JSTests/wasm/stress/non-canonical-extended-ops.js: Added.
(instance):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
(JSC::IPInt::initialize):
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLength):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::truncSaturated):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addMemoryFill):
(JSC::Wasm::IPIntGenerator::addMemoryCopy):
(JSC::Wasm::IPIntGenerator::atomicLoad):
(JSC::Wasm::IPIntGenerator::atomicStore):
(JSC::Wasm::IPIntGenerator::atomicBinaryRMW):
(JSC::Wasm::IPIntGenerator::atomicCompareExchange):
(JSC::Wasm::IPIntGenerator::atomicWait):
(JSC::Wasm::IPIntGenerator::atomicNotify):
(JSC::Wasm::IPIntGenerator::atomicFence):
(JSC::Wasm::IPIntGenerator::truncSaturated):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::memoryAtomicWait32):
(JSC::Wasm::memoryAtomicWait64):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/268469@main">https://commits.webkit.org/268469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/834fc0d276a58e81491897bf144e09fcd0f99699

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18480 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20341 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/19994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/19989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22524 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/17994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24285 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17196 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22267 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19149 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15896 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23173 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17923 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4732 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22275 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24426 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18588 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5412 "Passed tests") | 
<!--EWS-Status-Bubble-End-->