### PR TITLE
REGRESSION(266828@main): Nested setTimeout not being throttled in the background

### DIFF
--- a/LayoutTests/fast/dom/timer-throttling-hidden-page-2-expected.txt
+++ b/LayoutTests/fast/dom/timer-throttling-hidden-page-2-expected.txt
@@ -3,17 +3,8 @@ Tests that DOM timers gets throttled on hidden pages once they reach the max nes
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime < 100 is true
-PASS timerEndTime - timerStartTime > 100 is true
+PASS throttledCount > maxNestingLevel / 2 is true
+PASS unthrottledCount > maxNestingLevel / 2 is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/timer-throttling-hidden-page-2.html
+++ b/LayoutTests/fast/dom/timer-throttling-hidden-page-2.html
@@ -11,6 +11,7 @@
         let timerHandle = 0;
         let timerStartTime = 0;
         let timerEndTime = 0;
+        const timerFiredTimes = [];
 
         function testTimer()
         {
@@ -19,14 +20,23 @@
             timerEndTime = performance.now();
 
             timerHandle = setTimeout(testTimer, timeoutInterval);
-            if (timerCount > maxNestingLevel) {
-                shouldBeTrue('timerEndTime - timerStartTime > 100');
+            timerFiredTimes.push(timerEndTime - timerStartTime);
+            if (timerCount > 2 * maxNestingLevel) {
+                unthrottledCount = 0;
+                throttledCount = 0;
+                for (let i = 0; i < timerCount; ++i) {
+                    if (timerFiredTimes[i] < 300)
+                        unthrottledCount++;
+                    else
+                        throttledCount++;
+                }
+                shouldBeTrue('throttledCount > maxNestingLevel / 2');
+                shouldBeTrue('unthrottledCount > maxNestingLevel / 2');
                 testRunner.resetPageVisibility();
                 clearTimeout(timerHandle);
                 finishJSTest();
                 return;
-            } else
-                shouldBeTrue('timerEndTime - timerStartTime < 100');
+            }
             timerStartTime = timerEndTime;
         }
 


### PR DESCRIPTION
#### bdd0a5694f219fda470504daacc7f0af43c863e7
<pre>
REGRESSION(266828@main): Nested setTimeout not being throttled in the background
<a href="https://bugs.webkit.org/show_bug.cgi?id=262086">https://bugs.webkit.org/show_bug.cgi?id=262086</a>

Reviewed by Chris Dumez.

Only expect half of the timers to be throttled to avoid flakiness.

* LayoutTests/fast/dom/timer-throttling-hidden-page-2-expected.txt:
* LayoutTests/fast/dom/timer-throttling-hidden-page-2.html:

Canonical link: <a href="https://commits.webkit.org/268585@main">https://commits.webkit.org/268585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c9348fc1e67a84bd1eb73e07bc62bcae55913e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18621 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20140 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22687 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24405 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22392 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16033 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17982 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22427 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2467 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->