### PR TITLE
REGRESSION (268069@main): Date picker fails to present when switching focus from a text field to a date input

### DIFF
--- a/LayoutTests/fast/forms/ios/change-focus-from-text-field-to-date-input-expected.txt
+++ b/LayoutTests/fast/forms/ios/change-focus-from-text-field-to-date-input-expected.txt
@@ -1,0 +1,12 @@
+Tests that focusing a text field and then immediately focusing a date input on iOS does not result in a hang.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Showed date picker
+PASS Dismissed date picker
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/forms/ios/change-focus-from-text-field-to-date-input.html
+++ b/LayoutTests/fast/forms/ios/change-focus-from-text-field-to-date-input.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    margin-top: 100px;
+    font-size: 16px;
+}
+</style>
+</head>
+<body>
+<input id="textfield" type="text">
+<br>
+<input id="date" type="date" value="1976-04-01">
+<script>
+jsTestIsAsync = true;
+
+description("Tests that focusing a text field and then immediately focusing a date input on iOS does not result in a hang.");
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    const textField = document.getElementById("textfield");
+    const dateInput = document.getElementById("date");
+
+    await UIHelper.setHardwareKeyboardAttached(false);
+    await UIHelper.activateElementAndWaitForInputSession(textField);
+
+    await UIHelper.activateElement(dateInput);
+    await UIHelper.waitForContextMenuToShow();
+    testPassed("Showed date picker");
+
+    dateInput.blur();
+    await UIHelper.waitForContextMenuToHide();
+    testPassed("Dismissed date picker");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h
@@ -38,7 +38,7 @@
 
 @interface WKDatePickerPopoverController : UIViewController
 - (instancetype)initWithDatePicker:(UIDatePicker *)datePicker delegate:(id<WKDatePickerPopoverControllerDelegate>)delegate;
-- (void)presentInView:(UIView *)view sourceRect:(CGRect)rect interactionBounds:(CGRect)interactionBounds completion:(void(^)())completion;
+- (void)presentInView:(UIView *)view sourceRect:(CGRect)rect completion:(void(^)())completion;
 - (void)dismissDatePicker;
 @end
 

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -154,7 +154,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 - (void)showDateTimePicker
 {
     _datePickerController = adoptNS([[WKDatePickerPopoverController alloc] initWithDatePicker:_datePicker.get() delegate:self]);
-    [_datePickerController presentInView:_view sourceRect:_view.focusedElementInformation.interactionRect interactionBounds:_view.webView._contentRectForUserInteraction completion:[strongSelf = retainPtr(self)] {
+    [_datePickerController presentInView:_view sourceRect:_view.focusedElementInformation.interactionRect completion:[strongSelf = retainPtr(self)] {
         [strongSelf->_view.webView _didShowContextMenu];
     }];
 }


### PR DESCRIPTION
#### 05c27ae25006e9c39e40a712ac4bdf28611e2884
<pre>
REGRESSION (268069@main): Date picker fails to present when switching focus from a text field to a date input
<a href="https://bugs.webkit.org/show_bug.cgi?id=262144">https://bugs.webkit.org/show_bug.cgi?id=262144</a>

Reviewed by Tim Horton and Aditya Keerthi.

After refactoring date pickers to use popover presentation controllers in 268069@main, it&apos;s now
possible for the UI process to hang when presenting a date picker in the case where there&apos;s
insufficient space to present the popover, and autolayout code in UIKit takes (seemingly) forever
attempting to resize individual cells in the date picker view to make the view fit.

Avoid this problem by teaching `WKDatePickerPopoverController` to only present the popover in
directions that contain sufficient space to lay out the popover contents correctly. Additionally,
stop using `_contentRectForUserInteraction` when computing available space; this didn&apos;t really make
sense, since it considers the input view as part of the obscured inset area, despite the fact that
the popover can animate over the keyboard. Instead, just map the `targetRect` to window coordinates,
and use the containing window&apos;s bounds to compute available space.

See below for more details.

* LayoutTests/fast/forms/ios/change-focus-from-text-field-to-date-input-expected.txt: Added.
* LayoutTests/fast/forms/ios/change-focus-from-text-field-to-date-input.html: Added.

Add a layout test to exercise the change.

* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h:
* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverView initWithDatePicker:]):

Use `-sizeToFit` to size the accessory view and date picker, and save the combined size here so that
we can estimate how much available space we need in order to present this popover.

(-[WKDatePickerPopoverView estimatedMaximumPopoverSize]):

Return an estimate of the maximum size of the content view when it&apos;s presented in a popover. Note
that we add some extra height here to ensure that the accessory view toolbar doesn&apos;t end up getting
clipped.

(-[WKDatePickerPopoverController presentInView:sourceRect:completion:]):
(-[WKDatePickerPopoverController presentInView:sourceRect:interactionBounds:completion:]): Deleted.

Use the estimated popover size above to set `permittedArrowDirections` to only the directions where
the popover has enough space to fully present, without either:

1. Hanging under autolayout code, or
2. Clipping the accessory view.

If there is not enough space to show the popover in *any* direction, instead of falling back to
`UIPopoverArrowDirectionAny`, we fall back to `0` (no permitted arrow directions), and set the
target rect to the entire bounds of the window, mapped into root view coordinates. This allows us to
simply present the popover in the center of the window with no arrow, which avoids the two issues
above.

* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker showDateTimePicker]):

Canonical link: <a href="https://commits.webkit.org/268526@main">https://commits.webkit.org/268526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/066476c445150090fcd84a4088adc9785c8f31b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18622 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20517 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22689 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18142 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22393 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16035 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17978 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4776 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22429 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->