### PR TITLE
NetworkProcessConnection.cpp: fix incomplete type WebCore::Page

### DIFF
--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -68,6 +68,7 @@
 #include <WebCore/InspectorInstrumentationWebKit.h>
 #include <WebCore/MemoryCache.h>
 #include <WebCore/MessagePort.h>
+#include <WebCore/Page.h>
 #include <WebCore/SharedBuffer.h>
 #include <pal/SessionID.h>
 


### PR DESCRIPTION
#### e92f5f33fd267fc387efd7099bb6970e24e71afd
<pre>
NetworkProcessConnection.cpp: fix incomplete type WebCore::Page

<a href="https://bugs.webkit.org/show_bug.cgi?id=262359">https://bugs.webkit.org/show_bug.cgi?id=262359</a>

Reviewed by Michael Catanzaro.

webkitgtk-2.42.0/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:327:11: error: incomplete type ‘WebCore::Page’ used in nested name specifier
  327 |     Page::forEachPage([&amp;] (auto&amp; page) {
      |           ^~~~~~~~~~~

Signed-off-by: Thomas Devoogdt &lt;thomas.devoogdt@barco.com&gt;
Canonical link: <a href="https://commits.webkit.org/266719.77@bugfix/NetworkProcessConnection-2.42">https://commits.webkit.org/266719.77@bugfix/NetworkProcessConnection-2.42</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f446d7b91c29ca40064d8165a7e9ad425d8eb9fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20234 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22134 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/18883 "The change is no longer eligible for processing.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20328 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20453 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/20384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22984 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24654 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/18629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22626 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19151 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18356 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/4875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22698 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2497 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->