### PR TITLE
Typo: horiztonalBorder instead of horizontalBorder

### DIFF
--- a/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp
@@ -121,18 +121,18 @@ void TableWrapperBlockFormattingContext::computeBorderAndPaddingForTableBox(cons
 
     topBorder = std::max(topBorder, formattingGeometry().computedBorder(*tableBox.firstChild()).vertical.top);
     for (auto& section : childrenOfType<ElementBox>(tableBox)) {
-        auto horiztonalBorder = formattingGeometry().computedBorder(section).horizontal;
-        leftBorder = std::max(leftBorder, horiztonalBorder.left);
-        rightBorder = std::max(rightBorder, horiztonalBorder.right);
+        auto horizontalBorder = formattingGeometry().computedBorder(section).horizontal;
+        leftBorder = std::max(leftBorder, horizontalBorder.left);
+        rightBorder = std::max(rightBorder, horizontalBorder.right);
     }
     bottomBorder = std::max(bottomBorder, formattingGeometry().computedBorder(*tableBox.lastChild()).vertical.bottom);
 
     auto& rows = grid.rows().list();
     topBorder = std::max(topBorder, formattingGeometry().computedBorder(rows.first().box()).vertical.top);
     for (auto& row : rows) {
-        auto horiztonalBorder = formattingGeometry().computedBorder(row.box()).horizontal;
-        leftBorder = std::max(leftBorder, horiztonalBorder.left);
-        rightBorder = std::max(rightBorder, horiztonalBorder.right);
+        auto horizontalBorder = formattingGeometry().computedBorder(row.box()).horizontal;
+        leftBorder = std::max(leftBorder, horizontalBorder.left);
+        rightBorder = std::max(rightBorder, horizontalBorder.right);
     }
     bottomBorder = std::max(bottomBorder, formattingGeometry().computedBorder(rows.last().box()).vertical.bottom);
 


### PR DESCRIPTION
#### 99d5287148f201a43c27ae3917aac6fc38572dd3
<pre>
Typo: horiztonalBorder instead of horizontalBorder
<a href="https://bugs.webkit.org/show_bug.cgi?id=262284">https://bugs.webkit.org/show_bug.cgi?id=262284</a>
rdar://116164873

Reviewed by Tim Horton.

This is just fixing a typo which is in the code.
It replaces horiztonalBorder by horizontalBorder.

* Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.cpp:
(WebCore::Layout::TableWrapperBlockFormattingContext::computeBorderAndPaddingForTableBox):

Canonical link: <a href="https://commits.webkit.org/268574@main">https://commits.webkit.org/268574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1bc3ab4c1c89030dbfdfe3a18734be5d7480217

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20660 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22812 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24490 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22480 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19004 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18200 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4812 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->