### PR TITLE
[scroll-anchoring] Exclude absolutely positioned elements with containing blocks outside the parent scroller

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Abs-pos descendant with containing block outside the scroller. assert_equals: expected 50 but got 25
+PASS Abs-pos descendant with containing block outside the scroller.
 


### PR DESCRIPTION
#### c3a46a009b283eb50ea3aac59bc0881a44620de1
<pre>
[scroll-anchoring] Exclude absolutely positioned elements with containing blocks outside the parent scroller
<a href="https://bugs.webkit.org/show_bug.cgi?id=262329">https://bugs.webkit.org/show_bug.cgi?id=262329</a>
<a href="https://rdar.apple.com/116201738">rdar://116201738</a>

Reviewed by Simon Fraser.

Exclude absolutely positioned elements with containing blocks outside the parent scroller.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller-expected.txt:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::absolutePositionedElementOutsideScroller):
(WebCore::ScrollAnchoringController::computeOffset):
(WebCore::ScrollAnchoringController::examineCandidate):

Canonical link: <a href="https://commits.webkit.org/270551@main">https://commits.webkit.org/270551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49a68a0b2fe8d98b96a569862ca60d4196eee9f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23635 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28343 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29148 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23435 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27003 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1068 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4208 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6191 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->