### PR TITLE
GraphicsContextCG should initialize interpolation quality to an explicit value

### DIFF
--- a/Source/WebCore/platform/cocoa/DragImageCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragImageCocoa.mm
@@ -300,7 +300,7 @@ DragImageRef createDragImageForLink(Element& element, URL& url, const String& ti
     RetainPtr<NSImage> dragImage = adoptNS([[NSImage alloc] initWithSize:imageSize]);
     [dragImage _web_lockFocusWithDeviceScaleFactor:deviceScaleFactor];
 
-    GraphicsContextCG context([NSGraphicsContext currentContext].CGContext);
+    GraphicsContextCG context([NSGraphicsContext currentContext].CGContext, GraphicsContextCG::ContextSource::PlatformView);
 
     context.fillRoundedRect(FloatRoundedRect(layout.boundingRect, FloatRoundedRect::Radii(linkImageCornerRadius)), colorFromCocoaColor([NSColor controlBackgroundColor]));
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -34,11 +34,12 @@ namespace WebCore {
 
 class WEBCORE_EXPORT GraphicsContextCG : public GraphicsContext {
 public:
-    enum CGContextSource {
-        Unknown,
-        CGContextFromCALayer
+    enum class ContextSource : uint8_t {
+        WebKit,
+        PlatformView,
+        CALayer
     };
-    GraphicsContextCG(CGContextRef, CGContextSource = CGContextSource::Unknown, std::optional<RenderingMode> knownRenderingMode = std::nullopt);
+    GraphicsContextCG(CGContextRef, ContextSource, std::optional<RenderingMode> knownRenderingMode = std::nullopt);
 
     ~GraphicsContextCG();
 
@@ -154,7 +155,8 @@ private:
 
     const RetainPtr<CGContextRef> m_cgContext;
     const RenderingMode m_renderingMode;
-    const bool m_isLayerCGContext;
+    const ContextSource m_contextSource;
+    const CGInterpolationQuality m_savedInterpolationQuality; // Only for WebKit non-owned contexts.
     mutable bool m_userToDeviceTransformKnownToBeIdentity { false };
     // Flag for pending draws. Start with true because we do not know what commands have been scheduled to the context.
     bool m_hasDrawn { true };

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -85,7 +85,7 @@ std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(c
     if (!cgContext)
         return nullptr;
 
-    auto context = makeUnique<GraphicsContextCG>(cgContext.get());
+    auto context = makeUnique<GraphicsContextCG>(cgContext.get(), GraphicsContextCG::ContextSource::WebKit);
 
     auto dataProvider = adoptCF(CGDataProviderCreateWithData(nullptr, data, numBytes, [] (void*, const void* data, size_t) {
         fastFree(const_cast<void*>(data));

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -115,7 +115,7 @@ ImageBufferIOSurfaceBackend::~ImageBufferIOSurfaceBackend()
 GraphicsContext& ImageBufferIOSurfaceBackend::context()
 {
     if (!m_context) {
-        m_context = makeUnique<GraphicsContextCG>(ensurePlatformContext());
+        m_context = makeUnique<GraphicsContextCG>(ensurePlatformContext(), GraphicsContextCG::ContextSource::WebKit);
         applyBaseTransform(*m_context);
     }
     return *m_context;

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -398,7 +398,7 @@ bool PathCG::strokeContains(const FloatPoint& point, const Function<void(Graphic
     CGContextBeginPath(context);
     CGContextAddPath(context, platformPath());
 
-    GraphicsContextCG graphicsContext(context);
+    GraphicsContextCG graphicsContext(context, GraphicsContextCG::ContextSource::WebKit);
     strokeStyleApplier(graphicsContext);
 
     bool hitSuccess = CGContextPathContainsPoint(context, point, kCGPathStroke);
@@ -437,7 +437,7 @@ FloatRect PathCG::strokeBoundingRect(const Function<void(GraphicsContext&)>& str
     CGContextAddPath(context, platformPath());
 
     if (strokeStyleApplier) {
-        GraphicsContextCG graphicsContext(context);
+        GraphicsContextCG graphicsContext(context, GraphicsContextCG::ContextSource::WebKit);
         strokeStyleApplier(graphicsContext);
     }
 

--- a/Source/WebCore/platform/graphics/cg/PatternCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PatternCG.cpp
@@ -43,7 +43,7 @@ static void patternCallback(void* info, CGContextRef context)
     if (!platformImage)
         return;
 
-    CGRect rect = GraphicsContextCG(context).roundToDevicePixels(
+    CGRect rect = GraphicsContextCG(context, GraphicsContextCG::ContextSource::WebKit).roundToDevicePixels(
         FloatRect(0, 0, CGImageGetWidth(platformImage), CGImageGetHeight(platformImage)));
     CGContextDrawImage(context, rect, platformImage);
 }

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
@@ -84,7 +84,7 @@ UniqueRef<GraphicsContext> DrawGlyphsRecorder::createInternalContext()
     auto contextType = kCGContextTypeWindow;
 #endif
     auto context = adoptCF(CGContextCreateWithDelegate(contextDelegate.get(), contextType, nullptr, nullptr));
-    return makeUniqueRef<GraphicsContextCG>(context.get());
+    return makeUniqueRef<GraphicsContextCG>(context.get(), GraphicsContextCG::ContextSource::WebKit);
 }
 
 DrawGlyphsRecorder::DrawGlyphsRecorder(GraphicsContext& owner, float scaleFactor, DeriveFontFromContext deriveFontFromContext)

--- a/Source/WebCore/platform/graphics/mac/ColorMac.mm
+++ b/Source/WebCore/platform/graphics/mac/ColorMac.mm
@@ -86,7 +86,7 @@ static std::optional<SRGBA<uint8_t>> makeSimpleColorFromNSColor(NSColor *color)
         RetainPtr<NSBitmapImageRep> offscreenRep = adoptNS([[NSBitmapImageRep alloc] initWithBitmapDataPlanes:nil pixelsWide:1 pixelsHigh:1
             bitsPerSample:8 samplesPerPixel:4 hasAlpha:YES isPlanar:NO colorSpaceName:NSDeviceRGBColorSpace bytesPerRow:4 bitsPerPixel:32]);
 
-        GraphicsContextCG bitmapContext([NSGraphicsContext graphicsContextWithBitmapImageRep:offscreenRep.get()].CGContext);
+        GraphicsContextCG bitmapContext([NSGraphicsContext graphicsContextWithBitmapImageRep:offscreenRep.get()].CGContext, GraphicsContextCG::ContextSource::PlatformView);
         LocalCurrentGraphicsContext localContext(bitmapContext);
 
         [color drawSwatchInRect:NSMakeRect(0, 0, 1, 1)];

--- a/Source/WebCore/platform/graphics/mac/WebLayer.mm
+++ b/Source/WebCore/platform/graphics/mac/WebLayer.mm
@@ -51,7 +51,7 @@
 {
     auto layer = WebCore::PlatformCALayer::platformCALayerForLayer((__bridge void*)self);
     if (layer) {
-        WebCore::GraphicsContextCG graphicsContext(context, WebCore::GraphicsContextCG::CGContextFromCALayer);
+        WebCore::GraphicsContextCG graphicsContext(context, WebCore::GraphicsContextCG::ContextSource::CALayer);
         WebCore::PlatformCALayer::RepaintRectList rectsToPaint = WebCore::PlatformCALayer::collectRectsToPaint(graphicsContext, layer.get());
         OptionSet<WebCore::GraphicsLayerPaintBehavior> paintBehavior;
         if (self.isRenderingInContext)
@@ -138,7 +138,7 @@
     ASSERT(isMainThread());
     auto layer = WebCore::PlatformCALayer::platformCALayerForLayer((__bridge void*)self);
     if (layer && layer->owner()) {
-        WebCore::GraphicsContextCG graphicsContext(context, WebCore::GraphicsContextCG::CGContextFromCALayer);
+        WebCore::GraphicsContextCG graphicsContext(context, WebCore::GraphicsContextCG::ContextSource::CALayer);
         WebCore::FloatRect clipBounds = CGContextGetClipBoundingBox(context);
         OptionSet<WebCore::GraphicsLayerPaintBehavior> paintBehavior;
         if (self.isRenderingInContext)

--- a/Source/WebCore/platform/ios/DragImageIOS.mm
+++ b/Source/WebCore/platform/ios/DragImageIOS.mm
@@ -95,7 +95,7 @@ DragImageRef createDragImageFromImage(Image* image, ImageOrientation orientation
 
     RetainPtr<UIGraphicsImageRenderer> render = adoptNS([PAL::allocUIGraphicsImageRendererInstance() initWithSize:imageSize]);
     UIImage *imageCopy = [render imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
-        GraphicsContextCG context(rendererContext.CGContext);
+        GraphicsContextCG context(rendererContext.CGContext, GraphicsContextCG::ContextSource::PlatformView);
         context.translate(0, imageSize.height);
         context.scale({ adjustedImageScale, -adjustedImageScale });
         context.drawImage(*image, FloatPoint(), { orientation });
@@ -137,7 +137,7 @@ DragImageRef createDragImageForLink(Element& linkElement, URL& url, const String
 
     auto renderer = adoptNS([PAL::allocUIGraphicsImageRendererInstance() initWithSize:imageRect.size]);
     auto image = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
-        GraphicsContextCG context(rendererContext.CGContext);
+        GraphicsContextCG context(rendererContext.CGContext, GraphicsContextCG::ContextSource::PlatformView);
         context.translate(0, CGRectGetHeight(imageRect));
         context.scale({ 1, -1 });
         context.fillRoundedRect(FloatRoundedRect(imageRect, FloatRoundedRect::Radii(4)), Color::white);
@@ -205,7 +205,7 @@ DragImageRef createDragImageForSelection(LocalFrame& frame, TextIndicatorData& i
 
     auto renderer = adoptNS([PAL::allocUIGraphicsImageRendererInstance() initWithSize:imageRect.size()]);
     return [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
-        GraphicsContextCG context(rendererContext.CGContext);
+        GraphicsContextCG context(rendererContext.CGContext, GraphicsContextCG::ContextSource::PlatformView);
         // FIXME: The context flip here should not be necessary, and suggests that somewhere else in the regular
         // drag initiation flow, we unnecessarily flip the graphics context.
         context.translate(0, imageRect.height());
@@ -239,7 +239,7 @@ DragImageRef createDragImageForRange(LocalFrame& frame, const SimpleRange& range
     auto& image = *textIndicator->contentImage();
     auto render = adoptNS([PAL::allocUIGraphicsImageRendererInstance() initWithSize:image.size()]);
     UIImage *finalImage = [render imageWithActions:[&image](UIGraphicsImageRendererContext *rendererContext) {
-        GraphicsContextCG context(rendererContext.CGContext);
+        GraphicsContextCG context(rendererContext.CGContext, GraphicsContextCG::ContextSource::PlatformView);
         context.drawImage(image, FloatPoint());
     }];
 
@@ -253,7 +253,7 @@ DragImageRef createDragImageForColor(const Color& color, const FloatRect& elemen
 
     auto render = adoptNS([PAL::allocUIGraphicsImageRendererInstance() initWithSize:imageRect.size()]);
     UIImage *image = [render imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {
-        GraphicsContextCG context { rendererContext.CGContext };
+        GraphicsContextCG context { rendererContext.CGContext, GraphicsContextCG::ContextSource::PlatformView };
         context.translate(0, CGRectGetHeight(imageRect));
         context.scale({ 1, -1 });
         context.fillRoundedRect(swatch, color);

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
@@ -58,7 +58,7 @@ static CFDictionaryRef makeContextOptions(const DynamicContentScalingImageBuffer
 class GraphicsContextDynamicContentScaling : public WebCore::GraphicsContextCG {
 public:
     GraphicsContextDynamicContentScaling(const DynamicContentScalingImageBufferBackend::Parameters& parameters, WebCore::IntSize backendSize, WebCore::RenderingMode renderingMode)
-        : GraphicsContextCG(adoptCF(RECGCommandsContextCreate(backendSize, makeContextOptions(parameters))).autorelease(), GraphicsContextCG::Unknown, renderingMode)
+        : GraphicsContextCG(adoptCF(RECGCommandsContextCreate(backendSize, makeContextOptions(parameters))).autorelease(), GraphicsContextCG::ContextSource::WebKit, renderingMode)
     {
     }
 

--- a/Source/WebKit/Shared/cg/ShareableBitmapCG.mm
+++ b/Source/WebKit/Shared/cg/ShareableBitmapCG.mm
@@ -181,7 +181,7 @@ std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
     CGContextTranslateCTM(bitmapContext.get(), 0, size().height());
     CGContextScaleCTM(bitmapContext.get(), 1, -1);
 
-    return makeUnique<GraphicsContextCG>(bitmapContext.get());
+    return makeUnique<GraphicsContextCG>(bitmapContext.get(), GraphicsContextCG::ContextSource::WebKit);
 }
 
 void ShareableBitmap::paint(GraphicsContext& context, const IntPoint& destination, const IntRect& source)

--- a/Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm
+++ b/Source/WebKit/UIProcess/Inspector/ios/WKInspectorHighlightView.mm
@@ -271,7 +271,7 @@ static void layerPath(CAShapeLayer *layer, const WebCore::FloatQuad& outerQuad)
     if (!_highlight)
         return;
 
-    auto context = WebCore::GraphicsContextCG(UIGraphicsGetCurrentContext());
+    WebCore::GraphicsContextCG context { UIGraphicsGetCurrentContext(), WebCore::GraphicsContextCG::ContextSource::PlatformView };
     context.clip({ dirtyRect });
     context.translate(-self.frame.origin.x, -self.frame.origin.y);
 

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -559,7 +559,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     RefPtr<WebKit::ShareableBitmap> bitmap = pagePreviewIterator->value;
 
-    WebCore::GraphicsContextCG context([[NSGraphicsContext currentContext] CGContext]);
+    WebCore::GraphicsContextCG context([[NSGraphicsContext currentContext] CGContext], WebCore::GraphicsContextCG::ContextSource::PlatformView);
     WebCore::GraphicsContextStateSaver stateSaver(context);
 
     bitmap->paint(context, _webFrame->page()->deviceScaleFactor(), WebCore::IntPoint(nsRect.origin), bitmap->bounds());

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -63,7 +63,7 @@ ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSu
     , m_lock(WTFMove(lockAndContext.lock))
     , m_ioSurfacePool(ioSurfacePool)
 {
-    m_context = makeUnique<GraphicsContextCG>(lockAndContext.context.get());
+    m_context = makeUnique<GraphicsContextCG>(lockAndContext.context.get(), GraphicsContextCG::ContextSource::WebKit);
     applyBaseTransform(*m_context);
 }
 
@@ -101,7 +101,7 @@ GraphicsContext& ImageBufferShareableMappedIOSurfaceBitmapBackend::context()
         auto lockAndContext = m_surface->createBitmapPlatformContext();
         if (lockAndContext) {
             m_lock = WTFMove(lockAndContext->lock);
-            m_context = makeUnique<GraphicsContextCG>(lockAndContext->context.get());
+            m_context = makeUnique<GraphicsContextCG>(lockAndContext->context.get(), GraphicsContextCG::ContextSource::WebKit);
             applyBaseTransform(*m_context);
             return *m_context;
         }
@@ -109,7 +109,7 @@ GraphicsContext& ImageBufferShareableMappedIOSurfaceBitmapBackend::context()
     // For some reason we ran into an error. Construct an invalid context, with current API we must
     // return an object.
     RELEASE_LOG(RemoteLayerBuffers, "ImageBufferShareableMappedIOSurfaceBitmapBackend::context() - failed to create or update the context");
-    m_context = makeUnique<GraphicsContextCG>(nullptr);
+    m_context = makeUnique<GraphicsContextCG>(nullptr, GraphicsContextCG::ContextSource::WebKit);
     applyBaseTransform(*m_context);
     return *m_context;
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1878,7 +1878,7 @@ void PDFPlugin::paintControlForLayerInContext(CALayer *layer, CGContextRef conte
     LocalDefaultSystemAppearance localAppearance(page->useDarkAppearance());
 #endif
 
-    GraphicsContextCG graphicsContext(context, WebCore::GraphicsContextCG::CGContextFromCALayer);
+    GraphicsContextCG graphicsContext(context, WebCore::GraphicsContextCG::ContextSource::CALayer);
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
     if (layer == m_scrollCornerLayer) {

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -430,7 +430,7 @@ RetainPtr<CFDataRef> WebPage::pdfSnapshotAtSize(IntRect rect, IntSize bitmapSize
 
         CGPDFContextBeginPage(pdfContext.get(), dictionary);
 
-        GraphicsContextCG graphicsContext { pdfContext.get() };
+        GraphicsContextCG graphicsContext { pdfContext.get(), GraphicsContextCG::ContextSource::WebKit };
         graphicsContext.scale({ 1, -1 });
         graphicsContext.translate(0, -bitmapSize.height());
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6218,7 +6218,7 @@ void WebPage::drawPagesToPDFImpl(FrameIdentifier frameID, const PrintInfo& print
                 RetainPtr<CFDictionaryRef> pageInfo = adoptCF(CFDictionaryCreateMutable(0, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
                 CGPDFContextBeginPage(context.get(), pageInfo.get());
 
-                GraphicsContextCG ctx(context.get());
+                GraphicsContextCG ctx(context.get(), GraphicsContextCG::ContextSource::PlatformView);
                 ctx.scale(FloatSize(1, -1));
                 ctx.translate(0, -m_printContext->pageRect(page).height());
                 m_printContext->spoolPage(ctx, page, m_printContext->pageRect(page).width());

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -305,7 +305,7 @@ static OptionSet<RenderAsTextFlag> toRenderAsTextFlags(WebRenderTreeAsTextOption
     if (!coreFrame)
         return;
 
-    GraphicsContextCG graphicsContext(cgContext);
+    GraphicsContextCG graphicsContext(cgContext, GraphicsContextCG::ContextSource::PlatformView);
     PrintContext::spoolAllPagesWithBoundaries(*coreFrame, graphicsContext, FloatSize(pageWidthInPixels, pageHeightInPixels));
 }
 

--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -78,7 +78,7 @@ static bool canUseFastRenderer(const UniChar* buffer, unsigned length)
 
         NSGraphicsContext *nsContext = [NSGraphicsContext currentContext];
         CGContextRef cgContext = [nsContext CGContext];
-        GraphicsContextCG graphicsContext { cgContext };
+        GraphicsContextCG graphicsContext { cgContext, GraphicsContextCG::ContextSource::PlatformView };
 
         // WebCore requires a flipped graphics context.
         bool flipped = [nsContext isFlipped];

--- a/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
+++ b/Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm
@@ -98,7 +98,7 @@ using namespace WebCore;
 
         ASSERT([[NSGraphicsContext currentContext] isFlipped]);
 
-        GraphicsContextCG context([[NSGraphicsContext currentContext] CGContext]);
+        GraphicsContextCG context([[NSGraphicsContext currentContext] CGContext], GraphicsContextCG::ContextSource::PlatformView);
         [_webNodeHighlight inspectorController]->drawHighlight(context);
         [NSGraphicsContext restoreGraphicsState];
     }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -639,7 +639,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #else
     CGContextRef ctx = WKGetCurrentGraphicsContext();
 #endif
-    WebCore::GraphicsContextCG context(ctx);
+    WebCore::GraphicsContextCG context(ctx, WebCore::GraphicsContextCG::ContextSource::PlatformView);
     auto* view = _private->coreFrame->view();
     
     OptionSet<WebCore::PaintBehavior> oldBehavior = view->paintBehavior();

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp
@@ -49,7 +49,7 @@ TEST(BifurcatedGraphicsContextTests, Basic)
     auto colorSpace = DestinationColorSpace::SRGB();
     auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
-    GraphicsContextCG primaryContext(primaryCGContext.get());
+    GraphicsContextCG primaryContext(primaryCGContext.get(), GraphicsContextCG::ContextSource::WebKit);
 
     DisplayList displayList;
     RecorderImpl secondaryContext(displayList, { }, FloatRect(0, 0, contextWidth, contextHeight), { });
@@ -122,8 +122,8 @@ TEST(BifurcatedGraphicsContextTests, DrawTiledGradientImage)
     auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
     auto secondaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
-    GraphicsContextCG primaryContext(primaryCGContext.get());
-    GraphicsContextCG secondaryContext(secondaryCGContext.get());
+    GraphicsContextCG primaryContext(primaryCGContext.get(), GraphicsContextCG::ContextSource::WebKit);
+    GraphicsContextCG secondaryContext(secondaryCGContext.get(), GraphicsContextCG::ContextSource::WebKit);
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
 
     auto gradient = Gradient::create(Gradient::LinearData { { 0, 0 }, { 1, 1 } }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
@@ -154,8 +154,8 @@ TEST(BifurcatedGraphicsContextTests, DrawGradientImage)
     auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
     auto secondaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
-    GraphicsContextCG primaryContext(primaryCGContext.get());
-    GraphicsContextCG secondaryContext(secondaryCGContext.get());
+    GraphicsContextCG primaryContext(primaryCGContext.get(), GraphicsContextCG::ContextSource::WebKit);
+    GraphicsContextCG secondaryContext(secondaryCGContext.get(), GraphicsContextCG::ContextSource::WebKit);
     BifurcatedGraphicsContext ctx(primaryContext, secondaryContext);
 
     auto gradient = Gradient::create(Gradient::LinearData { { 0, 0 }, { 1, 1 } }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
@@ -185,7 +185,7 @@ TEST(BifurcatedGraphicsContextTests, Borders)
     auto colorSpace = DestinationColorSpace::SRGB();
     auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
-    GraphicsContextCG primaryContext(primaryCGContext.get());
+    GraphicsContextCG primaryContext(primaryCGContext.get(), GraphicsContextCG::ContextSource::WebKit);
 
     DisplayList displayList;
     RecorderImpl secondaryContext(displayList, { }, FloatRect(0, 0, contextWidth, contextHeight), { });
@@ -211,7 +211,7 @@ TEST(BifurcatedGraphicsContextTests, TransformedClip)
     auto colorSpace = DestinationColorSpace::SRGB();
     auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, 100, 100, 8, 4 * 100, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
-    GraphicsContextCG primaryContextCG(primaryCGContext.get());
+    GraphicsContextCG primaryContextCG(primaryCGContext.get(), GraphicsContextCG::ContextSource::WebKit);
     GraphicsContext& primaryContext = primaryContextCG;
 
     DisplayList displayList;
@@ -270,7 +270,7 @@ TEST(BifurcatedGraphicsContextTests, ApplyDeviceScaleFactor)
     auto colorSpace = DestinationColorSpace::SRGB();
     auto primaryCGContext = adoptCF(CGBitmapContextCreate(nullptr, 100, 100, 8, 4 * 100, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
 
-    GraphicsContextCG primaryContextCG(primaryCGContext.get());
+    GraphicsContextCG primaryContextCG(primaryCGContext.get(), GraphicsContextCG::ContextSource::WebKit);
     GraphicsContext& primaryContext = primaryContextCG;
 
     DisplayList displayList;

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -50,7 +50,7 @@ TEST(DisplayListTests, ReplayWithMissingResource)
 
     auto colorSpace = DestinationColorSpace::SRGB();
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
-    GraphicsContextCG context { cgContext.get() };
+    GraphicsContextCG context { cgContext.get(), GraphicsContextCG::ContextSource::WebKit };
 
     auto imageBuffer = ImageBuffer::create({ 100, 100 }, RenderingPurpose::Unspecified, 1, colorSpace, PixelFormat::BGRA8);
     auto imageBufferIdentifier = imageBuffer->renderingResourceIdentifier();
@@ -87,7 +87,7 @@ TEST(DisplayListTests, ItemValidationFailure)
 
     auto colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.get(), kCGImageAlphaPremultipliedLast));
-    GraphicsContextCG context { cgContext.get() };
+    GraphicsContextCG context { cgContext.get(), GraphicsContextCG::ContextSource::WebKit };
 
     auto runTestWithInvalidIdentifier = [&](RenderingResourceIdentifier identifier) {
         EXPECT_FALSE(identifier.isValid());

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm
@@ -44,7 +44,7 @@
 
 - (void)drawInContext:(CGContextRef)cgContext
 {
-    WebCore::GraphicsContextCG context { cgContext, WebCore::GraphicsContextCG::CGContextFromCALayer };
+    WebCore::GraphicsContextCG context { cgContext, WebCore::GraphicsContextCG::ContextSource::CALayer };
     self.didDraw = true;
     self.lastRenderingMode = context.renderingMode();
 }
@@ -61,7 +61,7 @@ RetainPtr<CGImageRef> greenImage()
 {
     auto colorSpace = DestinationColorSpace::SRGB();
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
-    GraphicsContextCG ctx(cgContext.get());
+    GraphicsContextCG ctx(cgContext.get(), GraphicsContextCG::ContextSource::WebKit);
     ctx.fillRect(FloatRect(0, 0, contextWidth, contextHeight), Color::green);
     return adoptCF(CGBitmapContextCreateImage(cgContext.get()));
 }
@@ -70,7 +70,7 @@ TEST(GraphicsContextTests, DrawNativeImageDoesNotLeakCompositeOperator)
 {
     auto colorSpace = DestinationColorSpace::SRGB();
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
-    GraphicsContextCG ctx(cgContext.get());
+    GraphicsContextCG ctx(cgContext.get(), GraphicsContextCG::ContextSource::WebKit);
 
     EXPECT_EQ(ctx.compositeOperation(), CompositeOperator::SourceOver);
     EXPECT_EQ(ctx.blendMode(), BlendMode::Normal);
@@ -100,7 +100,7 @@ TEST(GraphicsContextTests, CGBitmapRenderingModeIsUnaccelerated)
     auto srgb = DestinationColorSpace::SRGB();
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, 3, 3, 8, 4 * 3, srgb.platformColorSpace(), kCGImageAlphaPremultipliedLast));
     ASSERT_NE(cgContext, nullptr);
-    GraphicsContextCG context(cgContext.get());
+    GraphicsContextCG context(cgContext.get(), GraphicsContextCG::ContextSource::WebKit);
     EXPECT_EQ(context.renderingMode(), RenderingMode::Unaccelerated);
 }
 
@@ -114,7 +114,7 @@ TEST(GraphicsContextTests, IOSurfaceRenderingModeIsAccelerated)
     auto bitsPerComponent = 8;
     auto bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
     auto cgContext = adoptCF(CGIOSurfaceContextCreate(surface->surface(), size.width(), size.height(), bitsPerComponent, bitsPerPixel, srgb.platformColorSpace(), bitmapInfo));
-    GraphicsContextCG context(cgContext.get());
+    GraphicsContextCG context(cgContext.get(), GraphicsContextCG::ContextSource::WebKit);
     EXPECT_EQ(context.renderingMode(), RenderingMode::Accelerated);
 }
 
@@ -198,7 +198,7 @@ TEST(GraphicsContextTests, DrawsReportHasDrawn)
     auto bitsPerComponent = 8;
     auto bitmapInfo = static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
     auto cgContext = adoptCF(CGIOSurfaceContextCreate(surface->surface(), size.width(), size.height(), bitsPerComponent, bitsPerPixel, srgb.platformColorSpace(), bitmapInfo));
-    GraphicsContextCG context(cgContext.get());
+    GraphicsContextCG context(cgContext.get(), GraphicsContextCG::ContextSource::WebKit);
 
     // Context starts saying has drawn, conservative estimate.
     EXPECT_TRUE(context.consumeHasDrawn());


### PR DESCRIPTION
#### 2ed0f354748c96ee4fa07a4de493eb673d451934
<pre>
GraphicsContextCG should initialize interpolation quality to an explicit value
<a href="https://bugs.webkit.org/show_bug.cgi?id=262294">https://bugs.webkit.org/show_bug.cgi?id=262294</a>
rdar://116172538

Reviewed by NOBODY (OOPS!).

Intialize image interpolation quality to High for all GraphicsContextCG
instances.
Fixes:
 - If the platform context had non-default value, the rendering results
   would not be as WebKit expects until the drawing would toggle the
   value.
 - The CG context default, kCGInterpolationDefault, does not mean High.
   It means &quot;use the CGImage interpolationQuality&quot;. Since various codepaths
   toggle this value in varying ways, the used value could end up being
   non-deterministic.

Set the value to be deterministic: Unless drawNativeImage has any other
specification, use High.

FIXME: Filter code *tries to* construct NativeImages with ShouldInterpolate::No.
How to catch all such filter draws and change them to contain ImageOptions
that specify quality?

* Source/WebCore/platform/cocoa/DragImageCocoa.mm:
(WebCore::createDragImageForLink):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::renderingModeForCGContext):
(WebCore::GraphicsContextCG::GraphicsContextCG):
(WebCore::GraphicsContextCG::~GraphicsContextCG):
(WebCore::drawPatternCallback):
(WebCore::GraphicsContextCG::isCALayerContext const):
(WebCore::coreInterpolationQuality): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::create):
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::context):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::PathCG::strokeContains const):
(WebCore::PathCG::strokeBoundingRect const):
* Source/WebCore/platform/graphics/cg/PatternCG.cpp:
(WebCore::patternCallback):
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::DrawGlyphsRecorder::createInternalContext):
* Source/WebCore/platform/graphics/mac/ColorMac.mm:
(WebCore::makeSimpleColorFromNSColor):
* Source/WebCore/platform/graphics/mac/WebLayer.mm:
(-[WebLayer drawInContext:]):
(-[WebSimpleLayer drawInContext:]):
* Source/WebCore/platform/ios/DragImageIOS.mm:
(WebCore::createDragImageFromImage):
(WebCore::createDragImageForLink):
(WebCore::createDragImageForSelection):
(WebCore::createDragImageForRange):
(WebCore::createDragImageForColor):
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
(WebKit::GraphicsContextDynamicContentScaling::GraphicsContextDynamicContentScaling):
* Source/WebKit/Shared/cg/ShareableBitmapCG.mm:
(WebKit::ShareableBitmap::createGraphicsContext):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _drawPreview:]):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSurfaceBitmapBackend):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::context):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::paintControlForLayerInContext):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::pdfSnapshotAtSize):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawPagesToPDFImpl):
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(-[WebFrame printToCGContext:pageWidth:pageHeight:]):
* Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm:
(-[NSString _web_drawAtPoint:font:textColor:]):
* Source/WebKitLegacy/mac/WebInspector/WebNodeHighlightView.mm:
(-[WebNodeHighlightView drawRect:]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _drawRect:contentsOnly:]):
* Tools/TestWebKitAPI/Tests/WebCore/cg/BifurcatedGraphicsContextTestsCG.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm:
(-[TestDrawingLayer drawInContext:]):
(TestWebKitAPI::greenImage):
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ed0f354748c96ee4fa07a4de493eb673d451934

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20228 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20307 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20223 "1 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17453 "15 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22835 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17393 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18250 "4 flakes 1 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24506 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18470 "15 api tests failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18426 "1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22496 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19027 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16153 "6 flakes 10 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->