### PR TITLE
[commits.webkit.org] Ignore requests for invalid refs

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 8, 1)
+version = Version(0, 8, 2)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
@@ -153,6 +153,8 @@ class Redirector(object):
 
 
 class CheckoutRoute(AuthedBlueprint):
+    VALID_REF_RE = re.compile(r'^[a-zA-Z0-9\/\.\@-]+$')
+
     @classmethod
     def find_newer(cls, a, b):
         if not a or not b:
@@ -201,6 +203,9 @@ class CheckoutRoute(AuthedBlueprint):
         self.add_url_rule('/changeset/<path:revision>/webkit', 'trac', self.trac, methods=('GET',))
 
     def commit(self, ref=None):
+        if ref and (not isinstance(ref, str) or not self.VALID_REF_RE.match(ref)):
+            return None
+
         try:
             retrieved = self.database.get(ref)
             if retrieved:

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
@@ -162,6 +162,22 @@ class CheckoutRouteUnittest(testing.PathTestCase):
             self.assertEqual(response.json(), reference)
 
     @mock_app
+    def test_json_invalid(self, app=None, client=None):
+        with mocks.local.Git(self.path) as repo:
+            app.register_blueprint(CheckoutRoute(
+                Checkout(path=self.path, url=repo.remote, sentinal=False),
+                redirectors=[Redirector('https://trac.webkit.org')],
+            ))
+
+            response = client.get('bae5d1e90999~1/json')
+            self.assertEqual(response.status_code, 404)
+            self.assertEqual(response.json(), dict(
+                status='Not Found',
+                error='Object of type NoneType is not JSON serializable',
+                message='No commit with the specified reference could be found',
+            ))
+
+    @mock_app
     def test_redirect(self, app=None, client=None):
         with mocks.local.Git(self.path) as repo:
             app.register_blueprint(CheckoutRoute(

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.8.1',
+    version='0.8.2',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 0441827bd96ffc097aaa85a6af664efedf153260
<pre>
[commits.webkit.org] Ignore requests for invalid refs
<a href="https://bugs.webkit.org/show_bug.cgi?id=262164">https://bugs.webkit.org/show_bug.cgi?id=262164</a>
rdar://116099852

Reviewed by Dewei Zhu.

Requests which contain strings not valid in a git ref can be
rejected before checking the cache or checkout.

* Tools/Scripts/libraries/reporelaypy/setup.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py:
(CheckoutRoute): Add regex for valid refs.
(CheckoutRoute.commit): Ignore requests for invalid refs.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py:
(CheckoutRouteUnittest.test_json_invalid):

Canonical link: <a href="https://commits.webkit.org/268522@main">https://commits.webkit.org/268522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0df53b0b3f2c64f0d593927b0fc9351a280f1e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/19952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/20377 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/20999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/21847 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/20188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/23633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/20529 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/21847 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/20173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/23633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/20999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/22701 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/20139 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/23633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/20999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/22701 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/23633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/20999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/22701 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/20529 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/18092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/20999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/22441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2440 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->