### PR TITLE
[iOS] Cannot scroll page by dragging on a bare <video> element

### DIFF
--- a/LayoutTests/fast/scrolling/ios/video-scrolling-with-overflow-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/video-scrolling-with-overflow-expected.txt
@@ -1,0 +1,9 @@
+
+RUN(video.src = findMediaFile("video", "../../../media/content/test"))
+EVENT(canplay)
+RUN(video.play())
+Promise resolved OK
+Simulate drag on video element
+EVENT(scroll)
+END OF TEST
+

--- a/LayoutTests/fast/scrolling/ios/video-scrolling-with-overflow.html
+++ b/LayoutTests/fast/scrolling/ios/video-scrolling-with-overflow.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>video-scrolling-with-overflow</title>
+    <script src=../../../media/video-test.js></script>
+    <script src=../../../media/media-file.js></script>
+    <script src=../../../resources/basic-gestures.js></script>
+    <script>
+    async function runTest() {
+        findMediaElement();
+        run('video.src = findMediaFile("video", "../../../media/content/test")');
+        await waitFor(video, 'canplay');
+        await shouldResolve(run('video.play()'));
+
+        consoleWrite('Simulate drag on video element');
+
+        let middleX = video.offsetLeft + video.offsetWidth / 2;
+        let middleY = video.offsetTop + video.offsetHeight / 2;
+        await Promise.all([
+            touchAndDragFromPointToPoint(middleX, middleY, middleX, 0),
+            waitFor(scroller, 'scroll')
+        ]);
+        await liftUpAtPoint(middleX, 0);
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    })
+    </script>
+    <style>
+        html, body { height: 100vh; overflow: hidden; }
+        #spacer { width: 100vw; height: 120vh; }
+        #scroller { border: 1px solid green; height: 50vh; width: 100vw; overflow-y: scroll; }
+    </style>
+</head>
+<body>
+    <div id=scroller>
+        <video muted playsinline></video>
+        <div id=spacer></div>
+    </div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -731,6 +731,8 @@ RetainPtr<WKVideoView> VideoFullscreenManagerProxy::createViewWithID(PlaybackSes
         [playerLayer setFullscreenModel:model.get()];
         [playerLayer setVideoSublayer:[view layer]];
 
+        [playerView addSubview:view.get()];
+
         // The videoView may already be reparented in fullscreen, so only parent the view
         // if it has no existing parent:
         if (![[view layer] superlayer])

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -76,8 +76,9 @@ static void collectDescendantViewsAtPoint(Vector<UIView *, 16>& viewsAtPoint, UI
 
             if (![view isKindOfClass:[WKCompositingView class]])
                 return true;
-            auto* node = RemoteLayerTreeNode::forCALayer(view.layer);
-            return node->eventRegion().contains(WebCore::IntPoint(subviewPoint));
+            if (auto* node = RemoteLayerTreeNode::forCALayer(view.layer))
+                return node->eventRegion().contains(WebCore::IntPoint(subviewPoint));
+            return false;
         }();
 
         if (handlesEvent)


### PR DESCRIPTION
#### 7fa44a650d9a3604421d1c3807e48a0feaa85706
<pre>
[iOS] Cannot scroll page by dragging on a bare &lt;video&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=261563">https://bugs.webkit.org/show_bug.cgi?id=261563</a>
rdar://114720841

Reviewed by Eric Carlson.

Hit testing in the WebKit utility method isScrolledBy() works by walking up the view heirarchy looking for a view which return a valid node from RemoteLayerTreeNode::forCALayer(). However, while WKLayerHostView is a subview of WebAVPlayerLayerView, it&apos;s superview property is nil. This occurs because while the WKLayerHostView.layer is made a sublayer of the WebAVPlayerLayerView.playerLayer, the WKLayerHostView itself is not made a subview of the WebAVPlayerLayerView.

Drive-by fix: in testing this patch, a crash will occasionally occur where a null pointer is dereferenced in collectDescendantViewsAtPoint(). Add a null check and return false if that check fails.

* LayoutTests/fast/scrolling/ios/video-scrolling-with-overflow-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/video-scrolling-with-overflow.html: Added.
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenManagerProxy::createViewWithID):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(WebKit::collectDescendantViewsAtPoint):

Canonical link: <a href="https://commits.webkit.org/268566@main">https://commits.webkit.org/268566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82cb168e0a8a5607ac27d257d124dff343d7f27b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18722 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20653 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22805 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24482 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18404 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16116 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18064 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4806 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->