### PR TITLE
Fix Contributors Meeting registration with a local copy of contributors.json

### DIFF
--- a/Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php
+++ b/Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php
@@ -17,7 +17,7 @@ class WebKit_Meeting_Registration {
     const MEETING_TAXONOMY = 'webkit_meeting';
     const CURRENT_MEETING_OPTION = 'current_webkit_meeting';
     const MEETING_REGISTRATION_STATE_SETTING = 'meeting-registration-state';
-    const CONTRIBUTORS_JSON = 'https://raw.githubusercontent.com/WebKit/WebKit/main/metadata/contributors.json';
+    const CONTRIBUTORS_JSON = '/var/www/data/contributors.json';
     const EXTRA_FIELDS = [
         'slack'       => FILTER_SANITIZE_STRING,
         'affiliation' => FILTER_SANITIZE_STRING,


### PR DESCRIPTION
#### 06973c055345e5e6cf86acd7b9bccc6b4a1be81c
<pre>
Fix Contributors Meeting registration with a local copy of contributors.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=262189">https://bugs.webkit.org/show_bug.cgi?id=262189</a>

Reviewed by Tim Nguyen.

Switching to using a local copy of contributors.json mitigates timeouts
caused by slow connections to GitHub hosted content.

* Websites/webkit.org/wp-content/plugins/meeting-registration/plugin.php:

Canonical link: <a href="https://commits.webkit.org/268515@main">https://commits.webkit.org/268515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf954ef333e30da9263b3c31b28ec06c516d8d4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18610 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20500 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22673 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17289 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24397 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22384 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16025 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22416 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2438 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->