### PR TITLE
REGRESSION(268408@main): [ macOS ] TestWebKitAPI.WebPushDPushNotificationEventTest.Basic is constantly timing out.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -1805,9 +1805,7 @@ static constexpr ASCIILiteral json45 = R"JSONRESOURCE(
     "default_action_url": "https://example.com/",
     "title": "Test a default action URL override",
     "mutable": true,
-    "options": {
-        "tag": "defaultactionurl https://webkit.org/"
-    },
+    "tag": "defaultactionurl https://webkit.org/",
     "app_badge": "12"
 }
 )JSONRESOURCE"_s;
@@ -1816,9 +1814,7 @@ static constexpr ASCIILiteral json46 = R"JSONRESOURCE(
     "default_action_url": "https://example.com/",
     "title": "Test a missing default action URL override",
     "mutable": true,
-    "options": {
-        "tag": "emptydefaultactionurl"
-    },
+    "tag": "emptydefaultactionurl",
     "app_badge": "12"
 }
 )JSONRESOURCE"_s;
@@ -2082,8 +2078,7 @@ public:
     }
 };
 
-// FIXME after rdar://116087660 is resolved.
-TEST_F(WebPushDPushNotificationEventTest, DISABLED_Basic)
+TEST_F(WebPushDPushNotificationEventTest, Basic)
 {
     prep();
     runTest(json39);


### PR DESCRIPTION
#### 860991a7920d2f60a54d108defe3f18169c3bb32
<pre>
REGRESSION(268408@main): [ macOS ] TestWebKitAPI.WebPushDPushNotificationEventTest.Basic is constantly timing out.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262150">https://bugs.webkit.org/show_bug.cgi?id=262150</a>
rdar://116087660

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/268491@main">https://commits.webkit.org/268491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bff8a6293d9d7677f90f8d5c108ebddc9e8dfd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21747 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20425 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22601 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18061 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22318 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/17999 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4747 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22348 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->