### PR TITLE
[Gardening]: REGRESSION(267579@main): [ Debug ] ASSERTION FAILED: !m_pendingNavigationID causing 5 tests under TestWebKitAPI.WKBackForwardList to constantly timeout.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -703,24 +703,21 @@ static void runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest(Function
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, lastURL.absoluteString.UTF8String);
 }
 
-// FIXME after rdar://116090758 is resolved.
-TEST(WKBackForwardList, DISABLED_BackForwardNavigationDoesNotSkipItemsWithUserGesturePushState)
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGesturePushState)
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
         [webView evaluateJavaScript:makeString("history.pushState(null, document.title, location.pathname + '"_s, fragment, "');"_s) completionHandler:nil];
     });
 }
 
-// FIXME after rdar://116090758 is resolved.
-TEST(WKBackForwardList, DISABLED_BackForwardNavigationDoesNotSkipItemsWithUserGestureFragment)
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithUserGestureFragment)
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
         [webView evaluateJavaScript:makeString("location.href = location.pathname + '"_s, fragment, "';"_s) completionHandler:nil];
     });
 }
 
-// FIXME after rdar://116090758 is resolved.
-TEST(WKBackForwardList, DISABLED_BackForwardNavigationDoesNotSkipItemsFromLoadRequest)
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsFromLoadRequest)
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
         auto newURLString = makeString(String([webView URL].absoluteString), fragment);
@@ -728,8 +725,7 @@ TEST(WKBackForwardList, DISABLED_BackForwardNavigationDoesNotSkipItemsFromLoadRe
     });
 }
 
-// FIXME after rdar://116090758 is resolved.
-TEST(WKBackForwardList, DISABLED_BackForwardNavigationDoesNotSkipItemsWithRecentUserGesturePushState)
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGesturePushState)
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
         // Call pushState() in a setTimeout() so that it has a recent user gesture but not a current one.
@@ -737,8 +733,7 @@ TEST(WKBackForwardList, DISABLED_BackForwardNavigationDoesNotSkipItemsWithRecent
     });
 }
 
-// FIXME after rdar://116090758 is resolved.
-TEST(WKBackForwardList, DISABLED_BackForwardNavigationDoesNotSkipItemsWithRecentUserGestureFragment)
+TEST(WKBackForwardList, BackForwardNavigationDoesNotSkipItemsWithRecentUserGestureFragment)
 {
     runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest([](WKWebView *webView, ASCIILiteral fragment) {
         // Do fragment navigation in a setTimeout() so that it has a recent user gesture but not a current one.


### PR DESCRIPTION
#### 50af8e9215336b97ecb1222fc4712db4471427a2
<pre>
[Gardening]: REGRESSION(267579@main): [ Debug ] ASSERTION FAILED: !m_pendingNavigationID causing 5 tests under TestWebKitAPI.WKBackForwardList to constantly timeout.
rdar://116090758
<a href="https://bugs.webkit.org/show_bug.cgi?id=262152">https://bugs.webkit.org/show_bug.cgi?id=262152</a>

Unreviewed test gardening.

Re-enabling API tests disabled in <a href="https://commits.webkit.org/268489@main.">https://commits.webkit.org/268489@main.</a>

* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/268560@main">https://commits.webkit.org/268560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a8d118daa1b7e6c3a2d6d55b6d7c335372a3c70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20047 "Failed to checkout and rebase branch from PR 18327") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21104 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/21946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20277 "Failed to checkout and rebase branch from PR 18327") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20644 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/21946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20267 "Failed to checkout and rebase branch from PR 18327") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/20193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/22796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/18218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/22796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/18440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/22796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18989 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18184 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22529 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2464 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->