### PR TITLE
[Cocoa] Clean up WebAVContentKeyGroup

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1993,4 +1993,5 @@ using WTF::copyToVector;
 using WTF::copyToVectorOf;
 using WTF::copyToVectorSpecialization;
 using WTF::compactMap;
+using WTF::flatMap;
 using WTF::removeRepeatedElements;

--- a/Source/WebCore/PAL/pal/graphics/cocoa/WebAVContentKeyGrouping.h
+++ b/Source/WebCore/PAL/pal/graphics/cocoa/WebAVContentKeyGrouping.h
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// FIXME (116158267): This file can be removed and its implementation merged directly into
+// CDMInstanceSessionFairPlayStreamingAVFObjC once we no logner need to support a configuration
+// where the BuiltInCDMKeyGroupingStrategyEnabled preference is off.
+
 #if HAVE(AVCONTENTKEYSESSION)
 
 #import <Foundation/Foundation.h>

--- a/Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h
+++ b/Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h
@@ -23,18 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// FIXME (116158267): This file can be removed and its implementation merged directly into
+// CDMInstanceSessionFairPlayStreamingAVFObjC once we no logner need to support a configuration
+// where the BuiltInCDMKeyGroupingStrategyEnabled preference is off.
+
 #pragma once
 
 #if HAVE(AVCONTENTKEYSESSION)
 
+#include <wtf/Assertions.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
 
 OBJC_CLASS AVContentKey;
 
 namespace WebCore {
 
-class ContentKeyGroupDataSource : public CanMakeWeakPtr<ContentKeyGroupDataSource> {
+class ContentKeyGroupDataSource : public CanMakeCheckedPtr {
 public:
     virtual ~ContentKeyGroupDataSource() = default;
 
@@ -42,6 +47,7 @@ public:
 #if !RELEASE_LOG_DISABLED
     virtual const void* contentKeyGroupDataSourceLogIdentifier() const = 0;
     virtual const Logger& contentKeyGroupDataSourceLogger() const = 0;
+    virtual WTFLogChannel& contentKeyGroupDataSourceLogChannel() const = 0;
 #endif // !RELEASE_LOG_DISABLED
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -165,10 +165,6 @@ class CDMInstanceSessionFairPlayStreamingAVFObjC final
     , public AVContentKeySessionDelegateClient
     , private ContentKeyGroupDataSource {
 public:
-    using AVContentKeySessionDelegateClient::weakPtrFactory;
-    using AVContentKeySessionDelegateClient::WeakValueType;
-    using AVContentKeySessionDelegateClient::WeakPtrImplType;
-
     CDMInstanceSessionFairPlayStreamingAVFObjC(Ref<CDMInstanceFairPlayStreamingAVFObjC>&&);
     virtual ~CDMInstanceSessionFairPlayStreamingAVFObjC() = default;
 
@@ -232,10 +228,11 @@ private:
     void updateProtectionStatusForDisplayID(PlatformDisplayID);
 
     // ContentKeyGroupDataSource
-    virtual Vector<RetainPtr<AVContentKey>> contentKeyGroupDataSourceKeys() const;
+    Vector<RetainPtr<AVContentKey>> contentKeyGroupDataSourceKeys() const final;
 #if !RELEASE_LOG_DISABLED
-    virtual const void* contentKeyGroupDataSourceLogIdentifier() const;
-    virtual const Logger& contentKeyGroupDataSourceLogger() const;
+    const void* contentKeyGroupDataSourceLogIdentifier() const final;
+    const Logger& contentKeyGroupDataSourceLogger() const final;
+    WTFLogChannel& contentKeyGroupDataSourceLogChannel() const final;
 #endif // !RELEASE_LOG_DISABLED
 
     Ref<CDMInstanceFairPlayStreamingAVFObjC> m_instance;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1613,8 +1613,8 @@ bool CDMInstanceSessionFairPlayStreamingAVFObjC::isLicenseTypeSupported(LicenseT
 
 Vector<RetainPtr<AVContentKey>> CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourceKeys() const
 {
-    return WTF::flatMap(m_requests, [](auto& request) {
-        return WTF::compactMap(request.requests, [](auto& request) {
+    return flatMap(m_requests, [](auto& request) {
+        return compactMap(request.requests, [](auto& request) {
             return RetainPtr { [request contentKey] };
         });
     });
@@ -1630,6 +1630,11 @@ const void* CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourc
 const Logger& CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourceLogger() const
 {
     return logger();
+}
+
+WTFLogChannel& CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourceLogChannel() const
+{
+    return logChannel();
 }
 
 #endif // !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ContentKeyGroupFactoryAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ContentKeyGroupFactoryAVFObjC.h
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// FIXME (116158267): This file can be removed and its implementation merged directly into
+// CDMInstanceSessionFairPlayStreamingAVFObjC once we no logner need to support a configuration
+// where the BuiltInCDMKeyGroupingStrategyEnabled preference is off.
+
 #pragma once
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ContentKeyGroupFactoryAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ContentKeyGroupFactoryAVFObjC.mm
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// FIXME (116158267): This file can be removed and its implementation merged directly into
+// CDMInstanceSessionFairPlayStreamingAVFObjC once we no logner need to support a configuration
+// where the BuiltInCDMKeyGroupingStrategyEnabled preference is off.
+
 #import "config.h"
 #import "ContentKeyGroupFactoryAVFObjC.h"
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.h
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// FIXME (116158267): This file can be removed and its implementation merged directly into
+// CDMInstanceSessionFairPlayStreamingAVFObjC once we no logner need to support a configuration
+// where the BuiltInCDMKeyGroupingStrategyEnabled preference is off.
+
 #if HAVE(AVCONTENTKEYSESSION)
 
 #import <pal/graphics/cocoa/WebAVContentKeyGrouping.h>


### PR DESCRIPTION
#### 435b71a7ab459529141228d215c9fc3e4553ee27
<pre>
[Cocoa] Clean up WebAVContentKeyGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=262257">https://bugs.webkit.org/show_bug.cgi?id=262257</a>
rdar://116159842

Reviewed by Jer Noble.

Addressed several issues in WebAVContentKeyGroup and ContentKeyGroupDataSource:

- Added FIXMEs indicating that WebAVContentKeyGroup and friends can be removed once we no longer
need to support a configuration where the BuiltInCDMKeyGroupingStrategyEnabled preference is off.
- Taught WebAVContentKeyGroup to get its log channel from the data source rather than hard-coding.
- Changed WebAVContentKeyGroup to store ContentKeyGroupDataSource as a CheckedPtr rather than a
WeakPtr and removed unnecessary null checks of _dataSource (note that we can&apos;t use CheckedRef
because ivars must support default initialization).
- Added a comment explaining the implementation of -associateContentKeyRequest:.
- Added a `using WTF::flatMap` to Vector.h and removed the WTF:: prefixes from compactMap and
flatMap calls in CDMInstanceSessionFairPlayStreamingAVFObjC.

* Source/WTF/wtf/Vector.h:
* Source/WebCore/PAL/pal/graphics/cocoa/WebAVContentKeyGrouping.h:
* Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourceKeys const):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::contentKeyGroupDataSourceLogChannel const):
* Source/WebCore/platform/graphics/avfoundation/objc/ContentKeyGroupFactoryAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/ContentKeyGroupFactoryAVFObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.h:
* Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm:
(-[WebAVContentKeyGroup initWithContentKeySession:dataSource:]):
(-[WebAVContentKeyGroup associateContentKeyRequest:]):
(-[WebAVContentKeyGroup expire]):
(-[WebAVContentKeyGroup logIdentifier]):
(-[WebAVContentKeyGroup loggerPtr]):
(-[WebAVContentKeyGroup logChannel]):

Canonical link: <a href="https://commits.webkit.org/268621@main">https://commits.webkit.org/268621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c3be5ecbe7c0c82cf59b3d5721dc2fa84d761e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20765 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22918 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17461 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18329 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17540 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22577 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19532 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16212 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23575 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18296 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5665 "Found 3 jsc stress test failures: stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.no-cjit-collect-continuously, wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-eager") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4842 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22636 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24831 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18918 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5489 "Found 2 jsc stress test failures: microbenchmarks/array-from-object-func.js.lockdown, microbenchmarks/array-from-object.js.lockdown") | 
<!--EWS-Status-Bubble-End-->