### PR TITLE
[commits.webkit.org] Add ability to block user agents

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 8, 4)
+version = Version(0, 8, 5)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py
@@ -163,8 +163,8 @@ class CheckoutRoute(AuthedBlueprint):
             return b, a
         return a, b
 
-    def __init__(self, checkout, redirectors=None, import_name=__name__, auth_decorator=None, database=None):
-        super(CheckoutRoute, self).__init__('checkout', import_name, url_prefix=None, auth_decorator=auth_decorator)
+    def __init__(self, checkout, redirectors=None, import_name=__name__, auth_decorator=None, database=None, blocked_user_agents=None):
+        super(CheckoutRoute, self).__init__('checkout', import_name, url_prefix=None, auth_decorator=auth_decorator, blocked_user_agents=blocked_user_agents)
 
         self.checkout = checkout
         self.database = database or Database()

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py
@@ -22,6 +22,7 @@
 
 import json
 import os
+import re
 
 from flask_cors import CORS
 
@@ -42,6 +43,7 @@ checkout = Checkout.from_json(os.environ.get('CHECKOUT', '{}'))
 checkout_routes = CheckoutRoute(
     checkout, redirectors=Redirector.from_json(os.environ.get('REDIRECTORS', '[]')),
     import_name=__name__, database=database,
+    blocked_user_agents=json.loads(os.environ.get('BLOCKED_USER_AGENTS', '[]')),
 )
 
 hook_args = json.loads(os.environ.get('HOOKS', '{}'))

--- a/Tools/Scripts/libraries/reporelaypy/run
+++ b/Tools/Scripts/libraries/reporelaypy/run
@@ -130,7 +130,7 @@ def main(args=None):
     print('Connected to database!')
 
     remotes = {}
-    for pair in args.remotes:
+    for pair in args.remotes or []:
         name, remote = pair.split(':', 1)
         if not remote:
             sys.stderr("Invalid forwarding remote '{}'".format(pair))

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.8.4',
+    version='0.8.5',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitflaskpy/setup.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitflaskpy',
-    version='0.5.0',
+    version='0.6.0',
     description="Library supporting the WebKit Team's flask based web services.",
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py
@@ -43,7 +43,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 5, 0)
+version = Version(0, 6, 0)
 
 AutoInstall.register(Package('click', Version(7, 1, 2)))
 AutoInstall.register(Package('flask', Version(1, 1, 2)))

--- a/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/authed_blueprint.py
+++ b/Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/authed_blueprint.py
@@ -20,15 +20,37 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from flask import Blueprint
+import re
+
+from flask import abort, request as frequest, Blueprint
 
 
 class AuthedBlueprint(Blueprint):
-    def __init__(self, name, import_name, auth_decorator=None, **kwargs):
+    @classmethod
+    def blocked_user_agent_decorator(cls, method, user_agents):
+
+        def real_method(*args, **kwargs):
+            user_agent = frequest.headers.get('User-Agent') or ''
+            for regex in user_agents:
+                if regex.match(user_agent):
+                    abort(404, description='No data available for user')
+
+            return method(*args, **kwargs)
+
+        real_method.__name__ = method.__name__
+        return real_method
+
+    def __init__(self, name, import_name, auth_decorator=None, blocked_user_agents=None, **kwargs):
         super(AuthedBlueprint, self).__init__(name, import_name, **kwargs)
         self.auth_decorator = auth_decorator
+        self.blocked_user_agents = [
+            re.compile(value) if isinstance(value, str) else value
+            for value in blocked_user_agents or []
+        ]
 
     def add_url_rule(self, rule, endpoint=None, view_func=None, authed=True, **options):
+        if self.blocked_user_agents:
+            view_func = self.blocked_user_agent_decorator(view_func, self.blocked_user_agents)
         if not self.auth_decorator or not authed:
             return super(AuthedBlueprint, self).add_url_rule(rule, endpoint=endpoint, view_func=view_func, **options)
         return super(AuthedBlueprint, self).add_url_rule(rule, endpoint=endpoint, view_func=self.auth_decorator(view_func), **options)


### PR DESCRIPTION
#### 6e6c491c33087f64beffcf48de3d03587412ff31
<pre>
[commits.webkit.org] Add ability to block user agents
<a href="https://bugs.webkit.org/show_bug.cgi?id=262236">https://bugs.webkit.org/show_bug.cgi?id=262236</a>
rdar://116155811

Reviewed by Aakash Jain and Elliott Williams.

Some user agents (particularly search engine spiders) should not be accessing
the redirect endpoints of commits.webkit.org. Those endpoints just redirect to
GitHub, which is presumably where the crawlers got the links in the first place.

* Tools/Scripts/libraries/reporelaypy/setup.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkoutroute.py:
(CheckoutRoute.__init__): Pass blocked user agents to base class.
* Tools/Scripts/libraries/webkitflaskpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/__init__.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/webserver.py: Extract blocked
user agents from environment.
* Tools/Scripts/libraries/reporelaypy/run:
(main): Fix local run command.
* Tools/Scripts/libraries/webkitflaskpy/webkitflaskpy/authed_blueprint.py:
(AuthedBlueprint):
(AuthedBlueprint.blocked_user_agent_decorator): Return method which checks user agent
before invoking the provided method.
(AuthedBlueprint.__init__): Accept list of user agents to block.
(AuthedBlueprint.add_url_rule): Check user agent before invoking the provided method.

Canonical link: <a href="https://commits.webkit.org/268740@main">https://commits.webkit.org/268740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2675db27a1206498e300588283c38bb0176ee94f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22433 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20771 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/24216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21138 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20757 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/24216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23291 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20723 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/24216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/18662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/24216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/18640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/22979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2536 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/19244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->