### PR TITLE
Add smart pointers to ImageBuffer uses

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -253,7 +253,7 @@ void GPUQueue::copyExternalImageToTexture(
     const GPUImageCopyTextureTagged& destination,
     const GPUExtent3D& copySize)
 {
-    auto imageBuffer = imageBufferForSource(source.source);
+    RefPtr imageBuffer = imageBufferForSource(source.source);
     if (!imageBuffer || !destination.texture)
         return;
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -823,7 +823,7 @@ RefPtr<VideoFrame> HTMLCanvasElement::toVideoFrame()
         return downcast<WebGLRenderingContextBase>(*m_context).paintCompositedResultsToVideoFrame();
     }
 #endif
-    auto* imageBuffer = buffer();
+    RefPtr imageBuffer = buffer();
     if (!imageBuffer)
         return nullptr;
     if (document().settings().webAPIStatisticsEnabled())

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -495,7 +495,7 @@ void OffscreenCanvas::pushBufferToPlaceholder()
 
 void OffscreenCanvas::commitToPlaceholderCanvas()
 {
-    auto* imageBuffer = buffer();
+    RefPtr imageBuffer = buffer();
     if (!imageBuffer)
         return;
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1709,7 +1709,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
 
     Ref protectedCanvas { sourceCanvas };
     // FIXME: Do this through platform-independent GraphicsContext API.
-    ImageBuffer* buffer = sourceCanvas.buffer();
+    RefPtr buffer = sourceCanvas.buffer();
     if (!buffer)
         return { };
 
@@ -1823,7 +1823,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(ImageBitmap& imageBitm
     if (!state().hasInvertibleTransform)
         return { };
 
-    ImageBuffer* buffer = imageBitmap.buffer();
+    RefPtr buffer = imageBitmap.buffer();
     if (!buffer)
         return { };
 
@@ -2277,7 +2277,7 @@ void CanvasRenderingContext2DBase::prepareForDisplay()
 
 bool CanvasRenderingContext2DBase::needsPreparationForDisplay() const
 {
-    auto buffer = canvasBase().buffer();
+    RefPtr buffer = canvasBase().buffer();
     if (buffer && buffer->prefersPreparationForDisplay())
         return true;
 
@@ -2425,7 +2425,7 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
         m_cachedImageData->imageData = nullptr;
 
     canvasBase().makeRenderingResultsAvailable();
-    ImageBuffer* buffer = canvasBase().buffer();
+    RefPtr buffer = canvasBase().buffer();
     if (!buffer) {
         auto imageData = ImageData::createUninitialized(imageDataRect.width(), imageDataRect.height(), m_settings.colorSpace, settings);
         if (!imageData.hasException())
@@ -2453,7 +2453,7 @@ void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy)
 
 void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy, int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight)
 {
-    ImageBuffer* buffer = canvasBase().buffer();
+    RefPtr buffer = canvasBase().buffer();
     if (!buffer)
         return;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -621,7 +621,7 @@ protected:
         LRUImageBufferCache(int capacity);
         // Returns pointer to a cleared image buffer that is owned by the cache. The pointer is valid until next call.
         // Using fillOperator == CompositeOperator::Copy can be used to omit the clear of the buffer.
-        ImageBuffer* imageBuffer(const IntSize&, DestinationColorSpace, CompositeOperator fillOperator = CompositeOperator::SourceOver);
+        RefPtr<ImageBuffer> imageBuffer(const IntSize&, DestinationColorSpace, CompositeOperator fillOperator = CompositeOperator::SourceOver);
     private:
         void bubbleToFront(size_t idx);
         Vector<std::optional<std::pair<DestinationColorSpace, Ref<ImageBuffer>>>> m_buffers;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -390,7 +390,7 @@ void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const Fl
     if (!result)
         return;
     
-    auto imageBuffer = result->imageBuffer();
+    RefPtr imageBuffer = result->imageBuffer();
     if (!imageBuffer)
         return;
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -329,7 +329,7 @@ RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter)
     if (!result)
         return nullptr;
 
-    auto imageBuffer = result->imageBuffer();
+    RefPtr imageBuffer = result->imageBuffer();
     if (!imageBuffer)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm
@@ -40,7 +40,7 @@ bool SourceGraphicCoreImageApplier::apply(const Filter&, const FilterImageVector
 {
     auto& input = inputs[0].get();
 
-    auto sourceImage = input.imageBuffer();
+    RefPtr sourceImage = input.imageBuffer();
     if (!sourceImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -301,7 +301,7 @@ void FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const Int
             // We prefer a conversion from the image buffer.
             if (m_imageBuffer) {
                 IntRect rect { { }, m_absoluteImageRect.size() };
-                if (auto convertedPixelBuffer = getConvertedPixelBuffer(*m_imageBuffer, alphaFormat, rect, colorSpace, m_allocator))
+                if (auto convertedPixelBuffer = getConvertedPixelBuffer(Ref { *m_imageBuffer }, alphaFormat, rect, colorSpace, m_allocator))
                     copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
                 return;
             }
@@ -381,7 +381,7 @@ void FilterImage::transformToColorSpace(const DestinationColorSpace& colorSpace)
 
     // FIXME: We can avoid this potentially unnecessary ImageBuffer conversion by adding
     // color space transform support for the {pre,un}multiplied arrays.
-    if (auto imageBuffer = this->imageBuffer())
+    if (RefPtr imageBuffer = this->imageBuffer())
         imageBuffer->transformToColorSpace(colorSpace);
 
     m_colorSpace = colorSpace;

--- a/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp
@@ -79,7 +79,7 @@ void FilterImageTargetSwitcher::endDrawSourceImage(GraphicsContext& destinationC
         return;
 
     FilterResults results;
-    destinationContext.drawFilteredImageBuffer(m_sourceImage.get(), m_sourceImageRect, *m_filter, m_results ? *m_results : results);
+    destinationContext.drawFilteredImageBuffer(m_sourceImage.get(), m_sourceImageRect, Ref { *m_filter }, m_results ? *m_results : results);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp
@@ -40,12 +40,12 @@ bool FEBlendSoftwareApplier::apply(const Filter&, const FilterImageVector& input
     auto& input = inputs[0].get();
     auto& input2 = inputs[1].get();
 
-    auto resultImage = result.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
-    auto inputImage = input.imageBuffer();
-    auto inputImage2 = input2.imageBuffer();
+    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage2 = input2.imageBuffer();
     if (!inputImage || !inputImage2)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -258,11 +258,11 @@ bool FEColorMatrixSoftwareApplier::apply(const Filter&, const FilterImageVector&
 {
     auto& input = inputs[0].get();
 
-    auto resultImage = result.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
-    auto inputImage = input.imageBuffer();
+    RefPtr inputImage = input.imageBuffer();
     if (inputImage) {
         auto inputImageRect = input.absoluteImageRectRelativeTo(result);
         resultImage->context().drawImageBuffer(*inputImage, inputImageRect);

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -153,12 +153,12 @@ bool FECompositeSoftwareApplier::applyArithmetic(FilterImage& input, FilterImage
 
 bool FECompositeSoftwareApplier::applyNonArithmetic(FilterImage& input, FilterImage& input2, FilterImage& result) const
 {
-    auto resultImage = result.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
-    auto inputImage = input.imageBuffer();
-    auto inputImage2 = input2.imageBuffer();
+    RefPtr inputImage = input.imageBuffer();
+    RefPtr inputImage2 = input2.imageBuffer();
     if (!inputImage || !inputImage2)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
@@ -34,7 +34,7 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, const FilterImageV
 {
     auto& input = inputs[0].get();
 
-    auto resultImage = result.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
@@ -48,7 +48,7 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, const FilterImageV
     FloatRect inputImageRectWithOffset(inputImageRect);
     inputImageRectWithOffset.move(absoluteOffset);
 
-    auto inputImage = input.imageBuffer();
+    RefPtr inputImage = input.imageBuffer();
     if (!inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 bool FEFloodSoftwareApplier::apply(const Filter&, const FilterImageVector&, FilterImage& result) const
 {
-    auto resultImage = result.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 bool FEImageSoftwareApplier::apply(const Filter& filter, const FilterImageVector&, FilterImage& result) const
 {
-    auto resultImage = result.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp
@@ -33,14 +33,14 @@ bool FEMergeSoftwareApplier::apply(const Filter&, const FilterImageVector& input
 {
     ASSERT(inputs.size() == m_effect.numberOfEffectInputs());
 
-    auto resultImage = result.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
 
     auto& filterContext = resultImage->context();
 
     for (auto& input : inputs) {
-        auto inputImage = input->imageBuffer();
+        RefPtr inputImage = input->imageBuffer();
         if (!inputImage)
             continue;
 

--- a/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp
@@ -36,8 +36,8 @@ bool FEOffsetSoftwareApplier::apply(const Filter& filter, const FilterImageVecto
 {
     auto& input = inputs[0].get();
 
-    auto resultImage = result.imageBuffer();
-    auto inputImage = input.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
+    RefPtr inputImage = input.imageBuffer();
     if (!resultImage || !inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
@@ -35,8 +35,8 @@ bool FETileSoftwareApplier::apply(const Filter& filter, const FilterImageVector&
 {
     auto& input = inputs[0].get();
 
-    auto resultImage = result.imageBuffer();
-    auto inputImage = input.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
+    RefPtr inputImage = input.imageBuffer();
     if (!resultImage || !inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp
@@ -32,11 +32,11 @@ bool SourceAlphaSoftwareApplier::apply(const Filter&, const FilterImageVector& i
 {
     auto& input = inputs[0].get();
 
-    auto resultImage = result.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
     if (!resultImage)
         return false;
     
-    auto inputImage = input.imageBuffer();
+    RefPtr inputImage = input.imageBuffer();
     if (!inputImage)
         return false;
 

--- a/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp
@@ -31,8 +31,8 @@ bool SourceGraphicSoftwareApplier::apply(const Filter&, const FilterImageVector&
 {
     auto& input = inputs[0].get();
 
-    auto resultImage = result.imageBuffer();
-    auto sourceImage = input.imageBuffer();
+    RefPtr resultImage = result.imageBuffer();
+    RefPtr sourceImage = input.imageBuffer();
     if (!resultImage || !sourceImage)
         return false;
 

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
@@ -82,7 +82,7 @@ MockRealtimeVideoSourceMac::MockRealtimeVideoSourceMac(String&& deviceID, AtomSt
 
 void MockRealtimeVideoSourceMac::updateSampleBuffer()
 {
-    auto imageBuffer = this->imageBuffer();
+    RefPtr imageBuffer = this->imageBuffer();
     if (!imageBuffer)
         return;
 

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -486,7 +486,7 @@ void MockRealtimeVideoSource::generateFrame()
         m_delayUntil = MonotonicTime();
     }
 
-    ImageBuffer* buffer = imageBuffer();
+    RefPtr buffer = imageBuffer();
     if (!buffer)
         return;
 


### PR DESCRIPTION
#### 8924915b479332318589c9d627f38851276164e1
<pre>
Add smart pointers to ImageBuffer uses
<a href="https://bugs.webkit.org/show_bug.cgi?id=262267">https://bugs.webkit.org/show_bug.cgi?id=262267</a>
rdar://problem/116161504

Reviewed by Ryosuke Niwa and Alex Christensen.

Add explicit Ref/RefPtr (or similar measures) where needed to ensure that
ImageBuffers cannot be deleted during function calls.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::copyExternalImageToTexture):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toVideoFrame):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::commitToPlaceholderCanvas):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::needsPreparationForDisplay const):
(WebCore::CanvasRenderingContext2DBase::getImageData const):
(WebCore::CanvasRenderingContext2DBase::putImageData):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource):
(WebCore::WebGLRenderingContextBase::drawImageIntoBuffer):
(WebCore::WebGLRenderingContextBase::videoFrameToImage):
(WebCore::WebGLRenderingContextBase::LRUImageBufferCache::imageBuffer):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawFilteredImageBuffer):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::filteredImage):
* Source/WebCore/platform/graphics/coreimage/SourceGraphicCoreImageApplier.mm:
(WebCore::SourceGraphicCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::copyPixelBuffer):
(WebCore::FilterImage::transformToColorSpace):
* Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp:
(WebCore::FilterImageTargetSwitcher::endDrawSourceImage):
* Source/WebCore/platform/graphics/filters/software/FEBlendSoftwareApplier.cpp:
(WebCore::FEBlendSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp:
(WebCore::FEColorMatrixSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp:
(WebCore::FECompositeSoftwareApplier::applyNonArithmetic const):
* Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp:
(WebCore::FEDropShadowSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEFloodSoftwareApplier.cpp:
(WebCore::FEFloodSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEImageSoftwareApplier.cpp:
(WebCore::FEImageSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEMergeSoftwareApplier.cpp:
(WebCore::FEMergeSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FEOffsetSoftwareApplier.cpp:
(WebCore::FEOffsetSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp:
(WebCore::FETileSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/SourceAlphaSoftwareApplier.cpp:
(WebCore::SourceAlphaSoftwareApplier::apply const):
* Source/WebCore/platform/graphics/filters/software/SourceGraphicSoftwareApplier.cpp:
(WebCore::SourceGraphicSoftwareApplier::apply const):
* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm:
(WebCore::MockRealtimeVideoSourceMac::updateSampleBuffer):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::generateFrame):

Canonical link: <a href="https://commits.webkit.org/268632@main">https://commits.webkit.org/268632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6e5392c0b144901a3783747b7a7c0c78ef0544a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20206 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22802 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24481 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22471 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/18995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16120 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18190 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4857 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->