### PR TITLE
[WGSL] Add type declarations for functions that operate on texture_storage

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -648,7 +648,6 @@ void FunctionDefinitionWriter::visit(const Type* type)
         },
         [&](const TextureStorage& texture) {
             const char* base;
-            const char* type;
             const char* mode;
             switch (texture.kind) {
             case Types::TextureStorage::Kind::TextureStorage1d:
@@ -658,35 +657,10 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 base = "texture2d";
                 break;
             case Types::TextureStorage::Kind::TextureStorage2dArray:
-                base = "texture2d_aray";
+                base = "texture2d_array";
                 break;
             case Types::TextureStorage::Kind::TextureStorage3d:
                 base = "texture3d";
-                break;
-            }
-            switch (texture.format) {
-            case TexelFormat::BGRA8unorm:
-            case TexelFormat::RGBA8unorm:
-            case TexelFormat::RGBA8snorm:
-            case TexelFormat::RGBA16float:
-            case TexelFormat::R32float:
-            case TexelFormat::RG32float:
-            case TexelFormat::RGBA32float:
-                type = "float";
-                break;
-            case TexelFormat::RGBA8uint:
-            case TexelFormat::RGBA16uint:
-            case TexelFormat::R32uint:
-            case TexelFormat::RG32uint:
-            case TexelFormat::RGBA32uint:
-                type = "uint";
-                break;
-            case TexelFormat::RGBA8sint:
-            case TexelFormat::RGBA16sint:
-            case TexelFormat::R32sint:
-            case TexelFormat::RG32sint:
-            case TexelFormat::RGBA32sint:
-                type = "int";
                 break;
             }
             switch (texture.access) {
@@ -700,7 +674,9 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 mode = "read_write";
                 break;
             }
-            m_stringBuilder.append(base, "<", type, ", access::", mode, ">");
+            m_stringBuilder.append(base, "<");
+            visit(shaderTypeForTexelFormat(texture.format, m_callGraph.ast().types()));
+            m_stringBuilder.append(", access::", mode, ">");
         },
         [&](const TextureDepth& texture) {
             const char* base;

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -43,6 +43,8 @@ struct TypeVariable {
 struct AbstractVector;
 struct AbstractMatrix;
 struct AbstractTexture;
+struct AbstractTextureStorage;
+struct AbstractChannelFormat;
 struct AbstractReference;
 struct AbstractPointer;
 struct AbstractArray;
@@ -51,6 +53,8 @@ using AbstractTypeImpl = std::variant<
     AbstractVector,
     AbstractMatrix,
     AbstractTexture,
+    AbstractTextureStorage,
+    AbstractChannelFormat,
     AbstractReference,
     AbstractPointer,
     AbstractArray,
@@ -73,6 +77,16 @@ struct AbstractMatrix {
 struct AbstractTexture {
     Types::Texture::Kind kind;
     AbstractType element;
+};
+
+struct AbstractTextureStorage {
+    Types::TextureStorage::Kind kind;
+    AbstractValue format;
+    AbstractValue access;
+};
+
+struct AbstractChannelFormat {
+    AbstractValue format;
 };
 
 struct AbstractReference {
@@ -126,4 +140,5 @@ void printInternal(PrintStream&, const WGSL::TypeVariable&);
 void printInternal(PrintStream&, const WGSL::AbstractType&);
 void printInternal(PrintStream&, const WGSL::OverloadCandidate&);
 void printInternal(PrintStream&, WGSL::Types::Texture::Kind);
+void printInternal(PrintStream&, WGSL::Types::TextureStorage::Kind);
 } // namespace WTF

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -581,7 +581,7 @@ operator :textureDimensions, {
     # T is texture_1d<ST> or texture_storage_1d<F,A>
     # @must_use fn textureDimensions(t: T) -> u32
     [S < Concrete32BitNumber].(texture_1d[S]) => u32,
-    # FIXME: add declarations for texture storage
+    [F, AM].(texture_storage_1d[F, AM]) => u32,
 
     # ST is i32, u32, or f32
     # T is texture_1d<ST>
@@ -604,7 +604,8 @@ operator :textureDimensions, {
     [].(texture_depth_cube) => vec2[u32],
     [].(texture_depth_cube_array) => vec2[u32],
     [].(texture_depth_multisampled_2d) => vec2[u32],
-    # FIXME: add declarations for texture storage
+    [F, AM].(texture_storage_2d[F, AM]) => vec2[u32],
+    [F, AM].(texture_storage_2d_array[F, AM]) => vec2[u32],
     [].(texture_external) => vec2[u32],
 
     # ST is i32, u32, or f32
@@ -626,7 +627,7 @@ operator :textureDimensions, {
     # T is texture_3d<ST> or texture_storage_3d<F,A>
     # @must_use fn textureDimensions(t: T) -> vec3<u32>
     [S < Concrete32BitNumber].(texture_3d[S]) => vec3[u32],
-    # FIXME: add declarations for texture storage
+    [F, AM].(texture_storage_3d[F, AM]) => vec3[u32],
 
     # ST is i32, u32, or f32
     # T is texture_3d<ST>
@@ -713,7 +714,7 @@ operator :textureNumLayers, {
     [S < Concrete32BitNumber].(texture_cube_array[S]) => u32,
     [].(texture_depth_2d_array) => u32,
     [].(texture_depth_cube_array) => u32,
-    # FIXME: add declarations for texture storage
+    [F, AM].(texture_storage_2d_array[F, AM]) => u32,
 }
 
 # 16.7.6
@@ -877,4 +878,29 @@ operator :textureSampleBaseClampToEdge, {
 }
 
 # 16.7.15 textureStore
-# FIXME: this only applies to texture_storage, implement
+operator :textureStore, {
+    # F is a texel format
+    # C is i32, or u32
+    # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
+    # fn textureStore(t: texture_storage_1d<F,write>, coords: C, value: vec4<CF>)
+    [F, T < ConcreteInteger].(texture_storage_1d[F, write], T, vec4[ChannelFormat[F]]) => void,
+
+    # F is a texel format
+    # C is i32, or u32
+    # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
+    # fn textureStore(t: texture_storage_2d<F,write>, coords: vec2<C>, value: vec4<CF>)
+    [F, T < ConcreteInteger].(texture_storage_2d[F, write], vec2[T], vec4[ChannelFormat[F]]) => void,
+
+    # F is a texel format
+    # C is i32, or u32
+    # A is i32, or u32
+    # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
+    # fn textureStore(t: texture_storage_2d_array<F,write>, coords: vec2<C>, array_index: A, value: vec4<CF>)
+    [F, T < ConcreteInteger, S < ConcreteInteger].(texture_storage_2d_array[F, write], vec2[T], S, vec4[ChannelFormat[F]]) => void,
+
+    # F is a texel format
+    # C is i32, or u32
+    # CF depends on the storage texel format F. See the texel format table for the mapping of texel format to channel format.
+    # fn textureStore(t: texture_storage_3d<F,write>, coords: vec3<C>, value: vec4<CF>)
+    [F, T < ConcreteInteger].(texture_storage_3d[F, write], vec3[T], vec4[ChannelFormat[F]]) => void,
+}

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -27,6 +27,7 @@
 #include "Types.h"
 
 #include "ASTStructure.h"
+#include "TypeStore.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/text/StringHash.h>
@@ -471,6 +472,32 @@ bool isPrimitiveReference(const Type* type, Primitive::Kind kind)
     if (!reference)
         return false;
     return isPrimitive(reference->element, kind);
+}
+
+const Type* shaderTypeForTexelFormat(TexelFormat format, const TypeStore& types)
+{
+    switch (format) {
+    case TexelFormat::BGRA8unorm:
+    case TexelFormat::RGBA8unorm:
+    case TexelFormat::RGBA8snorm:
+    case TexelFormat::RGBA16float:
+    case TexelFormat::R32float:
+    case TexelFormat::RG32float:
+    case TexelFormat::RGBA32float:
+        return types.f32Type();
+    case TexelFormat::RGBA8uint:
+    case TexelFormat::RGBA16uint:
+    case TexelFormat::R32uint:
+    case TexelFormat::RG32uint:
+    case TexelFormat::RGBA32uint:
+        return types.u32Type();
+    case TexelFormat::RGBA8sint:
+    case TexelFormat::RGBA16sint:
+    case TexelFormat::R32sint:
+    case TexelFormat::RG32sint:
+    case TexelFormat::RGBA32sint:
+        return types.i32Type();
+    }
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -34,6 +34,7 @@
 namespace WGSL {
 
 class TypeChecker;
+class TypeStore;
 struct Type;
 
 enum class AddressSpace : uint8_t {
@@ -232,6 +233,7 @@ ConversionRank conversionRank(const Type* from, const Type* to);
 
 bool isPrimitive(const Type*, Types::Primitive::Kind);
 bool isPrimitiveReference(const Type*, Types::Primitive::Kind);
+const Type* shaderTypeForTexelFormat(TexelFormat, const TypeStore&);
 
 } // namespace WGSL
 

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -344,6 +344,8 @@ module DSL
         Vector = AbstractType.new(:Vector)
         Matrix = AbstractType.new(:Matrix)
         Texture = AbstractType.new(:Texture)
+        TextureStorage = AbstractType.new(:TextureStorage)
+        ChannelFormat = AbstractType.new(:ChannelFormat)
 
         array = AbstractType.new(:Array)
         ptr = AbstractType.new(:Pointer)
@@ -358,20 +360,27 @@ module DSL
         TextureCube = Variable.new(:"Types::Texture::Kind::TextureCube", nil)
         TextureCubeArray = Variable.new(:"Types::Texture::Kind::TextureCubeArray", nil)
 
+        # texture storage kinds
+        TextureStorage1d = Variable.new(:"Types::TextureStorage::Kind::TextureStorage1d", nil)
+        TextureStorage2d = Variable.new(:"Types::TextureStorage::Kind::TextureStorage2d", nil)
+        TextureStorage2dArray = Variable.new(:"Types::TextureStorage::Kind::TextureStorage2dArray", nil)
+        TextureStorage3d = Variable.new(:"Types::TextureStorage::Kind::TextureStorage3d", nil)
+
         # Variables
         S = Variable.new(:S, @TypeVariable)
         T = Variable.new(:T, @TypeVariable)
         U = Variable.new(:U, @TypeVariable)
         V = Variable.new(:V, @TypeVariable)
+
         N = Variable.new(:N, @ValueVariable)
         C = Variable.new(:C, @ValueVariable)
         R = Variable.new(:R, @ValueVariable)
         K = Variable.new(:K, @ValueVariable)
         AS = Variable.new(:AS, @ValueVariable)
+        F = Variable.new(:F, @ValueVariable)
         AM = Variable.new(:AM, @ValueVariable)
 
         # constraints
-
         Number = Constraint.new(:Number)
         Integer = Constraint.new(:Integer)
         Float = Constraint.new(:Float)
@@ -383,6 +392,7 @@ module DSL
         SignedNumber = Constraint.new(:SignedNumber)
 
         # primitives
+        void = PrimitiveType.new(:Void)
         bool = PrimitiveType.new(:Bool)
         i32 = PrimitiveType.new(:I32)
         u32 = PrimitiveType.new(:U32)
@@ -401,11 +411,13 @@ module DSL
         storage = AbstractValue.new(:"AddressSpace::Storage")
         read = AbstractValue.new(:"AccessMode::Read")
         read_write = AbstractValue.new(:"AccessMode::ReadWrite")
+        write = AbstractValue.new(:"AccessMode::Write")
 
         # helpers
         vec = AggregateConstructor.new(Vector, [1, 1])
         mat = AggregateConstructor.new(Matrix, [2, 1])
         texture = AggregateConstructor.new(Texture, [1, 1])
+        texture_storage = AggregateConstructor.new(TextureStorage, [1, 2])
 
         vec2 = vec[2]
         vec3 = vec[3]
@@ -428,6 +440,11 @@ module DSL
         texture_3d = texture[Texture3d]
         texture_cube = texture[TextureCube]
         texture_cube_array = texture[TextureCubeArray]
+
+        texture_storage_1d = texture_storage[TextureStorage1d]
+        texture_storage_2d = texture_storage[TextureStorage2d]
+        texture_storage_2d_array = texture_storage[TextureStorage2dArray]
+        texture_storage_3d = texture_storage[TextureStorage3d]
         EOS
     end
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2047,10 +2047,10 @@ fn testTrunc()
 @group(0) @binding(16) var tc: texture_cube<f32>;
 @group(0) @binding(17) var tca: texture_cube_array<f32>;
 
-@group(0) @binding(18) var ts1d: texture_storage_2d<rgba8unorm, read>;
+@group(0) @binding(18) var ts1d: texture_storage_1d<rgba8unorm, write>;
 @group(0) @binding(19) var ts2d: texture_storage_2d<rgba16uint, write>;
-@group(0) @binding(20) var ts2da: texture_storage_2d<r32sint, read_write>;
-@group(0) @binding(21) var ts3d: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(20) var ts2da: texture_storage_2d_array<r32sint, write>;
+@group(0) @binding(21) var ts3d: texture_storage_3d<rgba32float, write>;
 @group(0) @binding(22) var te: texture_external;
 
 var td2d: texture_depth_2d;
@@ -2064,10 +2064,10 @@ var tdms2d: texture_depth_multisampled_2d;
 @compute @workgroup_size(1)
 fn testTextureDimensions()
 {
-    // FIXME: add declarations for texture storage
-
     // [S < Concrete32BitNumber].(Texture[S, Texture1d]) => U32,
     _ = textureDimensions(t1d);
+    // [F, AM].(texture_storage_1d[F, AM]) => u32,
+    _ = textureDimensions(ts1d);
 
     // [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture1d], T) => U32,
     _ = textureDimensions(t1d, 0);
@@ -2094,6 +2094,11 @@ fn testTextureDimensions()
     // [].(texture_depth_multisampled_2d) => Vector[U32, 2],
     _ = textureDimensions(tdms2d);
 
+    // [F, AM].(texture_storage_2d[F, AM]) => vec2[u32],
+    _ = textureDimensions(ts2d);
+    // [F, AM].(texture_storage_2d_array[F, AM]) => vec2[u32],
+    _ = textureDimensions(ts2da);
+
     // [].(TextureExternal) => Vector[U32, 2],
     _ = textureDimensions(te);
 
@@ -2116,6 +2121,8 @@ fn testTextureDimensions()
 
     // [S < Concrete32BitNumber].(Texture[S, Texture3d]) => Vector[U32, 3],
     _ = textureDimensions(t3d);
+    // [F, AM].(texture_storage_3d[F, AM]) => vec3[u32],
+    _ = textureDimensions(ts3d);
 
     // [S < Concrete32BitNumber, T < ConcreteInteger].(Texture[S, Texture3d], T) => Vector[U32, 3],
     _ = textureDimensions(t3d, 0);
@@ -2296,8 +2303,6 @@ fn testTextureLoad()
 // 16.7.5
 fn testTextureNumLayers()
 {
-    // FIXME: add declarations for texture storage
-
     // [S < Concrete32BitNumber].(Texture[S, Texture2dArray]) => U32,
     _ = textureNumLayers(t2da);
 
@@ -2309,6 +2314,9 @@ fn testTextureNumLayers()
 
     // [].(texture_depth_cube_array) => U32,
     _ = textureNumLayers(tdca);
+
+    // [F, AM].(texture_storage_2d_array[F, AM]) => u32,
+    _ = textureNumLayers(ts2da);
 }
 
 // 16.7.6
@@ -2526,5 +2534,18 @@ fn testTextureSampleBaseClampToEdge() {
     _ = textureSampleBaseClampToEdge(t2d, s, vec2f(0));
 }
 
-// 16.7.15 textureStore
-// FIXME: this only applies to texture_storage, implement
+// 16.7.15
+fn testTextureStore()
+{
+    // [F, T < ConcreteInteger].(texture_storage_1d[F, write], T, vec4[ChannelFormat[F]]) => void,
+    textureStore(ts1d, 0, vec4f(0));
+
+    // [F, T < ConcreteInteger].(texture_storage_2d[F, write], vec2[T], vec4[ChannelFormat[F]]) => void,
+    textureStore(ts2d, vec2(0), vec4u(0));
+
+    // [F, T < ConcreteInteger, S < ConcreteInteger].(texture_storage_2d_array[F, write], vec2[T], S, vec4[ChannelFormat[F]]) => void,
+    textureStore(ts2da, vec2(0), 0, vec4i(0));
+
+    // [F, T < ConcreteInteger].(texture_storage_3d[F, write], vec3[T], vec4[ChannelFormat[F]]) => void,
+    textureStore(ts3d, vec3(0), vec4f(0));
+}


### PR DESCRIPTION
#### 41370a1f61a5212398a31bc6d625b292fa342bb5
<pre>
[WGSL] Add type declarations for functions that operate on texture_storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=262202">https://bugs.webkit.org/show_bug.cgi?id=262202</a>
rdar://116133188

Reviewed by Mike Wyrzykowski.

When I added all the type declarations for the texture built-in functions, we didn&apos;t
support texture_storage yet. This patch adds support for texture storage in the
overload resolution and adds the missing declarations.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WTF::printInternal):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::shaderTypeForTexelFormat):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268572@main">https://commits.webkit.org/268572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/540460a73ca25a01fb826b38c0442c57cdcaa8de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21861 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18640 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20156 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22713 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17313 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24420 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22409 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18925 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16052 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18103 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4811 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->