### PR TITLE
Store fewer raw pointers in containers in Source/WebKitLegacy

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -115,6 +115,8 @@ public:
     ALWAYS_INLINE T& operator*() const { ASSERT(m_ptr); return *get(); }
     ALWAYS_INLINE T* operator->() const { return get(); }
 
+    CheckedRef<T> releaseNonNull() { ASSERT(m_ptr); return CheckedRef { *PtrTraits::unwrap(std::exchange(m_ptr, nullptr)), CheckedRef<T>::Adopt }; }
+
     bool operator==(const T* other) const { return m_ptr == other; }
     template<typename U> bool operator==(U* other) const { return m_ptr == other; }
 

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -54,6 +54,12 @@ public:
         PtrTraits::unwrap(m_ptr)->incrementPtrCount();
     }
 
+    enum AdoptTag { Adopt };
+    CheckedRef(T& object, AdoptTag)
+        : m_ptr(&object)
+    {
+    }
+
     ALWAYS_INLINE CheckedRef(const CheckedRef& other)
         : m_ptr { PtrTraits::unwrap(other.m_ptr) }
     {

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -35,6 +35,7 @@
 #include "PolicyContainer.h"
 #include "SerializedScriptValue.h"
 #include <memory>
+#include <wtf/CheckedRef.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -66,7 +67,7 @@ protected:
     HistoryItemClient() = default;
 };
 
-class HistoryItem : public RefCounted<HistoryItem> {
+class HistoryItem : public RefCounted<HistoryItem>, public CanMakeCheckedPtr {
     friend class BackForwardCache;
 
 public:

--- a/Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp
+++ b/Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp
@@ -31,6 +31,7 @@
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/StorageMap.h>
 #include <WebCore/StorageType.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringHash.h>
@@ -39,9 +40,9 @@ using namespace WebCore;
 
 namespace WebKit {
 
-static HashMap<String, StorageNamespaceImpl*>& localStorageNamespaceMap()
+static HashMap<String, CheckedPtr<StorageNamespaceImpl>>& localStorageNamespaceMap()
 {
-    static NeverDestroyed<HashMap<String, StorageNamespaceImpl*>> localStorageNamespaceMap;
+    static NeverDestroyed<HashMap<String, CheckedPtr<StorageNamespaceImpl>>> localStorageNamespaceMap;
 
     return localStorageNamespaceMap;
 }

--- a/Source/WebKitLegacy/Storage/StorageNamespaceImpl.h
+++ b/Source/WebKitLegacy/Storage/StorageNamespaceImpl.h
@@ -29,6 +29,7 @@
 #include <WebCore/StorageArea.h>
 #include <WebCore/StorageNamespace.h>
 #include <pal/SessionID.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>
@@ -37,7 +38,7 @@ namespace WebKit {
 
 class StorageAreaImpl;
 
-class StorageNamespaceImpl final : public WebCore::StorageNamespace {
+class StorageNamespaceImpl final : public WebCore::StorageNamespace, public CanMakeCheckedPtr {
 public:
     static Ref<StorageNamespaceImpl> createSessionStorageNamespace(unsigned quota, PAL::SessionID);
     static Ref<StorageNamespaceImpl> getOrCreateLocalStorageNamespace(const String& databasePath, unsigned quota, PAL::SessionID);

--- a/Source/WebKitLegacy/Storage/StorageThread.cpp
+++ b/Source/WebKitLegacy/Storage/StorageThread.cpp
@@ -32,10 +32,10 @@
 
 namespace WebCore {
 
-static HashSet<StorageThread*>& activeStorageThreads()
+static HashSet<CheckedRef<StorageThread>>& activeStorageThreads()
 {
     ASSERT(isMainThread());
-    static NeverDestroyed<HashSet<StorageThread*>> threads;
+    static NeverDestroyed<HashSet<CheckedRef<StorageThread>>> threads;
     return threads;
 }
 
@@ -66,7 +66,7 @@ void StorageThread::start()
             });
         }
     }
-    activeStorageThreads().add(this);
+    activeStorageThreads().add(*this);
 }
 
 void StorageThread::threadEntryPoint()
@@ -90,7 +90,7 @@ void StorageThread::terminate()
 {
     ASSERT(isMainThread());
     ASSERT(!m_queue.killed() && m_thread);
-    activeStorageThreads().remove(this);
+    activeStorageThreads().remove(*this);
     // Even in weird, exceptional cases, don't wait on a nonexistent thread to terminate.
     if (!m_thread)
         return;

--- a/Source/WebKitLegacy/Storage/StorageThread.h
+++ b/Source/WebKitLegacy/Storage/StorageThread.h
@@ -26,6 +26,7 @@
 #ifndef StorageThread_h
 #define StorageThread_h
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/MessageQueue.h>
 #include <wtf/Threading.h>
@@ -36,7 +37,7 @@ namespace WebCore {
 class StorageAreaSync;
 class StorageTask;
 
-class StorageThread {
+class StorageThread : public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(StorageThread); WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type { LocalStorage, IndexedDB };

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
@@ -33,9 +33,9 @@ using namespace WebCore;
 
 namespace WebKit {
 
-static HashSet<WebStorageNamespaceProvider*>& storageNamespaceProviders()
+static HashSet<CheckedRef<WebStorageNamespaceProvider>>& storageNamespaceProviders()
 {
-    static NeverDestroyed<HashSet<WebStorageNamespaceProvider*>> storageNamespaceProviders;
+    static NeverDestroyed<HashSet<CheckedRef<WebStorageNamespaceProvider>>> storageNamespaceProviders;
 
     return storageNamespaceProviders;
 }
@@ -48,52 +48,52 @@ Ref<WebStorageNamespaceProvider> WebStorageNamespaceProvider::create(const Strin
 WebStorageNamespaceProvider::WebStorageNamespaceProvider(const String& localStorageDatabasePath)
     : m_localStorageDatabasePath(localStorageDatabasePath.isNull() ? emptyString() : localStorageDatabasePath)
 {
-    storageNamespaceProviders().add(this);
+    storageNamespaceProviders().add(*this);
 }
 
 WebStorageNamespaceProvider::~WebStorageNamespaceProvider()
 {
-    ASSERT(storageNamespaceProviders().contains(this));
-    storageNamespaceProviders().remove(this);
+    ASSERT(storageNamespaceProviders().contains(*this));
+    storageNamespaceProviders().remove(*this);
 }
 
 void WebStorageNamespaceProvider::closeLocalStorage()
 {
     for (const auto& storageNamespaceProvider : storageNamespaceProviders()) {
-        if (auto* localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
-            static_cast<StorageNamespaceImpl*>(localStorageNamespace)->close();
+        if (RefPtr localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
+            static_cast<StorageNamespaceImpl&>(*localStorageNamespace).close();
     }
 }
 
 void WebStorageNamespaceProvider::clearLocalStorageForAllOrigins()
 {
     for (const auto& storageNamespaceProvider : storageNamespaceProviders()) {
-        if (auto* localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
-            static_cast<StorageNamespaceImpl*>(localStorageNamespace)->clearAllOriginsForDeletion();
+        if (RefPtr localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
+            static_cast<StorageNamespaceImpl&>(*localStorageNamespace).clearAllOriginsForDeletion();
     }
 }
 
 void WebStorageNamespaceProvider::clearLocalStorageForOrigin(const SecurityOriginData& origin)
 {
     for (const auto& storageNamespaceProvider : storageNamespaceProviders()) {
-        if (auto* localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
-            static_cast<StorageNamespaceImpl*>(localStorageNamespace)->clearOriginForDeletion(origin);
+        if (RefPtr localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
+            static_cast<StorageNamespaceImpl&>(*localStorageNamespace).clearOriginForDeletion(origin);
     }
 }
 
 void WebStorageNamespaceProvider::closeIdleLocalStorageDatabases()
 {
     for (const auto& storageNamespaceProvider : storageNamespaceProviders()) {
-        if (auto* localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
-            static_cast<StorageNamespaceImpl*>(localStorageNamespace)->closeIdleLocalStorageDatabases();
+        if (RefPtr localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
+            static_cast<StorageNamespaceImpl&>(*localStorageNamespace).closeIdleLocalStorageDatabases();
     }
 }
 
 void WebStorageNamespaceProvider::syncLocalStorage()
 {
     for (const auto& storageNamespaceProvider : storageNamespaceProviders()) {
-        if (auto* localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
-            static_cast<StorageNamespaceImpl*>(localStorageNamespace)->sync();
+        if (RefPtr localStorageNamespace = storageNamespaceProvider->optionalLocalStorageNamespace())
+            static_cast<StorageNamespaceImpl&>(*localStorageNamespace).sync();
     }
 }
 

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/StorageNamespaceProvider.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakHashMap.h>
 
 namespace WebCore {
@@ -34,7 +35,7 @@ class SecurityOriginData;
 
 namespace WebKit {
 
-class WebStorageNamespaceProvider final : public WebCore::StorageNamespaceProvider {
+class WebStorageNamespaceProvider final : public WebCore::StorageNamespaceProvider, public CanMakeCheckedPtr {
 public:
     static Ref<WebStorageNamespaceProvider> create(const String& localStorageDatabasePath);
     virtual ~WebStorageNamespaceProvider();

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
@@ -61,23 +61,24 @@ WebResourceLoadScheduler& webResourceLoadScheduler()
     return static_cast<WebResourceLoadScheduler&>(*platformStrategies()->loaderStrategy());
 }
 
-WebResourceLoadScheduler::HostInformation* WebResourceLoadScheduler::hostForURL(const URL& url, CreateHostPolicy createHostPolicy)
+auto WebResourceLoadScheduler::hostForURL(const URL& url, CreateHostPolicy createHostPolicy) -> CheckedPtr<HostInformation>
 {
     if (!url.protocolIsInHTTPFamily())
-        return m_nonHTTPProtocolHost;
+        return m_nonHTTPProtocolHost.ptr();
 
     m_hosts.checkConsistency();
     String hostName = url.host().toString();
-    HostInformation* host = m_hosts.get(hostName);
+    CheckedPtr host = m_hosts.get(hostName);
     if (!host && createHostPolicy == CreateIfNotFound) {
-        host = new HostInformation(hostName, maxRequestsInFlightPerHost);
-        m_hosts.add(hostName, host);
+        auto newHost = makeUnique<HostInformation>(hostName, maxRequestsInFlightPerHost);
+        host = newHost.get();
+        m_hosts.add(hostName, WTFMove(newHost));
     }
     return host;
 }
 
 WebResourceLoadScheduler::WebResourceLoadScheduler()
-    : m_nonHTTPProtocolHost(new HostInformation(String(), maxRequestsInFlightForNonHTTPProtocols))
+    : m_nonHTTPProtocolHost(makeUniqueRef<HostInformation>(String(), maxRequestsInFlightForNonHTTPProtocols))
     , m_requestTimer(*this, &WebResourceLoadScheduler::requestTimerFired)
     , m_suspendPendingRequestsCount(0)
     , m_isSerialLoadingEnabled(false)
@@ -149,9 +150,9 @@ void WebResourceLoadScheduler::scheduleLoad(ResourceLoader* resourceLoader)
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    HostInformation* host = hostForURL(resourceLoader->iOSOriginalRequest().url(), CreateIfNotFound);
+    CheckedRef host = hostForURL(resourceLoader->iOSOriginalRequest().url(), CreateIfNotFound).releaseNonNull();
 #else
-    HostInformation* host = hostForURL(resourceLoader->url(), CreateIfNotFound);
+    CheckedRef host = hostForURL(resourceLoader->url(), CreateIfNotFound).releaseNonNull();
 #endif
 
     ResourceLoadPriority priority = resourceLoader->request().priority();
@@ -163,7 +164,7 @@ void WebResourceLoadScheduler::scheduleLoad(ResourceLoader* resourceLoader)
     if (ResourceRequest::resourcePrioritiesEnabled() && !isSuspendingPendingRequests()) {
         // Serve all requests at once to keep the pipeline full at the network layer.
         // FIXME: Does this code do anything useful, given that we also set maxRequestsInFlightPerHost to effectively unlimited on these platforms?
-        servePendingRequests(host, ResourceLoadPriority::VeryLow);
+        servePendingRequests(WTFMove(host), ResourceLoadPriority::VeryLow);
         return;
     }
 #endif
@@ -171,13 +172,13 @@ void WebResourceLoadScheduler::scheduleLoad(ResourceLoader* resourceLoader)
 #if PLATFORM(IOS_FAMILY)
     if ((priority > ResourceLoadPriority::Low || !resourceLoader->iOSOriginalRequest().url().protocolIsInHTTPFamily() || (priority == ResourceLoadPriority::Low && !hadRequests)) && !isSuspendingPendingRequests()) {
         // Try to request important resources immediately.
-        servePendingRequests(host, priority);
+        servePendingRequests(WTFMove(host), priority);
         return;
     }
 #else
     if (priority > ResourceLoadPriority::Low || !resourceLoader->url().protocolIsInHTTPFamily() || (priority == ResourceLoadPriority::Low && !hadRequests)) {
         // Try to request important resources immediately.
-        servePendingRequests(host, priority);
+        servePendingRequests(WTFMove(host), priority);
         return;
     }
 #endif
@@ -191,14 +192,14 @@ void WebResourceLoadScheduler::remove(ResourceLoader* resourceLoader)
 {
     ASSERT(resourceLoader);
 
-    HostInformation* host = hostForURL(resourceLoader->url());
+    CheckedPtr host = hostForURL(resourceLoader->url());
     if (host)
         host->remove(resourceLoader);
 #if PLATFORM(IOS_FAMILY)
     // ResourceLoader::url() doesn't start returning the correct value until the load starts. If we get canceled before that, we need to look for originalRequest url instead.
     // FIXME: ResourceLoader::url() should be made to return a sensible value at all times.
     if (!resourceLoader->iOSOriginalRequest().isNull()) {
-        HostInformation* originalHost = hostForURL(resourceLoader->iOSOriginalRequest().url());
+        CheckedPtr originalHost = hostForURL(resourceLoader->iOSOriginalRequest().url());
         if (originalHost && originalHost != host)
             originalHost->remove(resourceLoader);
     }
@@ -212,7 +213,8 @@ void WebResourceLoadScheduler::isResourceLoadFinished(CachedResource& resource, 
         callback(true);
         return;
     }
-    callback(!hostForURL(resource.loader()->url()));
+    bool didFinish = !hostForURL(resource.loader()->url());
+    callback(didFinish);
 }
 
 void WebResourceLoadScheduler::setDefersLoading(ResourceLoader& loader, bool defers)
@@ -225,12 +227,12 @@ void WebResourceLoadScheduler::setDefersLoading(ResourceLoader& loader, bool def
 
 void WebResourceLoadScheduler::crossOriginRedirectReceived(ResourceLoader* resourceLoader, const URL& redirectURL)
 {
-    HostInformation* oldHost = hostForURL(resourceLoader->url());
+    CheckedPtr oldHost = hostForURL(resourceLoader->url());
     ASSERT(oldHost);
     if (!oldHost)
         return;
 
-    HostInformation* newHost = hostForURL(redirectURL, CreateIfNotFound);
+    CheckedPtr newHost = hostForURL(redirectURL, CreateIfNotFound);
 
     if (oldHost->name() == newHost->name())
         return;
@@ -246,17 +248,22 @@ void WebResourceLoadScheduler::servePendingRequests(ResourceLoadPriority minimum
 
     m_requestTimer.stop();
     
-    servePendingRequests(m_nonHTTPProtocolHost, minimumPriority);
+    servePendingRequests(m_nonHTTPProtocolHost.get(), minimumPriority);
 
-    for (auto* host : copyToVector(m_hosts.values())) {
+    auto hosts = WTF::map(m_hosts.values(), [](auto&& host) {
+        return WeakPtr { host.get() };
+    });
+    for (auto&& host : WTFMove(hosts)) {
+        if (!host)
+            continue;
         if (host->hasRequests())
-            servePendingRequests(host, minimumPriority);
+            servePendingRequests(*host, minimumPriority);
         else
-            delete m_hosts.take(host->name());
+            m_hosts.take(host->name());
     }
 }
 
-void WebResourceLoadScheduler::servePendingRequests(HostInformation* host, ResourceLoadPriority minimumPriority)
+void WebResourceLoadScheduler::servePendingRequests(CheckedRef<HostInformation>&& host, ResourceLoadPriority minimumPriority)
 {
     auto priority = ResourceLoadPriority::Highest;
     while (true) {

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <WebCore/BackForwardClient.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 
@@ -35,7 +36,7 @@ OBJC_CLASS WebView;
 
 typedef HashSet<RefPtr<WebCore::HistoryItem>> HistoryItemHashSet;
 
-class BackForwardList : public WebCore::BackForwardClient {
+class BackForwardList : public WebCore::BackForwardClient, public CanMakeCheckedPtr {
 public: 
     static Ref<BackForwardList> create(WebView *webView) { return adoptRef(*new BackForwardList(webView)); }
     virtual ~BackForwardList();

--- a/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
@@ -52,7 +52,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-typedef HashMap<BackForwardList*, WebBackForwardList*> BackForwardListMap;
+using BackForwardListMap = HashMap<CheckedRef<BackForwardList>, WebBackForwardList*>;
 
 // FIXME: Instead of this we could just create a class derived from BackForwardList
 // with a pointer to a WebBackForwardList in it.
@@ -77,7 +77,7 @@ WebBackForwardList *kit(BackForwardList* backForwardList)
     if (!backForwardList)
         return nil;
 
-    if (WebBackForwardList *webBackForwardList = backForwardLists().get(backForwardList))
+    if (WebBackForwardList *webBackForwardList = backForwardLists().get(*backForwardList))
         return webBackForwardList;
 
     return adoptNS([[WebBackForwardList alloc] initWithBackForwardList:*backForwardList]).autorelease();
@@ -91,7 +91,7 @@ WebBackForwardList *kit(BackForwardList* backForwardList)
         return nil;
 
     _private = reinterpret_cast<WebBackForwardListPrivate*>(&backForwardList.leakRef());
-    backForwardLists().set(core(self), self);
+    backForwardLists().set(*core(self), self);
     return self;
 }
 
@@ -118,7 +118,7 @@ WebBackForwardList *kit(BackForwardList* backForwardList)
     ASSERT(backForwardList);
     if (backForwardList) {
         ASSERT(backForwardList->closed());
-        backForwardLists().remove(backForwardList);
+        backForwardLists().remove(*backForwardList);
         backForwardList->deref();
     }
 

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -98,7 +98,7 @@ using namespace WebCore;
 
 @end
 
-typedef HashMap<HistoryItem*, WebHistoryItem*> HistoryItemMap;
+using HistoryItemMap = HashMap<CheckedRef<HistoryItem>, WebHistoryItem*>;
 
 static inline WebCoreHistoryItem* core(WebHistoryItemPrivate* itemPrivate)
 {
@@ -152,7 +152,7 @@ void WKNotifyHistoryItemChanged()
     if (WebCoreObjCScheduleDeallocateOnMainThread([WebHistoryItem class], self))
         return;
 
-    historyItemWrappers().remove(_private->_historyItem.get());
+    historyItemWrappers().remove(*_private->_historyItem);
     [_private release];
 
     [super dealloc];
@@ -165,7 +165,7 @@ void WKNotifyHistoryItemChanged()
 
     copy->_private->_lastVisitedTime = _private->_lastVisitedTime;
 
-    historyItemWrappers().set(core(copy->_private), copy.get());
+    historyItemWrappers().set(*core(copy->_private), copy.get());
 
     return copy.leakRef();
 }
@@ -261,7 +261,7 @@ HistoryItem* core(WebHistoryItem *item)
 {
     if (!item)
         return nullptr;
-    ASSERT(historyItemWrappers().get(core(item->_private)) == item);
+    ASSERT(historyItemWrappers().get(*core(item->_private)) == item);
     return core(item->_private);
 }
 
@@ -269,7 +269,7 @@ WebHistoryItem *kit(HistoryItem* item)
 {
     if (!item)
         return nil;
-    if (auto wrapper = historyItemWrappers().get(item))
+    if (auto wrapper = historyItemWrappers().get(*item))
         return retainPtr(wrapper).autorelease();
     return adoptNS([[WebHistoryItem alloc] initWithWebCoreHistoryItem:*item]).autorelease();
 }
@@ -298,8 +298,8 @@ WebHistoryItem *kit(HistoryItem* item)
     _private = [[WebHistoryItemPrivate alloc] init];
     _private->_historyItem = WTFMove(item);
 
-    ASSERT(!historyItemWrappers().get(core(_private)));
-    historyItemWrappers().set(core(_private), self);
+    ASSERT(!historyItemWrappers().get(*core(_private)));
+    historyItemWrappers().set(*core(_private), self);
     return self;
 }
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.h
@@ -28,9 +28,10 @@
 
 #import <WebCore/SharedStringHash.h>
 #import <WebCore/VisitedLinkStore.h>
+#import <wtf/CheckedRef.h>
 #import <wtf/Ref.h>
 
-class WebVisitedLinkStore final : public WebCore::VisitedLinkStore {
+class WebVisitedLinkStore final : public WebCore::VisitedLinkStore, public CanMakeCheckedPtr {
 public:
     static Ref<WebVisitedLinkStore> create();
     virtual ~WebVisitedLinkStore();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -38,9 +38,9 @@ using namespace WebCore;
 
 static bool s_shouldTrackVisitedLinks;
 
-static HashSet<WebVisitedLinkStore*>& visitedLinkStores()
+static HashSet<CheckedRef<WebVisitedLinkStore>>& visitedLinkStores()
 {
-    static NeverDestroyed<HashSet<WebVisitedLinkStore*>> visitedLinkStores;
+    static NeverDestroyed<HashSet<CheckedRef<WebVisitedLinkStore>>> visitedLinkStores;
 
     return visitedLinkStores;
 }
@@ -54,12 +54,12 @@ Ref<WebVisitedLinkStore> WebVisitedLinkStore::create()
 WebVisitedLinkStore::WebVisitedLinkStore()
     : m_visitedLinksPopulated(false)
 {
-    visitedLinkStores().add(this);
+    visitedLinkStores().add(*this);
 }
 
 WebVisitedLinkStore::~WebVisitedLinkStore()
 {
-    visitedLinkStores().remove(this);
+    visitedLinkStores().remove(*this);
 }
 
 void WebVisitedLinkStore::setShouldTrackVisitedLinks(bool shouldTrackVisitedLinks)
@@ -74,7 +74,7 @@ void WebVisitedLinkStore::setShouldTrackVisitedLinks(bool shouldTrackVisitedLink
 void WebVisitedLinkStore::removeAllVisitedLinks()
 {
     for (auto& visitedLinkStore : visitedLinkStores())
-        visitedLinkStore->removeVisitedLinkHashes();
+        Ref { visitedLinkStore.get() }->removeVisitedLinkHashes();
 }
 
 void WebVisitedLinkStore::addVisitedLink(NSString *urlString)


### PR DESCRIPTION
#### c095d300811b451846fb81f29255b82d4f76b938
<pre>
Store fewer raw pointers in containers in Source/WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=262188">https://bugs.webkit.org/show_bug.cgi?id=262188</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/history/HistoryItem.h:
* Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp:
(WebKit::localStorageNamespaceMap):
(): Deleted.
* Source/WebKitLegacy/Storage/StorageNamespaceImpl.h:
* Source/WebKitLegacy/Storage/StorageThread.cpp:
(WebCore::activeStorageThreads):
(WebCore::StorageThread::start):
(WebCore::StorageThread::terminate):
(): Deleted.
* Source/WebKitLegacy/Storage/StorageThread.h:
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp:
(WebKit::storageNamespaceProviders):
(WebKit::WebStorageNamespaceProvider::WebStorageNamespaceProvider):
(WebKit::WebStorageNamespaceProvider::~WebStorageNamespaceProvider):
(WebKit::WebStorageNamespaceProvider::closeLocalStorage):
(WebKit::WebStorageNamespaceProvider::clearLocalStorageForAllOrigins):
(WebKit::WebStorageNamespaceProvider::clearLocalStorageForOrigin):
(WebKit::WebStorageNamespaceProvider::closeIdleLocalStorageDatabases):
(WebKit::WebStorageNamespaceProvider::syncLocalStorage):
(): Deleted.
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.h:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp:
(WebResourceLoadScheduler::hostForURL):
(WebResourceLoadScheduler::scheduleLoad):
(WebResourceLoadScheduler::remove):
(WebResourceLoadScheduler::crossOriginRedirectReceived):
(WebResourceLoadScheduler::servePendingRequests):
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Source/WebKitLegacy/mac/History/WebBackForwardList.mm:
(kit):
(-[WebBackForwardList initWithBackForwardList:]):
(-[WebBackForwardList dealloc]):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(-[WebHistoryItem dealloc]):
(-[WebHistoryItem copyWithZone:]):
(core):
(kit):
(-[WebHistoryItem initWithWebCoreHistoryItem:]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm:
(visitedLinkStores):
(WebVisitedLinkStore::WebVisitedLinkStore):
(WebVisitedLinkStore::~WebVisitedLinkStore):
(WebVisitedLinkStore::removeAllVisitedLinks):
* Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm:
(-[WebScriptWorld initWithWorld:]):
(-[WebScriptWorld dealloc]):
(+[WebScriptWorld findOrCreateWorld:]):

Canonical link: <a href="https://commits.webkit.org/268556@main">https://commits.webkit.org/268556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e3efa0236d2baf5527d8c0bb6020ad4b758116

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18689 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20590 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20185 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22760 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24454 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17408 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22443 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19380 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16086 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23417 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18146 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4798 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22496 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24673 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18788 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5458 "Found 1 jsc stress test failure: microbenchmarks/array-from-object-func.js.lockdown") | 
<!--EWS-Status-Bubble-End-->