### PR TITLE
Fix build issue

### DIFF
--- a/Source/WebKit/Configurations/GPUExtension.xcconfig
+++ b/Source/WebKit/Configurations/GPUExtension.xcconfig
@@ -26,3 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = GPUExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.GPUExtension;
+PRODUCT_BUNDLE_EXECUTABLE = GPUExtension;
+PRODUCT_BUNDLE_NAME = GPUExtension;
+PRODUCT_BUNDLE_VERSION = 1.0;

--- a/Source/WebKit/Configurations/NetworkingExtension.xcconfig
+++ b/Source/WebKit/Configurations/NetworkingExtension.xcconfig
@@ -26,3 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = NetworkingExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.NetworkingExtension;
+PRODUCT_BUNDLE_EXECUTABLE = NetworkingExtension;
+PRODUCT_BUNDLE_NAME = NetworkingExtension;
+PRODUCT_BUNDLE_VERSION = 1.0;

--- a/Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig
@@ -26,3 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = WebContentCaptivePortalExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContentExtension.CaptivePortal;
+PRODUCT_BUNDLE_EXECUTABLE = WebContentCaptivePortalExtension;
+PRODUCT_BUNDLE_NAME = WebContentCaptivePortalExtension;
+PRODUCT_BUNDLE_VERSION = 1.0;

--- a/Source/WebKit/Configurations/WebContentCrashyExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentCrashyExtension.xcconfig
@@ -26,3 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/WebContentExtension-Crashy-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = WebContentCrashyExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContentExtension.Crashy;
+PRODUCT_BUNDLE_EXECUTABLE = WebContentCrashyExtension;
+PRODUCT_BUNDLE_NAME = WebContentCrashyExtension;
+PRODUCT_BUNDLE_VERSION = 1.0;

--- a/Source/WebKit/Configurations/WebContentExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentExtension.xcconfig
@@ -26,3 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = WebContentExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContentExtension;
+PRODUCT_BUNDLE_EXECUTABLE = WebContentExtension;
+PRODUCT_BUNDLE_NAME = WebContentExtension;
+PRODUCT_BUNDLE_VERSION = 1.0;

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist
@@ -7,5 +7,13 @@
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.webkit.gpu.extension</string>
 	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleExecutable</key>
+	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<key>CFBundleVersion</key>
+	<string>${PRODUCT_BUNDLE_VERSION}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
@@ -6,6 +6,14 @@
 	<dict>
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.webkit.networking.extension</string>
+		<key>CFBundleIdentifier</key>
+		<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+		<key>CFBundleExecutable</key>
+		<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+		<key>CFBundleVersion</key>
+		<string>${PRODUCT_BUNDLE_VERSION}</string>
+		<key>CFBundleName</key>
+		<string>${PRODUCT_BUNDLE_NAME}</string>
 	</dict>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist
@@ -7,5 +7,13 @@
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.webkit.webcontent.captiveportal.extension</string>
 	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleExecutable</key>
+	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<key>CFBundleVersion</key>
+	<string>${PRODUCT_BUNDLE_VERSION}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Crashy-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Crashy-Info.plist
@@ -7,5 +7,13 @@
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.webkit.webcontent.crashy.extension</string>
 	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleExecutable</key>
+	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<key>CFBundleVersion</key>
+	<string>${PRODUCT_BUNDLE_VERSION}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
 </dict>
 </plist>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist
@@ -7,5 +7,13 @@
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.webkit.webcontent.extension</string>
 	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleExecutable</key>
+	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<key>CFBundleVersion</key>
+	<string>${PRODUCT_BUNDLE_VERSION}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
 </dict>
 </plist>


### PR DESCRIPTION
#### 9b6ffb3ba3c6614fb40d71e1df10859d4fa3cc8c
<pre>
Fix build issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=262217">https://bugs.webkit.org/show_bug.cgi?id=262217</a>
rdar://116140701

Reviewed by Brent Fulgham.

Fix build issue related to WebKit extensions. Add required items to Info.plist.

* Source/WebKit/Configurations/GPUExtension.xcconfig:
* Source/WebKit/Configurations/NetworkingExtension.xcconfig:
* Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig:
* Source/WebKit/Configurations/WebContentCrashyExtension.xcconfig:
* Source/WebKit/Configurations/WebContentExtension.xcconfig:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Crashy-Info.plist:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist:

Canonical link: <a href="https://commits.webkit.org/268544@main">https://commits.webkit.org/268544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e0c8d925e349aaf64b30ce720f79783ba126280

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21900 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20581 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22752 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17334 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18411 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22439 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18955 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18138 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4785 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22488 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->