### PR TITLE
Generate serializers for MemoryPressureHandler.h

### DIFF
--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -341,7 +341,7 @@ void MemoryPressureHandler::ReliefLogger::logMemoryUsageChange()
 void MemoryPressureHandler::platformInitialize() { }
 #endif
 
-MemoryPressureHandler::Configuration::Configuration()
+MemoryPressureHandlerConfiguration::MemoryPressureHandlerConfiguration()
     : baseThreshold(std::min(3 * GB, ramSize()))
     , conservativeThresholdFraction(s_conservativeThresholdFraction)
     , strictThresholdFraction(s_strictThresholdFraction)
@@ -350,7 +350,7 @@ MemoryPressureHandler::Configuration::Configuration()
 {
 }
 
-MemoryPressureHandler::Configuration::Configuration(size_t base, double conservative, double strict, std::optional<double> kill, Seconds interval)
+MemoryPressureHandlerConfiguration::MemoryPressureHandlerConfiguration(size_t base, double conservative, double strict, std::optional<double> kill, Seconds interval)
     : baseThreshold(base)
     , conservativeThresholdFraction(conservative)
     , strictThresholdFraction(strict)

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -71,6 +71,18 @@ enum class Synchronous : bool { No, Yes };
 
 typedef WTF::Function<void(Critical, Synchronous)> LowMemoryHandler;
 
+struct MemoryPressureHandlerConfiguration {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    WTF_EXPORT_PRIVATE MemoryPressureHandlerConfiguration();
+    WTF_EXPORT_PRIVATE MemoryPressureHandlerConfiguration(size_t, double, double, std::optional<double>, Seconds);
+
+    size_t baseThreshold;
+    double conservativeThresholdFraction;
+    double strictThresholdFraction;
+    std::optional<double> killThresholdFraction;
+    Seconds pollInterval;
+};
+
 class MemoryPressureHandler {
     WTF_MAKE_FAST_ALLOCATED;
     friend class WTF::LazyNeverDestroyed<MemoryPressureHandler>;
@@ -176,57 +188,8 @@ public:
         WTF_EXPORT_PRIVATE static bool s_loggingEnabled;
     };
 
-    struct Configuration {
-        WTF_MAKE_STRUCT_FAST_ALLOCATED;
-        WTF_EXPORT_PRIVATE Configuration();
-        WTF_EXPORT_PRIVATE Configuration(size_t, double, double, std::optional<double>, Seconds);
+    using Configuration = MemoryPressureHandlerConfiguration;
 
-        template<class Encoder> void encode(Encoder& encoder) const
-        {
-            encoder << baseThreshold;
-            encoder << conservativeThresholdFraction;
-            encoder << strictThresholdFraction;
-            encoder << killThresholdFraction;
-            encoder << pollInterval;
-        }
-
-        template<class Decoder>
-        static std::optional<Configuration> decode(Decoder& decoder)
-        {
-            std::optional<size_t> baseThreshold;
-            decoder >> baseThreshold;
-            if (!baseThreshold)
-                return std::nullopt;
-
-            std::optional<double> conservativeThresholdFraction;
-            decoder >> conservativeThresholdFraction;
-            if (!conservativeThresholdFraction)
-                return std::nullopt;
-
-            std::optional<double> strictThresholdFraction;
-            decoder >> strictThresholdFraction;
-            if (!strictThresholdFraction)
-                return std::nullopt;
-
-            std::optional<std::optional<double>> killThresholdFraction;
-            decoder >> killThresholdFraction;
-            if (!killThresholdFraction)
-                return std::nullopt;
-
-            std::optional<Seconds> pollInterval;
-            decoder >> pollInterval;
-            if (!pollInterval)
-                return std::nullopt;
-
-            return {{ *baseThreshold, *conservativeThresholdFraction, *strictThresholdFraction, *killThresholdFraction, *pollInterval }};
-        }
-
-        size_t baseThreshold;
-        double conservativeThresholdFraction;
-        double strictThresholdFraction;
-        std::optional<double> killThresholdFraction;
-        Seconds pollInterval;
-    };
     void setConfiguration(Configuration&& configuration) { m_configuration = WTFMove(configuration); }
     void setConfiguration(const Configuration& configuration) { m_configuration = configuration; }
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -58,6 +58,15 @@ using WTF::ProcessID = int;
 using WTF::ProcessID = pid_t;
 #endif
 
+header: <wtf/MemoryPressureHandler.h>
+[CustomHeader] struct WTF::MemoryPressureHandlerConfiguration {
+    size_t baseThreshold;
+    double conservativeThresholdFraction;
+    double strictThresholdFraction;
+    std::optional<double> killThresholdFraction;
+    Seconds pollInterval;
+}
+
 enum class WTFLogLevel : uint8_t {
     Always,
     Error,


### PR DESCRIPTION
#### c3745a742d7d83e0ba0b958240f4c3c42114feda
<pre>
Generate serializers for MemoryPressureHandler.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=262161">https://bugs.webkit.org/show_bug.cgi?id=262161</a>
rdar://116098010

Reviewed by Alex Christensen.

* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandlerConfiguration::MemoryPressureHandlerConfiguration):
(WTF::MemoryPressureHandler::Configuration::Configuration): Deleted.
* Source/WTF/wtf/MemoryPressureHandler.h:
(WTF::MemoryPressureHandler::Configuration::encode const): Deleted.
(WTF::MemoryPressureHandler::Configuration::decode): Deleted.
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268496@main">https://commits.webkit.org/268496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9738cfcba43e4deba6e166fe235c12cfbbb19d8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18560 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20444 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22620 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24348 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17278 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22334 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19240 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18845 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23275 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18017 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4750 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22365 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24529 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18669 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5436 "Passed tests") | 
<!--EWS-Status-Bubble-End-->