### PR TITLE
[JSC] Shouldn't use the fast path of copying indexed properties if saw indexed GetterSetter properties

### DIFF
--- a/JSTests/stress/object-assign-with-indexed-getter-setter-properties.js
+++ b/JSTests/stress/object-assign-with-indexed-getter-setter-properties.js
@@ -1,0 +1,152 @@
+
+function shouldBe(actual, expected) {
+    if (String(actual) !== String(expected))
+        throw new Error(`bad value: ${String(actual)}, expected ${String(expected)}`);
+}
+
+{
+    let getSum = 0;
+    let obj = {
+        p1: "p1"
+    };
+    let obj1 = Object.assign({}, obj);
+    let expected = "p1";
+    shouldBe(Object.values(obj), expected);
+    shouldBe(Object.values(obj1), expected);
+    shouldBe(getSum, 0);
+}
+
+{
+    let getSum = 0;
+    let obj = {
+        get 1() {
+            getSum += 1;
+            return 1;
+        },
+        set 2(value) {
+            return 2;
+        },
+    };
+    let obj1 = Object.assign({}, obj);      // get 1
+    let expected = [1, undefined];
+    shouldBe(Object.values(obj), expected); // get 1
+    shouldBe(Object.values(obj1), expected);
+    shouldBe(getSum, 2);
+}
+
+{
+    let getSum = 0;
+    let obj = {
+        get 5000() {
+            getSum += 5000;
+            return 5000;
+        },
+        set 6000(value) {
+            return 6000;
+        },
+    };
+    let obj1 = Object.assign({}, obj);      // get 5000
+    let expected = [5000, undefined];
+    shouldBe(Object.values(obj), expected); // get 5000
+    shouldBe(Object.values(obj1), expected);
+    shouldBe(getSum, 10000);
+}
+
+{
+    let getSum = 0;
+    let obj = {};
+    Object.defineProperty(obj, "a", {
+        value: 'a',
+        enumerable: true,
+    });
+    Object.defineProperty(obj, 3, {
+        value: '3',
+        enumerable: false,
+    });
+
+    let obj1 = Object.assign({}, obj);
+    let expected = 'a';
+    shouldBe(Object.values(obj), expected);
+    shouldBe(Object.values(obj1), expected);
+    shouldBe(getSum, 0);
+}
+
+{
+    let getSum = 0;
+    let obj = {};
+    Object.defineProperty(obj, 4, {
+        get: function () {
+            getSum += 4;
+            return 4;
+        }
+    });
+    Object.defineProperty(obj, 5, {
+        set: function (value) {
+            return 5;
+        },
+        enumerable: true,
+    });
+    Object.defineProperty(obj, 6, {
+        get: function () {
+            getSum += 6;
+            return 6;
+        },
+        enumerable: true,
+    });
+
+    let obj1 = Object.assign({}, obj);      // get 6
+    let expected = [undefined, 6];
+    shouldBe(Object.values(obj), expected); // get 6
+    shouldBe(Object.values(obj1), expected);
+    shouldBe(getSum, 12);
+}
+
+{
+    let getSum = 0;
+    let obj = {};
+    Object.defineProperty(obj, 1000, {
+        value: 1000,
+        writable: false,
+        enumerable: true,
+    });
+    Object.defineProperty(obj, 2000, {
+        value: 2000,
+        enumerable: false,
+    });
+
+    let obj1 = Object.assign({}, obj);
+    let expected = [1000];
+    shouldBe(Object.values(obj), expected);
+    shouldBe(Object.values(obj1), expected);
+    shouldBe(getSum, 0);
+}
+
+{
+    let getSum = 0;
+    let obj = {};
+    Object.defineProperty(obj, 3000, {
+        get: function () {
+            getSum += 3000;
+            return 3000;
+        }
+    });
+    Object.defineProperty(obj, 4000, {
+        set: function (value) {
+            return 4000;
+        },
+        enumerable: true,
+    });
+    Object.defineProperty(obj, 5000, {
+        get: function () {
+            getSum += 5000;
+            return 5000;
+        },
+        enumerable: true,
+    });
+
+    let obj1 = Object.assign({}, obj);      // get 5000
+    let expected = [undefined, 5000];
+    shouldBe(Object.values(obj), expected); // get 5000
+    shouldBe(Object.values(obj1), expected);
+    shouldBe(getSum, 10000);
+}

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2816,7 +2816,7 @@ static bool putIndexedDescriptor(JSGlobalObject* globalObject, SparseArrayValueM
         else if (oldDescriptor.isAccessorDescriptor())
             entryInMap->forceSet(vm, map, jsUndefined(), attributes);
         else
-            entryInMap->forceSet(attributes);
+            entryInMap->forceSet(map, attributes);
         return true;
     }
 
@@ -2838,7 +2838,7 @@ static bool putIndexedDescriptor(JSGlobalObject* globalObject, SparseArrayValueM
     }
 
     ASSERT(descriptor.isGenericDescriptor());
-    entryInMap->forceSet(descriptor.attributesOverridingCurrent(oldDescriptor));
+    entryInMap->forceSet(map, descriptor.attributesOverridingCurrent(oldDescriptor));
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -168,7 +168,7 @@ public:
     bool noSideEffectMayHaveNonIndexProperty(VM&, PropertyName);
 
     template<typename Functor>
-    void forEachIndexedProperty(JSGlobalObject*, const Functor&);
+    void forEachOwnIndexedProperty(JSGlobalObject*, const Functor&);
 
 private:
     static bool getOwnPropertySlotImpl(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
@@ -206,6 +206,29 @@ public:
         return m_butterfly->vectorLength();
     }
     
+    bool canHaveExistingOwnIndexedGetterSetterProperties()
+    {
+        if (!hasIndexedProperties(indexingType()))
+            return false;
+
+        switch (indexingType()) {
+        case ALL_BLANK_INDEXING_TYPES:
+        case ALL_UNDECIDED_INDEXING_TYPES:
+        case ALL_INT32_INDEXING_TYPES:
+        case ALL_CONTIGUOUS_INDEXING_TYPES:
+        case ALL_DOUBLE_INDEXING_TYPES:
+            return false;
+        case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
+            SparseArrayValueMap* map = m_butterfly->arrayStorage()->m_sparseMap.get();
+            if (!map)
+                return false;
+            return map->hasAnyKindOfGetterSetterProperties();
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }
+
     // This is only valid after using canPerformFastPropertyEnumerationCommon().
     // This code is not checking getOwnPropertySlot override etc.
     unsigned canHaveExistingOwnIndexedProperties() const

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -55,7 +55,7 @@ ALWAYS_INLINE void objectAssignIndexedPropertiesFast(JSGlobalObject* globalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    source->forEachIndexedProperty(globalObject, [&](unsigned index, JSValue value) {
+    source->forEachOwnIndexedProperty(globalObject, [&](unsigned index, JSValue value) {
         target->putDirectIndex(globalObject, index, value);
         RETURN_IF_EXCEPTION(scope, IterationStatus::Done);
         return IterationStatus::Continue;
@@ -83,6 +83,9 @@ ALWAYS_INLINE bool objectAssignFast(JSGlobalObject* globalObject, JSObject* targ
     auto scope = DECLARE_THROW_SCOPE(vm);
     properties.resize(0);
     values.clear();
+
+    if (source->canHaveExistingOwnIndexedGetterSetterProperties())
+        return false;
     bool canUseFastPath = source->fastForEachPropertyWithSideEffectFreeFunctor(vm, [&](const PropertyTableEntry& entry) -> bool {
         if (entry.attributes() & PropertyAttribute::DontEnum)
             return true;

--- a/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
+++ b/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
@@ -205,6 +205,11 @@ JSValue SparseArrayEntry::getNonSparseMode() const
     return Base::get();
 }
 
+JSValue SparseArrayEntry::get() const
+{
+    return Base::get();
+}
+
 template<typename Visitor>
 void SparseArrayValueMap::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {


### PR DESCRIPTION
#### ecb799021d899bd16a98c35ef40279b4f8ee3596
<pre>
[JSC] Shouldn&apos;t use the fast path of copying indexed properties if saw indexed GetterSetter properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=262228">https://bugs.webkit.org/show_bug.cgi?id=262228</a>
rdar://115790723

Reviewed by Yusuke Suzuki.

Previously, we introduced a fast path for `Object.assign` by copying
indexed properties directly (<a href="https://commits.webkit.org/267797@main).">https://commits.webkit.org/267797@main).</a>
This is wrong since indexed properties may contain getter or setter
properties which have side effects. So, we should avoid to use the
fast path of copying indexed properties when saw any indexed getter
or setter property.

* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::putIndexedDescriptor):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::canHaveExistingOwnIndexedGetterSetterProperties):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::forEachOwnIndexedProperty):
(JSC::JSObject::forEachIndexedProperty): Deleted.
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignIndexedPropertiesFast):
(JSC::objectAssignFast):
* Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp:
(JSC::SparseArrayEntry::get const):
* Source/JavaScriptCore/runtime/SparseArrayValueMap.h:
(JSC::SparseArrayEntry::SparseArrayEntry):
(JSC::SparseArrayEntry::attributes const):
(JSC::SparseArrayEntry::forceSet):
(JSC::SparseArrayEntry::asValue):

Canonical link: <a href="https://commits.webkit.org/268567@main">https://commits.webkit.org/268567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e296daa2e05b1fb619873a8662aed0b1a7c4498

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22770 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24461 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17414 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22450 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19387 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16091 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23428 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18153 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4808 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22512 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24684 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18794 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5461 "Passed tests") | 
<!--EWS-Status-Bubble-End-->