### PR TITLE
[CG] Add the path segments directly to the CGContext instead of creating a CGPath then adding it

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -408,6 +408,8 @@ platform/graphics/cg/IntSizeCG.cpp
 platform/graphics/cg/NativeImageCG.cpp
 platform/graphics/cg/PDFDocumentImage.cpp
 platform/graphics/cg/PathCG.cpp
+platform/graphics/cg/PathSegmentDataCG.cpp
+platform/graphics/cg/PathSegmentUtilitiesCG.cpp
 platform/graphics/cg/PatternCG.cpp
 platform/graphics/cg/TransformationMatrixCG.cpp
 platform/graphics/cg/UTIRegistry.cpp

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -558,6 +558,14 @@ FloatRect Path::strokeBoundingRect(const Function<void(GraphicsContext&)>& strok
     return const_cast<Path&>(*this).ensurePlatformPathImpl().strokeBoundingRect(strokeStyleApplier);
 }
 
+void Path::addToContext(PlatformGraphicsContext* context) const
+{
+    if (auto segment = asSingle())
+        segment->addToContext(context);
+    else if (auto impl = asImpl())
+        impl->addToContext(context);
+}
+
 TextStream& operator<<(TextStream& ts, const Path& path)
 {
     bool isFirst = true;

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -30,6 +30,7 @@
 #include "PathElement.h"
 #include "PathImpl.h"
 #include "PathSegment.h"
+#include "PlatformGraphicsContext.h"
 #include "PlatformPath.h"
 #include "WindRule.h"
 #include <wtf/FastMalloc.h>
@@ -113,6 +114,8 @@ public:
     WEBCORE_EXPORT FloatRect fastBoundingRect() const;
     FloatRect boundingRect() const;
     FloatRect strokeBoundingRect(const Function<void(GraphicsContext&)>& strokeStyleApplier = { }) const;
+
+    void addToContext(PlatformGraphicsContext*) const;
 
 private:
     PlatformPathImpl& ensurePlatformPathImpl();

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -28,6 +28,7 @@
 #include "FloatRoundedRect.h"
 #include "PathElement.h"
 #include "PathSegment.h"
+#include "PlatformGraphicsContext.h"
 #include <wtf/FastMalloc.h>
 #include <wtf/UniqueRef.h>
 
@@ -88,6 +89,8 @@ public:
 
     virtual FloatRect fastBoundingRect() const = 0;
     virtual FloatRect boundingRect() const = 0;
+
+    virtual void addToContext(PlatformGraphicsContext*) const { }
 
 protected:
     PathImpl() = default;

--- a/Source/WebCore/platform/graphics/PathSegment.cpp
+++ b/Source/WebCore/platform/graphics/PathSegment.cpp
@@ -72,6 +72,17 @@ void PathSegment::addToImpl(PathImpl& impl) const
     });
 }
 
+void PathSegment::addToContext(PlatformGraphicsContext* context) const
+{
+#if USE(CG)
+    WTF::switchOn(m_data, [&](auto& data) {
+        data.addToContext(context);
+    });
+#else
+    UNUSED_PARAM(context);
+#endif
+}
+
 bool PathSegment::canApplyElements() const
 {
     return WTF::switchOn(m_data, [&](auto& data) {

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "PathSegmentData.h"
+#include "PlatformGraphicsContext.h"
 #include <wtf/Function.h>
 
 namespace WebCore {
@@ -67,6 +68,7 @@ public:
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
     bool canApplyElements() const;
     bool applyElements(const PathElementApplier&) const;

--- a/Source/WebCore/platform/graphics/PathSegmentData.h
+++ b/Source/WebCore/platform/graphics/PathSegmentData.h
@@ -28,6 +28,7 @@
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"
 #include "PathElement.h"
+#include "PlatformGraphicsContext.h"
 #include "RotationDirection.h"
 
 namespace WTF {
@@ -53,8 +54,9 @@ struct PathMoveTo {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
-    void applyElements(const PathElementApplier&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
+    void applyElements(const PathElementApplier&) const;
     void transform(const AffineTransform&);
 };
 
@@ -75,8 +77,9 @@ struct PathLineTo {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
-    void applyElements(const PathElementApplier&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
+    void applyElements(const PathElementApplier&) const;
     void transform(const AffineTransform&);
 };
 
@@ -98,8 +101,9 @@ struct PathQuadCurveTo {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
-    void applyElements(const PathElementApplier&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
+    void applyElements(const PathElementApplier&) const;
     void transform(const AffineTransform&);
 };
 
@@ -122,8 +126,9 @@ struct PathBezierCurveTo {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
-    void applyElements(const PathElementApplier&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
+    void applyElements(const PathElementApplier&) const;
     void transform(const AffineTransform&);
 };
 
@@ -146,6 +151,7 @@ struct PathArcTo {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathArcTo&);
@@ -169,6 +175,7 @@ struct PathArc {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathArc&);
@@ -194,6 +201,7 @@ struct PathEllipse {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathEllipse&);
@@ -213,6 +221,7 @@ struct PathEllipseInRect {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathEllipseInRect&);
@@ -232,6 +241,7 @@ struct PathRect {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathRect&);
@@ -257,6 +267,7 @@ struct PathRoundedRect {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathRoundedRect&);
@@ -277,8 +288,9 @@ struct PathDataLine {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
-    void applyElements(const PathElementApplier&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
+    void applyElements(const PathElementApplier&) const;
     void transform(const AffineTransform&);
 };
 
@@ -301,8 +313,9 @@ struct PathDataQuadCurve {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
-    void applyElements(const PathElementApplier&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
+    void applyElements(const PathElementApplier&) const;
     void transform(const AffineTransform&);
 };
 
@@ -326,8 +339,9 @@ struct PathDataBezierCurve {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
-    void applyElements(const PathElementApplier&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
+    void applyElements(const PathElementApplier&) const;
     void transform(const AffineTransform&);
 };
 
@@ -351,6 +365,7 @@ struct PathDataArc {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataArc&);
@@ -368,8 +383,9 @@ struct PathCloseSubpath {
     void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
 
     void addToImpl(PathImpl&) const;
-    void applyElements(const PathElementApplier&) const;
+    void addToContext(PlatformGraphicsContext*) const;
 
+    void applyElements(const PathElementApplier&) const;
     void transform(const AffineTransform&);
 };
 

--- a/Source/WebCore/platform/graphics/PathStream.cpp
+++ b/Source/WebCore/platform/graphics/PathStream.cpp
@@ -328,4 +328,10 @@ FloatRect PathStream::boundingRect() const
     return computeBoundingRect(m_segmentsData->segments.span());
 }
 
+void PathStream::addToContext(PlatformGraphicsContext* context) const
+{
+    for (auto& segment : m_segmentsData->segments)
+        segment.addToContext(context);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -78,6 +78,8 @@ public:
     static FloatRect computeFastBoundingRect(std::span<const PathSegment>);
     static FloatRect computeBoundingRect(std::span<const PathSegment>);
 
+    void addToContext(PlatformGraphicsContext*) const final;
+
 private:
     struct SegmentsData : public ThreadSafeRefCounted<SegmentsData> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -698,7 +698,7 @@ void GraphicsContextCG::drawPath(const Path& path)
         CGContextDrawPathDirect(context, drawingMode, path.platformPath(), nullptr);
 #else
         CGContextBeginPath(context);
-        CGContextAddPath(context, path.platformPath());
+        path.addToContext(context);
         CGContextDrawPath(context, drawingMode);
 #endif
     }
@@ -722,7 +722,7 @@ void GraphicsContextCG::fillPath(const Path& path)
             CGContextScaleCTM(layerContext, layerSize.width() / rect.width(), layerSize.height() / rect.height());
             CGContextTranslateCTM(layerContext, -rect.x(), -rect.y());
             CGContextBeginPath(layerContext);
-            CGContextAddPath(layerContext, path.platformPath());
+            path.addToContext(layerContext);
             CGContextConcatCTM(layerContext, fillGradientSpaceTransform());
 
             if (fillRule() == WindRule::EvenOdd)
@@ -734,7 +734,7 @@ void GraphicsContextCG::fillPath(const Path& path)
             CGContextDrawLayerInRect(context, rect, layer.get());
         } else {
             CGContextBeginPath(context);
-            CGContextAddPath(context, path.platformPath());
+            path.addToContext(context);
             CGContextStateSaver stateSaver(context);
             CGContextConcatCTM(context, fillGradientSpaceTransform());
 
@@ -755,7 +755,7 @@ void GraphicsContextCG::fillPath(const Path& path)
     CGContextDrawPathDirect(context, fillRule() == WindRule::EvenOdd ? kCGPathEOFill : kCGPathFill, path.platformPath(), nullptr);
 #else
     CGContextBeginPath(context);
-    CGContextAddPath(context, path.platformPath());
+    path.addToContext(context);
     if (fillRule() == WindRule::EvenOdd)
         CGContextEOFillPath(context);
     else
@@ -792,7 +792,7 @@ void GraphicsContextCG::strokePath(const Path& path)
             CGContextScaleCTM(layerContext, layerSize.width() / adjustedWidth, layerSize.height() / adjustedHeight);
             CGContextTranslateCTM(layerContext, translationX, translationY);
 
-            CGContextAddPath(layerContext, path.platformPath());
+            path.addToContext(layerContext);
             CGContextReplacePathWithStrokedPath(layerContext);
             CGContextClip(layerContext);
             CGContextConcatCTM(layerContext, strokeGradientSpaceTransform());
@@ -804,7 +804,7 @@ void GraphicsContextCG::strokePath(const Path& path)
         } else {
             CGContextStateSaver stateSaver(context);
             CGContextBeginPath(context);
-            CGContextAddPath(context, path.platformPath());
+            path.addToContext(context);
             CGContextReplacePathWithStrokedPath(context);
             CGContextClip(context);
             CGContextConcatCTM(context, strokeGradientSpaceTransform());
@@ -828,7 +828,7 @@ void GraphicsContextCG::strokePath(const Path& path)
     CGContextDrawPathDirect(context, kCGPathStroke, path.platformPath(), nullptr);
 #else
     CGContextBeginPath(context);
-    CGContextAddPath(context, path.platformPath());
+    path.addToContext(context);
     CGContextStrokePath(context);
 #endif
 }
@@ -1017,7 +1017,7 @@ void GraphicsContextCG::clipOut(const Path& path)
     CGContextBeginPath(platformContext());
     CGContextAddRect(platformContext(), CGContextGetClipBoundingBox(platformContext()));
     if (!path.isEmpty())
-        CGContextAddPath(platformContext(), path.platformPath());
+        path.addToContext(platformContext());
     CGContextEOClip(platformContext());
 }
 
@@ -1028,7 +1028,7 @@ void GraphicsContextCG::clipPath(const Path& path, WindRule clipRule)
         CGContextClipToRect(context, CGRectZero);
     else {
         CGContextBeginPath(platformContext());
-        CGContextAddPath(platformContext(), path.platformPath());
+        path.addToContext(platformContext());
 
         if (clipRule == WindRule::EvenOdd)
             CGContextEOClip(context);

--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -90,6 +90,8 @@ private:
     FloatRect fastBoundingRect() const final;
     FloatRect boundingRect() const final;
 
+    void addToContext(PlatformGraphicsContext*) const final;
+
     RetainPtr<CGMutablePathRef> m_platformPath;
 };
 

--- a/Source/WebCore/platform/graphics/cg/PathSegmentDataCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathSegmentDataCG.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PathSegmentData.h"
+
+#if USE(CG)
+
+#include "PathSegmentUtilitiesCG.h"
+
+namespace WebCore {
+
+void PathMoveTo::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextMoveToPoint(context, point.x(), point.y());
+}
+
+void PathLineTo::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextAddLineToPoint(context, point.x(), point.y());
+}
+
+void PathQuadCurveTo::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextAddQuadCurveToPoint(context, controlPoint.x(), controlPoint.y(), endPoint.x(), endPoint.y());
+}
+
+void PathBezierCurveTo::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextAddCurveToPoint(context, controlPoint1.x(), controlPoint1.y(), controlPoint2.x(), controlPoint2.y(), endPoint.x(), endPoint.y());
+}
+
+void PathArcTo::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextAddArcToPoint(context, controlPoint1.x(), controlPoint1.y(), controlPoint2.x(), controlPoint2.y(), radius);
+}
+
+void PathArc::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextAddArc(context, center.x(), center.y(), radius, startAngle, endAngle, direction == RotationDirection::Counterclockwise);
+}
+
+void PathEllipse::addToContext(PlatformGraphicsContext* context) const
+{
+    auto platformPath = adoptCF(CGPathCreateMutable());
+    addEllipseToPlatformPath(platformPath.get(), center, radiusX, radiusY, rotation, startAngle, endAngle, direction);
+    CGContextAddPath(context, platformPath.get());
+}
+
+void PathEllipseInRect::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextAddEllipseInRect(context, rect);
+}
+
+void PathRect::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextAddRect(context, rect);
+}
+
+void PathRoundedRect::addToContext(PlatformGraphicsContext* context) const
+{
+    if (strategy == PathRoundedRect::Strategy::PreferNative) {
+        auto platformPath = adoptCF(CGPathCreateMutable());
+        if (addRoundedRectToPlatformPath(platformPath.get(), roundedRect)) {
+            CGContextAddPath(context, platformPath.get());
+            return;
+        }
+    }
+
+    PathStream stream;
+    stream.addBeziersForRoundedRect(roundedRect);
+    stream.addToContext(context);
+}
+
+void PathDataLine::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextMoveToPoint(context, start.x(), start.y());
+    CGContextAddLineToPoint(context, end.x(), end.y());
+}
+
+void PathDataQuadCurve::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextMoveToPoint(context, start.x(), start.y());
+    CGContextAddQuadCurveToPoint(context, controlPoint.x(), controlPoint.y(), endPoint.x(), endPoint.y());
+}
+
+void PathDataBezierCurve::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextMoveToPoint(context, start.x(), start.y());
+    CGContextAddCurveToPoint(context, controlPoint1.x(), controlPoint1.y(), controlPoint2.x(), controlPoint2.y(), endPoint.x(), endPoint.y());
+}
+
+void PathDataArc::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextMoveToPoint(context, start.x(), start.y());
+    CGContextAddArcToPoint(context, controlPoint1.x(), controlPoint1.y(), controlPoint2.x(), controlPoint2.y(), radius);
+}
+
+void PathCloseSubpath::addToContext(PlatformGraphicsContext* context) const
+{
+    CGContextClosePath(context);
+}
+
+} // namespace WebCore
+
+#endif // USE(CG)

--- a/Source/WebCore/platform/graphics/cg/PathSegmentUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathSegmentUtilitiesCG.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PathSegmentUtilitiesCG.h"
+
+#if USE(CG)
+
+namespace WebCore {
+
+void addEllipseToPlatformPath(PlatformPathPtr platformPath, const FloatPoint& center, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection direction)
+{
+    AffineTransform transform;
+    transform.translate(center.x(), center.y()).rotate(rad2deg(rotation)).scale(radiusX, radiusY);
+
+    CGAffineTransform cgTransform = transform;
+    // CG coordinates system increases the angle in the anticlockwise direction.
+    CGPathAddArc(platformPath, &cgTransform, 0, 0, 1, startAngle, endAngle, direction == RotationDirection::Counterclockwise);
+}
+
+static void addEvenCornersRoundedRect(PlatformPathPtr platformPath, const FloatRect& rect, const FloatSize& radius)
+{
+    // Ensure that CG can render the rounded rect.
+    CGFloat radiusWidth = radius.width();
+    CGFloat radiusHeight = radius.height();
+    CGRect rectToDraw = rect;
+
+    CGFloat rectWidth = CGRectGetWidth(rectToDraw);
+    CGFloat rectHeight = CGRectGetHeight(rectToDraw);
+    if (2 * radiusWidth > rectWidth)
+        radiusWidth = rectWidth / 2 - std::numeric_limits<CGFloat>::epsilon();
+    if (2 * radiusHeight > rectHeight)
+        radiusHeight = rectHeight / 2 - std::numeric_limits<CGFloat>::epsilon();
+    CGPathAddRoundedRect(platformPath, nullptr, rectToDraw, radiusWidth, radiusHeight);
+}
+
+#if HAVE(CG_PATH_UNEVEN_CORNERS_ROUNDEDRECT)
+static void addUnevenCornersRoundedRect(PlatformPathPtr platformPath, const FloatRoundedRect& roundedRect)
+{
+    enum Corners {
+        BottomLeft,
+        BottomRight,
+        TopRight,
+        TopLeft
+    };
+
+    CGSize corners[4] = {
+        roundedRect.radii().bottomLeft(),
+        roundedRect.radii().bottomRight(),
+        roundedRect.radii().topRight(),
+        roundedRect.radii().topLeft()
+    };
+
+    CGRect rectToDraw = roundedRect.rect();
+    CGFloat rectWidth = CGRectGetWidth(rectToDraw);
+    CGFloat rectHeight = CGRectGetHeight(rectToDraw);
+
+    // Clamp the radii after conversion to CGFloats.
+    corners[TopRight].width = std::min(corners[TopRight].width, rectWidth - corners[TopLeft].width);
+    corners[BottomRight].width = std::min(corners[BottomRight].width, rectWidth - corners[BottomLeft].width);
+    corners[BottomLeft].height = std::min(corners[BottomLeft].height, rectHeight - corners[TopLeft].height);
+    corners[BottomRight].height = std::min(corners[BottomRight].height, rectHeight - corners[TopRight].height);
+
+    CGPathAddUnevenCornersRoundedRect(platformPath, nullptr, rectToDraw, corners);
+}
+#endif
+
+bool addRoundedRectToPlatformPath(PlatformPathPtr platformPath, const FloatRoundedRect& roundedRect)
+{
+    const auto& radii = roundedRect.radii();
+
+    if (radii.hasEvenCorners()) {
+        addEvenCornersRoundedRect(platformPath, roundedRect.rect(), radii.topLeft());
+        return true;
+    }
+
+#if HAVE(CG_PATH_UNEVEN_CORNERS_ROUNDEDRECT)
+    addUnevenCornersRoundedRect(platformPath, roundedRect);
+    return true;
+#else
+    return false;
+#endif
+}
+
+} // namespace WebCore
+
+#endif // USE(CG)
+

--- a/Source/WebCore/platform/graphics/cg/PathSegmentUtilitiesCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathSegmentUtilitiesCG.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "PlatformPath.h"
+
+#if USE(CG)
+
+namespace WebCore {
+
+void addEllipseToPlatformPath(PlatformPathPtr, const FloatPoint& center, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection);
+bool addRoundedRectToPlatformPath(PlatformPathPtr, const FloatRoundedRect&);
+
+} // namespace WebCore
+
+#endif // USE(CG)


### PR DESCRIPTION
#### 07bace78ac540ef167f923868af6f62fff9f1e0a
<pre>
[CG] Add the path segments directly to the CGContext instead of creating a CGPath then adding it
<a href="https://bugs.webkit.org/show_bug.cgi?id=262198">https://bugs.webkit.org/show_bug.cgi?id=262198</a>
rdar://116090971

Reviewed by NOBODY (OOPS!).

If the Path is represented as PathStream, it is better to directly add these
segments to the CGContext instead of creating a CGPath then adding the CGPath to
the CGContext. CGContextBeginPath() creates a CGPath to receive the PathSegments
to the intermediate CGPath.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::addToContext const):
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/PathImpl.h:
* Source/WebCore/platform/graphics/PathSegment.cpp:
(WebCore::PathSegment::addToContext const):
* Source/WebCore/platform/graphics/PathSegment.h:
* Source/WebCore/platform/graphics/PathSegmentData.h:
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::addToContext const):
* Source/WebCore/platform/graphics/PathStream.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawPath):
(WebCore::GraphicsContextCG::fillPath):
(WebCore::GraphicsContextCG::strokePath):
(WebCore::GraphicsContextCG::clipOut):
(WebCore::GraphicsContextCG::clipPath):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::PathCG::addEllipse):
(WebCore::PathCG::addRoundedRect):
(WebCore::PathCG::addToContext const):
(WebCore::addEvenCornersRoundedRect): Deleted.
(WebCore::addUnevenCornersRoundedRect): Deleted.
* Source/WebCore/platform/graphics/cg/PathCG.h:
* Source/WebCore/platform/graphics/cg/PathSegmentDataCG.cpp: Added.
(WebCore::PathMoveTo::addToContext const):
(WebCore::PathLineTo::addToContext const):
(WebCore::PathQuadCurveTo::addToContext const):
(WebCore::PathBezierCurveTo::addToContext const):
(WebCore::PathArcTo::addToContext const):
(WebCore::PathArc::addToContext const):
(WebCore::PathEllipse::addToContext const):
(WebCore::PathEllipseInRect::addToContext const):
(WebCore::PathRect::addToContext const):
(WebCore::PathRoundedRect::addToContext const):
(WebCore::PathDataLine::addToContext const):
(WebCore::PathDataQuadCurve::addToContext const):
(WebCore::PathDataBezierCurve::addToContext const):
(WebCore::PathDataArc::addToContext const):
(WebCore::PathCloseSubpath::addToContext const):
* Source/WebCore/platform/graphics/cg/PathSegmentUtilitiesCG.cpp: Added.
(WebCore::addEllipseToPlatformPath):
(WebCore::addEvenCornersRoundedRect):
(WebCore::addUnevenCornersRoundedRect):
(WebCore::addRoundedRectToPlatformPath):
* Source/WebCore/platform/graphics/cg/PathSegmentUtilitiesCG.h: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07bace78ac540ef167f923868af6f62fff9f1e0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21883 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20172 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22734 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24436 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22425 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16066 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->