### PR TITLE
Update serialization for InspectorFrontendClient and PlatformTextTrackData

### DIFF
--- a/Source/WebCore/inspector/InspectorFrontendClient.h
+++ b/Source/WebCore/inspector/InspectorFrontendClient.h
@@ -54,6 +54,19 @@ class FloatRect;
 class InspectorFrontendAPIDispatcher;
 class Page;
 
+enum class InspectorFrontendClientAppearance : uint8_t {
+    System,
+    Light,
+    Dark,
+};
+
+struct InspectorFrontendClientSaveData {
+    String displayType;
+    String url;
+    String content;
+    bool base64Encoded;
+};
+
 class InspectorFrontendClient : public CanMakeWeakPtr<InspectorFrontendClient> {
 public:
     enum class DockSide {
@@ -90,11 +103,8 @@ public:
     virtual void reopen() = 0;
     virtual void resetState() = 0;
 
-    enum class Appearance {
-        System,
-        Light,
-        Dark,
-    };
+    using Appearance = WebCore::InspectorFrontendClientAppearance;
+
     WEBCORE_EXPORT virtual void setForcedAppearance(Appearance) = 0;
 
     virtual UserInterfaceLayoutDirection userInterfaceLayoutDirection() const = 0;
@@ -114,15 +124,9 @@ public:
         SingleFile,
         FileVariants,
     };
-    struct SaveData {
-        String displayType;
-        String url;
-        String content;
-        bool base64Encoded;
 
-        template<class Encoder> void encode(Encoder&) const;
-        template<class Decoder> static std::optional<SaveData> decode(Decoder&);
-    };
+    using SaveData = InspectorFrontendClientSaveData;
+
     virtual bool canSave(SaveMode) = 0;
     virtual void save(Vector<SaveData>&&, bool forceSaveAs) = 0;
 
@@ -158,58 +162,4 @@ public:
     WEBCORE_EXPORT virtual bool isUnderTest() = 0;
 };
 
-template<class Encoder>
-void InspectorFrontendClient::SaveData::encode(Encoder& encoder) const
-{
-    encoder << displayType;
-    encoder << url;
-    encoder << content;
-    encoder << base64Encoded;
-}
-
-template<class Decoder>
-std::optional<InspectorFrontendClient::SaveData> InspectorFrontendClient::SaveData::decode(Decoder& decoder)
-{
-#define DECODE(name, type) \
-    std::optional<type> name; \
-    decoder >> name; \
-    if (!name) \
-        return std::nullopt; \
-
-    DECODE(displayType, String)
-    DECODE(url, String)
-    DECODE(content, String)
-    DECODE(base64Encoded, bool)
-
-#undef DECODE
-
-    return { {
-        WTFMove(*displayType),
-        WTFMove(*url),
-        WTFMove(*content),
-        WTFMove(*base64Encoded),
-    } };
-}
-
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::InspectorFrontendClient::Appearance> {
-    using values = EnumValues<
-        WebCore::InspectorFrontendClient::Appearance,
-        WebCore::InspectorFrontendClient::Appearance::System,
-        WebCore::InspectorFrontendClient::Appearance::Light,
-        WebCore::InspectorFrontendClient::Appearance::Dark
-    >;
-};
-
-template<> struct EnumTraits<WebCore::InspectorFrontendClient::SaveMode> {
-    using values = EnumValues<
-        WebCore::InspectorFrontendClient::SaveMode,
-        WebCore::InspectorFrontendClient::SaveMode::SingleFile,
-        WebCore::InspectorFrontendClient::SaveMode::FileVariants
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/platform/graphics/PlatformTextTrack.h
+++ b/Source/WebCore/platform/graphics/PlatformTextTrack.h
@@ -144,38 +144,4 @@ protected:
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::PlatformTextTrackData::TrackKind> {
-    using values = EnumValues<
-        WebCore::PlatformTextTrackData::TrackKind,
-        WebCore::PlatformTextTrackData::TrackKind::Subtitle,
-        WebCore::PlatformTextTrackData::TrackKind::Caption,
-        WebCore::PlatformTextTrackData::TrackKind::Description,
-        WebCore::PlatformTextTrackData::TrackKind::Chapter,
-        WebCore::PlatformTextTrackData::TrackKind::MetaData,
-        WebCore::PlatformTextTrackData::TrackKind::Forced
-    >;
-};
-
-template<> struct EnumTraits<WebCore::PlatformTextTrackData::TrackType> {
-    using values = EnumValues<
-        WebCore::PlatformTextTrackData::TrackType,
-        WebCore::PlatformTextTrackData::TrackType::InBand,
-        WebCore::PlatformTextTrackData::TrackType::OutOfBand,
-        WebCore::PlatformTextTrackData::TrackType::Script
-    >;
-};
-
-template<> struct EnumTraits<WebCore::PlatformTextTrackData::TrackMode> {
-    using values = EnumValues<
-        WebCore::PlatformTextTrackData::TrackMode,
-        WebCore::PlatformTextTrackData::TrackMode::Disabled,
-        WebCore::PlatformTextTrackData::TrackMode::Hidden,
-        WebCore::PlatformTextTrackData::TrackMode::Showing
-    >;
-};
-
-} // namespace WTF
-
 #endif // ENABLE(VIDEO)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6007,6 +6007,66 @@ struct WebCore::LinkDecorationFilteringData {
     String linkDecoration;
 };
 
+header: <WebCore/InspectorFrontendClient.h>
+[CustomHeader] enum class WebCore::InspectorFrontendClientAppearance : uint8_t {
+    System,
+    Light,
+    Dark,
+};
+using WebCore::InspectorFrontendClient::Appearance = WebCore::InspectorFrontendClientAppearance;
+
+[Nested] enum class WebCore::InspectorFrontendClient::SaveMode : uint8_t {
+    SingleFile,
+    FileVariants,
+};
+
+header: <WebCore/InspectorFrontendClient.h>
+[CustomHeader] struct WebCore::InspectorFrontendClientSaveData {
+    String displayType;
+    String url;
+    String content;
+    bool base64Encoded;
+};
+using WebCore::InspectorFrontendClient::SaveData = WebCore::InspectorFrontendClientSaveData;
+
+#if ENABLE(VIDEO)
+header: <WebCore/PlatformTextTrack.h>
+[Nested, CustomHeader] enum class WebCore::PlatformTextTrackData::TrackKind : uint8_t {
+    Subtitle,
+    Caption,
+    Description,
+    Chapter,
+    MetaData,
+    Forced,
+};
+
+header: <WebCore/PlatformTextTrack.h>
+[Nested, CustomHeader] enum class WebCore::PlatformTextTrackData::TrackType : uint8_t {
+    InBand,
+    OutOfBand,
+    Script,
+};
+
+header: <WebCore/PlatformTextTrack.h>
+[Nested, CustomHeader] enum class WebCore::PlatformTextTrackData::TrackMode : uint8_t {
+    Disabled,
+    Hidden,
+    Showing,
+};
+
+header: <WebCore/PlatformTextTrack.h>
+[CustomHeader] struct WebCore::PlatformTextTrackData {
+    String m_label;
+    String m_language;
+    String m_url;
+    WebCore::PlatformTextTrackData::TrackMode m_mode;
+    WebCore::PlatformTextTrackData::TrackKind m_kind;
+    WebCore::PlatformTextTrackData::TrackType m_type;
+    int m_uniqueId;
+    bool m_isDefault;
+}
+#endif // ENABLE(VIDEO)
+
 [WebKitPlatform] struct WebCore::NotificationPayload {
     URL defaultActionURL;
     String title;
@@ -6135,18 +6195,6 @@ struct WebCore::NowPlayingInfo {
     bool isPlaying;
     bool allowsNowPlayingControlsVisibility;
     std::optional<WebCore::NowPlayingInfoArtwork> artwork;
-}
-
-header: <WebCore/PlatformTextTrack.h>
-[CustomHeader] struct WebCore::PlatformTextTrackData {
-    String m_label;
-    String m_language;
-    String m_url;
-    WebCore::PlatformTextTrackData::TrackMode m_mode;
-    WebCore::PlatformTextTrackData::TrackKind m_kind;
-    WebCore::PlatformTextTrackData::TrackType m_type;
-    int m_uniqueId;
-    bool m_isDefault;
 }
 
 struct WebCore::VideoConfiguration {


### PR DESCRIPTION
#### 77a5b5dffe62f0481c8315e7d7236666702f959a
<pre>
Update serialization for InspectorFrontendClient and PlatformTextTrackData
<a href="https://bugs.webkit.org/show_bug.cgi?id=262162">https://bugs.webkit.org/show_bug.cgi?id=262162</a>
rdar://116098797

Reviewed by Alex Christensen.

* Source/WebCore/inspector/InspectorFrontendClient.h:
(WebCore::InspectorFrontendClient::SaveData::encode const): Deleted.
(WebCore::InspectorFrontendClient::SaveData::decode): Deleted.
* Source/WebCore/platform/graphics/PlatformTextTrack.h:
(WebCore::PlatformTextTrackData::decode): Deleted.
(WebCore::PlatformTextTrackData::encode const): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268507@main">https://commits.webkit.org/268507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efb26e46ede87917300a191b8c02e5f54b32faa7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21808 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20489 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22662 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18116 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22372 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18057 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4760 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22406 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->