### PR TITLE
[WGSL] Add sampler_comparison and declarations for all texture comparison functions

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -64,6 +64,7 @@ static ConstantValue zeroValue(const Type* type)
                 return { static_cast<double>(false) };
             case Types::Primitive::Void:
             case Types::Primitive::Sampler:
+            case Types::Primitive::SamplerComparison:
             case Types::Primitive::TextureExternal:
             case Types::Primitive::AccessMode:
             case Types::Primitive::TexelFormat:

--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -321,6 +321,7 @@ void ConstantRewriter::materialize(Node& expression, const ConstantValue& value)
                 break;
             case Primitive::Void:
             case Primitive::Sampler:
+            case Primitive::SamplerComparison:
             case Primitive::TextureExternal:
             case Primitive::AccessMode:
             case Primitive::TexelFormat:

--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -60,6 +60,7 @@ bool satisfies(const Type* type, Constraint constraint)
 
     case Types::Primitive::Void:
     case Types::Primitive::Sampler:
+    case Types::Primitive::SamplerComparison:
     case Types::Primitive::TextureExternal:
     case Types::Primitive::AccessMode:
     case Types::Primitive::TexelFormat:
@@ -134,6 +135,7 @@ const Type* satisfyOrPromote(const Type* type, Constraint constraint, const Type
 
     case Types::Primitive::Void:
     case Types::Primitive::Sampler:
+    case Types::Primitive::SamplerComparison:
     case Types::Primitive::TextureExternal:
     case Types::Primitive::AccessMode:
     case Types::Primitive::TexelFormat:

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -619,6 +619,10 @@ static BindGroupLayoutEntry::BindingMember bindingMemberForGlobal(auto& global)
             return SamplerBindingLayout {
                 .type = SamplerBindingType::Filtering
             };
+        case Types::Primitive::SamplerComparison:
+            return SamplerBindingLayout {
+                .type = SamplerBindingType::Comparison
+            };
         case Types::Primitive::TextureExternal:
             return ExternalTextureBindingLayout { };
         case Types::Primitive::AccessMode:
@@ -827,6 +831,7 @@ void RewriteGlobalVariables::usesOverride(AST::Variable& variable)
     case Types::Primitive::AbstractInt:
     case Types::Primitive::AbstractFloat:
     case Types::Primitive::Sampler:
+    case Types::Primitive::SamplerComparison:
     case Types::Primitive::TextureExternal:
     case Types::Primitive::AccessMode:
     case Types::Primitive::TexelFormat:

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -397,6 +397,7 @@ bool FunctionDefinitionWriter::emitPackedVector(const Types::Vector& vector)
     case Types::Primitive::Bool:
     case Types::Primitive::Void:
     case Types::Primitive::Sampler:
+    case Types::Primitive::SamplerComparison:
     case Types::Primitive::TextureExternal:
     case Types::Primitive::AccessMode:
     case Types::Primitive::TexelFormat:
@@ -584,6 +585,7 @@ void FunctionDefinitionWriter::visit(const Type* type)
             case Types::Primitive::Void:
             case Types::Primitive::Bool:
             case Types::Primitive::Sampler:
+            case Types::Primitive::SamplerComparison:
                 m_stringBuilder.append(*type);
                 break;
             case Types::Primitive::TextureExternal:

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -161,6 +161,7 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
     introduceType(AST::Identifier::make("u32"_s), m_types.u32Type());
     introduceType(AST::Identifier::make("f32"_s), m_types.f32Type());
     introduceType(AST::Identifier::make("sampler"_s), m_types.samplerType());
+    introduceType(AST::Identifier::make("sampler_comparison"_s), m_types.samplerComparisonType());
     introduceType(AST::Identifier::make("texture_external"_s), m_types.textureExternalType());
 
     introduceType(AST::Identifier::make("texture_depth_2d"_s), m_types.textureDepth2dType());

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -672,8 +672,29 @@ operator :textureGather, {
     [U < ConcreteInteger].(texture_depth_cube_array, sampler, vec3[f32], U) => vec4[f32],
 }
 
-# 16.7.3 textureGatherCompare
-# FIXME: Implement sampler_comparison
+# 16.7.3
+operator :textureGatherCompare, {
+    # @must_use fn textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> vec4<f32>
+    [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => vec4[f32],
+
+    # @must_use fn textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
+    [].(texture_depth_2d, sampler_comparison, vec2[f32], f32, vec2[i32]) => vec4[f32],
+
+    # A is i32, or u32
+    # @must_use fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: A, depth_ref: f32) -> vec4<f32>
+    [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32) => vec4[f32],
+
+    # A is i32, or u32
+    # @must_use fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: A, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
+    [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32, vec2[i32]) => vec4[f32],
+
+    # @must_use fn textureGatherCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> vec4<f32>
+    [].(texture_depth_cube, sampler_comparison, vec3[f32], f32) => vec4[f32],
+
+    # A is i32, or u32
+    # @must_use fn textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: A, depth_ref: f32) -> vec4<f32>
+    [T < ConcreteInteger].(texture_depth_cube_array, sampler_comparison, vec3[f32], T, f32) => vec4[f32],
+}
 
 # 16.7.4
 operator :textureLoad, {
@@ -802,11 +823,53 @@ operator :textureSampleBias, {
     [T < ConcreteInteger].(texture_cube_array[f32], sampler, vec3[f32], T, f32) => vec4[f32],
 }
 
-# 16.7.10 textureSampleCompare
-# FIXME: Implement sampler_comparison
+# 16.7.10
+operator :textureSampleCompare, {
+    # @must_use fn textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
+    [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => f32,
 
-# 16.7.11 textureSampleCompareLevel
-# FIXME: Implement sampler_comparison
+    # @must_use fn textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> f32
+    [].(texture_depth_2d, sampler_comparison, vec2[f32], f32, vec2[i32]) => f32,
+
+    # A is i32, or u32
+    # @must_use fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: A, depth_ref: f32) -> f32
+    [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32) => f32,
+
+    # A is i32, or u32
+    # @must_use fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: A, depth_ref: f32, offset: vec2<i32>) -> f32
+    [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32, vec2[i32]) => f32,
+
+    # @must_use fn textureSampleCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
+    [].(texture_depth_cube, sampler_comparison, vec3[f32], f32) => f32,
+
+    # A is i32, or u32
+    # @must_use fn textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: A, depth_ref: f32) -> f32
+    [T < ConcreteInteger].(texture_depth_cube_array, sampler_comparison, vec3[f32], T, f32) => f32,
+}
+
+# 16.7.11
+operator :textureSampleCompareLevel, {
+    # @must_use fn textureSampleCompareLevel(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
+    [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => f32,
+
+    # @must_use fn textureSampleCompareLevel(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> f32
+    [].(texture_depth_2d, sampler_comparison, vec2[f32], f32, vec2[i32]) => f32,
+
+    # A is i32, or u32
+    # @must_use fn textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: A, depth_ref: f32) -> f32
+    [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32) => f32,
+
+    # A is i32, or u32
+    # @must_use fn textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: A, depth_ref: f32, offset: vec2<i32>) -> f32
+    [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32, vec2[i32]) => f32,
+
+    # @must_use fn textureSampleCompareLevel(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
+    [].(texture_depth_cube, sampler_comparison, vec3[f32], f32) => f32,
+
+    # A is i32, or u32
+    # @must_use fn textureSampleCompareLevel(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: A, depth_ref: f32) -> f32
+    [T < ConcreteInteger].(texture_depth_cube_array, sampler_comparison, vec3[f32], T, f32) => f32,
+}
 
 # 16.7.12
 operator :textureSampleGrad, {

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -113,6 +113,7 @@ TypeStore::TypeStore()
     m_u32 = allocateType<Primitive>(Primitive::U32);
     m_f32 = allocateType<Primitive>(Primitive::F32);
     m_sampler = allocateType<Primitive>(Primitive::Sampler);
+    m_samplerComparison = allocateType<Primitive>(Primitive::SamplerComparison);
     m_textureExternal = allocateType<Primitive>(Primitive::TextureExternal);
     m_accessMode = allocateType<Primitive>(Primitive::AccessMode);
     m_texelFormat = allocateType<Primitive>(Primitive::TexelFormat);

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -78,6 +78,7 @@ public:
     const Type* abstractFloatType() const { return m_abstractFloat; }
     const Type* f32Type() const { return m_f32; }
     const Type* samplerType() const { return m_sampler; }
+    const Type* samplerComparisonType() const { return m_samplerComparison; }
     const Type* textureExternalType() const { return m_textureExternal; }
     const Type* accessModeType() const { return m_accessMode; }
     const Type* texelFormatType() const { return m_texelFormat; }
@@ -117,6 +118,7 @@ private:
     const Type* m_u32;
     const Type* m_f32;
     const Type* m_sampler;
+    const Type* m_samplerComparison;
     const Type* m_textureExternal;
     const Type* m_accessMode;
     const Type* m_texelFormat;

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -260,6 +260,7 @@ unsigned Type::size() const
             case Types::Primitive::AbstractInt:
             case Types::Primitive::AbstractFloat:
             case Types::Primitive::Sampler:
+            case Types::Primitive::SamplerComparison:
             case Types::Primitive::TextureExternal:
             case Types::Primitive::AccessMode:
             case Types::Primitive::TexelFormat:
@@ -335,6 +336,7 @@ unsigned Type::alignment() const
             case Types::Primitive::AbstractInt:
             case Types::Primitive::AbstractFloat:
             case Types::Primitive::Sampler:
+            case Types::Primitive::SamplerComparison:
             case Types::Primitive::TextureExternal:
             case Types::Primitive::AccessMode:
             case Types::Primitive::TexelFormat:

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -49,6 +49,7 @@ namespace Types {
     f(Void, "void") \
     f(Bool, "bool") \
     f(Sampler, "sampler") \
+    f(SamplerComparison, "sampler_comparion") \
     f(TextureExternal, "texture_external") \
     f(AccessMode, "access_mode") \
     f(TexelFormat, "texel_format") \

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -398,6 +398,7 @@ module DSL
         u32 = PrimitiveType.new(:U32)
         f32 = PrimitiveType.new(:F32)
         sampler = PrimitiveType.new(:Sampler)
+        sampler_comparison = PrimitiveType.new(:SamplerComparison)
         texture_external = PrimitiveType.new(:TextureExternal)
         abstract_int = PrimitiveType.new(:AbstractInt)
         abstract_float = PrimitiveType.new(:AbstractFloat)

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2023,6 +2023,7 @@ fn testTrunc()
 // 16.7. Texture Built-in Functions (https://gpuweb.github.io/gpuweb/wgsl/#texture-builtin-functions)
 
 @group(0) @binding( 0) var s: sampler;
+@group(0) @binding(31) var sc: sampler_comparison;
 
 @group(0) @binding( 1) var t1d: texture_1d<f32>;
 @group(0) @binding( 2) var t1di: texture_1d<i32>;
@@ -2169,7 +2170,26 @@ fn testTextureGather()
 }
 
 // 16.7.3 textureGatherCompare
-// FIXME: this only applies to texture_depth, implement
+fn testTextureGatherCompare()
+{
+    // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => vec4[f32],
+    _ = textureGatherCompare(td2d, sc, vec2f(0), 0f);
+
+    // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32, vec2[i32]) => vec4[f32],
+    _ = textureGatherCompare(td2d, sc, vec2f(0), 0f, vec2i(0));
+
+    // [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32) => vec4[f32],
+    _ = textureGatherCompare(td2da, sc, vec2f(0), 0i, 0f);
+
+    // [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32, vec2[i32]) => vec4[f32],
+    _ = textureGatherCompare(td2da, sc, vec2f(0), 0i, 0f, vec2i(0));
+
+    // [].(texture_depth_cube, sampler_comparison, vec3[f32], f32) => vec4[f32],
+    _ = textureGatherCompare(tdc, sc, vec3f(0), 0f);
+
+    // [T < ConcreteInteger].(texture_depth_cube_array, sampler_comparison, vec3[f32], T, f32) => vec4[f32],
+    _ = textureGatherCompare(tdca, sc, vec3f(0), 0i, 0f);
+}
 
 // 16.7.4
 // RUN: %metal-compile testTextureLoad
@@ -2443,11 +2463,49 @@ fn testTextureSampleBias()
     _ = textureSampleBias(tca, s, vec3f(0), 0, 0);
 }
 
-// 16.7.10 textureSampleCompare
-// FIXME: this only applies to texture_depth, implement
+// 16.7.10
+fn testTextureSampleCompare()
+{
+    // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => f32,
+    _ = textureSampleCompare(td2d, sc, vec2f(0), 0);
 
-// 16.7.11 textureSampleCompareLevel
-// FIXME: this only applies to texture_depth, implement
+    // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32, vec2[i32]) => f32,
+    _ = textureSampleCompare(td2d, sc, vec2f(0), 0, vec2i(0));
+
+    // [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32) => f32,
+    _ = textureSampleCompare(td2da, sc, vec2f(0), 0i, 0f);
+
+    // [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32, vec2[i32]) => f32,
+    _ = textureSampleCompare(td2da, sc, vec2f(0), 0i, 0f, vec2i(0));
+
+    // [].(texture_depth_cube, sampler_comparison, vec3[f32], f32) => f32,
+    _ = textureSampleCompare(tdc, sc, vec3f(0), 0);
+
+    // [T < ConcreteInteger].(texture_depth_cube_array, sampler_comparison, vec3[f32], T, f32) => f32,
+    _ = textureSampleCompare(tdca, sc, vec3f(0), 0i, 0f);
+}
+
+// 16.7.11
+fn testTextureSampleCompareLevel()
+{
+    // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32) => f32,
+    _ = textureSampleCompareLevel(td2d, sc, vec2f(0), 0);
+
+    // [].(texture_depth_2d, sampler_comparison, vec2[f32], f32, vec2[i32]) => f32,
+    _ = textureSampleCompareLevel(td2d, sc, vec2f(0), 0, vec2i(0));
+
+    // [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32) => f32,
+    _ = textureSampleCompareLevel(td2da, sc, vec2f(0), 0i, 0f);
+
+    // [T < ConcreteInteger].(texture_depth_2d_array, sampler_comparison, vec2[f32], T, f32, vec2[i32]) => f32,
+    _ = textureSampleCompareLevel(td2da, sc, vec2f(0), 0i, 0f, vec2i(0));
+
+    // [].(texture_depth_cube, sampler_comparison, vec3[f32], f32) => f32,
+    _ = textureSampleCompareLevel(tdc, sc, vec3f(0), 0);
+
+    // [T < ConcreteInteger].(texture_depth_cube_array, sampler_comparison, vec3[f32], T, f32) => f32,
+    _ = textureSampleCompareLevel(tdca, sc, vec3f(0), 0i, 0f);
+}
 
 // 16.7.12
 fn testTextureSampleGrad()


### PR DESCRIPTION
#### e2b5f644393e6c9579bbb4e72f0f6b9819687978
<pre>
[WGSL] Add sampler_comparison and declarations for all texture comparison functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=262302">https://bugs.webkit.org/show_bug.cgi?id=262302</a>
rdar://116179097

Reviewed by Mike Wyrzykowski.

Add the missing the sampler_comparison type and the missing texture comparison functions
that depended on it: textureGatherCompare, textureSampleCompare and textureSampleCompareLevel

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::zeroValue):
* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::materialize):
* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::satisfies):
(WGSL::satisfyOrPromote):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::bindingMemberForGlobal):
(WGSL::RewriteGlobalVariables::usesOverride):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitPackedVector):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::TypeStore):
* Source/WebGPU/WGSL/TypeStore.h:
(WGSL::TypeStore::samplerComparisonType const):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::size const):
(WGSL::Type::alignment const):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268640@main">https://commits.webkit.org/268640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/099dc747a6fd80f76c90b46f296d5e41fd234755

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21994 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18759 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20236 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22843 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17399 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24517 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22507 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16158 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18231 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4860 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->