### PR TITLE
REGRESSION(268154@main): [ macOS ] TestWebKitAPI.WKNavigation.WebProcessLimit is a constant failure

### DIFF
--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -133,6 +133,7 @@ public:
     // the list, it is moved to the end.
     AddResult appendOrMoveToLast(const ValueType&);
     AddResult appendOrMoveToLast(ValueType&&);
+    bool moveToLastIfPresent(const ValueType&);
 
     // Add the value to the beginning of the collection. If the value was already in
     // the list, it is moved to the beginning.
@@ -581,6 +582,18 @@ auto ListHashSet<T, U>::appendOrMoveToLast(ValueType&& value) -> AddResult
     appendNode(node);
 
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);
+}
+
+template<typename T, typename U>
+bool ListHashSet<T, U>::moveToLastIfPresent(const ValueType& value)
+{
+    auto iterator = m_impl.template find<BaseTranslator>(value);
+    if (iterator == m_impl.end())
+        return false;
+    Node* node = *iterator;
+    unlink(node);
+    appendNode(node);
+    return true;
 }
 
 template<typename T, typename U>

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -213,6 +213,13 @@ public:
     }
 
     template <typename U>
+    bool moveToLastIfPresent(const U& value)
+    {
+        amortizedCleanupIfNeeded();
+        return m_set.moveToLastIfPresent(*static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(value), assertionsPolicy).m_impl);
+    }
+
+    template <typename U>
     AddResult prependOrMoveToFirst(const U& value)
     {
         amortizedCleanupIfNeeded();

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2444,7 +2444,7 @@ void WebProcessProxy::enableRemoteWorkers(RemoteWorkerType workerType, const Use
 
 void WebProcessProxy::markProcessAsRecentlyUsed()
 {
-    liveProcessesLRU().appendOrMoveToLast(*this);
+    liveProcessesLRU().moveToLastIfPresent(*this);
 }
 
 void WebProcessProxy::systemBeep()

--- a/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
@@ -132,6 +132,49 @@ TEST(WTF_ListHashSet, AppendOrMoveToLastWithDuplicates)
     ++iterator;
 }
 
+TEST(WTF_ListHashSet, MoveToLastIfPresent)
+{
+    ListHashSet<int> list;
+    EXPECT_EQ(list.size(), 0U);
+    EXPECT_FALSE(list.moveToLastIfPresent(1));
+    EXPECT_EQ(list.size(), 0U);
+
+    list.add(1);
+    EXPECT_EQ(list.size(), 1U);
+    EXPECT_FALSE(list.moveToLastIfPresent(2));
+    EXPECT_EQ(list.size(), 1U);
+    EXPECT_EQ(list.first(), 1);
+
+    EXPECT_TRUE(list.moveToLastIfPresent(1));
+    EXPECT_EQ(list.size(), 1U);
+    EXPECT_EQ(list.first(), 1);
+
+    list.add(2);
+    list.add(3);
+    list.add(4);
+    EXPECT_EQ(list.size(), 4U);
+
+    EXPECT_TRUE(list.moveToLastIfPresent(1));
+    auto iterator = list.begin();
+    ASSERT_EQ(2, *iterator);
+    ++iterator;
+    ASSERT_EQ(3, *iterator);
+    ++iterator;
+    ASSERT_EQ(4, *iterator);
+    ++iterator;
+    ASSERT_EQ(1, *iterator);
+
+    EXPECT_TRUE(list.moveToLastIfPresent(4));
+    iterator = list.begin();
+    ASSERT_EQ(2, *iterator);
+    ++iterator;
+    ASSERT_EQ(3, *iterator);
+    ++iterator;
+    ASSERT_EQ(1, *iterator);
+    ++iterator;
+    ASSERT_EQ(4, *iterator);
+}
+
 TEST(WTF_ListHashSet, PrependOrMoveToLastNewItems)
 {
     ListHashSet<int> list;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm
@@ -416,12 +416,7 @@ TEST(WKNavigation, WebViewURLInProcessDidTerminate)
     TestWebKitAPI::Util::run(&done);
 }
 
-// FIXME when rdar://116069794 is resolved.
-#if PLATFORM(MAC)
-TEST(WKNavigation, DISABLED_WebProcessLimit)
-#else
 TEST(WKNavigation, WebProcessLimit)
-#endif
 {
     constexpr unsigned maxProcessCount = 10;
     [WKProcessPool _setWebProcessCountLimit:maxProcessCount];


### PR DESCRIPTION
#### 50b0cd282f38a8dbfdc330d43c4b4de536b56715
<pre>
REGRESSION(268154@main): [ macOS ] TestWebKitAPI.WKNavigation.WebProcessLimit is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=262134">https://bugs.webkit.org/show_bug.cgi?id=262134</a>
rdar://116069794

Reviewed by Ryosuke Niwa.

In 268154@main, I updated WebProcessProxy::markProcessAsRecentlyUsed() to call:
```
liveProcessesLRU().appendOrMoveToLast(*this);
```

instead of
```
if (liveProcessesLRU().contains(this))
    liveProcessesLRU().appendOrMoveToLast(this);
```

I was trying to avoid a double HashMap lookup and mistakenly thought that the
process was always in liveProcessesLRU(). However, it turns out that dummy
WebProcessProxy objects (which don&apos;t have a backing process) are not part of
liveProcessesLRU() and were now getting inserted, causing the API test to fail.

To address the issue while avoiding the double HashMap lookup, I am introducing
a ListHashSet::moveToLastIfPresent() operation. I now use this in
markProcessAsRecentlyUsed().

* Source/WTF/wtf/ListHashSet.h:
(WTF::U&gt;::moveToLastIfPresent):
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::markProcessAsRecentlyUsed):
* Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebContentProcessDidTerminate.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/268492@main">https://commits.webkit.org/268492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3a22280e4f6ccb537c2dd54c528ce49f71e462a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20406 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22581 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24325 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17242 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22308 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15938 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23235 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17980 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22328 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24489 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2432 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18634 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5430 "Passed tests") | 
<!--EWS-Status-Bubble-End-->