### PR TITLE
REGRESSION(266896@main): [ wk2 debug ] imported/w3c/web-platform-tests/fetch/private-network-access/iframe.tentative.https.window.html is a near-constant failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/resources/support.sub.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/resources/support.sub.js
@@ -413,7 +413,7 @@ async function iframeTest(t, { source, target, expected }) {
   const result = await Promise.race([
       messagePromise.then((data) => data.message),
       new Promise((resolve) => {
-        t.step_timeout(() => resolve("timeout"), 500 /* ms */);
+        t.step_timeout(() => resolve("timeout"), 2000 /* ms */);
       }),
   ]);
 

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -885,6 +885,4 @@ webkit.org/b/260926 imported/w3c/web-platform-tests/html/browsers/browsing-the-w
 
 webkit.org/b/261920 fast/mediastream/video-srcObject-set-twice.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/262088 [ Debug ] imported/w3c/web-platform-tests/fetch/private-network-access/iframe.tentative.https.window.html [ Pass Failure ]
-
 webkit.org/b/262157 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ Pass ImageOnlyFailure Crash ]


### PR DESCRIPTION
#### 1cfc40dde59d41519e91dda02b8f21090ef2dd1c
<pre>
REGRESSION(266896@main): [ wk2 debug ] imported/w3c/web-platform-tests/fetch/private-network-access/iframe.tentative.https.window.html is a near-constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262088">https://bugs.webkit.org/show_bug.cgi?id=262088</a>

Reviewed by Chris Dumez.

Increase the timeout from 500ms to 2s, which is more consistent with other test cases, to make this test less flaky.

* LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/resources/support.sub.js:

Canonical link: <a href="https://commits.webkit.org/268519@main">https://commits.webkit.org/268519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05fa07ab7ba9aaad612b0e31b323e0e55babc6c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18613 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20505 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22678 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24395 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22382 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18899 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18070 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22419 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2439 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->