### PR TITLE
Begin implementing RemoteDOMWindow properties

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/window-properties-child.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-properties-child.html
@@ -1,0 +1,1 @@
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/window-properties-grandchild.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/window-properties-grandchild.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-properties-grandchild.html
@@ -1,0 +1,4 @@
+<script>
+    window.parent.top.postMessage("top children: " + window.parent.top.length + ", parent children: " + window.parent.length + ", parent parent is top: " + (window.parent.parent === window.top), "*");
+    window.parent.top.customFunction();
+</script>

--- a/LayoutTests/http/tests/site-isolation/window-properties-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-properties-expected.txt
@@ -1,0 +1,3 @@
+ALERT: custom function called
+ALERT: postMessage received: top children: 1, parent children: 1, parent parent is top: true
+

--- a/LayoutTests/http/tests/site-isolation/window-properties.html
+++ b/LayoutTests/http/tests/site-isolation/window-properties.html
@@ -1,0 +1,15 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<iframe src="http://localhost:8000/site-isolation/resources/window-properties-child.html"></iframe>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+addEventListener("message", (e) => {
+    alert("postMessage received: " + e.data);
+    if (window.testRunner) { testRunner.notifyDone() }
+});
+window.customFunction = function() {
+    alert("custom function called");
+}
+</script>

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -126,7 +126,7 @@ static bool inScope(Frame& frame, TreeScope& scope)
 {
     auto* localFrame = dynamicDowncast<LocalFrame>(frame);
     if (!localFrame)
-        return false;
+        return true;
     Document* document = localFrame->document();
     if (!document)
         return false;

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -72,9 +72,8 @@ bool RemoteDOMWindow::closed() const
     return !m_frame;
 }
 
-void RemoteDOMWindow::focus(LocalDOMWindow& incumbentWindow)
+void RemoteDOMWindow::focus(LocalDOMWindow&)
 {
-    UNUSED_PARAM(incumbentWindow);
     // FIXME: Implemented this. <rdar://116203970>
 }
 
@@ -85,8 +84,10 @@ void RemoteDOMWindow::blur()
 
 unsigned RemoteDOMWindow::length() const
 {
-    // FIXME: Implemented this.
-    return 0;
+    if (!m_frame)
+        return 0;
+
+    return m_frame->tree().childCount();
 }
 
 WindowProxy* RemoteDOMWindow::top() const
@@ -94,8 +95,7 @@ WindowProxy* RemoteDOMWindow::top() const
     if (!m_frame)
         return nullptr;
 
-    // FIXME: Implemented this.
-    return &m_frame->windowProxy();
+    return &m_frame->tree().top().windowProxy();
 }
 
 WindowProxy* RemoteDOMWindow::opener() const
@@ -103,7 +103,7 @@ WindowProxy* RemoteDOMWindow::opener() const
     if (!m_frame)
         return nullptr;
 
-    auto* openerFrame = m_frame->opener();
+    RefPtr openerFrame = m_frame->opener();
     if (!openerFrame)
         return nullptr;
 
@@ -115,8 +115,11 @@ WindowProxy* RemoteDOMWindow::parent() const
     if (!m_frame)
         return nullptr;
 
-    // FIXME: Implemented this.
-    return &m_frame->windowProxy();
+    RefPtr parent = m_frame->tree().parent();
+    if (!parent)
+        return nullptr;
+
+    return &parent->windowProxy();
 }
 
 ExceptionOr<void> RemoteDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&& options)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6093,10 +6093,10 @@ void WebPageProxy::didFinishLoadForFrame(FrameIdentifier frameID, FrameInfoData&
 
         frame->didFinishLoad();
 
-        auto remotePageProxy = internals().domainToRemotePageProxyMap.get(RegistrableDomain(frame->url()));
-
-        if (remotePageProxy && frame->parentFrame())
-            frame->parentFrame()->process().send(Messages::WebPage::DidFinishLoadInAnotherProcess(frameID), webPageID());
+        if (RefPtr parentFrame = frame->parentFrame()) {
+            if (parentFrame->process().coreProcessIdentifier() != frame->process().coreProcessIdentifier())
+                parentFrame->process().send(Messages::WebPage::DidFinishLoadInAnotherProcess(frameID), webPageID());
+        }
 
         internals().pageLoadState.commitChanges();
     }


### PR DESCRIPTION
#### c44dcfa19a644523ebdc60d75d94dbdcf8a71e4b
<pre>
Begin implementing RemoteDOMWindow properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=262327">https://bugs.webkit.org/show_bug.cgi?id=262327</a>
rdar://116199379

Reviewed by Pascoe.

A cross-origin iframe has some properties that can be queried without site isolation,
and these properties need to continue to work with site isolation enabled.

length is the number of subframes, which we can get from the frame tree.
parent goes up in the frame tree by one frame
top goes up in the frame tree all the way to ... the top

Scoped children checks work a little differently with RemoteFrames and RemoteDOMWindows
because we don&apos;t have a Document or a TreeScope from that Frame.  For now, consider these
in scope until removed by an incoming IPC message.  This definition may need some refining
later, but this makes these cases work as they used to without site isolation enabled.

In order to get the test to finish successfully, I had to correct the conditions under
which WebPage::DidFinishLoadInAnotherProcess would be sent.  Instead of checking if the
parent frame has a RemotePageProxy, we need to check if the frame is in a different process
than its parent.  This makes the test finish successfully when the grandchild
is in the same process as the main frame (so it has no RemotePageProxy) but its parent
is not.  They are in different processes, so IPC is required to inform of the frame
load completion.

* LayoutTests/http/tests/site-isolation/resources/window-properties-child.html: Added.
* LayoutTests/http/tests/site-isolation/resources/window-properties-grandchild.html: Added.
* LayoutTests/http/tests/site-isolation/window-properties-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/window-properties.html: Added.
* Source/WebCore/page/FrameTree.cpp:
(WebCore::inScope):
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::focus):
(WebCore::RemoteDOMWindow::length const):
(WebCore::RemoteDOMWindow::top const):
(WebCore::RemoteDOMWindow::parent const):

Canonical link: <a href="https://commits.webkit.org/268688@main">https://commits.webkit.org/268688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96a701dbc79fdbf94b8c187330a5df88bde96027

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22230 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20392 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23080 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24786 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22720 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19239 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16340 "10 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18319 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22788 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2526 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->