### PR TITLE
Devirtualize many of the renderer type checks

### DIFF
--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -184,7 +184,7 @@ RenderPtr<RenderText> Text::createTextRenderer(const RenderStyle& style)
     if (style.hasTextCombine())
         return createRenderer<RenderCombineText>(*this, data());
 
-    return createRenderer<RenderText>(*this, data());
+    return createRenderer<RenderText>(RenderObject::Type::Text, *this, data());
 }
 
 Ref<Text> Text::virtualCreate(String&& data)

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -97,7 +97,7 @@ HTMLDetailsElement::HTMLDetailsElement(const QualifiedName& tagName, Document& d
 
 RenderPtr<RenderElement> HTMLDetailsElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    return createRenderer<RenderBlockFlow>(*this, WTFMove(style));
+    return createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, *this, WTFMove(style));
 }
 
 void HTMLDetailsElement::didAddUserAgentShadowRoot(ShadowRoot& root)

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -435,7 +435,7 @@ RenderPtr<RenderElement> HTMLImageElement::createElementRenderer(RenderStyle&& s
     if (style.hasContent())
         return RenderElement::createFor(*this, WTFMove(style));
 
-    return createRenderer<RenderImage>(*this, WTFMove(style), nullptr, m_imageDevicePixelRatio);
+    return createRenderer<RenderImage>(RenderObject::Type::Image, *this, WTFMove(style), nullptr, m_imageDevicePixelRatio);
 }
 
 bool HTMLImageElement::canStartSelection() const

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -858,7 +858,7 @@ bool HTMLMediaElement::rendererIsNeeded(const RenderStyle& style)
 
 RenderPtr<RenderElement> HTMLMediaElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    return createRenderer<RenderMedia>(*this, WTFMove(style));
+    return createRenderer<RenderMedia>(RenderObject::Type::Media, *this, WTFMove(style));
 }
 
 bool HTMLMediaElement::childShouldCreateRenderer(const Node& child) const

--- a/Source/WebCore/html/HTMLPlugInImageElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInImageElement.cpp
@@ -136,7 +136,7 @@ RenderPtr<RenderElement> HTMLPlugInImageElement::createElementRenderer(RenderSty
         return RenderElement::createFor(*this, WTFMove(style));
 
     if (isImageType())
-        return createRenderer<RenderImage>(*this, WTFMove(style));
+        return createRenderer<RenderImage>(RenderObject::Type::Image, *this, WTFMove(style));
 
     return HTMLPlugInElement::createElementRenderer(WTFMove(style), insertionPosition);
 }

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -111,7 +111,7 @@ void ImageInputType::handleDOMActivateEvent(Event& event)
 RenderPtr<RenderElement> ImageInputType::createInputRenderer(RenderStyle&& style)
 {
     ASSERT(element());
-    return createRenderer<RenderImage>(*element(), WTFMove(style));
+    return createRenderer<RenderImage>(RenderObject::Type::Image, *element(), WTFMove(style));
 }
 
 void ImageInputType::attributeChanged(const QualifiedName& name)

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -304,7 +304,7 @@ bool TextFieldInputType::shouldSubmitImplicitly(Event& event)
 RenderPtr<RenderElement> TextFieldInputType::createInputRenderer(RenderStyle&& style)
 {
     ASSERT(element());
-    return createRenderer<RenderTextControlSingleLine>(*element(), WTFMove(style));
+    return createRenderer<RenderTextControlSingleLine>(RenderObject::Type::TextControlSingleLine, *element(), WTFMove(style));
 }
 
 bool TextFieldInputType::needsContainer() const

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -82,7 +82,7 @@ MediaControlTextTrackContainerElement::MediaControlTextTrackContainerElement(Doc
 
 RenderPtr<RenderElement> MediaControlTextTrackContainerElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    return createRenderer<RenderBlockFlow>(*this, WTFMove(style));
+    return createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, *this, WTFMove(style));
 }
 
 static bool compareCueIntervalForDisplay(const CueInterval& one, const CueInterval& two)

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -90,7 +90,7 @@ class RenderSliderContainer final : public RenderFlexibleBox {
     WTF_MAKE_ISO_ALLOCATED_INLINE(RenderSliderContainer);
 public:
     RenderSliderContainer(SliderContainerElement& element, RenderStyle&& style)
-        : RenderFlexibleBox(element, WTFMove(style))
+        : RenderFlexibleBox(Type::SliderContainer, element, WTFMove(style))
     {
     }
 

--- a/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp
+++ b/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp
@@ -48,7 +48,7 @@ YouTubeEmbedShadowElement::YouTubeEmbedShadowElement(Document& document)
 
 RenderPtr<RenderElement> YouTubeEmbedShadowElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    return createRenderer<RenderBlockFlow>(*this, WTFMove(style));
+    return createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, *this, WTFMove(style));
 }
 
 }

--- a/Source/WebCore/mathml/MathMLAnnotationElement.cpp
+++ b/Source/WebCore/mathml/MathMLAnnotationElement.cpp
@@ -62,7 +62,7 @@ RenderPtr<RenderElement> MathMLAnnotationElement::createElementRenderer(RenderSt
         return MathMLElement::createElementRenderer(WTFMove(style), insertionPosition);
 
     ASSERT(hasTagName(annotation_xmlTag));
-    return createRenderer<RenderMathMLBlock>(*this, WTFMove(style));
+    return createRenderer<RenderMathMLBlock>(RenderObject::Type::MathMLBlock, *this, WTFMove(style));
 }
 
 bool MathMLAnnotationElement::childShouldCreateRenderer(const Node& child) const

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -269,7 +269,7 @@ void MathMLOperatorElement::attributeChanged(const QualifiedName& name, const At
 RenderPtr<RenderElement> MathMLOperatorElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
     ASSERT(hasTagName(MathMLNames::moTag));
-    return createRenderer<RenderMathMLOperator>(*this, WTFMove(style));
+    return createRenderer<RenderMathMLOperator>(RenderObject::Type::MathMLOperator, *this, WTFMove(style));
 }
 
 }

--- a/Source/WebCore/mathml/MathMLRowElement.cpp
+++ b/Source/WebCore/mathml/MathMLRowElement.cpp
@@ -68,7 +68,7 @@ RenderPtr<RenderElement> MathMLRowElement::createElementRenderer(RenderStyle&& s
         return createRenderer<RenderMathMLFenced>(*this, WTFMove(style));
 
     ASSERT(hasTagName(merrorTag) || hasTagName(mphantomTag) || hasTagName(mrowTag) || hasTagName(mstyleTag));
-    return createRenderer<RenderMathMLRow>(*this, WTFMove(style));
+    return createRenderer<RenderMathMLRow>(RenderObject::Type::MathMLRow, *this, WTFMove(style));
 }
 
 bool MathMLRowElement::acceptsMathVariantAttribute()

--- a/Source/WebCore/mathml/MathMLScriptsElement.cpp
+++ b/Source/WebCore/mathml/MathMLScriptsElement.cpp
@@ -90,7 +90,7 @@ void MathMLScriptsElement::attributeChanged(const QualifiedName& name, const Ato
 RenderPtr<RenderElement> MathMLScriptsElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
     ASSERT(hasTagName(msubTag) || hasTagName(msupTag) || hasTagName(msubsupTag) || hasTagName(mmultiscriptsTag));
-    return createRenderer<RenderMathMLScripts>(*this, WTFMove(style));
+    return createRenderer<RenderMathMLScripts>(RenderObject::Type::MathMLScripts, *this, WTFMove(style));
 }
 
 }

--- a/Source/WebCore/mathml/MathMLSelectElement.cpp
+++ b/Source/WebCore/mathml/MathMLSelectElement.cpp
@@ -58,7 +58,7 @@ Ref<MathMLSelectElement> MathMLSelectElement::create(const QualifiedName& tagNam
 
 RenderPtr<RenderElement> MathMLSelectElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    return createRenderer<RenderMathMLRow>(*this, WTFMove(style));
+    return createRenderer<RenderMathMLRow>(RenderObject::Type::MathMLRow, *this, WTFMove(style));
 }
 
 //  We recognize the following values for the encoding attribute of the <semantics> element:

--- a/Source/WebCore/mathml/MathMLTokenElement.cpp
+++ b/Source/WebCore/mathml/MathMLTokenElement.cpp
@@ -71,7 +71,7 @@ RenderPtr<RenderElement> MathMLTokenElement::createElementRenderer(RenderStyle&&
 {
     ASSERT(hasTagName(MathMLNames::miTag) || hasTagName(MathMLNames::mnTag) || hasTagName(MathMLNames::msTag) || hasTagName(MathMLNames::mtextTag));
 
-    return createRenderer<RenderMathMLToken>(*this, WTFMove(style));
+    return createRenderer<RenderMathMLToken>(RenderObject::Type::MathMLToken, *this, WTFMove(style));
 }
 
 bool MathMLTokenElement::childShouldCreateRenderer(const Node& child) const

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -46,7 +46,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderAttachment);
 
 RenderAttachment::RenderAttachment(HTMLAttachmentElement& element, RenderStyle&& style)
-    : RenderReplaced(element, WTFMove(style), LayoutSize())
+    : RenderReplaced(Type::Attachment, element, WTFMove(style), LayoutSize())
     , m_isWideLayout(element.isWideLayout())
 {
 #if ENABLE(SERVICE_CONTROLS)

--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -53,7 +53,6 @@ public:
 
 private:
     void element() const = delete;
-    bool isAttachment() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderAttachment"_s; }
     LayoutSize layoutWideLayoutAttachmentOnly();
     void layoutShadowContent(const LayoutSize&);

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -304,13 +304,13 @@ private:
     bool m_hadVerticalLayoutOverflow;
 };
 
-RenderBlock::RenderBlock(Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderBox(element, WTFMove(style), baseTypeFlags | RenderBlockFlag)
+RenderBlock::RenderBlock(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+    : RenderBox(type, element, WTFMove(style), baseTypeFlags | RenderBlockFlag)
 {
 }
 
-RenderBlock::RenderBlock(Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderBox(document, WTFMove(style), baseTypeFlags | RenderBlockFlag)
+RenderBlock::RenderBlock(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+    : RenderBox(type, document, WTFMove(style), baseTypeFlags | RenderBlockFlag)
 {
 }
 
@@ -2846,9 +2846,9 @@ RenderPtr<RenderBlock> RenderBlock::createAnonymousBlockWithStyleAndDisplay(Docu
     // FIXME: Do we need to convert all our inline displays to block-type in the anonymous logic ?
     RenderPtr<RenderBlock> newBox;
     if (display == DisplayType::Flex || display == DisplayType::InlineFlex)
-        newBox = createRenderer<RenderFlexibleBox>(document, RenderStyle::createAnonymousStyleWithDisplay(style, DisplayType::Flex));
+        newBox = createRenderer<RenderFlexibleBox>(RenderObject::Type::FlexibleBox, document, RenderStyle::createAnonymousStyleWithDisplay(style, DisplayType::Flex));
     else
-        newBox = createRenderer<RenderBlockFlow>(document, RenderStyle::createAnonymousStyleWithDisplay(style, DisplayType::Block));
+        newBox = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, RenderStyle::createAnonymousStyleWithDisplay(style, DisplayType::Block));
     
     newBox->initializeStyle();
     return newBox;

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -59,8 +59,8 @@ public:
     virtual ~RenderBlock();
 
 protected:
-    RenderBlock(Element&, RenderStyle&&, BaseTypeFlags);
-    RenderBlock(Document&, RenderStyle&&, BaseTypeFlags);
+    RenderBlock(Type, Element&, RenderStyle&&, BaseTypeFlags);
+    RenderBlock(Type, Document&, RenderStyle&&, BaseTypeFlags);
 
 public:
     // These two functions are overridden for inline-block.

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -115,8 +115,8 @@ RenderBlockFlow::MarginInfo::MarginInfo(const RenderBlockFlow& block, LayoutUnit
     m_negativeMargin = m_canCollapseMarginBeforeWithChildren ? block.maxNegativeMarginBefore() : 0_lu;
 }
 
-RenderBlockFlow::RenderBlockFlow(Element& element, RenderStyle&& style)
-    : RenderBlock(element, WTFMove(style), RenderBlockFlowFlag)
+RenderBlockFlow::RenderBlockFlow(Type type, Element& element, RenderStyle&& style)
+    : RenderBlock(type, element, WTFMove(style), RenderBlockFlowFlag)
 #if ENABLE(TEXT_AUTOSIZING)
     , m_widthForTextAutosizing(-1)
     , m_lineCountForTextAutosizing(NOT_SET)
@@ -125,8 +125,8 @@ RenderBlockFlow::RenderBlockFlow(Element& element, RenderStyle&& style)
     setChildrenInline(true);
 }
 
-RenderBlockFlow::RenderBlockFlow(Document& document, RenderStyle&& style)
-    : RenderBlock(document, WTFMove(style), RenderBlockFlowFlag)
+RenderBlockFlow::RenderBlockFlow(Type type, Document& document, RenderStyle&& style)
+    : RenderBlock(type, document, WTFMove(style), RenderBlockFlowFlag)
 #if ENABLE(TEXT_AUTOSIZING)
     , m_widthForTextAutosizing(-1)
     , m_lineCountForTextAutosizing(NOT_SET)

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -54,8 +54,8 @@ enum LineCount {
 class RenderBlockFlow : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderBlockFlow);
 public:
-    RenderBlockFlow(Element&, RenderStyle&&);
-    RenderBlockFlow(Document&, RenderStyle&&);
+    RenderBlockFlow(Type, Element&, RenderStyle&&);
+    RenderBlockFlow(Type, Document&, RenderStyle&&);
     virtual ~RenderBlockFlow();
         
     void layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) override;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -151,14 +151,14 @@ static void removeControlStatesForRenderer(const RenderBox& renderer)
 
 bool RenderBox::s_hadNonVisibleOverflow = false;
 
-RenderBox::RenderBox(Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderBoxModelObject(element, WTFMove(style), baseTypeFlags)
+RenderBox::RenderBox(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+    : RenderBoxModelObject(type, element, WTFMove(style), baseTypeFlags)
 {
     setIsBox();
 }
 
-RenderBox::RenderBox(Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderBoxModelObject(document, WTFMove(style), baseTypeFlags)
+RenderBox::RenderBox(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+    : RenderBoxModelObject(type, document, WTFMove(style), baseTypeFlags)
 {
     setIsBox();
 }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -657,8 +657,8 @@ public:
     bool computeHasTransformRelatedProperty(const RenderStyle&) const;
 
 protected:
-    RenderBox(Element&, RenderStyle&&, BaseTypeFlags);
-    RenderBox(Document&, RenderStyle&&, BaseTypeFlags);
+    RenderBox(Type, Element&, RenderStyle&&, BaseTypeFlags);
+    RenderBox(Type, Document&, RenderStyle&&, BaseTypeFlags);
 
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -167,13 +167,13 @@ bool RenderBoxModelObject::hasAcceleratedCompositing() const
     return view().compositor().hasAcceleratedCompositing();
 }
 
-RenderBoxModelObject::RenderBoxModelObject(Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderLayerModelObject(element, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
+RenderBoxModelObject::RenderBoxModelObject(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+    : RenderLayerModelObject(type, element, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
 {
 }
 
-RenderBoxModelObject::RenderBoxModelObject(Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderLayerModelObject(document, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
+RenderBoxModelObject::RenderBoxModelObject(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+    : RenderLayerModelObject(type, document, WTFMove(style), baseTypeFlags | RenderBoxModelObjectFlag)
 {
 }
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -211,8 +211,8 @@ public:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption>) const override;
 
 protected:
-    RenderBoxModelObject(Element&, RenderStyle&&, BaseTypeFlags);
-    RenderBoxModelObject(Document&, RenderStyle&&, BaseTypeFlags);
+    RenderBoxModelObject(Type, Element&, RenderStyle&&, BaseTypeFlags);
+    RenderBoxModelObject(Type, Document&, RenderStyle&&, BaseTypeFlags);
 
     void willBeDestroyed() override;
 

--- a/Source/WebCore/rendering/RenderButton.cpp
+++ b/Source/WebCore/rendering/RenderButton.cpp
@@ -47,7 +47,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderButton);
 
 RenderButton::RenderButton(HTMLFormControlElement& element, RenderStyle&& style)
-    : RenderFlexibleBox(element, WTFMove(style))
+    : RenderFlexibleBox(Type::Button, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderButton.h
+++ b/Source/WebCore/rendering/RenderButton.h
@@ -68,7 +68,6 @@ private:
     void element() const = delete;
 
     ASCIILiteral renderName() const override { return "RenderButton"_s; }
-    bool isRenderButton() const override { return true; }
 
     bool hasLineIfEmpty() const override;
 

--- a/Source/WebCore/rendering/RenderCombineText.cpp
+++ b/Source/WebCore/rendering/RenderCombineText.cpp
@@ -34,7 +34,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderCombineText);
 const float textCombineMargin = 1.15f; // Allow em + 15% margin
 
 RenderCombineText::RenderCombineText(Text& textNode, const String& string)
-    : RenderText(textNode, string)
+    : RenderText(Type::CombineText, textNode, string)
     , m_isCombined(false)
     , m_needsFontUpdate(false)
 {

--- a/Source/WebCore/rendering/RenderCombineText.h
+++ b/Source/WebCore/rendering/RenderCombineText.h
@@ -44,7 +44,6 @@ public:
 private:
     void node() const = delete;
 
-    bool isCombineText() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderCombineText"_s; }
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
     void setRenderedText(const String&) override;

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -432,7 +432,7 @@ static CounterNode* makeCounterNode(RenderElement& renderer, const AtomString& i
 }
 
 RenderCounter::RenderCounter(Document& document, const CounterContent& counter)
-    : RenderText(document, emptyString())
+    : RenderText(Type::Counter, document, emptyString())
     , m_counter(counter)
 {
     view().addCounterNeedingUpdate(*this);
@@ -456,11 +456,6 @@ void RenderCounter::willBeDestroyed()
 ASCIILiteral RenderCounter::renderName() const
 {
     return "RenderCounter"_s;
-}
-
-bool RenderCounter::isCounter() const
-{
-    return true;
 }
 
 String RenderCounter::originalText() const

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -48,7 +48,6 @@ private:
     static void rendererStyleChangedSlowCase(RenderElement&, const RenderStyle* oldStyle, const RenderStyle& newStyle);
     
     ASCIILiteral renderName() const override;
-    bool isCounter() const override;
     String originalText() const override;
     
     RefPtr<CSSCounterStyle> counterStyle() const;

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -129,8 +129,8 @@ private:
     unsigned m_ordinalIteration;
 };
 
-RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox(Element& element, RenderStyle&& style)
-    : RenderBlock(element, WTFMove(style), 0)
+RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox(Type type, Element& element, RenderStyle&& style)
+    : RenderBlock(type, element, WTFMove(style), 0)
 {
     setChildrenInline(false); // All of our children must be block-level
     m_stretchingChildren = false;

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
@@ -31,7 +31,7 @@ class FlexBoxIterator;
 class RenderDeprecatedFlexibleBox final : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderDeprecatedFlexibleBox);
 public:
-    RenderDeprecatedFlexibleBox(Element&, RenderStyle&&);
+    RenderDeprecatedFlexibleBox(Type, Element&, RenderStyle&&);
     virtual ~RenderDeprecatedFlexibleBox();
 
     Element& element() const { return downcast<Element>(nodeForNonAnonymous()); }

--- a/Source/WebCore/rendering/RenderDetailsMarker.cpp
+++ b/Source/WebCore/rendering/RenderDetailsMarker.cpp
@@ -38,7 +38,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderDetailsMarker);
 
 RenderDetailsMarker::RenderDetailsMarker(DetailsMarkerControl& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::DetailsMarker, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderDetailsMarker.h
+++ b/Source/WebCore/rendering/RenderDetailsMarker.h
@@ -36,7 +36,6 @@ public:
 
 private:
     ASCIILiteral renderName() const override { return "RenderDetailsMarker"_s; }
-    bool isDetailsMarker() const override { return true; }
     void paint(PaintInfo&, const LayoutPoint&) override;
 
     bool isOpen() const;

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -307,8 +307,8 @@ protected:
     
     typedef unsigned BaseTypeFlags;
 
-    RenderElement(Element&, RenderStyle&&, BaseTypeFlags);
-    RenderElement(Document&, RenderStyle&&, BaseTypeFlags);
+    RenderElement(Type, Element&, RenderStyle&&, BaseTypeFlags);
+    RenderElement(Type, Document&, RenderStyle&&, BaseTypeFlags);
 
     bool layerCreationAllowedForSubtree() const;
 
@@ -351,7 +351,7 @@ protected:
     inline bool shouldApplySizeOrStyleContainment(bool) const;
 
 private:
-    RenderElement(ContainerNode&, RenderStyle&&, BaseTypeFlags);
+    RenderElement(Type, ContainerNode&, RenderStyle&&, BaseTypeFlags);
     void node() const = delete;
     void nonPseudoNode() const = delete;
     void generatingNode() const = delete;

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -81,7 +81,7 @@ static constexpr auto replacementTextColor = SRGBA<uint8_t> { 240, 240, 240 };
 static constexpr auto unavailablePluginBorderColor = Color::white.colorWithAlphaByte(216);
 
 RenderEmbeddedObject::RenderEmbeddedObject(HTMLFrameOwnerElement& element, RenderStyle&& style)
-    : RenderWidget(element, WTFMove(style))
+    : RenderWidget(Type::EmbeddedObject, element, WTFMove(style))
     , m_isPluginUnavailable(false)
     , m_unavailablePluginIndicatorIsPressed(false)
     , m_mouseDownWasInUnavailablePluginIndicator(false)

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -71,7 +71,6 @@ private:
     void willBeDestroyed() final;
 
     ASCIILiteral renderName() const final { return "RenderEmbeddedObject"_s; }
-    bool isEmbeddedObject() const final { return true; }
 
     bool showsUnavailablePluginIndicator() const { return isPluginUnavailable() && m_isUnavailablePluginIndicatorState != UnavailablePluginIndicatorState::Hidden; }
 

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -67,7 +67,7 @@ constexpr int defaultWidthNumChars = 38;
 #endif
 
 RenderFileUploadControl::RenderFileUploadControl(HTMLInputElement& input, RenderStyle&& style)
-    : RenderBlockFlow(input, WTFMove(style))
+    : RenderBlockFlow(Type::FileUploadControl, input, WTFMove(style))
     , m_canReceiveDroppedFiles(input.canReceiveDroppedFiles())
 {
 }

--- a/Source/WebCore/rendering/RenderFileUploadControl.h
+++ b/Source/WebCore/rendering/RenderFileUploadControl.h
@@ -44,8 +44,6 @@ public:
 private:
     void element() const = delete;
 
-    bool isFileUploadControl() const override { return true; }
-
     ASCIILiteral renderName() const override { return "RenderFileUploadControl"_s; }
 
     void updateFromElement() override;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -80,14 +80,14 @@ struct RenderFlexibleBox::LineState {
     FlexItems flexItems;
 };
 
-RenderFlexibleBox::RenderFlexibleBox(Element& element, RenderStyle&& style)
-    : RenderBlock(element, WTFMove(style), 0)
+RenderFlexibleBox::RenderFlexibleBox(Type type, Element& element, RenderStyle&& style)
+    : RenderBlock(type, element, WTFMove(style), 0)
 {
     setChildrenInline(false); // All of our children must be block-level.
 }
 
-RenderFlexibleBox::RenderFlexibleBox(Document& document, RenderStyle&& style)
-    : RenderBlock(document, WTFMove(style), 0)
+RenderFlexibleBox::RenderFlexibleBox(Type type, Document& document, RenderStyle&& style)
+    : RenderBlock(type, document, WTFMove(style), 0)
 {
     setChildrenInline(false); // All of our children must be block-level.
 }

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -45,8 +45,8 @@ class FlexLayout;
 class RenderFlexibleBox : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderFlexibleBox);
 public:
-    RenderFlexibleBox(Element&, RenderStyle&&);
-    RenderFlexibleBox(Document&, RenderStyle&&);
+    RenderFlexibleBox(Type, Element&, RenderStyle&&);
+    RenderFlexibleBox(Type, Document&, RenderStyle&&);
     virtual ~RenderFlexibleBox();
 
     using Direction = BlockFlowDirection;

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -54,14 +54,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFragmentContainer);
 
-RenderFragmentContainer::RenderFragmentContainer(Element& element, RenderStyle&& style, RenderFragmentedFlow* fragmentedFlow)
-    : RenderBlockFlow(element, WTFMove(style))
+RenderFragmentContainer::RenderFragmentContainer(Type type, Element& element, RenderStyle&& style, RenderFragmentedFlow* fragmentedFlow)
+    : RenderBlockFlow(type, element, WTFMove(style))
     , m_fragmentedFlow(fragmentedFlow)
 {
 }
 
-RenderFragmentContainer::RenderFragmentContainer(Document& document, RenderStyle&& style, RenderFragmentedFlow* fragmentedFlow)
-    : RenderBlockFlow(document, WTFMove(style))
+RenderFragmentContainer::RenderFragmentContainer(Type type, Document& document, RenderStyle&& style, RenderFragmentedFlow* fragmentedFlow)
+    : RenderBlockFlow(type, document, WTFMove(style))
     , m_fragmentedFlow(fragmentedFlow)
 {
 }

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -119,8 +119,8 @@ public:
     virtual Vector<LayoutRect> fragmentRectsForFlowContentRect(const LayoutRect&) const;
 
 protected:
-    RenderFragmentContainer(Element&, RenderStyle&&, RenderFragmentedFlow*);
-    RenderFragmentContainer(Document&, RenderStyle&&, RenderFragmentedFlow*);
+    RenderFragmentContainer(Type, Element&, RenderStyle&&, RenderFragmentedFlow*);
+    RenderFragmentContainer(Type, Document&, RenderStyle&&, RenderFragmentedFlow*);
 
     void ensureOverflowForBox(const RenderBox*, RefPtr<RenderOverflow>&, bool) const;
 

--- a/Source/WebCore/rendering/RenderFragmentContainerSet.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainerSet.cpp
@@ -35,8 +35,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFragmentContainerSet);
 
-RenderFragmentContainerSet::RenderFragmentContainerSet(Document& document, RenderStyle&& style, RenderFragmentedFlow& fragmentedFlow)
-    : RenderFragmentContainer(document, WTFMove(style), &fragmentedFlow)
+RenderFragmentContainerSet::RenderFragmentContainerSet(Type type, Document& document, RenderStyle&& style, RenderFragmentedFlow& fragmentedFlow)
+    : RenderFragmentContainer(type, document, WTFMove(style), &fragmentedFlow)
 {
 }
 

--- a/Source/WebCore/rendering/RenderFragmentContainerSet.h
+++ b/Source/WebCore/rendering/RenderFragmentContainerSet.h
@@ -48,7 +48,7 @@ public:
     void expandToEncompassFragmentedFlowContentsIfNeeded();
 
 protected:
-    RenderFragmentContainerSet(Document&, RenderStyle&&, RenderFragmentedFlow&);
+    RenderFragmentContainerSet(Type, Document&, RenderStyle&&, RenderFragmentedFlow&);
 
 private:
     void installFragmentedFlow() final;

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -55,8 +55,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFragmentedFlow);
 
-RenderFragmentedFlow::RenderFragmentedFlow(Document& document, RenderStyle&& style)
-    : RenderBlockFlow(document, WTFMove(style))
+RenderFragmentedFlow::RenderFragmentedFlow(Type type, Document& document, RenderStyle&& style)
+    : RenderBlockFlow(type, document, WTFMove(style))
     , m_currentFragmentMaintainer(nullptr)
     , m_fragmentsInvalidated(false)
     , m_fragmentsHaveUniformLogicalWidth(true)

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -182,7 +182,7 @@ private:
     bool requiresLayer() const final { return true; }
 
 protected:
-    RenderFragmentedFlow(Document&, RenderStyle&&);
+    RenderFragmentedFlow(Type, Document&, RenderStyle&&);
 
     RenderFragmentedFlow* locateEnclosingFragmentedFlow() const override { return const_cast<RenderFragmentedFlow*>(this); }
 

--- a/Source/WebCore/rendering/RenderFrame.cpp
+++ b/Source/WebCore/rendering/RenderFrame.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFrame);
 
 RenderFrame::RenderFrame(HTMLFrameElement& frame, RenderStyle&& style)
-    : RenderFrameBase(frame, WTFMove(style))
+    : RenderFrameBase(Type::Frame, frame, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderFrame.h
+++ b/Source/WebCore/rendering/RenderFrame.h
@@ -43,7 +43,6 @@ private:
     void frameOwnerElement() const = delete;
 
     ASCIILiteral renderName() const final { return "RenderFrame"_s; }
-    bool isFrame() const final { return true; }
 };
 
 inline RenderFrame* HTMLFrameElement::renderer() const

--- a/Source/WebCore/rendering/RenderFrameBase.cpp
+++ b/Source/WebCore/rendering/RenderFrameBase.cpp
@@ -39,8 +39,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFrameBase);
 
-RenderFrameBase::RenderFrameBase(HTMLFrameElementBase& element, RenderStyle&& style)
-    : RenderWidget(element, WTFMove(style))
+RenderFrameBase::RenderFrameBase(Type type, HTMLFrameElementBase& element, RenderStyle&& style)
+    : RenderWidget(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderFrameBase.h
+++ b/Source/WebCore/rendering/RenderFrameBase.h
@@ -37,7 +37,7 @@ class RenderView;
 class RenderFrameBase : public RenderWidget {
     WTF_MAKE_ISO_ALLOCATED(RenderFrameBase);
 protected:
-    RenderFrameBase(HTMLFrameElementBase&, RenderStyle&&);
+    RenderFrameBase(Type, HTMLFrameElementBase&, RenderStyle&&);
 
 public:
     LocalFrameView* childView() const { return downcast<LocalFrameView>(RenderWidget::widget()); }

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -55,7 +55,7 @@ static constexpr auto borderFillColor = SRGBA<uint8_t> { 208, 208, 208 };
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFrameSet);
 
 RenderFrameSet::RenderFrameSet(HTMLFrameSetElement& frameSet, RenderStyle&& style)
-    : RenderBox(frameSet, WTFMove(style), 0)
+    : RenderBox(Type::FrameSet, frameSet, WTFMove(style), 0)
     , m_isResizing(false)
 {
     setInline(false);

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -87,7 +87,6 @@ private:
     };
 
     ASCIILiteral renderName() const override { return "RenderFrameSet"_s; }
-    bool isFrameSet() const override { return true; }
 
     void layout() override;
     void paint(PaintInfo&, const LayoutPoint&) override;

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -51,7 +51,7 @@ enum TrackSizeRestriction {
 };
 
 RenderGrid::RenderGrid(Element& element, RenderStyle&& style)
-    : RenderBlock(element, WTFMove(style), 0)
+    : RenderBlock(Type::Grid, element, WTFMove(style), 0)
     , m_grid(*this)
     , m_trackSizingAlgorithm(this, currentGrid())
     , m_masonryLayout(*this)

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -139,7 +139,6 @@ private:
     }
 
     ASCIILiteral renderName() const override;
-    bool isRenderGrid() const override { return true; }
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
 
     bool selfAlignmentChangedToStretch(GridAxis, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox&) const;

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -50,7 +50,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderHTMLCanvas);
 
 RenderHTMLCanvas::RenderHTMLCanvas(HTMLCanvasElement& element, RenderStyle&& style)
-    : RenderReplaced(element, WTFMove(style), element.size())
+    : RenderReplaced(Type::HTMLCanvas, element, WTFMove(style), element.size())
 {
 }
 

--- a/Source/WebCore/rendering/RenderHTMLCanvas.h
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.h
@@ -43,7 +43,6 @@ public:
 private:
     void element() const = delete;
     bool requiresLayer() const override;
-    bool isCanvas() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderHTMLCanvas"_s; }
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
     void intrinsicSizeChanged() override { canvasSizeChanged(); }

--- a/Source/WebCore/rendering/RenderIFrame.cpp
+++ b/Source/WebCore/rendering/RenderIFrame.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderIFrame);
 using namespace HTMLNames;
     
 RenderIFrame::RenderIFrame(HTMLIFrameElement& element, RenderStyle&& style)
-    : RenderFrameBase(element, WTFMove(style))
+    : RenderFrameBase(Type::IFrame, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderIFrame.h
+++ b/Source/WebCore/rendering/RenderIFrame.h
@@ -46,8 +46,6 @@ private:
 
     void layout() override;
 
-    bool isRenderIFrame() const override { return true; }
-
     ASCIILiteral renderName() const override { return "RenderIFrame"_s; }
 
     bool requiresLayer() const override;

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -145,8 +145,8 @@ void RenderImage::collectSelectionGeometries(Vector<SelectionGeometry>& geometri
 
 using namespace HTMLNames;
 
-RenderImage::RenderImage(Element& element, RenderStyle&& style, StyleImage* styleImage, const float imageDevicePixelRatio)
-    : RenderReplaced(element, WTFMove(style), IntSize())
+RenderImage::RenderImage(Type type, Element& element, RenderStyle&& style, StyleImage* styleImage, const float imageDevicePixelRatio)
+    : RenderReplaced(type, element, WTFMove(style), IntSize())
     , m_imageResource(styleImage ? makeUnique<RenderImageResourceStyleImage>(*styleImage) : makeUnique<RenderImageResource>())
     , m_hasImageOverlay(is<HTMLElement>(element) && ImageOverlay::hasOverlay(downcast<HTMLElement>(element)))
     , m_imageDevicePixelRatio(imageDevicePixelRatio)
@@ -158,8 +158,8 @@ RenderImage::RenderImage(Element& element, RenderStyle&& style, StyleImage* styl
 #endif
 }
 
-RenderImage::RenderImage(Document& document, RenderStyle&& style, StyleImage* styleImage)
-    : RenderReplaced(document, WTFMove(style), IntSize())
+RenderImage::RenderImage(Type type, Document& document, RenderStyle&& style, StyleImage* styleImage)
+    : RenderReplaced(type, document, WTFMove(style), IntSize())
     , m_imageResource(styleImage ? makeUnique<RenderImageResourceStyleImage>(*styleImage) : makeUnique<RenderImageResource>())
 {
 }

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -40,8 +40,8 @@ enum ImageSizeChangeType {
 class RenderImage : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(RenderImage);
 public:
-    RenderImage(Element&, RenderStyle&&, StyleImage* = nullptr, const float = 1.0f);
-    RenderImage(Document&, RenderStyle&&, StyleImage* = nullptr);
+    RenderImage(Type, Element&, RenderStyle&&, StyleImage* = nullptr, const float = 1.0f);
+    RenderImage(Type, Document&, RenderStyle&&, StyleImage* = nullptr);
     virtual ~RenderImage();
 
     RenderImageResource& imageResource() { return *m_imageResource; }

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -64,14 +64,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderInline);
 
-RenderInline::RenderInline(Element& element, RenderStyle&& style)
-    : RenderBoxModelObject(element, WTFMove(style), RenderInlineFlag)
+RenderInline::RenderInline(Type type, Element& element, RenderStyle&& style)
+    : RenderBoxModelObject(type, element, WTFMove(style), RenderInlineFlag)
 {
     setChildrenInline(true);
 }
 
-RenderInline::RenderInline(Document& document, RenderStyle&& style)
-    : RenderBoxModelObject(document, WTFMove(style), RenderInlineFlag)
+RenderInline::RenderInline(Type type, Document& document, RenderStyle&& style)
+    : RenderBoxModelObject(type, document, WTFMove(style), RenderInlineFlag)
 {
     setChildrenInline(true);
 }

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -33,8 +33,8 @@ class RenderFragmentContainer;
 class RenderInline : public RenderBoxModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderInline);
 public:
-    RenderInline(Element&, RenderStyle&&);
-    RenderInline(Document&, RenderStyle&&);
+    RenderInline(Type, Element&, RenderStyle&&);
+    RenderInline(Type, Document&, RenderStyle&&);
 
     LayoutUnit marginLeft() const final;
     LayoutUnit marginRight() const final;

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -56,13 +56,13 @@ bool RenderLayerModelObject::s_hadLayer = false;
 bool RenderLayerModelObject::s_wasTransformed = false;
 bool RenderLayerModelObject::s_layerWasSelfPainting = false;
 
-RenderLayerModelObject::RenderLayerModelObject(Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderElement(element, WTFMove(style), baseTypeFlags | RenderLayerModelObjectFlag)
+RenderLayerModelObject::RenderLayerModelObject(Type type, Element& element, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+    : RenderElement(type, element, WTFMove(style), baseTypeFlags | RenderLayerModelObjectFlag)
 {
 }
 
-RenderLayerModelObject::RenderLayerModelObject(Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
-    : RenderElement(document, WTFMove(style), baseTypeFlags | RenderLayerModelObjectFlag)
+RenderLayerModelObject::RenderLayerModelObject(Type type, Document& document, RenderStyle&& style, BaseTypeFlags baseTypeFlags)
+    : RenderElement(type, document, WTFMove(style), baseTypeFlags | RenderLayerModelObjectFlag)
 {
 }
 

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -104,8 +104,8 @@ public:
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox) const;
 
 protected:
-    RenderLayerModelObject(Element&, RenderStyle&&, BaseTypeFlags);
-    RenderLayerModelObject(Document&, RenderStyle&&, BaseTypeFlags);
+    RenderLayerModelObject(Type, Element&, RenderStyle&&, BaseTypeFlags);
+    RenderLayerModelObject(Type, Document&, RenderStyle&&, BaseTypeFlags);
 
     void createLayer();
     void willBeDestroyed() override;

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -50,12 +50,11 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderLineBreak);
 static const int invalidLineHeight = -1;
 
 RenderLineBreak::RenderLineBreak(HTMLElement& element, RenderStyle&& style)
-    : RenderBoxModelObject(element, WTFMove(style), 0)
+    : RenderBoxModelObject(Type::LineBreak, element, WTFMove(style), 0)
     , m_inlineBoxWrapper(nullptr)
     , m_cachedLineHeight(invalidLineHeight)
     , m_isWBR(is<HTMLWBRElement>(element))
 {
-    setIsLineBreak();
 }
 
 RenderLineBreak::~RenderLineBreak()

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -89,7 +89,7 @@ const int defaultSize = 4;
 const int baselineAdjustment = 7;
 
 RenderListBox::RenderListBox(HTMLSelectElement& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::ListBox, element, WTFMove(style))
 {
     view().frameView().addScrollableArea(this);
 }

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -76,8 +76,6 @@ private:
 
     ASCIILiteral renderName() const override { return "RenderListBox"_s; }
 
-    bool isListBox() const override { return true; }
-
     void updateFromElement() override;
     bool hasControlClip() const override { return true; }
     void paintObject(PaintInfo&, const LayoutPoint&) override;

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -50,7 +50,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderListItem);
 
 RenderListItem::RenderListItem(Element& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::ListItem, element, WTFMove(style))
 {
     setInline(false);
 }

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -60,8 +60,6 @@ public:
 
 private:
     ASCIILiteral renderName() const final { return "RenderListItem"_s; }
-
-    bool isListItem() const final { return true; }
     
     void insertedIntoTree(IsInternalMove) final;
     void willBeRemovedFromTree(IsInternalMove) final;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderListMarker);
 constexpr int cMarkerPadding = 7;
 
 RenderListMarker::RenderListMarker(RenderListItem& listItem, RenderStyle&& style)
-    : RenderBox(listItem.document(), WTFMove(style), 0)
+    : RenderBox(Type::ListMarker, listItem.document(), WTFMove(style), 0)
     , m_listItem(listItem)
 {
     setInline(true);

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -55,7 +55,6 @@ private:
     void willBeDestroyed() final;
     ASCIILiteral renderName() const final { return "RenderListMarker"_s; }
     void computePreferredLogicalWidths() final;
-    bool isListMarker() const final { return true; }
     bool canHaveChildren() const final { return false; }
     void paint(PaintInfo&, const LayoutPoint&) final;
     void layout() final;

--- a/Source/WebCore/rendering/RenderMedia.cpp
+++ b/Source/WebCore/rendering/RenderMedia.cpp
@@ -39,14 +39,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMedia);
 
-RenderMedia::RenderMedia(HTMLMediaElement& element, RenderStyle&& style)
-    : RenderImage(element, WTFMove(style))
+RenderMedia::RenderMedia(Type type, HTMLMediaElement& element, RenderStyle&& style)
+    : RenderImage(type, element, WTFMove(style))
 {
     setHasShadowControls(true);
 }
 
-RenderMedia::RenderMedia(HTMLMediaElement& element, RenderStyle&& style, const IntSize& intrinsicSize)
-    : RenderImage(element, WTFMove(style))
+RenderMedia::RenderMedia(Type type, HTMLMediaElement& element, RenderStyle&& style, const IntSize& intrinsicSize)
+    : RenderImage(type, element, WTFMove(style))
 {
     setIntrinsicSize(intrinsicSize);
     setHasShadowControls(true);

--- a/Source/WebCore/rendering/RenderMedia.h
+++ b/Source/WebCore/rendering/RenderMedia.h
@@ -35,8 +35,8 @@ namespace WebCore {
 class RenderMedia : public RenderImage {
     WTF_MAKE_ISO_ALLOCATED(RenderMedia);
 public:
-    RenderMedia(HTMLMediaElement&, RenderStyle&&);
-    RenderMedia(HTMLMediaElement&, RenderStyle&&, const IntSize& intrinsicSize);
+    RenderMedia(Type, HTMLMediaElement&, RenderStyle&&);
+    RenderMedia(Type, HTMLMediaElement&, RenderStyle&&, const IntSize& intrinsicSize);
     virtual ~RenderMedia();
 
     HTMLMediaElement& mediaElement() const { return downcast<HTMLMediaElement>(nodeForNonAnonymous()); }

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -82,7 +82,7 @@ static size_t selectedOptionCount(const RenderMenuList& renderMenuList)
 #endif
 
 RenderMenuList::RenderMenuList(HTMLSelectElement& element, RenderStyle&& style)
-    : RenderFlexibleBox(element, WTFMove(style))
+    : RenderFlexibleBox(Type::MenuList, element, WTFMove(style))
     , m_needsOptionsWidthUpdate(true)
     , m_optionsWidth(0)
 #if !PLATFORM(IOS_FAMILY)
@@ -284,7 +284,7 @@ void RenderMenuList::setText(const String& s)
         m_buttonText->setText(textToUse.impl(), true);
         m_buttonText->dirtyLineBoxes(false);
     } else {
-        auto newButtonText = createRenderer<RenderText>(document(), textToUse);
+        auto newButtonText = createRenderer<RenderText>(Type::Text, document(), textToUse);
         m_buttonText = *newButtonText;
         // FIXME: This mutation should go through the normal RenderTreeBuilder path.
         if (RenderTreeBuilder::current())

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -73,8 +73,6 @@ private:
 
     void element() const = delete;
 
-    bool isMenuList() const override { return true; }
-
     bool createsAnonymousWrapper() const override { return true; }
 
     void updateFromElement() override;

--- a/Source/WebCore/rendering/RenderMeter.cpp
+++ b/Source/WebCore/rendering/RenderMeter.cpp
@@ -35,7 +35,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMeter);
 
 RenderMeter::RenderMeter(HTMLElement& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::Meter, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderMeter.h
+++ b/Source/WebCore/rendering/RenderMeter.h
@@ -40,7 +40,6 @@ private:
     LogicalExtentComputedValues computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const override;
 
     ASCIILiteral renderName() const override { return "RenderMeter"_s; }
-    bool isMeter() const override { return true; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderModel.cpp
+++ b/Source/WebCore/rendering/RenderModel.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderModel);
 
 RenderModel::RenderModel(HTMLModelElement& element, RenderStyle&& style)
-    : RenderReplaced { element, WTFMove(style) }
+    : RenderReplaced { Type::Model, element, WTFMove(style) }
 {
 }
 

--- a/Source/WebCore/rendering/RenderModel.h
+++ b/Source/WebCore/rendering/RenderModel.h
@@ -44,7 +44,6 @@ public:
 private:
     void element() const = delete;
     ASCIILiteral renderName() const final { return "RenderModel"_s; }
-    bool isRenderModel() const final { return true; }
 
     bool requiresLayer() const final;
     void updateFromElement() final;

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMultiColumnFlow);
 
 RenderMultiColumnFlow::RenderMultiColumnFlow(Document& document, RenderStyle&& style)
-    : RenderFragmentedFlow(document, WTFMove(style))
+    : RenderFragmentedFlow(Type::MultiColumnFlow, document, WTFMove(style))
     , m_spannerMap(makeUnique<SpannerMap>())
 {
     setFragmentedFlowState(InsideInFragmentedFlow);

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.h
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.h
@@ -99,7 +99,6 @@ public:
     SpannerMap& spannerMap() { return *m_spannerMap; }
 
 private:
-    bool isRenderMultiColumnFlow() const override { return true; }
     ASCIILiteral renderName() const override;
     void addFragmentToThread(RenderFragmentContainer*) override;
     void willBeRemovedFromTree(IsInternalMove) override;

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMultiColumnSet);
 
 RenderMultiColumnSet::RenderMultiColumnSet(RenderFragmentedFlow& fragmentedFlow, RenderStyle&& style)
-    : RenderFragmentContainerSet(fragmentedFlow.document(), WTFMove(style), fragmentedFlow)
+    : RenderFragmentContainerSet(Type::MultiColumnSet, fragmentedFlow.document(), WTFMove(style), fragmentedFlow)
     , m_maxColumnHeight(RenderFragmentedFlow::maxLogicalHeight())
     , m_minSpaceShortage(RenderFragmentedFlow::maxLogicalHeight())
 {

--- a/Source/WebCore/rendering/RenderMultiColumnSet.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.h
@@ -142,8 +142,7 @@ public:
 
 private:
     void addOverflowFromChildren() override;
-    
-    bool isRenderMultiColumnSet() const override { return true; }
+
     void layout() override;
 
     Node* nodeForHitTest() const override;

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
@@ -49,7 +49,7 @@ RenderPtr<RenderMultiColumnSpannerPlaceholder> RenderMultiColumnSpannerPlacehold
 }
 
 RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder(RenderMultiColumnFlow& fragmentedFlow, RenderBox& spanner, RenderStyle&& style)
-    : RenderBox(fragmentedFlow.document(), WTFMove(style), RenderBoxModelObjectFlag)
+    : RenderBox(Type::MultiColumnSpannerPlaceholder, fragmentedFlow.document(), WTFMove(style), RenderBoxModelObjectFlag)
     , m_spanner(spanner)
     , m_fragmentedFlow(fragmentedFlow)
 {

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h
@@ -46,7 +46,6 @@ private:
     template<class T, class... Args> friend RenderPtr<T> createRenderer(Args&&...);
 
     RenderMultiColumnSpannerPlaceholder(RenderMultiColumnFlow&, RenderBox& spanner, RenderStyle&&);
-    bool isRenderMultiColumnSpannerPlaceholder() const override { return true; }
 
     bool canHaveChildren() const override { return false; }
     void paint(PaintInfo&, const LayoutPoint&) override { }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -124,7 +124,9 @@ struct SameSizeAsRenderObject : CanMakeWeakPtr<SameSizeAsRenderObject> {
 #endif
     unsigned m_bitfields;
     CheckedRef<Node> node;
-    void* pointers[3];
+    void* pointers[2];
+    PackedPtr<RenderObject> m_next;
+    uint8_t m_type;
     CheckedPtr<Layout::Box> layoutBox;
 };
 
@@ -139,7 +141,7 @@ void RenderObjectDeleter::operator() (RenderObject* renderer) const
     renderer->destroy();
 }
 
-RenderObject::RenderObject(Node& node)
+RenderObject::RenderObject(Type type, Node& node)
     : CachedImageClient()
 #if ASSERT_ENABLED
     , m_hasAXObject(false)
@@ -150,6 +152,7 @@ RenderObject::RenderObject(Node& node)
     , m_parent(nullptr)
     , m_previous(nullptr)
     , m_next(nullptr)
+    , m_type(type)
 {
     if (RenderView* renderView = node.document().renderView())
         renderView->didCreateRenderer();

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -105,11 +105,123 @@ class RenderObject : public CachedImageClient, public CanMakeCheckedPtr {
     friend class RenderLayer;
     friend class RenderLayerScrollableArea;
 public:
+    enum class Type : uint8_t {
+#if ENABLE(ATTACHMENT_ELEMENT)
+        Attachment,
+#endif
+        BlockFlow,
+        Button,
+        CombineText,
+        Counter,
+        DeprecatedFlexibleBox,
+        DetailsMarker,
+        EmbeddedObject,
+        FileUploadControl,
+        FlexibleBox,
+        Frame,
+        FrameSet,
+        Grid,
+        HTMLCanvas,
+        IFrame,
+        Image,
+        Inline,
+        LineBreak,
+        ListBox,
+        ListItem,
+        ListMarker,
+        Media,
+        MenuList,
+        Meter,
+#if ENABLE(MODEL_ELEMENT)
+        Model,
+#endif
+        MultiColumnFlow,
+        MultiColumnSet,
+        MultiColumnSpannerPlaceholder,
+        Progress,
+        Quote,
+        Replica,
+        RubyAsInline,
+        RubyAsBlock,
+        RubyBase,
+        RubyRun,
+        RubyText,
+        ScrollbarPart,
+        SearchField,
+        Slider,
+        SliderContainer,
+        Table,
+        TableCaption,
+        TableCell,
+        TableCol,
+        TableRow,
+        TableSection,
+        Text,
+        TextControlInnerBlock,
+        TextControlInnerContainer,
+        TextControlMultiLine,
+        TextControlSingleLine,
+        TextFragment,
+        VTTCue,
+        Video,
+        View,
+#if ENABLE(MATHML)
+        MathMLBlock,
+        MathMLFenced,
+        MathMLFencedOperator,
+        MathMLFraction,
+        MathMLMath,
+        MathMLMenclose,
+        MathMLOperator,
+        MathMLPadded,
+        MathMLRoot,
+        MathMLRow,
+        MathMLScripts,
+        MathMLSpace,
+        MathMLTable,
+        MathMLToken,
+        MathMLUnderOver,
+#endif
+        SVGEllipse,
+        SVGForeignObject,
+        SVGGradientStop,
+        SVGHiddenContainer,
+        SVGImage,
+        SVGInline,
+        SVGInlineText,
+        SVGPath,
+        SVGRect,
+        SVGResourceFilter,
+        SVGResourceFilterPrimitive,
+        SVGResourceLinearGradient,
+        SVGResourceMarker,
+        SVGResourceMasker,
+        SVGResourcePattern,
+        SVGResourceRadialGradient,
+        SVGRoot,
+        SVGTSpan,
+        SVGText,
+        SVGTextPath,
+        SVGTransformableContainer,
+        SVGViewportContainer,
+        LegacySVGEllipse,
+        LegacySVGForeignObject,
+        LegacySVGHiddenContainer,
+        LegacySVGImage,
+        LegacySVGPath,
+        LegacySVGRect,
+        LegacySVGResourceClipper,
+        LegacySVGRoot,
+        LegacySVGTransformableContainer,
+        LegacySVGViewportContainer
+    };
+
     // Anonymous objects should pass the document as their node, and they will then automatically be
     // marked as anonymous in the constructor.
-    explicit RenderObject(Node&);
+    RenderObject(Type, Node&);
     virtual ~RenderObject();
 
+    Type type() const { return m_type; }
     Layout::Box* layoutBox() { return m_layoutBox.get(); }
     const Layout::Box* layoutBox() const { return m_layoutBox.get(); }
     void setLayoutBox(Layout::Box&);
@@ -123,7 +235,7 @@ public:
     bool isDescendantOf(const RenderObject*) const;
 
     RenderObject* previousSibling() const { return m_previous; }
-    RenderObject* nextSibling() const { return m_next; }
+    RenderObject* nextSibling() const { return m_next.get(); }
     RenderObject* previousInFlowSibling() const;
     RenderObject* nextInFlowSibling() const;
 
@@ -209,65 +321,66 @@ public:
 
     inline bool isAtomicInlineLevelBox() const;
 
-    virtual bool isCounter() const { return false; }
-    virtual bool isQuote() const { return false; }
+    bool isCounter() const { return type() == Type::Counter; }
+    bool isQuote() const { return type() == Type::Quote; }
 
-    virtual bool isDetailsMarker() const { return false; }
-    virtual bool isEmbeddedObject() const { return false; }
+    bool isDetailsMarker() const { return type() == Type::DetailsMarker; }
+    bool isEmbeddedObject() const { return type() == Type::EmbeddedObject; }
     bool isFieldset() const;
-    virtual bool isFileUploadControl() const { return false; }
-    virtual bool isFrame() const { return false; }
-    virtual bool isFrameSet() const { return false; }
+    bool isFileUploadControl() const { return type() == Type::FileUploadControl; }
+    bool isFrame() const { return type() == Type::Frame; }
+    bool isFrameSet() const { return type() == Type::FrameSet; }
     virtual bool isImage() const { return false; }
     virtual bool isInlineBlockOrInlineTable() const { return false; }
-    virtual bool isListBox() const { return false; }
-    virtual bool isListItem() const { return false; }
-    virtual bool isListMarker() const { return false; }
+    bool isListBox() const { return type() == Type::ListBox; }
+    bool isListItem() const { return type() == Type::ListItem; }
+    bool isListMarker() const { return type() == Type::ListMarker; }
     virtual bool isMedia() const { return false; }
-    virtual bool isMenuList() const { return false; }
-    virtual bool isMeter() const { return false; }
-    virtual bool isProgress() const { return false; }
-    virtual bool isRenderButton() const { return false; }
-    virtual bool isRenderIFrame() const { return false; }
+    bool isMenuList() const { return type() == Type::MenuList; }
+    bool isMeter() const { return type() == Type::Meter; }
+    bool isProgress() const { return type() == Type::Progress; }
+    bool isRenderButton() const { return type() == Type::Button; }
+    bool isRenderIFrame() const { return type() == Type::IFrame; }
     virtual bool isRenderImage() const { return false; }
+    bool isTextFragment() const { return type() == Type::TextFragment; }
 #if ENABLE(MODEL_ELEMENT)
-    virtual bool isRenderModel() const { return false; }
+    bool isRenderModel() const { return type() == Type::Model; }
 #endif
     virtual bool isRenderFragmentContainer() const { return false; }
-    virtual bool isReplica() const { return false; }
+    bool isReplica() const { return type() == Type::Replica; }
 
-    virtual bool isRubyInline() const { return false; }
-    virtual bool isRubyBlock() const { return false; }
-    virtual bool isRubyBase() const { return false; }
-    virtual bool isRubyRun() const { return false; }
-    virtual bool isRubyText() const { return false; }
+    bool isRubyInline() const { return type() == Type::RubyAsInline; }
+    bool isRubyBlock() const { return type() == Type::RubyAsBlock; }
+    bool isRubyBase() const { return type() == Type::RubyBase; }
+    bool isRubyRun() const { return type() == Type::RubyRun; }
+    bool isRubyText() const { return type() == Type::RubyText; }
 
-    virtual bool isSlider() const { return false; }
+    bool isSlider() const { return type() == Type::Slider; }
     virtual bool isTable() const { return false; }
-    virtual bool isTableCell() const { return false; }
-    virtual bool isRenderTableCol() const { return false; }
-    virtual bool isTableCaption() const { return false; }
-    virtual bool isTableSection() const { return false; }
+    bool isTableCell() const { return type() == Type::TableCell; }
+    bool isRenderTableCol() const { return type() == Type::TableCol; }
+    bool isTableCaption() const { return type() == Type::TableCaption; }
+    bool isTableSection() const { return type() == Type::TableSection; }
     virtual bool isTextControl() const { return false; }
-    virtual bool isTextArea() const { return false; }
+    bool isTextArea() const { return type() == Type::TextControlMultiLine; }
     virtual bool isTextField() const { return false; }
-    virtual bool isSearchField() const { return false; }
-    virtual bool isTextControlInnerBlock() const { return false; }
-    virtual bool isVideo() const { return false; }
+    bool isSearchField() const { return type() == Type::SearchField; }
+    bool isTextControlInnerBlock() const { return type() == Type::TextControlInnerBlock; }
+    bool isVideo() const { return type() == Type::Video; }
     virtual bool isWidget() const { return false; }
-    virtual bool isCanvas() const { return false; }
+    bool isCanvas() const { return type() == Type::HTMLCanvas; }
 #if ENABLE(ATTACHMENT_ELEMENT)
-    virtual bool isAttachment() const { return false; }
+    bool isAttachment() const { return type() == Type::Attachment; }
 #endif
-    virtual bool isRenderGrid() const { return false; }
+    bool isRenderGrid() const { return type() == Type::Grid; }
 
     virtual bool isMultiColumnBlockFlow() const { return false; }
-    virtual bool isRenderMultiColumnSet() const { return false; }
-    virtual bool isRenderMultiColumnFlow() const { return false; }
-    virtual bool isRenderMultiColumnSpannerPlaceholder() const { return false; }
+    bool isRenderMultiColumnSet() const { return type() == Type::MultiColumnSet; }
+    bool isRenderMultiColumnFlow() const { return type() == Type::MultiColumnFlow; }
+    bool isRenderMultiColumnSpannerPlaceholder() const { return type() == Type::MultiColumnSpannerPlaceholder; }
 
-    virtual bool isRenderScrollbarPart() const { return false; }
-    virtual bool isRenderVTTCue() const { return false; }
+    bool isRenderScrollbarPart() const { return type() == Type::ScrollbarPart; }
+    bool isRenderVTTCue() const { return type() == Type::VTTCue; }
 
     bool isDocumentElementRenderer() const { return document().documentElement() == m_node.ptr(); }
     bool isBody() const { return node() && node()->hasTagName(HTMLNames::bodyTag); }
@@ -305,54 +418,54 @@ public:
 
 #if ENABLE(MATHML)
     virtual bool isRenderMathMLBlock() const { return false; }
-    virtual bool isRenderMathMLTable() const { return false; }
+    virtual bool isRenderMathMLTable() const { return type() == Type::MathMLTable; }
     virtual bool isRenderMathMLOperator() const { return false; }
-    virtual bool isRenderMathMLRow() const { return false; }
-    virtual bool isRenderMathMLMath() const { return false; }
-    virtual bool isRenderMathMLMenclose() const { return false; }
-    virtual bool isRenderMathMLFenced() const { return false; }
-    virtual bool isRenderMathMLFencedOperator() const { return false; }
-    virtual bool isRenderMathMLFraction() const { return false; }
-    virtual bool isRenderMathMLPadded() const { return false; }
-    virtual bool isRenderMathMLRoot() const { return false; }
-    virtual bool isRenderMathMLSpace() const { return false; }
+    bool isRenderMathMLRow() const;
+    bool isRenderMathMLMath() const { return type() == Type::MathMLMath; }
+    bool isRenderMathMLMenclose() const { return type() == Type::MathMLMenclose; }
+    bool isRenderMathMLFenced() const { return type() == Type::MathMLFenced; }
+    bool isRenderMathMLFencedOperator() const { return type() == Type::MathMLFencedOperator; }
+    bool isRenderMathMLFraction() const { return type() == Type::MathMLFraction; }
+    bool isRenderMathMLPadded() const { return type() == Type::MathMLPadded; }
+    bool isRenderMathMLRoot() const { return type() == Type::MathMLRoot; }
+    bool isRenderMathMLSpace() const { return type() == Type::MathMLSpace; }
     virtual bool isRenderMathMLSquareRoot() const { return false; }
     virtual bool isRenderMathMLScripts() const { return false; }
     virtual bool isRenderMathMLToken() const { return false; }
-    virtual bool isRenderMathMLUnderOver() const { return false; }
+    bool isRenderMathMLUnderOver() const { return type() == Type::MathMLUnderOver; }
 #endif // ENABLE(MATHML)
 
     virtual bool isLegacyRenderSVGModelObject() const { return false; }
     virtual bool isRenderSVGModelObject() const { return false; }
-    virtual bool isRenderSVGBlock() const { return false; };
-    virtual bool isLegacySVGRoot() const { return false; }
-    virtual bool isSVGRoot() const { return false; }
+    virtual bool isRenderSVGBlock() const { return false; }
+    bool isLegacySVGRoot() const { return type() == Type::LegacySVGRoot; }
+    bool isSVGRoot() const { return type() == Type::SVGRoot; }
     virtual bool isSVGContainer() const { return false; }
     virtual bool isLegacySVGContainer() const { return false; }
-    virtual bool isSVGTransformableContainer() const { return false; }
-    virtual bool isLegacySVGTransformableContainer() const { return false; }
-    virtual bool isSVGViewportContainer() const { return false; }
-    virtual bool isLegacySVGViewportContainer() const { return false; }
-    virtual bool isSVGGradientStop() const { return false; }
+    bool isSVGTransformableContainer() const { return type() == Type::SVGTransformableContainer; }
+    bool isLegacySVGTransformableContainer() const { return type() == Type::LegacySVGTransformableContainer; }
+    bool isSVGViewportContainer() const { return type() == Type::SVGViewportContainer; }
+    bool isLegacySVGViewportContainer() const { return type() == Type::LegacySVGViewportContainer; }
+    bool isSVGGradientStop() const { return type() == Type::SVGGradientStop; }
     virtual bool isLegacySVGHiddenContainer() const { return false; }
-    virtual bool isSVGHiddenContainer() const { return false; }
-    virtual bool isLegacySVGPath() const { return false; }
-    virtual bool isSVGPath() const { return false; }
+    bool isSVGHiddenContainer() const { return type() == Type::SVGHiddenContainer; }
+    bool isLegacySVGPath() const { return type() == Type::LegacySVGPath; }
+    bool isSVGPath() const { return type() == Type::SVGPath; }
     virtual bool isSVGShape() const { return false; }
     virtual bool isLegacySVGShape() const { return false; }
-    virtual bool isSVGText() const { return false; }
-    virtual bool isSVGTextPath() const { return false; }
-    virtual bool isSVGTSpan() const { return false; }
-    virtual bool isSVGInline() const { return false; }
-    virtual bool isSVGInlineText() const { return false; }
-    virtual bool isLegacySVGImage() const { return false; }
-    virtual bool isSVGImage() const { return false; }
-    virtual bool isLegacySVGForeignObject() const { return false; }
-    virtual bool isSVGForeignObject() const { return false; }
+    bool isSVGText() const { return type() == Type::SVGText; }
+    bool isSVGTextPath() const { return type() == Type::SVGTextPath; }
+    bool isSVGTSpan() const { return type() == Type::SVGTSpan; }
+    bool isSVGInline() const { return type() == Type::SVGInline || type() == Type::SVGTSpan || type() == Type::SVGTextPath; }
+    bool isSVGInlineText() const { return type() == Type::SVGInlineText; }
+    bool isLegacySVGImage() const { return type() == Type::LegacySVGImage; }
+    bool isSVGImage() const { return type() == Type::SVGImage; }
+    bool isLegacySVGForeignObject() const { return type() == Type::LegacySVGForeignObject; }
+    bool isSVGForeignObject() const { return type() == Type::SVGForeignObject; }
     virtual bool isSVGResourceContainer() const { return false; }
-    virtual bool isSVGResourceFilter() const { return false; }
-    virtual bool isSVGResourceClipper() const { return false; }
-    virtual bool isSVGResourceFilterPrimitive() const { return false; }
+    bool isSVGResourceFilter() const { return type() == Type::SVGResourceFilter; }
+    bool isSVGResourceClipper() const { return type() == Type::LegacySVGResourceClipper; }
+    bool isSVGResourceFilterPrimitive() const { return type() == Type::SVGResourceFilterPrimitive; }
     bool isSVGRootOrLegacySVGRoot() const { return isSVGRoot() || isLegacySVGRoot(); }
     bool isSVGShapeOrLegacySVGShape() const { return isSVGShape() || isLegacySVGShape(); }
     bool isSVGPathOrLegacySVGPath() const { return isSVGPath() || isLegacySVGPath(); }
@@ -423,14 +536,14 @@ public:
     bool isStickilyPositioned() const { return m_bitfields.isStickilyPositioned(); }
     bool shouldUsePositionedClipping() const { return isAbsolutelyPositioned() || isSVGForeignObject(); }
 
-    bool isText() const  { return !m_bitfields.isBox() && m_bitfields.isTextOrRenderView(); }
-    bool isLineBreak() const { return m_bitfields.isLineBreak(); }
+    bool isText() const { return m_bitfields.isText(); }
+    bool isLineBreak() const { return type() == Type::LineBreak; }
     bool isBR() const { return isLineBreak() && !isWBR(); }
     bool isLineBreakOpportunity() const { return isLineBreak() && isWBR(); }
     bool isTextOrLineBreak() const { return isText() || isLineBreak(); }
     bool isBox() const { return m_bitfields.isBox(); }
-    bool isTableRow() const { return m_bitfields.isTableRow(); }
-    bool isRenderView() const  { return m_bitfields.isBox() && m_bitfields.isTextOrRenderView(); }
+    bool isTableRow() const { return type() == Type::TableRow; }
+    bool isRenderView() const  { return type() == Type::View; }
     bool isInline() const { return m_bitfields.isInline(); } // inline object
     bool isReplacedOrInlineBlock() const { return m_bitfields.isReplacedOrInlineBlock(); }
     bool isHorizontalWritingMode() const { return m_bitfields.horizontalWritingMode(); }
@@ -537,11 +650,8 @@ public:
     void invalidateBackgroundObscurationStatus();
     virtual bool computeBackgroundIsKnownToBeObscured(const LayoutPoint&) { return false; }
 
-    void setIsText() { ASSERT(!isBox()); m_bitfields.setIsTextOrRenderView(true); }
-    void setIsLineBreak() { m_bitfields.setIsLineBreak(true); }
+    void setIsText() { ASSERT(!isBox()); m_bitfields.setIsText(true); }
     void setIsBox() { m_bitfields.setIsBox(true); }
-    void setIsTableRow() { m_bitfields.setIsTableRow(true); }
-    void setIsRenderView() { ASSERT(isBox()); m_bitfields.setIsTextOrRenderView(true); }
     void setReplacedOrInlineBlock(bool b = true) { m_bitfields.setIsReplacedOrInlineBlock(b); }
     void setHorizontalWritingMode(bool b = true) { m_bitfields.setHorizontalWritingMode(b); }
     void setHasNonVisibleOverflow(bool b = true) { m_bitfields.setHasNonVisibleOverflow(b); }
@@ -755,7 +865,7 @@ public:
     virtual bool isFlexibleBox() const { return false; }
     bool isFlexibleBoxIncludingDeprecated() const { return isFlexibleBox() || isDeprecatedFlexibleBox(); }
 
-    virtual bool isCombineText() const { return false; }
+    bool isCombineText() const { return type() == Type::CombineText; }
 
     virtual int caretMinOffset() const;
     virtual int caretMaxOffset() const;
@@ -903,12 +1013,10 @@ private:
             , m_preferredLogicalWidthsDirty(false)
             , m_floating(false)
             , m_isAnonymous(node.isDocumentNode())
-            , m_isTextOrRenderView(false)
+            , m_isText(false)
             , m_isBox(false)
-            , m_isTableRow(false)
             , m_isInline(true)
             , m_isReplacedOrInlineBlock(false)
-            , m_isLineBreak(false)
             , m_horizontalWritingMode(true)
             , m_hasLayer(false)
             , m_hasNonVisibleOverflow(false)
@@ -935,12 +1043,10 @@ private:
         ADD_BOOLEAN_BITFIELD(floating, Floating);
 
         ADD_BOOLEAN_BITFIELD(isAnonymous, IsAnonymous);
-        ADD_BOOLEAN_BITFIELD(isTextOrRenderView, IsTextOrRenderView);
+        ADD_BOOLEAN_BITFIELD(isText, IsText);
         ADD_BOOLEAN_BITFIELD(isBox, IsBox);
-        ADD_BOOLEAN_BITFIELD(isTableRow, IsTableRow);
         ADD_BOOLEAN_BITFIELD(isInline, IsInline);
         ADD_BOOLEAN_BITFIELD(isReplacedOrInlineBlock, IsReplacedOrInlineBlock);
-        ADD_BOOLEAN_BITFIELD(isLineBreak, IsLineBreak);
         ADD_BOOLEAN_BITFIELD(horizontalWritingMode, HorizontalWritingMode);
 
         ADD_BOOLEAN_BITFIELD(hasLayer, HasLayer);
@@ -953,6 +1059,8 @@ private:
         ADD_BOOLEAN_BITFIELD(childrenInline, ChildrenInline);
         
         ADD_BOOLEAN_BITFIELD(isExcludedFromNormalLayout, IsExcludedFromNormalLayout);
+
+        // 3 bits remaining.
 
     private:
         unsigned m_positionedState : 2; // PositionedState
@@ -989,7 +1097,8 @@ private:
 
     RenderElement* m_parent;
     RenderObject* m_previous;
-    RenderObject* m_next;
+    PackedPtr<RenderObject> m_next;
+    Type m_type;
 
     CheckedPtr<Layout::Box> m_layoutBox;
 
@@ -1253,6 +1362,24 @@ inline bool RenderObject::hasPotentiallyScrollableOverflow() const
     // with 'clip' or 'visible' in the other dimension (see Style::Adjuster::adjust).
     return hasNonVisibleOverflow() && style().overflowX() != Overflow::Clip && style().overflowX() != Overflow::Visible;
 }
+
+#if ENABLE(MATHML)
+inline bool RenderObject::isRenderMathMLRow() const
+{
+    switch (type()) {
+    case Type::MathMLFenced:
+    case Type::MathMLMath:
+    case Type::MathMLMenclose:
+    case Type::MathMLPadded:
+    case Type::MathMLRoot:
+    case Type::MathMLRow:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+#endif
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderObject&);
 

--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderProgress);
 
 RenderProgress::RenderProgress(HTMLElement& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::Progress, element, WTFMove(style))
     , m_position(HTMLProgressElement::InvalidPosition)
     , m_animationTimer(*this, &RenderProgress::animationTimerFired)
 {

--- a/Source/WebCore/rendering/RenderProgress.h
+++ b/Source/WebCore/rendering/RenderProgress.h
@@ -43,7 +43,6 @@ public:
 
 private:
     ASCIILiteral renderName() const override { return "RenderProgress"_s; }
-    bool isProgress() const override { return true; }
     LogicalExtentComputedValues computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const override;
 
     void animationTimerFired();

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -37,7 +37,7 @@ using namespace WTF::Unicode;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderQuote);
 
 RenderQuote::RenderQuote(Document& document, RenderStyle&& style, QuoteType quote)
-    : RenderInline(document, WTFMove(style))
+    : RenderInline(Type::Quote, document, WTFMove(style))
     , m_type(quote)
     , m_text(emptyString())
 {

--- a/Source/WebCore/rendering/RenderQuote.h
+++ b/Source/WebCore/rendering/RenderQuote.h
@@ -36,7 +36,6 @@ public:
 
 private:
     ASCIILiteral renderName() const override { return "RenderQuote"_s; }
-    bool isQuote() const override { return true; }
     bool isOpen() const;
     void styleDidChange(StyleDifference, const RenderStyle*) override;
     void insertedIntoTree(IsInternalMove) override;

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -65,22 +65,22 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderReplaced);
 const int cDefaultWidth = 300;
 const int cDefaultHeight = 150;
 
-RenderReplaced::RenderReplaced(Element& element, RenderStyle&& style)
-    : RenderBox(element, WTFMove(style), RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style)
+    : RenderBox(type, element, WTFMove(style), RenderReplacedFlag)
     , m_intrinsicSize(cDefaultWidth, cDefaultHeight)
 {
     setReplacedOrInlineBlock(true);
 }
 
-RenderReplaced::RenderReplaced(Element& element, RenderStyle&& style, const LayoutSize& intrinsicSize)
-    : RenderBox(element, WTFMove(style), RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Element& element, RenderStyle&& style, const LayoutSize& intrinsicSize)
+    : RenderBox(type, element, WTFMove(style), RenderReplacedFlag)
     , m_intrinsicSize(intrinsicSize)
 {
     setReplacedOrInlineBlock(true);
 }
 
-RenderReplaced::RenderReplaced(Document& document, RenderStyle&& style, const LayoutSize& intrinsicSize)
-    : RenderBox(document, WTFMove(style), RenderReplacedFlag)
+RenderReplaced::RenderReplaced(Type type, Document& document, RenderStyle&& style, const LayoutSize& intrinsicSize)
+    : RenderBox(type, document, WTFMove(style), RenderReplacedFlag)
     , m_intrinsicSize(intrinsicSize)
 {
     setReplacedOrInlineBlock(true);

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -50,9 +50,9 @@ public:
     void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const override;
 
 protected:
-    RenderReplaced(Element&, RenderStyle&&);
-    RenderReplaced(Element&, RenderStyle&&, const LayoutSize& intrinsicSize);
-    RenderReplaced(Document&, RenderStyle&&, const LayoutSize& intrinsicSize);
+    RenderReplaced(Type, Element&, RenderStyle&&);
+    RenderReplaced(Type, Element&, RenderStyle&&, const LayoutSize& intrinsicSize);
+    RenderReplaced(Type, Document&, RenderStyle&&, const LayoutSize& intrinsicSize);
 
     void layout() override;
 

--- a/Source/WebCore/rendering/RenderReplica.cpp
+++ b/Source/WebCore/rendering/RenderReplica.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderReplica);
 
 RenderReplica::RenderReplica(Document& document, RenderStyle&& style)
-    : RenderBox(document, WTFMove(style), 0)
+    : RenderBox(Type::Replica, document, WTFMove(style), 0)
 {
     // This is a hack. Replicas are synthetic, and don't pick up the attributes of the
     // renderers being replicated, so they always report that they are inline, non-replaced.

--- a/Source/WebCore/rendering/RenderReplica.h
+++ b/Source/WebCore/rendering/RenderReplica.h
@@ -47,7 +47,6 @@ public:
     void paint(PaintInfo&, const LayoutPoint&) override;
 
 private:
-    bool isReplica() const override { return true; }
     bool canHaveChildren() const override { return false; }
     void computePreferredLogicalWidths() override;
 };

--- a/Source/WebCore/rendering/RenderRuby.cpp
+++ b/Source/WebCore/rendering/RenderRuby.cpp
@@ -49,7 +49,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderRubyAsBlock);
 //=== ruby as inline object ===
 
 RenderRubyAsInline::RenderRubyAsInline(Element& element, RenderStyle&& style)
-    : RenderInline(element, WTFMove(style))
+    : RenderInline(Type::RubyAsInline, element, WTFMove(style))
 {
 }
 
@@ -64,7 +64,7 @@ void RenderRubyAsInline::styleDidChange(StyleDifference diff, const RenderStyle*
 //=== ruby as block object ===
 
 RenderRubyAsBlock::RenderRubyAsBlock(Element& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::RubyAsBlock, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderRuby.h
+++ b/Source/WebCore/rendering/RenderRuby.h
@@ -59,7 +59,6 @@ public:
 private:
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
-    bool isRubyInline() const final { return true; }
     ASCIILiteral renderName() const override { return "RenderRuby (inline)"_s; }
     bool createsAnonymousWrapper() const override { return true; }
 };
@@ -76,7 +75,6 @@ public:
 private:
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
-    bool isRubyBlock() const final { return true; }
     ASCIILiteral renderName() const override { return "RenderRuby (block)"_s; }
     bool createsAnonymousWrapper() const override { return true; }
 };

--- a/Source/WebCore/rendering/RenderRubyBase.cpp
+++ b/Source/WebCore/rendering/RenderRubyBase.cpp
@@ -44,7 +44,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderRubyBase);
 
 RenderRubyBase::RenderRubyBase(Document& document, RenderStyle&& style)
-    : RenderBlockFlow(document, WTFMove(style))
+    : RenderBlockFlow(Type::RubyBase, document, WTFMove(style))
     , m_initialOffset(0)
     , m_isAfterExpansion(true)
 {

--- a/Source/WebCore/rendering/RenderRubyBase.h
+++ b/Source/WebCore/rendering/RenderRubyBase.h
@@ -63,7 +63,6 @@ public:
     bool isEmptyOrHasInFlowContent() const;
 
 private:
-    bool isRubyBase() const override { return true; }
     bool isChildAllowed(const RenderObject&, const RenderStyle&) const override;
     std::optional<TextAlignMode> overrideTextAlignmentForLine(bool endsWithSoftBreak) const override;
     void adjustInlineDirectionLineBounds(int expansionOpportunityCount, float& logicalLeft, float& logicalWidth) const override;

--- a/Source/WebCore/rendering/RenderRubyRun.cpp
+++ b/Source/WebCore/rendering/RenderRubyRun.cpp
@@ -50,7 +50,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderRubyRun);
 
 RenderRubyRun::RenderRubyRun(Document& document, RenderStyle&& style)
-    : RenderBlockFlow(document, WTFMove(style))
+    : RenderBlockFlow(Type::RubyRun, document, WTFMove(style))
     , m_lastCharacter(0)
     , m_secondToLastCharacter(0)
 {

--- a/Source/WebCore/rendering/RenderRubyRun.h
+++ b/Source/WebCore/rendering/RenderRubyRun.h
@@ -77,7 +77,6 @@ public:
     RenderPtr<RenderRubyBase> createRubyBase() const;
 
 private:
-    bool isRubyRun() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderRubyRun (anonymous)"_s; }
     bool createsAnonymousWrapper() const override { return true; }
     bool canDropAnonymousBlockChild() const override { return false; }

--- a/Source/WebCore/rendering/RenderRubyText.cpp
+++ b/Source/WebCore/rendering/RenderRubyText.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderRubyText);
 
 RenderRubyText::RenderRubyText(Element& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::RubyText, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderRubyText.h
+++ b/Source/WebCore/rendering/RenderRubyText.h
@@ -51,7 +51,6 @@ public:
    
 private:
     ASCIILiteral renderName() const override { return "RenderRubyText"_s; }
-    bool isRubyText() const override { return true; }
 
     bool avoidsFloats() const override;
 

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderScrollbarPart);
 
 RenderScrollbarPart::RenderScrollbarPart(Document& document, RenderStyle&& style, RenderScrollbar* scrollbar, ScrollbarPart part)
-    : RenderBlock(document, WTFMove(style), 0)
+    : RenderBlock(Type::ScrollbarPart, document, WTFMove(style), 0)
     , m_scrollbar(scrollbar)
     , m_part(part)
 {

--- a/Source/WebCore/rendering/RenderScrollbarPart.h
+++ b/Source/WebCore/rendering/RenderScrollbarPart.h
@@ -59,8 +59,6 @@ private:
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
     void imageChanged(WrappedImagePtr, const IntRect* = nullptr) override;
 
-    bool isRenderScrollbarPart() const override { return true; }
-
     void layoutHorizontalPart();
     void layoutVerticalPart();
 

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -56,7 +56,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSearchField);
 
 RenderSearchField::RenderSearchField(HTMLInputElement& element, RenderStyle&& style)
-    : RenderTextControlSingleLine(element, WTFMove(style))
+    : RenderTextControlSingleLine(Type::SearchField, element, WTFMove(style))
     , m_searchPopupIsVisible(false)
     , m_searchPopup(nullptr)
 {

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -47,8 +47,6 @@ public:
     WEBCORE_EXPORT std::span<const RecentSearch> recentSearches();
 
 private:
-    bool isSearchField() const final { return true; }
-
     void willBeDestroyed() override;
     LayoutUnit computeControlLogicalHeight(LayoutUnit lineHeight, LayoutUnit nonContentHeight) const override;
     void updateFromElement() override;

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -51,7 +51,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSlider);
 const int RenderSlider::defaultTrackLength = 129;
 
 RenderSlider::RenderSlider(HTMLInputElement& element, RenderStyle&& style)
-    : RenderFlexibleBox(element, WTFMove(style))
+    : RenderFlexibleBox(Type::Slider, element, WTFMove(style))
 {
     // We assume RenderSlider works only with <input type=range>.
     ASSERT(element.isRangeControl());

--- a/Source/WebCore/rendering/RenderSlider.h
+++ b/Source/WebCore/rendering/RenderSlider.h
@@ -43,7 +43,6 @@ public:
 
 private:
     ASCIILiteral renderName() const override { return "RenderSlider"_s; }
-    bool isSlider() const override { return true; }
 
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const override;
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -67,8 +67,8 @@ using namespace HTMLNames;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTable);
 
-RenderTable::RenderTable(Element& element, RenderStyle&& style)
-    : RenderBlock(element, WTFMove(style), 0)
+RenderTable::RenderTable(Type type, Element& element, RenderStyle&& style)
+    : RenderBlock(type, element, WTFMove(style), 0)
     , m_columnPos(1, 0)
     , m_currentBorder(nullptr)
     , m_collapsedBordersValid(false)
@@ -86,8 +86,8 @@ RenderTable::RenderTable(Element& element, RenderStyle&& style)
     setChildrenInline(false);
 }
 
-RenderTable::RenderTable(Document& document, RenderStyle&& style)
-    : RenderBlock(document, WTFMove(style), 0)
+RenderTable::RenderTable(Type type, Document& document, RenderStyle&& style)
+    : RenderBlock(type, document, WTFMove(style), 0)
     , m_columnPos(1, 0)
     , m_currentBorder(nullptr)
     , m_collapsedBordersValid(false)
@@ -1635,7 +1635,7 @@ bool RenderTable::nodeAtPoint(const HitTestRequest& request, HitTestResult& resu
 
 RenderPtr<RenderTable> RenderTable::createTableWithStyle(Document& document, const RenderStyle& style)
 {
-    auto table = createRenderer<RenderTable>(document, RenderStyle::createAnonymousStyleWithDisplay(style, style.display() == DisplayType::Inline ? DisplayType::InlineTable : DisplayType::Table));
+    auto table = createRenderer<RenderTable>(Type::Table, document, RenderStyle::createAnonymousStyleWithDisplay(style, style.display() == DisplayType::Inline ? DisplayType::InlineTable : DisplayType::Table));
     table->initializeStyle();
     return table;
 }

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -45,8 +45,8 @@ enum class TableIntrinsics : uint8_t { ForLayout, ForKeyword };
 class RenderTable : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderTable);
 public:
-    RenderTable(Element&, RenderStyle&&);
-    RenderTable(Document&, RenderStyle&&);
+    RenderTable(Type, Element&, RenderStyle&&);
+    RenderTable(Type, Document&, RenderStyle&&);
     virtual ~RenderTable();
 
     // Per CSS 3 writing-mode: "The first and second values of the 'border-spacing' property represent spacing between columns

--- a/Source/WebCore/rendering/RenderTableCaption.cpp
+++ b/Source/WebCore/rendering/RenderTableCaption.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTableCaption);
 
 RenderTableCaption::RenderTableCaption(Element& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::TableCaption, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderTableCaption.h
+++ b/Source/WebCore/rendering/RenderTableCaption.h
@@ -34,8 +34,6 @@ public:
     Element& element() const { return downcast<Element>(nodeForNonAnonymous()); }
 
 private:
-    bool isTableCaption() const override { return true; }
-
     void insertedIntoTree(IsInternalMove) override;
     void willBeRemovedFromTree(IsInternalMove) override;
     LayoutUnit containingBlockLogicalWidthForContent() const final;

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -68,7 +68,7 @@ static_assert(sizeof(RenderTableCell) == sizeof(SameSizeAsRenderTableCell), "Ren
 static_assert(sizeof(CollapsedBorderValue) <= 24, "CollapsedBorderValue should stay small");
 
 RenderTableCell::RenderTableCell(Element& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::TableCell, element, WTFMove(style))
     , m_column(unsetColumnIndex)
     , m_cellWidthChanged(false)
     , m_hasColSpan(false)
@@ -84,7 +84,7 @@ RenderTableCell::RenderTableCell(Element& element, RenderStyle&& style)
 }
 
 RenderTableCell::RenderTableCell(Document& document, RenderStyle&& style)
-    : RenderBlockFlow(document, WTFMove(style))
+    : RenderBlockFlow(Type::TableCell, document, WTFMove(style))
     , m_column(unsetColumnIndex)
     , m_cellWidthChanged(false)
     , m_hasColSpan(false)

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -144,8 +144,6 @@ private:
 
     ASCIILiteral renderName() const override { return (isAnonymous() || isPseudoElement()) ? "RenderTableCell (anonymous)"_s : "RenderTableCell"_s; }
 
-    bool isTableCell() const override { return true; }
-
     void willBeRemovedFromTree(IsInternalMove) override;
 
     void updateLogicalWidth() override;

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -46,7 +46,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTableCol);
 
 RenderTableCol::RenderTableCol(Element& element, RenderStyle&& style)
-    : RenderBox(element, WTFMove(style), 0)
+    : RenderBox(Type::TableCol, element, WTFMove(style), 0)
 {
     // init RenderObject attributes
     setInline(true); // our object is not Inline
@@ -54,7 +54,7 @@ RenderTableCol::RenderTableCol(Element& element, RenderStyle&& style)
 }
 
 RenderTableCol::RenderTableCol(Document& document, RenderStyle&& style)
-    : RenderBox(document, WTFMove(style), 0)
+    : RenderBox(Type::TableCol, document, WTFMove(style), 0)
 {
     setInline(true);
 }

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -67,7 +67,6 @@ public:
 
 private:
     ASCIILiteral renderName() const override { return "RenderTableCol"_s; }
-    bool isRenderTableCol() const override { return true; }
     void computePreferredLogicalWidths() override { ASSERT_NOT_REACHED(); }
 
     void insertedIntoTree(IsInternalMove) override;

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -48,19 +48,17 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTableRow);
 
 RenderTableRow::RenderTableRow(Element& element, RenderStyle&& style)
-    : RenderBox(element, WTFMove(style), 0)
+    : RenderBox(Type::TableRow, element, WTFMove(style), 0)
     , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
-    setIsTableRow();
 }
 
 RenderTableRow::RenderTableRow(Document& document, RenderStyle&& style)
-    : RenderBox(document, WTFMove(style), 0)
+    : RenderBox(Type::TableRow, document, WTFMove(style), 0)
     , m_rowIndex(unsetRowIndex)
 {
     setInline(false);
-    setIsTableRow();
 }
 
 void RenderTableRow::willBeRemovedFromTree(IsInternalMove isInternalMove)

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -91,13 +91,13 @@ static inline void updateLogicalHeightForCell(RenderTableSection::RowStruct& row
 }
 
 RenderTableSection::RenderTableSection(Element& element, RenderStyle&& style)
-    : RenderBox(element, WTFMove(style), 0)
+    : RenderBox(Type::TableSection, element, WTFMove(style), 0)
 {
     setInline(false);
 }
 
 RenderTableSection::RenderTableSection(Document& document, RenderStyle&& style)
-    : RenderBox(document, WTFMove(style), 0)
+    : RenderBox(Type::TableSection, document, WTFMove(style), 0)
 {
     setInline(false);
 }

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -165,8 +165,6 @@ private:
 
     bool canHaveChildren() const override { return true; }
 
-    bool isTableSection() const override { return true; }
-
     void willBeRemovedFromTree(IsInternalMove) override;
 
     void layout() override;

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -245,8 +245,8 @@ static unsigned offsetForPositionInRun(const InlineIterator::TextBox& textBox, f
     return textBox.fontCascade().offsetForPosition(textBox.textRun(InlineIterator::TextRunMode::Editing), x - textBox.logicalLeftIgnoringInlineDirection(), true);
 }
 
-inline RenderText::RenderText(Node& node, const String& text)
-    : RenderObject(node)
+inline RenderText::RenderText(Type type, Node& node, const String& text)
+    : RenderObject(type, node)
     , m_containsOnlyASCII(text.impl()->containsOnlyASCII())
     , m_text(text)
 {
@@ -255,13 +255,13 @@ inline RenderText::RenderText(Node& node, const String& text)
     m_canUseSimpleFontCodePath = computeCanUseSimpleFontCodePath();
 }
 
-RenderText::RenderText(Text& textNode, const String& text)
-    : RenderText(static_cast<Node&>(textNode), text)
+RenderText::RenderText(Type type, Text& textNode, const String& text)
+    : RenderText(type, static_cast<Node&>(textNode), text)
 {
 }
 
-RenderText::RenderText(Document& document, const String& text)
-    : RenderText(static_cast<Node&>(document), text)
+RenderText::RenderText(Type type, Document& document, const String& text)
+    : RenderText(type, static_cast<Node&>(document), text)
 {
 }
 
@@ -279,11 +279,6 @@ ASCIILiteral RenderText::renderName() const
 Text* RenderText::textNode() const
 {
     return downcast<Text>(RenderObject::node());
-}
-
-bool RenderText::isTextFragment() const
-{
-    return false;
 }
 
 bool RenderText::computeUseBackslashAsYenSymbol() const

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -42,14 +42,12 @@ class LineLayout;
 class RenderText : public RenderObject {
     WTF_MAKE_ISO_ALLOCATED(RenderText);
 public:
-    RenderText(Text&, const String&);
-    RenderText(Document&, const String&);
+    RenderText(Type, Text&, const String&);
+    RenderText(Type, Document&, const String&);
 
     virtual ~RenderText();
 
     WEBCORE_EXPORT Text* textNode() const;
-
-    virtual bool isTextFragment() const;
 
     const RenderStyle& style() const;
     const RenderStyle& firstLineStyle() const;
@@ -199,7 +197,7 @@ protected:
     RenderTextLineBoxes m_lineBoxes;
 
 private:
-    RenderText(Node&, const String&);
+    RenderText(Type, Node&, const String&);
 
     ASCIILiteral renderName() const override;
 

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -43,8 +43,8 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControl);
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlInnerContainer);
 
-RenderTextControl::RenderTextControl(HTMLTextFormControlElement& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+RenderTextControl::RenderTextControl(Type type, HTMLTextFormControlElement& element, RenderStyle&& style)
+    : RenderBlockFlow(type, element, WTFMove(style))
 {
 }
 
@@ -226,7 +226,7 @@ int RenderTextControl::innerLineHeight() const
 #endif
 
 RenderTextControlInnerContainer::RenderTextControlInnerContainer(Element& element, RenderStyle&& style)
-    : RenderFlexibleBox(element, WTFMove(style))
+    : RenderFlexibleBox(Type::TextControlInnerContainer, element, WTFMove(style))
 {
 
 }

--- a/Source/WebCore/rendering/RenderTextControl.h
+++ b/Source/WebCore/rendering/RenderTextControl.h
@@ -44,7 +44,7 @@ public:
 #endif
 
 protected:
-    RenderTextControl(HTMLTextFormControlElement&, RenderStyle&&);
+    RenderTextControl(Type, HTMLTextFormControlElement&, RenderStyle&&);
 
     // This convenience function should not be made public because innerTextElement may outlive the render tree.
     RefPtr<TextControlInnerTextElement> innerTextElement() const;

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlMultiLine);
 
 RenderTextControlMultiLine::RenderTextControlMultiLine(HTMLTextAreaElement& element, RenderStyle&& style)
-    : RenderTextControl(element, WTFMove(style))
+    : RenderTextControl(Type::TextControlMultiLine, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.h
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.h
@@ -37,8 +37,6 @@ public:
 private:
     void element() const = delete;
 
-    bool isTextArea() const override { return true; }
-
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 
     float getAverageCharWidth() override;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -59,8 +59,8 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlSingleLine);
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextControlInnerBlock);
 
-RenderTextControlSingleLine::RenderTextControlSingleLine(HTMLInputElement& element, RenderStyle&& style)
-    : RenderTextControl(element, WTFMove(style))
+RenderTextControlSingleLine::RenderTextControlSingleLine(Type type, HTMLInputElement& element, RenderStyle&& style)
+    : RenderTextControl(type, element, WTFMove(style))
 {
 }
 
@@ -469,7 +469,7 @@ HTMLInputElement& RenderTextControlSingleLine::inputElement() const
 }
 
 RenderTextControlInnerBlock::RenderTextControlInnerBlock(Element& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::TextControlInnerBlock, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -30,7 +30,7 @@ namespace WebCore {
 class RenderTextControlSingleLine : public RenderTextControl {
     WTF_MAKE_ISO_ALLOCATED(RenderTextControlSingleLine);
 public:
-    RenderTextControlSingleLine(HTMLInputElement&, RenderStyle&&);
+    RenderTextControlSingleLine(Type, HTMLInputElement&, RenderStyle&&);
     virtual ~RenderTextControlSingleLine();
 
 protected:
@@ -90,7 +90,6 @@ public:
 
 private:
     bool hasLineIfEmpty() const override { return true; }
-    bool isTextControlInnerBlock() const override { return true; }
     bool canBeProgramaticallyScrolled() const override
     {
         auto* shadowHost = element()->shadowHost();

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderTextFragment);
 
 RenderTextFragment::RenderTextFragment(Text& textNode, const String& text, int startOffset, int length)
-    : RenderText(textNode, text.substring(startOffset, length))
+    : RenderText(Type::TextFragment, textNode, text.substring(startOffset, length))
     , m_start(startOffset)
     , m_end(length)
     , m_firstLetter(nullptr)
@@ -44,7 +44,7 @@ RenderTextFragment::RenderTextFragment(Text& textNode, const String& text, int s
 }
 
 RenderTextFragment::RenderTextFragment(Document& document, const String& text, int startOffset, int length)
-    : RenderText(document, text.substring(startOffset, length))
+    : RenderText(Type::TextFragment, document, text.substring(startOffset, length))
     , m_start(startOffset)
     , m_end(length)
     , m_firstLetter(nullptr)
@@ -52,7 +52,7 @@ RenderTextFragment::RenderTextFragment(Document& document, const String& text, i
 }
 
 RenderTextFragment::RenderTextFragment(Document& textNode, const String& text)
-    : RenderText(textNode, text)
+    : RenderText(Type::TextFragment, textNode, text)
     , m_start(0)
     , m_end(text.length())
     , m_contentString(text)

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -59,8 +59,6 @@ public:
 private:
     void setTextInternal(const String&, bool force) override;
 
-    bool isTextFragment() const override { return true; }
-
     UChar previousCharacter() const override;
 
     unsigned m_start;

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderVTTCue);
 
 RenderVTTCue::RenderVTTCue(VTTCueBox& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+    : RenderBlockFlow(Type::VTTCue, element, WTFMove(style))
     , m_cue(downcast<VTTCue>(element.getCue()))
 {
     ASSERT(m_cue);

--- a/Source/WebCore/rendering/RenderVTTCue.h
+++ b/Source/WebCore/rendering/RenderVTTCue.h
@@ -43,8 +43,6 @@ public:
     RenderVTTCue(VTTCueBox&, RenderStyle&&);
 
 private:
-    bool isRenderVTTCue() const final { return true; }
-
     void layout() override;
 
     bool isOutside() const;

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -52,7 +52,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderVideo);
 
 RenderVideo::RenderVideo(HTMLVideoElement& element, RenderStyle&& style)
-    : RenderMedia(element, WTFMove(style))
+    : RenderMedia(Type::Video, element, WTFMove(style))
 {
     setIntrinsicSize(calculateIntrinsicSize());
 }

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -71,7 +71,6 @@ private:
     ASCIILiteral renderName() const final { return "RenderVideo"_s; }
 
     bool requiresLayer() const final { return true; }
-    bool isVideo() const final { return true; }
 
     void paintReplaced(PaintInfo&, const LayoutPoint&) final;
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -76,15 +76,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderView);
 
 RenderView::RenderView(Document& document, RenderStyle&& style)
-    : RenderBlockFlow(document, WTFMove(style))
+    : RenderBlockFlow(Type::View, document, WTFMove(style))
     , m_frameView(*document.view())
     , m_initialContainingBlock(makeUniqueRef<Layout::InitialContainingBlock>(RenderStyle::clone(this->style())))
     , m_layoutState(makeUniqueRef<Layout::LayoutState>(document, *m_initialContainingBlock, Layout::LayoutState::FormattingContextIntegrationType::Inline))
     , m_selection(*this)
     , m_lazyRepaintTimer(*this, &RenderView::lazyRepaintTimerFired)
 {
-    setIsRenderView();
-
     // FIXME: We should find a way to enforce this at compile time.
     ASSERT(document.view());
 

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -94,8 +94,8 @@ static void moveWidgetToParentSoon(Widget& child, LocalFrameView* parent)
     WidgetHierarchyUpdatesSuspensionScope::scheduleWidgetToMove(child, parent);
 }
 
-RenderWidget::RenderWidget(HTMLFrameOwnerElement& element, RenderStyle&& style)
-    : RenderReplaced(element, WTFMove(style))
+RenderWidget::RenderWidget(Type type, HTMLFrameOwnerElement& element, RenderStyle&& style)
+    : RenderReplaced(type, element, WTFMove(style))
 {
     relaxAdoptionRequirement();
     setInline(false);

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -83,7 +83,7 @@ public:
     RemoteFrame* remoteFrame() const;
 
 protected:
-    RenderWidget(HTMLFrameOwnerElement&, RenderStyle&&);
+    RenderWidget(Type, HTMLFrameOwnerElement&, RenderStyle&&);
 
     void willBeDestroyed() override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -51,15 +51,15 @@ using namespace MathMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLBlock);
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLTable);
 
-RenderMathMLBlock::RenderMathMLBlock(MathMLPresentationElement& container, RenderStyle&& style)
-    : RenderBlock(container, WTFMove(style), 0)
+RenderMathMLBlock::RenderMathMLBlock(Type type, MathMLPresentationElement& container, RenderStyle&& style)
+    : RenderBlock(type, container, WTFMove(style), 0)
     , m_mathMLStyle(MathMLStyle::create())
 {
     setChildrenInline(false); // All of our children must be block-level.
 }
 
-RenderMathMLBlock::RenderMathMLBlock(Document& document, RenderStyle&& style)
-    : RenderBlock(document, WTFMove(style), 0)
+RenderMathMLBlock::RenderMathMLBlock(Type type, Document& document, RenderStyle&& style)
+    : RenderBlock(type, document, WTFMove(style), 0)
     , m_mathMLStyle(MathMLStyle::create())
 {
     setChildrenInline(false); // All of our children must be block-level.

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
@@ -41,8 +41,8 @@ class MathMLPresentationElement;
 class RenderMathMLBlock : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLBlock);
 public:
-    RenderMathMLBlock(MathMLPresentationElement&, RenderStyle&&);
-    RenderMathMLBlock(Document&, RenderStyle&&);
+    RenderMathMLBlock(Type, MathMLPresentationElement&, RenderStyle&&);
+    RenderMathMLBlock(Type, Document&, RenderStyle&&);
     virtual ~RenderMathMLBlock();
 
     MathMLStyle& mathMLStyle() const { return m_mathMLStyle; }
@@ -96,7 +96,6 @@ public:
     MathMLStyle& mathMLStyle() const { return m_mathMLStyle; }
 
 private:
-    bool isRenderMathMLTable() const final { return true; }
     ASCIILiteral renderName() const final { return "RenderMathMLTable"_s; }
     std::optional<LayoutUnit> firstLineBaseline() const final;
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 inline RenderMathMLTable::RenderMathMLTable(MathMLElement& element, RenderStyle&& style)
-    : RenderTable(element, WTFMove(style))
+    : RenderTable(Type::MathMLTable, element, WTFMove(style))
     , m_mathMLStyle(MathMLStyle::create())
 {
 }

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
@@ -51,7 +51,7 @@ static constexpr auto gOpeningBraceChar = "("_s;
 static constexpr auto gClosingBraceChar = ")"_s;
 
 RenderMathMLFenced::RenderMathMLFenced(MathMLRowElement& element, RenderStyle&& style)
-    : RenderMathMLRow(element, WTFMove(style))
+    : RenderMathMLRow(Type::MathMLFenced, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.h
@@ -49,7 +49,6 @@ public:
     void updateFromElement();
 
 private:
-    bool isRenderMathMLFenced() const final { return true; }
     ASCIILiteral renderName() const final { return "RenderMathMLFenced"_s; }
 
     String m_open;

--- a/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp
@@ -42,7 +42,7 @@ using namespace MathMLOperatorDictionary;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLFencedOperator);
 
 RenderMathMLFencedOperator::RenderMathMLFencedOperator(Document& document, RenderStyle&& style, const String& operatorString, MathMLOperatorDictionary::Form form, unsigned short flags)
-    : RenderMathMLOperator(document, WTFMove(style))
+    : RenderMathMLOperator(Type::MathMLFencedOperator, document, WTFMove(style))
     , m_operatorForm(form)
     , m_operatorFlags(flags)
 {

--- a/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.h
@@ -40,7 +40,6 @@ public:
     void updateOperatorContent(const String&);
 
 private:
-    bool isRenderMathMLFencedOperator() const final { return true; }
     bool isVertical() const final { return m_operatorChar.isVertical; }
     UChar32 textContent() const final { return m_operatorChar.character; }
     LayoutUnit leadingSpace() const final;

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLFraction);
 
 RenderMathMLFraction::RenderMathMLFraction(MathMLFractionElement& element, RenderStyle&& style)
-    : RenderMathMLBlock(element, WTFMove(style))
+    : RenderMathMLBlock(Type::MathMLFraction, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.h
@@ -46,7 +46,6 @@ public:
     float relativeLineThickness() const;
 
 private:
-    bool isRenderMathMLFraction() const final { return true; }
     ASCIILiteral renderName() const final { return "RenderMathMLFraction"_s; }
 
     void computePreferredLogicalWidths() final;

--- a/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
@@ -42,7 +42,7 @@ using namespace MathMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLMath);
 
 RenderMathMLMath::RenderMathMLMath(MathMLRowElement& element, RenderStyle&& style)
-    : RenderMathMLRow(element, WTFMove(style))
+    : RenderMathMLRow(Type::MathMLMath, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLMath.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMath.h
@@ -39,7 +39,6 @@ public:
     RenderMathMLMath(MathMLRowElement&, RenderStyle&&);
 
 private:
-    bool isRenderMathMLMath() const final { return true; }
     ASCIILiteral renderName() const final { return "RenderMathMLMath"_s; }
 
     void centerChildren(LayoutUnit contentWidth);

--- a/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
@@ -49,7 +49,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLMenclose);
 const unsigned short longDivLeftSpace = 10;
 
 RenderMathMLMenclose::RenderMathMLMenclose(MathMLMencloseElement& element, RenderStyle&& style)
-    : RenderMathMLRow(element, WTFMove(style))
+    : RenderMathMLRow(Type::MathMLMenclose, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -52,14 +52,14 @@ using namespace MathMLNames;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLOperator);
 
-RenderMathMLOperator::RenderMathMLOperator(MathMLOperatorElement& element, RenderStyle&& style)
-    : RenderMathMLToken(element, WTFMove(style))
+RenderMathMLOperator::RenderMathMLOperator(Type type, MathMLOperatorElement& element, RenderStyle&& style)
+    : RenderMathMLToken(type, element, WTFMove(style))
 {
     updateTokenContent();
 }
 
-RenderMathMLOperator::RenderMathMLOperator(Document& document, RenderStyle&& style)
-    : RenderMathMLToken(document, WTFMove(style))
+RenderMathMLOperator::RenderMathMLOperator(Type type, Document& document, RenderStyle&& style)
+    : RenderMathMLToken(type, document, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.h
@@ -38,8 +38,8 @@ class MathMLOperatorElement;
 class RenderMathMLOperator : public RenderMathMLToken {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLOperator);
 public:
-    RenderMathMLOperator(MathMLOperatorElement&, RenderStyle&&);
-    RenderMathMLOperator(Document&, RenderStyle&&);
+    RenderMathMLOperator(Type, MathMLOperatorElement&, RenderStyle&&);
+    RenderMathMLOperator(Type, Document&, RenderStyle&&);
     MathMLOperatorElement& element() const;
 
     void stretchTo(LayoutUnit heightAboveBaseline, LayoutUnit depthBelowBaseline);

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLPadded);
 
 RenderMathMLPadded::RenderMathMLPadded(MathMLPaddedElement& element, RenderStyle&& style)
-    : RenderMathMLRow(element, WTFMove(style))
+    : RenderMathMLRow(Type::MathMLPadded, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.h
@@ -39,7 +39,6 @@ public:
 
 private:
     ASCIILiteral renderName() const final { return "RenderMathMLPadded"_s; }
-    bool isRenderMathMLPadded() const final { return true; }
 
     void computePreferredLogicalWidths() final;
     void layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) final;

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -48,7 +48,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLRoot);
 
 RenderMathMLRoot::RenderMathMLRoot(MathMLRootElement& element, RenderStyle&& style)
-    : RenderMathMLRow(element, WTFMove(style))
+    : RenderMathMLRow(Type::MathMLRoot, element, WTFMove(style))
 {
     m_radicalOperator.setOperator(RenderMathMLRoot::style(), gRadicalCharacter, MathOperator::Type::VerticalOperator);
 }

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
@@ -48,7 +48,6 @@ private:
     bool isValid() const;
     RenderBox& getBase() const;
     RenderBox& getIndex() const;
-    bool isRenderMathMLRoot() const final { return true; }
     ASCIILiteral renderName() const final { return "RenderMathMLRoot"_s; }
     MathMLRootElement& element() const;
     RootType rootType() const;

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -44,8 +44,8 @@ using namespace MathMLNames;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLRow);
 
-RenderMathMLRow::RenderMathMLRow(MathMLRowElement& element, RenderStyle&& style)
-    : RenderMathMLBlock(element, WTFMove(style))
+RenderMathMLRow::RenderMathMLRow(Type type, MathMLRowElement& element, RenderStyle&& style)
+    : RenderMathMLBlock(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.h
@@ -37,7 +37,7 @@ class MathMLRowElement;
 class RenderMathMLRow : public RenderMathMLBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLRow);
 public:
-    RenderMathMLRow(MathMLRowElement&, RenderStyle&&);
+    RenderMathMLRow(Type, MathMLRowElement&, RenderStyle&&);
     MathMLRowElement& element() const;
 
 protected:
@@ -50,7 +50,6 @@ protected:
     void computePreferredLogicalWidths() override;
 
 private:
-    bool isRenderMathMLRow() const final { return true; }
     ASCIILiteral renderName() const override { return "RenderMathMLRow"_s; }
 };
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -45,8 +45,8 @@ static bool isPrescriptDelimiter(const RenderObject& renderObject)
     return renderObject.node() && renderObject.node()->hasTagName(MathMLNames::mprescriptsTag);
 }
 
-RenderMathMLScripts::RenderMathMLScripts(MathMLScriptsElement& element, RenderStyle&& style)
-    : RenderMathMLBlock(element, WTFMove(style))
+RenderMathMLScripts::RenderMathMLScripts(Type type, MathMLScriptsElement& element, RenderStyle&& style)
+    : RenderMathMLBlock(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.h
@@ -38,7 +38,7 @@ namespace WebCore {
 class RenderMathMLScripts : public RenderMathMLBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLScripts);
 public:
-    RenderMathMLScripts(MathMLScriptsElement&, RenderStyle&&);
+    RenderMathMLScripts(Type, MathMLScriptsElement&, RenderStyle&&);
     RenderMathMLOperator* unembellishedOperator() const final;
 
 protected:

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLSpace);
 
 RenderMathMLSpace::RenderMathMLSpace(MathMLSpaceElement& element, RenderStyle&& style)
-    : RenderMathMLBlock(element, WTFMove(style))
+    : RenderMathMLBlock(Type::MathMLSpace, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.h
@@ -40,7 +40,6 @@ public:
 
 private:
     ASCIILiteral renderName() const final { return "RenderMathMLSpace"_s; }
-    bool isRenderMathMLSpace() const final { return true; }
     bool isChildAllowed(const RenderObject&, const RenderStyle&) const final { return false; }
     void computePreferredLogicalWidths() final;
     void layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) final;

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -47,13 +47,13 @@ using namespace MathMLNames;
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLToken);
 
-RenderMathMLToken::RenderMathMLToken(MathMLTokenElement& element, RenderStyle&& style)
-    : RenderMathMLBlock(element, WTFMove(style))
+RenderMathMLToken::RenderMathMLToken(Type type, MathMLTokenElement& element, RenderStyle&& style)
+    : RenderMathMLBlock(type, element, WTFMove(style))
 {
 }
 
-RenderMathMLToken::RenderMathMLToken(Document& document, RenderStyle&& style)
-    : RenderMathMLBlock(document, WTFMove(style))
+RenderMathMLToken::RenderMathMLToken(Type type, Document& document, RenderStyle&& style)
+    : RenderMathMLBlock(type, document, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.h
@@ -38,8 +38,8 @@ class MathMLTokenElement;
 class RenderMathMLToken : public RenderMathMLBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLToken);
 public:
-    RenderMathMLToken(MathMLTokenElement&, RenderStyle&&);
-    RenderMathMLToken(Document&, RenderStyle&&);
+    RenderMathMLToken(Type, MathMLTokenElement&, RenderStyle&&);
+    RenderMathMLToken(Type, Document&, RenderStyle&&);
 
     MathMLTokenElement& element();
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderMathMLUnderOver);
 
 RenderMathMLUnderOver::RenderMathMLUnderOver(MathMLUnderOverElement& element, RenderStyle&& style)
-    : RenderMathMLScripts(element, WTFMove(style))
+    : RenderMathMLScripts(Type::MathMLUnderOver, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.h
@@ -41,7 +41,6 @@ public:
 
 private:
     bool isRenderMathMLScripts() const final { return false; }
-    bool isRenderMathMLUnderOver() const final { return true; }
     ASCIILiteral renderName() const final { return "RenderMathMLUnderOver"_s; }
     MathMLUnderOverElement& element() const;
 

--- a/Source/WebCore/rendering/style/ContentData.cpp
+++ b/Source/WebCore/rendering/style/ContentData.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<ContentData> ContentData::clone() const
 
 RenderPtr<RenderObject> ImageContentData::createContentRenderer(Document& document, const RenderStyle& pseudoStyle) const
 {
-    auto image = createRenderer<RenderImage>(document, RenderStyle::createStyleInheritingFromPseudoStyle(pseudoStyle), const_cast<StyleImage*>(m_image.ptr()));
+    auto image = createRenderer<RenderImage>(RenderObject::Type::Image, document, RenderStyle::createStyleInheritingFromPseudoStyle(pseudoStyle), const_cast<StyleImage*>(m_image.ptr()));
     image->initializeStyle();
     image->setAltText(altText());
     return image;

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -36,8 +36,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGBlock);
 
-RenderSVGBlock::RenderSVGBlock(SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderBlockFlow(element, WTFMove(style))
+RenderSVGBlock::RenderSVGBlock(Type type, SVGGraphicsElement& element, RenderStyle&& style)
+    : RenderBlockFlow(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.h
@@ -32,7 +32,7 @@ public:
     inline SVGGraphicsElement& graphicsElement() const;
 
 protected:
-    RenderSVGBlock(SVGGraphicsElement&, RenderStyle&&);
+    RenderSVGBlock(Type, SVGGraphicsElement&, RenderStyle&&);
     void willBeDestroyed() override;
 
     void computeOverflow(LayoutUnit oldClientAfterEdge, bool recomputeFloats = false) override;

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -47,13 +47,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGContainer);
 
-RenderSVGContainer::RenderSVGContainer(Document& document, RenderStyle&& style)
-    : RenderSVGModelObject(document, WTFMove(style))
+RenderSVGContainer::RenderSVGContainer(Type type, Document& document, RenderStyle&& style)
+    : RenderSVGModelObject(type, document, WTFMove(style))
 {
 }
 
-RenderSVGContainer::RenderSVGContainer(SVGElement& element, RenderStyle&& style)
-    : RenderSVGModelObject(element, WTFMove(style))
+RenderSVGContainer::RenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style)
+    : RenderSVGModelObject(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -48,8 +48,8 @@ public:
     FloatRect repaintRectInLocalCoordinates() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
 protected:
-    RenderSVGContainer(Document&, RenderStyle&&);
-    RenderSVGContainer(SVGElement&, RenderStyle&&);
+    RenderSVGContainer(Type, Document&, RenderStyle&&);
+    RenderSVGContainer(Type, SVGElement&, RenderStyle&&);
 
     ASCIILiteral renderName() const override { return "RenderSVGContainer"_s; }
     bool canHaveChildren() const final { return true; }

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGEllipse);
 
 RenderSVGEllipse::RenderSVGEllipse(SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderSVGShape(element, WTFMove(style))
+    : RenderSVGShape(Type::SVGEllipse, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -47,7 +47,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGForeignObject);
 
 RenderSVGForeignObject::RenderSVGForeignObject(SVGForeignObjectElement& element, RenderStyle&& style)
-    : RenderSVGBlock(element, WTFMove(style))
+    : RenderSVGBlock(Type::SVGForeignObject, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -49,7 +49,6 @@ public:
     FloatRect repaintRectInLocalCoordinates() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
 private:
-    bool isSVGForeignObject() const override { return true; }
     void graphicsElement() const = delete;
     ASCIILiteral renderName() const override { return "RenderSVGForeignObject"_s; }
 

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -38,7 +38,7 @@ using namespace SVGNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGGradientStop);
 
 RenderSVGGradientStop::RenderSVGGradientStop(SVGStopElement& element, RenderStyle&& style)
-    : RenderElement(element, WTFMove(style), 0)
+    : RenderElement(Type::SVGGradientStop, element, WTFMove(style), 0)
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.h
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.h
@@ -51,7 +51,6 @@ private:
     FloatRect repaintRectInLocalCoordinates() const override { return FloatRect(); }
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint&, HitTestAction) override { return false; }
 
-    bool isSVGGradientStop() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderSVGGradientStop"_s; }
 
     bool canHaveChildren() const override { return false; }

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGHiddenContainer);
 
 RenderSVGHiddenContainer::RenderSVGHiddenContainer(SVGElement& element, RenderStyle&& style)
-    : RenderSVGContainer(element, WTFMove(style))
+    : RenderSVGContainer(Type::SVGHiddenContainer, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
@@ -29,7 +29,7 @@ class SVGElement;
 
 // This class is for containers which are never drawn, but do need to support style
 // <defs>, <linearGradient>, <radialGradient> are all good examples
-class RenderSVGHiddenContainer : public RenderSVGContainer {
+class RenderSVGHiddenContainer final : public RenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGHiddenContainer);
 public:
     RenderSVGHiddenContainer(SVGElement&, RenderStyle&&);
@@ -38,7 +38,6 @@ protected:
     void layout() override;
 
 private:
-    bool isSVGHiddenContainer() const final { return true; }
     ASCIILiteral renderName() const override { return "RenderSVGHiddenContainer"_s; }
 
     void paint(PaintInfo&, const LayoutPoint&) final { }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -57,7 +57,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGImage);
 
 RenderSVGImage::RenderSVGImage(SVGImageElement& element, RenderStyle&& style)
-    : RenderSVGModelObject(element, WTFMove(style))
+    : RenderSVGModelObject(Type::SVGImage, element, WTFMove(style))
     , m_imageResource(makeUnique<RenderImageResource>())
 {
     imageResource().initialize(*this);

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -52,7 +52,6 @@ private:
     void element() const = delete;
 
     ASCIILiteral renderName() const final { return "RenderSVGImage"_s; }
-    bool isSVGImage() const final { return true; }
     bool canHaveChildren() const final { return false; }
 
     FloatRect calculateObjectBoundingBox() const;

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -37,8 +37,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGInline);
     
-RenderSVGInline::RenderSVGInline(SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderInline(element, WTFMove(style))
+RenderSVGInline::RenderSVGInline(Type type, SVGGraphicsElement& element, RenderStyle&& style)
+    : RenderInline(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -29,7 +29,7 @@ class SVGGraphicsElement;
 class RenderSVGInline : public RenderInline {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGInline);
 public:
-    RenderSVGInline(SVGGraphicsElement&, RenderStyle&&);
+    RenderSVGInline(Type, SVGGraphicsElement&, RenderStyle&&);
 
     inline SVGGraphicsElement& graphicsElement() const;
 
@@ -38,7 +38,6 @@ private:
 
     ASCIILiteral renderName() const override { return "RenderSVGInline"_s; }
     bool requiresLayer() const final { return false; }
-    bool isSVGInline() const final { return true; }
 
     void updateFromStyle() final;
 

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -72,7 +72,7 @@ static String applySVGWhitespaceRules(const String& string, bool preserveWhiteSp
 }
 
 RenderSVGInlineText::RenderSVGInlineText(Text& textNode, const String& string)
-    : RenderText(textNode, applySVGWhitespaceRules(string, false))
+    : RenderText(Type::SVGInlineText, textNode, applySVGWhitespaceRules(string, false))
     , m_scalingFactor(1)
     , m_layoutAttributes(*this)
 {

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -64,8 +64,6 @@ private:
 
     FloatRect objectBoundingBox() const override { return floatLinesBoundingBox(); }
 
-    bool isSVGInlineText() const override { return true; }
-
     VisiblePosition positionForPoint(const LayoutPoint&, const RenderFragmentContainer*) override;
     IntRect linesBoundingBox() const override;
     std::unique_ptr<LegacyInlineTextBox> createTextBox() override;

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -54,13 +54,13 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGModelObject);
 
-RenderSVGModelObject::RenderSVGModelObject(Document& document, RenderStyle&& style)
-    : RenderLayerModelObject(document, WTFMove(style), 0)
+RenderSVGModelObject::RenderSVGModelObject(Type type, Document& document, RenderStyle&& style)
+    : RenderLayerModelObject(type, document, WTFMove(style), 0)
 {
 }
 
-RenderSVGModelObject::RenderSVGModelObject(SVGElement& element, RenderStyle&& style)
-    : RenderLayerModelObject(element, WTFMove(style), 0)
+RenderSVGModelObject::RenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style)
+    : RenderLayerModelObject(type, element, WTFMove(style), 0)
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -81,8 +81,8 @@ public:
     LayoutRect overflowClipRectForChildLayers(const LayoutPoint& location, RenderFragmentContainer* fragment, OverlayScrollbarSizeRelevancy relevancy) { return overflowClipRect(location, fragment, relevancy); }
 
 protected:
-    RenderSVGModelObject(Document&, RenderStyle&&);
-    RenderSVGModelObject(SVGElement&, RenderStyle&&);
+    RenderSVGModelObject(Type, Document&, RenderStyle&&);
+    RenderSVGModelObject(Type, SVGElement&, RenderStyle&&);
 
     void willBeDestroyed() override;
     void updateFromStyle() override;

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGPath);
 
 RenderSVGPath::RenderSVGPath(SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderSVGShape(element, WTFMove(style))
+    : RenderSVGShape(Type::SVGPath, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -38,7 +38,6 @@ public:
     virtual ~RenderSVGPath();
 
 private:
-    bool isSVGPath() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderSVGPath"_s; }
 
     void updateShapeFromElement() override;

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGRect);
 
 RenderSVGRect::RenderSVGRect(SVGRectElement& element, RenderStyle&& style)
-    : RenderSVGShape(element, WTFMove(style))
+    : RenderSVGShape(Type::SVGRect, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(FilterData);
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceFilter);
 
 RenderSVGResourceFilter::RenderSVGResourceFilter(SVGFilterElement& element, RenderStyle&& style)
-    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(Type::SVGResourceFilter, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -83,7 +83,6 @@ private:
     void element() const = delete;
 
     ASCIILiteral renderName() const override { return "RenderSVGResourceFilter"_s; }
-    bool isSVGResourceFilter() const override { return true; }
 
     HashMap<RenderObject*, std::unique_ptr<FilterData>> m_rendererFilterDataMap;
 };

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp
@@ -44,7 +44,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceFilterPrimitive);
 
 RenderSVGResourceFilterPrimitive::RenderSVGResourceFilterPrimitive(SVGFilterPrimitiveStandardAttributes& filterPrimitiveElement, RenderStyle&& style)
-    : LegacyRenderSVGHiddenContainer(filterPrimitiveElement, WTFMove(style))
+    : LegacyRenderSVGHiddenContainer(Type::SVGResourceFilterPrimitive, filterPrimitiveElement, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h
@@ -47,7 +47,6 @@ public:
     void markFilterEffectForRebuild();
 
 private:
-    bool isSVGResourceFilterPrimitive() const override { return true; }
     void element() const = delete;
 };
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -36,8 +36,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceGradient);
 
-RenderSVGResourceGradient::RenderSVGResourceGradient(SVGGradientElement& node, RenderStyle&& style)
-    : LegacyRenderSVGResourceContainer(node, WTFMove(style))
+RenderSVGResourceGradient::RenderSVGResourceGradient(Type type, SVGGradientElement& node, RenderStyle&& style)
+    : LegacyRenderSVGResourceContainer(type, node, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -69,7 +69,7 @@ public:
     FloatRect resourceBoundingBox(const RenderObject&) final { return FloatRect(); }
 
 protected:
-    RenderSVGResourceGradient(SVGGradientElement&, RenderStyle&&);
+    RenderSVGResourceGradient(Type, SVGGradientElement&, RenderStyle&&);
 
     static GradientColorStops stopsByApplyingColorFilter(const GradientColorStops&, const RenderStyle&);
     static GradientSpreadMethod platformSpreadMethodFromSVGType(SVGSpreadMethodType);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp
@@ -29,7 +29,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceLinearGradient);
 
 RenderSVGResourceLinearGradient::RenderSVGResourceLinearGradient(SVGLinearGradientElement& element, RenderStyle&& style)
-    : RenderSVGResourceGradient(element, WTFMove(style))
+    : RenderSVGResourceGradient(Type::SVGResourceLinearGradient, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceMarker);
 
 RenderSVGResourceMarker::RenderSVGResourceMarker(SVGMarkerElement& element, RenderStyle&& style)
-    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(Type::SVGResourceMarker, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceMasker);
 
 RenderSVGResourceMasker::RenderSVGResourceMasker(SVGMaskElement& element, RenderStyle&& style)
-    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(Type::SVGResourceMasker, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourcePattern);
 
 RenderSVGResourcePattern::RenderSVGResourcePattern(SVGPatternElement& element, RenderStyle&& style)
-    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(Type::SVGResourcePattern, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGResourceRadialGradient);
 
 RenderSVGResourceRadialGradient::RenderSVGResourceRadialGradient(SVGRadialGradientElement& element, RenderStyle&& style)
-    : RenderSVGResourceGradient(element, WTFMove(style))
+    : RenderSVGResourceGradient(Type::SVGResourceRadialGradient, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -68,7 +68,7 @@ const int defaultWidth = 300;
 const int defaultHeight = 150;
 
 RenderSVGRoot::RenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
-    : RenderReplaced(element, WTFMove(style))
+    : RenderReplaced(Type::SVGRoot, element, WTFMove(style))
 {
     LayoutSize intrinsicSize(calculateIntrinsicSize());
     if (!intrinsicSize.width())

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -76,7 +76,6 @@ public:
 private:
     void element() const = delete;
 
-    bool isSVGRoot() const final { return true; }
     ASCIILiteral renderName() const final { return "RenderSVGRoot"_s; }
     bool requiresLayer() const final { return true; }
 

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -54,8 +54,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGShape);
 
-RenderSVGShape::RenderSVGShape(SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderSVGModelObject(element, WTFMove(style))
+RenderSVGShape::RenderSVGShape(Type type, SVGGraphicsElement& element, RenderStyle&& style)
+    : RenderSVGModelObject(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -51,7 +51,7 @@ public:
         GlobalCoordinateSpace,
         LocalCoordinateSpace
     };
-    RenderSVGShape(SVGGraphicsElement&, RenderStyle&&);
+    RenderSVGShape(Type, SVGGraphicsElement&, RenderStyle&&);
     virtual ~RenderSVGShape();
 
     inline SVGGraphicsElement& graphicsElement() const;

--- a/Source/WebCore/rendering/svg/RenderSVGTSpan.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTSpan.h
@@ -31,7 +31,7 @@ class RenderSVGTSpan final : public RenderSVGInline {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGTSpan);
 public:
     explicit RenderSVGTSpan(SVGTextPositioningElement& element, RenderStyle&& style)
-        : RenderSVGInline(element, WTFMove(style))
+        : RenderSVGInline(Type::SVGTSpan, element, WTFMove(style))
     {
     }
 
@@ -39,7 +39,6 @@ public:
 private:
     void graphicsElement() const = delete;
     ASCIILiteral renderName() const override { return "RenderSVGTSpan"_s; }
-    bool isSVGTSpan() const override { return true; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -60,7 +60,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGText);
 
 RenderSVGText::RenderSVGText(SVGTextElement& element, RenderStyle&& style)
-    : RenderSVGBlock(element, WTFMove(style))
+    : RenderSVGBlock(Type::SVGText, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -73,7 +73,6 @@ private:
     void graphicsElement() const = delete;
 
     ASCIILiteral renderName() const override { return "RenderSVGText"_s; }
-    bool isSVGText() const override { return true; }
 
     void paint(PaintInfo&, const LayoutPoint&) override;
 #if ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGTextPath);
 
 RenderSVGTextPath::RenderSVGTextPath(SVGTextPathElement& element, RenderStyle&& style)
-    : RenderSVGInline(element, WTFMove(style))
+    : RenderSVGInline(Type::SVGTextPath, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.h
@@ -42,7 +42,6 @@ public:
 private:
     void graphicsElement() const = delete;
 
-    bool isSVGTextPath() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderSVGTextPath"_s; }
 
     Path m_layoutPath;

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGTransformableContainer);
 
 RenderSVGTransformableContainer::RenderSVGTransformableContainer(SVGGraphicsElement& element, RenderStyle&& style)
-    : RenderSVGContainer(element, WTFMove(style))
+    : RenderSVGContainer(Type::SVGTransformableContainer, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
@@ -33,8 +33,6 @@ class RenderSVGTransformableContainer final : public RenderSVGContainer {
 public:
     RenderSVGTransformableContainer(SVGGraphicsElement&, RenderStyle&&);
 
-    bool isSVGTransformableContainer() const final { return true; }
-
 private:
     ASCIILiteral renderName() const final { return "RenderSVGTransformableContainer"_s; }
 

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -38,13 +38,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGViewportContainer);
 
 RenderSVGViewportContainer::RenderSVGViewportContainer(RenderSVGRoot& parent, RenderStyle&& style)
-    : RenderSVGContainer(parent.document(), WTFMove(style))
+    : RenderSVGContainer(Type::SVGViewportContainer, parent.document(), WTFMove(style))
     , m_owningSVGRoot(parent)
 {
 }
 
 RenderSVGViewportContainer::RenderSVGViewportContainer(SVGSVGElement& element, RenderStyle&& style)
-    : RenderSVGContainer(element, WTFMove(style))
+    : RenderSVGContainer(Type::SVGViewportContainer, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
@@ -44,7 +44,6 @@ public:
     void updateFromStyle() final;
 
 private:
-    bool isSVGViewportContainer() const final { return true; }
     ASCIILiteral renderName() const final { return "RenderSVGViewportContainer"_s; }
 
     void element() const = delete;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -42,8 +42,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGContainer);
 
-LegacyRenderSVGContainer::LegacyRenderSVGContainer(SVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGModelObject(element, WTFMove(style))
+LegacyRenderSVGContainer::LegacyRenderSVGContainer(Type type, SVGElement& element, RenderStyle&& style)
+    : LegacyRenderSVGModelObject(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -40,7 +40,7 @@ public:
     bool isObjectBoundingBoxValid() const { return m_objectBoundingBoxValid; }
 
 protected:
-    LegacyRenderSVGContainer(SVGElement&, RenderStyle&&);
+    LegacyRenderSVGContainer(Type, SVGElement&, RenderStyle&&);
 
     ASCIILiteral renderName() const override { return "RenderSVGContainer"_s; }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGEllipse);
 
 LegacyRenderSVGEllipse::LegacyRenderSVGEllipse(SVGGraphicsElement& element, RenderStyle&& style)
-    : LegacyRenderSVGShape(element, WTFMove(style))
+    : LegacyRenderSVGShape(Type::LegacySVGEllipse, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp
@@ -44,7 +44,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGForeignObject);
 
 LegacyRenderSVGForeignObject::LegacyRenderSVGForeignObject(SVGForeignObjectElement& element, RenderStyle&& style)
-    : RenderSVGBlock(element, WTFMove(style))
+    : RenderSVGBlock(Type::LegacySVGForeignObject, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
@@ -51,7 +51,6 @@ public:
     void setNeedsTransformUpdate() override { m_needsTransformUpdate = true; }
 
 private:
-    bool isLegacySVGForeignObject() const override { return true; }
     void graphicsElement() const = delete;
     ASCIILiteral renderName() const override { return "RenderSVGForeignObject"_s; }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.cpp
@@ -27,8 +27,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGHiddenContainer);
 
-LegacyRenderSVGHiddenContainer::LegacyRenderSVGHiddenContainer(SVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGContainer(element, WTFMove(style))
+LegacyRenderSVGHiddenContainer::LegacyRenderSVGHiddenContainer(Type type, SVGElement& element, RenderStyle&& style)
+    : LegacyRenderSVGContainer(type, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
@@ -30,7 +30,7 @@ class SVGElement;
 class LegacyRenderSVGHiddenContainer : public LegacyRenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGHiddenContainer);
 public:
-    LegacyRenderSVGHiddenContainer(SVGElement&, RenderStyle&&);
+    LegacyRenderSVGHiddenContainer(Type, SVGElement&, RenderStyle&&);
 
 protected:
     void layout() override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGImage);
 
 LegacyRenderSVGImage::LegacyRenderSVGImage(SVGImageElement& element, RenderStyle&& style)
-    : LegacyRenderSVGModelObject(element, WTFMove(style))
+    : LegacyRenderSVGModelObject(Type::LegacySVGImage, element, WTFMove(style))
     , m_needsBoundariesUpdate(true)
     , m_needsTransformUpdate(true)
     , m_imageResource(makeUnique<RenderImageResource>())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -57,7 +57,6 @@ private:
     void element() const = delete;
 
     ASCIILiteral renderName() const override { return "RenderSVGImage"_s; }
-    bool isLegacySVGImage() const override { return true; }
     bool canHaveChildren() const override { return false; }
 
     const AffineTransform& localToParentTransform() const override { return m_localTransform; }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -46,8 +46,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGModelObject);
 
-LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(SVGElement& element, RenderStyle&& style)
-    : RenderElement(element, WTFMove(style), 0)
+LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(Type type, SVGElement& element, RenderStyle&& style)
+    : RenderElement(type, element, WTFMove(style), 0)
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -63,7 +63,7 @@ public:
     SVGElement& element() const { return downcast<SVGElement>(nodeForNonAnonymous()); }
 
 protected:
-    LegacyRenderSVGModelObject(SVGElement&, RenderStyle&&);
+    LegacyRenderSVGModelObject(Type, SVGElement&, RenderStyle&&);
 
     void willBeDestroyed() override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGPath);
 
 LegacyRenderSVGPath::LegacyRenderSVGPath(SVGGraphicsElement& element, RenderStyle&& style)
-    : LegacyRenderSVGShape(element, WTFMove(style))
+    : LegacyRenderSVGShape(Type::LegacySVGPath, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
@@ -36,7 +36,6 @@ public:
     virtual ~LegacyRenderSVGPath();
 
 private:
-    bool isLegacySVGPath() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderSVGPath"_s; }
 
     void updateShapeFromElement() override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGRect);
 
 LegacyRenderSVGRect::LegacyRenderSVGRect(SVGRectElement& element, RenderStyle&& style)
-    : LegacyRenderSVGShape(element, WTFMove(style))
+    : LegacyRenderSVGShape(Type::LegacySVGRect, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -51,7 +51,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGResourceClipper);
 
 LegacyRenderSVGResourceClipper::LegacyRenderSVGResourceClipper(SVGClipPathElement& element, RenderStyle&& style)
-    : LegacyRenderSVGResourceContainer(element, WTFMove(style))
+    : LegacyRenderSVGResourceContainer(Type::LegacySVGResourceClipper, element, WTFMove(style))
 {
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -88,7 +88,6 @@ private:
     void element() const = delete;
 
     ASCIILiteral renderName() const override { return "RenderSVGResourceClipper"_s; }
-    bool isSVGResourceClipper() const override { return true; }
 
     ClipperData::Inputs computeInputs(const GraphicsContext&, const RenderElement&, const FloatRect& objectBoundingBox, const FloatRect& clippedContentBounds, float effectiveZoom);
     bool pathOnlyClipping(GraphicsContext&, const AffineTransform&, const FloatRect&, float effectiveZoom);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -35,8 +35,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGResourceContainer);
 
-LegacyRenderSVGResourceContainer::LegacyRenderSVGResourceContainer(SVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGHiddenContainer(element, WTFMove(style))
+LegacyRenderSVGResourceContainer::LegacyRenderSVGResourceContainer(Type type, SVGElement& element, RenderStyle&& style)
+    : LegacyRenderSVGHiddenContainer(type, element, WTFMove(style))
     , m_id(element.getIdAttribute())
 {
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -49,7 +49,7 @@ public:
     void markAllClientLayersForInvalidation();
 
 protected:
-    LegacyRenderSVGResourceContainer(SVGElement&, RenderStyle&&);
+    LegacyRenderSVGResourceContainer(Type, SVGElement&, RenderStyle&&);
 
     enum InvalidationMode {
         LayoutAndBoundariesInvalidation,

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -60,7 +60,7 @@ const int defaultWidth = 300;
 const int defaultHeight = 150;
 
 LegacyRenderSVGRoot::LegacyRenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
-    : RenderReplaced(element, WTFMove(style))
+    : RenderReplaced(Type::LegacySVGRoot, element, WTFMove(style))
     , m_isLayoutSizeChanged(false)
     , m_needsBoundariesOrTransformUpdate(true)
     , m_hasBoxDecorations(false)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -68,8 +68,6 @@ public:
 private:
     void element() const = delete;
 
-    bool isLegacySVGRoot() const override { return true; }
-
     // Intentially left 'RenderSVGRoot' instead of 'LegacyRenderSVGRoot', to avoid breaking layout tests.
     ASCIILiteral renderName() const override { return "RenderSVGRoot"_s; }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -53,8 +53,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGShape);
 
-LegacyRenderSVGShape::LegacyRenderSVGShape(SVGGraphicsElement& element, RenderStyle&& style)
-    : LegacyRenderSVGModelObject(element, WTFMove(style))
+LegacyRenderSVGShape::LegacyRenderSVGShape(Type type, SVGGraphicsElement& element, RenderStyle&& style)
+    : LegacyRenderSVGModelObject(type, element, WTFMove(style))
     , m_needsBoundariesUpdate(false) // Default is false, the cached rects are empty from the beginning.
     , m_needsShapeUpdate(true) // Default is true, so we grab a Path object once from SVGGraphicsElement.
     , m_needsTransformUpdate(true) // Default is true, so we grab a AffineTransform object once from SVGGraphicsElement.

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -46,7 +46,7 @@ public:
         GlobalCoordinateSpace,
         LocalCoordinateSpace
     };
-    LegacyRenderSVGShape(SVGGraphicsElement&, RenderStyle&&);
+    LegacyRenderSVGShape(Type, SVGGraphicsElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGShape();
 
     inline SVGGraphicsElement& graphicsElement() const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGTransformableContainer);
 
 LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer(SVGGraphicsElement& element, RenderStyle&& style)
-    : LegacyRenderSVGContainer(element, WTFMove(style))
+    : LegacyRenderSVGContainer(Type::LegacySVGTransformableContainer, element, WTFMove(style))
     , m_needsTransformUpdate(true)
     , m_didTransformToRootUpdate(false)
 {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
@@ -31,7 +31,6 @@ class LegacyRenderSVGTransformableContainer final : public LegacyRenderSVGContai
 public:
     LegacyRenderSVGTransformableContainer(SVGGraphicsElement&, RenderStyle&&);
 
-    bool isLegacySVGTransformableContainer() const override { return true; }
     const AffineTransform& localToParentTransform() const override { return m_localTransform; }
     void setNeedsTransformUpdate() override { m_needsTransformUpdate = true; }
     bool didTransformToRootUpdate() override { return m_didTransformToRootUpdate; }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGViewportContainer);
 
 LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer(SVGSVGElement& element, RenderStyle&& style)
-    : LegacyRenderSVGContainer(element, WTFMove(style))
+    : LegacyRenderSVGContainer(Type::LegacySVGViewportContainer, element, WTFMove(style))
     , m_didTransformToRootUpdate(false)
     , m_isLayoutSizeChanged(false)
     , m_needsTransformUpdate(true)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
@@ -48,7 +48,6 @@ public:
 private:
     void element() const = delete;
 
-    bool isLegacySVGViewportContainer() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderSVGViewportContainer"_s; }
 
     AffineTransform viewportTransform() const;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -185,9 +185,9 @@ void RenderTreeBuilder::FirstLetter::updateStyle(RenderBlock& firstLetterBlock, 
         // The first-letter renderer needs to be replaced. Create a new renderer of the right type.
         RenderPtr<RenderBoxModelObject> newFirstLetter;
         if (pseudoStyle->display() == DisplayType::Inline)
-            newFirstLetter = createRenderer<RenderInline>(firstLetterBlock.document(), WTFMove(*pseudoStyle));
+            newFirstLetter = createRenderer<RenderInline>(RenderObject::Type::Inline, firstLetterBlock.document(), WTFMove(*pseudoStyle));
         else
-            newFirstLetter = createRenderer<RenderBlockFlow>(firstLetterBlock.document(), WTFMove(*pseudoStyle));
+            newFirstLetter = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, firstLetterBlock.document(), WTFMove(*pseudoStyle));
         newFirstLetter->initializeStyle();
         newFirstLetter->setIsFirstLetter();
 
@@ -231,9 +231,9 @@ void RenderTreeBuilder::FirstLetter::createRenderers(RenderText& currentTextChil
 
     RenderPtr<RenderBoxModelObject> newFirstLetter;
     if (pseudoStyle->display() == DisplayType::Inline)
-        newFirstLetter = createRenderer<RenderInline>(currentTextChild.document(), WTFMove(*pseudoStyle));
+        newFirstLetter = createRenderer<RenderInline>(RenderObject::Type::Inline, currentTextChild.document(), WTFMove(*pseudoStyle));
     else
-        newFirstLetter = createRenderer<RenderBlockFlow>(currentTextChild.document(), WTFMove(*pseudoStyle));
+        newFirstLetter = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, currentTextChild.document(), WTFMove(*pseudoStyle));
     newFirstLetter->initializeStyle();
     newFirstLetter->setIsFirstLetter();
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -81,7 +81,7 @@ static RenderBoxModelObject* continuationBefore(RenderInline& parent, RenderObje
 
 static RenderPtr<RenderInline> cloneAsContinuation(RenderInline& renderer)
 {
-    RenderPtr<RenderInline> cloneInline = createRenderer<RenderInline>(*renderer.element(), RenderStyle::clone(renderer.style()));
+    RenderPtr<RenderInline> cloneInline = createRenderer<RenderInline>(RenderObject::Type::Inline, *renderer.element(), RenderStyle::clone(renderer.style()));
     cloneInline->initializeStyle();
     cloneInline->setFragmentedFlowState(renderer.fragmentedFlowState());
     cloneInline->setHasOutlineAutoAncestor(renderer.hasOutlineAutoAncestor());
@@ -178,7 +178,7 @@ void RenderTreeBuilder::Inline::attachIgnoringContinuation(RenderInline& parent,
         if (auto positionedAncestor = inFlowPositionedInlineAncestor(parent))
             newStyle.setPosition(positionedAncestor->style().position());
 
-        auto newBox = createRenderer<RenderBlockFlow>(parent.document(), WTFMove(newStyle));
+        auto newBox = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, parent.document(), WTFMove(newStyle));
         newBox->initializeStyle();
         newBox->setIsContinuation();
         RenderBoxModelObject* oldContinuation = parent.continuation();

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -100,7 +100,7 @@ static inline RenderBlock* rubyAfterBlock(const RenderElement* ruby)
 
 static auto createAnonymousRubyInlineBlock(RenderObject& ruby)
 {
-    auto newBlock = createRenderer<RenderBlockFlow>(ruby.document(), RenderStyle::createAnonymousStyleWithDisplay(ruby.style(), DisplayType::InlineBlock));
+    auto newBlock = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, ruby.document(), RenderStyle::createAnonymousStyleWithDisplay(ruby.style(), DisplayType::InlineBlock));
     newBlock->initializeStyle();
     return newBlock;
 }
@@ -369,7 +369,7 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
         return parent;
 
     if (parent.style().display() != DisplayType::Ruby) {
-        auto rubyContainer = createRenderer<RenderInline>(parent.document(), RenderStyle::createAnonymousStyleWithDisplay(parent.style(), DisplayType::Ruby));
+        auto rubyContainer = createRenderer<RenderInline>(RenderObject::Type::Inline, parent.document(), RenderStyle::createAnonymousStyleWithDisplay(parent.style(), DisplayType::Ruby));
         WeakPtr newParent = rubyContainer.get();
         m_builder.attach(parent, WTFMove(rubyContainer), beforeChild);
         beforeChild = nullptr;
@@ -388,7 +388,7 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
         return downcast<RenderElement>(*previous);
     }
 
-    auto rubyBase = createRenderer<RenderInline>(parent.document(), RenderStyle::createAnonymousStyleWithDisplay(parent.style(), DisplayType::RubyBase));
+    auto rubyBase = createRenderer<RenderInline>(RenderObject::Type::Inline, parent.document(), RenderStyle::createAnonymousStyleWithDisplay(parent.style(), DisplayType::RubyBase));
     WeakPtr newParent = rubyBase.get();
     m_builder.inlineBuilder().attach(downcast<RenderInline>(parent), WTFMove(rubyBase), beforeChild);
     beforeChild = nullptr;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -492,7 +492,7 @@ void RenderTreeUpdater::createTextRenderer(Text& textNode, const Style::TextUpda
     if (textUpdate && textUpdate->inheritedDisplayContentsStyle && *textUpdate->inheritedDisplayContentsStyle) {
         // Wrap text renderer into anonymous inline so we can give it a style.
         // This is to support "<div style='display:contents;color:green'>text</div>" type cases
-        auto newDisplayContentsAnonymousWrapper = WebCore::createRenderer<RenderInline>(textNode.document(), RenderStyle::clone(**textUpdate->inheritedDisplayContentsStyle));
+        auto newDisplayContentsAnonymousWrapper = WebCore::createRenderer<RenderInline>(RenderObject::Type::Inline, textNode.document(), RenderStyle::clone(**textUpdate->inheritedDisplayContentsStyle));
         newDisplayContentsAnonymousWrapper->initializeStyle();
         auto& displayContentsAnonymousWrapper = *newDisplayContentsAnonymousWrapper;
         m_builder.attach(renderTreePosition.parent(), WTFMove(newDisplayContentsAnonymousWrapper), renderTreePosition.nextSibling());

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -211,7 +211,7 @@ void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& 
     if (auto backdropRenderer = renderer.backdropRenderer())
         backdropRenderer->setStyle(WTFMove(newStyle));
     else {
-        auto newBackdropRenderer = WebCore::createRenderer<RenderBlockFlow>(renderer.document(), WTFMove(newStyle));
+        auto newBackdropRenderer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, renderer.document(), WTFMove(newStyle));
         newBackdropRenderer->initializeStyle();
         renderer.setBackdropRenderer(*newBackdropRenderer.get());
         m_updater.m_builder.attach(renderer.view(), WTFMove(newBackdropRenderer));

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -110,7 +110,7 @@ void SVGAElement::svgAttributeChanged(const QualifiedName& attrName)
 RenderPtr<RenderElement> SVGAElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
     if (is<SVGElement>(parentNode()) && downcast<SVGElement>(*parentNode()).isTextContent())
-        return createRenderer<RenderSVGInline>(*this, WTFMove(style));
+        return createRenderer<RenderSVGInline>(RenderObject::Type::SVGInline, *this, WTFMove(style));
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (document().settings().layerBasedSVGEngineEnabled())

--- a/Source/WebCore/svg/SVGDefsElement.cpp
+++ b/Source/WebCore/svg/SVGDefsElement.cpp
@@ -53,7 +53,7 @@ RenderPtr<RenderElement> SVGDefsElement::createElementRenderer(RenderStyle&& sty
     if (document().settings().layerBasedSVGEngineEnabled())
         return createRenderer<RenderSVGHiddenContainer>(*this, WTFMove(style));
 #endif
-    return createRenderer<LegacyRenderSVGHiddenContainer>(*this, WTFMove(style));
+    return createRenderer<LegacyRenderSVGHiddenContainer>(RenderObject::Type::LegacySVGHiddenContainer, *this, WTFMove(style));
 }
 
 }

--- a/Source/WebCore/svg/SVGGElement.cpp
+++ b/Source/WebCore/svg/SVGGElement.cpp
@@ -67,7 +67,7 @@ RenderPtr<RenderElement> SVGGElement::createElementRenderer(RenderStyle&& style,
     // subtree may be hidden - we only want the resource renderers to exist so they can be
     // referenced from somewhere else.
     if (style.display() == DisplayType::None)
-        return createRenderer<LegacyRenderSVGHiddenContainer>(*this, WTFMove(style));
+        return createRenderer<LegacyRenderSVGHiddenContainer>(RenderObject::Type::LegacySVGHiddenContainer, *this, WTFMove(style));
     return createRenderer<LegacyRenderSVGTransformableContainer>(*this, WTFMove(style));
 }
 

--- a/Source/WebCore/svg/SVGSymbolElement.cpp
+++ b/Source/WebCore/svg/SVGSymbolElement.cpp
@@ -61,7 +61,7 @@ RenderPtr<RenderElement> SVGSymbolElement::createElementRenderer(RenderStyle&& s
     if (document().settings().layerBasedSVGEngineEnabled())
         return createRenderer<RenderSVGHiddenContainer>(*this, WTFMove(style));
 #endif
-    return createRenderer<LegacyRenderSVGHiddenContainer>(*this, WTFMove(style));
+    return createRenderer<LegacyRenderSVGHiddenContainer>(RenderObject::Type::LegacySVGHiddenContainer, *this, WTFMove(style));
 }
 
 }

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -191,7 +191,7 @@ void SVGTRefElement::svgAttributeChanged(const QualifiedName& attrName)
 
 RenderPtr<RenderElement> SVGTRefElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    return createRenderer<RenderSVGInline>(*this, WTFMove(style));
+    return createRenderer<RenderSVGInline>(RenderObject::Type::SVGInline, *this, WTFMove(style));
 }
 
 bool SVGTRefElement::childShouldCreateRenderer(const Node& child) const


### PR DESCRIPTION
#### 7b1df14b9fdfa295ac951576f819b3d3156a1c4d
<pre>
Devirtualize many of the renderer type checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=262308">https://bugs.webkit.org/show_bug.cgi?id=262308</a>

Reviewed by Yusuke Suzuki and Ryosuke Niwa.

Add a m_type data member to RenderObject in order to devirtualize most
renderer type checks.

* Source/WebCore/dom/Text.cpp:
(WebCore::Text::createTextRenderer):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::createElementRenderer):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::createElementRenderer):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::createElementRenderer):
* Source/WebCore/html/HTMLPlugInImageElement.cpp:
(WebCore::HTMLPlugInImageElement::createElementRenderer):
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::createInputRenderer):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createInputRenderer):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::createElementRenderer):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
* Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp:
(WebCore::YouTubeEmbedShadowElement::createElementRenderer):
* Source/WebCore/mathml/MathMLAnnotationElement.cpp:
(WebCore::MathMLAnnotationElement::createElementRenderer):
* Source/WebCore/mathml/MathMLOperatorElement.cpp:
(WebCore::MathMLOperatorElement::createElementRenderer):
* Source/WebCore/mathml/MathMLRowElement.cpp:
(WebCore::MathMLRowElement::createElementRenderer):
* Source/WebCore/mathml/MathMLScriptsElement.cpp:
(WebCore::MathMLScriptsElement::createElementRenderer):
* Source/WebCore/mathml/MathMLSelectElement.cpp:
(WebCore::MathMLSelectElement::createElementRenderer):
* Source/WebCore/mathml/MathMLTokenElement.cpp:
(WebCore::MathMLTokenElement::createElementRenderer):
* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::RenderAttachment):
* Source/WebCore/rendering/RenderAttachment.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::RenderBlock):
(WebCore::RenderBlock::createAnonymousBlockWithStyleAndDisplay):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::RenderBlockFlow):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::RenderBox):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::RenderBoxModelObject):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderButton.cpp:
(WebCore::RenderButton::RenderButton):
* Source/WebCore/rendering/RenderButton.h:
* Source/WebCore/rendering/RenderCombineText.cpp:
(WebCore::RenderCombineText::RenderCombineText):
* Source/WebCore/rendering/RenderCombineText.h:
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::RenderCounter::RenderCounter):
(WebCore::RenderCounter::isCounter const): Deleted.
* Source/WebCore/rendering/RenderCounter.h:
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::RenderDeprecatedFlexibleBox):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h:
* Source/WebCore/rendering/RenderDetailsMarker.cpp:
(WebCore::RenderDetailsMarker::RenderDetailsMarker):
* Source/WebCore/rendering/RenderDetailsMarker.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::RenderElement):
(WebCore::RenderElement::createFor):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::RenderEmbeddedObject):
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::RenderFileUploadControl):
* Source/WebCore/rendering/RenderFileUploadControl.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::RenderFlexibleBox):
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(WebCore::RenderFragmentContainer::RenderFragmentContainer):
* Source/WebCore/rendering/RenderFragmentContainer.h:
* Source/WebCore/rendering/RenderFragmentContainerSet.cpp:
(WebCore::RenderFragmentContainerSet::RenderFragmentContainerSet):
* Source/WebCore/rendering/RenderFragmentContainerSet.h:
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::RenderFragmentedFlow):
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/RenderFrame.cpp:
(WebCore::RenderFrame::RenderFrame):
* Source/WebCore/rendering/RenderFrame.h:
* Source/WebCore/rendering/RenderFrameBase.cpp:
(WebCore::RenderFrameBase::RenderFrameBase):
* Source/WebCore/rendering/RenderFrameBase.h:
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::RenderFrameSet):
* Source/WebCore/rendering/RenderFrameSet.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::RenderGrid):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::RenderHTMLCanvas):
* Source/WebCore/rendering/RenderHTMLCanvas.h:
* Source/WebCore/rendering/RenderIFrame.cpp:
(WebCore::RenderIFrame::RenderIFrame):
* Source/WebCore/rendering/RenderIFrame.h:
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::RenderImage):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::RenderInline):
* Source/WebCore/rendering/RenderInline.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::RenderLayerModelObject):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::RenderLineBreak):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::RenderListBox):
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::RenderListItem):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::RenderListMarker):
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/RenderMedia.cpp:
(WebCore::RenderMedia::RenderMedia):
* Source/WebCore/rendering/RenderMedia.h:
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderMenuList::RenderMenuList):
(RenderMenuList::setText):
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderMeter.cpp:
(WebCore::RenderMeter::RenderMeter):
* Source/WebCore/rendering/RenderMeter.h:
* Source/WebCore/rendering/RenderModel.cpp:
(WebCore::RenderModel::RenderModel):
* Source/WebCore/rendering/RenderModel.h:
* Source/WebCore/rendering/RenderMultiColumnFlow.cpp:
(WebCore::RenderMultiColumnFlow::RenderMultiColumnFlow):
* Source/WebCore/rendering/RenderMultiColumnFlow.h:
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::RenderMultiColumnSet):
* Source/WebCore/rendering/RenderMultiColumnSet.h:
* Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp:
(WebCore::RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder):
* Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::RenderObject):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::type const):
(WebCore::RenderObject::nextSibling const):
(WebCore::RenderObject::isCounter const):
(WebCore::RenderObject::isQuote const):
(WebCore::RenderObject::isDetailsMarker const):
(WebCore::RenderObject::isEmbeddedObject const):
(WebCore::RenderObject::isFileUploadControl const):
(WebCore::RenderObject::isFrame const):
(WebCore::RenderObject::isFrameSet const):
(WebCore::RenderObject::isListBox const):
(WebCore::RenderObject::isListItem const):
(WebCore::RenderObject::isListMarker const):
(WebCore::RenderObject::isMenuList const):
(WebCore::RenderObject::isMeter const):
(WebCore::RenderObject::isProgress const):
(WebCore::RenderObject::isRenderButton const):
(WebCore::RenderObject::isRenderIFrame const):
(WebCore::RenderObject::isTextFragment const):
(WebCore::RenderObject::isRenderModel const):
(WebCore::RenderObject::isReplica const):
(WebCore::RenderObject::isRubyInline const):
(WebCore::RenderObject::isRubyBlock const):
(WebCore::RenderObject::isRubyBase const):
(WebCore::RenderObject::isRubyRun const):
(WebCore::RenderObject::isRubyText const):
(WebCore::RenderObject::isSlider const):
(WebCore::RenderObject::isTableCell const):
(WebCore::RenderObject::isRenderTableCol const):
(WebCore::RenderObject::isTableCaption const):
(WebCore::RenderObject::isTableSection const):
(WebCore::RenderObject::isTextArea const):
(WebCore::RenderObject::isSearchField const):
(WebCore::RenderObject::isTextControlInnerBlock const):
(WebCore::RenderObject::isVideo const):
(WebCore::RenderObject::isCanvas const):
(WebCore::RenderObject::isAttachment const):
(WebCore::RenderObject::isRenderGrid const):
(WebCore::RenderObject::isRenderMultiColumnSet const):
(WebCore::RenderObject::isRenderMultiColumnFlow const):
(WebCore::RenderObject::isRenderMultiColumnSpannerPlaceholder const):
(WebCore::RenderObject::isRenderScrollbarPart const):
(WebCore::RenderObject::isRenderVTTCue const):
(WebCore::RenderObject::isRenderMathMLTable const):
(WebCore::RenderObject::isRenderMathMLMath const):
(WebCore::RenderObject::isRenderMathMLMenclose const):
(WebCore::RenderObject::isRenderMathMLFenced const):
(WebCore::RenderObject::isRenderMathMLFencedOperator const):
(WebCore::RenderObject::isRenderMathMLFraction const):
(WebCore::RenderObject::isRenderMathMLPadded const):
(WebCore::RenderObject::isRenderMathMLRoot const):
(WebCore::RenderObject::isRenderMathMLSpace const):
(WebCore::RenderObject::isRenderMathMLUnderOver const):
(WebCore::RenderObject::isRenderSVGBlock const):
(WebCore::RenderObject::isLegacySVGRoot const):
(WebCore::RenderObject::isSVGRoot const):
(WebCore::RenderObject::isSVGTransformableContainer const):
(WebCore::RenderObject::isLegacySVGTransformableContainer const):
(WebCore::RenderObject::isSVGViewportContainer const):
(WebCore::RenderObject::isLegacySVGViewportContainer const):
(WebCore::RenderObject::isSVGGradientStop const):
(WebCore::RenderObject::isSVGHiddenContainer const):
(WebCore::RenderObject::isLegacySVGPath const):
(WebCore::RenderObject::isSVGPath const):
(WebCore::RenderObject::isSVGText const):
(WebCore::RenderObject::isSVGTextPath const):
(WebCore::RenderObject::isSVGTSpan const):
(WebCore::RenderObject::isSVGInline const):
(WebCore::RenderObject::isSVGInlineText const):
(WebCore::RenderObject::isLegacySVGImage const):
(WebCore::RenderObject::isSVGImage const):
(WebCore::RenderObject::isLegacySVGForeignObject const):
(WebCore::RenderObject::isSVGForeignObject const):
(WebCore::RenderObject::isSVGResourceFilter const):
(WebCore::RenderObject::isSVGResourceClipper const):
(WebCore::RenderObject::isSVGResourceFilterPrimitive const):
(WebCore::RenderObject::isText const):
(WebCore::RenderObject::isLineBreak const):
(WebCore::RenderObject::isTableRow const):
(WebCore::RenderObject::isRenderView const):
(WebCore::RenderObject::setIsText):
(WebCore::RenderObject::setIsBox):
(WebCore::RenderObject::isCombineText const):
(WebCore::RenderObject::RenderObjectBitfields::RenderObjectBitfields):
(WebCore::RenderObject::isRenderMathMLRow const):
(WebCore::RenderObject::setIsLineBreak): Deleted.
(WebCore::RenderObject::setIsTableRow): Deleted.
(WebCore::RenderObject::setIsRenderView): Deleted.
* Source/WebCore/rendering/RenderProgress.cpp:
(WebCore::RenderProgress::RenderProgress):
* Source/WebCore/rendering/RenderProgress.h:
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::RenderQuote::RenderQuote):
* Source/WebCore/rendering/RenderQuote.h:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::RenderReplaced):
* Source/WebCore/rendering/RenderReplaced.h:
* Source/WebCore/rendering/RenderReplica.cpp:
(WebCore::RenderReplica::RenderReplica):
* Source/WebCore/rendering/RenderReplica.h:
* Source/WebCore/rendering/RenderRuby.cpp:
(WebCore::RenderRubyAsInline::RenderRubyAsInline):
(WebCore::RenderRubyAsBlock::RenderRubyAsBlock):
* Source/WebCore/rendering/RenderRuby.h:
* Source/WebCore/rendering/RenderRubyBase.cpp:
(WebCore::RenderRubyBase::RenderRubyBase):
* Source/WebCore/rendering/RenderRubyBase.h:
* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::RenderRubyRun):
* Source/WebCore/rendering/RenderRubyRun.h:
* Source/WebCore/rendering/RenderRubyText.cpp:
(WebCore::RenderRubyText::RenderRubyText):
* Source/WebCore/rendering/RenderRubyText.h:
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
(WebCore::RenderScrollbarPart::RenderScrollbarPart):
* Source/WebCore/rendering/RenderScrollbarPart.h:
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::RenderSearchField):
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/rendering/RenderSlider.cpp:
(WebCore::RenderSlider::RenderSlider):
* Source/WebCore/rendering/RenderSlider.h:
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::RenderTable):
(WebCore::RenderTable::createTableWithStyle):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableCaption.cpp:
(WebCore::RenderTableCaption::RenderTableCaption):
* Source/WebCore/rendering/RenderTableCaption.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::RenderTableCell):
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::RenderTableCol):
* Source/WebCore/rendering/RenderTableCol.h:
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableRow::RenderTableRow):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::RenderTableSection):
* Source/WebCore/rendering/RenderTableSection.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::RenderText):
(WebCore::RenderText::isTextFragment const): Deleted.
* Source/WebCore/rendering/RenderText.h:
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::RenderTextControl):
(WebCore::RenderTextControlInnerContainer::RenderTextControlInnerContainer):
* Source/WebCore/rendering/RenderTextControl.h:
* Source/WebCore/rendering/RenderTextControlMultiLine.cpp:
(WebCore::RenderTextControlMultiLine::RenderTextControlMultiLine):
* Source/WebCore/rendering/RenderTextControlMultiLine.h:
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::RenderTextControlSingleLine):
(WebCore::RenderTextControlInnerBlock::RenderTextControlInnerBlock):
* Source/WebCore/rendering/RenderTextControlSingleLine.h:
* Source/WebCore/rendering/RenderTextFragment.cpp:
(WebCore::RenderTextFragment::RenderTextFragment):
* Source/WebCore/rendering/RenderTextFragment.h:
* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::RenderVTTCue):
* Source/WebCore/rendering/RenderVTTCue.h:
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::RenderVideo):
* Source/WebCore/rendering/RenderVideo.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::RenderView):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::RenderWidget):
* Source/WebCore/rendering/RenderWidget.h:
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
(WebCore::RenderMathMLBlock::RenderMathMLBlock):
* Source/WebCore/rendering/mathml/RenderMathMLBlock.h:
* Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h:
(WebCore::RenderMathMLTable::RenderMathMLTable):
* Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp:
(WebCore::RenderMathMLFenced::RenderMathMLFenced):
* Source/WebCore/rendering/mathml/RenderMathMLFenced.h:
* Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp:
(WebCore::RenderMathMLFencedOperator::RenderMathMLFencedOperator):
* Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.h:
* Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
(WebCore::RenderMathMLFraction::RenderMathMLFraction):
* Source/WebCore/rendering/mathml/RenderMathMLFraction.h:
* Source/WebCore/rendering/mathml/RenderMathMLMath.cpp:
(WebCore::RenderMathMLMath::RenderMathMLMath):
* Source/WebCore/rendering/mathml/RenderMathMLMath.h:
* Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp:
(WebCore::RenderMathMLMenclose::RenderMathMLMenclose):
* Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
(WebCore::RenderMathMLOperator::RenderMathMLOperator):
* Source/WebCore/rendering/mathml/RenderMathMLOperator.h:
* Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp:
(WebCore::RenderMathMLPadded::RenderMathMLPadded):
* Source/WebCore/rendering/mathml/RenderMathMLPadded.h:
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::RenderMathMLRoot):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.h:
* Source/WebCore/rendering/mathml/RenderMathMLRow.cpp:
(WebCore::RenderMathMLRow::RenderMathMLRow):
* Source/WebCore/rendering/mathml/RenderMathMLRow.h:
* Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
(WebCore::RenderMathMLScripts::RenderMathMLScripts):
* Source/WebCore/rendering/mathml/RenderMathMLScripts.h:
* Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp:
(WebCore::RenderMathMLSpace::RenderMathMLSpace):
* Source/WebCore/rendering/mathml/RenderMathMLSpace.h:
* Source/WebCore/rendering/mathml/RenderMathMLToken.cpp:
(WebCore::RenderMathMLToken::RenderMathMLToken):
* Source/WebCore/rendering/mathml/RenderMathMLToken.h:
* Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp:
(WebCore::RenderMathMLUnderOver::RenderMathMLUnderOver):
* Source/WebCore/rendering/mathml/RenderMathMLUnderOver.h:
* Source/WebCore/rendering/style/ContentData.cpp:
(WebCore::ImageContentData::createContentRenderer const):
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::RenderSVGBlock):
* Source/WebCore/rendering/svg/RenderSVGBlock.h:
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::RenderSVGContainer):
* Source/WebCore/rendering/svg/RenderSVGContainer.h:
* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
(WebCore::RenderSVGEllipse::RenderSVGEllipse):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
(WebCore::RenderSVGForeignObject::RenderSVGForeignObject):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::RenderSVGGradientStop):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.h:
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp:
(WebCore::RenderSVGHiddenContainer::RenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::RenderSVGImage):
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::RenderSVGInline):
* Source/WebCore/rendering/svg/RenderSVGInline.h:
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::RenderSVGInlineText):
* Source/WebCore/rendering/svg/RenderSVGInlineText.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::RenderSVGModelObject):
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::RenderSVGPath):
* Source/WebCore/rendering/svg/RenderSVGPath.h:
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::RenderSVGRect):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::RenderSVGResourceFilter):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp:
(WebCore::RenderSVGResourceFilterPrimitive::RenderSVGResourceFilterPrimitive):
* Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
(WebCore::RenderSVGResourceGradient::RenderSVGResourceGradient):
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.cpp:
(WebCore::RenderSVGResourceLinearGradient::RenderSVGResourceLinearGradient):
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
(WebCore::RenderSVGResourceMarker::RenderSVGResourceMarker):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::RenderSVGResourceMasker):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::RenderSVGResourcePattern):
* Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.cpp:
(WebCore::RenderSVGResourceRadialGradient::RenderSVGResourceRadialGradient):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::RenderSVGRoot):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::RenderSVGShape):
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/RenderSVGTSpan.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::RenderSVGText):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:
(WebCore::RenderSVGTextPath::RenderSVGTextPath):
* Source/WebCore/rendering/svg/RenderSVGTextPath.h:
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
(WebCore::RenderSVGTransformableContainer::RenderSVGTransformableContainer):
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::RenderSVGViewportContainer):
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::LegacyRenderSVGContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
(WebCore::LegacyRenderSVGEllipse::LegacyRenderSVGEllipse):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.cpp:
(WebCore::LegacyRenderSVGForeignObject::LegacyRenderSVGForeignObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.cpp:
(WebCore::LegacyRenderSVGHiddenContainer::LegacyRenderSVGHiddenContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::LegacyRenderSVGImage):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::LegacyRenderSVGModelObject):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::LegacyRenderSVGPath):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
(WebCore::LegacyRenderSVGRect::LegacyRenderSVGRect):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::LegacyRenderSVGResourceClipper):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::LegacyRenderSVGResourceContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::LegacyRenderSVGRoot):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::LegacyRenderSVGShape):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp:
(WebCore::LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp:
(WebCore::LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::RenderTreeBuilder::FirstLetter::updateStyle):
(WebCore::RenderTreeBuilder::FirstLetter::createRenderers):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::cloneAsContinuation):
(WebCore::RenderTreeBuilder::Inline::attachIgnoringContinuation):
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::createAnonymousRubyInlineBlock):
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::createTextRenderer):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateBackdropRenderer):
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::createElementRenderer):
* Source/WebCore/svg/SVGDefsElement.cpp:
(WebCore::SVGDefsElement::createElementRenderer):
* Source/WebCore/svg/SVGGElement.cpp:
(WebCore::SVGGElement::createElementRenderer):
* Source/WebCore/svg/SVGSymbolElement.cpp:
(WebCore::SVGSymbolElement::createElementRenderer):
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::createElementRenderer):

Canonical link: <a href="https://commits.webkit.org/268604@main">https://commits.webkit.org/268604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ef4870bcee74a737905343daa327df17d672444

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20251 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22872 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24533 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18458 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22525 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16176 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22597 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2479 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->