### PR TITLE
[UnifiedPDF] Get initial painting working

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -95,8 +95,6 @@ public:
 
     static WebCore::PluginInfo pluginInfo();
 
-    WebCore::IntSize size() const { return m_size; }
-
     void didMutatePDFDocument() { m_pdfDocumentWasMutated = true; }
 
     void paintControlForLayerInContext(CALayer *, CGContextRef);
@@ -300,8 +298,6 @@ private:
     String m_lastFoundString;
 
     RetainPtr<WKPDFLayerControllerDelegate> m_pdfLayerControllerDelegate;
-
-    WebCore::IntSize m_size;
 
     URL m_sourceURL;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -2008,7 +2008,8 @@ void PDFPlugin::geometryDidChange(const IntSize& pluginSize, const AffineTransfo
     if (size() == pluginSize && m_view->pageScaleFactor() == [m_pdfLayerController contentScaleFactor])
         return;
 
-    m_size = pluginSize;
+    PDFPluginBase::geometryDidChange(pluginSize, pluginToRootViewTransform);
+
     m_rootViewToPluginTransform = valueOrDefault(pluginToRootViewTransform.inverse());
     [m_pdfLayerController setFrameSize:pluginSize];
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -76,13 +76,15 @@ public:
 
     virtual bool isComposited() const { return false; }
 
+    virtual void paint(WebCore::GraphicsContext&, const WebCore::IntRect&) { }
+
     virtual CGFloat scaleFactor() const = 0;
 
     // FIXME: Can we use PDFDocument here?
     virtual RetainPtr<PDFDocument> pdfDocumentForPrinting() const = 0;
     virtual WebCore::FloatSize pdfDocumentSizeForPrinting() const = 0;
 
-    virtual void geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform) { }
+    virtual void geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform);
     virtual void visibilityDidChange(bool) { }
     virtual void contentsScaleFactorChanged(float) { }
 
@@ -119,6 +121,7 @@ public:
     bool isBeingDestroyed() const { return m_isBeingDestroyed; }
 
     bool isFullFramePlugin() const;
+    WebCore::IntSize size() const { return m_size; }
 
     void streamDidReceiveResponse(const WebCore::ResourceResponse&);
     void streamDidReceiveData(const WebCore::SharedBuffer&);
@@ -148,6 +151,8 @@ protected:
 
     String m_suggestedFilename;
     uint64_t m_streamedBytes { 0 };
+
+    WebCore::IntSize m_size;
 
     bool m_documentFinishedLoading { false };
     bool m_isBeingDestroyed { false };

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -148,6 +148,11 @@ void PDFPluginBase::addArchiveResource()
     m_view->frame()->document()->loader()->addArchiveResource(resource.releaseNonNull());
 }
 
+void PDFPluginBase::geometryDidChange(const IntSize& pluginSize, const AffineTransform& pluginToRootViewTransform)
+{
+    m_size = pluginSize;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(PDFKIT_PLUGIN) || ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -46,10 +46,14 @@ private:
     void createPDFDocument() override;
     void installPDFDocument() override;
 
+    void paint(WebCore::GraphicsContext&, const WebCore::IntRect&) override;
+
     CGFloat scaleFactor() const override;
 
     RetainPtr<PDFDocument> pdfDocumentForPrinting() const override;
     WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
+
+    void geometryDidChange(const WebCore::IntSize&, const WebCore::AffineTransform&) override;
 
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
 
@@ -75,6 +79,8 @@ private:
     id accessibilityHitTest(const WebCore::IntPoint&) const override;
     id accessibilityObject() const override;
     id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
+
+    RetainPtr<CGPDFDocumentRef> m_pdfDocument;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -452,7 +452,7 @@ void PluginView::setFrameRect(const WebCore::IntRect& rect)
     viewGeometryDidChange();
 }
 
-void PluginView::paint(GraphicsContext& context, const IntRect& /*dirtyRect*/, Widget::SecurityOriginPaintPolicy, RegionContext*)
+void PluginView::paint(GraphicsContext& context, const IntRect& dirtyRect, Widget::SecurityOriginPaintPolicy, RegionContext*)
 {
     if (!m_isInitialized)
         return;
@@ -481,7 +481,10 @@ void PluginView::paint(GraphicsContext& context, const IntRect& /*dirtyRect*/, W
                 deviceScaleFactor = page->deviceScaleFactor();
             m_transientPaintingSnapshot->paint(context, deviceScaleFactor, frameRect().location(), m_transientPaintingSnapshot->bounds());
         }
+        return;
     }
+
+    m_plugin->paint(context, dirtyRect);
 }
 
 void PluginView::frameRectsChanged()


### PR DESCRIPTION
#### 8b9d4c49a75fde19cd57e64783ef6bc912606314
<pre>
[UnifiedPDF] Get initial painting working
<a href="https://bugs.webkit.org/show_bug.cgi?id=262311">https://bugs.webkit.org/show_bug.cgi?id=262311</a>
rdar://116185973

Reviewed by Tim Horton.

Start getting PDF drawing working for Unified PDF. Currently this just draws the first
page via `CGPDFDocumentCreateWithProvider()` and `CGPDFDocumentGetPage()`.

Move two bits of code into PDFPluginBase; first, have it handle `geometryDidChange()` so
we can store the size. Second, because UnifiedPDFPlugin isn&apos;t layer-backed, we need to
plumb through a `paint()` function from `PluginView`.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::geometryDidChange):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::paint):
(WebKit::PDFPluginBase::size const):
(WebKit::PDFPluginBase::geometryDidChange): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::geometryDidChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createPDFDocument):
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::paint):
(WebKit::UnifiedPDFPlugin::geometryDidChange):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::paint):

Canonical link: <a href="https://commits.webkit.org/268610@main">https://commits.webkit.org/268610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dbd5dcbe40eb3c1a960fa9ea7759ea0e1376c2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18794 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20733 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22885 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17433 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24541 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22533 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16184 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18267 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4835 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->