### PR TITLE
'run-benchmark' should log Speedometer3 version

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan
@@ -1,8 +1,7 @@
 {
     "timeout": 600,
     "count": 4,
-    "remote_archive":"https://github.com/WebKit/Speedometer/archive/refs/heads/main.zip",
-    "github_source": "https://github.com/WebKit/WebKit/tree/d0bce574a12b3524176d177f737f324e1694dcfc/PerformanceTests/Speedometer",
+    "git_repository": "https://github.com/WebKit/Speedometer.git",
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer3.patch",
     "signpost_patch": "data/patches/signposts/Speedometer3.patch",
     "entry_point": "index.html",


### PR DESCRIPTION
#### 9bad69393c6280b5eb2d7e70023a1e51d6431f3d
<pre>
&apos;run-benchmark&apos; should log Speedometer3 version
<a href="https://bugs.webkit.org/show_bug.cgi?id=262234">https://bugs.webkit.org/show_bug.cgi?id=262234</a>
rdar://116153728

Reviewed by Ryosuke Niwa.

Add &apos;git_repository&apos; support to plan file and it&apos;s intended for the benchmark that has its
own repository like Speedometer3.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py: Added support to checkout
a git repository specified by &apos;git_repository&apos;.
(BenchmarkBuilder.__enter__):
(BenchmarkBuilder._clone_git_repository):
(BenchmarkBuilder._apply_patch): Updated code to avoid manually invoking os.chdir
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan: Updated plan file
to use &apos;git_repository&apos;.

Canonical link: <a href="https://commits.webkit.org/268559@main">https://commits.webkit.org/268559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc4b6de50a673308e76ef59cd85c49156fba4c8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21938 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20636 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22787 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20225 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18212 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22458 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18981 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18176 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4800 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22521 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->