### PR TITLE
[Win] Ninja clang-cl and MSBuild clang-cl should use the same compiler warning flags

### DIFF
--- a/Source/cmake/OptionsMSVC.cmake
+++ b/Source/cmake/OptionsMSVC.cmake
@@ -1,119 +1,121 @@
-# List of disabled warnings
-# When adding to the list add a short description and link to the warning's text if available
-#
-# https://bugs.webkit.org/show_bug.cgi?id=221508 is for tracking removal of warnings
-add_compile_options(
-    /wd4018 # 'token' : signed/unsigned mismatch
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018
+if (NOT COMPILER_IS_CLANG_CL)
+    # List of disabled warnings
+    # When adding to the list add a short description and link to the warning's text if available
+    #
+    # https://bugs.webkit.org/show_bug.cgi?id=221508 is for tracking removal of warnings
+    add_compile_options(
+        /wd4018 # 'token' : signed/unsigned mismatch
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018
 
-    /wd4060 # switch statement contains no 'case' or 'default' labels
+        /wd4060 # switch statement contains no 'case' or 'default' labels
 
-    /wd4068 # unknown pragma
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4068
+        /wd4068 # unknown pragma
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4068
 
-    /wd4100 # 'identifier' : unreferenced formal parameter
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4100
+        /wd4100 # 'identifier' : unreferenced formal parameter
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4100
 
-    /wd4127 # conditional expression is constant
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4127
+        /wd4127 # conditional expression is constant
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4127
 
-    /wd4146 # unary minus operator applied to unsigned type, result still unsigned
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
+        /wd4146 # unary minus operator applied to unsigned type, result still unsigned
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
 
-    /wd4189 # 'identifier' : local variable is initialized but not referenced
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4189
+        /wd4189 # 'identifier' : local variable is initialized but not referenced
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4189
 
-    /wd4201 # nonstandard extension used : nameless struct/union
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4201
+        /wd4201 # nonstandard extension used : nameless struct/union
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4201
 
-    /wd4244 # 'argument' : conversion from 'type1' to 'type2', possible loss of data
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
+        /wd4244 # 'argument' : conversion from 'type1' to 'type2', possible loss of data
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
 
-    /wd4245 # 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4245
+        /wd4245 # 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4245
 
-    /wd4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251
+        /wd4251 # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251
 
-    /wd4275 # non - DLL-interface class 'class_1' used as base for DLL-interface class 'class_2'
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275
+        /wd4275 # non - DLL-interface class 'class_1' used as base for DLL-interface class 'class_2'
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275
 
-    /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267
+        /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267
 
-    /wd4305 # 'context' : truncation from 'type1' to 'type2'
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305
+        /wd4305 # 'context' : truncation from 'type1' to 'type2'
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305
 
-    /wd4309 # 'conversion' : truncation of constant value
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4309
+        /wd4309 # 'conversion' : truncation of constant value
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4309
 
-    /wd4312 # 'operation' : conversion from 'type1' to 'type2' of greater size
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4312
+        /wd4312 # 'operation' : conversion from 'type1' to 'type2' of greater size
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4312
 
-    /wd4324 # 'struct_name' : structure was padded due to __declspec(align())
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4324
+        /wd4324 # 'struct_name' : structure was padded due to __declspec(align())
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4324
 
-    /wd4389 # 'operator' : signed/unsigned mismatch
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4389
+        /wd4389 # 'operator' : signed/unsigned mismatch
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4389
 
-    /wd4456 # declaration of 'identifier' hides previous local declaration
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4456
+        /wd4456 # declaration of 'identifier' hides previous local declaration
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4456
 
-    /wd4457 # declaration of 'identifier' hides function parameter
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4457
+        /wd4457 # declaration of 'identifier' hides function parameter
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4457
 
-    /wd4458 # declaration of 'identifier' hides class member
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4458
+        /wd4458 # declaration of 'identifier' hides class member
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4458
 
-    /wd4459 # declaration of 'identifier' hides global declaration
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4459
+        /wd4459 # declaration of 'identifier' hides global declaration
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4459
 
-    /wd4505 # 'function' : unreferenced local function has been removed
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4505
+        /wd4505 # 'function' : unreferenced local function has been removed
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4505
 
 
-    /wd4611 # interaction between 'function' and C++ object destruction is non-portable
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4611
+        /wd4611 # interaction between 'function' and C++ object destruction is non-portable
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4611
 
-    /wd4646 # function declared with __declspec(noreturn) has non-void return type
-            # https://docs.microsoft.com/mt-mt/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4646
+        /wd4646 # function declared with __declspec(noreturn) has non-void return type
+                # https://docs.microsoft.com/mt-mt/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4646
 
-    /wd4701 # Potentially uninitialized local variable 'name' used
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4701
+        /wd4701 # Potentially uninitialized local variable 'name' used
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4701
 
-    /wd4702 # unreachable code
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4702
+        /wd4702 # unreachable code
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4702
 
-    /wd4706 # assignment within conditional expression
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706
-            # NOTE: Can't fix without changes to style guide
+        /wd4706 # assignment within conditional expression
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706
+                # NOTE: Can't fix without changes to style guide
 
-    /wd4715 # 'function' : not all control paths return a value
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4715
+        /wd4715 # 'function' : not all control paths return a value
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4715
 
-    /wd4722 # 'function' : destructor never returns, potential memory leak
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4722
+        /wd4722 # 'function' : destructor never returns, potential memory leak
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4722
 
-    /wd4723 # The second operand in a divide operation evaluated to zero at compile time, giving undefined results.
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4723
+        /wd4723 # The second operand in a divide operation evaluated to zero at compile time, giving undefined results.
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4723
 
-    /wd4805 # 'operation' : unsafe mix of type 'type' and type 'type' in operation
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4805
-            
-    /wd4838 # conversion from 'type_1' to 'type_2' requires a narrowing conversion
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4838
+        /wd4805 # 'operation' : unsafe mix of type 'type' and type 'type' in operation
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4805
 
-    /wd4840 # non-portable use of class 'type' as an argument to a variadic function
-            # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4840
+        /wd4838 # conversion from 'type_1' to 'type_2' requires a narrowing conversion
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4838
 
-    /wd4996 # Your code uses a function, class member, variable, or typedef that's marked deprecated
+        /wd4840 # non-portable use of class 'type' as an argument to a variadic function
+                # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4840
 
-    /wd5205 # delete of an abstract class 'type-name' that has a non-virtual destructor results in undefined behavior
+        /wd4996 # Your code uses a function, class member, variable, or typedef that's marked deprecated
 
-    /wd5054 # operator 'operator-name': deprecated between enumerations of different types
+        /wd5205 # delete of an abstract class 'type-name' that has a non-virtual destructor results in undefined behavior
 
-    /wd5055 # operator 'operator-name': deprecated between enumerations and floating-point types
-)
+        /wd5054 # operator 'operator-name': deprecated between enumerations of different types
+
+        /wd5055 # operator 'operator-name': deprecated between enumerations and floating-point types
+    )
+endif ()
 
 # Create pdb files for debugging purposes, also for Release builds
 add_compile_options(/Zi /GS)

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -113,6 +113,8 @@ if (COMPILER_IS_GCC_OR_CLANG)
                                              -Wno-macro-redefined
                                              -Wno-unknown-pragmas
                                              -Wno-nonportable-include-path
+                                             -Wno-sign-compare
+                                             -Wno-deprecated-declarations
                                              -Wno-unknown-argument)
     else ()
         WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-exceptions)


### PR DESCRIPTION
#### 0c72c18c1345de2fd7f98b39e2e6d85808a13592
<pre>
[Win] Ninja clang-cl and MSBuild clang-cl should use the same compiler warning flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=262166">https://bugs.webkit.org/show_bug.cgi?id=262166</a>

Reviewed by Ross Kirsling.

CMake Visual Studio generator ignores MSVC-style compiler warning
flags for clang-cl, for example /wd4100, while CMake Ninja generator
doesn&apos;t. They should be aligned.

Don&apos;t use MSVC-style compiler warning flags for clang-cl. Instead, use
GCC-style for it.

* Source/cmake/OptionsMSVC.cmake:
* Source/cmake/WebKitCompilerFlags.cmake:

Canonical link: <a href="https://commits.webkit.org/268497@main">https://commits.webkit.org/268497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9ef622e9f37815912f7c7ac16f8b76d17da8736

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18565 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20450 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22625 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17245 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24355 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17283 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22341 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19248 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18850 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/15973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23280 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18022 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22370 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24534 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2434 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18674 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5438 "Passed tests") | 
<!--EWS-Status-Bubble-End-->