### PR TITLE
Move off of UIKit SPI: UIWebFormAccessory and UIWebFormAccessoryDelegate

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -87,7 +87,6 @@
 #import <UIKit/UIWKTextInteractionAssistant.h>
 #import <UIKit/UIWebBrowserView.h>
 #import <UIKit/UIWebDocumentView.h>
-#import <UIKit/UIWebFormAccessory.h>
 #import <UIKit/UIWebScrollView.h>
 #import <UIKit/UIWebTiledView.h>
 #import <UIKit/UIWindowScene_Private.h>
@@ -793,32 +792,6 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (void)startAutoscroll:(CGPoint)point;
 - (void)cancelAutoscroll;
 - (void)scrollSelectionToVisible:(BOOL)animated;
-@end
-
-
-@protocol UIWebFormAccessoryDelegate;
-
-@interface UIWebFormAccessory : UIInputView
-@end
-
-@interface UIWebFormAccessory ()
-- (void)hideAutoFillButton;
-- (void)setClearVisible:(BOOL)flag;
-- (void)setNextPreviousItemsVisible:(BOOL)visible;
-- (void)showAutoFillButtonWithTitle:(NSString *)title;
-@property (nonatomic, retain) UIBarButtonItem *_autofill;
-@property (nonatomic, assign) id <UIWebFormAccessoryDelegate> delegate;
-
-@property (nonatomic, assign, getter=isNextEnabled) BOOL nextEnabled;
-@property (nonatomic, assign, getter=isPreviousEnabled) BOOL previousEnabled;
-- (id)initWithInputAssistantItem:(UITextInputAssistantItem *)inputAssistantItem;
-@end
-
-@protocol UIWebFormAccessoryDelegate
-- (void)accessoryAutoFill;
-- (void)accessoryClear;
-- (void)accessoryDone;
-- (void)accessoryTab:(BOOL)isNext;
 @end
 
 @interface _UILookupGestureRecognizer : UIGestureRecognizer

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -446,6 +446,7 @@ UIProcess/ios/forms/WKDatePickerViewController.mm
 UIProcess/ios/forms/WKDateTimeInputControl.mm
 UIProcess/ios/forms/WKFileUploadPanel.mm
 UIProcess/ios/forms/WKFocusedFormControlView.mm
+UIProcess/ios/forms/WKFormAccessoryView.mm
 UIProcess/ios/forms/WKFormColorControl.mm
 UIProcess/ios/forms/WKFormPeripheralBase.mm
 UIProcess/ios/forms/WKFormPopover.mm

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -48,6 +48,7 @@
 #import <WebKit/WKContactPicker.h>
 #import <WebKit/WKDeferringGestureRecognizer.h>
 #import <WebKit/WKFileUploadPanel.h>
+#import <WebKit/WKFormAccessoryView.h>
 #import <WebKit/WKFormPeripheral.h>
 #import <WebKit/WKKeyboardScrollingAnimator.h>
 #import <WebKit/WKShareSheet.h>
@@ -344,7 +345,7 @@ struct ImageAnalysisContextMenuActionData {
     OptionSet<WebKit::SuppressSelectionAssistantReason> _suppressSelectionAssistantReasons;
 
     RetainPtr<UITextInputTraits> _traits;
-    RetainPtr<UIWebFormAccessory> _formAccessoryView;
+    RetainPtr<WKFormAccessoryView> _formAccessoryView;
     RetainPtr<WKTapHighlightView> _tapHighlightView;
     RetainPtr<UIView> _interactionViewsContainerView;
     RetainPtr<WKTargetedPreviewContainer> _contextMenuHintContainerView;
@@ -562,7 +563,7 @@ struct ImageAnalysisContextMenuActionData {
 
 @end
 
-@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextAutoscrolling, UITextInputMultiDocument, UITextInputPrivate, UIWebFormAccessoryDelegate, WKTouchEventsGestureRecognizerDelegate, UIWKInteractionViewProtocol, _UITextInputTranslationSupport, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
+@interface WKContentView (WKInteraction) <UIGestureRecognizerDelegate, UITextAutoscrolling, UITextInputMultiDocument, UITextInputPrivate, WKFormAccessoryViewDelegate, WKTouchEventsGestureRecognizerDelegate, UIWKInteractionViewProtocol, _UITextInputTranslationSupport, WKActionSheetAssistantDelegate, WKFileUploadPanelDelegate, WKKeyboardScrollViewAnimatorDelegate, WKDeferringGestureRecognizerDelegate
 #if HAVE(CONTACTSUI)
     , WKContactPickerDelegate
 #endif
@@ -591,7 +592,7 @@ struct ImageAnalysisContextMenuActionData {
 @property (nonatomic, readonly) const WebKit::InteractionInformationAtPosition& positionInformation;
 @property (nonatomic, readonly) const WebKit::WKAutoCorrectionData& autocorrectionData;
 @property (nonatomic, readonly) const WebKit::FocusedElementInformation& focusedElementInformation;
-@property (nonatomic, readonly) UIWebFormAccessory *formAccessoryView;
+@property (nonatomic, readonly) WKFormAccessoryView *formAccessoryView;
 @property (nonatomic, readonly) UITextInputAssistantItem *inputAssistantItemForWebView;
 @property (nonatomic, readonly) UIView *inputViewForWebView;
 @property (nonatomic, readonly) UIView *inputAccessoryViewForWebView;
@@ -718,9 +719,9 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)startRelinquishingFirstResponderToFocusedElement;
 - (void)stopRelinquishingFirstResponderToFocusedElement;
 
-// UIWebFormAccessoryDelegate protocol
 - (void)accessoryDone;
 - (void)accessoryOpen;
+- (void)accessoryTab:(BOOL)isNext;
 
 - (void)updateFocusedElementValueAsColor:(UIColor *)value;
 - (void)updateFocusedElementValue:(NSString *)value;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+#import <UIKit/UIKit.h>
+
+namespace WebKit {
+enum class TabDirection : bool { Next, Previous };
+}
+
+@class WKFormAccessoryView;
+
+@protocol WKFormAccessoryViewDelegate <NSObject>
+
+- (void)accessoryViewDone:(WKFormAccessoryView *)view;
+- (void)accessoryView:(WKFormAccessoryView *)view tabInDirection:(WebKit::TabDirection)direction;
+- (void)accessoryViewAutoFill:(WKFormAccessoryView *)view;
+
+@end
+
+@interface WKFormAccessoryView : UIInputView
+
+- (instancetype)initWithInputAssistantItem:(UITextInputAssistantItem *)inputAssistantItem delegate:(id<WKFormAccessoryViewDelegate>)delegate;
+- (void)showAutoFillButtonWithTitle:(NSString *)title;
+- (void)hideAutoFillButton;
+- (void)setNextPreviousItemsVisible:(BOOL)visible;
+
+@property (nonatomic, readonly) UIBarButtonItem *autoFillButtonItem;
+@property (nonatomic, getter=isNextEnabled) BOOL nextEnabled;
+@property (nonatomic, getter=isPreviousEnabled) BOOL previousEnabled;
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
@@ -1,0 +1,432 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKFormAccessoryView.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import <pal/system/ios/UserInterfaceIdiom.h>
+#import <wtf/RetainPtr.h>
+
+namespace WebKit {
+
+static constexpr auto fixedSpaceBetweenButtonItems = 6;
+
+inline static UIFont *doneButtonFont()
+{
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+}
+
+inline static UIFont *singleLineAutoFillButtonFont()
+{
+    return [UIFont fontWithDescriptor:[UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleSubheadline] size:0];
+}
+
+inline static UIFont *multipleLineAutoFillButtonFont()
+{
+    return [UIFont fontWithDescriptor:[UIFontDescriptor preferredFontDescriptorWithTextStyle:UIFontTextStyleFootnote] size:0];
+}
+
+inline static UIImage *upArrow()
+{
+    return [UIImage systemImageNamed:@"chevron.up"];
+}
+
+inline static UIImage *downArrow()
+{
+    return [UIImage systemImageNamed:@"chevron.down"];
+}
+
+inline static RetainPtr<UIToolbar> createToolbarWithItems(NSArray<UIBarButtonItem *> *items)
+{
+    auto bar = adoptNS([[UIToolbar alloc] init]);
+    [bar setBarStyle:UIBarStyleDefault];
+    [bar setTranslucent:YES];
+    [bar setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
+    [bar setItems:items];
+    return bar;
+}
+
+} // namespace WebKit
+
+@implementation WKFormAccessoryView {
+    __weak id<WKFormAccessoryViewDelegate> _delegate;
+    RetainPtr<UIToolbar> _leftToolbar;
+    RetainPtr<UIToolbar> _rightToolbar;
+    RetainPtr<UIBarButtonItem> _doneButton;
+    RetainPtr<UIBarButtonItem> _flexibleSpaceItem;
+    RetainPtr<UIBarButtonItem> _previousItem;
+    RetainPtr<UIBarButtonItem> _nextItem;
+    RetainPtr<UIBarButtonItem> _nextPreviousSpacer;
+    RetainPtr<UIBarButtonItem> _autoFillButtonItem;
+    RetainPtr<UIBarButtonItem> _autoFillButtonItemSpacer;
+    RetainPtr<UIBarButtonItemGroup> _buttonGroupAutoFill;
+    RetainPtr<UIBarButtonItemGroup> _buttonGroupNavigation;
+    RetainPtr<UIView> _leftContainerView;
+    RetainPtr<UIView> _rightContainerView;
+    BOOL _usesUniversalControlBar;
+}
+
+- (instancetype)_initForUniversalControlBar:(UITextInputAssistantItem *)inputAssistant
+{
+    _usesUniversalControlBar = YES;
+
+    auto button = [UIButton buttonWithType:UIButtonTypeSystem];
+    [button addTarget:self action:@selector(_autoFill) forControlEvents:UIControlEventTouchUpInside];
+    auto buttonFrame = CGRectMake(0, 0, 0, self.bounds.size.height);
+    button.frame = buttonFrame;
+    button.tintColor = UIColor.labelColor;
+
+    auto label = button.titleLabel;
+    label.frame = buttonFrame;
+    label.numberOfLines = 2;
+    _autoFillButtonItem = adoptNS([[UIBarButtonItem alloc] initWithCustomView:button]);
+
+    _previousItem = adoptNS([[UIBarButtonItem alloc] initWithImage:WebKit::upArrow() style:UIBarButtonItemStylePlain target:self action:@selector(_previousTapped)]);
+    [_previousItem setTintColor:UIColor.blackColor];
+    [_previousItem setEnabled:NO];
+
+    _nextItem = adoptNS([[UIBarButtonItem alloc] initWithImage:WebKit::downArrow() style:UIBarButtonItemStylePlain target:self action:@selector(_nextTapped)]);
+    [_nextItem setTintColor:UIColor.blackColor];
+    [_nextItem setEnabled:NO];
+
+    _buttonGroupAutoFill = adoptNS([[UIBarButtonItemGroup alloc] initWithBarButtonItems:@[ _autoFillButtonItem.get() ] representativeItem:nil]);
+    [_buttonGroupAutoFill setHidden:YES];
+    _buttonGroupNavigation = adoptNS([[UIBarButtonItemGroup alloc] initWithBarButtonItems:@[ _previousItem.get(), _nextItem.get() ] representativeItem:nil]);
+
+    auto assistantItem = inputAssistant;
+    auto leadingGroup = adoptNS([assistantItem.leadingBarButtonGroups mutableCopy]);
+    [leadingGroup addObject:_buttonGroupAutoFill.get()];
+    assistantItem.leadingBarButtonGroups = leadingGroup.get();
+
+    auto trailingGroup = adoptNS([assistantItem.trailingBarButtonGroups mutableCopy]);
+    [trailingGroup addObject:_buttonGroupNavigation.get()];
+    assistantItem.trailingBarButtonGroups = trailingGroup.get();
+
+    return self;
+}
+
+- (instancetype)initWithInputAssistantItem:(UITextInputAssistantItem *)inputAssistant delegate:(id<WKFormAccessoryViewDelegate>)delegate
+{
+    self = [self init];
+    if (!self)
+        return nil;
+
+    _delegate = delegate;
+
+    auto subviews = self.subviews;
+    _leftContainerView = subviews.firstObject;
+    _rightContainerView = subviews.lastObject;
+
+    if (!PAL::currentUserInterfaceIdiomIsSmallScreen())
+        return [self _initForUniversalControlBar:inputAssistant];
+
+    // Add all items to left side toolbar. If the keyboard is split, the right-side toolbar will hold the AutoFill button.
+    auto items = [NSMutableArray array];
+
+    _previousItem = adoptNS([[UIBarButtonItem alloc] initWithImage:WebKit::upArrow() style:UIBarButtonItemStylePlain target:self action:@selector(_previousTapped)]);
+    [_previousItem setEnabled:NO];
+    [items addObject:_previousItem.get()];
+
+    _nextPreviousSpacer = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil]);
+    [_nextPreviousSpacer setWidth:WebKit::fixedSpaceBetweenButtonItems];
+    [items addObject:_nextPreviousSpacer.get()];
+
+    _nextItem = adoptNS([[UIBarButtonItem alloc] initWithImage:WebKit::downArrow() style:UIBarButtonItemStylePlain target:self action:@selector(_nextTapped)]);
+    [_nextItem setEnabled:NO];
+    [items addObject:_nextItem.get()];
+
+    _flexibleSpaceItem = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil]);
+    _autoFillButtonItemSpacer = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil]);
+    [_autoFillButtonItemSpacer setWidth:WebKit::fixedSpaceBetweenButtonItems];
+
+    // iPad doesn't show the "Done" button since the keyboard has its own dismiss key.
+    _doneButton = adoptNS([[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(_done)]);
+    [items addObject:_flexibleSpaceItem.get()];
+    [items addObject:_doneButton.get()];
+
+    _leftToolbar = WebKit::createToolbarWithItems(items);
+    [_leftContainerView addSubview:_leftToolbar.get()];
+
+    _rightToolbar = WebKit::createToolbarWithItems(@[ ]);
+    [_rightContainerView addSubview:_rightToolbar.get()];
+
+    [self _updateFrame];
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    // FIXME (262139): Adopt -registerForTraitChanges: once iOS 17 is the minimum supported iOS version.
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_updateFrame) name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    return self;
+}
+
+ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+// FIXME (262139): Adopt -registerForTraitChanges: once iOS 17 is the minimum supported iOS version.
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    auto newTraitCollection = self.traitCollection;
+    if (![newTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection])
+        return;
+
+    auto doneButtonAttributes = [NSMutableDictionary dictionaryWithObject:WebKit::doneButtonFont() forKey:NSFontAttributeName];
+
+    UIColor *tintColor = nil;
+
+    if (newTraitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+        tintColor = UIColor.whiteColor;
+        doneButtonAttributes[NSForegroundColorAttributeName] = tintColor;
+    }
+
+    self.tintColor = tintColor;
+
+    [_doneButton setTitleTextAttributes:doneButtonAttributes forState:UIControlStateNormal];
+}
+ALLOW_DEPRECATED_DECLARATIONS_END
+ALLOW_DEPRECATED_IMPLEMENTATIONS_END
+
+- (void)_updateFrame
+{
+    auto frame = self.frame;
+    frame.size.height = [_leftToolbar sizeThatFits:frame.size].height;
+    self.frame = frame;
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+
+    if ((_usesUniversalControlBar && [_buttonGroupAutoFill isHidden]) || !_autoFillButtonItem)
+        return;
+
+    [self _refreshAutofillPresentation];
+    [self _applyTreatmentToAutoFillLabel];
+
+    [_autoFillButtonItem setWidth:self._autoFillButton.frame.size.width];
+}
+
+- (void)_done
+{
+    [_delegate accessoryViewDone:self];
+}
+
+- (void)_previousTapped
+{
+    [_delegate accessoryView:self tabInDirection:WebKit::TabDirection::Previous];
+}
+
+- (void)_nextTapped
+{
+    [_delegate accessoryView:self tabInDirection:WebKit::TabDirection::Next];
+}
+
+- (void)_autoFill
+{
+    [_delegate accessoryViewAutoFill:self];
+}
+
+- (UIButton *)_autoFillButton
+{
+    return dynamic_objc_cast<UIButton>([_autoFillButtonItem customView]);
+}
+
+- (void)_refreshAutofillPresentation
+{
+    if (!_autoFillButtonItem)
+        return;
+
+    // For the AutoFill button there are three cases:
+    // 1) iPhone. There will be a Done button that dictates AutoFill button width.
+    // 2) iPad, unified keyboard. No Done button, AutoFill goes in left toolbar.
+    // 3) iPad, split keyboard. No Done button, AutoFill goes in right toolbar.
+    BOOL isSplit = CGRectGetMaxX([_leftContainerView frame]) != CGRectGetMinX([_rightContainerView frame]);
+
+    auto leftItems = adoptNS([[_leftToolbar items] mutableCopy]);
+    auto rightItems = adoptNS([[_rightToolbar items] mutableCopy]);
+
+    [leftItems removeObject:_autoFillButtonItemSpacer.get()];
+    [leftItems removeObject:_autoFillButtonItem.get()];
+    [rightItems removeObject:_flexibleSpaceItem.get()];
+    [rightItems removeObject:_autoFillButtonItem.get()];
+
+    if (isSplit) {
+        [rightItems insertObject:_flexibleSpaceItem.get() atIndex:0];
+        [rightItems addObject:_autoFillButtonItem.get()];
+    } else {
+        NSUInteger indexAfterNextItem = 0;
+        if ([leftItems containsObject:_nextItem.get()])
+            indexAfterNextItem = [leftItems indexOfObject:_nextItem.get()] + 1;
+        [leftItems insertObject:_autoFillButtonItemSpacer.get() atIndex:indexAfterNextItem];
+        [leftItems insertObject:_autoFillButtonItem.get() atIndex:indexAfterNextItem + 1];
+    }
+
+    [_leftToolbar setItems:leftItems.get()];
+    [_rightToolbar setItems:rightItems.get()];
+}
+
+- (void)_applyTreatmentToAutoFillLabel
+{
+    auto button = self._autoFillButton;
+    __block UILabel *label = nil;
+    // This -performWithoutAnimation: works around <rdar://14476163>.
+    [UIView performWithoutAnimation:^{
+        label = button.titleLabel;
+    }];
+    auto labelFrame = label.frame;
+    label.font = WebKit::singleLineAutoFillButtonFont();
+
+    BOOL compactScreen = self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
+    auto autoFillMaximumButtonWidth = compactScreen ? 180 : 200;
+
+    if ([label sizeThatFits:CGSizeMake(CGFLOAT_MAX, labelFrame.size.height)].width > autoFillMaximumButtonWidth)
+        label.font = WebKit::multipleLineAutoFillButtonFont();
+
+    labelFrame.size.width = [label sizeThatFits:CGSizeMake(autoFillMaximumButtonWidth, CGFLOAT_MAX)].width;
+    label.frame = labelFrame;
+
+    auto buttonFrame = button.frame;
+    buttonFrame.size.width = labelFrame.size.width;
+    button.frame = buttonFrame;
+}
+
+- (void)hideAutoFillButton
+{
+    if (!_autoFillButtonItem)
+        return;
+
+    auto leftItems = adoptNS([[_leftToolbar items] mutableCopy]);
+    [leftItems removeObject:_autoFillButtonItem.get()];
+    [_leftToolbar setItems:leftItems.get()];
+
+    if (_usesUniversalControlBar)
+        [_buttonGroupAutoFill setHidden:YES];
+    else
+        _autoFillButtonItem = nil;
+}
+
+- (void)showAutoFillButtonWithTitle:(NSString *)title
+{
+    auto button = self._autoFillButton;
+    if (!button) {
+        ASSERT(!_autoFillButtonItem);
+        button = [UIButton buttonWithType:UIButtonTypeSystem];
+        [button addTarget:self action:@selector(_autoFill) forControlEvents:UIControlEventTouchUpInside];
+        auto buttonFrame = CGRectMake(0, 0, 0, self.bounds.size.height);
+        button.frame = buttonFrame;
+
+        auto label = button.titleLabel;
+        label.frame = buttonFrame;
+        label.numberOfLines = 2;
+        _autoFillButtonItem = adoptNS([[UIBarButtonItem alloc] initWithCustomView:button]);
+    }
+
+    if (![title isEqualToString:[button titleForState:UIControlStateNormal]])
+        [button setTitle:title forState:UIControlStateNormal];
+
+    if (_usesUniversalControlBar)
+        [_buttonGroupAutoFill setHidden:NO];
+
+    [self setNeedsLayout];
+}
+
+- (UIBarButtonItem *)autoFillButtonItem
+{
+    return _autoFillButtonItem.get();
+}
+
+- (void)setNextPreviousItemsVisible:(BOOL)visible
+{
+    if (_usesUniversalControlBar) {
+        [_buttonGroupNavigation setHidden:!visible];
+        return;
+    }
+
+    auto leftToolbarItems = [_leftToolbar items];
+    BOOL toolbarContainsPreviousItem = [leftToolbarItems containsObject:_previousItem.get()];
+    BOOL toolbarContainsNextPreviousSpacer = [leftToolbarItems containsObject:_nextPreviousSpacer.get()];
+    BOOL toolbarContainsNextItem = [leftToolbarItems containsObject:_nextItem.get()];
+
+    if (visible && toolbarContainsPreviousItem && toolbarContainsNextPreviousSpacer && toolbarContainsNextItem)
+        return;
+
+    if (!visible && !toolbarContainsPreviousItem && !toolbarContainsNextPreviousSpacer && !toolbarContainsNextItem)
+        return;
+
+    auto newLeftToolbarItems = adoptNS(leftToolbarItems.mutableCopy);
+    if (visible) {
+        if (!toolbarContainsNextItem)
+            [newLeftToolbarItems insertObject:_nextItem.get() atIndex:0];
+        if (!toolbarContainsNextPreviousSpacer)
+            [newLeftToolbarItems insertObject:_nextPreviousSpacer.get() atIndex:0];
+        if (!toolbarContainsPreviousItem)
+            [newLeftToolbarItems insertObject:_previousItem.get() atIndex:0];
+    } else {
+        if (toolbarContainsPreviousItem)
+            [newLeftToolbarItems removeObject:_previousItem.get()];
+        if (toolbarContainsNextPreviousSpacer)
+            [newLeftToolbarItems removeObject:_nextPreviousSpacer.get()];
+        if (toolbarContainsNextItem)
+            [newLeftToolbarItems removeObject:_nextItem.get()];
+    }
+
+    [_leftToolbar setItems:newLeftToolbarItems.get()];
+
+    [self setNeedsLayout];
+}
+
+- (void)setNextEnabled:(BOOL)enabled
+{
+    [_nextItem setEnabled:enabled];
+}
+
+- (BOOL)isNextEnabled
+{
+    return [_nextItem isEnabled];
+}
+
+- (void)setPreviousEnabled:(BOOL)enabled
+{
+    [_previousItem setEnabled:enabled];
+}
+
+- (BOOL)isPreviousEnabled
+{
+    return [_previousItem isEnabled];
+}
+
+- (CGFloat)contentRatio
+{
+    // FIXME: Adopt future API to make the left container fill the content width instead
+    // of overriding this method.
+    return 1;
+}
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -245,7 +245,7 @@ void DisplayCaptureSessionManager::promptForGetDisplayMedia(UserMediaPermissionR
 #elif PLATFORM(MAC)
 
     // There is no picker on systems without ScreenCaptureKit, so share the main screen.
-    completionHandler(CGDisplayStreamScreenCaptureSource::screenCaptureDeviceForMainDisplay());
+    completionHandler(WebCore::CGDisplayStreamScreenCaptureSource::screenCaptureDeviceForMainDisplay());
 
 #endif
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2270,6 +2270,7 @@
 		F499BAA32947C1A4001241D6 /* RevealFocusedElementDeferrer.h in Headers */ = {isa = PBXBuildFile; fileRef = F499BAA12947C1A4001241D6 /* RevealFocusedElementDeferrer.h */; };
 		F4A7B1C128E4DDC30042C75A /* ShareableBitmapHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = F4A7B1C028E4DDC30042C75A /* ShareableBitmapHandle.h */; };
 		F4BA33F225757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */; };
+		F4BCBBEC2AC332AA00C1858D /* WKFormAccessoryView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */; };
 		F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */; };
 		F4C627E72A7AC17B00F546BF /* WKMouseInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = F4C627E62A7AC17400F546BF /* WKMouseInteraction.h */; };
 		F4CB09E5225D5A0900891487 /* WebsiteMediaSourcePolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CB09E4225D5A0300891487 /* WebsiteMediaSourcePolicy.h */; };
@@ -7462,6 +7463,8 @@
 		F4B378D021DDBBAB0095A378 /* WebUndoStepID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebUndoStepID.h; sourceTree = "<group>"; };
 		F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKImageAnalysisGestureRecognizer.h; path = ios/WKImageAnalysisGestureRecognizer.h; sourceTree = "<group>"; };
 		F4BA33F125757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKImageAnalysisGestureRecognizer.mm; path = ios/WKImageAnalysisGestureRecognizer.mm; sourceTree = "<group>"; };
+		F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKFormAccessoryView.h;  path = ios/forms/WKFormAccessoryView.h; sourceTree = "<group>"; };
+		F4BCBBE72AC3295300C1858D /* WKFormAccessoryView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKFormAccessoryView.mm; path = ios/forms/WKFormAccessoryView.mm; sourceTree = "<group>"; };
 		F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlaybackSessionContextIdentifier.h; sourceTree = "<group>"; };
 		F4C627E52A7AC17300F546BF /* WKMouseInteraction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKMouseInteraction.mm; path = ios/WKMouseInteraction.mm; sourceTree = "<group>"; };
 		F4C627E62A7AC17400F546BF /* WKMouseInteraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKMouseInteraction.h; path = ios/WKMouseInteraction.h; sourceTree = "<group>"; };
@@ -14021,6 +14024,8 @@
 				A58B6F0718FCA733008CBA53 /* WKFileUploadPanel.mm */,
 				2E16B6CD2017B7AC008996D6 /* WKFocusedFormControlView.h */,
 				2E16B6CC2017B7AB008996D6 /* WKFocusedFormControlView.mm */,
+				F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */,
+				F4BCBBE72AC3295300C1858D /* WKFormAccessoryView.mm */,
 				E5CB07DA20E1678F0022C183 /* WKFormColorControl.h */,
 				E5CB07DB20E1678F0022C183 /* WKFormColorControl.mm */,
 				C54256B118BEC18B00DE4179 /* WKFormPeripheral.h */,
@@ -15679,6 +15684,7 @@
 				51489CC32370DBFA0044E68A /* WKFindResult.h in Headers */,
 				51489CC7237237800044E68A /* WKFindResultInternal.h in Headers */,
 				2E16B6CF2017B7AD008996D6 /* WKFocusedFormControlView.h in Headers */,
+				F4BCBBEC2AC332AA00C1858D /* WKFormAccessoryView.h in Headers */,
 				E5CB07DC20E1678F0022C183 /* WKFormColorControl.h in Headers */,
 				C54256B718BEC18C00DE4179 /* WKFormPeripheral.h in Headers */,
 				CE70EE5D22442BD000E0AF0F /* WKFormPeripheralBase.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -39,6 +39,7 @@
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKitLegacy/WebEvent.h>
 #import <cmath>
@@ -275,11 +276,6 @@ TEST(KeyboardInputTests, FormNavigationAssistantBarButtonItems)
 
     EXPECT_EQ(2U, [webView lastTrailingBarButtonGroup].barButtonItems.count);
     EXPECT_FALSE([webView lastTrailingBarButtonGroup].hidden);
-
-    if (![UIWebFormAccessory instancesRespondToSelector:@selector(setNextPreviousItemsVisible:)]) {
-        // The rest of this test requires UIWebFormAccessory to be able to show or hide its next and previous items.
-        return;
-    }
 
     [webView _setEditable:YES];
     EXPECT_TRUE([webView lastTrailingBarButtonGroup].hidden);
@@ -796,7 +792,7 @@ TEST(KeyboardInputTests, TestWebViewAccessoryDoneDuringStrongPasswordAssistance)
     [webView synchronouslyLoadHTMLString:@"<input type='password' id='input'>"];
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.getElementById('input').focus()"];
     EXPECT_WK_STREQ("INPUT", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
-    [(id <UIWebFormAccessoryDelegate>)[webView textInputContentView] accessoryDone];
+    [webView dismissFormAccessoryView];
     EXPECT_WK_STREQ("BODY", [webView stringByEvaluatingJavaScript:@"document.activeElement.tagName"]);
     EXPECT_TRUE([webView _contentViewIsFirstResponder]);
 }

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -48,7 +48,6 @@
 #import <UIKit/UITextInput_Private.h>
 #import <UIKit/UIViewController_Private.h>
 #import <UIKit/UIWKTextInteractionAssistant.h>
-#import <UIKit/UIWebFormAccessory.h>
 #import <UIKit/_UINavigationInteractiveTransition.h>
 
 IGNORE_WARNINGS_BEGIN("deprecated-implementations")
@@ -112,16 +111,6 @@ WTF_EXTERN_C_END
 - (NSDictionary *)_autofillContext;
 - (UIFont *)fontForCaretSelection;
 @end
-
-@interface UIWebFormAccessory : UIInputView
-- (void)setNextPreviousItemsVisible:(BOOL)visible;
-@end
-
-#if !HAVE(UIKIT_BAR_BUTTON_LAYOUT_CUSTOMIZATION)
-@interface UIBarButtonItemGroup ()
-@property (nonatomic, readwrite, assign, getter=_isHidden, setter=_setHidden:) BOOL hidden;
-@end
-#endif
 
 @protocol UITextInputMultiDocument <NSObject>
 @optional
@@ -188,10 +177,6 @@ typedef NS_OPTIONS(NSInteger, UIWKDocumentRequestFlags) {
 @property (nonatomic, copy) NSString *contextBeforeSelection;
 @property (nonatomic, copy) NSString *selectedText;
 @property (nonatomic, copy) NSString *contextAfterSelection;
-@end
-
-@protocol UIWebFormAccessoryDelegate
-- (void)accessoryDone;
 @end
 
 typedef NS_ENUM(NSInteger, UIWKGestureType) {


### PR DESCRIPTION
#### edd2d7016e2d3e144e9cdf36b13da64e92b1c994
<pre>
Move off of UIKit SPI: UIWebFormAccessory and UIWebFormAccessoryDelegate
<a href="https://bugs.webkit.org/show_bug.cgi?id=262121">https://bugs.webkit.org/show_bug.cgi?id=262121</a>

Reviewed by Tim Horton.

Stop using this SPI class and delegate protocol; instead, introduce `WKFormAccessoryView` and
`WKFormAccessoryViewDelegate`, which are (nearly) drop-in replacements for `UIWebFormAccessory`.
The only functionality on `UIWebFormAccessory` which we drop in our new WebKit class is support for
showing a &quot;Clear&quot; button (`-setClearVisible:`), which was only necessary when using the &quot;wheels of
time&quot; UI in the keyboard on iPhone; this hasn&apos;t been necessary since the form control refresh,
which moved date pickers into a context menu presentation (and more recently, into popover UI).

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove now-unused SPI declarations.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKFormInputSession accessoryViewCustomButtonTitle]):
(-[WKContentView accessoryDone]):
(-[WKContentView accessoryViewDone:]):
(-[WKContentView accessoryTab:]):
(-[WKContentView accessoryView:tabInDirection:]):

Instead of using the existing `-accessoryTab:` delegate that takes a `BOOL`, we can instead use an
`enum class` to represent the direction (next or previous) for slightly better clarity.

(-[WKContentView accessoryViewAutoFill:]):
(-[WKContentView formAccessoryView]):
(-[WKContentView _updateAccessory]):
(-[WKContentView accessoryClear]): Deleted.
(-[WKContentView accessoryAutoFill]): Deleted.

Make `_formAccessoryView` a `WKFormAccessoryView` instead of a `UIWebFormAccessory`, and conform to
`WKFormAccessoryViewDelegate` instead of `UIWebFormAccessoryDelegate`.

* Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.h: Added.
* Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm: Added.
(WebKit::doneButtonFont):
(WebKit::singleLineAutoFillButtonFont):
(WebKit::multipleLineAutoFillButtonFont):
(WebKit::upArrow):
(WebKit::downArrow):
(WebKit::createToolbarWithItems):
(-[WKFormAccessoryView _initForUniversalControlBar:]):
(-[WKFormAccessoryView initWithInputAssistantItem:delegate:]):
(-[WKFormAccessoryView traitCollectionDidChange:]):
(-[WKFormAccessoryView _updateFrame]):
(-[WKFormAccessoryView layoutSubviews]):
(-[WKFormAccessoryView _done]):
(-[WKFormAccessoryView _previousTapped]):
(-[WKFormAccessoryView _nextTapped]):
(-[WKFormAccessoryView _autoFill]):
(-[WKFormAccessoryView _autoFillButton]):
(-[WKFormAccessoryView _refreshAutofillPresentation]):
(-[WKFormAccessoryView _applyTreatmentToAutoFillLabel]):
(-[WKFormAccessoryView hideAutoFillButton]):
(-[WKFormAccessoryView showAutoFillButtonWithTitle:]):
(-[WKFormAccessoryView autoFillButtonItem]):
(-[WKFormAccessoryView setNextPreviousItemsVisible:]):
(-[WKFormAccessoryView setNextEnabled:]):
(-[WKFormAccessoryView isNextEnabled]):
(-[WKFormAccessoryView setPreviousEnabled:]):
(-[WKFormAccessoryView isPreviousEnabled]):
(-[WKFormAccessoryView contentRatio]):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::promptForGetDisplayMedia):

Unrelated unified source build fix.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/ios/UIKitSPI.h:

Canonical link: <a href="https://commits.webkit.org/268485@main">https://commits.webkit.org/268485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bdedfe73f796e7db117fe6d2720c21a8b60471e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21725 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20404 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22579 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18041 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22302 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17978 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4743 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22326 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->