### PR TITLE
[WebGPU] Buffer dynamic offsets are not implemented (

### DIFF
--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -65,6 +65,8 @@ struct SourceMap {
 
 struct Configuration {
     uint32_t maxBuffersPlusVertexBuffersForVertexStage = 8;
+    uint32_t maxBuffersForFragmentStage = 8;
+    uint32_t maxBuffersForComputeStage = 8;
 };
 
 std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const std::optional<SourceMap>&, const Configuration&);
@@ -143,6 +145,9 @@ struct BindGroupLayoutEntry {
     OptionSet<ShaderStage> visibility;
     using BindingMember = std::variant<BufferBindingLayout, SamplerBindingLayout, TextureBindingLayout, StorageTextureBindingLayout, ExternalTextureBindingLayout>;
     BindingMember bindingMember;
+    std::optional<uint32_t> vertexBufferDynamicOffset;
+    std::optional<uint32_t> fragmentBufferDynamicOffset;
+    std::optional<uint32_t> computeBufferDynamicOffset;
 };
 
 struct BindGroupLayout {

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -27,6 +27,7 @@
 
 #import "CommandsMixin.h"
 #import <wtf/FastMalloc.h>
+#import <wtf/HashMap.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
@@ -80,6 +81,7 @@ private:
     bool validatePopDebugGroup() const;
 
     void makeInvalid();
+    void executePreDispatchCommands();
 
     id<MTLComputeCommandEncoder> m_computeCommandEncoder { nil };
 
@@ -92,6 +94,9 @@ private:
 
     const Ref<Device> m_device;
     MTLSize m_threadsPerThreadgroup;
+    Vector<uint32_t> m_computeDynamicOffsets;
+    const ComputePipeline* m_pipeline { nullptr };
+    HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ComputePipeline.h
+++ b/Source/WebGPU/WebGPU/ComputePipeline.h
@@ -67,6 +67,8 @@ public:
     Device& device() const { return m_device; }
     MTLSize threadsPerThreadgroup() const { return m_threadsPerThreadgroup; }
 
+    PipelineLayout& pipelineLayout() const;
+
 private:
     ComputePipeline(id<MTLComputePipelineState>, Ref<PipelineLayout>&&, MTLSize, Device&);
     ComputePipeline(Device&);

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -146,6 +146,11 @@ void ComputePipeline::setLabel(String&&)
     // MTLComputePipelineState's labels are read-only.
 }
 
+PipelineLayout& ComputePipeline::pipelineLayout() const
+{
+    return m_pipelineLayout;
+}
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -122,6 +122,8 @@ public:
     bool hasUnifiedMemory() const { return m_device.hasUnifiedMemory; }
 
     uint32_t maxBuffersPlusVertexBuffersForVertexStage() const;
+    uint32_t maxBuffersForFragmentStage() const;
+    uint32_t maxBuffersForComputeStage() const;
     uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex) const;
 
 private:

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -307,7 +307,18 @@ void Device::generateAnInternalError(String&& message)
 
 uint32_t Device::maxBuffersPlusVertexBuffersForVertexStage() const
 {
-    return m_capabilities.limits.maxBindGroupsPlusVertexBuffers;
+    ASSERT(m_capabilities.limits.maxBindGroupsPlusVertexBuffers > 0);
+    return m_capabilities.limits.maxBindGroupsPlusVertexBuffers - 1;
+}
+
+uint32_t Device::maxBuffersForFragmentStage() const
+{
+    return m_capabilities.limits.maxBindGroups;
+}
+
+uint32_t Device::maxBuffersForComputeStage() const
+{
+    return m_capabilities.limits.maxBindGroups;
 }
 
 uint32_t Device::vertexBufferIndexForBindGroup(uint32_t groupIndex) const

--- a/Source/WebGPU/WebGPU/PipelineLayout.h
+++ b/Source/WebGPU/WebGPU/PipelineLayout.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #import <wtf/FastMalloc.h>
+#import <wtf/HashMap.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
@@ -65,12 +66,34 @@ public:
 
     Device& device() const { return m_device; }
     void makeInvalid();
+    size_t sizeOfVertexDynamicOffsets() const;
+    size_t sizeOfFragmentDynamicOffsets() const;
+    size_t sizeOfComputeDynamicOffsets() const;
+
+    size_t vertexOffsetForBindGroup(uint32_t) const;
+    size_t fragmentOffsetForBindGroup(uint32_t) const;
+    size_t computeOffsetForBindGroup(uint32_t) const;
+
+    const Vector<uint32_t>* vertexOffsets(uint32_t, const Vector<uint32_t>&);
+    const Vector<uint32_t>* fragmentOffsets(uint32_t, const Vector<uint32_t>&);
+    const Vector<uint32_t>* computeOffsets(uint32_t, const Vector<uint32_t>&);
 
 private:
     PipelineLayout(std::optional<Vector<Ref<BindGroupLayout>>>&&, Device&);
     PipelineLayout(Device&);
 
     std::optional<Vector<Ref<BindGroupLayout>>> m_bindGroupLayouts;
+    using DynamicOffsetMap = HashMap<uint32_t, uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    DynamicOffsetMap m_vertexDynamicOffsets;
+    DynamicOffsetMap m_fragmentDynamicOffsets;
+    DynamicOffsetMap m_computeDynamicOffsets;
+
+    using DynamicOffsetBufferMap = HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    mutable DynamicOffsetBufferMap m_vertexOffsets;
+    mutable DynamicOffsetBufferMap m_fragmentOffsets;
+    mutable DynamicOffsetBufferMap m_computeOffsets;
+    const Vector<uint32_t>* offsetVectorForBindGroup(uint32_t bindGroupIndex, DynamicOffsetBufferMap& stageOffsets, const Vector<uint32_t>& dynamicOffsets, WGPUShaderStage);
+
 
     const Ref<Device> m_device;
     bool m_isValid { true };

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -52,10 +52,35 @@ Ref<PipelineLayout> Device::createPipelineLayout(const WGPUPipelineLayoutDescrip
     return PipelineLayout::create(WTFMove(optionalBindGroupLayouts), *this);
 }
 
-PipelineLayout::PipelineLayout(std::optional<Vector<Ref<BindGroupLayout>>>&& bindGroupLayouts, Device& device)
-    : m_bindGroupLayouts(WTFMove(bindGroupLayouts))
+static void addInitialOffset(uint32_t initialOffset, uint32_t offset, uint32_t groupIndex, auto& offsets, auto& dynamicOffets)
+{
+    if (initialOffset != offset) {
+        offsets.add(groupIndex, Vector<uint32_t>((offset - initialOffset) / sizeof(uint32_t)));
+        dynamicOffets.add(groupIndex, initialOffset);
+    }
+}
+
+PipelineLayout::PipelineLayout(std::optional<Vector<Ref<BindGroupLayout>>>&& optionalBindGroupLayouts, Device& device)
+    : m_bindGroupLayouts(WTFMove(optionalBindGroupLayouts))
     , m_device(device)
 {
+    if (!m_bindGroupLayouts)
+        return;
+
+    auto& bindGroupLayouts = *m_bindGroupLayouts;
+    auto bindGroupLayoutsSize = bindGroupLayouts.size();
+    uint32_t vertexOffset = 0, fragmentOffset = 0, computeOffset = 0;
+    for (size_t groupIndex = 0; groupIndex < bindGroupLayoutsSize; ++groupIndex) {
+        auto& bindGroupLayout = bindGroupLayouts[groupIndex];
+        uint32_t initialVertexOffset = vertexOffset, initialFragmentOffset = fragmentOffset, initialComputeOffset = computeOffset;
+        vertexOffset += bindGroupLayout->sizeOfVertexDynamicOffsets();
+        fragmentOffset += bindGroupLayout->sizeOfFragmentDynamicOffsets();
+        computeOffset += bindGroupLayout->sizeOfComputeDynamicOffsets();
+
+        addInitialOffset(initialVertexOffset, vertexOffset, groupIndex, m_vertexOffsets, m_vertexDynamicOffsets);
+        addInitialOffset(initialFragmentOffset, fragmentOffset, groupIndex, m_fragmentOffsets, m_fragmentDynamicOffsets);
+        addInitialOffset(initialComputeOffset, computeOffset, groupIndex, m_computeOffsets, m_computeDynamicOffsets);
+    }
 }
 
 PipelineLayout::PipelineLayout(Device& device)
@@ -89,6 +114,101 @@ void PipelineLayout::makeInvalid()
     m_isValid = false;
     if (m_bindGroupLayouts)
         m_bindGroupLayouts->clear();
+}
+
+static size_t returnTotalSize(auto& container)
+{
+    size_t totalSize = 0;
+    for (auto& v : container) {
+        ASSERT(v.value.size() < std::numeric_limits<uint32_t>::max());
+        totalSize += v.value.size();
+    }
+
+    return totalSize;
+}
+
+size_t PipelineLayout::sizeOfVertexDynamicOffsets() const
+{
+    return returnTotalSize(m_vertexOffsets);
+}
+
+size_t PipelineLayout::sizeOfFragmentDynamicOffsets() const
+{
+    return returnTotalSize(m_fragmentOffsets);
+}
+
+size_t PipelineLayout::sizeOfComputeDynamicOffsets() const
+{
+    return returnTotalSize(m_computeOffsets);
+}
+
+static size_t returnOffsetOfGroup0(auto& v, auto groupIndex)
+{
+    if (auto it = v.find(groupIndex); it != v.end())
+        return it->value;
+
+    return 0;
+}
+
+size_t PipelineLayout::vertexOffsetForBindGroup(uint32_t groupIndex) const
+{
+    return returnOffsetOfGroup0(m_vertexDynamicOffsets, groupIndex);
+}
+
+size_t PipelineLayout::fragmentOffsetForBindGroup(uint32_t groupIndex) const
+{
+    return returnOffsetOfGroup0(m_fragmentDynamicOffsets, groupIndex);
+}
+
+size_t PipelineLayout::computeOffsetForBindGroup(uint32_t groupIndex) const
+{
+    return returnOffsetOfGroup0(m_computeDynamicOffsets, groupIndex);
+}
+
+const Vector<uint32_t>* PipelineLayout::offsetVectorForBindGroup(uint32_t bindGroupIndex, PipelineLayout::DynamicOffsetBufferMap& stageOffsets, const Vector<uint32_t>& dynamicOffsets, WGPUShaderStage stage)
+{
+    if (!m_bindGroupLayouts)
+        return nullptr;
+
+    auto& bindGroupLayouts = *m_bindGroupLayouts;
+    if (auto it = stageOffsets.find(bindGroupIndex); it != stageOffsets.end()) {
+        auto& container = it->value;
+        uint32_t dynamicOffsetIndex = 0, stageOffsetIndex = 0;
+        auto& bindGroupLayout = bindGroupLayouts[bindGroupIndex];
+        for (auto& entryKvp : bindGroupLayout->entries()) {
+            auto& entry = entryKvp.value;
+            bool hasDynamicOffset = entry.vertexDynamicOffset || entry.fragmentDynamicOffset || entry.computeDynamicOffset;
+            if (!hasDynamicOffset)
+                continue;
+
+            if (entry.visibility & stage) {
+                ASSERT(container.size() > stageOffsetIndex && dynamicOffsets.size() > dynamicOffsetIndex);
+                container[stageOffsetIndex] = dynamicOffsets[dynamicOffsetIndex];
+                ++stageOffsetIndex;
+            }
+
+            ++dynamicOffsetIndex;
+        }
+
+        return &container;
+    }
+
+    return nullptr;
+}
+
+const Vector<uint32_t>* PipelineLayout::vertexOffsets(uint32_t bindGroupIndex, const Vector<uint32_t>& dynamicOffsets)
+{
+    return offsetVectorForBindGroup(bindGroupIndex, m_vertexOffsets, dynamicOffsets, WGPUShaderStage_Vertex);
+}
+
+const Vector<uint32_t>* PipelineLayout::fragmentOffsets(uint32_t bindGroupIndex, const Vector<uint32_t>& dynamicOffsets)
+{
+    return offsetVectorForBindGroup(bindGroupIndex, m_fragmentOffsets, dynamicOffsets, WGPUShaderStage_Fragment);
+}
+
+const Vector<uint32_t>* PipelineLayout::computeOffsets(uint32_t bindGroupIndex, const Vector<uint32_t>& dynamicOffsets)
+{
+    return offsetVectorForBindGroup(bindGroupIndex, m_computeOffsets, dynamicOffsets, WGPUShaderStage_Compute);
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -29,6 +29,7 @@
 #import "RenderBundle.h"
 #import <wtf/FastMalloc.h>
 #import <wtf/Function.h>
+#import <wtf/HashMap.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
@@ -107,10 +108,16 @@ private:
     struct BufferAndOffset {
         id<MTLBuffer> buffer { nil };
         uint64_t offset { 0 };
+        uint32_t dynamicOffsetCount { 0 };
+        const uint32_t* dynamicOffsets { nullptr };
     };
     Vector<BufferAndOffset> m_vertexBuffers;
     Vector<BufferAndOffset> m_fragmentBuffers;
     const Ref<Device> m_device;
+    Vector<uint32_t> m_vertexDynamicOffsets;
+    Vector<uint32_t> m_fragmentDynamicOffsets;
+    const RenderPipeline* m_pipeline { nullptr };
+    HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -27,6 +27,7 @@
 
 #import "CommandsMixin.h"
 #import <wtf/FastMalloc.h>
+#import <wtf/HashMap.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/Vector.h>
@@ -92,6 +93,7 @@ private:
     bool validatePopDebugGroup() const;
 
     void makeInvalid();
+    void executePreDrawCommands();
 
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };
 
@@ -111,6 +113,10 @@ private:
     NSUInteger m_visibilityResultBufferSize { 0 };
     bool m_depthReadOnly { false };
     bool m_stencilReadOnly { false };
+    Vector<uint32_t> m_vertexDynamicOffsets;
+    Vector<uint32_t> m_fragmentDynamicOffsets;
+    const RenderPipeline* m_pipeline { nullptr };
+    HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -70,6 +70,7 @@ public:
     MTLDepthClipMode depthClipMode() const { return m_clipMode; }
 
     Device& device() const { return m_device; }
+    PipelineLayout& pipelineLayout() const;
 
 private:
     RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthClipMode, MTLDepthStencilDescriptor *, Ref<PipelineLayout>&&, Device&);

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -746,6 +746,11 @@ bool RenderPipeline::validateDepthStencilState(bool depthReadOnly, bool stencilR
     return true;
 }
 
+PipelineLayout& RenderPipeline::pipelineLayout() const
+{
+    return m_pipelineLayout;
+}
+
 } // namespace WebGPU
 
 #pragma mark WGPU Stubs

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -114,7 +114,7 @@ Ref<ShaderModule> Device::createShaderModule(const WGPUShaderModuleDescriptor& d
     if (!shaderModuleParameters)
         return ShaderModule::createInvalid(*this);
 
-    auto checkResult = WGSL::staticCheck(fromAPI(shaderModuleParameters->wgsl.code), std::nullopt, { maxBuffersPlusVertexBuffersForVertexStage() });
+    auto checkResult = WGSL::staticCheck(fromAPI(shaderModuleParameters->wgsl.code), std::nullopt, { maxBuffersPlusVertexBuffersForVertexStage(), maxBuffersForFragmentStage(), maxBuffersForComputeStage() });
 
     if (std::holds_alternative<WGSL::SuccessfulCheck>(checkResult)) {
         if (shaderModuleParameters->hints && descriptor.hintCount) {
@@ -363,9 +363,12 @@ WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& p
         WGSL::BindGroupLayout wgslBindGroupLayout;
         for (auto& entry : bindGroupLayout.entries()) {
             WGSL::BindGroupLayoutEntry wgslEntry;
-            wgslEntry.binding = entry.binding;
-            wgslEntry.visibility.fromRaw(entry.visibility);
-            wgslEntry.bindingMember = convertBindingLayout(entry.bindingLayout);
+            wgslEntry.binding = entry.value.binding;
+            wgslEntry.visibility.fromRaw(entry.value.visibility);
+            wgslEntry.bindingMember = convertBindingLayout(entry.value.bindingLayout);
+            wgslEntry.vertexBufferDynamicOffset = entry.value.vertexDynamicOffset;
+            wgslEntry.fragmentBufferDynamicOffset = entry.value.fragmentDynamicOffset;
+            wgslEntry.computeBufferDynamicOffset = entry.value.computeDynamicOffset;
             wgslBindGroupLayout.entries.append(wgslEntry);
         }
 


### PR DESCRIPTION
#### c82031ffbbcbcc0b383b95d87c0fe0c6aa5e3fb4
<pre>
[WebGPU] Buffer dynamic offsets are not implemented (
<a href="https://bugs.webkit.org/show_bug.cgi?id=262067">https://bugs.webkit.org/show_bug.cgi?id=262067</a>
&lt;radar://116013294&gt;

Reviewed by Tadeu Zagallo.

Encode the dynamic offsets which are needed by the bind group layout
and pass it to the WGSL::BindGroupLayout.

* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU/BindGroupLayout.h:
(WebGPU::BindGroupLayout::create):
(WebGPU::BindGroupLayout::entries const):
Add optional dynamic offsets.

* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::createArgumentDescriptor):
(WebGPU::Device::createBindGroupLayout):
(WebGPU::BindGroupLayout::BindGroupLayout):
(WebGPU::BindGroupLayout::sizeOfVertexDynamicOffsets const):
(WebGPU::BindGroupLayout::sizeOfFragmentDynamicOffsets const):
(WebGPU::BindGroupLayout::sizeOfComputeDynamicOffsets const):
Compute space for the dynamic offsets.

* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
(WebGPU::ComputePassEncoder::dispatch):
(WebGPU::ComputePassEncoder::dispatchIndirect):
(WebGPU::ComputePassEncoder::setBindGroup):
(WebGPU::ComputePassEncoder::setPipeline):
Set the side buffer prior to executing any draw commands.

* Source/WebGPU/WebGPU/ComputePipeline.h:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::ComputePipeline::pipelineLayout const):
Allow access to the pipeline layout.

* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::maxBuffersPlusVertexBuffersForVertexStage const):
(WebGPU::Device::maxBuffersForFragmentStage const):
(WebGPU::Device::maxBuffersForComputeStage const):
Encode the side buffer offsets in the last available buffer.

* Source/WebGPU/WebGPU/PipelineLayout.h:
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::Device::createPipelineLayout):
(WebGPU::addInitialOffset):
(WebGPU::PipelineLayout::PipelineLayout):
(WebGPU::returnTotalSize):
(WebGPU::PipelineLayout::sizeOfVertexDynamicOffsets const):
(WebGPU::PipelineLayout::sizeOfFragmentDynamicOffsets const):
(WebGPU::PipelineLayout::sizeOfComputeDynamicOffsets const):
(WebGPU::returnOffsetOfGroup0):
(WebGPU::PipelineLayout::vertexOffsetForBindGroup const):
(WebGPU::PipelineLayout::fragmentOffsetForBindGroup const):
(WebGPU::PipelineLayout::computeOffsetForBindGroup const):
(WebGPU::PipelineLayout::offsetVectorForBindGroup):
(WebGPU::PipelineLayout::vertexOffsets):
(WebGPU::PipelineLayout::fragmentOffsets):
(WebGPU::PipelineLayout::computeOffsets):
Add member functions for populating the dynamic offsets specified by setBindGroup

* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::setBindGroup):
(WebGPU::RenderBundleEncoder::setPipeline):
To be implemented in <a href="https://bugs.webkit.org/show_bug.cgi?id=262208">https://bugs.webkit.org/show_bug.cgi?id=262208</a>

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::draw):
(WebGPU::RenderPassEncoder::drawIndexed):
(WebGPU::RenderPassEncoder::drawIndexedIndirect):
(WebGPU::RenderPassEncoder::drawIndirect):
(WebGPU::RenderPassEncoder::setBindGroup):
(WebGPU::RenderPassEncoder::setPipeline):
Same as ComputePassEncoder.

* Source/WebGPU/WebGPU/RenderPipeline.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::pipelineLayout const):
Allow access to the pipeline layout.

* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::Device::createShaderModule):
(WebGPU::ShaderModule::convertPipelineLayout):
Pass the dynamic offsets to WGSL.

Canonical link: <a href="https://commits.webkit.org/268689@main">https://commits.webkit.org/268689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fed113b6dbdfff0e195b422be1b9c8de1d20669e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18862 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20314 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22962 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17504 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24637 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22608 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16243 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18335 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4896 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->