### PR TITLE
Fix TextStream dumping of Objective-C types

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		0FA6F38F20CC580F00A03DCD /* SegmentedVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA6F38E20CC580E00A03DCD /* SegmentedVector.cpp */; };
 		0FA6F39320CC73A300A03DCD /* SmallSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA6F39220CC73A200A03DCD /* SmallSet.cpp */; };
 		0FA6F39520CCACE900A03DCD /* UniqueArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA6F39420CCACE900A03DCD /* UniqueArray.cpp */; };
+		0FC0CD722AF1ADC5009E2AD4 /* TextStreamCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC0CD712AF1ADC5009E2AD4 /* TextStreamCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FDDBFA71666DFA300C55FEF /* StringPrintStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDDBFA51666DFA300C55FEF /* StringPrintStream.cpp */; };
 		0FE1646A1B6FFC9600400E7C /* Lock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE164681B6FFC9600400E7C /* Lock.cpp */; };
 		0FE4479C1B7AAA03009498EB /* WordLock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE4479A1B7AAA03009498EB /* WordLock.cpp */; };
@@ -1025,6 +1026,7 @@
 		0FB399B820AF5A580017E213 /* BooleanLattice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BooleanLattice.h; sourceTree = "<group>"; };
 		0FB467821FDE282B003FCB09 /* ConcurrentBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConcurrentBuffer.h; sourceTree = "<group>"; };
 		0FB467831FDE282C003FCB09 /* ConcurrentVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConcurrentVector.h; sourceTree = "<group>"; };
+		0FC0CD712AF1ADC5009E2AD4 /* TextStreamCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextStreamCocoa.h; sourceTree = "<group>"; };
 		0FC4488216FE9FE100844BE9 /* ProcessID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessID.h; sourceTree = "<group>"; };
 		0FC4EDE51696149600F65041 /* CommaPrinter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommaPrinter.h; sourceTree = "<group>"; };
 		0FD81AC4154FB22E00983E72 /* FastBitVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FastBitVector.h; sourceTree = "<group>"; };
@@ -2543,6 +2545,7 @@
 				A8A4732C151A825B004123FF /* TextPosition.h */,
 				A3E4DD911F3A803400DED0B4 /* TextStream.cpp */,
 				A3E4DD921F3A803400DED0B4 /* TextStream.h */,
+				0FC0CD712AF1ADC5009E2AD4 /* TextStreamCocoa.h */,
 				70ECA60C1B02426800449739 /* UniquedStringImpl.h */,
 				FEF295BF20B49DCB00CF283A /* UTF8ConversionError.h */,
 				A8A4732D151A825B004123FF /* WTFString.cpp */,
@@ -3353,6 +3356,7 @@
 				DDF307E727C086DF006A526F /* TextBreakIteratorInternalICU.h in Headers */,
 				DDF307E027C086DF006A526F /* TextPosition.h in Headers */,
 				DDF307EE27C086DF006A526F /* TextStream.h in Headers */,
+				0FC0CD722AF1ADC5009E2AD4 /* TextStreamCocoa.h in Headers */,
 				DD3DC8AB27A4BF8E007E5B61 /* ThreadAssertions.h in Headers */,
 				DD3DC87327A4BF8E007E5B61 /* ThreadGroup.h in Headers */,
 				DD3DC8A327A4BF8E007E5B61 /* Threading.h in Headers */,

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -209,4 +209,4 @@ void writeIndent(TextStream& ts, int indent)
         ts << "  ";
 }
 
-}
+} // namespace WTF

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -84,12 +84,6 @@ public:
 
 #if PLATFORM(COCOA)
     WTF_EXPORT_PRIVATE TextStream& operator<<(id);
-#ifdef __OBJC__
-    WTF_EXPORT_PRIVATE TextStream& operator<<(NSArray *);
-    WTF_EXPORT_PRIVATE TextStream& operator<<(CGRect);
-    WTF_EXPORT_PRIVATE TextStream& operator<<(CGSize);
-    WTF_EXPORT_PRIVATE TextStream& operator<<(CGPoint);
-#endif
 #endif
 
     OptionSet<Formatting> formattingFlags() const { return m_formattingFlags; }

--- a/Source/WTF/wtf/text/TextStreamCocoa.h
+++ b/Source/WTF/wtf/text/TextStreamCocoa.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include <CoreGraphics/CGGeometry.h>
+#include <wtf/text/TextStream.h>
+
+namespace WTF {
+
+#if PLATFORM(COCOA)
+
+WTF_EXPORT_PRIVATE TextStream& operator<<(TextStream&, CGRect);
+WTF_EXPORT_PRIVATE TextStream& operator<<(TextStream&, CGSize);
+WTF_EXPORT_PRIVATE TextStream& operator<<(TextStream&, CGPoint);
+
+#endif
+
+} // namespace WTF

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TextStreamCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TextStreamCocoa.mm
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import <wtf/text/TextStream.h>
+#import <wtf/text/TextStreamCocoa.h>
 
 #import <Foundation/Foundation.h>
 
@@ -35,17 +35,38 @@ TEST(WTF_TextStream, NSString)
     EXPECT_EQ(ts.release(), "Test"_s);
 }
 
+TEST(WTF_TextStream, Class)
+{
+    TextStream ts;
+    ts << [NSString class];
+    EXPECT_EQ(ts.release(), "NSString"_s);
+}
+
 TEST(WTF_TextStream, NSArray)
 {
     {
         TextStream ts;
-        ts << @[@"Test1", @"Test2"];
+        ts << @[ @"Test1", @"Test2" ];
         EXPECT_EQ(ts.release(), "[Test1, Test2]"_s);
     }
     {
         TextStream ts;
-        ts << @[@"Test1", @[@"Test2", @"Test3"]];
+        ts << @[ @"Test1", @[ @"Test2", @"Test3" ] ];
         EXPECT_EQ(ts.release(), "[Test1, [Test2, Test3]]"_s);
+    }
+}
+
+TEST(WTF_TextStream, NSDictionary)
+{
+    {
+        TextStream ts;
+        ts << @{ @"Test1" : @(3), @"Test2" : @"Hello" };
+        EXPECT_EQ(ts.release(), "{Test1: 3, Test2: Hello}"_s);
+    }
+    {
+        TextStream ts;
+        ts << @{ @"Test1" : @(3), @"Test2" : @[ @"Hello", @" ", @"there" ] };
+        EXPECT_EQ(ts.release(), "{Test1: 3, Test2: [Hello,  , there]}"_s);
     }
 }
 


### PR DESCRIPTION
#### 71add0ad8094e5feccf1bec54608d1889f1be051
<pre>
Fix TextStream dumping of Objective-C types
<a href="https://bugs.webkit.org/show_bug.cgi?id=262160">https://bugs.webkit.org/show_bug.cgi?id=262160</a>
<a href="https://rdar.apple.com/116094853">rdar://116094853</a>

Reviewed by Richard Robinson.

Having both `operator&lt;&lt;(id)` and `operator&lt;&lt;(NSArray *)` caused problems, specifically
trying to dump a Class would hit the latter for some reason.

Remove ambiguity by removing `operator&lt;&lt;(NSArray *)` and have all dumping of Objective-C
types go through `operator&lt;&lt;(id)` which internally queries the object type. Add support
for dumping `Class` and `NSDictionary`.

Move functions that dump CG types out of TextStream and into TextStreamCocoa.h as standalone
functions, so that platform-independent headers aren&apos;t polluted with CG types.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/text/TextStream.cpp:
* Source/WTF/wtf/text/TextStream.h:
* Source/WTF/wtf/text/TextStreamCocoa.h: Added.
* Source/WTF/wtf/text/cocoa/TextStreamCocoa.mm:
(WTF::TextStream::operator&lt;&lt;):
(WTF::operator&lt;&lt;):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TextStreamCocoa.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/270118@main">https://commits.webkit.org/270118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d8eb604a1b0093e0a1fed9d706bb560676b2240

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26710 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22976 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27293 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28344 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21373 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26142 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23858 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/166 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31267 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3152 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6860 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5897 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2299 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31236 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2214 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6534 "Passed tests") | 
<!--EWS-Status-Bubble-End-->