### PR TITLE
Use more smart pointers in editing code

### DIFF
--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -198,6 +198,11 @@ Text* Position::containerText() const
     return nullptr;
 }
 
+RefPtr<Text> Position::protectedContainerText() const
+{
+    return containerText();
+}
+
 Element* Position::containerOrParentElement() const
 {
     auto* container = containerNode();

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -84,6 +84,7 @@ public:
     WEBCORE_EXPORT Node* containerNode() const; // null for a before/after position anchored to a node with no parent
     RefPtr<Node> protectedContainerNode() const { return containerNode(); }
     Text* containerText() const;
+    RefPtr<Text> protectedContainerText() const;
     Element* containerOrParentElement() const;
 
     int computeOffsetInContainerNode() const;  // O(n) for before/after-anchored positions, O(1) for parent-anchored positions

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -113,7 +113,7 @@ void AlternativeTextController::startAlternativeTextUITimer(AlternativeTextType 
     if (type == AlternativeTextType::Correction)
         m_rangeWithAlternative = std::nullopt;
     m_type = type;
-    m_timer = m_document.eventLoop().scheduleTask(correctionPanelTimerInterval, TaskSource::UserInteraction, [weakThis = WeakPtr { *this }] {
+    m_timer = protectedDocument()->eventLoop().scheduleTask(correctionPanelTimerInterval, TaskSource::UserInteraction, [weakThis = WeakPtr { *this }] {
         if (!weakThis)
             return;
         weakThis->timerFired();
@@ -129,7 +129,7 @@ void AlternativeTextController::stopAlternativeTextUITimer()
 void AlternativeTextController::stopPendingCorrection(const VisibleSelection& oldSelection)
 {
     // Make sure there's no pending autocorrection before we call markMisspellingsAndBadGrammar() below.
-    VisibleSelection currentSelection(m_document.selection().selection());
+    VisibleSelection currentSelection(protectedDocument()->selection().selection());
     if (currentSelection == oldSelection)
         return;
 
@@ -163,7 +163,7 @@ bool AlternativeTextController::hasPendingCorrection() const
 
 bool AlternativeTextController::isSpellingMarkerAllowed(const SimpleRange& misspellingRange) const
 {
-    return !m_document.markers().hasMarkers(misspellingRange, DocumentMarker::SpellCheckingExemption);
+    return !protectedDocument()->markers().hasMarkers(misspellingRange, DocumentMarker::SpellCheckingExemption);
 }
 
 void AlternativeTextController::show(const SimpleRange& rangeToReplace, const String& replacement)
@@ -175,7 +175,7 @@ void AlternativeTextController::show(const SimpleRange& rangeToReplace, const St
     m_rangeWithAlternative = rangeToReplace;
     m_details = replacement;
     m_isActive = true;
-    if (AlternativeTextClient* client = alternativeTextClient())
+    if (CheckedPtr client = alternativeTextClient())
         client->showCorrectionAlternative(m_type, boundingBox, m_originalText, replacement, { });
 }
 
@@ -193,7 +193,7 @@ void AlternativeTextController::dismiss(ReasonForDismissingAlternativeText reaso
         return;
     m_isActive = false;
     m_isDismissedByEditing = true;
-    if (AlternativeTextClient* client = alternativeTextClient())
+    if (CheckedPtr client = alternativeTextClient())
         client->dismissAlternative(reasonForDismissing);
 }
 
@@ -203,7 +203,7 @@ String AlternativeTextController::dismissSoon(ReasonForDismissingAlternativeText
         return String();
     m_isActive = false;
     m_isDismissedByEditing = true;
-    if (AlternativeTextClient* client = alternativeTextClient())
+    if (CheckedPtr client = alternativeTextClient())
         return client->dismissAlternativeSoon(reasonForDismissing);
     return String();
 }
@@ -216,7 +216,7 @@ bool AlternativeTextController::applyAutocorrectionBeforeTypingIfAppropriate()
     if (m_type != AlternativeTextType::Correction)
         return false;
 
-    Position caretPosition = m_document.selection().selection().start();
+    Position caretPosition = protectedDocument()->selection().selection().start();
 
     if (makeDeprecatedLegacyPosition(m_rangeWithAlternative->end) == caretPosition) {
         handleAlternativeTextUIResult(dismissSoon(ReasonForDismissingAlternativeText::Accepted));
@@ -231,14 +231,15 @@ bool AlternativeTextController::applyAutocorrectionBeforeTypingIfAppropriate()
 
 void AlternativeTextController::respondToUnappliedSpellCorrection(const VisibleSelection& selectionOfCorrected, const String& corrected, const String& correction)
 {
-    if (auto client = alternativeTextClient())
+    if (CheckedPtr client = alternativeTextClient())
         client->recordAutocorrectionResponse(AutocorrectionResponse::Reverted, corrected, correction);
 
-    RefPtr protector(m_document.frame());
-    m_document.updateLayout();
+    auto document = protectedDocument();
+    RefPtr protectedFrame { document->frame() };
+    document->updateLayout();
 
-    m_document.selection().setSelection(selectionOfCorrected, FrameSelection::defaultSetSelectionOptions() | FrameSelection::SetSelectionOption::SpellCorrectionTriggered);
-    auto range = m_document.selection().selection().firstRange();
+    document->selection().setSelection(selectionOfCorrected, FrameSelection::defaultSetSelectionOptions() | FrameSelection::SetSelectionOption::SpellCorrectionTriggered);
+    auto range = document->selection().selection().firstRange();
     if (!range)
         return;
     removeMarkers(*range, OptionSet<DocumentMarker::MarkerType> { DocumentMarker::Spelling, DocumentMarker::Autocorrected }, RemovePartiallyOverlappingMarker::Yes);
@@ -251,12 +252,13 @@ void AlternativeTextController::timerFired()
     m_isDismissedByEditing = false;
     switch (m_type) {
     case AlternativeTextType::Correction: {
-        VisibleSelection selection(m_document.selection().selection());
+        auto document = protectedDocument();
+        VisibleSelection selection(document->selection().selection());
         VisiblePosition start(selection.start(), selection.affinity());
         VisiblePosition p = startOfWord(start, WordSide::LeftWordIfOnBoundary);
         VisibleSelection adjacentWords = VisibleSelection(p, start);
         auto adjacentWordRange = adjacentWords.toNormalizedRange();
-        m_document.editor().markAllMisspellingsAndBadGrammarInRanges({ TextCheckingType::Spelling, TextCheckingType::Replacement, TextCheckingType::ShowCorrectionPanel }, adjacentWordRange, adjacentWordRange, std::nullopt);
+        document->editor().markAllMisspellingsAndBadGrammarInRanges({ TextCheckingType::Spelling, TextCheckingType::Replacement, TextCheckingType::ShowCorrectionPanel }, adjacentWordRange, adjacentWordRange, std::nullopt);
     }
         break;
     case AlternativeTextType::Reversion: {
@@ -269,7 +271,7 @@ void AlternativeTextController::timerFired()
         m_originalText = plainText(*m_rangeWithAlternative);
         auto boundingBox = rootViewRectForRange(*m_rangeWithAlternative);
         if (!boundingBox.isEmpty()) {
-            if (AlternativeTextClient* client = alternativeTextClient()) {
+            if (CheckedPtr client = alternativeTextClient()) {
                 removeMarkers(*m_rangeWithAlternative, { DocumentMarker::CorrectionIndicator });
                 client->showCorrectionAlternative(m_type, boundingBox, m_originalText, replacementString, { });
             }
@@ -283,13 +285,13 @@ void AlternativeTextController::timerFired()
 
         Vector<String> suggestions;
         if (m_type == AlternativeTextType::GrammarSuggestions) {
-            if (auto* editorClient = this->editorClient()) {
+            if (CheckedPtr editorClient = this->editorClient()) {
                 TextCheckingHelper checker(*editorClient, *m_rangeWithAlternative);
                 suggestions = checker.guessesForMisspelledWordOrUngrammaticalPhrase(true).guesses;
             }
         } else {
             auto paragraphText = plainText(TextCheckingParagraph(*m_rangeWithAlternative).paragraphRange());
-            textChecker()->getGuessesForWord(m_originalText, paragraphText, m_document.selection().selection(), suggestions);
+            textChecker()->getGuessesForWord(m_originalText, paragraphText, protectedDocument()->selection().selection(), suggestions);
         }
 
         if (suggestions.isEmpty()) {
@@ -301,7 +303,7 @@ void AlternativeTextController::timerFired()
         m_isActive = true;
         auto boundingBox = rootViewRectForRange(*m_rangeWithAlternative);
         if (!boundingBox.isEmpty()) {
-            if (AlternativeTextClient* client = alternativeTextClient())
+            if (CheckedPtr client = alternativeTextClient())
                 client->showCorrectionAlternative(m_type, boundingBox, m_originalText, topSuggestion, suggestions);
         }
     }
@@ -317,7 +319,7 @@ void AlternativeTextController::timerFired()
         auto boundingBox = rootViewRectForRange(*m_rangeWithAlternative);
         m_isActive = true;
         if (!boundingBox.isEmpty()) {
-            if (auto client = alternativeTextClient())
+            if (CheckedPtr client = alternativeTextClient())
                 client->showDictationAlternativeUI(boundingBox, dictationContext);
         }
 #endif
@@ -328,7 +330,7 @@ void AlternativeTextController::timerFired()
 
 void AlternativeTextController::handleAlternativeTextUIResult(const String& result)
 {
-    if (!m_rangeWithAlternative || &m_document != &m_rangeWithAlternative->start.document())
+    if (!m_rangeWithAlternative || m_document.ptr() != &m_rangeWithAlternative->start.document())
         return;
 
     String currentWord = plainText(*m_rangeWithAlternative);
@@ -363,7 +365,7 @@ void AlternativeTextController::handleAlternativeTextUIResult(const String& resu
 bool AlternativeTextController::canEnableAutomaticSpellingCorrection() const
 {
 #if ENABLE(AUTOCORRECT)
-    auto position = m_document.selection().selection().start();
+    auto position = protectedDocument()->selection().selection().start();
     if (RefPtr control = enclosingTextFormControl(position)) {
         if (!control->shouldAutocorrect())
             return false;
@@ -384,7 +386,7 @@ bool AlternativeTextController::isAutomaticSpellingCorrectionEnabled()
 
 FloatRect AlternativeTextController::rootViewRectForRange(const SimpleRange& range) const
 {
-    auto* view = m_document.view();
+    RefPtr view = m_document->view();
     if (!view)
         return { };
     return view->contentsToRootView(unitedBoundingBoxes(RenderObject::absoluteTextQuads(range)));
@@ -392,7 +394,7 @@ FloatRect AlternativeTextController::rootViewRectForRange(const SimpleRange& ran
 
 void AlternativeTextController::respondToChangedSelection(const VisibleSelection& oldSelection)
 {
-    VisibleSelection currentSelection(m_document.selection().selection());
+    VisibleSelection currentSelection(protectedDocument()->selection().selection());
     // When user moves caret to the end of autocorrected word and pauses, we show the panel
     // containing the original pre-correction word so that user can quickly revert the
     // undesired autocorrection. Here, we start correction panel timer once we confirm that
@@ -415,7 +417,7 @@ void AlternativeTextController::respondToChangedSelection(const VisibleSelection
     if (position.anchorType() != Position::PositionIsOffsetInAnchor)
         return;
 
-    Node* node = position.containerNode();
+    RefPtr node = position.containerNode();
     ASSERT(node);
     for (auto& marker : node->document().markers().markersFor(*node)) {
         ASSERT(marker);
@@ -437,19 +439,19 @@ void AlternativeTextController::respondToUnappliedEditing(EditCommandComposition
 
 EditorClient* AlternativeTextController::editorClient()
 {
-    return m_document.page() ? &m_document.page()->editorClient() : nullptr;
+    return m_document->page() ? &m_document->page()->editorClient() : nullptr;
 }
 
 TextCheckerClient* AlternativeTextController::textChecker()
 {
-    if (EditorClient* owner = editorClient())
+    if (CheckedPtr owner = editorClient())
         return owner->textChecker();
     return nullptr;
 }
 
 void AlternativeTextController::recordAutocorrectionResponse(AutocorrectionResponse response, const String& replacedString, const SimpleRange& replacementRange)
 {
-    if (auto client = alternativeTextClient())
+    if (CheckedPtr client = alternativeTextClient())
         client->recordAutocorrectionResponse(response, replacedString, plainText(replacementRange));
 }
 
@@ -476,7 +478,7 @@ void AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection(
     if (correctedOnceMarkers.isEmpty())
         return;
 
-    if (AlternativeTextClient* client = alternativeTextClient()) {
+    if (CheckedPtr client = alternativeTextClient()) {
         // Spelling corrected text has been edited. We need to determine whether user has reverted it to original text or
         // edited it to something else, and notify spellchecker accordingly.
         if (markersHaveIdenticalDescription(correctedOnceMarkers) && correctedOnceMarkers[0]->description() == corrected)
@@ -519,7 +521,8 @@ void AlternativeTextController::markPrecedingWhitespaceForDeletedAutocorrectionA
 
 bool AlternativeTextController::processMarkersOnTextToBeReplacedByResult(const TextCheckingResult& result, const SimpleRange& rangeWithAlternative, const String& stringToBeReplaced)
 {
-    auto& markers = m_document.markers();
+    auto document = protectedDocument();
+    auto& markers = document->markers();
     if (markers.hasMarkers(rangeWithAlternative, DocumentMarker::Replacement)) {
         if (result.type == TextCheckingType::Correction)
             recordSpellcheckerResponseForModifiedCorrection(rangeWithAlternative, stringToBeReplaced, result.replacement);
@@ -565,7 +568,7 @@ bool AlternativeTextController::respondToMarkerAtEndOfWord(const DocumentMarker&
 {
     if (!shouldStartTimerFor(marker, endOfWordPosition.offsetInContainerNode()))
         return false;
-    Node* node = endOfWordPosition.containerNode();
+    RefPtr node = endOfWordPosition.containerNode();
     auto wordRange = makeSimpleRange(*node, marker);
     String currentWord = plainText(wordRange);
     if (!currentWord.length())
@@ -605,7 +608,7 @@ bool AlternativeTextController::respondToMarkerAtEndOfWord(const DocumentMarker&
 
 AlternativeTextClient* AlternativeTextController::alternativeTextClient()
 {
-    return m_document.frame() && m_document.page() ? m_document.page()->alternativeTextClient() : nullptr;
+    return m_document->frame() && m_document->page() ? m_document->page()->alternativeTextClient() : nullptr;
 }
 
 String AlternativeTextController::markerDescriptionForAppliedAlternativeText(AlternativeTextType alternativeTextType, DocumentMarker::MarkerType markerType)
@@ -639,7 +642,7 @@ void AlternativeTextController::applyAlternativeTextToRange(const SimpleRange& r
 
     // Recalculate pragraphRangeContainingCorrection, since SpellingCorrectionCommand modified the DOM, such that the original paragraphRangeContainingCorrection is no longer valid. Radar: 10305315 Bugzilla: 89526
     auto updatedParagraphStartContainingCorrection = resolveCharacterLocation(makeRangeSelectingNodeContents(treeScopeRoot), paragraphOffsetInTreeScope);
-    auto updatedParagraphEndContainingCorrection = makeBoundaryPoint(m_document.selection().selection().start());
+    auto updatedParagraphEndContainingCorrection = makeBoundaryPoint(protectedDocument()->selection().selection().start());
     if (!updatedParagraphEndContainingCorrection)
         return;
     auto replacementRange = resolveCharacterRange({ updatedParagraphStartContainingCorrection, *updatedParagraphEndContainingCorrection }, CharacterRange(correctionOffsetInParagraph, alternative.length()));
@@ -657,9 +660,9 @@ void AlternativeTextController::applyAlternativeTextToRange(const SimpleRange& r
 void AlternativeTextController::removeCorrectionIndicatorMarkers()
 {
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)
-    m_document.markers().dismissMarkers(DocumentMarker::CorrectionIndicator);
+    protectedDocument()->markers().dismissMarkers(DocumentMarker::CorrectionIndicator);
 #else
-    m_document.markers().removeMarkers(DocumentMarker::CorrectionIndicator);
+    protectedDocument()->markers().removeMarkers(DocumentMarker::CorrectionIndicator);
 #endif
 }
 
@@ -683,15 +686,17 @@ void AlternativeTextController::respondToAppliedEditing(CompositeEditCommand* co
 
 bool AlternativeTextController::insertDictatedText(const String& text, const Vector<DictationAlternative>& dictationAlternatives, Event* triggeringEvent)
 {
-    EventTarget* target;
+    RefPtr<EventTarget> target;
+    auto document = protectedDocument();
     if (triggeringEvent)
         target = triggeringEvent->target();
     else
-        target = eventTargetElementForDocument(&m_document);
+        target = eventTargetElementForDocument(document.ptr());
     if (!target)
         return false;
 
-    auto event = TextEvent::createForDictation(&m_document.frame()->windowProxy(), text, dictationAlternatives);
+    Ref windowProxy = document->frame()->windowProxy();
+    auto event = TextEvent::createForDictation(windowProxy.ptr(), text, dictationAlternatives);
     event->setUnderlyingEvent(triggeringEvent);
 
     target->dispatchEvent(event);
@@ -701,7 +706,7 @@ bool AlternativeTextController::insertDictatedText(const String& text, const Vec
 void AlternativeTextController::removeDictationAlternativesForMarker(const DocumentMarker& marker)
 {
 #if USE(DICTATION_ALTERNATIVES)
-    if (auto* client = alternativeTextClient())
+    if (CheckedPtr client = alternativeTextClient())
         client->removeDictationAlternatives(std::get<DocumentMarker::DictationData>(marker.data()).context);
 #else
     UNUSED_PARAM(marker);
@@ -711,7 +716,7 @@ void AlternativeTextController::removeDictationAlternativesForMarker(const Docum
 Vector<String> AlternativeTextController::dictationAlternativesForMarker(const DocumentMarker& marker)
 {
 #if USE(DICTATION_ALTERNATIVES)
-    if (auto* client = alternativeTextClient())
+    if (CheckedPtr client = alternativeTextClient())
         return client->dictationAlternatives(std::get<DocumentMarker::DictationData>(marker.data()).context);
     return Vector<String>();
 #else
@@ -723,7 +728,8 @@ Vector<String> AlternativeTextController::dictationAlternativesForMarker(const D
 void AlternativeTextController::applyDictationAlternative(const String& alternativeString)
 {
 #if USE(DICTATION_ALTERNATIVES)
-    auto& editor = m_document.editor();
+    auto document = protectedDocument();
+    auto& editor = document->editor();
     auto selection = editor.selectedRange();
     if (!selection || !editor.shouldInsertText(alternativeString, *selection, EditorInsertAction::Pasted))
         return;

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -135,10 +135,11 @@ private:
     void applyAlternativeTextToRange(const SimpleRange&, const String&, AlternativeTextType, OptionSet<DocumentMarker::MarkerType>);
     AlternativeTextClient* alternativeTextClient();
 #endif
+    Ref<Document> protectedDocument() const { return m_document.get(); }
 
     void removeCorrectionIndicatorMarkers();
 
-    Document& m_document;
+    CheckedRef<Document> m_document;
 };
 
 #undef UNLESS_ENABLED

--- a/Source/WebCore/editing/AppendNodeCommand.cpp
+++ b/Source/WebCore/editing/AppendNodeCommand.cpp
@@ -45,10 +45,11 @@ AppendNodeCommand::AppendNodeCommand(Ref<ContainerNode>&& parent, Ref<Node>&& no
 
 void AppendNodeCommand::doApply()
 {
-    if (!m_parent->hasEditableStyle() && m_parent->renderer())
+    auto parent = protectedParent();
+    if (!parent->hasEditableStyle() && parent->renderer())
         return;
 
-    m_parent->appendChild(m_node);
+    parent->appendChild(m_node);
 }
 
 void AppendNodeCommand::doUnapply()
@@ -56,7 +57,7 @@ void AppendNodeCommand::doUnapply()
     if (!m_parent->hasEditableStyle())
         return;
 
-    m_node->remove();
+    protectedNode()->remove();
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/AppendNodeCommand.h
+++ b/Source/WebCore/editing/AppendNodeCommand.h
@@ -46,6 +46,9 @@ private:
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif
 
+    Ref<ContainerNode> protectedParent() const { return m_parent; }
+    Ref<Node> protectedNode() const { return m_node; }
+
     Ref<ContainerNode> m_parent;
     Ref<Node> m_node;
 };

--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -92,7 +92,7 @@ void ApplyBlockElementCommand::doApply()
 
     formatSelection(startOfSelection, endOfSelection);
 
-    document().updateLayoutIgnorePendingStylesheets();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
     ASSERT(startScope == endScope);
     ASSERT(startIndex >= 0);
@@ -121,7 +121,7 @@ void ApplyBlockElementCommand::formatSelection(const VisiblePosition& startOfSel
     if (isAtUnsplittableElement(start) && startOfParagraph(start) == endOfParagraph(endOfSelection)) {
         auto blockquote = createBlockElement();
         insertNodeAt(blockquote.copyRef(), start);
-        auto placeholder = HTMLBRElement::create(document());
+        auto placeholder = HTMLBRElement::create(protectedDocument());
         appendNode(placeholder.copyRef(), WTFMove(blockquote));
         setEndingSelection(VisibleSelection(positionBeforeNode(placeholder.ptr()), Affinity::Downstream, endingSelection().isDirectional()));
         return;
@@ -152,7 +152,6 @@ void ApplyBlockElementCommand::formatSelection(const VisiblePosition& startOfSel
             end = endOfCurrentParagraph.deepEquivalent();
         }
 
-        Position afterEnd = end.next();
         RefPtr enclosingCell = enclosingNodeOfType(start, &isTableCell);
         VisiblePosition endOfNextParagraph = endOfNextParagraphSplittingTextNodesIfNeeded(endOfCurrentParagraph, start, end);
 
@@ -180,11 +179,13 @@ void ApplyBlockElementCommand::formatSelection(const VisiblePosition& startOfSel
 
 static bool isNewLineAtPosition(const Position& position)
 {
-    RefPtr textNode = position.containerNode();
-    unsigned offset = position.offsetInContainerNode();
-    if (!is<Text>(textNode) || offset >= downcast<Text>(*textNode).length())
+    RefPtr textNode = dynamicDowncast<Text>(position.containerNode());
+    if (!textNode)
         return false;
-    return downcast<Text>(*textNode).data()[offset] == '\n';
+    unsigned offset = position.offsetInContainerNode();
+    if (offset >= textNode->length())
+        return false;
+    return textNode->data()[offset] == '\n';
 }
 
 const RenderStyle* ApplyBlockElementCommand::renderStyleOfEnclosingTextNode(const Position& position)
@@ -194,9 +195,9 @@ const RenderStyle* ApplyBlockElementCommand::renderStyleOfEnclosingTextNode(cons
         || !position.containerNode()->isTextNode())
         return nullptr;
 
-    document().updateStyleIfNeeded();
+    protectedDocument()->updateStyleIfNeeded();
 
-    RenderObject* renderer = position.containerNode()->renderer();
+    CheckedPtr renderer = position.containerNode()->renderer();
     if (!renderer)
         return nullptr;
 
@@ -256,7 +257,7 @@ void ApplyBlockElementCommand::rangeForParagraphSplittingTextNodesIfNeeded(const
 
         // If end is in the middle of a text node and the text node is editable, split.
         if (userModify != UserModify::ReadOnly && !collapseWhiteSpace && endOffset && endOffset < end.containerNode()->length()) {
-            RefPtr<Text> endContainer = end.containerText();
+            RefPtr endContainer = end.containerText();
             splitTextNode(*endContainer, endOffset);
             if (is<Text>(endContainer) && !endContainer->previousSibling()) {
                 start = { };
@@ -287,7 +288,7 @@ VisiblePosition ApplyBlockElementCommand::endOfNextParagraphSplittingTextNodesIf
     bool preserveNewLine = style->preserveNewline();
     style = nullptr;
 
-    RefPtr<Text> text = position.containerText();
+    RefPtr text = position.containerText();
     if (!preserveNewLine || !position.offsetInContainerNode() || !isNewLineAtPosition(firstPositionInNode(text.get())))
         return endOfNextParagraph;
 
@@ -295,7 +296,7 @@ VisiblePosition ApplyBlockElementCommand::endOfNextParagraphSplittingTextNodesIf
     // If endOfNextParagraph was pointing at this same text node, endOfNextParagraph will be shifted by one paragraph.
     // Avoid this by splitting "\n"
     splitTextNode(*text, 1);
-    auto previousSiblingOfText = RefPtr { text->previousSibling() };
+    RefPtr previousSiblingOfText { text->previousSibling() };
 
     if (text == start.containerNode() && previousSiblingOfText && is<Text>(previousSiblingOfText)) {
         ASSERT(start.offsetInContainerNode() < position.offsetInContainerNode());
@@ -320,7 +321,7 @@ VisiblePosition ApplyBlockElementCommand::endOfNextParagraphSplittingTextNodesIf
 
 Ref<HTMLElement> ApplyBlockElementCommand::createBlockElement()
 {
-    auto element = createHTMLElement(document(), m_tagName);
+    auto element = createHTMLElement(protectedDocument(), m_tagName);
     if (m_inlineStyle.length())
         element->setAttribute(styleAttr, m_inlineStyle);
     return element;

--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -128,17 +128,17 @@ void BreakBlockquoteCommand::doApply()
     ASSERT(startNode);
     // Split at pos if in the middle of a text node.
     if (is<Text>(*startNode)) {
-        Text& textNode = downcast<Text>(*startNode);
-        if ((unsigned)pos.deprecatedEditingOffset() >= textNode.length()) {
-            if (auto* nextNode = NodeTraversal::next(*startNode))
-                startNode = nextNode;
+        Ref textNode = downcast<Text>(*startNode);
+        if (static_cast<unsigned>(pos.deprecatedEditingOffset()) >= textNode->length()) {
+            if (RefPtr nextNode = NodeTraversal::next(*startNode))
+                startNode = WTFMove(nextNode);
         } else if (pos.deprecatedEditingOffset() > 0)
             splitTextNode(textNode, pos.deprecatedEditingOffset());
     } else if (pos.deprecatedEditingOffset() > 0) {
-        if (auto* child = startNode->traverseToChildAt(pos.deprecatedEditingOffset()))
-            startNode = child;
-        else if (auto* next = NodeTraversal::next(*startNode))
-            startNode = next;
+        if (RefPtr child = startNode->traverseToChildAt(pos.deprecatedEditingOffset()))
+            startNode = WTFMove(child);
+        else if (RefPtr next = NodeTraversal::next(*startNode))
+            startNode = WTFMove(next);
     }
     
     // If there's nothing inside topBlockquote to move, we're finished.
@@ -149,8 +149,8 @@ void BreakBlockquoteCommand::doApply()
     
     // Build up list of ancestors in between the start node and the top blockquote.
     Vector<RefPtr<Element>> ancestors;    
-    for (Element* node = startNode->parentElement(); node && node != topBlockquote; node = node->parentElement())
-        ancestors.append(node);
+    for (RefPtr node = startNode->parentElement(); node && node != topBlockquote; node = node->parentElement())
+        ancestors.append(node.copyRef());
     
     // Insert a clone of the top blockquote after the break.
     auto clonedBlockquote = downcast<Element>(*topBlockquote).cloneElementWithoutChildren(document());
@@ -165,7 +165,7 @@ void BreakBlockquoteCommand::doApply()
         auto clonedChild = ancestors[i - 1]->cloneElementWithoutChildren(document());
         // Preserve list item numbering in cloned lists.
         if (clonedChild->isElementNode() && clonedChild->hasTagName(olTag)) {
-            Node* listChildNode = i > 1 ? ancestors[i - 2].get() : startNode.get();
+            RefPtr<Node> listChildNode = i > 1 ? ancestors[i - 2].get() : startNode.get();
             // The first child of the cloned list might not be a list item element, 
             // find the first one so that we know where to start numbering.
             while (listChildNode && !listChildNode->hasTagName(liTag))
@@ -196,7 +196,7 @@ void BreakBlockquoteCommand::doApply()
         }
 
         // If the startNode's original parent is now empty, remove it
-        Node* originalParent = ancestors.first().get();
+        RefPtr originalParent = ancestors.first().get();
         if (!originalParent->hasChildNodes())
             removeNode(*originalParent);
     }

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -94,6 +94,7 @@ private:
     String label() const final;
     void didRemoveFromUndoManager() final { }
     bool areRootEditabledElementsConnected();
+    RefPtr<Document> protectedDocument() const { return m_document; }
 
     RefPtr<Document> m_document;
     VisibleSelection m_startingSelection;
@@ -172,7 +173,7 @@ protected:
     void removeNodeAttribute(Element&, const QualifiedName& attribute);
     void removeChildrenInRange(Node&, unsigned from, unsigned to);
     virtual void removeNode(Node&, ShouldAssumeContentIsAlwaysEditable = DoNotAssumeContentIsAlwaysEditable);
-    HTMLElement* replaceElementWithSpanPreservingChildrenAndAttributes(HTMLElement&);
+    RefPtr<HTMLElement> replaceElementWithSpanPreservingChildrenAndAttributes(HTMLElement&);
     void removeNodePreservingChildren(Node&, ShouldAssumeContentIsAlwaysEditable = DoNotAssumeContentIsAlwaysEditable);
     void removeNodeAndPruneAncestors(Node&);
     void moveRemainingSiblingsToNewParent(Node*, Node* pastLastNodeToMove, Element& newParent);

--- a/Source/WebCore/editing/CreateLinkCommand.cpp
+++ b/Source/WebCore/editing/CreateLinkCommand.cpp
@@ -43,14 +43,15 @@ void CreateLinkCommand::doApply()
     if (endingSelection().isNoneOrOrphaned())
         return;
 
-    auto anchorElement = HTMLAnchorElement::create(document());
+    auto document = protectedDocument();
+    auto anchorElement = HTMLAnchorElement::create(document);
     anchorElement->setHref(AtomString { m_url });
     
     if (endingSelection().isRange())
         applyStyledElement(WTFMove(anchorElement));
     else {
         insertNodeAt(anchorElement.copyRef(), endingSelection().start());
-        appendNode(Text::create(document(), String { m_url }), anchorElement.copyRef());
+        appendNode(Text::create(document, String { m_url }), anchorElement.copyRef());
         setEndingSelection(VisibleSelection(positionInParentBeforeNode(anchorElement.ptr()), positionInParentAfterNode(anchorElement.ptr()), Affinity::Downstream, endingSelection().isDirectional()));
     }
 }

--- a/Source/WebCore/editing/CustomUndoStep.cpp
+++ b/Source/WebCore/editing/CustomUndoStep.cpp
@@ -76,7 +76,7 @@ String CustomUndoStep::label() const
 
 void CustomUndoStep::didRemoveFromUndoManager()
 {
-    if (auto undoItem = std::exchange(m_undoItem, nullptr))
+    if (RefPtr undoItem = std::exchange(m_undoItem, nullptr).get())
         undoItem->invalidate();
 }
 

--- a/Source/WebCore/editing/DeleteFromTextNodeCommand.cpp
+++ b/Source/WebCore/editing/DeleteFromTextNodeCommand.cpp
@@ -45,29 +45,36 @@ DeleteFromTextNodeCommand::DeleteFromTextNodeCommand(Ref<Text>&& node, unsigned 
 
 void DeleteFromTextNodeCommand::doApply()
 {
-    if (!isEditableNode(m_node))
+    auto node = protectedNode();
+    if (!isEditableNode(node))
         return;
 
-    auto result = m_node->substringData(m_offset, m_count);
+    auto result = node->substringData(m_offset, m_count);
     if (result.hasException())
         return;
     m_text = result.releaseReturnValue();
-    m_node->deleteData(m_offset, m_count);
+    node->deleteData(m_offset, m_count);
 }
 
 void DeleteFromTextNodeCommand::doUnapply()
 {
-    if (!m_node->hasEditableStyle())
+    auto node = protectedNode();
+    if (!node->hasEditableStyle())
         return;
 
-    m_node->insertData(m_offset, m_text);
+    node->insertData(m_offset, m_text);
 }
 
 #ifndef NDEBUG
 void DeleteFromTextNodeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
 {
-    addNodeAndDescendants(m_node.ptr(), nodes);
+    addNodeAndDescendants(protectedNode().ptr(), nodes);
 }
 #endif
+
+inline Ref<Text> DeleteFromTextNodeCommand::protectedNode() const
+{
+    return m_node;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/editing/DeleteFromTextNodeCommand.h
+++ b/Source/WebCore/editing/DeleteFromTextNodeCommand.h
@@ -48,6 +48,8 @@ private:
 #ifndef NDEBUG
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif
+
+    Ref<Text> protectedNode() const;
     
     Ref<Text> m_node;
     unsigned m_offset;

--- a/Source/WebCore/editing/DeleteSelectionCommand.h
+++ b/Source/WebCore/editing/DeleteSelectionCommand.h
@@ -78,6 +78,10 @@ private:
     void removeNodeUpdatingStates(Node&, ShouldAssumeContentIsAlwaysEditable);
     void insertBlockPlaceholderForTableCellIfNeeded(Element&);
 
+    RefPtr<Node> protectedStartBlock() const { return m_startBlock; }
+    RefPtr<Node> protectedEndBlock() const { return m_endBlock; }
+    RefPtr<Node> protectedEndTableRow() const { return m_endTableRow; }
+
     bool m_hasSelectionToDelete;
     bool m_smartDelete;
     bool m_mergeBlocksAfterDelete;

--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -40,31 +40,32 @@ namespace WebCore {
 
 class DictationCommandLineOperation {
 public:
-    DictationCommandLineOperation(DictationCommand* dictationCommand)
-    : m_dictationCommand(dictationCommand)
+    DictationCommandLineOperation(DictationCommand& dictationCommand)
+        : m_dictationCommand(dictationCommand)
     { }
     
     void operator()(size_t lineOffset, size_t lineLength, bool isLastLine) const
     {
         if (lineLength > 0)
-            m_dictationCommand->insertTextRunWithoutNewlines(lineOffset, lineLength);
+            Ref { m_dictationCommand.get() }->insertTextRunWithoutNewlines(lineOffset, lineLength);
         if (!isLastLine)
-            m_dictationCommand->insertParagraphSeparator();
+            Ref { m_dictationCommand.get() }->insertParagraphSeparator();
     }
 private:
-    DictationCommand* m_dictationCommand;
+    CheckedRef<DictationCommand> m_dictationCommand;
 };
 
 class DictationMarkerSupplier : public TextInsertionMarkerSupplier {
 public:
-    static Ref<DictationMarkerSupplier> create(const Vector<DictationAlternative>& alternatives)
+    static Ref<DictationMarkerSupplier> create(Vector<DictationAlternative>&& alternatives)
     {
-        return adoptRef(*new DictationMarkerSupplier(alternatives));
+        return adoptRef(*new DictationMarkerSupplier(WTFMove(alternatives)));
     }
 
     void addMarkersToTextNode(Text& textNode, unsigned offsetOfInsertion, const String& textToBeInserted) override
     {
-        auto& markerController = textNode.document().markers();
+        Ref document = textNode.document();
+        auto& markerController = document->markers();
         for (auto& alternative : m_alternatives) {
             DocumentMarker::DictationData data { alternative.context, textToBeInserted.substring(alternative.range.location, alternative.range.length) };
             markerController.addMarker(textNode, alternative.range.location + offsetOfInsertion, alternative.range.length, DocumentMarker::DictationAlternatives, WTFMove(data));
@@ -73,8 +74,8 @@ public:
     }
 
 protected:
-    DictationMarkerSupplier(const Vector<DictationAlternative>& alternatives)
-    : m_alternatives(alternatives)
+    DictationMarkerSupplier(Vector<DictationAlternative>&& alternatives)
+        : m_alternatives(WTFMove(alternatives))
     {
     }
 private:
@@ -100,16 +101,17 @@ void DictationCommand::insertText(Ref<Document>&& document, const String& text, 
     RefPtr<DictationCommand> cmd;
     if (newText == text)
         cmd = DictationCommand::create(WTFMove(document), newText, alternatives);
-    else
+    else {
         // If the text was modified before insertion, the location of dictation alternatives
         // will not be valid anymore. We will just drop the alternatives.
         cmd = DictationCommand::create(WTFMove(document), newText, Vector<DictationAlternative>());
+    }
     applyTextInsertionCommand(frame.get(), *cmd, selectionForInsertion, currentSelection);
 }
 
 void DictationCommand::doApply()
 {
-    DictationCommandLineOperation operation(this);
+    DictationCommandLineOperation operation(*this);
     forEachLineInString(m_textToInsert, operation);
     postTextStateChangeNotification(AXTextEditTypeDictation, m_textToInsert);
 }
@@ -118,7 +120,7 @@ void DictationCommand::insertTextRunWithoutNewlines(size_t lineStart, size_t lin
 {
     Vector<DictationAlternative> alternativesInLine;
     collectDictationAlternativesInRange(lineStart, lineLength, alternativesInLine);
-    auto command = InsertTextCommand::createWithMarkerSupplier(document(), m_textToInsert.substring(lineStart, lineLength), DictationMarkerSupplier::create(alternativesInLine), EditAction::Dictation);
+    auto command = InsertTextCommand::createWithMarkerSupplier(protectedDocument(), m_textToInsert.substring(lineStart, lineLength), DictationMarkerSupplier::create(WTFMove(alternativesInLine)), EditAction::Dictation);
     applyCommandToComposite(WTFMove(command), endingSelection());
 }
 

--- a/Source/WebCore/editing/DictationCommand.h
+++ b/Source/WebCore/editing/DictationCommand.h
@@ -27,10 +27,11 @@
 
 #include "DictationAlternative.h"
 #include "TextInsertionBaseCommand.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
-class DictationCommand : public TextInsertionBaseCommand {
+class DictationCommand : public TextInsertionBaseCommand, public CanMakeCheckedPtr {
     friend class DictationCommandLineOperation;
 public:
     static void insertText(Ref<Document>&&, const String&, const Vector<DictationAlternative>& alternatives, const VisibleSelection&);

--- a/Source/WebCore/editing/EditCommand.cpp
+++ b/Source/WebCore/editing/EditCommand.cpp
@@ -189,13 +189,13 @@ void EditCommand::setEndingSelection(const VisibleSelection& selection)
     }
 }
 
-void EditCommand::setParent(CompositeEditCommand* parent)
+void EditCommand::setParent(RefPtr<CompositeEditCommand>&& parent)
 {
     ASSERT((parent && !m_parent) || (!parent && m_parent));
-    m_parent = parent;
-    if (parent) {
-        m_startingSelection = parent->m_endingSelection;
-        m_endingSelection = parent->m_endingSelection;
+    m_parent = WTFMove(parent);
+    if (m_parent) {
+        m_startingSelection = m_parent->m_endingSelection;
+        m_endingSelection = m_parent->m_endingSelection;
     }
 }
 
@@ -212,7 +212,8 @@ void EditCommand::postTextStateChangeNotification(AXTextEditType type, const Str
         return;
     if (!text.length())
         return;
-    auto* cache = document().existingAXObjectCache();
+    auto document = protectedDocument();
+    CheckedPtr cache = document->existingAXObjectCache();
     if (!cache)
         return;
     RefPtr node { highestEditableRoot(position.deepEquivalent(), HasEditableAXRole) };
@@ -232,7 +233,7 @@ void SimpleEditCommand::doReapply()
 #ifndef NDEBUG
 void SimpleEditCommand::addNodeAndDescendants(Node* startNode, HashSet<Ref<Node>>& nodes)
 {
-    for (Node* node = startNode; node; node = NodeTraversal::next(*node, startNode))
+    for (RefPtr node = startNode; node; node = NodeTraversal::next(*node, startNode))
         nodes.add(*node);
 }
 #endif

--- a/Source/WebCore/editing/EditCommand.h
+++ b/Source/WebCore/editing/EditCommand.h
@@ -47,7 +47,7 @@ class EditCommand : public RefCounted<EditCommand> {
 public:
     virtual ~EditCommand();
 
-    void setParent(CompositeEditCommand*);
+    void setParent(RefPtr<CompositeEditCommand>&&);
 
     virtual EditAction editingAction() const;
 

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -51,19 +51,19 @@ struct SimpleRange;
 RefPtr<ContainerNode> highestEditableRoot(const Position&, EditableType = ContentIsEditable);
 
 RefPtr<Node> highestEnclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node&), EditingBoundaryCrossingRule = CannotCrossEditingBoundary, Node* stayWithin = nullptr);
-Node* highestNodeToRemoveInPruning(Node*);
+RefPtr<Node> highestNodeToRemoveInPruning(Node*);
 Element* lowestEditableAncestor(Node*);
 
 Element* deprecatedEnclosingBlockFlowElement(Node*); // Use enclosingBlock instead.
 RefPtr<Element> enclosingBlock(RefPtr<Node>, EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
 RefPtr<Element> enclosingTableCell(const Position&);
-Node* enclosingEmptyListItem(const VisiblePosition&);
-Element* enclosingAnchorElement(const Position&);
+RefPtr<Node> enclosingEmptyListItem(const VisiblePosition&);
+RefPtr<Element> enclosingAnchorElement(const Position&);
 Element* enclosingElementWithTag(const Position&, const QualifiedName&);
 RefPtr<Node> enclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node&), EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
 HTMLSpanElement* tabSpanNode(const Node*);
-Element* isLastPositionBeforeTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
-Element* isFirstPositionAfterTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
+RefPtr<Element> isLastPositionBeforeTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
+RefPtr<Element> isFirstPositionAfterTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
 
 // These two deliver leaf nodes as if the whole DOM tree were a linear chain of its leaf nodes.
 Node* nextLeafNode(const Node*);
@@ -161,9 +161,9 @@ WEBCORE_EXPORT Ref<HTMLElement> createDefaultParagraphElement(Document&);
 Ref<HTMLElement> createHTMLElement(Document&, const QualifiedName&);
 Ref<HTMLElement> createHTMLElement(Document&, const AtomString&);
 
-WEBCORE_EXPORT HTMLElement* enclosingList(Node*);
-HTMLElement* outermostEnclosingList(Node*, Node* rootList = nullptr);
-Node* enclosingListChild(Node*);
+WEBCORE_EXPORT RefPtr<HTMLElement> enclosingList(Node*);
+RefPtr<HTMLElement> outermostEnclosingList(Node*, Node* rootList = nullptr);
+RefPtr<Node> enclosingListChild(Node*);
 
 // -------------------------------------------------------------------------
 // Element

--- a/Source/WebCore/editing/InsertListCommand.h
+++ b/Source/WebCore/editing/InsertListCommand.h
@@ -52,11 +52,11 @@ private:
     EditAction editingAction() const final;
 
     HTMLElement* fixOrphanedListChild(Node&);
-    bool selectionHasListOfType(const VisibleSelection& selection, const QualifiedName&);
+    bool selectionHasListOfType(const VisibleSelection&, const HTMLQualifiedName&);
     Ref<HTMLElement> mergeWithNeighboringLists(HTMLElement&);
     void doApplyForSingleParagraph(bool forceCreateList, const HTMLQualifiedName&, SimpleRange& currentSelection);
     void unlistifyParagraph(const VisiblePosition& originalStart, HTMLElement& listNode, Node* listChildNode);
-    RefPtr<HTMLElement> listifyParagraph(const VisiblePosition& originalStart, const QualifiedName& listTag);
+    RefPtr<HTMLElement> listifyParagraph(const VisiblePosition& originalStart, const HTMLQualifiedName& listTag);
     RefPtr<HTMLElement> m_listElement;
     Type m_type;
 };

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -705,8 +705,8 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
             // Extend the selection backward into the last cell, then deletion will handle the move.
             selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, granularity);
         // If the caret is just after a table, select the table and don't delete anything.
-        } else if (Node* table = isFirstPositionAfterTable(visibleStart)) {
-            setEndingSelection(VisibleSelection(positionBeforeNode(table), endingSelection().start(), Affinity::Downstream, endingSelection().isDirectional()));
+        } else if (RefPtr table = isFirstPositionAfterTable(visibleStart)) {
+            setEndingSelection(VisibleSelection(positionBeforeNode(table.get()), endingSelection().start(), Affinity::Downstream, endingSelection().isDirectional()));
             typingAddedToOpenCommand(Type::DeleteKey);
             return;
         }

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -299,7 +299,7 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
                 // the next one) to match TextEdit.
                 end = wordEnd.next();
                 
-                if (auto* table = isFirstPositionAfterTable(end)) {
+                if (RefPtr table = isFirstPositionAfterTable(end)) {
                     // The paragraph break after the last paragraph in the last cell of a block table ends
                     // at the start of the paragraph after the table.
                     if (isBlock(*table))
@@ -352,7 +352,7 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
             // of the next one) in the selection.
             VisiblePosition end(visibleParagraphEnd.next());
 
-            if (Node* table = isFirstPositionAfterTable(end)) {
+            if (RefPtr table = isFirstPositionAfterTable(end)) {
                 // The paragraph break after the last paragraph in the last cell of a block table ends
                 // at the start of the paragraph after the table, not at the position just after the table.
                 if (isBlock(*table))

--- a/Source/WebCore/page/AlternativeTextClient.h
+++ b/Source/WebCore/page/AlternativeTextClient.h
@@ -27,6 +27,7 @@
 
 #include "DictationContext.h"
 #include "FloatRect.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -52,7 +53,7 @@ enum class AutocorrectionResponse : uint8_t {
     Accepted
 };
 
-class AlternativeTextClient {
+class AlternativeTextClient : public CanMakeCheckedPtr {
 public:
     virtual ~AlternativeTextClient() = default;
 #if USE(AUTOCORRECTION_PANEL)

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1193,9 +1193,8 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             // selected.  In this case, we should expand the selection to
             // the enclosing anchor element
             Position pos = sourceSelection.base();
-            Node* node = enclosingAnchorElement(pos);
-            if (node)
-                src.selection().setSelection(VisibleSelection::selectionFromContentsOfNode(node));
+            if (RefPtr node = enclosingAnchorElement(pos))
+                src.selection().setSelection(VisibleSelection::selectionFromContentsOfNode(node.get()));
         }
 
         client().willPerformDragSourceAction(DragSourceAction::Link, dragOrigin, dataTransfer);

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -31,6 +31,7 @@
 #include "TextAffinity.h"
 #include "TextChecking.h"
 #include "UndoStep.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -56,7 +57,7 @@ struct GapRects;
 struct GrammarDetail;
 struct SimpleRange;
 
-class EditorClient : public CanMakeWeakPtr<EditorClient> {
+class EditorClient : public CanMakeWeakPtr<EditorClient>, public CanMakeCheckedPtr {
 public:
     virtual ~EditorClient() = default;
 


### PR DESCRIPTION
#### 3b05ce368eccb0c5c42dbdeb17e541e6418fbef8
<pre>
Use more smart pointers in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=262200">https://bugs.webkit.org/show_bug.cgi?id=262200</a>

Reviewed by Brent Fulgham.

* Source/WebCore/dom/Position.cpp:
(WebCore::Position::protectedContainerText const):
* Source/WebCore/dom/Position.h:
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::startAlternativeTextUITimer):
(WebCore::AlternativeTextController::stopPendingCorrection):
(WebCore::AlternativeTextController::isSpellingMarkerAllowed const):
(WebCore::AlternativeTextController::show):
(WebCore::AlternativeTextController::dismiss):
(WebCore::AlternativeTextController::dismissSoon):
(WebCore::AlternativeTextController::applyAutocorrectionBeforeTypingIfAppropriate):
(WebCore::AlternativeTextController::respondToUnappliedSpellCorrection):
(WebCore::AlternativeTextController::timerFired):
(WebCore::AlternativeTextController::handleAlternativeTextUIResult):
(WebCore::AlternativeTextController::canEnableAutomaticSpellingCorrection const):
(WebCore::AlternativeTextController::rootViewRectForRange const):
(WebCore::AlternativeTextController::respondToChangedSelection):
(WebCore::AlternativeTextController::editorClient):
(WebCore::AlternativeTextController::textChecker):
(WebCore::AlternativeTextController::recordAutocorrectionResponse):
(WebCore::AlternativeTextController::recordSpellcheckerResponseForModifiedCorrection):
(WebCore::AlternativeTextController::processMarkersOnTextToBeReplacedByResult):
(WebCore::AlternativeTextController::respondToMarkerAtEndOfWord):
(WebCore::AlternativeTextController::alternativeTextClient):
(WebCore::AlternativeTextController::applyAlternativeTextToRange):
(WebCore::AlternativeTextController::removeCorrectionIndicatorMarkers):
(WebCore::AlternativeTextController::insertDictatedText):
(WebCore::AlternativeTextController::removeDictationAlternativesForMarker):
(WebCore::AlternativeTextController::dictationAlternativesForMarker):
(WebCore::AlternativeTextController::applyDictationAlternative):
* Source/WebCore/editing/AlternativeTextController.h:
(WebCore::AlternativeTextController::protectedDocument const):
* Source/WebCore/editing/AppendNodeCommand.cpp:
(WebCore::AppendNodeCommand::doApply):
(WebCore::AppendNodeCommand::doUnapply):
* Source/WebCore/editing/AppendNodeCommand.h:
(WebCore::AppendNodeCommand::protectedParent const):
(WebCore::AppendNodeCommand::protectedNode const):
* Source/WebCore/editing/ApplyBlockElementCommand.cpp:
(WebCore::ApplyBlockElementCommand::doApply):
(WebCore::ApplyBlockElementCommand::formatSelection):
(WebCore::isNewLineAtPosition):
(WebCore::ApplyBlockElementCommand::renderStyleOfEnclosingTextNode):
(WebCore::ApplyBlockElementCommand::rangeForParagraphSplittingTextNodesIfNeeded):
(WebCore::ApplyBlockElementCommand::endOfNextParagraphSplittingTextNodesIfNeeded):
(WebCore::ApplyBlockElementCommand::createBlockElement):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyBlockStyle):
(WebCore::ApplyStyleCommand::splitAncestorsWithUnicodeBidi):
(WebCore::ApplyStyleCommand::applyInlineStyle):
(WebCore::ApplyStyleCommand::applyInlineStyleToNodeRange):
(WebCore::ApplyStyleCommand::replaceWithSpanOrRemoveIfWithoutAttributes):
(WebCore::ApplyStyleCommand::highestAncestorWithConflictingInlineStyle):
(WebCore::ApplyStyleCommand::applyInlineStyleToPushDown):
(WebCore::ApplyStyleCommand::pushDownInlineStyleAroundNode):
(WebCore::ApplyStyleCommand::nodeFullySelected const):
(WebCore::ApplyStyleCommand::nodeFullyUnselected const):
(WebCore::ApplyStyleCommand::splitTextAtStart):
(WebCore::ApplyStyleCommand::splitTextAtEnd):
(WebCore::ApplyStyleCommand::splitTextElementAtStart):
(WebCore::ApplyStyleCommand::splitTextElementAtEnd):
(WebCore::ApplyStyleCommand::isValidCaretPositionInTextNode):
(WebCore::ApplyStyleCommand::mergeStartWithPreviousIfIdentical):
(WebCore::ApplyStyleCommand::mergeEndWithNextIfIdentical):
(WebCore::ApplyStyleCommand::joinChildTextNodes):
* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
(WebCore::BreakBlockquoteCommand::doApply):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::EditCommandComposition::unapply):
(WebCore::EditCommandComposition::reapply):
(WebCore::CompositeEditCommand::willApplyCommand):
(WebCore::CompositeEditCommand::didApplyCommand):
(WebCore::CompositeEditCommand::composition const):
(WebCore::CompositeEditCommand::ensureComposition):
(WebCore::CompositeEditCommand::isRemovableBlock):
(WebCore::CompositeEditCommand::replaceElementWithSpanPreservingChildrenAndAttributes):
(WebCore::CompositeEditCommand::textNodeForRebalance const):
(WebCore::CompositeEditCommand::prepareWhitespaceAtPositionForSplit):
(WebCore::CompositeEditCommand::replaceCollapsibleWhitespaceWithNonBreakingSpaceIfNeeded):
(WebCore::CompositeEditCommand::deleteInsignificantText):
(WebCore::CompositeEditCommand::addBlockPlaceholderIfNeeded):
(WebCore::CompositeEditCommand::removePlaceholderAt):
(WebCore::CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary):
(WebCore::CompositeEditCommand::cloneParagraphUnderNewElement):
(WebCore::CompositeEditCommand::cleanupAfterDeletion):
(WebCore::CompositeEditCommand::moveParagraphWithClones):
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/CompositeEditCommand.h:
(WebCore::EditCommandComposition::protectedDocument const):
* Source/WebCore/editing/CreateLinkCommand.cpp:
(WebCore::CreateLinkCommand::doApply):
* Source/WebCore/editing/CustomUndoStep.cpp:
(WebCore::CustomUndoStep::didRemoveFromUndoManager):
* Source/WebCore/editing/DeleteFromTextNodeCommand.cpp:
(WebCore::DeleteFromTextNodeCommand::doApply):
(WebCore::DeleteFromTextNodeCommand::doUnapply):
(WebCore::DeleteFromTextNodeCommand::getNodesInCommand):
(WebCore::DeleteFromTextNodeCommand::protectedNode const):
* Source/WebCore/editing/DeleteFromTextNodeCommand.h:
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::isSpecialHTMLElement):
(WebCore::positionBeforeContainingSpecialElement):
(WebCore::positionAfterContainingSpecialElement):
(WebCore::DeleteSelectionCommand::saveTypingStyleState):
(WebCore::DeleteSelectionCommand::insertBlockPlaceholderForTableCellIfNeeded):
(WebCore::DeleteSelectionCommand::removeNodeUpdatingStates):
(WebCore::DeleteSelectionCommand::removeNode):
(WebCore::DeleteSelectionCommand::handleGeneralDelete):
(WebCore::DeleteSelectionCommand::fixupWhitespace):
(WebCore::DeleteSelectionCommand::mergeParagraphs):
(WebCore::DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows):
(WebCore::DeleteSelectionCommand::calculateTypingStyleAfterDelete):
(WebCore::DeleteSelectionCommand::originalStringForAutocorrectionAtBeginningOfSelection):
(WebCore::DeleteSelectionCommand::doApply):
* Source/WebCore/editing/DeleteSelectionCommand.h:
(WebCore::DeleteSelectionCommand::protectedStartBlock const):
(WebCore::DeleteSelectionCommand::protectedEndBlock const):
(WebCore::DeleteSelectionCommand::protectedEndTableRow const):
* Source/WebCore/editing/DictationCommand.cpp:
(WebCore::DictationCommandLineOperation::DictationCommandLineOperation):
(WebCore::DictationCommandLineOperation::operator() const):
(WebCore::DictationMarkerSupplier::create):
(WebCore::DictationMarkerSupplier::DictationMarkerSupplier):
(WebCore::DictationCommand::insertText):
(WebCore::DictationCommand::doApply):
(WebCore::DictationCommand::insertTextRunWithoutNewlines):
* Source/WebCore/editing/DictationCommand.h:
* Source/WebCore/editing/EditCommand.cpp:
(WebCore::EditCommand::setParent):
(WebCore::EditCommand::postTextStateChangeNotification):
(WebCore::SimpleEditCommand::addNodeAndDescendants):
* Source/WebCore/editing/EditCommand.h:
* Source/WebCore/editing/Editing.cpp:
(WebCore::isEditablePosition):
(WebCore::isRichlyEditablePosition):
(WebCore::editableRootForPosition):
(WebCore::nextVisuallyDistinctCandidate):
(WebCore::previousVisuallyDistinctCandidate):
(WebCore::firstEditablePositionAfterPositionInRoot):
(WebCore::lastEditablePositionBeforePositionInRoot):
(WebCore::isFirstPositionAfterTable):
(WebCore::isLastPositionBeforeTable):
(WebCore::closestEditablePositionInElementForAbsolutePoint):
(WebCore::highestEnclosingNodeOfType):
(WebCore::hasARenderedDescendant):
(WebCore::highestNodeToRemoveInPruning):
(WebCore::enclosingAnchorElement):
(WebCore::enclosingList):
(WebCore::enclosingListChild):
(WebCore::enclosingEmptyListItem):
(WebCore::outermostEnclosingList):
(WebCore::canMergeLists):
(WebCore::nextNodeConsideringAtomicNodes):
(WebCore::isEmptyTableCell):
(WebCore::selectionForParagraphIteration):
(WebCore::indexForVisiblePosition):
(WebCore::localCaretRectInRendererForRect):
(WebCore::visibleImageElementsInRangeWithNonLoadedImages):
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::enclosingListChild):
(WebCore::InsertListCommand::selectionHasListOfType):
(WebCore::InsertListCommand::doApplyForSingleParagraph):
(WebCore::adjacentEnclosingList):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::deleteKeyPressed):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::adjustSelectionRespectingGranularity):
* Source/WebCore/page/AlternativeTextClient.h:
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::startDrag):
* Source/WebCore/page/EditorClient.h:

Canonical link: <a href="https://commits.webkit.org/268548@main">https://commits.webkit.org/268548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/254ec02d3ce7da2002166b8d5b1bfaef60259001

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21880 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18666 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20560 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22731 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24434 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22423 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18120 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4791 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->