### PR TITLE
Have NativePromise takes an optional LogSiteIdentifier

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -446,6 +446,16 @@
 #define UNUSED_VARIABLE(variable) UNUSED_PARAM(variable)
 #endif
 
+/* UNUSED_VARIADIC_PARAMS */
+
+#if !defined(UNUSED_VARIADIC_PARAMS) && (COMPILER(GCC) || COMPILER(CLANG))
+#define UNUSED_VARIADIC_PARAMS __attribute__((unused))
+#endif
+
+#if !defined(UNUSED_VARIADIC_PARAMS)
+#define UNUSED_VARIADIC_PARAMS
+#endif
+
 /* WARN_UNUSED_RETURN */
 
 #if !defined(WARN_UNUSED_RETURN) && COMPILER(GCC_COMPATIBLE)

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -139,7 +139,7 @@ public:
     }
 
     template<typename... Arguments>
-    inline void logAlways(WTFLogChannel& channel, UNUSED_FUNCTION const Arguments&... arguments) const
+    inline void logAlways(WTFLogChannel& channel, UNUSED_VARIADIC_PARAMS const Arguments&... arguments) const
     {
 #if RELEASE_LOG_DISABLED
         // "Standard" WebCore logging goes to stderr, which is captured in layout test output and can generally be a problem
@@ -306,6 +306,7 @@ public:
 
 private:
     friend class AggregateLogger;
+    friend class NativePromiseBase;
 
     Logger(const void* owner)
         : m_owner { owner }

--- a/Source/WTF/wtf/NativePromise.cpp
+++ b/Source/WTF/wtf/NativePromise.cpp
@@ -32,9 +32,9 @@
 
 namespace WTF {
 
-WTFLogChannel* NativePromiseBase::logChannel()
+WTFLogChannel& NativePromiseBase::logChannel()
 {
-    return &WTFLogNativePromise;
+    return WTFLogNativePromise;
 }
 
 } // namespace WTF

--- a/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp
@@ -42,13 +42,13 @@ AsyncAudioDecoder::AsyncAudioDecoder()
 
 Ref<DecodingTaskPromise> AsyncAudioDecoder::decodeAsync(Ref<ArrayBuffer>&& audioData, float sampleRate)
 {
-    return WTF::invokeAsync(m_runLoop, __func__, [audioData = WTFMove(audioData), sampleRate] () mutable {
+    return WTF::invokeAsync(m_runLoop, [audioData = WTFMove(audioData), sampleRate] () mutable {
         auto audioBuffer = AudioBuffer::createFromAudioFileData(audioData->data(), audioData->byteLength(), false, sampleRate);
         // The ArrayBuffer must be deleted on the main thread, send it back there to be derefed.
         callOnMainThread([audioData = WTFMove(audioData)] { });
         if (!audioBuffer)
-            return DecodingTaskPromise::createAndReject(EncodingError, __func__);
-        return DecodingTaskPromise::createAndResolve(audioBuffer.releaseNonNull(), __func__);
+            return DecodingTaskPromise::createAndReject(EncodingError);
+        return DecodingTaskPromise::createAndResolve(audioBuffer.releaseNonNull());
     });
 }
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -300,7 +300,7 @@ void BaseAudioContext::decodeAudioData(Ref<ArrayBuffer>&& audioData, RefPtr<Audi
         m_audioDecoder = makeUnique<AsyncAudioDecoder>();
 
     auto p = m_audioDecoder->decodeAsync(WTFMove(audioData), sampleRate());
-    p->whenSettled(RunLoop::main(), __func__, [this, activity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise)] (DecodingTaskPromise::Result&& result) mutable {
+    p->whenSettled(RunLoop::main(), [this, activity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise)] (DecodingTaskPromise::Result&& result) mutable {
         queueTaskKeepingObjectAlive(*this, TaskSource::InternalAsyncTask, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise), result = WTFMove(result)]() mutable {
             if (!result) {
                 if (promise)

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -509,7 +509,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReply)
     dispatchAndWait(runLoop, [&] {
         ASSERT_TRUE(openB());
         for (uint64_t i = 100u; i < 160u; ++i) {
-            b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, i)->then(runLoop, __func__,
+            b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, i)->then(runLoop,
                 [&, j = i] (uint64_t value) {
                     if (!value)
                         WTFLogAlways("GOT: %llu", j);
@@ -554,7 +554,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOrder)
         ASSERT_TRUE(openB());
         for (uint64_t i = 0; i < counter; ++i) {
             if (!(i % 2)) {
-                b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(runLoop, __func__, [&, i] (Promise::Result result) {
+                b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(runLoop, [&, i] (Promise::Result result) {
                     EXPECT_TRUE(result.has_value());
                     EXPECT_EQ(result.value(), i);
                     replies.uncheckedAppend(i);

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
@@ -98,7 +98,7 @@ TEST_P(MessageSenderTest, SendWithPromisedReply)
 
     bool done = false;
 
-    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), __func__, [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
         EXPECT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
         done = true;
@@ -127,7 +127,7 @@ TEST_P(MessageSenderTest, SendAsyncWithErrorAsynchronousCallback)
         RunLoop::current().cycle();
 
     done = false;
-    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), __func__, [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
         EXPECT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
         done = true;


### PR DESCRIPTION
#### 1001da37687abd8a91e11af93764908c35181323
<pre>
Have NativePromise takes an optional LogSiteIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=262231">https://bugs.webkit.org/show_bug.cgi?id=262231</a>
rdar://116151538

Reviewed by Eric Carlson.

NativePromise and related methods now takes an optional LogSiteIdentifier
for logging purposes created by default as `LogSiteIdentifier(__builtin_FUNCTION(), nullptr)`

Ideally we would use `std::source_location::current().function_name()`
however, clang used in EWS bots do not have it, and on XCode version 15
it&apos;s also broken, acting like `__func__` which isn&apos;t particularly useful
where it&apos;s the caller&apos;s name that is of interest.

Also changing logging to the more modern WebKit style and add a LogArgument
specialisation for NativePromise. Makes for much more readable logging.

* Source/WTF/wtf/Logger.h: Make NativePromise friend.
* Source/WTF/wtf/NativePromise.cpp:
(WTF::NativePromiseBase::logChannel):
* Source/WTF/wtf/NativePromise.h:
(WTF::NativePromiseBase::log):
(WTF::invokeAsync):
(WTF::LogArgument&lt;GenericPromise&gt;::toString):
* Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp:
(WebCore::AsyncAudioDecoder::decodeAsync):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::decodeAudioData):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithPromisedReply):
(IPC::Connection::makeAsyncReplyHandler):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::doFailAndReject):
(TestWebKitAPI::TEST):
(TestWebKitAPI::myMethod):
(TestWebKitAPI::myMethodReturningThenCommand):
(TestWebKitAPI::myMethodReturningProducer):

Canonical link: <a href="https://commits.webkit.org/268692@main">https://commits.webkit.org/268692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9472d3c6329300359caecc42b6b63ab83b2a29ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22266 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20968 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23117 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17640 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18521 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24807 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17723 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22742 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19752 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16368 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23775 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18485 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5693 "Found 1 jsc stress test failure: stress/sampling-profiler-microtasks.js.dfg-eager") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4898 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22819 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25032 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19094 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5515 "Passed tests") | 
<!--EWS-Status-Bubble-End-->