### PR TITLE
GraphicsContext InterpolationQuality::Default is misleading name, add documentation

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -53,11 +53,9 @@ static std::atomic<size_t> s_activePixelMemory { 0 };
 namespace WebCore {
 
 #if USE(CG)
-// FIXME: It seems strange that the default quality is not the one that is literally named "default".
-// Should fix names to make this easier to understand, or write an excellent comment here explaining why not.
-const InterpolationQuality defaultInterpolationQuality = InterpolationQuality::Low;
+constexpr InterpolationQuality defaultInterpolationQuality = InterpolationQuality::Low;
 #else
-const InterpolationQuality defaultInterpolationQuality = InterpolationQuality::Default;
+constexpr InterpolationQuality defaultInterpolationQuality = InterpolationQuality::Medium;
 #endif
 
 static std::optional<size_t> maxCanvasAreaForTesting;

--- a/Source/WebCore/platform/graphics/GraphicsTypes.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypes.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -102,6 +102,18 @@ enum class GradientSpreadMethod : uint8_t {
     Repeat
 };
 
+// InterpolationQuality::Default
+// For ImagePaintingOptions, it means:
+//  - Use context image interpolation quality.
+// For GraphicsContext CG it means:
+//  - If the CGImage has shouldInterpolate == true, use High
+//  - Else use None
+// For GraphicsContext Cairo it means:
+//  - Use Medium
+//
+// FIXME: Remove InterpolationQuality::Default since it does not mean what it should
+// obviously mean and because the CG context behavior is unusable in general case where
+// the draw call sites cannot track where the native images are generated from.
 enum class InterpolationQuality : uint8_t {
     Default,
     DoNotInterpolate,

--- a/Source/WebCore/platform/graphics/cocoa/IconCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IconCocoa.mm
@@ -79,8 +79,7 @@ void Icon::paint(GraphicsContext& context, const FloatRect& destRect)
     auto image = NativeImage::create(cgImage);
 
     FloatRect srcRect(FloatPoint::zero(), image->size());
-    context.setImageInterpolationQuality(InterpolationQuality::High);
-    context.drawNativeImage(*image, srcRect.size(), destRect, srcRect);
+    context.drawNativeImage(*image, srcRect.size(), destRect, srcRect, { InterpolationQuality::High });
 }
 
 }

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -43,7 +43,6 @@ void BitmapTexture::updateContents(GraphicsLayer* sourceLayer, const IntRect& ta
         return;
 
     GraphicsContext& context = imageBuffer->context();
-    context.setImageInterpolationQuality(InterpolationQuality::Default);
     context.setTextDrawingMode(TextDrawingMode::Fill);
 
     IntRect sourceRect(targetRect);

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -516,7 +516,6 @@ ImageBuffer* MockRealtimeVideoSource::imageBuffer() const
     if (!m_imageBuffer)
         return nullptr;
 
-    m_imageBuffer->context().setImageInterpolationQuality(InterpolationQuality::Default);
     m_imageBuffer->context().setStrokeThickness(1);
 
     return m_imageBuffer.get();


### PR DESCRIPTION
#### a54c64ccb14bfa9db06f6649ecc9a843120247e5
<pre>
GraphicsContext InterpolationQuality::Default is misleading name, add documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=262288">https://bugs.webkit.org/show_bug.cgi?id=262288</a>
rdar://116169474

Reviewed by Antti Koivisto.

Add a FIXME documentation what InterpolationQuality::Default means and
why it should be removed.
Remove the FIXME question in CanvasBase asking what is the InterpolationQuality::Default.

Remove few uses of
GraphicsContext::setImageInterpolationQuality(InterpolationQuality::Default)
where a newly created context obviously tries to use the default quality.
The default quality should be the quality set to a newly created context
by default.

Change a call to GraphicsContext::setImageInterpolationQuality(InterpolationQuality::High)
to use ImagePaintingOptions { InterpolationQuality::High }. This conveys
the idea better, limit the quality setting to that particular draw.
This leaves the setImageInterpolationQuality call-sites to cases
where the intention is to leave the state on indefinitively.

* Source/WebCore/html/CanvasBase.cpp:
* Source/WebCore/platform/graphics/GraphicsTypes.h:
* Source/WebCore/platform/graphics/cocoa/IconCocoa.mm:
(WebCore::Icon::paint):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::updateContents):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::imageBuffer const):

Canonical link: <a href="https://commits.webkit.org/268720@main">https://commits.webkit.org/268720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/997856b3296e3d29f3ac1ce923a1230007b34418

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22142 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20333 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22992 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24658 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22630 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16270 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18364 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4918 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->