### PR TITLE
Highlights are not repainted if associated live ranges are changed.

### DIFF
--- a/LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt
@@ -1,0 +1,5 @@
+Highlight this first and then this.
+(repaint rects
+  (rect 8 8 784 37)
+)
+

--- a/LayoutTests/fast/repaint/highlight-paint-after-range-change.html
+++ b/LayoutTests/fast/repaint/highlight-paint-after-range-change.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test that highlights gets repainted properly when the underlying range is changed.</title>
+    <style>
+        html { 
+            font-size: 24pt;
+        }
+        ::highlight(yellowHighlight)  {
+            background-color: yellow;
+        }
+    </style>
+</head>
+<body>
+    <title>When run, the first "this" should be highlighted, followed by the second "this", and the first highlight should be removed.</title>
+    <div id="highlight_area">Highlight this first and then this.</div>
+    <pre id="result"></pre>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+ 
+async function test() {   
+
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    let highlightRange = new Range();
+    let highlightOne = new Highlight(highlightRange);
+    CSS.highlights.set("yellowHighlight", highlightOne);
+    let highlightNode = highlight_area;
+
+    highlightRange.setStart(highlightNode.firstChild, 11);
+    highlightRange.setEnd(highlightNode.firstChild, 14);
+
+    setTimeout(() => {
+
+        highlightRange.setStart(highlightNode.firstChild, 25);
+        highlightRange.setEnd(highlightNode.firstChild, 29);
+        if (window.internals) {
+            let repaintRects = internals.repaintRectsAsText();
+            internals.stopTrackingRepaints();
+            result.textContent = repaintRects;
+        }
+        if (window.testRunner)
+            testRunner.notifyDone();
+     }, 100);
+    
+};
+test();
+</script>
+</html>

--- a/Source/WebCore/Modules/highlight/Highlight.cpp
+++ b/Source/WebCore/Modules/highlight/Highlight.cpp
@@ -36,14 +36,13 @@
 
 namespace WebCore {
 
-static void repaintRange(const AbstractRange& range)
+void Highlight::repaintRange(const AbstractRange& range)
 {
-    // FIXME: Unclear precisely why we need to handle out of order cases here, but not unordered cases.
-    SimpleRange sortedRange = makeSimpleRange(range);
+    auto sortedRange = makeSimpleRange(range);
     if (is_gt(treeOrder<ComposedTree>(sortedRange.start, sortedRange.end)))
         std::swap(sortedRange.start, sortedRange.end);
-    for (auto& node : intersectingNodes(sortedRange)) {
-        if (auto renderer = node.renderer())
+    for (Ref node : intersectingNodes(sortedRange)) {
+        if (auto renderer = node->renderer())
             renderer->repaint();
     }
 }

--- a/Source/WebCore/Modules/highlight/Highlight.h
+++ b/Source/WebCore/Modules/highlight/Highlight.h
@@ -27,6 +27,7 @@
 
 #include "ExceptionOr.h"
 #include "Position.h"
+#include "Range.h"
 #include "StaticRange.h"
 #include <wtf/RefCounted.h>
 
@@ -53,6 +54,8 @@ private:
     explicit HighlightRange(Ref<AbstractRange>&& range)
         : m_range(WTFMove(range))
     {
+        if (auto liveRange = dynamicDowncast<Range>(m_range))
+            liveRange->didAssociateWithHighlight();
     }
 
     Ref<AbstractRange> m_range;
@@ -63,6 +66,7 @@ private:
 class Highlight : public RefCounted<Highlight> {
 public:
     WEBCORE_EXPORT static Ref<Highlight> create(FixedVector<std::reference_wrapper<AbstractRange>>&&);
+    static void repaintRange(const AbstractRange&);
     void clearFromSetLike();
     bool addToSetLike(AbstractRange&);
     bool removeFromSetLike(const AbstractRange&);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1912,7 +1912,7 @@ private:
 
     void platformSuspendOrStopActiveDOMObjects();
 
-    void collectRangeDataFromRegister(Vector<WeakPtr<HighlightRange>>&, const HighlightRegister&);
+    void collectHighlightRangesFromRegister(Vector<WeakPtr<HighlightRange>>&, const HighlightRegister&);
 
     bool isBodyPotentiallyScrollable(HTMLBodyElement&);
 

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -108,6 +108,14 @@ void Range::updateAssociatedSelection()
         m_ownerDocument->selection().updateFromAssociatedLiveRange();
 }
 
+void Range::updateAssociatedHighlight()
+{
+    if (m_isAssociatedWithHighlight) {
+        m_didChangeForHighlight = true;
+        m_ownerDocument->scheduleRenderingUpdate({ });
+    }
+}
+
 void Range::updateDocument()
 {
     auto& document = startContainer().document();
@@ -130,7 +138,7 @@ ExceptionOr<void> Range::setStart(Ref<Node>&& container, unsigned offset)
         m_end = m_start;
     updateAssociatedSelection();
     updateDocument();
-    m_didChangeHighlight = true;
+    updateAssociatedHighlight();
     return { };
 }
 
@@ -145,7 +153,7 @@ ExceptionOr<void> Range::setEnd(Ref<Node>&& container, unsigned offset)
         m_start = m_end;
     updateAssociatedSelection();
     updateDocument();
-    m_didChangeHighlight = true;
+    updateAssociatedHighlight();
     return { };
 }
 
@@ -899,7 +907,7 @@ void Range::nodeChildrenChanged(ContainerNode& container)
     ASSERT(&container.document() == m_ownerDocument.ptr());
     boundaryNodeChildrenChanged(m_start, container);
     boundaryNodeChildrenChanged(m_end, container);
-    m_didChangeHighlight = true;
+    m_didChangeForHighlight = true;
 }
 
 static inline void boundaryNodeChildrenWillBeRemoved(RangeBoundaryPoint& boundary, ContainerNode& containerOfNodesToBeRemoved)
@@ -913,7 +921,7 @@ void Range::nodeChildrenWillBeRemoved(ContainerNode& container)
     ASSERT(&container.document() == m_ownerDocument.ptr());
     boundaryNodeChildrenWillBeRemoved(m_start, container);
     boundaryNodeChildrenWillBeRemoved(m_end, container);
-    m_didChangeHighlight = true;
+    m_didChangeForHighlight = true;
 }
 
 static inline void boundaryNodeWillBeRemoved(RangeBoundaryPoint& boundary, Node& nodeToBeRemoved)
@@ -931,7 +939,7 @@ void Range::nodeWillBeRemoved(Node& node)
     ASSERT(node.parentNode());
     boundaryNodeWillBeRemoved(m_start, node);
     boundaryNodeWillBeRemoved(m_end, node);
-    m_didChangeHighlight = true;
+    m_didChangeForHighlight = true;
 }
 
 bool Range::parentlessNodeMovedToNewDocumentAffectsRange(Node& node)
@@ -961,7 +969,7 @@ void Range::textInserted(Node& text, unsigned offset, unsigned length)
     ASSERT(&text.document() == m_ownerDocument.ptr());
     boundaryTextInserted(m_start, text, offset, length);
     boundaryTextInserted(m_end, text, offset, length);
-    m_didChangeHighlight = true;
+    m_didChangeForHighlight = true;
 }
 
 static inline void boundaryTextRemoved(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
@@ -982,7 +990,7 @@ void Range::textRemoved(Node& text, unsigned offset, unsigned length)
     ASSERT(&text.document() == m_ownerDocument.ptr());
     boundaryTextRemoved(m_start, text, offset, length);
     boundaryTextRemoved(m_end, text, offset, length);
-    m_didChangeHighlight = true;
+    m_didChangeForHighlight = true;
 }
 
 static inline void boundaryTextNodesMerged(RangeBoundaryPoint& boundary, NodeWithIndex& oldNode, unsigned offset)
@@ -1003,7 +1011,7 @@ void Range::textNodesMerged(NodeWithIndex& oldNode, unsigned offset)
     ASSERT(oldNode.node()->previousSibling()->isTextNode());
     boundaryTextNodesMerged(m_start, oldNode, offset);
     boundaryTextNodesMerged(m_end, oldNode, offset);
-    m_didChangeHighlight = true;
+    m_didChangeForHighlight = true;
 }
 
 static inline void boundaryTextNodesSplit(RangeBoundaryPoint& boundary, Text& oldNode)
@@ -1036,7 +1044,7 @@ void Range::textNodeSplit(Text& oldNode)
     ASSERT(!oldNode.parentNode() || oldNode.nextSibling()->isTextNode());
     boundaryTextNodesSplit(m_start, oldNode);
     boundaryTextNodesSplit(m_end, oldNode);
-    m_didChangeHighlight = true;
+    m_didChangeForHighlight = true;
 }
 
 ExceptionOr<void> Range::expand(const String& unit)

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -42,6 +42,7 @@ struct SimpleRange;
 
 class Range final : public AbstractRange, public CanMakeWeakPtr<Range>, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(Range);
+    WTF_MAKE_NONCOPYABLE(Range);
 public:
     WEBCORE_EXPORT static Ref<Range> create(Document&);
     WEBCORE_EXPORT ~Range();
@@ -53,8 +54,8 @@ public:
     bool collapsed() const final { return m_start == m_end; }
     WEBCORE_EXPORT Node* commonAncestorContainer() const;
 
-    void resetDidChangeHighlight() { m_didChangeHighlight = false; }
-    bool didChangeHighlight() const { return m_didChangeHighlight; }
+    void resetDidChangeForHighlight() { m_didChangeForHighlight = false; }
+    bool didChangeForHighlight() const { return m_didChangeForHighlight; }
 
     WEBCORE_EXPORT ExceptionOr<void> setStart(Ref<Node>&&, unsigned offset);
     WEBCORE_EXPORT ExceptionOr<void> setEnd(Ref<Node>&&, unsigned offset);
@@ -111,6 +112,12 @@ public:
     void didDisassociateFromSelection() { m_isAssociatedWithSelection = false; }
     void updateFromSelection(const SimpleRange&);
 
+    void didAssociateWithHighlight()
+    {
+        m_isAssociatedWithHighlight = true;
+        m_didChangeForHighlight = true;
+    }
+
     // For use by garbage collection. Returns nullptr for ranges not assocated with selection.
     LocalDOMWindow* window() const;
 
@@ -131,13 +138,15 @@ private:
 
     void updateDocument();
     void updateAssociatedSelection();
+    void updateAssociatedHighlight();
     ExceptionOr<RefPtr<DocumentFragment>> processContents(ActionType);
 
     Ref<Document> m_ownerDocument;
     RangeBoundaryPoint m_start;
     RangeBoundaryPoint m_end;
     bool m_isAssociatedWithSelection { false };
-    bool m_didChangeHighlight { false };
+    bool m_didChangeForHighlight { false };
+    bool m_isAssociatedWithHighlight { false };
 };
 
 WEBCORE_EXPORT SimpleRange makeSimpleRange(const Range&);


### PR DESCRIPTION
#### 306860296d33ebc428b319f6d705faa3a51f6e33
<pre>
Highlights are not repainted if associated live ranges are changed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262168">https://bugs.webkit.org/show_bug.cgi?id=262168</a>
rdar://116108148

Reviewed by Wenson Hsieh.

When a range is changed, we need to repaint the previous and the new range.
Fortunately, we already had a mechanism to get Positions from the ranges
so that we have the information we need at paint time. We can use these
stale positions to know what the range was before updating, and repaint the old
range, as well as the new range.
Also a rename for more clarity around setting flags for highlights in Range.

* LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt: Added.
* LayoutTests/fast/repaint/highlight-paint-after-range-change.html: Added.
* Source/WebCore/Modules/highlight/Highlight.h:
(WebCore::HighlightRange::HighlightRange):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::collectHighlightRangesFromRegister):
(WebCore::repaintRange):
(WebCore::Document::updateHighlightPositions):
(WebCore::Document::collectRangeDataFromRegister): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::updateAssociatedHighlight):
(WebCore::Range::setStart):
(WebCore::Range::setEnd):
(WebCore::Range::nodeChildrenChanged):
(WebCore::Range::nodeChildrenWillBeRemoved):
(WebCore::Range::nodeWillBeRemoved):
(WebCore::Range::textInserted):
(WebCore::Range::textRemoved):
(WebCore::Range::textNodesMerged):
(WebCore::Range::textNodeSplit):
* Source/WebCore/dom/Range.h:

Canonical link: <a href="https://commits.webkit.org/268660@main">https://commits.webkit.org/268660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95c763d2f16729eed6eda1a777cce749ead5a5e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22177 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20879 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23027 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18436 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19193 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16299 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18272 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4884 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->