### PR TITLE
ImageBuffer::backendSize() waits for GPUP to create the backend

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -78,18 +78,7 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingPurpose 
     return create<ImageBufferPlatformBitmapBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, { });
 }
 
-template<typename BackendType, typename ImageBufferType, typename... Arguments>
-RefPtr<ImageBufferType> ImageBuffer::create(const FloatSize& size, const GraphicsContext& context, RenderingPurpose purpose, Arguments&&... arguments)
-{
-    auto parameters = ImageBufferBackend::Parameters { size, 1, context.colorSpace(), PixelFormat::BGRA8, purpose };
-    auto backend = BackendType::create(parameters, { });
-    if (!backend)
-        return nullptr;
-    auto backendInfo = populateBackendInfo<BackendType>(parameters);
-    return create<ImageBufferType>(parameters, backendInfo, WTFMove(backend), std::forward<Arguments>(arguments)...);
-}
-
-ImageBuffer::ImageBuffer(const ImageBufferBackend::Parameters& parameters, const ImageBufferBackend::Info& backendInfo, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier renderingResourceIdentifier)
+ImageBuffer::ImageBuffer(Parameters parameters, const ImageBufferBackend::Info& backendInfo, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier renderingResourceIdentifier)
     : m_parameters(parameters)
     , m_backendInfo(backendInfo)
     , m_backend(WTFMove(backend))
@@ -98,6 +87,19 @@ ImageBuffer::ImageBuffer(const ImageBufferBackend::Parameters& parameters, const
 }
 
 ImageBuffer::~ImageBuffer() = default;
+
+IntSize ImageBuffer::calculateBackendSize(FloatSize logicalSize, float resolutionScale)
+{
+    FloatSize scaledSize = { ceilf(resolutionScale * logicalSize.width()), ceilf(resolutionScale * logicalSize.height()) };
+    if (scaledSize.isEmpty() || !scaledSize.isExpressibleAsIntSize())
+        return { };
+    return IntSize { scaledSize };
+}
+
+ImageBufferBackendParameters ImageBuffer::backendParameters(const ImageBufferParameters& parameters)
+{
+    return { calculateBackendSize(parameters.logicalSize, parameters.resolutionScale), parameters.resolutionScale, parameters.colorSpace, parameters.pixelFormat, parameters.purpose };
+}
 
 bool ImageBuffer::sizeNeedsClamping(const FloatSize& size)
 {
@@ -275,10 +277,9 @@ std::unique_ptr<ImageBufferBackend> ImageBuffer::takeBackend()
 
 IntSize ImageBuffer::backendSize() const
 {
-    if (auto* backend = ensureBackendCreated())
-        return backend->backendSize();
-    return { };
+    return calculateBackendSize(m_parameters.logicalSize, m_parameters.resolutionScale);
 }
+
 
 RefPtr<NativeImage> ImageBuffer::copyNativeImage() const
 {

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -33,15 +33,6 @@
 
 namespace WebCore {
 
-IntSize ImageBufferBackend::calculateBackendSize(const Parameters& parameters)
-{
-    FloatSize scaledSize = { ceilf(parameters.resolutionScale * parameters.logicalSize.width()), ceilf(parameters.resolutionScale * parameters.logicalSize.height()) };
-    if (scaledSize.isEmpty() || !scaledSize.isExpressibleAsIntSize())
-        return { };
-
-    return IntSize(scaledSize);
-}
-
 size_t ImageBufferBackend::calculateMemoryCost(const IntSize& backendSize, unsigned bytesPerRow)
 {
     ASSERT(!backendSize.isEmpty());
@@ -62,7 +53,7 @@ RefPtr<NativeImage> ImageBufferBackend::sinkIntoNativeImage()
 
 void ImageBufferBackend::convertToLuminanceMask()
 {
-    auto sourceRect = backendRect();
+    IntRect sourceRect { { }, size() };
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, colorSpace() };
     auto pixelBuffer = ImageBufferAllocator().createPixelBuffer(format, sourceRect.size());
     if (!pixelBuffer)
@@ -87,7 +78,8 @@ void ImageBufferBackend::convertToLuminanceMask()
 
 void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, void* sourceData, PixelBuffer& destinationPixelBuffer)
 {
-    auto sourceRectClipped = intersection(backendRect(), sourceRect);
+    IntRect backendRect { { }, size() };
+    auto sourceRectClipped = intersection(backendRect, sourceRect);
     IntRect destinationRect { IntPoint::zero(), sourceRectClipped.size() };
 
     if (sourceRect.x() < 0)
@@ -117,6 +109,7 @@ void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, void* sourceD
 
 void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationAlphaFormat, void* destinationData)
 {
+    IntRect backendRect { { }, size() };
     auto sourceRectClipped = intersection({ IntPoint::zero(), sourcePixelBuffer.size() }, sourceRect);
     auto destinationRect = sourceRectClipped;
     destinationRect.moveBy(destinationPoint);
@@ -127,7 +120,7 @@ void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, co
     if (sourceRect.y() < 0)
         destinationRect.setY(destinationRect.y() - sourceRect.y());
 
-    destinationRect.intersect(backendRect());
+    destinationRect.intersect(backendRect);
     sourceRectClipped.setSize(destinationRect.size());
 
     unsigned sourceBytesPerRow = static_cast<unsigned>(4u * sourcePixelBuffer.size().width());
@@ -152,7 +145,7 @@ AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& par
 
     if (originAtBottomLeftCorner) {
         baseTransform.scale(1, -1);
-        baseTransform.translate(0, -calculateBackendSize(parameters).height());
+        baseTransform.translate(0, -parameters.backendSize.height());
     }
 
     baseTransform.scale(parameters.resolutionScale);

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -105,15 +105,12 @@ public:
 
     WEBCORE_EXPORT virtual ~ImageBufferBackend();
 
-    WEBCORE_EXPORT static IntSize calculateBackendSize(const Parameters&);
     WEBCORE_EXPORT static size_t calculateMemoryCost(const IntSize& backendSize, unsigned bytesPerRow);
     static size_t calculateExternalMemoryCost(const Parameters&) { return 0; }
     WEBCORE_EXPORT static AffineTransform calculateBaseTransform(const Parameters&, bool originAtBottomLeftCorner);
 
     virtual GraphicsContext& context() = 0;
     virtual void flushContext() { }
-
-    virtual IntSize backendSize() const { return { }; }
 
     virtual RefPtr<NativeImage> copyNativeImage() = 0;
     virtual RefPtr<NativeImage> createNativeImageReference() = 0;
@@ -163,15 +160,10 @@ protected:
 
     virtual unsigned bytesPerRow() const = 0;
 
-
-    IntSize logicalSize() const { return IntSize(m_parameters.logicalSize); }
+    IntSize size() const { return m_parameters.backendSize; };
     float resolutionScale() const { return m_parameters.resolutionScale; }
     const DestinationColorSpace& colorSpace() const { return m_parameters.colorSpace; }
     PixelFormat pixelFormat() const { return m_parameters.pixelFormat; }
-    RenderingPurpose renderingPurpose() const { return m_parameters.purpose; }
-
-    IntRect logicalRect() const { return IntRect(IntPoint::zero(), logicalSize()); };
-    IntRect backendRect() const { return IntRect(IntPoint::zero(), backendSize()); };
 
     WEBCORE_EXPORT void getPixelBuffer(const IntRect& srcRect, void* data, PixelBuffer& destination);
     WEBCORE_EXPORT void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat, void* destination);

--- a/Source/WebCore/platform/graphics/ImageBufferBackendParameters.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackendParameters.h
@@ -26,15 +26,15 @@
 #pragma once
 
 #include "DestinationColorSpace.h"
-#include "FloatSize.h"
+#include "IntSize.h"
 #include "PixelFormat.h"
 #include "RenderingMode.h"
 
 namespace WebCore {
 
 struct ImageBufferBackendParameters {
-    FloatSize logicalSize;
-    float resolutionScale;
+    IntSize backendSize;
+    float resolutionScale; // Resolution scale is of the ImageBuffer logical size.
     DestinationColorSpace colorSpace;
     PixelFormat pixelFormat;
     RenderingPurpose purpose;

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
@@ -55,11 +55,6 @@ GraphicsContext& ImageBufferCairoSurfaceBackend::context()
     return m_context;
 }
 
-IntSize ImageBufferCairoSurfaceBackend::backendSize() const
-{
-    return { cairo_image_surface_get_width(m_surface.get()), cairo_image_surface_get_height(m_surface.get()) };
-}
-
 unsigned ImageBufferCairoSurfaceBackend::bytesPerRow() const
 {
     return cairo_image_surface_get_stride(m_surface.get());

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
@@ -40,8 +40,6 @@ class ImageBufferCairoSurfaceBackend : public ImageBufferCairoBackend {
 public:
     GraphicsContext& context() override;
 
-    IntSize backendSize() const override;
-
     RefPtr<NativeImage> copyNativeImage() override;
     RefPtr<NativeImage> createNativeImageReference() override;
 

--- a/Source/WebCore/platform/graphics/cg/IOSurfaceImageBuffer.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfaceImageBuffer.h
@@ -37,11 +37,6 @@ public:
         return ImageBuffer::create<ImageBufferIOSurfaceBackend, IOSurfaceImageBuffer>(size, resolutionScale, colorSpace, pixelFormat, purpose, creationContext);
     }
 
-    static auto create(const FloatSize& size, const GraphicsContext& context, RenderingPurpose purpose)
-    {
-        return ImageBuffer::create<ImageBufferIOSurfaceBackend, IOSurfaceImageBuffer>(size, context, purpose);
-    }
-
     IOSurface& surface() { return *static_cast<ImageBufferIOSurfaceBackend&>(*m_backend).surface(); }
 
 protected:

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -41,7 +41,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(ImageBufferCGBitmapBackend);
 
 IntSize ImageBufferCGBitmapBackend::calculateSafeBackendSize(const Parameters& parameters)
 {
-    IntSize backendSize = calculateBackendSize(parameters);
+    IntSize backendSize = parameters.backendSize;
     if (backendSize.isEmpty())
         return backendSize;
     
@@ -58,8 +58,7 @@ IntSize ImageBufferCGBitmapBackend::calculateSafeBackendSize(const Parameters& p
 
 size_t ImageBufferCGBitmapBackend::calculateMemoryCost(const Parameters& parameters)
 {
-    IntSize backendSize = calculateBackendSize(parameters);
-    return ImageBufferBackend::calculateMemoryCost(backendSize, calculateBytesPerRow(backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
 }
 
 std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
@@ -113,15 +112,9 @@ GraphicsContext& ImageBufferCGBitmapBackend::context()
     return *m_context;
 }
 
-IntSize ImageBufferCGBitmapBackend::backendSize() const
-{
-    return calculateBackendSize(m_parameters);
-}
-
 unsigned ImageBufferCGBitmapBackend::bytesPerRow() const
 {
-    IntSize backendSize = calculateBackendSize(m_parameters);
-    return calculateBytesPerRow(backendSize);
+    return calculateBytesPerRow(m_parameters.backendSize);
 }
 
 RefPtr<NativeImage> ImageBufferCGBitmapBackend::copyNativeImage()
@@ -131,7 +124,7 @@ RefPtr<NativeImage> ImageBufferCGBitmapBackend::copyNativeImage()
 
 RefPtr<NativeImage> ImageBufferCGBitmapBackend::createNativeImageReference()
 {
-    auto backendSize = this->backendSize();
+    auto backendSize = size();
     return NativeImage::create(adoptCF(CGImageCreate(
         backendSize.width(), backendSize.height(), 8, 32, bytesPerRow(),
         colorSpace().platformColorSpace(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host), m_dataProvider.get(),

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
@@ -49,7 +49,6 @@ public:
 private:
     ImageBufferCGBitmapBackend(const Parameters&, void* data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);
 
-    IntSize backendSize() const final;
     unsigned bytesPerRow() const final;
 
     RefPtr<NativeImage> copyNativeImage() final;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(ImageBufferIOSurfaceBackend);
 
 IntSize ImageBufferIOSurfaceBackend::calculateSafeBackendSize(const Parameters& parameters)
 {
-    IntSize backendSize = calculateBackendSize(parameters);
+    IntSize backendSize = parameters.backendSize;
     if (backendSize.isEmpty())
         return { };
 
@@ -65,8 +65,7 @@ unsigned ImageBufferIOSurfaceBackend::calculateBytesPerRow(const IntSize& backen
 
 size_t ImageBufferIOSurfaceBackend::calculateMemoryCost(const Parameters& parameters)
 {
-    IntSize backendSize = calculateBackendSize(parameters);
-    return ImageBufferBackend::calculateMemoryCost(backendSize, calculateBytesPerRow(backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
 }
 
 size_t ImageBufferIOSurfaceBackend::calculateExternalMemoryCost(const Parameters& parameters)
@@ -143,11 +142,6 @@ CGContextRef ImageBufferIOSurfaceBackend::ensurePlatformContext()
         RELEASE_ASSERT(m_platformContext);
     }
     return m_platformContext.get();
-}
-
-IntSize ImageBufferIOSurfaceBackend::backendSize() const
-{
-    return m_surface->size();
 }
 
 unsigned ImageBufferIOSurfaceBackend::bytesPerRow() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -59,7 +59,6 @@ protected:
     CGContextRef ensurePlatformContext();
     // Returns true if flush happened.
     bool flushContextDraws();
-    IntSize backendSize() const override;
     
     RefPtr<NativeImage> copyNativeImage() override;
     RefPtr<NativeImage> createNativeImageReference() override;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -83,11 +83,11 @@ namespace WebKit {
 using namespace WebCore;
 
 #if PLATFORM(COCOA)
-static bool isSmallLayerBacking(const ImageBufferBackendParameters& parameters)
+static bool isSmallLayerBacking(const ImageBufferParameters& parameters)
 {
     const unsigned maxSmallLayerBackingArea = 64u * 64u; // 4096 == 16kb backing store which equals 1 page on AS.
     return parameters.purpose == RenderingPurpose::LayerBacking
-        && ImageBufferBackend::calculateBackendSize(parameters).area() <= maxSmallLayerBackingArea
+        && ImageBuffer::calculateBackendSize(parameters.logicalSize, parameters.resolutionScale).area() <= maxSmallLayerBackingArea
         && (parameters.pixelFormat == PixelFormat::BGRA8 || parameters.pixelFormat == PixelFormat::BGRX8);
 }
 #endif

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -766,6 +766,7 @@ def headers_for_type(type):
         'WebCore::HasInsecureContent': ['<WebCore/FrameLoaderTypes.h>'],
         'WebCore::HighlightRequestOriginatedInApp': ['<WebCore/AppHighlight.h>'],
         'WebCore::HighlightVisibility': ['<WebCore/HighlightVisibility.h>'],
+        'WebCore::ImageBufferParameters': ['<WebCore/ImageBuffer.h>'],
         'WebCore::IncludeSecureCookies': ['<WebCore/CookieJar.h>'],
         'WebCore::IndexedDB::ObjectStoreOverwriteMode': ['<WebCore/IndexedDB.h>'],
         'WebCore::InputMode': ['<WebCore/InputMode.h>'],

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
@@ -43,7 +43,6 @@ public:
     static std::unique_ptr<DynamicContentScalingImageBufferBackend> create(const Parameters&, const WebCore::ImageBufferCreationContext&);
 
     WebCore::GraphicsContext& context() final;
-    WebCore::IntSize backendSize() const final;
     std::optional<ImageBufferBackendHandle> createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
 
     void releaseGraphicsContext() final;

--- a/Source/WebKit/Shared/UserData.cpp
+++ b/Source/WebKit/Shared/UserData.cpp
@@ -385,11 +385,11 @@ bool UserData::decode(IPC::Decoder& decoder, RefPtr<API::Object>& result)
 
         if (!didEncode)
             break;
-        auto parameters = decoder.decode<WebCore::ImageBufferBackend::Parameters>();
+        auto parameters = decoder.decode<WebCore::ImageBufferParameters>();
         auto handle = decoder.decode<ShareableBitmap::Handle>();
         if (UNLIKELY(!decoder.isValid()))
             return false;
-        result = WebImage::create(*parameters, WTFMove(*handle));
+        result = WebImage::create(WTFMove(*parameters), WTFMove(*handle));
         break;
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4082,7 +4082,8 @@ enum class WebCore::VideoFrameRotation : uint16_t {
     Vector<WebCore::GradientColorStop, 2> stops();
 };
 
-struct WebCore::ImageBufferBackendParameters {
+header: <WebCore/ImageBuffer.h>
+[CustomHeader] struct WebCore::ImageBufferParameters {
     WebCore::FloatSize logicalSize;
     float resolutionScale;
     WebCore::DestinationColorSpace colorSpace

--- a/Source/WebKit/Shared/WebImage.cpp
+++ b/Source/WebKit/Shared/WebImage.cpp
@@ -56,15 +56,17 @@ RefPtr<WebImage> WebImage::create(const IntSize& size, ImageOptions options, con
     return WebImage::create(buffer.releaseNonNull());
 }
 
-RefPtr<WebImage> WebImage::create(const ImageBufferBackend::Parameters& parameters, ShareableBitmap::Handle&& handle)
+RefPtr<WebImage> WebImage::create(ImageBufferParameters&& parameters, ShareableBitmap::Handle&& handle)
 {
-    auto backend = ImageBufferShareableBitmapBackend::create(parameters, WTFMove(handle));
+    // FIXME: These should be abstracted as a encodable image buffer handle.
+    auto backendParameters = ImageBuffer::backendParameters(parameters);
+    auto backend = ImageBufferShareableBitmapBackend::create(backendParameters, WTFMove(handle));
     if (!backend)
         return nullptr;
     
-    auto info = ImageBuffer::populateBackendInfo<ImageBufferShareableBitmapBackend>(parameters);
+    auto info = ImageBuffer::populateBackendInfo<ImageBufferShareableBitmapBackend>(backendParameters);
 
-    auto buffer = ImageBuffer::create(parameters, info, WTFMove(backend));
+    auto buffer = ImageBuffer::create(WTFMove(parameters), info, WTFMove(backend));
     if (!buffer)
         return nullptr;
 
@@ -86,7 +88,7 @@ IntSize WebImage::size() const
     return m_buffer->backendSize();
 }
 
-const ImageBufferBackend::Parameters& WebImage::parameters() const
+const ImageBufferParameters& WebImage::parameters() const
 {
     return m_buffer->parameters();
 }

--- a/Source/WebKit/Shared/WebImage.h
+++ b/Source/WebKit/Shared/WebImage.h
@@ -28,7 +28,6 @@
 #include "APIObject.h"
 #include "ImageOptions.h"
 #include "ShareableBitmap.h"
-#include <WebCore/ImageBufferBackend.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {
@@ -37,6 +36,7 @@ class GraphicsContext;
 class ImageBuffer;
 class IntSize;
 class NativeImage;
+struct ImageBufferParameters;
 }
 
 namespace WebKit {
@@ -46,11 +46,11 @@ namespace WebKit {
 class WebImage : public API::ObjectImpl<API::Object::Type::Image> {
 public:
     static RefPtr<WebImage> create(const WebCore::IntSize&, ImageOptions, const WebCore::DestinationColorSpace&, WebCore::ChromeClient* = nullptr);
-    static RefPtr<WebImage> create(const WebCore::ImageBufferBackend::Parameters&, ShareableBitmap::Handle&&);
+    static RefPtr<WebImage> create(WebCore::ImageBufferParameters&&, ShareableBitmap::Handle&&);
     static Ref<WebImage> create(Ref<WebCore::ImageBuffer>&&);
 
     WebCore::IntSize size() const;
-    const WebCore::ImageBufferBackend::Parameters& parameters() const;
+    const WebCore::ImageBufferParameters& parameters() const;
 
     WebCore::GraphicsContext& context() const;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7919,9 +7919,9 @@ void WebPageProxy::didCountStringMatches(const String& string, uint32_t matchCou
     m_findClient->didCountStringMatches(this, string, matchCount);
 }
 
-void WebPageProxy::didGetImageForFindMatch(const ImageBufferBackend::Parameters& parameters, ShareableBitmap::Handle&& contentImageHandle, uint32_t matchIndex)
+void WebPageProxy::didGetImageForFindMatch(ImageBufferParameters&& parameters, ShareableBitmap::Handle&& contentImageHandle, uint32_t matchIndex)
 {
-    auto image = WebImage::create(parameters, WTFMove(contentImageHandle));
+    auto image = WebImage::create(WTFMove(parameters), WTFMove(contentImageHandle));
     if (!image) {
         ASSERT_NOT_REACHED();
         return;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -225,7 +225,7 @@ struct FrameIdentifierType;
 struct GrammarDetail;
 struct HTMLMediaElementIdentifierType;
 struct HTMLModelElementCamera;
-struct ImageBufferBackendParameters;
+struct ImageBufferParameters;
 struct InspectorOverlayHighlight;
 struct LinkIcon;
 struct LinkDecorationFilteringData;
@@ -1305,7 +1305,7 @@ public:
     void getImageForFindMatch(int32_t matchIndex);
     void selectFindMatch(int32_t matchIndex);
     void indicateFindMatch(int32_t matchIndex);
-    void didGetImageForFindMatch(const WebCore::ImageBufferBackendParameters&, ShareableBitmapHandle&& contentImageHandle, uint32_t matchIndex);
+    void didGetImageForFindMatch(WebCore::ImageBufferParameters&&, ShareableBitmapHandle&& contentImageHandle, uint32_t matchIndex);
     void hideFindUI();
     void hideFindIndicator();
     void countStringMatches(const String&, OptionSet<FindOptions>, unsigned maxMatchCount);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -247,7 +247,7 @@ messages -> WebPageProxy {
     DidFindString(String string, Vector<WebCore::IntRect> matchRect, uint32_t matchCount, int32_t matchIndex, bool didWrapAround)
     DidFailToFindString(String string)
     DidFindStringMatches(String string, Vector<Vector<WebCore::IntRect>> matches, int32_t firstIndexAfterSelection)
-    DidGetImageForFindMatch(struct WebCore::ImageBufferBackendParameters parameters, WebKit::ShareableBitmap::Handle contentImageHandle, uint32_t matchIndex)
+    DidGetImageForFindMatch(struct WebCore::ImageBufferParameters parameters, WebKit::ShareableBitmap::Handle contentImageHandle, uint32_t matchIndex)
 
     # PopupMenu messages
     ShowPopupMenu(WebCore::IntRect rect, uint64_t textDirection, Vector<WebKit::WebPopupItem> items, int32_t selectedIndex, struct WebKit::PlatformPopupMenuData data)

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(ImageBufferShareableBitmapBackend);
 
 IntSize ImageBufferShareableBitmapBackend::calculateSafeBackendSize(const Parameters& parameters)
 {
-    IntSize backendSize = calculateBackendSize(parameters);
+    IntSize backendSize = parameters.backendSize;
     if (backendSize.isEmpty())
         return { };
 
@@ -62,8 +62,7 @@ unsigned ImageBufferShareableBitmapBackend::calculateBytesPerRow(const Parameter
 
 size_t ImageBufferShareableBitmapBackend::calculateMemoryCost(const Parameters& parameters)
 {
-    IntSize backendSize = calculateBackendSize(parameters);
-    return ImageBufferBackend::calculateMemoryCost(backendSize, calculateBytesPerRow(parameters, backendSize));
+    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters, parameters.backendSize));
 }
 
 std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const Parameters& parameters, const WebCore::ImageBufferCreationContext&)
@@ -120,11 +119,6 @@ std::optional<ImageBufferBackendHandle> ImageBufferShareableBitmapBackend::creat
     if (auto handle = m_bitmap->createHandle(protection))
         return ImageBufferBackendHandle(WTFMove(*handle));
     return { };
-}
-
-IntSize ImageBufferShareableBitmapBackend::backendSize() const
-{
-    return m_bitmap->size();
 }
 
 unsigned ImageBufferShareableBitmapBackend::bytesPerRow() const

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -64,7 +64,6 @@ public:
     ImageBufferShareableBitmapBackend(const Parameters&, Ref<ShareableBitmap>&&, std::unique_ptr<WebCore::GraphicsContext>&&);
 
     WebCore::GraphicsContext& context() final { return *m_context; }
-    WebCore::IntSize backendSize() const final;
 
     std::optional<ImageBufferBackendHandle> createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
     RefPtr<ShareableBitmap> bitmap() const final { return m_bitmap.ptr(); }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -116,7 +116,7 @@ private:
 
 }
 
-RemoteImageBufferProxy::RemoteImageBufferProxy(const ImageBufferBackend::Parameters& parameters, const ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier identifier)
+RemoteImageBufferProxy::RemoteImageBufferProxy(Parameters parameters, const ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier identifier)
     : ImageBuffer(parameters, info, WTFMove(backend), identifier)
     , m_remoteRenderingBackendProxy(remoteRenderingBackendProxy)
     , m_remoteDisplayList(*this, remoteRenderingBackendProxy, { { }, ImageBuffer::logicalSize() }, ImageBuffer::baseTransform())
@@ -210,15 +210,16 @@ void RemoteImageBufferProxy::didCreateBackend(std::optional<ImageBufferBackendHa
     // This should match RemoteImageBufferProxy::create<>() call site and RemoteImageBuffer::create<>() call site.
     // FIXME: this will be removed and backend be constructed in the contructor.
     std::unique_ptr<ImageBufferBackend> backend;
+    auto backendParameters = this->backendParameters(parameters());
     if (renderingMode() == RenderingMode::Accelerated) {
 #if HAVE(IOSURFACE)
         if (canMapBackingStore())
-            backend = ImageBufferShareableMappedIOSurfaceBackend::create(parameters(), WTFMove(*handle));
+            backend = ImageBufferShareableMappedIOSurfaceBackend::create(backendParameters, WTFMove(*handle));
         else
-            backend = ImageBufferRemoteIOSurfaceBackend::create(parameters(), WTFMove(*handle));
+            backend = ImageBufferRemoteIOSurfaceBackend::create(backendParameters, WTFMove(*handle));
 #endif
     } else
-        backend = ImageBufferShareableBitmapBackend::create(parameters(), WTFMove(*handle));
+        backend = ImageBufferShareableBitmapBackend::create(backendParameters, WTFMove(*handle));
 
     setBackend(WTFMove(backend));
 }
@@ -445,7 +446,7 @@ std::unique_ptr<SerializedImageBuffer> RemoteImageBufferProxy::sinkIntoSerialize
 
     m_remoteRenderingBackendProxy->remoteResourceCacheProxy().forgetImageBuffer(m_renderingResourceIdentifier);
 
-    auto result = makeUnique<RemoteSerializedImageBufferProxy>(backend()->parameters(), backendInfo(), m_renderingResourceIdentifier, *m_remoteRenderingBackendProxy);
+    auto result = makeUnique<RemoteSerializedImageBufferProxy>(parameters(), backendInfo(), m_renderingResourceIdentifier, *m_remoteRenderingBackendProxy);
 
     clearBackend();
     m_remoteRenderingBackendProxy = nullptr;
@@ -460,7 +461,7 @@ IPC::StreamClientConnection& RemoteImageBufferProxy::streamConnection() const
     return m_remoteRenderingBackendProxy->streamConnection();
 }
 
-RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy(const WebCore::ImageBufferBackend::Parameters& parameters, const WebCore::ImageBufferBackend::Info& info, const WebCore::RenderingResourceIdentifier& renderingResourceIdentifier, RemoteRenderingBackendProxy& backend)
+RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy(WebCore::ImageBuffer::Parameters parameters, const WebCore::ImageBufferBackend::Info& info, const WebCore::RenderingResourceIdentifier& renderingResourceIdentifier, RemoteRenderingBackendProxy& backend)
     : m_parameters(parameters)
     , m_info(info)
     , m_renderingResourceIdentifier(renderingResourceIdentifier)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -47,16 +47,12 @@ public:
     template<typename BackendType>
     static RefPtr<RemoteImageBufferProxy> create(const WebCore::FloatSize& size, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::PixelFormat pixelFormat, WebCore::RenderingPurpose purpose, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, bool avoidBackendSizeCheck = false)
     {
-        auto parameters = WebCore::ImageBufferBackend::Parameters { size, resolutionScale, colorSpace, pixelFormat, purpose };
-        if (!avoidBackendSizeCheck && BackendType::calculateSafeBackendSize(parameters).isEmpty())
+        Parameters parameters { size, resolutionScale, colorSpace, pixelFormat, purpose };
+        auto backendParameters = ImageBuffer::backendParameters(parameters);
+        if (!avoidBackendSizeCheck && BackendType::calculateSafeBackendSize(backendParameters).isEmpty())
             return nullptr;
-        auto info = populateBackendInfo<BackendType>(parameters);
+        auto info = populateBackendInfo<BackendType>(backendParameters);
         return adoptRef(new RemoteImageBufferProxy(parameters, info, remoteRenderingBackendProxy));
-    }
-
-    static RefPtr<RemoteImageBufferProxy> create(const WebCore::ImageBufferBackend::Parameters& parameters, const WebCore::ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, std::unique_ptr<WebCore::ImageBufferBackend>&& backend, WebCore::RenderingResourceIdentifier identifier)
-    {
-        return adoptRef(new RemoteImageBufferProxy(parameters, info, remoteRenderingBackendProxy, WTFMove(backend), identifier));
     }
 
     ~RemoteImageBufferProxy();
@@ -73,7 +69,7 @@ public:
     void didCreateBackend(std::optional<ImageBufferBackendHandle>);
 
 private:
-    RemoteImageBufferProxy(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
+    RemoteImageBufferProxy(Parameters, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
 
     RefPtr<WebCore::NativeImage> copyNativeImage() const final;
     RefPtr<WebCore::NativeImage> createNativeImageReference() const final;
@@ -118,7 +114,7 @@ public:
 
     WebCore::RenderingResourceIdentifier renderingResourceIdentifier() { return m_renderingResourceIdentifier; }
 
-    RemoteSerializedImageBufferProxy(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, const WebCore::RenderingResourceIdentifier&, RemoteRenderingBackendProxy&);
+    RemoteSerializedImageBufferProxy(WebCore::ImageBuffer::Parameters, const WebCore::ImageBufferBackend::Info&, const WebCore::RenderingResourceIdentifier&, RemoteRenderingBackendProxy&);
 
     size_t memoryCost() final
     {
@@ -134,7 +130,7 @@ private:
 
     bool isRemoteSerializedImageBufferProxy() const final { return true; }
 
-    WebCore::ImageBufferBackend::Parameters m_parameters;
+    WebCore::ImageBuffer::Parameters m_parameters;
     WebCore::ImageBufferBackend::Info m_info;
     WebCore::RenderingResourceIdentifier m_renderingResourceIdentifier;
     RefPtr<IPC::Connection> m_connection;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -101,15 +101,9 @@ GraphicsContext& ImageBufferRemoteIOSurfaceBackend::context()
     return *(GraphicsContext*)nullptr;
 }
 
-IntSize ImageBufferRemoteIOSurfaceBackend::backendSize() const
-{
-    return calculateBackendSize(m_parameters);
-}
-
 unsigned ImageBufferRemoteIOSurfaceBackend::bytesPerRow() const
 {
-    IntSize backendSize = calculateBackendSize(m_parameters);
-    return ImageBufferIOSurfaceBackend::calculateBytesPerRow(backendSize);
+    return ImageBufferIOSurfaceBackend::calculateBytesPerRow(m_parameters.backendSize);
 }
 
 RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage()

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -59,7 +59,6 @@ public:
     std::optional<ImageBufferBackendHandle> takeBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) final;
 
 private:
-    WebCore::IntSize backendSize() const final;
     RefPtr<WebCore::NativeImage> copyNativeImage() final;
     RefPtr<WebCore::NativeImage> createNativeImageReference() final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -119,11 +119,6 @@ void ImageBufferShareableMappedIOSurfaceBitmapBackend::setOwnershipIdentity(cons
     m_surface->setOwnershipIdentity(resourceOwner);
 }
 
-IntSize ImageBufferShareableMappedIOSurfaceBitmapBackend::backendSize() const
-{
-    return m_surface->size();
-}
-
 unsigned ImageBufferShareableMappedIOSurfaceBitmapBackend::bytesPerRow() const
 {
     return m_surface->bytesPerRow();

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -61,7 +61,6 @@ private:
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
 
     // WebCore::ImageBufferCGBackend
-    WebCore::IntSize backendSize() const final;
     unsigned bytesPerRow() const final;
     RefPtr<WebCore::NativeImage> copyNativeImage() final;
     RefPtr<WebCore::NativeImage> createNativeImageReference() final;


### PR DESCRIPTION
#### f77323c9d2ad5455d94e42560ef4bdf89c0c9414
<pre>
ImageBuffer::backendSize() waits for GPUP to create the backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=262179">https://bugs.webkit.org/show_bug.cgi?id=262179</a>
rdar://116117019

Reviewed by Matt Woodrow.

The backend size is not backend logic, it is same for all backends.
Move the backend size calculation to ImageBuffer.

The logical size is not a ImageBufferBackend parameter, it is a ImageBuffer
parameter. Store the backend size in ImageBufferBackendParameters.

Use the new struct ImageBufferParameters when client code is communicating
parameters with the use-case of creating new ImageBuffer instances in
WebImage and RemoteSerializedImageBufferProxy.

Fixes a case where RemoteImageBufferProxy would wait for the GPUP
to send the image buffer handle to WP. This is not needed, the backend
size is always known.

Later commits will simplify other properties in ImageBufferBackend that
are not backend-dependent.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::ImageBuffer):
(WebCore::ImageBuffer::calculateBackendSize):
(WebCore::ImageBuffer::backendParameters):
(WebCore::ImageBuffer::backendSize const): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::create):
(WebCore::ImageBuffer::backendSize const):
(WebCore::ImageBuffer::parameters const):
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::convertToLuminanceMask):
(WebCore::ImageBufferBackend::getPixelBuffer):
(WebCore::ImageBufferBackend::putPixelBuffer):
(WebCore::ImageBufferBackend::calculateBaseTransform):
(WebCore::ImageBufferBackend::calculateBackendSize): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::size const):
(WebCore::ImageBufferBackend::pixelFormat const):
(WebCore::ImageBufferBackend::backendSize const): Deleted.
(WebCore::ImageBufferBackend::logicalSize const): Deleted.
(WebCore::ImageBufferBackend::renderingPurpose const): Deleted.
(WebCore::ImageBufferBackend::logicalRect const): Deleted.
(WebCore::ImageBufferBackend::backendRect const): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackendParameters.h:
* Source/WebCore/platform/graphics/PlatformImageBuffer.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.cpp:
(WebCore::ImageBufferCairoImageSurfaceBackend::calculateSafeBackendSize):
(WebCore::ImageBufferCairoImageSurfaceBackend::calculateMemoryCost):
(WebCore::ImageBufferCairoImageSurfaceBackend::bytesPerRow const):
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::ImageBufferCairoSurfaceBackend::backendSize const): Deleted.
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::calculateSafeBackendSize):
(WebCore::ImageBufferCGBitmapBackend::calculateMemoryCost):
(WebCore::ImageBufferCGBitmapBackend::bytesPerRow const):
(WebCore::ImageBufferCGBitmapBackend::createNativeImageReference):
(WebCore::ImageBufferCGBitmapBackend::backendSize const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::calculateSafeBackendSize):
(WebCore::ImageBufferIOSurfaceBackend::calculateMemoryCost):
(WebCore::ImageBufferIOSurfaceBackend::backendSize const): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::isSmallLayerBacking):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
(WebKit::GraphicsContextDynamicContentScaling::GraphicsContextDynamicContentScaling):
(WebKit::DynamicContentScalingImageBufferBackend::calculateMemoryCost):
(WebKit::DynamicContentScalingImageBufferBackend::create):
(WebKit::DynamicContentScalingImageBufferBackend::context):
(WebKit::DynamicContentScalingImageBufferBackend::bytesPerRow const):
(WebKit::DynamicContentScalingAcceleratedImageBufferBackend::create):
(WebKit::DynamicContentScalingImageBufferBackend::backendSize const): Deleted.
* Source/WebKit/Shared/UserData.cpp:
(WebKit::UserData::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebImage.cpp:
(WebKit::WebImage::create):
(WebKit::WebImage::parameters const):
* Source/WebKit/Shared/WebImage.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didGetImageForFindMatch):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::calculateSafeBackendSize):
(WebKit::ImageBufferShareableBitmapBackend::calculateMemoryCost):
(WebKit::ImageBufferShareableBitmapBackend::backendSize const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::RemoteImageBufferProxy):
(WebKit::RemoteImageBufferProxy::didCreateBackend):
(WebKit::RemoteImageBufferProxy::sinkIntoSerializedImageBuffer):
(WebKit::RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
(WebKit::RemoteImageBufferProxy::create):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::bytesPerRow const):
(WebKit::ImageBufferRemoteIOSurfaceBackend::backendSize const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::backendSize const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h:

Canonical link: <a href="https://commits.webkit.org/268631@main">https://commits.webkit.org/268631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b4e2f96c1f716c914409656db11ba45b5cae2f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18732 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20216 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22816 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20253 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24493 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18415 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22483 "1 api test failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16136 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18204 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4855 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->