### PR TITLE
Web Inspector: Sources: Sort resources by name then by extension(s)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js
@@ -84,19 +84,15 @@ WI.ResourceTreeElement = class ResourceTreeElement extends WI.SourceCodeTreeElem
         if (comparisonResult !== 0)
             return comparisonResult;
 
-        // Compare by title without file extensions when the subtitles are the same.
-        function filenameWithoutExtension(resourceTitle) {
-            return resourceTitle.substring(0, resourceTitle.lastIndexOf("."));
+        // Split filenames and extensions to compare by each
+        function splitFilename(resourceTitle) {
+            let [name, extensions] = resourceTitle.split(".", 1);
+            return {name, extensions: extensions || ""};
         }
         
-        let titleA = filenameWithoutExtension(a.mainTitle);
-        let titleB = filenameWithoutExtension(b.mainTitle);
-        comparisonResult = titleA.extendedLocaleCompare(titleB);
-        if (comparisonResult !== 0)
-            return comparisonResult;
-
-        // Compare by complete title (with extensions) when the filenames are the same.
-        return a.mainTitle.extendedLocaleCompare(b.mainTitle);
+        let splitA = splitFilename(a.mainTitle);
+        let splitB = splitFilename(b.mainTitle);
+        return splitA.name.extendedLocaleCompare(splitB.name) || splitA.extensions.extendedLocaleCompare(splitB.extensions);
     }
 
     static compareFolderAndResourceTreeElements(a, b)


### PR DESCRIPTION
#### c158bc48552e40e136ff5bcb80f50add20d8c0ea
<pre>
Web Inspector: Sources: Sort resources by name then by extension(s)
<a href="https://bugs.webkit.org/show_bug.cgi?id=220437">https://bugs.webkit.org/show_bug.cgi?id=220437</a>
rdar://problem/72905353

Reviewed by NOBODY (OOPS!).

This change splits the filenames by name and extension(s) and compares
against name then by extension. This handles cases like test.min.js
sorting before test-a.js.

* Source/WebInspectorUI/UserInterface/Views/ResourceTreeElement.js:
(WI.ResourceTreeElement.compareResourceTreeElements.splitFilename):
(WI.ResourceTreeElement.compareResourceTreeElements):
(WI.ResourceTreeElement.compareResourceTreeElements.filenameWithoutExtension): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c158bc48552e40e136ff5bcb80f50add20d8c0ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22015 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18777 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20246 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22865 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24528 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22520 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16170 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18249 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22593 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->