### PR TITLE
Optimize computeVisitedLinkHash()

### DIFF
--- a/Source/WebCore/platform/SharedStringHash.cpp
+++ b/Source/WebCore/platform/SharedStringHash.cpp
@@ -222,10 +222,10 @@ SharedStringHash computeSharedStringHash(const UChar* url, unsigned length)
 }
 
 template <typename CharacterType>
-static ALWAYS_INLINE void computeSharedStringHashInline(const URL& base, const CharacterType* characters, unsigned length, Vector<CharacterType, 512>& buffer)
+static ALWAYS_INLINE SharedStringHash computeSharedStringHashInline(const URL& base, const CharacterType* characters, unsigned length)
 {
     if (!length)
-        return;
+        return 0;
 
     // This is a poor man's completeURL. Faster with less memory allocation.
     // FIXME: It's missing a lot of what completeURL does and a lot of what URL does.
@@ -238,22 +238,19 @@ static ALWAYS_INLINE void computeSharedStringHashInline(const URL& base, const C
     // FIXME: needsTrailingSlash does not properly return true for a URL that has no path, but does
     // have a query or anchor.
 
-    bool hasColonSlashSlash = containsColonSlashSlash(characters, length);
+    if (containsColonSlashSlash(characters, length)) {
+        if (!needsTrailingSlash(characters, length))
+            return computeSharedStringHashInline(characters, length);
 
-    if (hasColonSlashSlash && !needsTrailingSlash(characters, length)) {
-        buffer.append(characters, length);
-        return;
-    }
-
-
-    if (hasColonSlashSlash) {
         // FIXME: This is incorrect for URLs that have a query or anchor; the "/" needs to go at the
         // end of the path, *before* the query or anchor.
-        buffer.append(characters, length);
-        buffer.append('/');
-        return;
+        SuperFastHash hasher;
+        hasher.addCharacters(characters, length);
+        hasher.addCharacter('/');
+        return AlreadyHashed::avoidDeletedValue(hasher.hash());
     }
 
+    Vector<CharacterType, 512> buffer;
     if (!length)
         append(buffer, base.string());
     else {
@@ -277,7 +274,7 @@ static ALWAYS_INLINE void computeSharedStringHashInline(const URL& base, const C
         buffer.append('/');
     }
 
-    return;
+    return computeSharedStringHashInline(buffer.data(), buffer.size());
 }
 
 SharedStringHash computeVisitedLinkHash(const URL& base, const AtomString& attributeURL)
@@ -285,23 +282,12 @@ SharedStringHash computeVisitedLinkHash(const URL& base, const AtomString& attri
     if (attributeURL.isEmpty())
         return 0;
 
-    if (!base.string().isEmpty() && base.string().is8Bit() && attributeURL.is8Bit()) {
-        Vector<LChar, 512> url;
-        computeSharedStringHashInline(base, attributeURL.characters8(), attributeURL.length(), url);
-        if (url.isEmpty())
-            return 0;
+    if ((base.string().isEmpty() || base.string().is8Bit()) && attributeURL.is8Bit())
+        return computeSharedStringHashInline(base, attributeURL.characters8(), attributeURL.length());
 
-        return computeSharedStringHashInline(url.data(), url.size());
-    }
-
-    Vector<UChar, 512> url;
     auto upconvertedCharacters = StringView(attributeURL.string()).upconvertedCharacters();
     const UChar* characters = upconvertedCharacters;
-    computeSharedStringHashInline(base, characters, attributeURL.length(), url);
-    if (url.isEmpty())
-        return 0;
-
-    return computeSharedStringHashInline(url.data(), url.size());
+    return computeSharedStringHashInline(base, characters, attributeURL.length());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 4d66b5dc7da014352ef32d6052b52fc8532ed02a
<pre>
Optimize computeVisitedLinkHash()
<a href="https://bugs.webkit.org/show_bug.cgi?id=262318">https://bugs.webkit.org/show_bug.cgi?id=262318</a>

Reviewed by Ryosuke Niwa.

Optimize computeVisitedLinkHash():
- Avoid copying URL characters to a temporary buffer if the URL is
  already absolute (contains &quot;://&quot;). Instead, compute the hash
  straight from the URL characters.
- If the base URL is empty and the attribute value is 8 bit, use
  the LChar code path instead of the UChar one.

* Source/WebCore/platform/SharedStringHash.cpp:
(WebCore::computeSharedStringHashInline):
(WebCore::computeVisitedLinkHash):

Canonical link: <a href="https://commits.webkit.org/268609@main">https://commits.webkit.org/268609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/060ef838440e85ab2f9157c04012b948f20f4fa8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20751 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22904 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24581 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18521 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22551 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19081 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18282 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4834 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22623 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->