### PR TITLE
Set expectedContentLength in ServiceWorkerDownloadTask didReceiveData callback

### DIFF
--- a/LayoutTests/http/tests/workers/service/resources/service-worker-download-worker.js
+++ b/LayoutTests/http/tests/workers/service/resources/service-worker-download-worker.js
@@ -13,7 +13,7 @@ self.addEventListener("fetch", (event) => {
                 setTimeout(() => { controller.close(); }, 200);
             }
         });
-        const response = new Response(stream, {"headers" : [["Content-Type", "application/binary"]]});
+        const response = new Response(stream, {"headers" : [["Content-Type", "application/binary"], ["Content-Length", 200]]});
         event.respondWith(response);
         return;
     }

--- a/LayoutTests/http/tests/workers/service/service-worker-download-stream.https-expected.txt
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-stream.https-expected.txt
@@ -1,5 +1,6 @@
 Download started.
 Downloading URL with suggested filename "download-stream"
 Download size: 34.
+Download expected size: 200.
 Download completed.
 

--- a/LayoutTests/http/tests/workers/service/service-worker-download-stream.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-stream.https.html
@@ -8,6 +8,7 @@ if (window.testRunner) {
   testRunner.dumpAsText();
   testRunner.setShouldLogDownloadCallbacks(true);
   testRunner.setShouldLogDownloadSize(true);
+  testRunner.setShouldLogDownloadExpectedSize(true);
   testRunner.waitUntilDownloadFinished();
   testRunner.setShouldDownloadUndisplayableMIMETypes(true);
 }

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt
@@ -1,5 +1,6 @@
 Download started.
 Downloading URL with suggested filename "fetch-service-worker-preload-script.py.vcf"
 Download size: 11.
+Download expected size: 11.
 Download completed.
 

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https.html
@@ -10,6 +10,7 @@ if (window.testRunner) {
   testRunner.dumpAsText();
   testRunner.setShouldLogDownloadCallbacks(true);
   testRunner.setShouldLogDownloadSize(true);
+  testRunner.setShouldLogDownloadExpectedSize(true);
   testRunner.waitUntilDownloadFinished();
   testRunner.setShouldDownloadUndisplayableMIMETypes(true);
 }

--- a/LayoutTests/platform/glib/http/tests/workers/service/service-worker-download-stream.https-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/workers/service/service-worker-download-stream.https-expected.txt
@@ -1,5 +1,6 @@
 Download started.
 Downloading URL with suggested filename ""
 Download size: 34.
+Download expected size: 200.
 Download completed.
 

--- a/LayoutTests/platform/glib/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt
+++ b/LayoutTests/platform/glib/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt
@@ -1,5 +1,6 @@
 Download started.
 Downloading URL with suggested filename "fetch-service-worker-preload-script.py"
 Download size: 0.
+Download expected size: 0.
 Download completed.
 

--- a/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt
+++ b/LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt
@@ -1,5 +1,6 @@
 Download started.
 Downloading URL with suggested filename "fetch-service-worker-preload-script.py"
 Download size: 11.
+Download expected size: 11.
 Download completed.
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -51,9 +51,9 @@ class WebSWServerToContextConnection;
 class ServiceWorkerDownloadTask : public NetworkDataTask, private FunctionDispatcher, private IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<ServiceWorkerDownloadTask> create(NetworkSession& session, NetworkDataTaskClient& client, WebSWServerToContextConnection& connection, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::FetchIdentifier fetchIdentifier, const WebCore::ResourceRequest& request, DownloadID downloadID)
+    static Ref<ServiceWorkerDownloadTask> create(NetworkSession& session, NetworkDataTaskClient& client, WebSWServerToContextConnection& connection, WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::FetchIdentifier fetchIdentifier, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, DownloadID downloadID)
     {
-        auto task = adoptRef(*new ServiceWorkerDownloadTask(session, client, connection, serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, request, downloadID));
+        auto task = adoptRef(*new ServiceWorkerDownloadTask(session, client, connection, serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, request, response, downloadID));
         task->startListeningForIPC();
         return task;
     }
@@ -65,7 +65,7 @@ public:
     void stop() { cancel(); }
 
 private:
-    ServiceWorkerDownloadTask(NetworkSession&, NetworkDataTaskClient&, WebSWServerToContextConnection&, WebCore::ServiceWorkerIdentifier, WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, const WebCore::ResourceRequest&, DownloadID);
+    ServiceWorkerDownloadTask(NetworkSession&, NetworkDataTaskClient&, WebSWServerToContextConnection&, WebCore::ServiceWorkerIdentifier, WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& response, DownloadID);
     void startListeningForIPC();
 
     // IPC Message
@@ -99,7 +99,8 @@ private:
     Ref<NetworkProcess> m_networkProcess;
     RefPtr<SandboxExtension> m_sandboxExtension;
     FileSystem::PlatformFileHandle m_downloadFile { FileSystem::invalidPlatformFileHandle };
-    int64_t m_downloadBytesWritten { 0 };
+    uint64_t m_downloadBytesWritten { 0 };
+    std::optional<uint64_t> m_expectedContentLength;
     State m_state { State::Suspended };
 };
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -542,7 +542,7 @@ bool ServiceWorkerFetchTask::convertToDownload(DownloadManager& manager, Downloa
     // FIXME: We might want to keep the service worker alive until the download ends.
     RefPtr<ServiceWorkerDownloadTask> serviceWorkerDownloadTask;
     auto serviceWorkerDownloadLoad = makeUnique<NetworkLoad>(*protectedLoader(), *session, [&](auto& client) {
-        serviceWorkerDownloadTask =  ServiceWorkerDownloadTask::create(*session, client, *m_serviceWorkerConnection, m_serviceWorkerIdentifier, m_serverConnectionIdentifier, m_fetchIdentifier, request, downloadID);
+        serviceWorkerDownloadTask =  ServiceWorkerDownloadTask::create(*session, client, *m_serviceWorkerConnection, m_serviceWorkerIdentifier, m_serverConnectionIdentifier, m_fetchIdentifier, request, response, downloadID);
         return serviceWorkerDownloadTask.copyRef();
     });
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -42,6 +42,7 @@ interface TestRunner {
     undefined waitUntilDownloadFinished();
     undefined setShouldLogDownloadCallbacks(boolean value);
     undefined setShouldLogDownloadSize(boolean value);
+    undefined setShouldLogDownloadExpectedSize(boolean value);
 
     const unsigned short RENDER_TREE_SHOW_ALL_LAYERS            = 1;
     const unsigned short RENDER_TREE_SHOW_LAYER_NESTING         = 2;

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1112,6 +1112,11 @@ void TestRunner::setShouldLogDownloadSize(bool value)
     postPageMessage("SetShouldLogDownloadSize", value);
 }
 
+void TestRunner::setShouldLogDownloadExpectedSize(bool value)
+{
+    postPageMessage("SetShouldLogDownloadExpectedSize", value);
+}
+
 void TestRunner::setAuthenticationUsername(JSStringRef username)
 {
     postPageMessage("SetAuthenticationUsername", toWK(username));

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -233,6 +233,7 @@ public:
     bool shouldFinishAfterDownload() const { return m_shouldFinishAfterDownload; }
     void setShouldLogDownloadCallbacks(bool);
     void setShouldLogDownloadSize(bool);
+    void setShouldLogDownloadExpectedSize(bool);
 
     bool shouldAllowEditing() const { return m_shouldAllowEditing; }
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1211,6 +1211,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     setPluginSupportedMode({ });
 
     m_shouldLogDownloadSize = false;
+    m_shouldLogDownloadExpectedSize = false;
     m_shouldLogDownloadCallbacks = false;
     m_shouldLogHistoryClientCallbacks = false;
     m_shouldLogCanAuthenticateAgainstProtectionSpace = false;
@@ -2500,6 +2501,8 @@ void TestController::downloadDidFinish(WKDownloadRef)
 {
     if (m_shouldLogDownloadSize)
         m_currentInvocation->outputText(makeString("Download size: ", m_downloadTotalBytesWritten.value_or(0), ".\n"));
+    if (m_shouldLogDownloadExpectedSize)
+        m_currentInvocation->outputText(makeString("Download expected size: ", m_downloadTotalBytesExpectedToWrite.value_or(0), ".\n"));
     if (m_shouldLogDownloadCallbacks)
         m_currentInvocation->outputText("Download completed.\n"_s);
     m_currentInvocation->notifyDownloadDone();
@@ -2537,16 +2540,17 @@ void TestController::downloadDidReceiveAuthenticationChallenge(WKDownloadRef, WK
     static_cast<TestController*>(const_cast<void*>(clientInfo))->didReceiveAuthenticationChallenge(nullptr, authenticationChallenge);
 }
 
-void TestController::downloadDidWriteData(long long totalBytesWritten)
+void TestController::downloadDidWriteData(long long totalBytesWritten, long long totalBytesExpectedToWrite)
 {
     if (!m_shouldLogDownloadCallbacks)
         return;
     m_downloadTotalBytesWritten = totalBytesWritten;
+    m_downloadTotalBytesExpectedToWrite = totalBytesExpectedToWrite;
 }
 
 void TestController::downloadDidWriteData(WKDownloadRef download, long long bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite, const void* clientInfo)
 {
-    static_cast<TestController*>(const_cast<void*>(clientInfo))->downloadDidWriteData(totalBytesWritten);
+    static_cast<TestController*>(const_cast<void*>(clientInfo))->downloadDidWriteData(totalBytesWritten, totalBytesExpectedToWrite);
 }
 
 void TestController::webProcessDidTerminate(WKProcessTerminationReason reason)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -201,6 +201,7 @@ public:
     void setShouldLogCanAuthenticateAgainstProtectionSpace(bool shouldLog) { m_shouldLogCanAuthenticateAgainstProtectionSpace = shouldLog; }
     void setShouldLogDownloadCallbacks(bool shouldLog) { m_shouldLogDownloadCallbacks = shouldLog; }
     void setShouldLogDownloadSize(bool shouldLog) { m_shouldLogDownloadSize = shouldLog; }
+    void setShouldLogDownloadExpectedSize(bool shouldLog) { m_shouldLogDownloadExpectedSize = shouldLog; }
 
     bool isCurrentInvocation(TestInvocation* invocation) const { return invocation == m_currentInvocation.get(); }
 
@@ -536,7 +537,7 @@ private:
     bool downloadDidReceiveServerRedirectToURL(WKDownloadRef, WKURLRequestRef);
     static void downloadDidReceiveAuthenticationChallenge(WKDownloadRef, WKAuthenticationChallengeRef, const void *clientInfo);
 
-    void downloadDidWriteData(long long totalBytesWritten);
+    void downloadDidWriteData(long long totalBytesWritten, long long totalBytesExpectedToWrite);
     static void downloadDidWriteData(WKDownloadRef, long long bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite, const void* clientInfo);
 
     static void webProcessDidTerminate(WKPageRef,  WKProcessTerminationReason, const void* clientInfo);
@@ -750,7 +751,9 @@ private:
     bool m_isMediaKeySystemPermissionGranted { true };
 
     std::optional<long long> m_downloadTotalBytesWritten;
+    std::optional<uint64_t> m_downloadTotalBytesExpectedToWrite;
     bool m_shouldLogDownloadSize { false };
+    bool m_shouldLogDownloadExpectedSize { false };
     bool m_dumpPolicyDelegateCallbacks { false };
 };
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -568,6 +568,11 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetShouldLogDownloadExpectedSize")) {
+        TestController::singleton().setShouldLogDownloadExpectedSize(booleanValue(messageBody));
+        return;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "SetAuthenticationUsername")) {
         WKStringRef username = stringValue(messageBody);
         TestController::singleton().setAuthenticationUsername(toWTFString(username));


### PR DESCRIPTION
#### 423d5f5dd0dbc7c48f3f1c931db7e5734fc692d5
<pre>
Set expectedContentLength in ServiceWorkerDownloadTask didReceiveData callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=262297">https://bugs.webkit.org/show_bug.cgi?id=262297</a>
rdar://109266074

Reviewed by Alex Christensen.

Store the Response expectedContentLength in ServiceWorkerDownloadTask.
Use it to set the totalExpectedSize parameter of the didReceiveData callback.
We use the max of the expectedContentLength and the size of data already written as service worker downloads may use synthetic response with zero expectedContentLength.
For synthetic responses, if the expectedContentLength is zero, we check the Content-Length header and parse it to compute a new expectedContentLength value.

* LayoutTests/http/tests/workers/service/resources/service-worker-download-worker.js:
(event.event.request.url.includes):
* LayoutTests/http/tests/workers/service/service-worker-download-stream.https-expected.txt:
* LayoutTests/http/tests/workers/service/service-worker-download-stream.https.html:
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt:
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https.html:
* LayoutTests/platform/glib/http/tests/workers/service/service-worker-download-stream.https-expected.txt:
* LayoutTests/platform/glib/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt:
* LayoutTests/platform/ios/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https-expected.txt:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::create):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::ServiceWorkerDownloadTask):
(WebKit::ServiceWorkerDownloadTask::didReceiveData):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
(WebKit::ServiceWorkerDownloadTask::create):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::convertToDownload):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setShouldLogDownloadExpectedSize):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):
(WTR::TestController::downloadDidFinish):
(WTR::TestController::downloadDidWriteData):
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::setShouldLogDownloadExpectedSize):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/268794@main">https://commits.webkit.org/268794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da734e22e19fc6b753c605ebfbd1f79c25d383bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20684 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21284 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23435 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18790 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18968 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/23012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19557 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18626 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4968 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->