### PR TITLE
[PointerEvents] pressure property is not spec-compliant when constructed from mouse event

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_hoverable_pointers_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_hoverable_pointers_mouse-expected.txt
@@ -73,7 +73,7 @@ PASS mouse pointerdown.isTrusted value is true
 PASS mouse pointerdown.composed value is valid
 PASS mouse pointerdown.bubbles value is valid
 PASS mouse pointerdown.cancelable value is valid
-FAIL mouse pointerdown.pressure value is valid assert_greater_than: pressure is greater than 0 with a button pressed expected a number greater than 0 but got 0
+PASS mouse pointerdown.pressure value is valid
 PASS mouse pointerdown properties for pointerType = mouse
 PASS mouse pointerdown.isPrimary attribute is true.
 PASS mouse pointerdown.pointerId should be the same as previous pointer events for this active pointer.

--- a/Source/WebCore/dom/PointerEvent.cpp
+++ b/Source/WebCore/dom/PointerEvent.cpp
@@ -28,6 +28,8 @@
 
 #include "EventNames.h"
 #include "Node.h"
+#include "PlatformMouseEvent.h"
+#include "PointerEventTypeNames.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -96,6 +98,9 @@ PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const Mou
         { mouseEvent.clientX(), mouseEvent.clientY() }, mouseEvent.movementX(), mouseEvent.movementY(), mouseEvent.modifierKeys(), button, mouseEvent.buttons(),
         mouseEvent.syntheticClickType(), mouseEvent.relatedTarget())
     , m_pointerId(pointerId)
+    // MouseEvent is a misnomer in this context, and can represent events from a pressure sensitive input device if the pointer type is "Pen" or "Touch".
+    // If it does represent a pressure sensitive input device, we consult MouseEvent::force() for the event pressure, else we fall back to spec defaults.
+    , m_pressure(pointerType != mousePointerEventType() ? std::clamp(mouseEvent.force(), 0., 1.) : pressureForPressureInsensitiveInputDevices(buttons()))
     , m_pointerType(pointerType)
     , m_isPrimary(true)
 {
@@ -104,6 +109,9 @@ PointerEvent::PointerEvent(const AtomString& type, MouseButton button, const Mou
 PointerEvent::PointerEvent(const AtomString& type, PointerID pointerId, const String& pointerType, IsPrimary isPrimary)
     : MouseEvent(type, typeCanBubble(type), typeIsCancelable(type), typeIsComposed(type), nullptr, 0, { }, { }, 0, 0, { }, buttonForType(type), buttonsForType(type), SyntheticClickType::NoTap, nullptr)
     , m_pointerId(pointerId)
+    // FIXME: This may be wrong because we can create an event from a pressure sensitive device.
+    // We don't have a backing MouseEvent to consult pressure/force information from, though, so let's do the next best thing.
+    , m_pressure(pressureForPressureInsensitiveInputDevices(buttons()))
     , m_pointerType(pointerType)
     , m_isPrimary(isPrimary == IsPrimary::Yes)
 {

--- a/Source/WebCore/dom/PointerEvent.h
+++ b/Source/WebCore/dom/PointerEvent.h
@@ -128,6 +128,13 @@ private:
         auto& eventNames = WebCore::eventNames();
         return (type == eventNames.pointerupEvent || type == eventNames.pointeroutEvent || type == eventNames.pointerleaveEvent || type == eventNames.pointercancelEvent) ? 0 : 1;
     }
+    static float pressureForPressureInsensitiveInputDevices(unsigned short buttons)
+    {
+        // https://www.w3.org/TR/pointerevents/#dfn-active-buttons-state
+        bool isInActiveButtonsState = buttons;
+        // https://www.w3.org/TR/pointerevents/#dom-pointerevent-pressure
+        return isInActiveButtonsState ? 0.5 : 0;
+    }
 
     PointerEvent();
     PointerEvent(const AtomString&, Init&&);

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -65,7 +65,7 @@ public:
             break;
         case WebEventType::MouseUp:
             m_type = WebCore::PlatformEvent::Type::MouseReleased;
-            m_force = WebCore::ForceAtClick;
+            m_force = 0;
             break;
         case WebEventType::MouseMove:
             m_type = WebCore::PlatformEvent::Type::MouseMoved;
@@ -81,7 +81,7 @@ public:
             break;
         case WebEventType::MouseForceUp:
             m_type = WebCore::PlatformEvent::Type::MouseForceUp;
-            m_force = WebCore::ForceAtForceClick;
+            m_force = 0;
             break;
         default:
             ASSERT_NOT_REACHED();

--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -39,6 +39,7 @@
 #import "DumpRenderTreePasteboard.h"
 #import "ModifierKeys.h"
 #import "WebCoreTestSupport.h"
+#import <WebCore/PlatformMouseEvent.h>
 #import <WebKit/DOMPrivate.h>
 #import <WebKit/WebViewPrivate.h>
 #import <functional>
@@ -600,7 +601,7 @@ static NSUInteger swizzledEventPressedMouseButtons()
                                          context:[NSGraphicsContext currentContext] 
                                      eventNumber:++eventNumber 
                                       clickCount:clickCount 
-                                        pressure:0.0]);
+                                        pressure:WebCore::ForceAtClick]);
 #else
     auto event = adoptNS([[WebEvent alloc] initWithMouseEventType:WebEventMouseDown
                                                      timeStamp:[self currentEventTime]
@@ -923,7 +924,7 @@ static NSUInteger swizzledEventPressedMouseButtons()
                                          context:[NSGraphicsContext currentContext] 
                                      eventNumber:++eventNumber 
                                       clickCount:clickCount 
-                                        pressure:0.0];
+                                        pressure:WebCore::ForceAtClick];
 
     NSView *subView = [[mainFrame webView] hitTest:[event locationInWindow]];
     NSMutableArray *menuItemStrings = [NSMutableArray array];

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -35,6 +35,7 @@
 #import "TestRunnerWKWebView.h"
 #import "WebKitTestRunnerWindow.h"
 #import <Carbon/Carbon.h>
+#import <WebCore/PlatformMouseEvent.h>
 #import <WebKit/WKString.h>
 #import <WebKit/WKPagePrivate.h>
 #import <WebKit/WKWebView.h>
@@ -339,7 +340,7 @@ void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifie
                                          context:[NSGraphicsContext currentContext] 
                                      eventNumber:++m_eventNumber 
                                       clickCount:m_clickCount 
-                                        pressure:0.0];
+                                        pressure:WebCore::ForceAtClick];
 
     NSView *targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
     if (targetView) {
@@ -397,7 +398,7 @@ void EventSenderProxy::sendMouseDownToStartPressureEvents()
         context:[NSGraphicsContext currentContext]
         eventNumber:++m_eventNumber
         clickCount:m_clickCount
-        pressure:0.0];
+        pressure:WebCore::ForceAtClick];
 
     [NSApp sendEvent:event];
 }


### PR DESCRIPTION
#### a13dcf305bd1d474c02191d1e4c3c9a517bb6603
<pre>
[PointerEvents] pressure property is not spec-compliant when constructed from mouse event
<a href="https://bugs.webkit.org/show_bug.cgi?id=262159">https://bugs.webkit.org/show_bug.cgi?id=262159</a>
rdar://116094696

Reviewed by Tim Nguyen.

Every PointerEvent object created from a backing MouseEvent object in
PointerCaptureController has an incorrect pressure value, namely 0. This
is the result of the coming together of a few issues:

1. We simply don&apos;t consult MouseEvent.force to initialize
   PointerEvent.pressure when creating a PointerEvent object from a
   backing MouseEvent. This is not the case when constructing from a
   PlatformTouchEvent, where we do correctly consult the force at given
   touch indices.
2. When creating a PointerEvent in a pressure insensitive context, we
   default to initializing the pressure property as zero, which is not
   compliant with the PointerEvents spec.
3. We don&apos;t populate the pressure attribute of NSEvent instances sent by
   EventSenderProxy, so even if we had consulted MouseEvent.force in
   the first issue, we would still be getting the wrong pressure values.

To address these issues, we define a helper static method
`PointerEvent::pressureForPressureInsensitiveInputDevices` that returns
the pressure value defined in the PointerEvents spec, conditioned on the
button currently being pressed. This method is then called if we are in
a pressure insensitive context (i.e. we&apos;re generating a PointerEvent
with Mouse pointer type, rather than Pen/Touch). However, if we&apos;re in a
pressure sensitive context, we simply consult the pressure attribute of
the backing event. Finally, to close the loop and plumb pressure values
from WKTR to generated pointer events, we make sure to supply the
appropriate pressure argument to NSEvent initializers for mouseDown
events.

This patch allows us to pass the following pressure-related assertion in
the pointerevents/pointerevent_attributes_hoverable_pointers.html?mouse WPT.

```
FAIL mouse pointerdown.pressure value is valid assert_greater_than: pressure is greater than 0 with a button pressed expected a number greater than 0 but got 0
```

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_attributes_hoverable_pointers_mouse-expected.txt:

Update test expectations with newly passing assertion.

* Source/WebCore/dom/PointerEvent.cpp:
* Source/WebCore/dom/PointerEvent.h:
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformMouseEvent::WebKit2PlatformMouseEvent):
* Tools/DumpRenderTree/mac/EventSendingController.mm:
(-[EventSendingController mouseDown:withModifiers:]):
(-[EventSendingController contextClick]):
* Tools/WebKitTestRunner/mac/EventSenderProxy.mm:
(WTR::EventSenderProxy::mouseDown):
(WTR::EventSenderProxy::sendMouseDownToStartPressureEvents):

Canonical link: <a href="https://commits.webkit.org/268552@main">https://commits.webkit.org/268552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/561945355c7d70dd670ed7231840db9257b01fb2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18662 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20556 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22726 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17323 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24431 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22420 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16061 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18116 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4794 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->