### PR TITLE
Generate serializes for ObjectIdentifier (by adding the ability to generate serializers for template specializations)

### DIFF
--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -33,7 +33,7 @@ namespace JSC {
 class CallFrame;
 class JSGlobalObject;
 
-enum MicrotaskIdentifierType { };
+enum class MicrotaskIdentifierType { };
 using MicrotaskIdentifier = AtomicObjectIdentifier<MicrotaskIdentifierType>;
 
 class Microtask : public RefCounted<Microtask> {

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -53,11 +53,7 @@ public:
         return String::number(m_identifier);
     }
 
-    template<typename Encoder> void encode(Encoder& encoder) const
-    {
-        ASSERT(isValidIdentifier(m_identifier));
-        encoder << m_identifier;
-    }
+    static bool isValidIdentifier(uint64_t identifier) { return identifier && identifier != hashTableDeletedValue(); }
 
 protected:
     explicit constexpr ObjectIdentifierGenericBase(uint64_t identifier)
@@ -70,16 +66,6 @@ protected:
     ObjectIdentifierGenericBase(HashTableDeletedValueType) : m_identifier(hashTableDeletedValue()) { }
 
     static uint64_t hashTableDeletedValue() { return std::numeric_limits<uint64_t>::max(); }
-    static bool isValidIdentifier(uint64_t identifier) { return identifier && identifier != hashTableDeletedValue(); }
-
-    template<typename Decoder> static std::optional<uint64_t> decode(Decoder& decoder)
-    {
-        std::optional<uint64_t> identifier;
-        decoder >> identifier;
-        if (!identifier || !isValidIdentifier(*identifier))
-            return std::nullopt;
-        return identifier;
-    }
 
 private:
     uint64_t m_identifier { 0 };
@@ -106,13 +92,6 @@ public:
 
     ObjectIdentifierGeneric() = default;
     ObjectIdentifierGeneric(HashTableDeletedValueType) : ObjectIdentifierGenericBase(HashTableDeletedValue) { }
-
-    template<typename Decoder> static std::optional<ObjectIdentifierGeneric> decode(Decoder& decoder)
-    {
-        if (auto identifier = ObjectIdentifierGenericBase::decode(decoder))
-            return ObjectIdentifierGeneric { *identifier };
-        return std::nullopt;
-    }
 
     struct MarkableTraits {
         static bool isEmptyValue(ObjectIdentifierGeneric identifier) { return !identifier; }

--- a/Source/WebCore/Modules/cache/DOMCacheIdentifier.h
+++ b/Source/WebCore/Modules/cache/DOMCacheIdentifier.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-enum DOMCacheIdentifierType { };
+enum class DOMCacheIdentifierType { };
 using DOMCacheIdentifier = ProcessQualified<AtomicObjectIdentifier<DOMCacheIdentifierType>>;
 
 }

--- a/Source/WebCore/Modules/fetch/FetchIdentifier.h
+++ b/Source/WebCore/Modules/fetch/FetchIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum FetchIdentifierType { };
+enum class FetchIdentifierType { };
 using FetchIdentifier = ObjectIdentifier<FetchIdentifierType>;
 
 }

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum FileSystemHandleIdentifierType { };
+enum class FileSystemHandleIdentifierType { };
 using FileSystemHandleIdentifier = AtomicObjectIdentifier<FileSystemHandleIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum FileSystemSyncAccessHandleIdentifierType { };
+enum class FileSystemSyncAccessHandleIdentifierType { };
 using FileSystemSyncAccessHandleIdentifier = AtomicObjectIdentifier<FileSystemSyncAccessHandleIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum WorkerFileSystemStorageConnectionCallbackIdentifierType { };
+enum class WorkerFileSystemStorageConnectionCallbackIdentifierType { };
 using WorkerFileSystemStorageConnectionCallbackIdentifier = AtomicObjectIdentifier<WorkerFileSystemStorageConnectionCallbackIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -50,7 +50,7 @@ class WritableStream;
 
 struct MessageWithMessagePorts;
 
-enum RTCRtpScriptTransformerIdentifierType { };
+enum class RTCRtpScriptTransformerIdentifierType { };
 using RTCRtpScriptTransformerIdentifier = AtomicObjectIdentifier<RTCRtpScriptTransformerIdentifierType>;
 
 class RTCRtpScriptTransformer

--- a/Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h
+++ b/Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum MainThreadPermissionObserverIdentifierType { };
+enum class  MainThreadPermissionObserverIdentifierType { };
 using MainThreadPermissionObserverIdentifier = AtomicObjectIdentifier<MainThreadPermissionObserverIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-enum PushSubscriptionIdentifierType { };
+enum class PushSubscriptionIdentifierType { };
 using PushSubscriptionIdentifier = ObjectIdentifier<PushSubscriptionIdentifierType>;
 
 struct PushSubscriptionSetIdentifier {

--- a/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClientIdentifier.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionConnectionClientIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum SpeechRecognitionConnectionClientIdentifierType { };
+enum class SpeechRecognitionConnectionClientIdentifierType { };
 using SpeechRecognitionConnectionClientIdentifier = ObjectIdentifier<SpeechRecognitionConnectionClientIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/web-locks/WebLockIdentifier.h
+++ b/Source/WebCore/Modules/web-locks/WebLockIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum WebLockIdentifierType { };
+enum class WebLockIdentifierType { };
 using WebLockIdentifier = ProcessQualified<AtomicObjectIdentifier<WebLockIdentifierType>>;
 
 } // namespace

--- a/Source/WebCore/Modules/websockets/WebSocketIdentifier.h
+++ b/Source/WebCore/Modules/websockets/WebSocketIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum WebSocketIdentifierType { };
+enum class WebSocketIdentifierType { };
 using WebSocketIdentifier = AtomicObjectIdentifier<WebSocketIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -94,7 +94,7 @@ struct AccessibilityText;
 struct CharacterRange;
 struct ScrollRectToVisibleOptions;
 
-enum AXIDType { };
+enum class AXIDType { };
 using AXID = ObjectIdentifier<AXIDType>;
 
 enum class AXAncestorFlag : uint8_t {

--- a/Source/WebCore/dom/BroadcastChannelIdentifier.h
+++ b/Source/WebCore/dom/BroadcastChannelIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum BroadcastChannelIdentifierType { };
+enum class BroadcastChannelIdentifierType { };
 using BroadcastChannelIdentifier = AtomicObjectIdentifier<BroadcastChannelIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ElementIdentifier.h
+++ b/Source/WebCore/dom/ElementIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum ElementIdentifierType { };
+enum class ElementIdentifierType { };
 using ElementIdentifier = ObjectIdentifier<ElementIdentifierType>;
 
 }

--- a/Source/WebCore/dom/PortIdentifier.h
+++ b/Source/WebCore/dom/PortIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum PortIdentifierType { };
+enum class PortIdentifierType { };
 using PortIdentifier = AtomicObjectIdentifier<PortIdentifierType>;
 
 }

--- a/Source/WebCore/editing/TextManipulationItemIdentifier.h
+++ b/Source/WebCore/editing/TextManipulationItemIdentifier.h
@@ -27,7 +27,7 @@
 
 namespace WebCore {
 
-enum TextManipulationItemIdentifierType { };
+enum class TextManipulationItemIdentifierType { };
 using TextManipulationItemIdentifier = ObjectIdentifier<TextManipulationItemIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/editing/TextManipulationToken.h
+++ b/Source/WebCore/editing/TextManipulationToken.h
@@ -26,7 +26,7 @@
 #pragma once
 namespace WebCore {
 
-enum TextManipulationTokenIdentifierType { };
+enum class TextManipulationTokenIdentifierType { };
 using TextManipulationTokenIdentifier = ObjectIdentifier<TextManipulationTokenIdentifierType>;
 
 struct TextManipulationTokenInfo {

--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -75,17 +75,20 @@ namespace WebCore {
 
 class Font;
 
+struct AttributedStringTextTableIDType;
+using AttributedStringTextTableID = ObjectIdentifier<AttributedStringTextTableIDType>;
+
+struct AttributedStringTextListIDType;
+using AttributedStringTextListID = ObjectIdentifier<AttributedStringTextListIDType>;
+
 struct WEBCORE_EXPORT AttributedString {
     struct Range {
         size_t location { 0 };
         size_t length { 0 };
     };
 
-    struct TextTableIDType;
-    using TextTableID = ObjectIdentifier<TextTableIDType>;
-
-    struct TextListIDType;
-    using TextListID = ObjectIdentifier<TextListIDType>;
+    using TextTableID = AttributedStringTextTableID;
+    using TextListID = AttributedStringTextListID;
 
     struct ParagraphStyleWithTableAndListIDs {
         RetainPtr<NSParagraphStyle> style;

--- a/Source/WebCore/page/GlobalWindowIdentifier.h
+++ b/Source/WebCore/page/GlobalWindowIdentifier.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-enum WindowIdentifierType { };
+enum class WindowIdentifierType { };
 using WindowIdentifier = ObjectIdentifier<WindowIdentifierType>;
 
 // Window identifier that is unique across all WebContent processes.

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class LocalFrame;
 class SecurityOrigin;
 
-enum OpaqueOriginIdentifierType { };
+enum class OpaqueOriginIdentifierType { };
 using OpaqueOriginIdentifier = AtomicObjectIdentifier<OpaqueOriginIdentifierType>;
 
 class SecurityOriginData {

--- a/Source/WebCore/page/cocoa/ImageOverlayDataDetectionResultIdentifier.h
+++ b/Source/WebCore/page/cocoa/ImageOverlayDataDetectionResultIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-enum ImageOverlayDataDetectionResultIdentifierType { };
+enum class ImageOverlayDataDetectionResultIdentifierType { };
 using ImageOverlayDataDetectionResultIdentifier = ObjectIdentifier<ImageOverlayDataDetectionResultIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/MediaSessionGroupIdentifier.h
+++ b/Source/WebCore/platform/MediaSessionGroupIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum MediaSessionGroupIdentifierType { };
+enum class MediaSessionGroupIdentifierType { };
 using MediaSessionGroupIdentifier = ObjectIdentifier<MediaSessionGroupIdentifierType>;
 
 }

--- a/Source/WebCore/platform/MediaUniqueIdentifier.h
+++ b/Source/WebCore/platform/MediaUniqueIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum MediaUniqueIdentifierType { };
+enum class MediaUniqueIdentifierType { };
 using MediaUniqueIdentifier = ObjectIdentifier<MediaUniqueIdentifierType>;
 
 }

--- a/Source/WebCore/platform/ProcessIdentifier.h
+++ b/Source/WebCore/platform/ProcessIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum ProcessIdentifierType { };
+enum class ProcessIdentifierType { };
 using ProcessIdentifier = ObjectIdentifier<ProcessIdentifierType>;
 
 namespace Process {

--- a/Source/WebCore/platform/graphics/ImageDecoderIdentifier.h
+++ b/Source/WebCore/platform/graphics/ImageDecoderIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum ImageDecoderIdentifierType { };
+enum class ImageDecoderIdentifierType { };
 using ImageDecoderIdentifier = ObjectIdentifier<ImageDecoderIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/InbandGenericCueIdentifier.h
+++ b/Source/WebCore/platform/graphics/InbandGenericCueIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum InbandGenericCueIdentifierType { };
+enum class InbandGenericCueIdentifierType { };
 using InbandGenericCueIdentifier = ObjectIdentifier<InbandGenericCueIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/LayerHostingContextIdentifier.h
+++ b/Source/WebCore/platform/graphics/LayerHostingContextIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum LayerHostingContextIdentifierType { };
+enum class LayerHostingContextIdentifierType { };
 using LayerHostingContextIdentifier = ObjectIdentifier<LayerHostingContextIdentifierType>;
 
 }

--- a/Source/WebCore/platform/graphics/RenderingResourceIdentifier.h
+++ b/Source/WebCore/platform/graphics/RenderingResourceIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum RenderingResourceIdentifierType { };
+enum class RenderingResourceIdentifierType { };
 using RenderingResourceIdentifier = AtomicObjectIdentifier<RenderingResourceIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.h
+++ b/Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-enum DisplayConfigurationClientIdentifierType { };
+enum class DisplayConfigurationClientIdentifierType { };
 using DisplayConfigurationClientIdentifier = AtomicObjectIdentifier<DisplayConfigurationClientIdentifierType>;
 
 class DisplayConfigurationMonitor {

--- a/Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-enum RTCDataChannelLocalIdentifierType { };
+enum class RTCDataChannelLocalIdentifierType { };
 using RTCDataChannelLocalIdentifier = AtomicObjectIdentifier<RTCDataChannelLocalIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceIdentifier.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum RealtimeMediaSourceIdentifierType { };
+enum class RealtimeMediaSourceIdentifierType { };
 using RealtimeMediaSourceIdentifier = ObjectIdentifier<RealtimeMediaSourceIdentifierType>;
 
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum LibWebRTCSocketIdentifierType { };
+enum class LibWebRTCSocketIdentifierType { };
 using LibWebRTCSocketIdentifier = AtomicObjectIdentifier<LibWebRTCSocketIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/text/TextCheckingRequestIdentifier.h
+++ b/Source/WebCore/platform/text/TextCheckingRequestIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum TextCheckingRequestIdentifierType { };
+enum class TextCheckingRequestIdentifierType { };
 using TextCheckingRequestIdentifier = ObjectIdentifier<TextCheckingRequestIdentifierType>;
 
 }

--- a/Source/WebCore/workers/service/ServiceWorkerIdentifier.h
+++ b/Source/WebCore/workers/service/ServiceWorkerIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-enum ServiceWorkerIdentifierType { };
+enum class ServiceWorkerIdentifierType { };
 using ServiceWorkerIdentifier = AtomicObjectIdentifier<ServiceWorkerIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerTypes.h
+++ b/Source/WebCore/workers/service/ServiceWorkerTypes.h
@@ -67,13 +67,13 @@ enum class ServiceWorkerClientFrameType : uint8_t {
 enum class ServiceWorkerIsInspectable : bool { No, Yes };
 enum class ShouldNotifyWhenResolved : bool { No, Yes };
 
-enum ServiceWorkerRegistrationIdentifierType { };
+enum class ServiceWorkerRegistrationIdentifierType { };
 using ServiceWorkerRegistrationIdentifier = AtomicObjectIdentifier<ServiceWorkerRegistrationIdentifierType>;
 
-enum ServiceWorkerJobIdentifierType { };
+enum class ServiceWorkerJobIdentifierType { };
 using ServiceWorkerJobIdentifier = AtomicObjectIdentifier<ServiceWorkerJobIdentifierType>;
 
-enum SWServerToContextConnectionIdentifierType { };
+enum class SWServerToContextConnectionIdentifierType { };
 using SWServerToContextConnectionIdentifier = ObjectIdentifier<SWServerToContextConnectionIdentifierType>;
 
 using SWServerConnectionIdentifierType = ProcessIdentifierType;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordIdentifier.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum BackgroundFetchRecordIdentifierType { };
+enum class BackgroundFetchRecordIdentifierType { };
 using BackgroundFetchRecordIdentifier = ObjectIdentifier<BackgroundFetchRecordIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/workers/shared/SharedWorkerIdentifier.h
+++ b/Source/WebCore/workers/shared/SharedWorkerIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum SharedWorkerIdentifierType { };
+enum class SharedWorkerIdentifierType { };
 using SharedWorkerIdentifier = ObjectIdentifier<SharedWorkerIdentifierType>;
 
 } // namespace WebCore

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -48,7 +48,7 @@ class WorkerScriptLoader;
 
 struct WorkletParameters;
 
-enum WorkletGlobalScopeIdentifierType { };
+enum class WorkletGlobalScopeIdentifierType { };
 using WorkletGlobalScopeIdentifier = ObjectIdentifier<WorkletGlobalScopeIdentifierType>;
 
 class WorkletGlobalScope : public WorkerOrWorkletGlobalScope {

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceIdentifier.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteMediaResourceIdentifierType { };
+enum class RemoteMediaResourceIdentifierType { };
 using RemoteMediaResourceIdentifier = ObjectIdentifier<RemoteMediaResourceIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferIdentifier.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteSourceBufferIdentifierType { };
+enum class RemoteSourceBufferIdentifierType { };
 using RemoteSourceBufferIdentifier = ObjectIdentifier<RemoteSourceBufferIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/TrackPrivateRemoteIdentifier.h
+++ b/Source/WebKit/GPUProcess/media/TrackPrivateRemoteIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum TrackPrivateRemoteIdentifierType { };
+enum class TrackPrivateRemoteIdentifierType { };
 using TrackPrivateRemoteIdentifier = ObjectIdentifier<TrackPrivateRemoteIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolID.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolID.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum LegacyCustomProtocolIDType { };
+enum class LegacyCustomProtocolIDType { };
 using LegacyCustomProtocolID = AtomicObjectIdentifier<LegacyCustomProtocolIDType>;
 
 }

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadID.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadID.h
@@ -31,7 +31,7 @@ namespace WebKit {
 
 enum class AllowOverwrite : bool { No, Yes };
 
-enum DownloadIdentifierType { };
+enum class DownloadIdentifierType { };
 using DownloadID = ObjectIdentifier<DownloadIdentifierType>;
 
 }

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -78,7 +78,7 @@ static bool trustsServerForLocalTests(NSURLAuthenticationChallenge *challenge)
 
 namespace WebKit::PCM {
 
-enum LoadTaskIdentifierType { };
+enum class LoadTaskIdentifierType { };
 using LoadTaskIdentifier = ObjectIdentifier<LoadTaskIdentifierType>;
 static HashMap<LoadTaskIdentifier, RetainPtr<NSURLSessionDataTask>>& taskMap()
 {

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -200,10 +200,13 @@ struct ConnectionAsyncReplyHandler {
     AsyncReplyID replyID;
 };
 
+enum class ConnectionSyncRequestIDType { };
+using ConnectionSyncRequestID = AtomicObjectIdentifier<ConnectionSyncRequestIDType>;
+
 class Connection : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Connection, WTF::DestructionThread::MainRunLoop> {
 public:
-    enum SyncRequestIDType { };
-    using SyncRequestID = AtomicObjectIdentifier<SyncRequestIDType>;
+    enum class SyncRequestIDType { };
+    using SyncRequestID = ConnectionSyncRequestID;
     using AsyncReplyID = IPC::AsyncReplyID;
 
     class Client : public MessageReceiver {

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -419,12 +419,17 @@ std::optional<WebCore::RegistrableDomain> Coder<WebCore::RegistrableDomain, void
 
 void Coder<WebCore::PushSubscriptionIdentifier>::encode(Encoder& encoder, const WebCore::PushSubscriptionIdentifier& instance)
 {
-    instance.encode(encoder);
+    encoder << instance.toUInt64();
 }
 
 std::optional<WebCore::PushSubscriptionIdentifier> Coder<WebCore::PushSubscriptionIdentifier>::decode(Decoder& decoder)
 {
-    return WebCore::PushSubscriptionIdentifier::decode(decoder);
+    std::optional<uint64_t> rawID;
+    decoder >> rawID;
+    if (!rawID)
+        return std::nullopt;
+
+    return { WebCore::PushSubscriptionIdentifier(*rawID) };
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -41,6 +41,7 @@
 #if ENABLE(TEST_FEATURE)
 #include "StructHeader.h"
 #endif
+#include "TemplateTest.h"
 #include <Namespace/EmptyConstructorStruct.h>
 #include <Namespace/EmptyConstructorWithIf.h>
 #include <Namespace/ReturnRefClass.h>
@@ -850,6 +851,106 @@ std::optional<WebKit::LayerProperties> ArgumentCoder<WebKit::LayerProperties>::d
     }
 
     return { WTFMove(result) };
+}
+
+void ArgumentCoder<WebKit::TemplateTest<WebKit::Fabulous>>::encode(Encoder& encoder, const WebKit::TemplateTest<WebKit::Fabulous>& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, bool>);
+    struct ShouldBeSameSizeAsTemplateTest : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::TemplateTest>, false> {
+        bool value;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsTemplateTest) == sizeof(WebKit::TemplateTest));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(WebKit::TemplateTest, value)
+    >::value);
+    encoder << instance.value;
+}
+
+std::optional<WebKit::TemplateTest<WebKit::Fabulous>> ArgumentCoder<WebKit::TemplateTest<WebKit::Fabulous>>::decode(Decoder& decoder)
+{
+    auto value = decoder.decode<bool>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::TemplateTest<WebKit::Fabulous> {
+            WTFMove(*value)
+        }
+    };
+}
+
+void ArgumentCoder<WebKit::TemplateTest<WebCore::Amazing>>::encode(Encoder& encoder, const WebKit::TemplateTest<WebCore::Amazing>& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, bool>);
+    struct ShouldBeSameSizeAsTemplateTest : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::TemplateTest>, false> {
+        bool value;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsTemplateTest) == sizeof(WebKit::TemplateTest));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(WebKit::TemplateTest, value)
+    >::value);
+    encoder << instance.value;
+}
+
+std::optional<WebKit::TemplateTest<WebCore::Amazing>> ArgumentCoder<WebKit::TemplateTest<WebCore::Amazing>>::decode(Decoder& decoder)
+{
+    auto value = decoder.decode<bool>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::TemplateTest<WebCore::Amazing> {
+            WTFMove(*value)
+        }
+    };
+}
+
+void ArgumentCoder<WebKit::TemplateTest<JSC::Incredible>>::encode(Encoder& encoder, const WebKit::TemplateTest<JSC::Incredible>& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, bool>);
+    struct ShouldBeSameSizeAsTemplateTest : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::TemplateTest>, false> {
+        bool value;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsTemplateTest) == sizeof(WebKit::TemplateTest));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(WebKit::TemplateTest, value)
+    >::value);
+    encoder << instance.value;
+}
+
+std::optional<WebKit::TemplateTest<JSC::Incredible>> ArgumentCoder<WebKit::TemplateTest<JSC::Incredible>>::decode(Decoder& decoder)
+{
+    auto value = decoder.decode<bool>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::TemplateTest<JSC::Incredible> {
+            WTFMove(*value)
+        }
+    };
+}
+
+void ArgumentCoder<WebKit::TemplateTest<Testing::StorageSize>>::encode(Encoder& encoder, const WebKit::TemplateTest<Testing::StorageSize>& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, bool>);
+    struct ShouldBeSameSizeAsTemplateTest : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::TemplateTest>, false> {
+        bool value;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsTemplateTest) == sizeof(WebKit::TemplateTest));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(WebKit::TemplateTest, value)
+    >::value);
+    encoder << instance.value;
+}
+
+std::optional<WebKit::TemplateTest<Testing::StorageSize>> ArgumentCoder<WebKit::TemplateTest<Testing::StorageSize>>::decode(Decoder& decoder)
+{
+    auto value = decoder.decode<bool>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::TemplateTest<Testing::StorageSize> {
+            WTFMove(*value)
+        }
+    };
 }
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -66,6 +66,10 @@ namespace WebCore { class MoveOnlyDerivedClass; }
 namespace WebKit { class PlatformClass; }
 namespace WebKit { class CustomEncoded; }
 namespace WebKit { class LayerProperties; }
+namespace WebKit { class Fabulous; }
+namespace WebCore { struct Amazing; }
+namespace JSC { enum class Incredible; }
+namespace Testing { enum class StorageSize : uint8_t; }
 
 namespace IPC {
 
@@ -182,6 +186,26 @@ template<> struct ArgumentCoder<WebKit::CustomEncoded> {
 template<> struct ArgumentCoder<WebKit::LayerProperties> {
     static void encode(Encoder&, const WebKit::LayerProperties&);
     static std::optional<WebKit::LayerProperties> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::TemplateTest<WebKit::Fabulous>> {
+    static void encode(Encoder&, const WebKit::TemplateTest<WebKit::Fabulous>&);
+    static std::optional<WebKit::TemplateTest<WebKit::Fabulous>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::TemplateTest<WebCore::Amazing>> {
+    static void encode(Encoder&, const WebKit::TemplateTest<WebCore::Amazing>&);
+    static std::optional<WebKit::TemplateTest<WebCore::Amazing>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::TemplateTest<JSC::Incredible>> {
+    static void encode(Encoder&, const WebKit::TemplateTest<JSC::Incredible>&);
+    static std::optional<WebKit::TemplateTest<JSC::Incredible>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::TemplateTest<Testing::StorageSize>> {
+    static void encode(Encoder&, const WebKit::TemplateTest<Testing::StorageSize>&);
+    static std::optional<WebKit::TemplateTest<Testing::StorageSize>> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -42,6 +42,7 @@
 #if ENABLE(TEST_FEATURE)
 #include "StructHeader.h"
 #endif
+#include "TemplateTest.h"
 #include <Namespace/EmptyConstructorStruct.h>
 #include <Namespace/EmptyConstructorWithIf.h>
 #include <Namespace/ReturnRefClass.h>
@@ -249,6 +250,12 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                     ", bool"
                 ">"_s,
                 "optionalTuple"_s
+            },
+        } },
+        { "WebKit::TemplateTest"_s, {
+            {
+                "bool"_s,
+                "value"_s
             },
         } },
         { "WebCore::SharedStringHash"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -191,3 +191,11 @@ using WTF::ProcessID = int;
 #else
 using WTF::ProcessID = pid_t;
 #endif
+
+template: class WebKit::Fabulous
+template: struct WebCore::Amazing
+template: enum class JSC::Incredible
+template: enum class Testing::StorageSize : uint8_t
+class WebKit::TemplateTest {
+  bool value;
+}

--- a/Source/WebKit/Shared/ContentWorldShared.h
+++ b/Source/WebKit/Shared/ContentWorldShared.h
@@ -30,7 +30,7 @@
 
 namespace WebKit {
 
-enum ContentWorldIdentifierType { };
+enum class ContentWorldIdentifierType { };
 using ContentWorldIdentifier = ObjectIdentifier<ContentWorldIdentifierType>;
 
 inline ContentWorldIdentifier pageContentWorldIdentifier()

--- a/Source/WebKit/Shared/Extensions/WebExtensionControllerIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionControllerIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum WebExtensionControllerIdentifierType { };
+enum class WebExtensionControllerIdentifierType { };
 using WebExtensionControllerIdentifier = ObjectIdentifier<WebExtensionControllerIdentifierType>;
 
 }

--- a/Source/WebKit/Shared/ShapeDetectionIdentifier.h
+++ b/Source/WebKit/Shared/ShapeDetectionIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum ShapeDetectionIdentifierType { };
+enum class ShapeDetectionIdentifierType { };
 using ShapeDetectionIdentifier = ObjectIdentifier<ShapeDetectionIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -20,6 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+webkit_platform_headers: "StreamConnectionEncoder.h"
+
 [WebKitPlatform] class WTF::URL {
     String string()
 }
@@ -50,6 +52,141 @@ header: <wtf/text/AtomString.h>
 [WebKitPlatform] class WTF::UUID {
     uint64_t high();
     [Validator='((static_cast<UInt128>(*high) << 64) | *low) != WTF::UUID::deletedValue'] uint64_t low();
+}
+
+template: class WebKit::WebURLSchemeHandler
+template: enum class WebCore::AXIDType
+template: enum class WebCore::BackgroundFetchRecordIdentifierType
+template: enum class WebCore::ElementIdentifierType
+template: enum class WebCore::FetchIdentifierType
+template: enum class WebCore::ImageDecoderIdentifierType
+template: enum class WebCore::ImageOverlayDataDetectionResultIdentifierType
+template: enum class WebCore::InbandGenericCueIdentifierType
+template: enum class WebCore::LayerHostingContextIdentifierType
+template: enum class WebCore::MediaSessionGroupIdentifierType
+template: enum class WebCore::MediaUniqueIdentifierType
+template: enum class WebCore::ProcessIdentifierType
+template: enum class WebCore::PushSubscriptionIdentifierType
+template: enum class WebCore::RealtimeMediaSourceIdentifierType
+template: enum class WebCore::SWServerToContextConnectionIdentifierType
+template: enum class WebCore::SharedWorkerIdentifierType
+template: enum class WebCore::SpeechRecognitionConnectionClientIdentifierType
+template: enum class WebCore::TextCheckingRequestIdentifierType
+template: enum class WebCore::TextManipulationItemIdentifierType
+template: enum class WebCore::TextManipulationTokenIdentifierType
+template: enum class WebCore::WindowIdentifierType
+template: enum class WebCore::WorkletGlobalScopeIdentifierType
+template: enum class WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifierType
+template: enum class WebKit::ContentWorldIdentifierType
+template: enum class WebKit::DownloadIdentifierType
+template: enum class WebKit::ImageAnalysisRequestIdentifierType
+template: enum class WebKit::MediaDevicePermissionRequestIdentifierType
+template: enum class WebKit::MediaRecorderIdentifierType
+template: enum class WebKit::RemoteAudioHardwareListenerIdentifierType
+template: enum class WebKit::RemoteAudioSessionIdentifierType
+template: enum class WebKit::RemoteCDMIdentifierType
+template: enum class WebKit::RemoteCDMInstanceIdentifierType
+template: enum class WebKit::RemoteCDMInstanceSessionIdentifierType
+template: enum class WebKit::RemoteLegacyCDMIdentifierType
+template: enum class WebKit::RemoteLegacyCDMSessionIdentifierType
+template: enum class WebKit::RemoteMediaResourceIdentifierType
+template: enum class WebKit::RemoteMediaSourceIdentifierType
+template: enum class WebKit::RemoteRemoteCommandListenerIdentifierType
+template: enum class WebKit::RemoteSourceBufferIdentifierType
+template: enum class WebKit::RenderingBackendIdentifierType
+template: enum class WebKit::RetrieveRecordResponseBodyCallbackIdentifierType
+template: enum class WebKit::SampleBufferDisplayLayerIdentifierType
+template: enum class WebKit::ShapeDetectionIdentifierType
+template: enum class WebKit::StorageAreaImplIdentifierType
+template: enum class WebKit::StorageAreaMapIdentifierType
+template: enum class WebKit::StorageNamespaceIdentifierType
+template: enum class WebKit::TrackPrivateRemoteIdentifierType
+template: enum class WebKit::WCLayerTreeHostIdentifierType
+template: enum class WebKit::WebExtensionControllerIdentifierType
+template: enum class WebKit::WebGPUIdentifierType
+template: enum class WebKit::XRDeviceIdentifierType
+template: struct WebCore::AttributedStringTextListIDType
+template: struct WebCore::AttributedStringTextTableIDType
+template: struct WebCore::BackForwardItemIdentifierType
+template: struct WebCore::DictationContextType
+template: struct WebCore::FrameIdentifierType
+template: struct WebCore::HTMLMediaElementIdentifierType
+template: struct WebCore::MediaKeySystemRequestIdentifierType
+template: struct WebCore::MediaPlayerIdentifierType
+template: struct WebCore::MediaSessionIdentifierType
+template: struct WebCore::PageIdentifierType
+template: struct WebCore::PlatformLayerIdentifierType
+template: struct WebCore::PlaybackTargetClientContextIdentifierType
+template: struct WebCore::PolicyCheckIdentifierType
+template: struct WebCore::SharedWorkerObjectIdentifierType
+template: struct WebCore::SleepDisablerIdentifierType
+template: struct WebCore::UserMediaRequestIdentifierType
+template: struct WebKit::AuthenticationChallengeIdentifierType
+template: struct WebKit::DataTaskIdentifierType
+template: struct WebKit::DisplayLinkObserverIDType
+template: struct WebKit::DrawingAreaIdentifierType
+template: struct WebKit::GeolocationIdentifierType
+template: struct WebKit::IPCConnectionTesterIdentifierType
+template: struct WebKit::IPCStreamTesterIdentifierType
+template: struct WebKit::MarkSurfacesAsVolatileRequestIdentifierType
+template: struct WebKit::NetworkResourceLoadIdentifierType
+template: struct WebKit::PDFPluginIdentifierType
+template: struct WebKit::PageGroupIdentifierType
+template: struct WebKit::RemoteAudioDestinationIdentifierType
+template: struct WebKit::TapIdentifierType
+template: struct WebKit::TextCheckerRequestType
+template: struct WebKit::UserContentControllerIdentifierType
+template: struct WebKit::WebExtensionContextIdentifierType
+template: struct WebKit::WebExtensionFrameIdentifierType
+template: struct WebKit::WebExtensionPortChannelIdentifierType
+template: struct WebKit::WebExtensionTabIdentifierType
+template: struct WebKit::WebExtensionWindowIdentifierType
+template: struct WebKit::WebPageProxyIdentifierType
+template: struct WebKit::WebTransportSessionIdentifierType
+template: struct WebKit::WebTransportStreamIdentifierType
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::ObjectIdentifier {
+    [Validator='WTF::ObjectIdentifierGenericBase::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
+}
+
+header: <wtf/ObjectIdentifier.h>
+template: class WebCore::ResourceLoader
+template: class WebCore::WebSocketChannel
+template: class WebCore::WebSocketChannelClient
+template: class WebCore::WebSocketChannelInspector
+template: enum class IPC::ConnectionSyncRequestIDType
+template: enum class JSC::MicrotaskIdentifierType
+template: enum class WebCore::BroadcastChannelIdentifierType
+template: enum class WebCore::DOMCacheIdentifierType
+template: enum class WebCore::DisplayConfigurationClientIdentifierType
+template: enum class WebCore::FileSystemHandleIdentifierType
+template: enum class WebCore::FileSystemSyncAccessHandleIdentifierType
+template: enum class WebCore::LibWebRTCSocketIdentifierType
+template: enum class WebCore::MainThreadPermissionObserverIdentifierType
+template: enum class WebCore::OpaqueOriginIdentifierType
+template: enum class WebCore::PortIdentifierType
+template: enum class WebCore::RTCDataChannelLocalIdentifierType
+template: enum class WebCore::RTCRtpScriptTransformerIdentifierType
+template: enum class WebCore::RenderingResourceIdentifierType
+template: enum class WebCore::ServiceWorkerIdentifierType
+template: enum class WebCore::ServiceWorkerJobIdentifierType
+template: enum class WebCore::ServiceWorkerRegistrationIdentifierType
+template: enum class WebCore::WebLockIdentifierType
+template: enum class WebCore::WebSocketIdentifierType
+template: enum class WebCore::WorkerFileSystemStorageConnectionCallbackIdentifierType
+template: enum class WebKit::GraphicsContextGLIdentifierType
+template: enum class WebKit::LegacyCustomProtocolIDType
+template: enum class WebKit::LibWebRTCResolverIdentifierType
+template: enum class WebKit::QuotaIncreaseRequestIdentifierType
+template: enum class WebKit::RemoteVideoFrameIdentifierType
+template: enum class WebKit::VideoDecoderIdentifierType
+template: enum class WebKit::VideoEncoderIdentifierType
+template: enum class WebKit::WCContentBufferIdentifierType
+template: struct IPC::AsyncReplyIDType
+template: struct WebCore::WebSocketFrame
+template: struct WebKit::ConnectionAsyncReplyHandler
+template: struct WebKit::StorageAreaIdentifierType
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WTF::AtomicObjectIdentifier {
+    [Validator='WTF::ObjectIdentifierGenericBase::isValidIdentifier(*toUInt64)'] uint64_t toUInt64()
 }
 
 #if OS(WINDOWS)

--- a/Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum WebGPUIdentifierType { };
+enum class WebGPUIdentifierType { };
 using WebGPUIdentifier = ObjectIdentifier<WebGPUIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h
+++ b/Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum QuotaIncreaseRequestIdentifierType { };
+enum class QuotaIncreaseRequestIdentifierType { };
 using QuotaIncreaseRequestIdentifier = AtomicObjectIdentifier<QuotaIncreaseRequestIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/XR/XRDeviceIdentifier.h
+++ b/Source/WebKit/Shared/XR/XRDeviceIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum XRDeviceIdentifierType { };
+enum class XRDeviceIdentifierType { };
 using XRDeviceIdentifier = ObjectIdentifier<XRDeviceIdentifierType>;
 
 }

--- a/Source/WebKit/Shared/wc/WCContentBufferIdentifier.h
+++ b/Source/WebKit/Shared/wc/WCContentBufferIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum WCContentBufferIdentifierType { };
+enum class WCContentBufferIdentifierType { };
 using WCContentBufferIdentifier = AtomicObjectIdentifier<WCContentBufferIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -51,7 +51,7 @@ namespace WebKit {
 
 class WebPageProxy;
 
-enum MediaDevicePermissionRequestIdentifierType { };
+enum class MediaDevicePermissionRequestIdentifierType { };
 using MediaDevicePermissionRequestIdentifier = ObjectIdentifier<MediaDevicePermissionRequestIdentifierType>;
 
 class UserMediaPermissionRequestManagerProxy

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -263,7 +263,7 @@ struct RemoveBackgroundData {
 
 enum class ProceedWithTextSelectionInImage : bool { No, Yes };
 
-enum ImageAnalysisRequestIdentifierType { };
+enum class ImageAnalysisRequestIdentifierType { };
 using ImageAnalysisRequestIdentifier = ObjectIdentifier<ImageAnalysisRequestIdentifierType>;
 
 struct ImageAnalysisContextMenuActionData {

--- a/Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum GraphicsContextGLIdentifierType { };
+enum class GraphicsContextGLIdentifierType { };
 using GraphicsContextGLIdentifier = AtomicObjectIdentifier<GraphicsContextGLIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RenderingBackendIdentifierType { };
+enum class RenderingBackendIdentifierType { };
 using RenderingBackendIdentifier = ObjectIdentifier<RenderingBackendIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/WCLayerTreeHostIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/WCLayerTreeHostIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum WCLayerTreeHostIdentifierType { };
+enum class WCLayerTreeHostIdentifierType { };
 using WCLayerTreeHostIdentifier = ObjectIdentifier<WCLayerTreeHostIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListenerIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListenerIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteAudioHardwareListenerIdentifierType { };
+enum class RemoteAudioHardwareListenerIdentifierType { };
 using RemoteAudioHardwareListenerIdentifier = ObjectIdentifier<RemoteAudioHardwareListenerIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteAudioSessionIdentifierType { };
+enum class RemoteAudioSessionIdentifierType { };
 using RemoteAudioSessionIdentifier = ObjectIdentifier<RemoteAudioSessionIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteCDMIdentifierType { };
+enum class RemoteCDMIdentifierType { };
 using RemoteCDMIdentifier = ObjectIdentifier<RemoteCDMIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteCDMInstanceIdentifierType { };
+enum class RemoteCDMInstanceIdentifierType { };
 using RemoteCDMInstanceIdentifier = ObjectIdentifier<RemoteCDMInstanceIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSessionIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSessionIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteCDMInstanceSessionIdentifierType { };
+enum class RemoteCDMInstanceSessionIdentifierType { };
 using RemoteCDMInstanceSessionIdentifier = ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteLegacyCDMIdentifierType { };
+enum class RemoteLegacyCDMIdentifierType { };
 using RemoteLegacyCDMIdentifier = ObjectIdentifier<RemoteLegacyCDMIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSessionIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSessionIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteLegacyCDMSessionIdentifierType { };
+enum class RemoteLegacyCDMSessionIdentifierType { };
 using RemoteLegacyCDMSessionIdentifier = ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaSourceIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaSourceIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteMediaSourceIdentifierType { };
+enum class RemoteMediaSourceIdentifierType { };
 using RemoteMediaSourceIdentifier = ObjectIdentifier<RemoteMediaSourceIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListenerIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListenerIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum RemoteRemoteCommandListenerIdentifierType { };
+enum class RemoteRemoteCommandListenerIdentifierType { };
 using RemoteRemoteCommandListenerIdentifier = ObjectIdentifier<RemoteRemoteCommandListenerIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-enum RemoteVideoFrameIdentifierType { };
+enum class RemoteVideoFrameIdentifierType { };
 using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>;
 using RemoteVideoFrameReadReference = IPC::ObjectIdentifierReadReference<RemoteVideoFrameIdentifier>;
 using RemoteVideoFrameWriteReference = IPC::ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>;

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum AudioMediaStreamTrackRendererInternalUnitIdentifierType { };
+enum class AudioMediaStreamTrackRendererInternalUnitIdentifierType { };
 using AudioMediaStreamTrackRendererInternalUnitIdentifier = ObjectIdentifier<AudioMediaStreamTrackRendererInternalUnitIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum MediaRecorderIdentifierType { };
+enum class MediaRecorderIdentifierType { };
 using MediaRecorderIdentifier = ObjectIdentifier<MediaRecorderIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerIdentifier.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-enum SampleBufferDisplayLayerIdentifierType { };
+enum class SampleBufferDisplayLayerIdentifierType { };
 using SampleBufferDisplayLayerIdentifier = ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum VideoDecoderIdentifierType { };
+enum class VideoDecoderIdentifierType { };
 using VideoDecoderIdentifier = AtomicObjectIdentifier<VideoDecoderIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum VideoEncoderIdentifierType { };
+enum class VideoEncoderIdentifierType { };
 using VideoEncoderIdentifier = AtomicObjectIdentifier<VideoEncoderIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolverIdentifier.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolverIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum LibWebRTCResolverIdentifierType { };
+enum class LibWebRTCResolverIdentifierType { };
 using LibWebRTCResolverIdentifier = AtomicObjectIdentifier<LibWebRTCResolverIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/RetrieveRecordResponseBodyCallbackIdentifier.h
+++ b/Source/WebKit/WebProcess/Storage/RetrieveRecordResponseBodyCallbackIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum RetrieveRecordResponseBodyCallbackIdentifierType { };
+enum class RetrieveRecordResponseBodyCallbackIdentifierType { };
 using RetrieveRecordResponseBodyCallbackIdentifier = ObjectIdentifier<RetrieveRecordResponseBodyCallbackIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaImplIdentifier.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaImplIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum StorageAreaImplIdentifierType { };
+enum class StorageAreaImplIdentifierType { };
 using StorageAreaImplIdentifier = ObjectIdentifier<StorageAreaImplIdentifierType>;
 
 }

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMapIdentifier.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMapIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum StorageAreaMapIdentifierType { };
+enum class StorageAreaMapIdentifierType { };
 using StorageAreaMapIdentifier = ObjectIdentifier<StorageAreaMapIdentifierType>;
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebStorage/StorageNamespaceIdentifier.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageNamespaceIdentifier.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-enum StorageNamespaceIdentifierType { };
+enum class StorageNamespaceIdentifierType { };
 using StorageNamespaceIdentifier = ObjectIdentifier<StorageNamespaceIdentifierType>;
 
 }


### PR DESCRIPTION
#### ef78eaa134b5c063abbe9664a9b365eca1ef82e8
<pre>
Generate serializes for ObjectIdentifier (by adding the ability to generate serializers for template specializations)
<a href="https://bugs.webkit.org/show_bug.cgi?id=262251">https://bugs.webkit.org/show_bug.cgi?id=262251</a>
rdar://116159092

Reviewed by Alex Christensen.

This seems like a huge, complicated patch just to add generated serialization of what is essentially a uint64_t wrapper.

And it is.

But in doing so, it let me flesh out adding support for templates to generate-serializers.py
Lack of template support is something we&apos;ve had to work around before, but no more! Hopefully!

(Sadly this also had to touch all the sites for identifiers that tagged with a raw enum,
as raw enums cannot be forward declared)

* Source/JavaScriptCore/runtime/Microtask.h:
(): Deleted.
* Source/WTF/wtf/ObjectIdentifier.h:
(WTF::ObjectIdentifierGenericBase::encode const): Deleted.
(WTF::ObjectIdentifierGenericBase::decode): Deleted.
(WTF::ObjectIdentifierGeneric::decode): Deleted.
* Source/WebCore/Modules/cache/DOMCacheIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/fetch/FetchIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/filesystemaccess/FileSystemHandleIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandleIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnectionCallbackIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/permissions/MainThreadPermissionObserverIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/push-api/PushSubscriptionIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/speech/SpeechRecognitionConnectionClientIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/web-locks/WebLockIdentifier.h:
(): Deleted.
* Source/WebCore/Modules/websockets/WebSocketIdentifier.h:
(): Deleted.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/dom/BroadcastChannelIdentifier.h:
(): Deleted.
* Source/WebCore/dom/ElementIdentifier.h:
(): Deleted.
* Source/WebCore/dom/PortIdentifier.h:
(): Deleted.
* Source/WebCore/editing/TextManipulationItemIdentifier.h:
(): Deleted.
* Source/WebCore/editing/TextManipulationToken.h:
* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/page/GlobalWindowIdentifier.h:
(): Deleted.
* Source/WebCore/page/SecurityOriginData.h:
(): Deleted.
* Source/WebCore/page/cocoa/ImageOverlayDataDetectionResultIdentifier.h:
(): Deleted.
* Source/WebCore/platform/MediaSessionGroupIdentifier.h:
(): Deleted.
* Source/WebCore/platform/MediaUniqueIdentifier.h:
(): Deleted.
* Source/WebCore/platform/ProcessIdentifier.h:
(): Deleted.
* Source/WebCore/platform/graphics/ImageDecoderIdentifier.h:
(): Deleted.
* Source/WebCore/platform/graphics/InbandGenericCueIdentifier.h:
(): Deleted.
* Source/WebCore/platform/graphics/LayerHostingContextIdentifier.h:
(): Deleted.
* Source/WebCore/platform/graphics/RenderingResourceIdentifier.h:
(): Deleted.
* Source/WebCore/platform/graphics/mac/DisplayConfigurationMonitor.h:
* Source/WebCore/platform/mediastream/RTCDataChannelLocalIdentifier.h:
(): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceIdentifier.h:
(): Deleted.
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCSocketIdentifier.h:
(): Deleted.
* Source/WebCore/platform/text/TextCheckingRequestIdentifier.h:
(): Deleted.
* Source/WebCore/workers/service/ServiceWorkerIdentifier.h:
(): Deleted.
* Source/WebCore/workers/service/ServiceWorkerTypes.h:
(): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRecordIdentifier.h:
(): Deleted.
* Source/WebCore/workers/shared/SharedWorkerIdentifier.h:
(): Deleted.
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceIdentifier.h:
(): Deleted.
* Source/WebKit/GPUProcess/media/RemoteSourceBufferIdentifier.h:
(): Deleted.
* Source/WebKit/GPUProcess/media/TrackPrivateRemoteIdentifier.h:
(): Deleted.
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolID.h:
(): Deleted.
* Source/WebKit/NetworkProcess/Downloads/DownloadID.h:
(): Deleted.
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm:
(): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionIdentifier&gt;::encode):
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionIdentifier&gt;::decode):
* Source/WebKit/Scripts/generate-serializers.py:
(Template):
(Template.__init__):
(Template.forward_declaration):
(Template.specialization):
(SerializedType.__init__):
(SerializedType.should_skip_forward_declare):
(one_argument_coder_declaration):
(argument_coder_declarations):
(generate_header):
(construct_type):
(construct_type.is):
(generate_one_impl):
(generate_impl):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;WebKit::Fabulous&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;WebKit::Fabulous&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;WebCore::Amazing&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;WebCore::Amazing&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;JSC::Incredible&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;JSC::Incredible&gt;&gt;::decode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;Testing::StorageSize&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::TemplateTest&lt;Testing::StorageSize&gt;&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/ContentWorldShared.h:
(): Deleted.
* Source/WebKit/Shared/Extensions/WebExtensionControllerIdentifier.h:
(): Deleted.
* Source/WebKit/Shared/ShapeDetectionIdentifier.h:
(): Deleted.
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h:
(): Deleted.
* Source/WebKit/Shared/WebsiteData/QuotaIncreaseRequestIdentifier.h:
(): Deleted.
* Source/WebKit/Shared/XR/XRDeviceIdentifier.h:
(): Deleted.
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/WebURLSchemeHandler.cpp:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/WebProcess/GPU/graphics/GraphicsContextGLIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RenderingBackendIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListenerIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteCDMIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSessionIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSessionIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaSourceIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListenerIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/VideoDecoderIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/VideoEncoderIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolverIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/Storage/RetrieveRecordResponseBodyCallbackIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/WebStorage/StorageAreaImplIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/WebStorage/StorageAreaMapIdentifier.h:
(): Deleted.
* Source/WebKit/WebProcess/WebStorage/StorageNamespaceIdentifier.h:
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/268623@main">https://commits.webkit.org/268623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84f228ff773575108fc2ca621960a1efc7d1bc09

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22082 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20780 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22933 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20369 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24612 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17555 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22583 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19547 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19104 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23589 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18308 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5667 "Found 6 jsc stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.dfg-eager, stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.mini-mode, stress/sampling-profiler-microtasks.js.no-llint ...") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4844 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22650 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24846 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18929 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5491 "Passed tests") | 
<!--EWS-Status-Bubble-End-->