### PR TITLE
[UnifiedPDF] Factor loading code into PDFPluginBase

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -196,6 +196,10 @@ private:
     void willDetachRenderer() override;
     bool isComposited() const override { return true; }
 
+    void createPDFDocument() override;
+    void installPDFDocument() override;
+    void tryRunScriptsInPDFDocument() override;
+
     CGFloat scaleFactor() const override;
 
     RetainPtr<PDFDocument> pdfDocumentForPrinting() const override { return m_pdfDocument; }
@@ -207,10 +211,6 @@ private:
 
     void updateControlTints(WebCore::GraphicsContext&) override;
 
-    void streamDidReceiveResponse(const WebCore::ResourceResponse&) override;
-    void streamDidReceiveData(const WebCore::SharedBuffer&) override;
-    void streamDidFinishLoading() override;
-    void streamDidFail() override;
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
 
     bool wantsWheelEvents() const override { return true; }
@@ -239,13 +239,14 @@ private:
     id accessibilityObject() const override;
     id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
 
+    void incrementalPDFStreamDidReceiveData(const WebCore::SharedBuffer&) override;
+    bool incrementalPDFStreamDidFinishLoading() override;
+    void incrementalPDFStreamDidFail() override;
+
     void updateScrollbars();
     Ref<WebCore::Scrollbar> createScrollbar(WebCore::ScrollbarOrientation);
     void destroyScrollbar(WebCore::ScrollbarOrientation);
-    void installPDFDocument();
-    void addArchiveResource();
     void calculateSizes();
-    void tryRunScriptsInPDFDocument();
 
     NSEvent *nsEventForWebMouseEvent(const WebMouseEvent&);
     WebCore::IntPoint convertFromPluginToPDFView(const WebCore::IntPoint&) const;
@@ -253,7 +254,6 @@ private:
     WebCore::IntPoint convertFromPDFViewToRootView(const WebCore::IntPoint&) const;
     WebCore::IntRect convertFromPDFViewToRootView(const WebCore::IntRect&) const;
     WebCore::IntRect frameForHUD() const;
-    void ensureDataBufferLength(uint64_t length);
 
     bool supportsForms();
 
@@ -304,10 +304,6 @@ private:
     WebCore::IntSize m_size;
 
     URL m_sourceURL;
-
-    String m_suggestedFilename;
-    RetainPtr<CFMutableDataRef> m_data;
-    uint64_t m_streamedBytes { 0 };
 
     RetainPtr<PDFDocument> m_pdfDocument;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -88,11 +88,6 @@ public:
 
     virtual void updateControlTints(WebCore::GraphicsContext&) { }
 
-    virtual void streamDidReceiveResponse(const WebCore::ResourceResponse&) = 0;
-    virtual void streamDidReceiveData(const WebCore::SharedBuffer&) = 0;
-    virtual void streamDidFinishLoading() = 0;
-    virtual void streamDidFail() = 0;
-
     virtual RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const = 0;
 
     virtual bool wantsWheelEvents() const { return false; }
@@ -125,13 +120,34 @@ public:
 
     bool isFullFramePlugin() const;
 
+    void streamDidReceiveResponse(const WebCore::ResourceResponse&);
+    void streamDidReceiveData(const WebCore::SharedBuffer&);
+    void streamDidFinishLoading();
+    void streamDidFail();
+
 protected:
     explicit PDFPluginBase(WebCore::HTMLPlugInElement&);
 
     virtual void teardown() = 0;
 
+    virtual void createPDFDocument() = 0;
+    virtual void installPDFDocument() = 0;
+    virtual void tryRunScriptsInPDFDocument() { }
+
+    virtual void incrementalPDFStreamDidReceiveData(const WebCore::SharedBuffer&) { }
+    virtual bool incrementalPDFStreamDidFinishLoading() { return false; }
+    virtual void incrementalPDFStreamDidFail() { }
+
+    void ensureDataBufferLength(uint64_t);
+    void addArchiveResource();
+
     WeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;
+
+    RetainPtr<CFMutableDataRef> m_data;
+
+    String m_suggestedFilename;
+    uint64_t m_streamedBytes { 0 };
 
     bool m_documentFinishedLoading { false };
     bool m_isBeingDestroyed { false };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -43,15 +43,14 @@ private:
 
     void teardown() override;
 
+    void createPDFDocument() override;
+    void installPDFDocument() override;
+
     CGFloat scaleFactor() const override;
 
     RetainPtr<PDFDocument> pdfDocumentForPrinting() const override;
     WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
 
-    void streamDidReceiveResponse(const WebCore::ResourceResponse&) override;
-    void streamDidReceiveData(const WebCore::SharedBuffer&) override;
-    void streamDidFinishLoading() override;
-    void streamDidFail() override;
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
 
     bool handleMouseEvent(const WebMouseEvent&) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -23,8 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
-#import "UnifiedPDFPlugin.h"
+#include "config.h"
+#include "UnifiedPDFPlugin.h"
 
 #if ENABLE(UNIFIED_PDF)
 
@@ -47,6 +47,16 @@ void UnifiedPDFPlugin::teardown()
 
 }
 
+void UnifiedPDFPlugin::createPDFDocument()
+{
+
+}
+
+void UnifiedPDFPlugin::installPDFDocument()
+{
+
+}
+
 CGFloat UnifiedPDFPlugin::scaleFactor() const
 {
     return 1;
@@ -60,26 +70,6 @@ RetainPtr<PDFDocument> UnifiedPDFPlugin::pdfDocumentForPrinting() const
 WebCore::FloatSize UnifiedPDFPlugin::pdfDocumentSizeForPrinting() const
 {
     return { };
-}
-
-void UnifiedPDFPlugin::streamDidReceiveResponse(const WebCore::ResourceResponse&)
-{
-
-}
-
-void UnifiedPDFPlugin::streamDidReceiveData(const WebCore::SharedBuffer&)
-{
-
-}
-
-void UnifiedPDFPlugin::streamDidFinishLoading()
-{
-
-}
-
-void UnifiedPDFPlugin::streamDidFail()
-{
-
 }
 
 RefPtr<FragmentedSharedBuffer> UnifiedPDFPlugin::liveResourceData() const


### PR DESCRIPTION
#### 7b5fdf2f4127b8104c6fe6ccb0b7ec6fff661b30
<pre>
[UnifiedPDF] Factor loading code into PDFPluginBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=262163">https://bugs.webkit.org/show_bug.cgi?id=262163</a>
rdar://116099771

Reviewed by Tim Horton.

Loading code is common to PDFPlugin and UnifiedPDFPlugin, so move it into the base class.
Virtual methods are added to handle incremental loading, which will be migrated in a future PR.

Also add stubs to create and install the PDF document.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::receivedNonLinearizedPDFSentinel):
(WebKit::PDFPlugin::installPDFDocument):
(WebKit::PDFPlugin::incrementalPDFStreamDidFinishLoading):
(WebKit::PDFPlugin::incrementalPDFStreamDidReceiveData):
(WebKit::PDFPlugin::incrementalPDFStreamDidFail):
(WebKit::PDFPlugin::createPDFDocument):
(WebKit::PDFPlugin::addArchiveResource): Deleted.
(WebKit::PDFPlugin::streamDidFinishLoading): Deleted.
(WebKit::PDFPlugin::streamDidReceiveResponse): Deleted.
(WebKit::PDFPlugin::ensureDataBufferLength): Deleted.
(WebKit::PDFPlugin::streamDidReceiveData): Deleted.
(WebKit::PDFPlugin::streamDidFail): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::tryRunScriptsInPDFDocument):
(WebKit::PDFPluginBase::incrementalPDFStreamDidReceiveData):
(WebKit::PDFPluginBase::incrementalPDFStreamDidFinishLoading):
(WebKit::PDFPluginBase::incrementalPDFStreamDidFail):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::ensureDataBufferLength):
(WebKit::PDFPluginBase::streamDidReceiveResponse):
(WebKit::PDFPluginBase::streamDidReceiveData):
(WebKit::PDFPluginBase::streamDidFinishLoading):
(WebKit::PDFPluginBase::streamDidFail):
(WebKit::PDFPluginBase::addArchiveResource):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createPDFDocument):
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::scaleFactor const):
(WebKit::UnifiedPDFPlugin::pdfDocumentForPrinting const):
(WebKit::UnifiedPDFPlugin::pdfDocumentSizeForPrinting const):
(WebKit::UnifiedPDFPlugin::streamDidReceiveResponse): Deleted.
(WebKit::UnifiedPDFPlugin::streamDidReceiveData): Deleted.
(WebKit::UnifiedPDFPlugin::streamDidFinishLoading): Deleted.
(WebKit::UnifiedPDFPlugin::streamDidFail): Deleted.

Canonical link: <a href="https://commits.webkit.org/268537@main">https://commits.webkit.org/268537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e29e4dc10f2771c6fd4aeaa46c00e85d56635ffb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18563 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20094 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22623 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17243 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24351 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22337 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18020 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4779 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->