### PR TITLE
[visionOS] Sign in with Apple window not anchored to the host app

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -232,6 +232,10 @@ struct UIEdgeInsets;
 - (void)_webView:(WKWebView *)webview mouseDidMoveOverElement:(_WKHitTestResult *)hitTestResult withFlags:(UIKeyModifierFlags)flags userInfo:(id <NSSecureCoding>)userInfo WK_API_AVAILABLE(ios(16.0));
 #endif
 
+#if TARGET_OS_VISION
+- (NSString *)_hostSceneIdentifierForWebView:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
+#endif
+
 - (BOOL)_webView:(WKWebView *)webView showCustomSheetForElement:(_WKActivatedElementInfo *)element WK_API_DEPRECATED_WITH_REPLACEMENT("_webView:contextMenuConfigurationForElement:completionHandler:", ios(10.0, 13.0));
 - (void)_webView:(WKWebView *)webView alternateActionForURL:(NSURL *)url WK_API_AVAILABLE(ios(10.0));
 - (NSArray *)_attachmentListForWebView:(WKWebView *)webView WK_API_AVAILABLE(ios(10.0));


### PR DESCRIPTION
#### c1aa715d6bc4bb5b18d29754e44809c98f0a82e0
<pre>
[visionOS] Sign in with Apple window not anchored to the host app
<a href="https://bugs.webkit.org/show_bug.cgi?id=262230">https://bugs.webkit.org/show_bug.cgi?id=262230</a>
rdar://116142970

Reviewed by NOBODY (OOPS!).

When the Sign in with Apple window is presented, AuthKit looks for a scene ID
to anchor the window to first, and uses the bundle identifier as a fallback to
grab an appropriate window to anchor to.

When an app uses an ASWebAuthenticationSession to handle the login flow, it uses
SVS to present an SFAuthenticationViewController. In this case, AuthKit
receives the wrong bundle identifier (com.apple.SafariViewService instead of the
host app), and we are not currently providing a scene identifier to AuthKit, so
it cannot find a reasonable window to anchor the sign in sheet to. This leads to
the issue described in the radar, where the SiwA sheet is presented in
unexpected places from a bincompat app using web authentication

AuthKit has made changes to accept a callerSceneIndetifier from the auth request
(ASAuthorizationProviderExtensionAuthorizationRequest). So the fix is to return
the correct sceneID in this class.

WebKit (in SOAuthorizationSession) is responsible for firing off the request,
which is actually an SOAuthorizationRequest. Later, AuthKit wraps this request
in the AS..AuthorizationRequest. So, to avoid modifying SOAuthorizationRequest
(which lives in AppSSO code), we hijack the authorizationOptions dictionary to
stuff in the `callerSceneIdentifier`, which we can return for the newly added
property in AS...AuthorizationRequest.

WebKit calls out to its UIDelegate to grab the correct scene identifier from
SVS, and sets it on the authorizationOptions dictionary of the request.

* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
Add a delegate method to retrieve the callerSceneIdentifier on visionOS.
This method is implemented in SafariViewService.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::continueStartAfterDecidePolicy):
Set the callerSceneIdentifier on the SOAuthorizationRequest options dict
to allow AuthenticationServices to retrieve it later and forward it to
AuthKit.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1aa715d6bc4bb5b18d29754e44809c98f0a82e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20036 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20475 "Failed to compile WebKit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21934 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23717 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20633 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20256 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/23717 "Failed to compile WebKit") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22783 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/23717 "Failed to compile WebKit") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/23717 "Failed to compile WebKit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18382 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18173 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22518 "Failed to compile WebKit") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->