### PR TITLE
[WGSL] Add support for atomic types

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -112,6 +112,9 @@ static ConstantValue zeroValue(const Type* type)
         [&](const Types::TextureDepth&) -> ConstantValue {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const Types::Atomic&) -> ConstantValue {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const Types::TypeConstructor&) -> ConstantValue {
             RELEASE_ASSERT_NOT_REACHED();
         },

--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -332,6 +332,9 @@ void ConstantRewriter::materialize(Node& expression, const ConstantValue& value)
         [&](const TextureDepth&) {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const Atomic&) {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const TypeConstructor&) {
             RELEASE_ASSERT_NOT_REACHED();
         },

--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -183,6 +183,9 @@ const Type* concretize(const Type* type, TypeStore& types)
         [&](const Reference&) -> const Type* {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const Atomic&) -> const Type* {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const TypeConstructor&) -> const Type* {
             RELEASE_ASSERT_NOT_REACHED();
         });

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -735,6 +735,12 @@ static BindGroupLayoutEntry::BindingMember bindingMemberForGlobal(auto& global)
             .viewDimension = viewDimension,
             .multisampled = multisampled
         };
+    }, [&](const Atomic&) -> BindGroupLayoutEntry::BindingMember {
+        return BufferBindingLayout {
+            .type = addressSpace(),
+            .hasDynamicOffset = false,
+            .minBindingSize = 0
+        };
     }, [&](const Reference&) -> BindGroupLayoutEntry::BindingMember {
         RELEASE_ASSERT_NOT_REACHED();
     }, [&](const Pointer&) -> BindGroupLayoutEntry::BindingMember {

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -778,6 +778,12 @@ void FunctionDefinitionWriter::visit(const Type* type)
             visit(pointer.element);
             m_stringBuilder.append("*");
         },
+        [&](const Atomic& atomic) {
+            if (atomic.element == m_callGraph.ast().types().i32Type())
+                m_stringBuilder.append("atomic_int");
+            else
+                m_stringBuilder.append("atomic_uint");
+        },
         [&](const Function&) {
             RELEASE_ASSERT_NOT_REACHED();
         },

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -122,6 +122,8 @@ TypeStore::TypeStore()
     m_textureDepthCube = allocateType<TextureDepth>(TextureDepth::Kind::TextureDepthCube);
     m_textureDepthArrayCube = allocateType<TextureDepth>(TextureDepth::Kind::TextureDepthCubeArray);
     m_textureDepthMultisampled2d = allocateType<TextureDepth>(TextureDepth::Kind::TextureDepthMultisampled2d);
+    m_atomicI32 = allocateType<Atomic>(m_i32);
+    m_atomicU32 = allocateType<Atomic>(m_u32);
 }
 
 const Type* TypeStore::structType(AST::Structure& structure, HashMap<String, const Type*>&& fields)
@@ -209,6 +211,14 @@ const Type* TypeStore::pointerType(AddressSpace addressSpace, const Type* elemen
     type = allocateType<Pointer>(addressSpace, accessMode, element);
     m_cache.insert(key, type);
     return type;
+}
+
+const Type* TypeStore::atomicType(const Type* type)
+{
+    if (type == m_i32)
+        return m_atomicI32;
+    ASSERT(type == m_u32);
+    return m_atomicU32;
 }
 
 const Type* TypeStore::typeConstructorType(ASCIILiteral name, std::function<const Type*(AST::ElaboratedTypeExpression&)>&& constructor)

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -98,6 +98,7 @@ public:
     const Type* functionType(Vector<const Type*>&&, const Type*);
     const Type* referenceType(AddressSpace, const Type*, AccessMode);
     const Type* pointerType(AddressSpace, const Type*, AccessMode);
+    const Type* atomicType(const Type*);
     const Type* typeConstructorType(ASCIILiteral, std::function<const Type*(AST::ElaboratedTypeExpression&)>&&);
 
 private:
@@ -125,6 +126,8 @@ private:
     const Type* m_textureDepthCube;
     const Type* m_textureDepthArrayCube;
     const Type* m_textureDepthMultisampled2d;
+    const Type* m_atomicI32;
+    const Type* m_atomicU32;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -208,6 +208,9 @@ void Type::dump(PrintStream& out) const
         [&](const Pointer& reference) {
             out.print("ptr<", reference.addressSpace, ", ", *reference.element, ", ", reference.accessMode, ">");
         },
+        [&](const Atomic& atomic) {
+            out.print("atomic<", *atomic.element, ">");
+        },
         [&](const TypeConstructor& constructor) {
             out.print(constructor.name);
         },
@@ -372,6 +375,9 @@ unsigned Type::size() const
         [&](const Pointer&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
+        [&](const Atomic&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
         [&](const TypeConstructor&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
@@ -438,6 +444,9 @@ unsigned Type::alignment() const
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Pointer&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Atomic&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const TypeConstructor&) -> unsigned {

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -175,6 +175,10 @@ struct Pointer {
     const Type* element;
 };
 
+struct Atomic {
+    const Type* element;
+};
+
 struct TypeConstructor {
     ASCIILiteral name;
     std::function<const Type*(AST::ElaboratedTypeExpression&)> construct;
@@ -197,6 +201,7 @@ struct Type : public std::variant<
     Types::TextureDepth,
     Types::Reference,
     Types::Pointer,
+    Types::Atomic,
     Types::TypeConstructor,
     Types::Bottom
 > {
@@ -212,6 +217,7 @@ struct Type : public std::variant<
         Types::TextureDepth,
         Types::Reference,
         Types::Pointer,
+        Types::Atomic,
         Types::TypeConstructor,
         Types::Bottom
         >::variant;

--- a/Source/WebGPU/WGSL/tests/invalid/atomics.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/atomics.wgsl
@@ -1,0 +1,7 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: 'atomic' requires 1 template argument
+@group(0) @binding(0) var<storage, read_write> x : atomic<i32, i32>;
+
+// CHECK-L: atomic only supports i32 or u32 types
+@group(0) @binding(1) var<storage, read_write> y : atomic<f32>;

--- a/Source/WebGPU/WGSL/tests/valid/atomics.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/atomics.wgsl
@@ -1,0 +1,8 @@
+// RUN: %metal-compile main
+
+@group(1) @binding(0) var<storage, read_write> x : atomic<i32>;
+
+@compute @workgroup_size(1)
+fn main() {
+  let y : ptr<storage, atomic<i32>, read_write> = &x;
+}


### PR DESCRIPTION
#### 9fdb10ebb1ce6765e0d1dc4199ac5140edc4f434
<pre>
[WGSL] Add support for atomic types
<a href="https://bugs.webkit.org/show_bug.cgi?id=262127">https://bugs.webkit.org/show_bug.cgi?id=262127</a>
rdar://116064944

Reviewed by Mike Wyrzykowski.

Add support for atomic according to the spec[1].

[1]: <a href="https://www.w3.org/TR/WGSL/#atomic-types">https://www.w3.org/TR/WGSL/#atomic-types</a>

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::materialize):
* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::concretize):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::bindingMemberForGlobal):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::TypeStore):
(WGSL::TypeStore::atomicType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
(WGSL::Type::size const):
(WGSL::Type::alignment const):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/tests/invalid/atomics.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/atomics.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/268504@main">https://commits.webkit.org/268504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/797e6d72406e875b120ab9c33f921916c6cf8e65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21788 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18581 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20467 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20087 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22642 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18334 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22351 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15990 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18038 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4755 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->