### PR TITLE
[WGSL] Add support for while statements

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -98,6 +98,7 @@ public:
     void visit(AST::PhonyAssignmentStatement&) override;
     void visit(AST::ReturnStatement&) override;
     void visit(AST::ForStatement&) override;
+    void visit(AST::WhileStatement&) override;
     void visit(AST::BreakStatement&) override;
     void visit(AST::ContinueStatement&) override;
 
@@ -1403,6 +1404,14 @@ void FunctionDefinitionWriter::visit(AST::ForStatement& statement)
         m_stringBuilder.append(" ");
         visit(*update);
     }
+    m_stringBuilder.append(") ");
+    visit(statement.body());
+}
+
+void FunctionDefinitionWriter::visit(AST::WhileStatement& statement)
+{
+    m_stringBuilder.append("while (");
+    visit(statement.test());
     m_stringBuilder.append(") ");
     visit(statement.body());
 }

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -985,6 +985,10 @@ Result<AST::Statement::Ref> Parser<Lexer>::parseStatement()
         // FIXME: Handle attributes attached to statement.
         return parseForStatement();
     }
+    case TokenType::KeywordWhile: {
+        // FIXME: Handle attributes attached to statement.
+        return parseWhileStatement();
+    }
     case TokenType::KeywordBreak: {
         consume();
         CONSUME_TYPE(Semicolon);
@@ -1122,6 +1126,19 @@ Result<AST::Statement::Ref> Parser<Lexer>::parseForStatement()
     PARSE(body, CompoundStatement);
 
     RETURN_ARENA_NODE(ForStatement, maybeInitializer, maybeTest, maybeUpdate, WTFMove(body));
+}
+
+template<typename Lexer>
+Result<AST::Statement::Ref> Parser<Lexer>::parseWhileStatement()
+{
+    START_PARSE();
+
+    CONSUME_TYPE(KeywordWhile);
+
+    PARSE(test, Expression);
+    PARSE(body, CompoundStatement);
+
+    RETURN_ARENA_NODE(WhileStatement, WTFMove(test), WTFMove(body));
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -81,6 +81,7 @@ public:
     Result<AST::Statement::Ref> parseIfStatement();
     Result<AST::Statement::Ref> parseIfStatementWithAttributes(AST::Attribute::List&&, SourcePosition _startOfElementPosition);
     Result<AST::Statement::Ref> parseForStatement();
+    Result<AST::Statement::Ref> parseWhileStatement();
     Result<AST::Statement::Ref> parseReturnStatement();
     Result<AST::Statement::Ref> parseVariableUpdatingStatement();
     Result<AST::Statement::Ref> parseVariableUpdatingStatement(AST::Expression::Ref&&);

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -82,6 +82,7 @@ public:
     void visit(AST::ReturnStatement&) override;
     void visit(AST::CompoundStatement&) override;
     void visit(AST::ForStatement&) override;
+    void visit(AST::WhileStatement&) override;
 
     // Expressions
     void visit(AST::Expression&) override;
@@ -592,6 +593,15 @@ void TypeChecker::visit(AST::ForStatement& statement)
 
     if (auto* update = statement.maybeUpdate())
         AST::Visitor::visit(*update);
+
+    visit(statement.body());
+}
+
+void TypeChecker::visit(AST::WhileStatement& statement)
+{
+    auto* testType = infer(statement.test());
+    if (!unify(m_types.boolType(), testType))
+        typeError(InferBottom::No, statement.test().span(), "while condition must be bool, got ", *testType);
 
     visit(statement.body());
 }

--- a/Source/WebGPU/WGSL/tests/invalid/while.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/while.wgsl
@@ -1,0 +1,8 @@
+// RUN: %not %wgslc | %check
+
+fn testWhileStatement() {
+    // CHECK-L: while condition must be bool, got ref<function, i32, read_write>
+    var i = 0;
+    while (i) {
+    }
+}

--- a/Source/WebGPU/WGSL/tests/valid/while.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/while.wgsl
@@ -1,0 +1,10 @@
+// RUN: %metal-compile testWhileStatement
+
+@compute
+@workgroup_size(1, 1, 1)
+fn testWhileStatement() {
+    var i = 0;
+    while i < 10 {
+        i = i + 1;
+    }
+}


### PR DESCRIPTION
#### 67c706376e768a8f5bf4495ca34e89e5fc1f662d
<pre>
[WGSL] Add support for while statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=262126">https://bugs.webkit.org/show_bug.cgi?id=262126</a>
rdar://116064615

Reviewed by Mike Wyrzykowski.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseWhileStatement):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/while.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/while.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/268501@main">https://commits.webkit.org/268501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb77186f5b896c06235d4b5b3ae0ced3f2fbfd75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20046 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22543 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17178 "5 flakes 4 failures") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24295 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22277 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15912 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17943 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4751 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->