### PR TITLE
[CSS Fonts] getComputedStyle() should return a resolved value for font-size-adjust:from-font

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-computed-expected.txt
@@ -7,10 +7,10 @@ PASS Property font-size-adjust value 'cap-height 0.8'
 PASS Property font-size-adjust value 'ch-width 0.4'
 PASS Property font-size-adjust value 'ic-width 0.9'
 PASS Property font-size-adjust value 'ic-height 1.1'
-FAIL Property font-size-adjust value 'from-font' assert_equals: expected "0.5" but got "from-font"
-FAIL Property font-size-adjust value 'ex-height from-font' assert_equals: expected "0.5" but got "from-font"
-FAIL Property font-size-adjust value 'cap-height from-font' assert_equals: expected "cap-height 0.5" but got "cap-height from-font"
-FAIL Property font-size-adjust value 'ch-width from-font' assert_equals: expected "ch-width 1" but got "ch-width from-font"
-FAIL Property font-size-adjust value 'ic-width from-font' assert_equals: expected "ic-width 1" but got "ic-width from-font"
-FAIL Property font-size-adjust value 'ic-height from-font' assert_equals: expected "ic-height 1" but got "ic-height from-font"
+PASS Property font-size-adjust value 'from-font'
+PASS Property font-size-adjust value 'ex-height from-font'
+PASS Property font-size-adjust value 'cap-height from-font'
+PASS Property font-size-adjust value 'ch-width from-font'
+PASS Property font-size-adjust value 'ic-width from-font'
+PASS Property font-size-adjust value 'ic-height from-font'
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -362,11 +362,11 @@ static Ref<CSSValue> fontSizeAdjustFromStyle(const RenderStyle& style)
         return CSSPrimitiveValue::create(CSSValueNone);
 
     auto metric = fontSizeAdjust.metric;
-    float value = *fontSizeAdjust.value;
+    auto value = fontSizeAdjust.isFromFont ? fontSizeAdjust.resolve(style.computedFontSize(), style.metricsOfPrimaryFont()) : fontSizeAdjust.value.asOptional();
     if (metric == FontSizeAdjust::Metric::ExHeight)
-        return fontSizeAdjust.isFromFont ? CSSPrimitiveValue::create(CSSValueFromFont) : CSSPrimitiveValue::create(value);
+        return CSSPrimitiveValue::create(*value);
 
-    return CSSValuePair::create(createConvertingToCSSValueID(metric), fontSizeAdjust.isFromFont ? CSSPrimitiveValue::create(CSSValueFromFont) : CSSPrimitiveValue::create(value));
+    return CSSValuePair::create(createConvertingToCSSValueID(metric), CSSPrimitiveValue::create(*value));
 }
 
 static Ref<CSSPrimitiveValue> textSpacingTrimFromStyle(const RenderStyle& style)


### PR DESCRIPTION
#### 00b96b0c358272590abe1075865af8e706b213c1
<pre>
[CSS Fonts] getComputedStyle() should return a resolved value for font-size-adjust:from-font
<a href="https://bugs.webkit.org/show_bug.cgi?id=262147">https://bugs.webkit.org/show_bug.cgi?id=262147</a>

Reviewed by Tim Nguyen.

We returned the from-font identifier for font-size-adjust as a computed style
value. But it was an incorrect behavior. This change makes getComputedStyle()
return an actual numeric value of the from-font for font-size-adjust instead.

Test: imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-computed.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-size-adjust-computed-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontSizeAdjustFromStyle):

Canonical link: <a href="https://commits.webkit.org/269084@main">https://commits.webkit.org/269084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1821294b43bfc8cfb4406e540c462cdac348eb6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20190 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22780 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22455 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16094 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18166 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5148 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->