### PR TITLE
[visionOS] Remote Effects don't work inside of `pointer-events: none` scrollers

### DIFF
--- a/LayoutTests/interaction-region/scroll-view-hit-testing-expected.txt
+++ b/LayoutTests/interaction-region/scroll-view-hit-testing-expected.txt
@@ -1,0 +1,321 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer anchorPoint [x: 0 y: 0])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer anchorPoint [x: 0 y: 0])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer position [x: 400 y: 400])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer anchorPoint [x: 0 y: 0])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer anchorPoint [x: 0 y: 0])
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0]))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 330 height: 330])
+                              (layer position [x: 201 y: 201])
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 300 height: 300])
+                                  (layer position [x: 165 y: 165])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 300 height: 600])
+                                      (layer anchorPoint [x: 0 y: 0])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (sublayers
+                                            (
+                                              (type 0)
+                                              (layer bounds [x: 0 y: 0 width: 53.328125 height: 36])
+                                              (layer position [x: 22.6640625 y: 22.6640625])
+                                              (layer cornerRadius 8))))))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 12 height: 300])
+                                      (layer position [x: 291 y: 291])
+                                      (layer zPosition 1000)
+                                      (layer opacity 0)
+                                      (sublayers
+                                        (
+                                          (hit testing disabled)
+                                          (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                          (layer position [x: 6 y: 6]))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 12 height: 300])
+                                          (layer position [x: 6 y: 6])
+                                          (sublayers
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                              (layer position [x: 6 y: 6])
+                                              (layer cornerRadius 6)
+                                              (sublayers
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                  (layer position [x: 6 y: 6])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                  (layer position [x: 6 y: 6])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                  (layer position [x: 6 y: 6])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                  (layer position [x: 6 y: 6])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                  (layer position [x: 6 y: 6])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                  (layer position [x: 6 y: 6])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                  (layer position [x: 6 y: 6])
+                                                  (layer opacity 0)
+                                                  (sublayers
+                                                    (
+                                                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                      (layer position [x: 3 y: 3])
+                                                      (layer opacity 0.15)
+                                                      (sublayers
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 3 y: 3])
+                                                          (layer cornerRadius 1))))))
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 6 height: 45])
+                                                  (layer position [x: 6 y: 6])
+                                                  (layer opacity 0.15)
+                                                  (layer cornerRadius 3))))))))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 300 height: 12])
+                                      (layer position [x: 150 y: 150])
+                                      (layer zPosition 1000)
+                                      (layer opacity 0)
+                                      (sublayers
+                                        (
+                                          (hit testing disabled)
+                                          (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                          (layer position [x: 150 y: 150]))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 300 height: 12])
+                                          (layer position [x: 150 y: 150])
+                                          (sublayers
+                                            (
+                                              (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                              (layer position [x: 150 y: 150])
+                                              (layer cornerRadius 6)
+                                              (sublayers
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                  (layer position [x: 48 y: 48])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                  (layer position [x: 48 y: 48])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                  (layer position [x: 48 y: 48])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                  (layer position [x: 48 y: 48])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                  (layer position [x: 48 y: 48])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (hit testing disabled)
+                                                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                  (layer position [x: 48 y: 48])
+                                                  (layer cornerRadius 6))
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                  (layer position [x: 48 y: 48])
+                                                  (layer opacity 0)
+                                                  (sublayers
+                                                    (
+                                                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                      (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                      (layer opacity 0.15)
+                                                      (sublayers
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))
+                                                        (
+                                                          (layer bounds [x: 0 y: 0 width: 4 height: 2])
+                                                          (layer position [x: 2.9999999999999973 y: 2.9999999999999973])
+                                                          (layer cornerRadius 1))))))
+                                                (
+                                                  (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                  (layer position [x: 48 y: 48])
+                                                  (layer opacity 0.15)
+                                                  (layer cornerRadius 3))))))))))))))))))))))))
+    (
+      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/scroll-view-hit-testing.html
+++ b/LayoutTests/interaction-region/scroll-view-hit-testing.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<style>
+    body {
+        margin: 0;
+        font-size: 24px;
+    }
+
+    .container {
+        position: absolute;
+        top: 50px;
+        left: 50px;
+        height: 300px;
+        width: 300px;
+        overflow: scroll;
+        border: 1px solid black;
+        pointer-events: none;
+        box-shadow: 0 0 10px black;
+    }
+
+    .content {
+        height: 600px;
+    }
+
+    .content a {
+        pointer-events: auto;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<section id="test">
+    <div class="container">
+        <div class="content">
+            Lorem ipsum dolor sit amet,
+            <a href="#">link!</a>
+            consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </div>
+    </div>
+</div>
+
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+let testEl = document.getElementById("test");
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getCALayerTree();
+    testEl.remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -427,8 +427,13 @@ void RemoteLayerTreePropertyApplier::updateMask(RemoteLayerTreeNode& node, const
 #if PLATFORM(IOS_FAMILY)
 void RemoteLayerTreePropertyApplier::applyPropertiesToUIView(UIView *view, const LayerProperties& properties, const RelatedLayerMap& relatedLayers)
 {
-    if (properties.changedProperties.containsAny({ LayerChange::ContentsHiddenChanged, LayerChange::UserInteractionEnabledChanged }))
-        view.userInteractionEnabled = !properties.contentsHidden && properties.userInteractionEnabled;
+    if (properties.changedProperties.containsAny({ LayerChange::ContentsHiddenChanged, LayerChange::UserInteractionEnabledChanged })) {
+        bool userInteractive = !properties.contentsHidden && properties.userInteractionEnabled;
+        if (auto scrollView = dynamic_objc_cast<WKChildScrollView>(view))
+            scrollView._wk_userInteractive = userInteractive;
+        else
+            view.userInteractionEnabled = userInteractive;
+    }
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -62,6 +62,10 @@
 #import "WKWebViewIOS.h"
 #endif
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#endif
+
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 @interface WKMediaSessionCoordinatorHelper : NSObject <_WKMediaSessionCoordinatorDelegate>
 - (id)initWithCoordinator:(WebCore::MediaSessionCoordinatorClient*)coordinator;
@@ -115,6 +119,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
             ts.dumpProperty("frame", rectToString(layer.mask.frame));
         }
     }
+
+    if (!layer.allowsHitTesting)
+        ts.dumpProperty("hit testing", "disabled");
 #endif
 
     ts.dumpProperty("layer bounds", rectToString(layer.bounds));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -70,6 +70,7 @@ class WebPageProxy;
 @end
 
 @interface WKChildScrollView : WKBaseScrollView <WKContentControlled>
+@property BOOL _wk_userInteractive;
 @end
 
 #if USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -60,9 +60,9 @@ static void collectDescendantViewsAtPoint(Vector<UIView *, 16>& viewsAtPoint, UI
             continue;
 
         auto handlesEvent = [&] {
-            // FIXME: isUserInteractionEnabled is mostly redundant with event regions for web content layers.
-            //        It is currently only needed for scroll views.
             if (!view.isUserInteractionEnabled)
+                return false;
+            if ([view isKindOfClass:[WKChildScrollView class]] && ![(WKChildScrollView *)view _wk_userInteractive])
                 return false;
 
             if (CGRectIsEmpty([view frame]))
@@ -105,9 +105,9 @@ static void collectDescendantViewsInRect(Vector<UIView *, 16>& viewsInRect, UIVi
         CGRect subviewRect = [view convertRect:rect fromView:parent];
 
         auto intersectsRect = [&] {
-            // FIXME: isUserInteractionEnabled is mostly redundant with event regions for web content layers.
-            //        It is currently only needed for scroll views.
             if (!view.isUserInteractionEnabled)
+                return false;
+            if ([view isKindOfClass:[WKChildScrollView class]] && ![(WKChildScrollView *)view _wk_userInteractive])
                 return false;
 
             if (CGRectIsEmpty(view.frame))
@@ -427,6 +427,8 @@ static Class scrollViewScrollIndicatorClass()
     self = [super initWithFrame:frame];
     if (!self)
         return nil;
+
+    self._wk_userInteractive = YES;
 
 // FIXME: Likely we can remove this special case for watchOS and tvOS.
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -92,9 +92,6 @@ public:
 
 private:
     RetainPtr<CALayer> m_scrollLayer;
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    RetainPtr<CALayer> m_interactionRegionsLayer;
-#endif
     RetainPtr<CALayer> m_scrolledContentsLayer;
     RetainPtr<WKScrollingNodeScrollViewDelegate> m_scrollViewDelegate;
     OptionSet<WebCore::TouchAction> m_activeTouchActions { };


### PR DESCRIPTION
#### 0fed4da451372d464b08bd8a0545e8a9024bb49c
<pre>
[visionOS] Remote Effects don&apos;t work inside of `pointer-events: none` scrollers
<a href="https://bugs.webkit.org/show_bug.cgi?id=262307">https://bugs.webkit.org/show_bug.cgi?id=262307</a>
&lt;<a href="https://rdar.apple.com/115776753">rdar://115776753</a>&gt;

Reviewed by NOBODY (OOPS!).

Remote Effects use CA-based hit-testing.
So when we set `userInteractionEnabled = NO` on a `pointer-events: none`
ScrollView, we also prevent potential `pointer-events: auto` children
from hit-testing.

This patch introduces a new `_wk_userInteractive` flag on
WKChildScrollViews that disables the scroll container without blocking
hit-testing of its children. Effectively taking the view out of
WKHitTesting without impacting its layer&apos;s `allowsHitTesting` property.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToUIView):
Use `_wk_userInteractive` instead of `userInteractionEnabled` for
WKChildScrollViews.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(-[WKChildScrollView initWithFrame:]):
Introduce the new `_wk_userInteractive` property defaulting to YES.
(WebKit::collectDescendantViewsAtPoint):
(WebKit::collectDescendantViewsInRect):
Remove the FIXME since we use `userInteractionEnabled` for
`WKNativelyInteractible` views.
Skip WKChildScrollViews marked as `_wk_userInteractive = NO`.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
Clean-up, remove unused member variable.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer):
Add `allowsHitTesting` to the dump format when Interaction Regions are
turned on.

* LayoutTests/interaction-region/scroll-view-hit-testing-expected.txt: Added.
* LayoutTests/interaction-region/scroll-view-hit-testing.html: Added.
Add a test covering the change, based on
`touch-scroll-pointer-events-none.html`.
* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
Update expectations with the new format.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fed4da451372d464b08bd8a0545e8a9024bb49c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/32556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/11304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/34404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/35122 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/29431 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/13653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/8498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28960 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/32990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/9526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8304 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/8440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/36458 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/29590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/29476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/34562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/8568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/6524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/32421 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/28780 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->