### PR TITLE
Site isolation process groups should be shared between opener and openee

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -389,6 +389,7 @@ Shared/XR/XRDeviceProxy.cpp
 
 UIProcess/AuxiliaryProcessProxy.cpp
 UIProcess/BackgroundProcessResponsivenessTimer.cpp
+UIProcess/BrowsingContextGroup.cpp
 UIProcess/DeviceIdHashSaltStorage.cpp
 UIProcess/DrawingAreaProxy.cpp
 UIProcess/FrameLoadState.cpp

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -28,6 +28,7 @@
 
 #include "APIProcessPoolConfiguration.h"
 #include "APIWebsitePolicies.h"
+#include "BrowsingContextGroup.h"
 #include "Logging.h"
 #include "WebInspectorUtilities.h"
 #include "WebPageGroup.h"
@@ -53,7 +54,10 @@ Ref<PageConfiguration> PageConfiguration::create()
     return adoptRef(*new PageConfiguration);
 }
 
-PageConfiguration::PageConfiguration() = default;
+PageConfiguration::PageConfiguration()
+    : m_data { BrowsingContextGroup::create() }
+{
+}
 
 PageConfiguration::~PageConfiguration() = default;
 
@@ -64,6 +68,10 @@ Ref<PageConfiguration> PageConfiguration::copy() const
     return copy;
 }
 
+BrowsingContextGroup& PageConfiguration::browsingContextGroup()
+{
+    return m_data.browsingContextGroup.get();
+}
 
 WebProcessPool* PageConfiguration::processPool()
 {

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
+#include "WebURLSchemeHandler.h"
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
 #include <wtf/Forward.h>
@@ -40,12 +41,12 @@ OBJC_PROTOCOL(_UIClickInteractionDriving);
 #endif
 
 namespace WebKit {
+class BrowsingContextGroup;
 class VisitedLinkStore;
 class WebPageGroup;
 class WebPageProxy;
 class WebPreferences;
 class WebProcessPool;
-class WebURLSchemeHandler;
 class WebUserContentControllerProxy;
 class WebsiteDataStore;
 
@@ -79,7 +80,9 @@ public:
 
     // FIXME: The configuration properties should return their default values
     // rather than nullptr.
-    
+
+    WebKit::BrowsingContextGroup& browsingContextGroup();
+
     WebKit::WebProcessPool* processPool();
     void setProcessPool(WebKit::WebProcessPool*);
 
@@ -222,53 +225,54 @@ public:
 
 private:
     struct Data {
-        RefPtr<WebKit::WebProcessPool> processPool;
-        RefPtr<WebKit::WebUserContentControllerProxy> userContentController;
+        Ref<WebKit::BrowsingContextGroup> browsingContextGroup;
+        RefPtr<WebKit::WebProcessPool> processPool { };
+        RefPtr<WebKit::WebUserContentControllerProxy> userContentController { };
 #if ENABLE(WK_WEB_EXTENSIONS)
-        RefPtr<WebKit::WebExtensionController> webExtensionController;
-        WeakPtr<WebKit::WebExtensionController> weakWebExtensionController;
+        RefPtr<WebKit::WebExtensionController> webExtensionController { };
+        WeakPtr<WebKit::WebExtensionController> weakWebExtensionController { };
 #endif
-        RefPtr<WebKit::WebPageGroup> pageGroup;
-        RefPtr<WebKit::WebPreferences> preferences;
-        RefPtr<WebKit::WebPageProxy> relatedPage;
-        WeakPtr<WebKit::WebPageProxy> pageToCloneSessionStorageFrom;
-        RefPtr<WebKit::VisitedLinkStore> visitedLinkStore;
+        RefPtr<WebKit::WebPageGroup> pageGroup { };
+        RefPtr<WebKit::WebPreferences> preferences { };
+        RefPtr<WebKit::WebPageProxy> relatedPage { };
+        WeakPtr<WebKit::WebPageProxy> pageToCloneSessionStorageFrom { };
+        RefPtr<WebKit::VisitedLinkStore> visitedLinkStore { };
 
-        RefPtr<WebKit::WebsiteDataStore> websiteDataStore;
-        RefPtr<WebsitePolicies> defaultWebsitePolicies;
+        RefPtr<WebKit::WebsiteDataStore> websiteDataStore { };
+        RefPtr<WebsitePolicies> defaultWebsitePolicies { };
 
 #if PLATFORM(IOS_FAMILY)
         bool canShowWhileLocked { false };
         WebKit::AttributionOverrideTesting appInitiatedOverrideValueForTesting { WebKit::AttributionOverrideTesting::NoOverride };
-        RetainPtr<_UIClickInteractionDriving> clickInteractionDriverForTesting;
+        RetainPtr<_UIClickInteractionDriving> clickInteractionDriverForTesting { };
 #endif
         bool initialCapitalizationEnabled { true };
         bool waitsForPaintAfterViewDidMoveToWindow { true };
         bool drawsBackground { true };
         bool controlledByAutomation { false };
         bool allowTestOnlyIPC { false };
-        std::optional<bool> delaysWebProcessLaunchUntilFirstLoad;
-        std::optional<double> cpuLimit;
+        std::optional<bool> delaysWebProcessLaunchUntilFirstLoad { };
+        std::optional<double> cpuLimit { };
 
-        WTF::String overrideContentSecurityPolicy;
+        WTF::String overrideContentSecurityPolicy { };
 
 #if PLATFORM(COCOA)
-        WTF::Vector<WTF::String> additionalSupportedImageTypes;
+        WTF::Vector<WTF::String> additionalSupportedImageTypes { };
         bool clientNavigationsRunAtForegroundPriority { true };
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
-        RefPtr<ApplicationManifest> applicationManifest;
+        RefPtr<ApplicationManifest> applicationManifest { };
 #endif
 
-        HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> urlSchemeHandlers;
-        Vector<WTF::String> corsDisablingPatterns;
-        HashSet<WTF::String> maskedURLSchemes;
+        HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> urlSchemeHandlers { };
+        Vector<WTF::String> corsDisablingPatterns { };
+        HashSet<WTF::String> maskedURLSchemes { };
         bool userScriptsShouldWaitUntilNotification { true };
         bool crossOriginAccessControlCheckEnabled { true };
-        WTF::String processDisplayName;
+        WTF::String processDisplayName { };
         bool loadsSubresources { true };
-        std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>> allowedNetworkHosts;
+        std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>> allowedNetworkHosts { };
 
 #if ENABLE(APP_BOUND_DOMAINS)
         bool ignoresAppBoundDomains { false };
@@ -279,7 +283,7 @@ private:
         bool httpsUpgradeEnabled { true };
 
         WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
-        WTF::String attributedBundleIdentifier;
+        WTF::String attributedBundleIdentifier { };
 
 #if HAVE(TOUCH_BAR)
         bool requiresUserActionForEditingControlsManager { false };

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,24 +25,23 @@
 
 #pragma once
 
-#include <wtf/CheckedRef.h>
-#include <wtf/RunLoop.h>
+#include <WebCore/RegistrableDomain.h>
+#include <wtf/RefCounted.h>
 
 namespace WebKit {
 
-class WebProcessPool;
+class WebProcessProxy;
 
-class HighPerformanceGraphicsUsageSampler {
-    WTF_MAKE_FAST_ALLOCATED;
+class BrowsingContextGroup : public RefCounted<BrowsingContextGroup> {
 public:
-    explicit HighPerformanceGraphicsUsageSampler(WebProcessPool&);
-    ~HighPerformanceGraphicsUsageSampler();
+    static Ref<BrowsingContextGroup> create() { return adoptRef(*new BrowsingContextGroup()); }
 
+    WebProcessProxy* processForDomain(const WebCore::RegistrableDomain&);
+    void addProcessForDomain(const WebCore::RegistrableDomain&, WebProcessProxy&);
 private:
-    void timerFired();
+    BrowsingContextGroup();
 
-    CheckedRef<WebProcessPool> m_webProcessPool;
-    RunLoop::Timer m_timer;
+    HashMap<WebCore::RegistrableDomain, WeakPtr<WebProcessProxy>> m_processMap;
 };
 
-} // namespace WebKit
+}

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -310,6 +310,8 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, WebCore::WindowF
     ASSERT(delegate);
 
     auto configuration = adoptNS([m_uiDelegate->m_webView.get()->_configuration copy]);
+    // FIXME: after calling triggerBrowsingContextGroupSwitchForNavigation this configuration's BrowsingContextGroup is incorrect.
+    // The fix should go into platform-independent code, though. Needs some refactoring. And also needs switching browsing context group.
     [configuration _setRelatedWebView:m_uiDelegate->m_webView.get().get()];
 
     auto apiWindowFeatures = API::WindowFeatures::create(windowFeatures);

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "DownloadID.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RetainPtr.h>

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/InspectorAgentRegistry.h>
 #include <JavaScriptCore/InspectorTargetAgent.h>
 #include <WebCore/PageIdentifier.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -318,6 +318,7 @@ namespace WebKit {
 
 class AudioSessionRoutingArbitratorProxy;
 class AuthenticationChallengeProxy;
+class BrowsingContextGroup;
 class CallbackID;
 class ContextMenuContextData;
 class DownloadProxy;
@@ -2157,8 +2158,9 @@ public:
     WKQuickLookPreviewController *quickLookPreviewController() const { return m_quickLookPreviewController.get(); }
 #endif
 
-    RemotePageProxy* remotePageProxyForRegistrableDomain(WebCore::RegistrableDomain) const;
-    void addRemotePageProxy(const WebCore::RegistrableDomain&, WeakPtr<RemotePageProxy>&&);
+    WebProcessProxy* processForRegistrableDomain(const WebCore::RegistrableDomain&);
+    RemotePageProxy* remotePageProxyForRegistrableDomain(const WebCore::RegistrableDomain&) const;
+    void addRemotePageProxy(const WebCore::RegistrableDomain&, RemotePageProxy&);
     void removeRemotePageProxy(const WebCore::RegistrableDomain&);
     void setRemotePageProxyInOpenerProcess(Ref<RemotePageProxy>&&);
     void addOpenedRemotePageProxy(Ref<RemotePageProxy>&&);
@@ -3309,6 +3311,7 @@ private:
 #endif
 
     RefPtr<WebPageProxy> m_pageToCloneSessionStorageFrom;
+    Ref<BrowsingContextGroup> m_browsingContextGroup;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1855,8 +1855,8 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
                 completionHandler(Ref { page.mainFrame()->process() }, nullptr, "Found process for the same registration domain as mainFrame domain"_s);
                 return;
             }
-            if (auto* remotePageProxy = page.remotePageProxyForRegistrableDomain(registrableDomain)) {
-                completionHandler(Ref { remotePageProxy->process() }, nullptr, "Found process for the same registration domain"_s);
+            if (auto* process = page.processForRegistrableDomain(registrableDomain)) {
+                completionHandler(Ref { *process }, nullptr, "Found process for the same registration domain"_s);
                 return;
             }
         }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5591,6 +5591,8 @@
 		5C6CE6D01F59BC460007C6CB /* PageClientImplCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PageClientImplCocoa.mm; sourceTree = "<group>"; };
 		5C6CE6D31F59EA350007C6CB /* PageClientImplCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageClientImplCocoa.h; sourceTree = "<group>"; };
 		5C6CED8E2900598000B5D522 /* EditorState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = EditorState.serialization.in; sourceTree = "<group>"; };
+		5C6D69352AC3935D0099BDAF /* BrowsingContextGroup.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BrowsingContextGroup.cpp; sourceTree = "<group>"; };
+		5C6D69362AC3935D0099BDAF /* BrowsingContextGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BrowsingContextGroup.h; sourceTree = "<group>"; };
 		5C6E7D86232361E700C2159D /* WKWebsiteDataStoreConfigurationRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebsiteDataStoreConfigurationRef.h; sourceTree = "<group>"; };
 		5C6E7D87232361E700C2159D /* WKWebsiteDataStoreConfigurationRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKWebsiteDataStoreConfigurationRef.cpp; sourceTree = "<group>"; };
 		5C74300E21500492004BFA17 /* WKWebProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebProcess.h; sourceTree = "<group>"; };
@@ -12551,6 +12553,8 @@
 				E1513C65166EABB200149FCB /* AuxiliaryProcessProxy.h */,
 				46A2B6061E5675A200C3DEDA /* BackgroundProcessResponsivenessTimer.cpp */,
 				46A2B6071E5675A200C3DEDA /* BackgroundProcessResponsivenessTimer.h */,
+				5C6D69352AC3935D0099BDAF /* BrowsingContextGroup.cpp */,
+				5C6D69362AC3935D0099BDAF /* BrowsingContextGroup.h */,
 				07297F9C1C1711EA003F0735 /* DeviceIdHashSaltStorage.cpp */,
 				07297F9D1C17BBEA223F0735 /* DeviceIdHashSaltStorage.h */,
 				BC2652121182608100243E12 /* DrawingAreaProxy.cpp */,


### PR DESCRIPTION
#### 1129619cf58a4dafe4c40528c4c7c321a78c7e5b
<pre>
Site isolation process groups should be shared between opener and openee
<a href="https://bugs.webkit.org/show_bug.cgi?id=262194">https://bugs.webkit.org/show_bug.cgi?id=262194</a>
rdar://116126764

Reviewed by Pascoe.

Introduce a new abstraction that will map to <a href="https://html.spec.whatwg.org/#browsing-context-group">https://html.spec.whatwg.org/#browsing-context-group</a>
from which I got the name.  This allows us to put site isolated frames and navigations in the right
process even after a window.open.

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::PageConfiguration):
(API::PageConfiguration::browsingContextGroup):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp: Copied from Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h.
(WebKit::BrowsingContextGroup::processForDomain):
(WebKit::BrowsingContextGroup::addProcessForDomain):
* Source/WebKit/UIProcess/BrowsingContextGroup.h: Copied from Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h.
(WebKit::BrowsingContextGroup::create):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::createNewPage):
* Source/WebKit/UIProcess/HighPerformanceGraphicsUsageSampler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_browsingContextGroup):
(WebKit::WebPageProxy::addRemotePageProxy):
(WebKit::WebPageProxy::processForRegistrableDomain):
(WebKit::WebPageProxy::remotePageProxyForRegistrableDomain const):
(WebKit::m_limitsNavigationsToAppBoundDomains): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::siteIsolatedViewAndDelegate):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268530@main">https://commits.webkit.org/268530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5150506ae304ab61dd55e758114aa0b893ab731

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21867 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20549 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22719 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18160 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22412 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18109 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22458 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2445 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->