### PR TITLE
[IFC][Integration] Implement legacy -webkit-line-align property

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2659,3 +2659,5 @@ webkit.org/b/261024 webgl/2.0.y/conformance/rendering/color-mask-preserved-durin
 webkit.org/b/261024 webrtc/utf8-sdp.html [ Pass Timeout ]
 
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-filter.html [ ImageOnlyFailure ]
+
+fast/line-grid [ Skip ]

--- a/LayoutTests/platform/ios/fast/line-grid/line-align-left-edges-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-align-left-edges-expected.txt
@@ -16,9 +16,9 @@ layer at (8,8) size 784x201
       RenderText {#text} at (96,2) size 216x25
         text run at (96,2) width 216: "X X X X X"
       RenderBR {BR} at (312,2) size 0x25
-      RenderBlock (floating) {DIV} at (96,30) size 78x78 [bgcolor=#800080]
-      RenderText {#text} at (192,32) size 216x25
-        text run at (192,32) width 216: "X X X X X"
+      RenderBlock (floating) {DIV} at (78,30) size 78x78 [bgcolor=#800080]
+      RenderText {#text} at (168,32) size 216x25
+        text run at (168,32) width 216: "X X X X X"
 layer at (181,308) size 300x30
   RenderBlock (positioned) {DIV} at (172,300) size 301x30 [bgcolor=#DDDDDD]
     RenderText {#text} at (19,2) size 121x25

--- a/LayoutTests/platform/ios/fast/line-grid/line-align-right-edges-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-align-right-edges-expected.txt
@@ -16,9 +16,9 @@ layer at (8,8) size 784x216
       RenderText {#text} at (456,2) size 216x25
         text run at (456,2) width 216: "X X X X X"
       RenderBR {BR} at (672,2) size 0x25
-      RenderBlock (floating) {DIV} at (594,30) size 78x78 [bgcolor=#800080]
-      RenderText {#text} at (360,32) size 216x25
-        text run at (360,32) width 216: "X X X X X"
+      RenderBlock (floating) {DIV} at (612,30) size 78x78 [bgcolor=#800080]
+      RenderText {#text} at (384,32) size 216x25
+        text run at (384,32) width 216: "X X X X X"
 layer at (342,308) size 300x30
   RenderBlock (positioned) {DIV} at (334,300) size 300x30 [bgcolor=#DDDDDD]
     RenderText {#text} at (170,2) size 120x25

--- a/LayoutTests/platform/mac/fast/line-grid/line-align-left-edges-expected.txt
+++ b/LayoutTests/platform/mac/fast/line-grid/line-align-left-edges-expected.txt
@@ -16,9 +16,9 @@ layer at (8,8) size 784x201
       RenderText {#text} at (96,3) size 216x24
         text run at (96,3) width 216: "X X X X X"
       RenderBR {BR} at (312,3) size 0x24
-      RenderBlock (floating) {DIV} at (96,30) size 78x78 [bgcolor=#800080]
-      RenderText {#text} at (192,33) size 216x24
-        text run at (192,33) width 216: "X X X X X"
+      RenderBlock (floating) {DIV} at (78,30) size 78x78 [bgcolor=#800080]
+      RenderText {#text} at (168,33) size 216x24
+        text run at (168,33) width 216: "X X X X X"
 layer at (181,308) size 300x30
   RenderBlock (positioned) {DIV} at (172,300) size 301x30 [bgcolor=#DDDDDD]
     RenderText {#text} at (19,3) size 121x24

--- a/LayoutTests/platform/mac/fast/line-grid/line-align-right-edges-expected.txt
+++ b/LayoutTests/platform/mac/fast/line-grid/line-align-right-edges-expected.txt
@@ -16,10 +16,10 @@ layer at (8,8) size 784x216
       RenderText {#text} at (456,3) size 216x24
         text run at (456,3) width 216: "X X X X X"
       RenderBR {BR} at (672,3) size 0x24
-      RenderBlock (floating) {DIV} at (594,30) size 78x78 [bgcolor=#800080]
-      RenderText {#text} at (360,33) size 216x24
-        text run at (360,33) width 216: "X X X X X"
+      RenderBlock (floating) {DIV} at (612,30) size 78x78 [bgcolor=#800080]
+      RenderText {#text} at (384,33) size 216x24
+        text run at (384,33) width 216: "X X X X X"
 layer at (342,308) size 300x30
   RenderBlock (positioned) {DIV} at (334,300) size 300x30 [bgcolor=#DDDDDD]
-    RenderText {#text} at (161,3) size 120x24
-      text run at (161,3) width 120: "X X X"
+    RenderText {#text} at (170,3) size 120x24
+      text run at (170,3) width 120: "X X X"

--- a/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
@@ -44,7 +44,13 @@ public:
         End   = 1 << 1
     };
     using TextBoxTrim = OptionSet<TextBoxTrimSide>;
-    BlockLayoutState(FloatingState&, std::optional<LineClamp> = { }, TextBoxTrim = { }, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom = { });
+
+    struct LineGrid {
+        LayoutSize logicalOffset;
+        InlineLayoutUnit columnWidth;
+    };
+
+    BlockLayoutState(FloatingState&, std::optional<LineClamp> = { }, TextBoxTrim = { }, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom = { }, std::optional<LineGrid> lineGrid = { });
 
     FloatingState& floatingState() { return m_floatingState; }
     const FloatingState& floatingState() const { return m_floatingState; }
@@ -53,19 +59,22 @@ public:
     TextBoxTrim textBoxTrim() const { return m_textBoxTrim; }
 
     std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom() const { return m_intrusiveInitialLetterLogicalBottom; }
+    const std::optional<LineGrid>& lineGrid() const { return m_lineGrid; }
 
 private:
     FloatingState& m_floatingState;
     std::optional<LineClamp> m_lineClamp;
     TextBoxTrim m_textBoxTrim;
     std::optional<LayoutUnit> m_intrusiveInitialLetterLogicalBottom;
+    std::optional<LineGrid> m_lineGrid;
 };
 
-inline BlockLayoutState::BlockLayoutState(FloatingState& floatingState, std::optional<LineClamp> lineClamp, TextBoxTrim textBoxTrim, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom)
+inline BlockLayoutState::BlockLayoutState(FloatingState& floatingState, std::optional<LineClamp> lineClamp, TextBoxTrim textBoxTrim, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom, std::optional<LineGrid> lineGrid)
     : m_floatingState(floatingState)
     , m_lineClamp(lineClamp)
     , m_textBoxTrim(textBoxTrim)
     , m_intrusiveInitialLetterLogicalBottom(intrusiveInitialLetterLogicalBottom)
+    , m_lineGrid(lineGrid)
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingQuirks.h
@@ -42,6 +42,7 @@ public:
     bool inlineBoxAffectsLineBox(const InlineLevelBox&) const;
     static bool lineBreakBoxAffectsParentInlineBox(const LineBox&);
     std::optional<LayoutUnit> initialLetterAlignmentOffset(const Box& floatBox, const RenderStyle& lineBoxStyle) const;
+    static std::optional<InlineRect> adjustedRectForLineGridLineAlign(const InlineRect&, const RenderStyle& rootBoxStyle, const InlineLayoutState&);
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -473,6 +473,8 @@ bool TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout(cons
         return false;
     if (rootStyle.textWrap() == TextWrap::Balance)
         return false;
+    if (rootStyle.lineAlign() != LineAlign::None)
+        return false;
 
     return true;
 }

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -58,8 +58,6 @@ static std::optional<AvoidanceReason> canUseForBlockStyle(const RenderBlockFlow&
     ASSERT(is<RenderBlockFlow>(blockContainer));
 
     auto& style = blockContainer.style();
-    if (style.lineAlign() != LineAlign::None)
-        return AvoidanceReason::FlowHasLineAlignEdges;
     if (style.lineSnap() != LineSnap::None)
         return AvoidanceReason::FlowHasLineSnap;
     return { };

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
@@ -37,12 +37,11 @@ namespace LayoutIntegration {
 class LineLayout;
 
 enum class AvoidanceReason : uint8_t {
-    ContentIsRuby                = 1 << 0,
-    ContentIsSVG                 = 1 << 1,
-    FlowHasLineAlignEdges        = 1 << 2,
-    FlowHasLineSnap              = 1 << 3,
-    FlowIsInitialContainingBlock = 1 << 4,
-    FeatureIsDisabled            = 1 << 5
+    ContentIsRuby,
+    ContentIsSVG,
+    FlowHasLineSnap,
+    FlowIsInitialContainingBlock,
+    FeatureIsDisabled
 };
 
 bool canUseForLineLayout(const RenderBlockFlow&);


### PR DESCRIPTION
#### e3642b7d4d2b8b9c6f8f42542458058d250a1891
<pre>
[IFC][Integration] Implement legacy -webkit-line-align property
<a href="https://bugs.webkit.org/show_bug.cgi?id=262174">https://bugs.webkit.org/show_bug.cgi?id=262174</a>
&lt;rdar://problem/116114203&gt;

Reviewed by Alan Baradlay.

This property snaps line edges to a grid defined by an ancestor box.

* LayoutTests/platform/mac/fast/line-grid/line-align-left-edges-expected.txt:
* LayoutTests/platform/mac/fast/line-grid/line-align-right-edges-expected.txt:

Floats are no longer aligned to the grid, just the actual line content.

* Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h:
(WebCore::Layout::BlockLayoutState::BlockLayoutState):
(WebCore::Layout::BlockLayoutState::lineGrid const):

Add line grid data.

* Source/WebCore/layout/formattingContexts/inline/InlineFormattingQuirks.cpp:
(WebCore::Layout::InlineFormattingQuirks::adjustedRectForLineGridLineAlign):

Adjust the line rect.
This is based on the code in RenderBlock::adjustLogicalLeftOffsetForLine/adjustLogicalRightOffsetForLine

* Source/WebCore/layout/formattingContexts/inline/InlineFormattingQuirks.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::initialConstraintsForLine const):
(WebCore::Layout::LineBuilder::floatConstrainedRect const):

The adjustment to the line rect is done after computing float constrains and has similar effect.

* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout):

Don&apos;t allow this property in simplified builder.

* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForBlockStyle):

Enable.

* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::lineGrid):
(WebCore::LayoutIntegration::LineLayout::layout):

Set up to the line grid to BlockLayoutState.

Canonical link: <a href="https://commits.webkit.org/268514@main">https://commits.webkit.org/268514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf309e31f00f2fa03f39b11aefdcd201ce67c12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21820 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20501 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22674 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18132 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22387 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18897 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18068 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4764 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->