### PR TITLE
[GTK] fix USE_EGL checks when GBM renderer is used

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -45,9 +45,11 @@
 #endif
 
 #if PLATFORM(GTK)
+#if USE(EGL)
 #include "AcceleratedBackingStoreDMABuf.h"
 #include "DMABufRendererBufferMode.h"
 #include <WebCore/PlatformDisplaySurfaceless.h>
+#endif
 #include <gtk/gtk.h>
 
 #if PLATFORM(WAYLAND)
@@ -164,6 +166,7 @@ static String dmabufRendererWithSupportedBuffers()
 {
     StringBuilder buffers;
     buffers.append("DMABuf (Supported buffers: "_s);
+#if USE(EGL)
     auto mode = AcceleratedBackingStoreDMABuf::rendererBufferMode();
     if (mode.contains(DMABufRendererBufferMode::Hardware))
         buffers.append("Hardware"_s);
@@ -172,6 +175,7 @@ static String dmabufRendererWithSupportedBuffers()
             buffers.append(", ");
         buffers.append("Shared Memory"_s);
     }
+#endif
     buffers.append(')');
     return buffers.toString();
 }
@@ -269,7 +273,11 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 #if PLATFORM(GTK)
     addTableRow(versionObject, "GTK version"_s, makeString(GTK_MAJOR_VERSION, '.', GTK_MINOR_VERSION, '.', GTK_MICRO_VERSION, " (build) "_s, gtk_get_major_version(), '.', gtk_get_minor_version(), '.', gtk_get_micro_version(), " (runtime)"_s));
 
+#if USE(EGL)
     bool usingDMABufRenderer = AcceleratedBackingStoreDMABuf::checkRequirements();
+#else
+    bool usingDMABufRenderer = false;
+#endif
 
 #if PLATFORM(WAYLAND)
     if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::Wayland && !usingDMABufRenderer) {

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -53,7 +53,9 @@
 #endif
 
 #if PLATFORM(GTK)
+#if USE(EGL)
 #include "AcceleratedBackingStoreDMABuf.h"
+#endif
 #include "GtkSettingsManager.h"
 #include "ScreenManager.h"
 #endif
@@ -89,7 +91,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
 #endif
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && USE(EGL)
     parameters.dmaBufRendererBufferMode = AcceleratedBackingStoreDMABuf::rendererBufferMode();
 #endif
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -40,7 +40,7 @@
 #include "AcceleratedBackingStoreX11.h"
 #endif
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && USE(EGL)
 #include "AcceleratedBackingStoreDMABuf.h"
 #endif
 
@@ -72,7 +72,7 @@ static bool gtkCanUseHardwareAcceleration()
 
 bool AcceleratedBackingStore::checkRequirements()
 {
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && USE(EGL)
     if (AcceleratedBackingStoreDMABuf::checkRequirements())
         return gtkCanUseHardwareAcceleration();
 #endif
@@ -93,7 +93,7 @@ std::unique_ptr<AcceleratedBackingStore> AcceleratedBackingStore::create(WebPage
     if (!HardwareAccelerationManager::singleton().canUseHardwareAcceleration())
         return nullptr;
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && USE(EGL)
     if (AcceleratedBackingStoreDMABuf::checkRequirements())
         return AcceleratedBackingStoreDMABuf::create(webPage);
 #endif

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "AcceleratedBackingStoreDMABuf.h"
 
+#if USE(EGL)
+
 #include "AcceleratedBackingStoreDMABufMessages.h"
 #include "AcceleratedSurfaceDMABufMessages.h"
 #include "DMABufRendererBufferMode.h"
@@ -519,3 +521,5 @@ bool AcceleratedBackingStoreDMABuf::paint(cairo_t* cr, const WebCore::IntRect& c
 #endif
 
 } // namespace WebKit
+
+#endif // USE(EGL)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(EGL)
+
 #include "AcceleratedBackingStore.h"
 
 #include "MessageReceiver.h"
@@ -232,3 +234,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(EGL)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
@@ -20,9 +20,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#if USE(EGL)
 messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
     DidCreateBuffer(uint64_t id, UnixFileDescriptor fd, WebCore::IntSize size, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier)
     DidCreateBufferSHM(uint64_t id, WebKit::ShareableBitmap::Handle handle)
     DidDestroyBuffer(uint64_t id)
     Frame(uint64_t id)
 }
+#endif

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
@@ -37,7 +37,7 @@
 #include "AcceleratedSurfaceLibWPE.h"
 #endif
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && USE(EGL)
 #include "AcceleratedSurfaceDMABuf.h"
 #endif
 
@@ -46,7 +46,7 @@ using namespace WebCore;
 
 std::unique_ptr<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Client& client)
 {
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && USE(EGL)
 #if USE(GBM)
     if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::GBM)
         return AcceleratedSurfaceDMABuf::create(webPage, client);

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "AcceleratedSurfaceDMABuf.h"
 
+#if USE(EGL)
+
 #include "AcceleratedBackingStoreDMABufMessages.h"
 #include "AcceleratedSurfaceDMABufMessages.h"
 #include "ShareableBitmap.h"
@@ -425,3 +427,5 @@ void AcceleratedSurfaceDMABuf::frameDone()
 }
 
 } // namespace WebKit
+
+#endif // USE(EGL)

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if USE(EGL)
+
 #include "AcceleratedSurface.h"
 
 #include "MessageReceiver.h"
@@ -173,3 +175,5 @@ private:
 };
 
 } // namespace WebKit
+
+#endif // USE(EGL)

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.messages.in
@@ -20,7 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#if USE(EGL)
 messages -> AcceleratedSurfaceDMABuf NotRefCounted {
     ReleaseBuffer(uint64_t id)
     FrameDone()
 }
+#endif

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -141,7 +141,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     WebCore::GBMDevice::singleton().initialize(parameters.renderDeviceFile);
 #endif
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && USE(EGL)
     m_dmaBufRendererBufferMode = parameters.dmaBufRendererBufferMode;
     if (!m_dmaBufRendererBufferMode.isEmpty()) {
 #if USE(GBM)


### PR DESCRIPTION
#### c124153d271be6c82398748bd9756b12b7ba7c0d
<pre>
[GTK] fix USE_EGL checks when GBM renderer is used

<a href="https://bugs.webkit.org/show_bug.cgi?id=262169">https://bugs.webkit.org/show_bug.cgi?id=262169</a>

Reviewed by Carlos Garcia Campos.

Regression since commit 81c064ddb4182a34a36def401025d223ca0d31ba.

webkitgtk-2.42.0/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:39:10: fatal error: epoxy/egl.h: No such file or directory
   39 | #include &lt;epoxy/egl.h&gt;
      |          ^~~~~~~~~~~~~

Signed-off-by: Thomas Devoogdt &lt;thomas.devoogdt@barco.com&gt;
Canonical link: <a href="https://commits.webkit.org/268598@main">https://commits.webkit.org/268598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e43cb50a143b2a78e34ee9922bf16cf715a93f73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22026 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20723 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22876 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17425 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24536 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22528 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16178 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18258 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4829 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22601 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->