### PR TITLE
[GStreamer][WebCodecs] Harness dumping for easier debugging

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -260,6 +260,11 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
         if (!gst_buffer_n_memory(outputBuffer.get()))
             return;
 
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [this] {
+            m_harness->dumpGraph("audio-decoder");
+        });
+
         GST_TRACE_OBJECT(m_harness->element(), "Got frame with PTS: %" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(outputBuffer.get())));
 
         const GstSegment* segment = nullptr;

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -256,6 +256,11 @@ GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder(const String& codec
             return;
         }
 
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [this] {
+            m_harness->dumpGraph("audio-encoder");
+        });
+
         bool isKeyFrame = !GST_BUFFER_FLAG_IS_SET(outputBuffer.get(), GST_BUFFER_FLAG_DELTA_UNIT);
         GST_TRACE_OBJECT(m_harness->element(), "Notifying encoded%s frame", isKeyFrame ? " key" : "");
         GstMappedBuffer mappedBuffer(outputBuffer.get(), GST_MAP_READ);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -241,6 +241,11 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
         if (m_isClosed)
             return;
 
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [this] {
+            m_harness->dumpGraph("video-decoder");
+        });
+
         GST_TRACE_OBJECT(m_harness->element(), "Got frame with PTS: %" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(outputBuffer.get())));
 
         if (m_presentationSize.isEmpty())

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -221,6 +221,11 @@ GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder(const String& codec
         if (m_isClosed)
             return;
 
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [this] {
+            m_harness->dumpGraph("video-encoder");
+        });
+
         bool isKeyFrame = !GST_BUFFER_FLAG_IS_SET(outputBuffer.get(), GST_BUFFER_FLAG_DELTA_UNIT);
         GST_TRACE_OBJECT(m_harness->element(), "Notifying encoded%s frame", isKeyFrame ? " key" : "");
         GstMappedBuffer encodedImage(outputBuffer.get(), GST_MAP_READ);

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -488,7 +488,7 @@ void MermaidBuilder::process(GStreamerElementHarness& harness, bool generateFoot
         if (!downstreamHarness)
             continue;
         process(*downstreamHarness, false);
-        m_stringBuilder.append(padId, "--->"_s, generatePadId(*downstreamHarness, downstreamHarness->inputPad()), '\n');
+        m_stringBuilder.append(padId, " ---> "_s, generatePadId(*downstreamHarness, downstreamHarness->inputPad()), '\n');
     }
 
     if (!generateFooter)
@@ -497,12 +497,12 @@ void MermaidBuilder::process(GStreamerElementHarness& harness, bool generateFoot
     for (auto& [padHarness, srcPad, sinkPad] : m_padLinks) {
         m_stringBuilder.append(generatePadId(padHarness, srcPad.get()), ":::"_s, getPadClass(srcPad));
         if (GST_IS_PROXY_PAD(srcPad.get()))
-            m_stringBuilder.append("--->"_s);
+            m_stringBuilder.append(" ---> "_s);
         else if (auto srcCaps = adoptGRef(gst_pad_get_current_caps(srcPad.get()))) {
             auto capsString = describeCaps(srcCaps.get());
-            m_stringBuilder.append("--\""_s, capsString, "\"-->"_s);
+            m_stringBuilder.append(" --\""_s, capsString, "\"--> "_s);
         } else
-            m_stringBuilder.append("--->"_s);
+            m_stringBuilder.append(" ---> "_s);
         m_stringBuilder.append(generatePadId(padHarness, sinkPad.get()), ":::"_s, getPadClass(sinkPad), '\n');
     }
 
@@ -572,7 +572,7 @@ void MermaidBuilder::dumpElement(GStreamerElementHarness& harness, GstElement* e
     // There is no clean way to maintain subgraph ordering, so draw invisible links between pads.
     // Upstream bug report: https://github.com/mermaid-js/mermaid/issues/815
     if (firstSinkPad && firstSrcPad) {
-        m_stringBuilder.append(generatePadId(harness, firstSinkPad.get()), "---"_s, generatePadId(harness, firstSrcPad.get()), '\n');
+        m_stringBuilder.append(generatePadId(harness, firstSinkPad.get()), " --- "_s, generatePadId(harness, firstSrcPad.get()), '\n');
         m_stringBuilder.append("linkStyle "_s, m_invisibleLinesCounter, " stroke-width:0px\n"_s);
         m_invisibleLinesCounter++;
     }


### PR DESCRIPTION
#### f025f714c6f0ab1693aa85530c5e0e01ae695e7a
<pre>
[GStreamer][WebCodecs] Harness dumping for easier debugging
<a href="https://bugs.webkit.org/show_bug.cgi?id=262177">https://bugs.webkit.org/show_bug.cgi?id=262177</a>

Reviewed by Xabier Rodriguez-Calvar.

Dump the harness graph to disk when the first encoded or decoded payload has been notified. This can
be useful for debugging purposes. Also driving-by in the Harness, add space characters at link
boundaries to prevent ambiguous links, especially for pads or element names starting with &apos;o&apos;.

* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::MermaidBuilder::process):
(WebCore::MermaidBuilder::dumpElement):

Canonical link: <a href="https://commits.webkit.org/268583@main">https://commits.webkit.org/268583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b0fcb0bf30961cd434d191c5da097cc622766f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18586 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22647 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24371 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22357 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/15997 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18043 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4820 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->