### PR TITLE
Optimize various SVGPropertyOwnerRegistry operations

### DIFF
--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -180,6 +180,16 @@ public:
         return enumerateRecursivelyBaseTypes(functor);
     }
 
+    template<typename Functor>
+    static bool lookupRecursivelyAndApply(const QualifiedName& attributeName, const Functor& functor)
+    {
+        if (auto* accessor = findAccessor(attributeName)) {
+            functor(*accessor);
+            return true;
+        }
+        return lookupRecursivelyAndApplyBaseTypes(attributeName, functor);
+    }
+
     // Returns true if OwnerType owns a property whose name is attributeName.
     static bool isKnownAttribute(const QualifiedName& attributeName)
     {
@@ -221,11 +231,8 @@ public:
 
     void setAnimatedPropertyDirty(const QualifiedName& attributeName, SVGAnimatedProperty& animatedProperty) const override
     {
-        enumerateRecursively([&](const auto& entry) -> bool {
-            if (!entry.key.matches(attributeName))
-                return true;
-            entry.value->setDirty(m_owner, animatedProperty);
-            return false;
+        lookupRecursivelyAndApply(attributeName, [&](auto& accessor) {
+            accessor.setDirty(m_owner, animatedProperty);
         });
     }
 
@@ -243,11 +250,8 @@ public:
     std::optional<String> synchronize(const QualifiedName& attributeName) const override
     {
         std::optional<String> value;
-        enumerateRecursively([&](const auto& entry) -> bool {
-            if (!entry.key.matches(attributeName))
-                return true;
-            value = entry.value->synchronize(m_owner);
-            return false;
+        lookupRecursivelyAndApply(attributeName, [&](auto& accessor) {
+            value = accessor.synchronize(m_owner);
         });
         return value;
     }
@@ -268,11 +272,8 @@ public:
     bool isAnimatedPropertyAttribute(const QualifiedName& attributeName) const override
     {
         bool isAnimatedPropertyAttribute = false;
-        enumerateRecursively([&attributeName, &isAnimatedPropertyAttribute](const auto& entry) -> bool {
-            if (!entry.key.matches(attributeName))
-                return true;
-            isAnimatedPropertyAttribute = entry.value->isAnimatedProperty();
-            return false;
+        lookupRecursivelyAndApply(attributeName, [&](auto& accessor) {
+            isAnimatedPropertyAttribute = accessor.isAnimatedProperty();
         });
         return isAnimatedPropertyAttribute;
     }
@@ -296,22 +297,16 @@ public:
     RefPtr<SVGAttributeAnimator> createAnimator(const QualifiedName& attributeName, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive) const override
     {
         RefPtr<SVGAttributeAnimator> animator;
-        enumerateRecursively([&](const auto& entry) -> bool {
-            if (!entry.key.matches(attributeName))
-                return true;
-            animator = entry.value->createAnimator(m_owner, attributeName, animationMode, calcMode, isAccumulated, isAdditive);
-            return false;
+        lookupRecursivelyAndApply(attributeName, [&](auto& accessor) {
+            animator = accessor.createAnimator(m_owner, attributeName, animationMode, calcMode, isAccumulated, isAdditive);
         });
         return animator;
     }
 
     void appendAnimatedInstance(const QualifiedName& attributeName, SVGAttributeAnimator& animator) const override
     {
-        enumerateRecursively([&](const auto& entry) -> bool {
-            if (!entry.key.matches(attributeName))
-                return true;
-            entry.value->appendAnimatedInstance(m_owner, animator);
-            return false;
+        lookupRecursivelyAndApply(attributeName, [&](auto& accessor) {
+            accessor.appendAnimatedInstance(m_owner, animator);
         });
     }
 
@@ -352,6 +347,20 @@ private:
     {
         auto it = attributeNameToAccessorMap().find(attributeName);
         return it != attributeNameToAccessorMap().end() ? it->value : nullptr;
+    }
+
+    template<typename Functor, size_t I = 0>
+    static typename std::enable_if<I == sizeof...(BaseTypes), bool>::type lookupRecursivelyAndApplyBaseTypes(const QualifiedName&, const Functor&) { return false; }
+
+    template<typename Functor, size_t I = 0>
+    static typename std::enable_if<I < sizeof...(BaseTypes), bool>::type lookupRecursivelyAndApplyBaseTypes(const QualifiedName& attributeName, const Functor& functor)
+    {
+        // Get the base type at index 'I' using std::tuple and std::tuple_element.
+        using BaseType = typename std::tuple_element<I, typename std::tuple<BaseTypes...>>::type;
+        if (BaseType::PropertyRegistry::lookupRecursivelyAndApply(attributeName, functor))
+            return true;
+        // BaseType does not want to break the recursion. So recurse to the next BaseType.
+        return lookupRecursivelyAndApplyBaseTypes<Functor, I + 1>(attributeName, functor);
     }
 
     OwnerType& m_owner;


### PR DESCRIPTION
#### f1f25a76c3445b463f6ff94ab3ec5e97e3bdec3d
<pre>
Optimize various SVGPropertyOwnerRegistry operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=262333">https://bugs.webkit.org/show_bug.cgi?id=262333</a>

Reviewed by Ryosuke Niwa.

Optimize various SVGPropertyOwnerRegistry operations by doing a HashMap lookup
instead of iterating all registered attributes.

Many operations on SVGPropertyOwnerRegistry (such as synchronize()) take an
attribute name and only need to affect a single attribute accessor.
SVGPropertyOwnerRegistry contains a HashMap of attribute to accessor so we
can quickly do a lookup to find the right accessor. Previously, the code
would enumerate all HashMap keys to find the expected attribute.

* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:
(WebCore::SVGPropertyOwnerRegistry::lookupRecursivelyAndApply):
(WebCore::SVGPropertyOwnerRegistry::lookupRecursivelyAndApplyBaseTypes):

Canonical link: <a href="https://commits.webkit.org/268626@main">https://commits.webkit.org/268626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07381356c0aa4c5b1fae1f5ea9f7388d58ee6f8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20292 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22934 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24614 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22585 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16220 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18309 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4850 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22651 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->