### PR TITLE
Remove RefPtr::releaseConstNonNull

### DIFF
--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -77,7 +77,6 @@ public:
     T* get() const { return PtrTraits::unwrap(m_ptr); }
 
     Ref<T> releaseNonNull() { ASSERT(m_ptr); Ref<T> tmp(adoptRef(*m_ptr)); m_ptr = nullptr; return tmp; }
-    Ref<const T> releaseConstNonNull() { ASSERT(m_ptr); Ref<const T> tmp(adoptRef(*m_ptr)); m_ptr = nullptr; return tmp; }
 
     T* leakRef() WARN_UNUSED_RETURN;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/RefLogger.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefLogger.cpp
@@ -33,12 +33,12 @@ RefLogger::RefLogger(const char* name)
 {
 }
 
-void RefLogger::ref()
+void RefLogger::ref() const
 {
     log() << "ref(" << &name << ") ";
 }
 
-void RefLogger::deref()
+void RefLogger::deref() const
 {
     log() << "deref(" << &name << ") ";
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/RefLogger.h
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefLogger.h
@@ -31,8 +31,8 @@ namespace TestWebKitAPI {
 
 struct RefLogger {
     RefLogger(const char* name);
-    void ref();
-    void deref();
+    void ref() const;
+    void deref() const;
     const char& name;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
@@ -322,7 +322,14 @@ TEST(WTF_RefPtr, ReleaseNonNull)
 
     {
         RefPtr<RefLogger> refPtr = &a;
-        RefPtr<RefLogger> ref = refPtr.releaseNonNull();
+        Ref<RefLogger> ref = refPtr.releaseNonNull();
+    }
+
+    EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
+
+    {
+        RefPtr<RefLogger> refPtr = &a;
+        Ref<const RefLogger> ref = refPtr.releaseNonNull();
     }
 
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());


### PR DESCRIPTION
#### b08052889f6e17a4ec33cbe934dbecdc1db4baf5
<pre>
Remove RefPtr::releaseConstNonNull
<a href="https://bugs.webkit.org/show_bug.cgi?id=262226">https://bugs.webkit.org/show_bug.cgi?id=262226</a>
rdar://116146895

Reviewed by Dan Glastonbury.

There are no users of releaseConstNonNull anymore. We can use Ref&apos;s
templated move constructor to move from releaseNonNull&apos;s Ref&lt;T&gt; to a
Ref&lt;const T&gt; which is the current pattern used by clients.

Adds a test to verify Ref&lt;const T&gt; can be constructed from
RefPtr&lt;T&gt;::releaseNonNull.

* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::releaseNonNull):
(WTF::RefPtr::releaseConstNonNull): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/RefLogger.cpp:
(TestWebKitAPI::RefLogger::ref const):
(TestWebKitAPI::RefLogger::deref const):
(TestWebKitAPI::RefLogger::ref): Deleted.
(TestWebKitAPI::RefLogger::deref): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/RefLogger.h:
* Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268558@main">https://commits.webkit.org/268558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa2cf31d874f8418755f606ad1ed5efce80402d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20591 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22761 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24459 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17409 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22448 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19381 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18964 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16087 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23418 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18147 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22497 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24674 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18789 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5460 "Passed tests") | 
<!--EWS-Status-Bubble-End-->