### PR TITLE
[WGSL] Add type declarations for all synchronization built-in functions

### DIFF
--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -48,6 +48,18 @@ inline void logLn(Arguments&&... arguments)
         dataLogLn(logPrefix, std::forward<Arguments>(arguments)...);
 }
 
+AbstractPointer::AbstractPointer(AbstractValue addressSpace, AbstractType element)
+    : AbstractPointer(addressSpace, WTFMove(element), WTF::enumToUnderlyingType(defaultAccessModeForAddressSpace(static_cast<AddressSpace>(std::get<unsigned>(addressSpace)))))
+{
+}
+
+AbstractPointer::AbstractPointer(AbstractValue addressSpace, AbstractType element, AbstractValue accessMode)
+    : addressSpace(addressSpace)
+    , element(WTFMove(element))
+    , accessMode(accessMode)
+{
+}
+
 struct ViableOverload {
     const OverloadCandidate* candidate;
     FixedVector<unsigned> ranks;

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -99,6 +99,9 @@ struct AbstractPointer {
     AbstractValue addressSpace;
     AbstractType element;
     AbstractValue accessMode;
+
+    AbstractPointer(AbstractValue, AbstractType);
+    AbstractPointer(AbstractValue, AbstractType, AbstractValue);
 };
 
 struct AbstractArray {

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -830,23 +830,8 @@ Result<AST::VariableQualifier::Ref> Parser<Lexer>::parseVariableQualifier()
         consume();
         PARSE(actualAccessMode, AccessMode);
         accessMode = actualAccessMode;
-    } else {
-        // Default access mode based on address space
-        // https://www.w3.org/TR/WGSL/#address-space
-        switch (addressSpace) {
-        case AddressSpace::Function:
-        case AddressSpace::Private:
-        case AddressSpace::Workgroup:
-            accessMode = AccessMode::ReadWrite;
-            break;
-        case AddressSpace::Uniform:
-        case AddressSpace::Storage:
-            accessMode = AccessMode::Read;
-            break;
-        case AddressSpace::Handle:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-    }
+    } else
+        accessMode = defaultAccessModeForAddressSpace(addressSpace);
 
     CONSUME_TYPE(TemplateArgsRight);
     RETURN_ARENA_NODE(VariableQualifier, addressSpace, accessMode);

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -967,3 +967,23 @@ operator :textureStore, {
     # fn textureStore(t: texture_storage_3d<F,write>, coords: vec3<C>, value: vec4<CF>)
     [F, T < ConcreteInteger].(texture_storage_3d[F, write], vec3[T], vec4[ChannelFormat[F]]) => void,
 }
+
+# 16.11. Synchronization Built-in Functions (https://www.w3.org/TR/WGSL/#sync-builtin-functions)
+
+# 16.11.1.
+operator :storageBarrier, {
+    # fn storageBarrier()
+    [].() => void,
+}
+
+# 16.11.2.
+operator :workgroupBarrier, {
+    # fn workgroupBarrier()
+    [].() => void,
+}
+
+# 16.11.3.
+operator :workgroupUniformLoad, {
+    # @must_use fn workgroupUniformLoad(p : ptr<workgroup, T>) -> T
+    [T].(ptr[workgroup, T]) => void,
+}

--- a/Source/WebGPU/WGSL/WGSLEnums.cpp
+++ b/Source/WebGPU/WGSL/WGSLEnums.cpp
@@ -87,4 +87,20 @@ ENUM_DEFINE(TexelFormat);
 #undef LPAREN
 #undef COMMA
 
+AccessMode defaultAccessModeForAddressSpace(AddressSpace addressSpace)
+{
+    // Default access mode based on address space
+    // https://www.w3.org/TR/WGSL/#address-space
+    switch (addressSpace) {
+    case AddressSpace::Function:
+    case AddressSpace::Private:
+    case AddressSpace::Workgroup:
+        return AccessMode::ReadWrite;
+    case AddressSpace::Uniform:
+    case AddressSpace::Storage:
+    case AddressSpace::Handle:
+        return AccessMode::Read;
+    }
+}
+
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSLEnums.h
+++ b/Source/WebGPU/WGSL/WGSLEnums.h
@@ -86,4 +86,6 @@ ENUM_DECLARE(TexelFormat);
 
 #undef ENUM_DECLARE
 
+AccessMode defaultAccessModeForAddressSpace(AddressSpace);
+
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -410,6 +410,8 @@ module DSL
         texture_depth_multisampled_2d = PrimitiveType.new(:TextureDepthMultisampled2d)
 
         storage = AbstractValue.new(:"AddressSpace::Storage")
+        workgroup = AbstractValue.new(:"AddressSpace::Workgroup")
+
         read = AbstractValue.new(:"AccessMode::Read")
         read_write = AbstractValue.new(:"AccessMode::ReadWrite")
         write = AbstractValue.new(:"AccessMode::Write")

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2611,3 +2611,27 @@ fn testTextureStore()
     // [F, T < ConcreteInteger].(texture_storage_3d[F, write], vec3[T], vec4[ChannelFormat[F]]) => void,
     textureStore(ts3d, vec3(0), vec4f(0));
 }
+
+// 16.11. Synchronization Built-in Functions (https://www.w3.org/TR/WGSL/#sync-builtin-functions)
+
+// 16.11.1.
+fn testStorageBarrier()
+{
+    // [].() => void,
+    storageBarrier();
+}
+
+// 16.11.2.
+fn testWorkgroupBarrier()
+{
+    // fn workgroupBarrier()
+    workgroupBarrier();
+}
+
+// 16.11.3.
+var<workgroup> testWorkgroupUniformLoadHelper: i32;
+fn testWorkgroupUniformLoad()
+{
+    // [T].(ptr[workgroup, T]) => void,
+    _ = workgroupUniformLoad(&testWorkgroupUniformLoadHelper);
+}


### PR DESCRIPTION
#### 18b61d61e1052ebbaf7834ccf2c534e97d37dd5c
<pre>
[WGSL] Add type declarations for all synchronization built-in functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=262303">https://bugs.webkit.org/show_bug.cgi?id=262303</a>
rdar://116179275

Reviewed by Mike Wyrzykowski.

Add declarations for the 3 synchronization built-in functions from section
16.11 of the spec[1].

[1]: <a href="https://www.w3.org/TR/WGSL/#sync-builtin-functions">https://www.w3.org/TR/WGSL/#sync-builtin-functions</a>

* Source/WebGPU/WGSL/Overload.h:
(WGSL::AbstractPointer::AbstractPointer):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseVariableQualifier):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/WGSLEnums.cpp:
(WGSL::defaultAccessModeForAddressSpace):
* Source/WebGPU/WGSL/WGSLEnums.h:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268642@main">https://commits.webkit.org/268642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc1211720bdc9d76b78048dbf97a0087c12993b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18774 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20244 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22862 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17413 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24526 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22517 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16167 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18246 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4865 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->