### PR TITLE
[WGSL] Add code generation for all synchronization built-in functions

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -833,6 +833,9 @@ void TypeChecker::visit(AST::CallExpression& call)
 
         auto* result = chooseOverload("initializer", call.span(), targetName, call.arguments(), typeArguments);
         if (result) {
+            // FIXME: this will go away once we track used intrinsics properly
+            if (targetName == "workgroupUniformLoad"_s)
+                m_shaderModule.setUsesWorkgroupUniformLoad();
             target.m_inferredType = result;
             return;
         }

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -72,6 +72,10 @@ public:
     void setUsesUnpackArray() { m_usesUnpackArray = true; }
     void clearUsesUnpackArray() { m_usesUnpackArray = false; }
 
+    bool usesWorkgroupUniformLoad() const { return m_usesWorkgroupUniformLoad; }
+    void setUsesWorkgroupUniformLoad() { m_usesWorkgroupUniformLoad = true; }
+    void clearUsesWorkgroupUniformLoad() { m_usesWorkgroupUniformLoad = false; }
+
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
     {
@@ -177,6 +181,7 @@ private:
     bool m_usesExternalTextures { false };
     bool m_usesPackArray { false };
     bool m_usesUnpackArray { false };
+    bool m_usesWorkgroupUniformLoad { false };
     Configuration m_configuration;
     AST::Directive::List m_directives;
     AST::Function::List m_functions;

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2615,6 +2615,8 @@ fn testTextureStore()
 // 16.11. Synchronization Built-in Functions (https://www.w3.org/TR/WGSL/#sync-builtin-functions)
 
 // 16.11.1.
+// RUN: %metal-compile testStorageBarrier
+@compute @workgroup_size(1)
 fn testStorageBarrier()
 {
     // [].() => void,
@@ -2622,6 +2624,8 @@ fn testStorageBarrier()
 }
 
 // 16.11.2.
+// RUN: %metal-compile testWorkgroupBarrier
+@compute @workgroup_size(1)
 fn testWorkgroupBarrier()
 {
     // fn workgroupBarrier()
@@ -2630,6 +2634,8 @@ fn testWorkgroupBarrier()
 
 // 16.11.3.
 var<workgroup> testWorkgroupUniformLoadHelper: i32;
+// RUN: %metal-compile testWorkgroupUniformLoad
+@compute @workgroup_size(1)
 fn testWorkgroupUniformLoad()
 {
     // [T].(ptr[workgroup, T]) => void,


### PR DESCRIPTION
#### fb776403dad825e8a62e236e9067cb555a696ee3
<pre>
[WGSL] Add code generation for all synchronization built-in functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=262304">https://bugs.webkit.org/show_bug.cgi?id=262304</a>
rdar://116179474

Reviewed by Mike Wyrzykowski.

Add code generation for storageBarrier, workgroupBarrier and workgroupUniformLoad.
The last one requires detecting whether the program actually uses it in order to
emit a helper, which is currently quite hacky, but we don&apos;t have a proper way of
tracking whether the built-ins are being called (or a function that shadows them),
so that will be improved on a later patch.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::serializeVariable):
(WGSL::Metal::emitStorageBarrier):
(WGSL::Metal::emitWorkgroupBarrier):
(WGSL::Metal::emitWorkgroupUniformLoad):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesWorkgroupUniformLoad const):
(WGSL::ShaderModule::setUsesWorkgroupUniformLoad):
(WGSL::ShaderModule::clearUsesWorkgroupUniformLoad):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268651@main">https://commits.webkit.org/268651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2102252889378149a86606f7f74b26eac315fb48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22152 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18900 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20852 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23002 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17546 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24666 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22638 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16279 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18374 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4877 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->