### PR TITLE
GPUExternalTextureDescriptor: fix compilation without video support

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
@@ -63,14 +63,13 @@ struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
 
     WebGPU::ExternalTextureDescriptor convertToBacking() const
     {
-#if ENABLE(VIDEO)
-        auto mediaIdentifier = mediaIdentifierForSource(source);
-#else
-        auto mediaIdentifier = WebGPU::VideoSourceIdentifier { 0 };
-#endif
         return {
             { label },
+#if ENABLE(VIDEO)
             mediaIdentifierForSource(source),
+#else
+            { 0 },
+#endif
             WebCore::convertToBacking(colorSpace),
         };
     }


### PR DESCRIPTION
#### e7b9f308ce4a9b9d3e171c66ef13390bc21ee0c9
<pre>
GPUExternalTextureDescriptor: fix compilation without video support

<a href="https://bugs.webkit.org/show_bug.cgi?id=262039">https://bugs.webkit.org/show_bug.cgi?id=262039</a>

Reviewed by Mike Wyrzykowski.

Commit ac630888d1faae104b5e8bed6c30078e9036abb1 accidentally readded
mediaIdentifier which was dropped in commit f9d7fea52f903441640365484bf48dc5d50d82ff.

Signed-off-by: Thomas Devoogdt &lt;thomas@devoogdt.com&gt;
Canonical link: <a href="https://commits.webkit.org/268475@main">https://commits.webkit.org/268475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/138db96c8f25d15515932cd89863121d5801f368

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20368 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22547 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18015 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22280 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18783 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17947 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4735 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->