### PR TITLE
[WGSL] Vector constants are incorrect

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -26,24 +26,143 @@
 #pragma once
 
 #include "ConstantValue.h"
+#include "Types.h"
+#include <wtf/Assertions.h>
 
 namespace WGSL {
 
-static ConstantValue constantPow(const FixedVector<ConstantValue>& arguments)
+static ConstantValue constantPow(AST::CallExpression&, const FixedVector<ConstantValue>& arguments)
 {
     const auto& value = arguments[0];
     const auto& exponent = arguments[1];
 
     if (value.isNumber())
-        return { value.type, std::pow(value.toDouble(), exponent.toDouble()) };
+        return { std::pow(value.toDouble(), exponent.toDouble()) };
 
     auto& baseVector = std::get<ConstantVector>(value);
     auto& expVector = std::get<ConstantVector>(exponent);
     auto size = baseVector.elements.size();
     ConstantVector result(size);
     for (unsigned i = 0; i < size; ++i)
-        result.elements[i] = { baseVector.elements[i].type, std::pow(baseVector.elements[i].toDouble(), expVector.elements[i].toDouble()) };
-    return { value.type, result };
+        result.elements[i] = { std::pow(baseVector.elements[i].toDouble(), expVector.elements[i].toDouble()) };
+    return { result };
+}
+
+static ConstantValue zeroValue(const Type* type)
+{
+    return WTF::switchOn(*type,
+        [&](const Types::Primitive& primitive) -> ConstantValue {
+            switch (primitive.kind) {
+            case Types::Primitive::AbstractInt:
+            case Types::Primitive::I32:
+            case Types::Primitive::U32:
+                return { static_cast<int64_t>(0) };
+            case Types::Primitive::AbstractFloat:
+            case Types::Primitive::F32:
+                return { static_cast<double>(0) };
+            case Types::Primitive::Bool:
+                return { static_cast<double>(false) };
+            case Types::Primitive::Void:
+            case Types::Primitive::Sampler:
+            case Types::Primitive::TextureExternal:
+            case Types::Primitive::AccessMode:
+            case Types::Primitive::TexelFormat:
+            case Types::Primitive::AddressSpace:
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        },
+        [&](const Types::Vector& vector) -> ConstantValue {
+            ConstantVector result(vector.size);
+            auto value = zeroValue(vector.element);
+            for (unsigned i = 0; i < vector.size; ++i)
+                result.elements[i] = value;
+            return result;
+        },
+        [&](const Types::Array& array) -> ConstantValue {
+            ASSERT(array.size.has_value());
+            ConstantArray result(*array.size);
+            auto value = zeroValue(array.element);
+            for (unsigned i = 0; i < array.size; ++i)
+                result.elements[i] = value;
+            return result;
+        },
+        [&](const Types::Struct&) -> ConstantValue {
+            // FIXME: this is valid and needs to be implemented, but we don't
+            // yet have ConstantStruct
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::Matrix&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::Reference&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::Pointer&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::Function&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::Texture&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::TextureStorage&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::TextureDepth&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::TypeConstructor&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Types::Bottom&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        });
+}
+
+static ConstantValue constantVector(AST::CallExpression& call, const FixedVector<ConstantValue>& arguments, unsigned size)
+{
+    ConstantVector result(size);
+    auto argumentCount = arguments.size();
+
+    if (!argumentCount) {
+        ASSERT(std::holds_alternative<Types::Vector>(*call.inferredType()));
+        return zeroValue(call.inferredType());
+    }
+
+    if (argumentCount == 1 && !std::holds_alternative<ConstantVector>(arguments[0])) {
+        for (unsigned i = 0; i < size; ++i)
+            result.elements[i] = arguments[0];
+        return result;
+    }
+
+    unsigned i = 0;
+    for (const auto& argument : arguments) {
+        const auto* vector = std::get_if<ConstantVector>(&argument);
+        if (!vector) {
+            result.elements[i++] = argument;
+            continue;
+        }
+        for (auto element : vector->elements)
+            result.elements[i++] = element;
+    }
+    ASSERT(i == size);
+    return { result };
+}
+
+static ConstantValue constantVector2(AST::CallExpression& call, const FixedVector<ConstantValue>& arguments)
+{
+    return constantVector(call, arguments, 2);
+}
+
+static ConstantValue constantVector3(AST::CallExpression& call, const FixedVector<ConstantValue>& arguments)
+{
+    return constantVector(call, arguments, 3);
+}
+
+static ConstantValue constantVector4(AST::CallExpression& call, const FixedVector<ConstantValue>& arguments)
+{
+    return constantVector(call, arguments, 4);
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -30,8 +30,6 @@
 
 namespace WGSL {
 
-struct Type;
-
 // A constant value might be:
 // - a scalar
 // - a vector
@@ -72,21 +70,7 @@ using BaseValue = std::variant<double, int64_t, bool, ConstantArray, ConstantVec
 struct ConstantValue : BaseValue {
     ConstantValue() = default;
 
-    template<typename T>
-    ConstantValue(const Type* type, T&& value)
-        : BaseValue(std::forward<T>(value))
-        , type(type)
-    {
-    }
-
-    static void constructDeletedValue(ConstantValue& slot)
-    {
-        slot.type = bitwise_cast<Type*>(static_cast<intptr_t>(-1));
-    }
-    static bool isDeletedValue(const ConstantValue& value)
-    {
-        return value.type == bitwise_cast<Type*>(static_cast<intptr_t>(-1));
-    }
+    using BaseValue::BaseValue;
 
     void dump(PrintStream&) const;
 
@@ -95,6 +79,8 @@ struct ConstantValue : BaseValue {
         return std::holds_alternative<int64_t>(*this) || std::holds_alternative<double>(*this);
     }
 
+    bool toBool() const { return std::get<bool>(*this); }
+    int64_t toInt() const { return std::get<int64_t>(*this); }
     double toDouble() const
     {
         ASSERT(isNumber());
@@ -102,8 +88,6 @@ struct ConstantValue : BaseValue {
             return std::get<double>(*this);
         return static_cast<double>(std::get<int64_t>(*this));
     }
-
-    const Type* type;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl
@@ -1,8 +1,10 @@
 // RUN: %metal main 2>&1 | %check
-const a = vec2(0);
+const a = vec2u(0);
+const b = vec2f(a);
 @compute @workgroup_size(1)
 fn main() {
-  // CHECK: vec.* local\d+ = vec.*
-  // CHECK: \(void\)\(local\d+\)
-  _ = a;
+  // CHECK: vec.* local\d+ = float2
+  // CHECK: \(void\)\(local\d+\[0\]\)
+  let x = vec4f(b, 0, 0);
+  _ = x[0];
 }


### PR DESCRIPTION
#### f19946127d6320625b638893878aad89de7af7e1
<pre>
[WGSL] Vector constants are incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=262125">https://bugs.webkit.org/show_bug.cgi?id=262125</a>
rdar://116063871

Reviewed by Mike Wyrzykowski.

The current implementation the constant vector constructor only works for the case
where the vector is constructor from N simple types (e.g. vec3(0,0)), but it doesn&apos;t
work when the constructor has to clone a single value (e.g. vec3(0)) or when the
constructor takes other vectors as an argument (e.g. vec3(vec2(0), 0) or vec3(vec3(0))).

This patch implements the constructor correctly, handling all of these cases. In order to
do, it also introduces the correct &quot;zero values&quot; for all types, according to the spec[1].

It also simplifies ConstantValue by removing the type from it, which wasn&apos;t necessary
and complicated the creation of values.

[1]: <a href="https://www.w3.org/TR/WGSL/#zero-value-builtin-function">https://www.w3.org/TR/WGSL/#zero-value-builtin-function</a>

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::constantPow):
(WGSL::zeroValue):
(WGSL::constantVector):
(WGSL::constantVector2):
(WGSL::constantVector3):
(WGSL::constantVector4):
* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::ConstantRewriter):
(WGSL::ConstantRewriter::visit):
(WGSL::ConstantRewriter::evaluate):
(WGSL::ConstantRewriter::materialize):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantValue::toBool const):
(WGSL::ConstantValue::toInt const):
(WGSL::ConstantValue::toDouble const):
(WGSL::ConstantValue::ConstantValue): Deleted.
(WGSL::ConstantValue::constructDeletedValue): Deleted.
(WGSL::ConstantValue::isDeletedValue): Deleted.
* Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl:

Canonical link: <a href="https://commits.webkit.org/268499@main">https://commits.webkit.org/268499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bedb423581cbb2023c8d100be7eb205071901b9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18574 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20459 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20082 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22634 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22345 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18859 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15983 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18031 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4752 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18683 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->