### PR TITLE
Implement keyboard events for site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/key-events-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/key-events-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS Received key event x
+

--- a/LayoutTests/http/tests/site-isolation/key-events.html
+++ b/LayoutTests/http/tests/site-isolation/key-events.html
@@ -1,0 +1,18 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+window.addEventListener("message", function (event) {
+    testPassed("Received key event " + event.data);
+    testRunner.notifyDone();
+});
+
+function test() {
+    document.getElementById("iframe").focus();
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+        eventSender.keyDown("x");
+    }
+}
+</script>
+<iframe onload="test()" id="iframe" src="http://localhost:8000/site-isolation/resources/key-event-handler.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/key-event-handler.html
+++ b/LayoutTests/http/tests/site-isolation/resources/key-event-handler.html
@@ -1,0 +1,3 @@
+<script>
+addEventListener('keydown', (event) => { window.parent.postMessage(event.key, '*') });
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4596,6 +4596,9 @@ imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-match
 
 webkit.org/b/257904 http/tests/site-isolation/basic-iframe.html [ Skip ]
 
+# This test can't be enabled on iOS until EventSenderProxyIOS::keyDown() is implemented.
+http/tests/site-isolation/key-events.html [ Skip ]
+
 # Initial css/compositing test import
 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-both-parent-and-blended-with-3D-transform.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-text.html [ ImageOnlyFailure ]

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1115,6 +1115,7 @@ public:
     void wheelEventHandlingCompleted(bool wasHandled);
 
     bool isProcessingKeyboardEvents() const;
+    void sendKeyEvent(const NativeWebKeyboardEvent&);
     bool handleKeyboardEvent(const NativeWebKeyboardEvent&);
 #if PLATFORM(WIN)
     void dispatchPendingCharEvents(const NativeWebKeyboardEvent&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1293,17 +1293,13 @@ WebCore::HandleMouseEventResult WebFrame::handleMouseEvent(const WebMouseEvent& 
 
 bool WebFrame::handleKeyEvent(const WebKeyboardEvent& keyboardEvent)
 {
-    if (!m_coreFrame)
+    auto* coreFrame = coreLocalFrame();
+    if (!coreFrame)
         return false;
 
-    auto* page = m_coreFrame->page();
-    if (!page)
-        return false;
-
-    Ref frame = page->focusController().focusedOrMainFrame();
     if (keyboardEvent.type() == WebEventType::Char && keyboardEvent.isSystemKey())
-        return frame->eventHandler().handleAccessKey(platform(keyboardEvent));
-    return frame->eventHandler().keyEvent(platform(keyboardEvent));
+        return coreFrame->eventHandler().handleAccessKey(platform(keyboardEvent));
+    return coreFrame->eventHandler().keyEvent(platform(keyboardEvent));
 }
 
 bool WebFrame::isFocused() const


### PR DESCRIPTION
#### 81ab068d217bd79ff4f6e841dfb8e7a854684ade
<pre>
Implement keyboard events for site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=262286">https://bugs.webkit.org/show_bug.cgi?id=262286</a>
rdar://116167166

Reviewed by Alex Christensen.

Currently, key events rely on `FocusController` in the web process to determine which frame should receive
a key event. For site isolation, we should reference information on the focused frame stored in the UI
process so we can send the key event directly to the web process hosting the focused frame.

EventSenderProxyIOS::keyDown() is not implemented, so disable the test on iOS.

* LayoutTests/http/tests/site-isolation/key-events-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/key-events.html: Added.
* LayoutTests/http/tests/site-isolation/resources/key-event-handler.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::sendKeyEvent):
(WebKit::WebPageProxy::handleKeyboardEvent):
(WebKit::WebPageProxy::didReceiveEvent):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::handleKeyEvent):

Canonical link: <a href="https://commits.webkit.org/268639@main">https://commits.webkit.org/268639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fcc6535210d6d95e76608457fc0c50968061c0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18867 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20315 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22967 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24638 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16247 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18216 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4863 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->