### PR TITLE
REGRESSION(266877@main): [ macOS wk2 ] requestidlecallback/requestidlecallback-in-page-cache.html is a flaky text failure/timeout.

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2108,7 +2108,6 @@ webkit.org/b/261226 fast/images/mac/play-pause-individual-animation-context-menu
 [ Monterey+ ] imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html [ Pass Failure ]
 [ Monterey+ X86_64 ] imported/w3c/web-platform-tests/webrtc/simulcast/getStats.https.html [ Pass Failure ]
 
-webkit.org/b/261341 requestidlecallback/requestidlecallback-in-page-cache.html [ Pass Failure Timeout ]
 webkit.org/b/261344 requestidlecallback/requestidlecallback-does-not-block-timer.html [ Pass Failure ]
 
 # rdar://115746676 (REGRESSION (267943@main): [ Sonoma wk2 ] 27 tests are a constant crash)

--- a/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html
@@ -10,20 +10,12 @@ jsTestIsAsync = true;
 const iframe = document.createElement('iframe');
 document.body.appendChild(iframe);
 
-let isInitialLoad = true;
 const logsA = [];
 const logsB = [];
-if (window.testRunner)
-  setTimeout(() => testRunner.notifyDone(), 3000);
 
 window.addEventListener("pageshow", function(event) {
-    if (isInitialLoad) {
-        isInitialLoad = false;
+    if (!event.persisted)
         return;
-    }
-  
-    if (window.testRunner)
-      setTimeout(() => testRunner.notifyDone(), 3000);
 
     shouldBeTrue('event.persisted');
     shouldBe('logsA.length', '0');
@@ -31,11 +23,15 @@ window.addEventListener("pageshow", function(event) {
     iframe.contentWindow.requestIdleCallback(() => logsB.push('B3'));
     requestIdleCallback(() => logsA.push('A4'));
     setTimeout(() => {
-        shouldBe('logsA.length', '4');
-        shouldBeEqualToString('logsA.join(", ")', 'A1, A2, A3, A4');
-        shouldBe('logsB.length', '3');
-        shouldBeEqualToString('logsB.join(", ")', 'B1, B2, B3');
-        finishJSTest();
+        requestIdleCallback(() => {
+            iframe.contentWindow.requestIdleCallback(() => {
+                shouldBe('logsA.length', '4');
+                shouldBeEqualToString('logsA.join(", ")', 'A1, A2, A3, A4');
+                shouldBe('logsB.length', '3');
+                shouldBeEqualToString('logsB.join(", ")', 'B1, B2, B3');
+                finishJSTest();
+            });
+        });
     }, 100);
 });
 


### PR DESCRIPTION
#### 2bac3341dc4875ff1592dfcf40989927694123a5
<pre>
REGRESSION(266877@main): [ macOS wk2 ] requestidlecallback/requestidlecallback-in-page-cache.html is a flaky text failure/timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261341">https://bugs.webkit.org/show_bug.cgi?id=261341</a>

Reviewed by Wenson Hsieh.

The flakiness was caused by the check sometimes running before idle callbacks.
Delay the check using idle callbacks to enforce the ordering.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/requestidlecallback/requestidlecallback-in-page-cache.html:

Canonical link: <a href="https://commits.webkit.org/268481@main">https://commits.webkit.org/268481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3b455a153ee32ea4da1bd5eed03cbfa8c6c4530

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21685 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18495 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20360 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22540 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24291 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22273 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15909 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17842 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22290 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2422 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->