### PR TITLE
[JSC] Align stringification algorithm of the Function constructor with the spec

### DIFF
--- a/JSTests/ChakraCore/test/Lib/noargs_2.baseline-jsc
+++ b/JSTests/ChakraCore/test/Lib/noargs_2.baseline-jsc
@@ -10,7 +10,8 @@ encodeURI = undefined
 decodeURIComponent = undefined
 encodeURIComponent = undefined
 Object = [object Object]
-Function = function anonymous() {
+Function = function anonymous(
+) {
 
 }
 Array = 

--- a/JSTests/stress/function-cache-with-parameters-end-position.js
+++ b/JSTests/stress/function-cache-with-parameters-end-position.js
@@ -22,7 +22,8 @@ for (var i = 0; i < 10; ++i) {
     var f = Function('/*) {\n*/', 'return 42');
     shouldBe(f.toString(),
 `function anonymous(/*) {
-*/) {
+*/
+) {
 return 42
 }`);
 }
@@ -33,7 +34,8 @@ for (var i = 0; i < 10; ++i) {
     var f = Function('/*) {\n*/', 'return 43');
     shouldBe(f.toString(),
 `function anonymous(/*) {
-*/) {
+*/
+) {
 return 43
 }`);
 }

--- a/JSTests/stress/function-constructor-name.js
+++ b/JSTests/stress/function-constructor-name.js
@@ -10,27 +10,31 @@ var AsyncGeneratorFunction = async function*(){}.constructor;
 var f = Function(`return 42`);
 shouldBe(typeof anonymous, `undefined`);
 shouldBe(f.toString(),
-`function anonymous() {
+`function anonymous(
+) {
 return 42
 }`);
 
 var gf = GeneratorFunction(`return 42`);
 shouldBe(typeof anonymous, `undefined`);
 shouldBe(gf.toString(),
-`function *anonymous() {
+`function* anonymous(
+) {
 return 42
 }`);
 
 var af = AsyncFunction(`return 42`);
 shouldBe(typeof anonymous, `undefined`);
 shouldBe(af.toString(),
-`async function anonymous() {
+`async function anonymous(
+) {
 return 42
 }`);
 
 var agf = AsyncGeneratorFunction(`return 42`);
 shouldBe(typeof anonymous, `undefined`);
 shouldBe(agf.toString(),
-`async function*anonymous() {
+`async function* anonymous(
+) {
 return 42
 }`);

--- a/JSTests/stress/function-constructor-semantics.js
+++ b/JSTests/stress/function-constructor-semantics.js
@@ -45,8 +45,8 @@ testError("a=20", "'use strict';");
 testError("{a}", "'use strict';");
 testError("...args", "'use strict';");
 testError("...args", "b", "");
-testError("//", "b", "");
 
+testOK("//", "b", "");
 testOK("/*", "*/", "");
 testOK("a", "/*b", "*/", "'use strict'; let b");
 testOK("{a}", "return a;");

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1,10 +1,4 @@
 ---
-test/annexB/built-ins/Function/createdynfn-html-close-comment-params.js:
-  default: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
-  strict mode: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
-test/annexB/built-ins/Function/createdynfn-html-open-comment-params.js:
-  default: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
-  strict mode: "SyntaxError: Unexpected token '}'. Expected a parameter pattern or a ')' in parameter list."
 test/annexB/language/function-code/block-decl-func-skip-arguments.js:
   default: 'Test262Error: Expected SameValue(«function arguments() {}», «[object Arguments]») to be true'
 test/built-ins/ArrayBuffer/prototype/detached/detached-buffer-resizable.js:
@@ -172,18 +166,6 @@ test/built-ins/Function/internals/Construct/derived-return-val-realm.js:
 test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js:
   default: 'Test262Error: Expected a ReferenceError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a ReferenceError but got a different error constructor with the same name'
-test/built-ins/Function/prototype/toString/AsyncFunction.js:
-  default: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-  strict mode: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-test/built-ins/Function/prototype/toString/AsyncGenerator.js:
-  default: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-  strict mode: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-test/built-ins/Function/prototype/toString/Function.js:
-  default: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-  strict mode: "SyntaxError: Unexpected token ';'. Expected a ')' or a ',' after a parameter declaration."
-test/built-ins/Function/prototype/toString/GeneratorFunction.js:
-  default: "SyntaxError: Unexpected keyword 'yield'. Expected a ')' or a ',' after a parameter declaration."
-  strict mode: "SyntaxError: Unexpected keyword 'yield'. Expected a ')' or a ',' after a parameter declaration."
 test/built-ins/Function/prototype/toString/built-in-function-object.js:
   default: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
   strict mode: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'

--- a/LayoutTests/inspector/console/messageAdded-from-named-evaluations-expected.txt
+++ b/LayoutTests/inspector/console/messageAdded-from-named-evaluations-expected.txt
@@ -8,6 +8,6 @@ Console messages in named evaluations should have call frames with the correct n
 PASS: Log ConsoleMessage top call frame should have sourceURL name.
 
 -- Running test case: TriggerExceptionFromNameFunctionConstructorEvaluation
-Uncaught exception in test page: TypeError: undefined is not an object (evaluating '({}).x.x') [undefined:3]
+Uncaught exception in test page: TypeError: undefined is not an object (evaluating '({}).x.x') [undefined:4]
 PASS: Exception ConsoleMessage top call frame should have sourceURL name.
 

--- a/LayoutTests/js/dom/function-names-expected.txt
+++ b/LayoutTests/js/dom/function-names-expected.txt
@@ -3,7 +3,7 @@ This test checks the names of all sorts of different functions.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS new Function(' return 1; ').toString().replace(/[ \n]+/g, ' ') is 'function anonymous() { return 1; }'
+PASS new Function(' return 1; ').toString().replace(/[ \n]+/g, ' ') is 'function anonymous( ) { return 1; }'
 PASS document.documentElement.onclick.toString().replace(/[ \n]+/g, ' ') is 'function onclick(event) { return 2; }'
 PASS ''.constructor is String
 PASS Boolean.toString() is 'function Boolean() {\n    [native code]\n}'

--- a/LayoutTests/js/dom/script-start-end-locations-expected.txt
+++ b/LayoutTests/js/dom/script-start-end-locations-expected.txt
@@ -243,35 +243,35 @@ function "exi2b" { 1:138 - 1:221 }
 eval { 1:1 - 1:56 }
 
   new Function Object:
-function "anonymous" { 1:19 - 2:228 }
-function "nf1a" { 2:57 - 2:219 }
-function "nf1b" { 2:87 - 2:209 }
-function "nf1c" { 2:117 - 2:199 }
+function "anonymous" { 1:19 - 3:228 }
+function "nf1a" { 3:57 - 3:219 }
+function "nf1b" { 3:87 - 3:209 }
+function "nf1c" { 3:117 - 3:199 }
 eval { 1:1 - 1:56 }
-function "anonymous" { 1:19 - 18:8 }
-function "nf2a" { 5:18 - 16:5 }
-function "nf2b" { 7:22 - 14:9 }
-function "nf2c" { 9:26 - 12:13 }
+function "anonymous" { 1:19 - 19:8 }
+function "nf2a" { 6:18 - 17:5 }
+function "nf2b" { 8:22 - 15:9 }
+function "nf2c" { 10:26 - 13:13 }
 eval { 1:1 - 1:56 }
-function "anonymous" { 1:19 - 2:228 }
-function "nf1a" { 2:57 - 2:219 }
-function "nf1b" { 2:87 - 2:209 }
-function "nf1c" { 2:117 - 2:199 }
+function "anonymous" { 1:19 - 3:228 }
+function "nf1a" { 3:57 - 3:219 }
+function "nf1b" { 3:87 - 3:209 }
+function "nf1c" { 3:117 - 3:199 }
 eval { 1:1 - 1:56 }
-function "anonymous" { 1:19 - 2:237 }
-function "nfi1a" { 2:58 - 2:227 }
-function "nfi1b" { 2:90 - 2:216 }
-function "nfi1c" { 2:122 - 2:205 }
+function "anonymous" { 1:19 - 3:237 }
+function "nfi1a" { 3:58 - 3:227 }
+function "nfi1b" { 3:90 - 3:216 }
+function "nfi1c" { 3:122 - 3:205 }
 eval { 1:1 - 1:56 }
-function "anonymous" { 1:19 - 18:8 }
-function "nf2a" { 5:18 - 16:5 }
-function "nf2b" { 7:22 - 14:9 }
-function "nf2c" { 9:26 - 12:13 }
+function "anonymous" { 1:19 - 19:8 }
+function "nf2a" { 6:18 - 17:5 }
+function "nf2b" { 8:22 - 15:9 }
+function "nf2c" { 10:26 - 13:13 }
 eval { 1:1 - 1:56 }
-function "anonymous" { 1:19 - 18:9 }
-function "nfi2a" { 5:19 - 16:5 }
-function "nfi2b" { 7:23 - 14:9 }
-function "nfi2c" { 9:27 - 12:13 }
+function "anonymous" { 1:19 - 19:9 }
+function "nfi2a" { 6:19 - 17:5 }
+function "nfi2b" { 8:23 - 15:9 }
+function "nfi2c" { 10:27 - 13:13 }
 eval { 1:1 - 1:56 }
 
 PASS successfullyParsed is true

--- a/LayoutTests/js/dom/script-tests/function-names.js
+++ b/LayoutTests/js/dom/script-tests/function-names.js
@@ -4,7 +4,7 @@ description(
 
 document.documentElement.setAttribute("onclick", " return 2; ");
 
-shouldBe("new Function(' return 1; ').toString().replace(/[ \\n]+/g, ' ')", "'function anonymous() { return 1; }'");
+shouldBe("new Function(' return 1; ').toString().replace(/[ \\n]+/g, ' ')", "'function anonymous( ) { return 1; }'");
 shouldBe("document.documentElement.onclick.toString().replace(/[ \\n]+/g, ' ')", "'function onclick(event) { return 2; }'");
 
 shouldBe("''.constructor", "String");

--- a/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
+++ b/Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp
@@ -66,7 +66,7 @@ int testFunctionOverrides()
         "'function f1() { /* Overridden f1 */ }\\n"
         "function() { /* Overridden f2 */ }\\n"
         "function() { /* Overridden f3 */ }\\n"
-        "function anonymous() { /* Overridden f4 */ }\\n';"
+        "function anonymous(\\n) { /* Overridden f4 */ }\\n';"
         "var result = (str == expectedStr);" "\n"
         "result";
 

--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1846,7 +1846,7 @@ int main(int argc, char* argv[])
     ASSERT(!JSObjectMakeFunction(context, NULL, 0, NULL, functionBody, NULL, 1, &exception));
     ASSERT(JSValueIsObject(context, exception));
     v = JSObjectGetProperty(context, JSValueToObject(context, exception, NULL), line, NULL);
-    assertEqualsAsNumber(v, 2);
+    assertEqualsAsNumber(v, 3);
     JSStringRelease(functionBody);
     JSStringRelease(line);
 
@@ -1856,7 +1856,7 @@ int main(int argc, char* argv[])
     ASSERT(!JSObjectMakeFunction(context, NULL, 0, NULL, functionBody, NULL, -42, &exception));
     ASSERT(JSValueIsObject(context, exception));
     v = JSObjectGetProperty(context, JSValueToObject(context, exception, NULL), line, NULL);
-    assertEqualsAsNumber(v, 2);
+    assertEqualsAsNumber(v, 3);
     JSStringRelease(functionBody);
     JSStringRelease(line);
 
@@ -1866,7 +1866,7 @@ int main(int argc, char* argv[])
     ASSERT(!JSObjectMakeFunction(context, NULL, 0, NULL, functionBody, NULL, 1, &exception));
     ASSERT(JSValueIsObject(context, exception));
     v = JSObjectGetProperty(context, JSValueToObject(context, exception, NULL), line, NULL);
-    assertEqualsAsNumber(v, 3);
+    assertEqualsAsNumber(v, 4);
     JSStringRelease(functionBody);
     JSStringRelease(line);
 
@@ -1900,7 +1900,7 @@ int main(int argc, char* argv[])
     JSStringRelease(functionBody);
     
     string = JSValueToStringCopy(context, function, NULL);
-    assertEqualsAsUTF8String(JSValueMakeString(context, string), "function foo(foo) {\nreturn foo;\n}");
+    assertEqualsAsUTF8String(JSValueMakeString(context, string), "function foo(foo\n) {\nreturn foo;\n}");
     JSStringRelease(string);
 
     JSStringRef print = JSStringCreateWithUTF8CString("print");

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.cpp
@@ -73,13 +73,13 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
         prefix = "function ";
         break;
     case FunctionConstructionMode::Generator:
-        prefix = "function *";
+        prefix = "function* ";
         break;
     case FunctionConstructionMode::Async:
         prefix = "async function ";
         break;
     case FunctionConstructionMode::AsyncGenerator:
-        prefix = "async function*";
+        prefix = "async function* ";
         break;
     }
 
@@ -88,11 +88,11 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
     String program;
     functionConstructorParametersEndPosition = std::nullopt;
     if (args.isEmpty())
-        program = makeString(prefix, functionName.string(), "() {\n\n}"_s);
+        program = makeString(prefix, functionName.string(), "(\n) {\n\n}"_s);
     else if (args.size() == 1) {
         auto body = args.at(0).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        program = tryMakeString(prefix, functionName.string(), "() {\n"_s, body, "\n}"_s);
+        program = tryMakeString(prefix, functionName.string(), "(\n) {\n"_s, body, "\n}"_s);
         if (UNLIKELY(!program)) {
             throwOutOfMemoryError(globalObject, scope);
             return { };
@@ -111,20 +111,20 @@ static String stringifyFunction(JSGlobalObject* globalObject, const ArgList& arg
             RETURN_IF_EXCEPTION(scope, { });
             auto viewWithString = jsString->viewWithUnderlyingString(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
-            builder.append(", ", viewWithString.view);
+            builder.append(",", viewWithString.view);
         }
         if (UNLIKELY(builder.hasOverflowed())) {
             throwOutOfMemoryError(globalObject, scope);
             return { };
         }
 
-        functionConstructorParametersEndPosition = builder.length() + 1;
+        functionConstructorParametersEndPosition = builder.length() + sizeof("\n)") - 1;
 
         auto* bodyString = args.at(args.size() - 1).toString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
         auto body = bodyString->viewWithUnderlyingString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        builder.append(") {\n", body.view, "\n}");
+        builder.append("\n) {\n", body.view, "\n}");
         if (UNLIKELY(builder.hasOverflowed())) {
             throwOutOfMemoryError(globalObject, scope);
             return { };
@@ -141,26 +141,26 @@ JSObject* constructFunction(JSGlobalObject* globalObject, const ArgList& args, c
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    std::optional<int> functionConstructorParametersEndPosition;
+    auto code = stringifyFunction(globalObject, args, functionName, functionConstructionMode, scope, functionConstructorParametersEndPosition);
+    EXCEPTION_ASSERT(!!scope.exception() == code.isNull());
+
     if (UNLIKELY(!globalObject->evalEnabled())) {
-        auto codeScope = DECLARE_THROW_SCOPE(vm);
-        std::optional<int> functionConstructorParametersEndPosition;
-        auto code = stringifyFunction(globalObject, args, functionName, functionConstructionMode, codeScope, functionConstructorParametersEndPosition);
+        scope.clearException();
         globalObject->globalObjectMethodTable()->reportViolationForUnsafeEval(globalObject, !code.isNull() ? jsNontrivialString(vm, WTFMove(code)) : nullptr);
         throwException(globalObject, scope, createEvalError(globalObject, globalObject->evalDisabledErrorMessage()));
         return nullptr;
     }
-    RELEASE_AND_RETURN(scope, constructFunctionSkippingEvalEnabledCheck(globalObject, args, functionName, sourceOrigin, sourceURL, taintedOrigin, position, -1, functionConstructionMode, newTarget));
+    if (UNLIKELY(code.isNull()))
+        return nullptr;
+
+    RELEASE_AND_RETURN(scope, constructFunctionSkippingEvalEnabledCheck(globalObject, WTFMove(code), functionName, sourceOrigin, sourceURL, taintedOrigin, position, -1, functionConstructorParametersEndPosition, functionConstructionMode, newTarget));
 }
 
-JSObject* constructFunctionSkippingEvalEnabledCheck(JSGlobalObject* globalObject, const ArgList& args, const Identifier& functionName, const SourceOrigin& sourceOrigin, const String& sourceURL, SourceTaintedOrigin taintedOrigin, const TextPosition& position, int overrideLineNumber, FunctionConstructionMode functionConstructionMode, JSValue newTarget)
+JSObject* constructFunctionSkippingEvalEnabledCheck(JSGlobalObject* globalObject, String&& program, const Identifier& functionName, const SourceOrigin& sourceOrigin, const String& sourceURL, SourceTaintedOrigin taintedOrigin, const TextPosition& position, int overrideLineNumber, std::optional<int> functionConstructorParametersEndPosition, FunctionConstructionMode functionConstructionMode, JSValue newTarget)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-
-    std::optional<int> functionConstructorParametersEndPosition;
-    auto program = stringifyFunction(globalObject, args, functionName, functionConstructionMode, scope, functionConstructorParametersEndPosition);
-    if (program.isNull())
-        return nullptr;
 
     SourceCode source = makeSource(program, sourceOrigin, taintedOrigin, sourceURL, position);
     JSObject* exception = nullptr;

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.h
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.h
@@ -62,8 +62,9 @@ JSObject* constructFunction(JSGlobalObject*, const ArgList&, const Identifier& f
 JSObject* constructFunction(JSGlobalObject*, CallFrame*, const ArgList&, FunctionConstructionMode = FunctionConstructionMode::Function, JSValue newTarget = JSValue());
 
 JS_EXPORT_PRIVATE JSObject* constructFunctionSkippingEvalEnabledCheck(
-    JSGlobalObject*, const ArgList&, const Identifier&, const SourceOrigin&,
+    JSGlobalObject*, String&& program, const Identifier&, const SourceOrigin&,
     const String&, SourceTaintedOrigin, const WTF::TextPosition&, int overrideLineNumber = -1,
+    std::optional<int> functionConstructorParametersEndPosition = std::nullopt,
     FunctionConstructionMode = FunctionConstructionMode::Function, JSValue newTarget = JSValue());
 
 } // namespace JSC

--- a/Source/WebCore/bindings/js/JSLazyEventListener.h
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.h
@@ -55,7 +55,7 @@ private:
     JSC::JSObject* initializeJSFunction(ScriptExecutionContext&) const final;
 
     String m_functionName;
-    const String& m_eventParameterName;
+    const String& m_functionParameters;
     String m_code;
     URL m_sourceURL;
     TextPosition m_sourcePosition;


### PR DESCRIPTION
#### ff01344c4f58839cfc9b7381f6416307f9e1e1c5
<pre>
[JSC] Align stringification algorithm of the Function constructor with the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=190501">https://bugs.webkit.org/show_bug.cgi?id=190501</a>
&lt;rdar://102065151&gt;

Reviewed by Yusuke Suzuki.

This change aligns stringification algorithm of the Function constructor with the spec [1].
In particular, fixes prefixes for (async) generator functions (steps 5 &amp; 7), joins parameters by &quot;,&quot;
instead of &quot;, &quot; (step 10.d.iii), and adds a newline character after the last parameter (step 13).

Since constructFunctionSkippingEvalEnabledCheck() is also being used for creating HTML attribute
event listeners, which uses different stringification algorithm [2], this patch tweaks its signature
to accept the source code instead, making bindings / disabled eval() code a little bit nicer.

Aligns JSC with V8 and SpiderMonkey.

[1]: <a href="https://tc39.es/ecma262/#sec-createdynamicfunction">https://tc39.es/ecma262/#sec-createdynamicfunction</a>
[2]: <a href="https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler">https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler</a> (step 9)

* JSTests/ChakraCore/test/Lib/noargs_2.baseline-jsc:
* JSTests/stress/function-cache-with-parameters-end-position.js:
* JSTests/stress/function-constructor-name.js:
* JSTests/stress/function-constructor-semantics.js:
* JSTests/test262/expectations.yaml: Mark 12 tests as passing.
* LayoutTests/inspector/console/messageAdded-from-named-evaluations-expected.txt:
* LayoutTests/js/dom/function-names-expected.txt:
* LayoutTests/js/dom/script-start-end-locations-expected.txt:
* LayoutTests/js/dom/script-tests/function-names.js:
* Source/JavaScriptCore/API/tests/FunctionOverridesTest.cpp:
* Source/JavaScriptCore/API/tests/testapi.c:
* Source/JavaScriptCore/runtime/FunctionConstructor.cpp:
(JSC::stringifyFunction):
(JSC::constructFunction):
This change is careful to preserve &quot;swallowing&quot; an argument coercion error in case of disabled eval(),
which is intentional since HostEnsureCanCompileStrings happens as early as on step 2 [1].

(JSC::constructFunctionSkippingEvalEnabledCheck):
* Source/JavaScriptCore/runtime/FunctionConstructor.h:
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::functionParameters):
(WebCore::JSLazyEventListener::JSLazyEventListener):
(WebCore::JSLazyEventListener::initializeJSFunction const):
(WebCore::eventParameterName): Deleted.
* Source/WebCore/bindings/js/JSLazyEventListener.h:

Co-authored-by: Keith Miller &lt;keith_miller@apple.com&gt;
Canonical link: <a href="https://commits.webkit.org/268633@main">https://commits.webkit.org/268633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f661ed03698e2738f29ce487220631c2a263f12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20290 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22935 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17476 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24611 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17557 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22582 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19550 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16222 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23591 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18310 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5668 "Found 5 jsc stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.dfg-eager, stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.no-cjit-collect-continuously, wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-eager") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22652 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24848 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2492 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18931 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5492 "Passed tests") | 
<!--EWS-Status-Bubble-End-->