### PR TITLE
REGRESSION (Sonoma): WKTR ref test images are HiDPI when running tests on a Retina display (should be 1x)

### DIFF
--- a/Tools/WebKitTestRunner/mac/WebKitTestRunnerWindow.mm
+++ b/Tools/WebKitTestRunner/mac/WebKitTestRunnerWindow.mm
@@ -103,4 +103,10 @@ static Vector<WebKitTestRunnerWindow *> allWindows;
     return NSMakeRect(_fakeOrigin.x, _fakeOrigin.y, currentFrame.size.width, currentFrame.size.height);
 }
 
+- (void)_adjustWindowResolution
+{
+    // Do not call super, so that AppKit can't update the resolution from the screen,
+    // except when we do so explicitly via `_setWindowResolution`.
+}
+
 @end


### PR DESCRIPTION
#### d792947a2e1b2afcc6fa691e14779a3b781dd9ba
<pre>
REGRESSION (Sonoma): WKTR ref test images are HiDPI when running tests on a Retina display (should be 1x)
<a href="https://bugs.webkit.org/show_bug.cgi?id=262339">https://bugs.webkit.org/show_bug.cgi?id=262339</a>
rdar://115752331

Reviewed by Aditya Keerthi.

* Tools/WebKitTestRunner/mac/WebKitTestRunnerWindow.mm:
(-[WebKitTestRunnerWindow _adjustWindowResolution]):
Don&apos;t let AppKit automatically adjust the window resolution (which will pull
it from the screen, which can have an arbitrary resolution). We force the
resolution to 1x or 2x for all WKTR windows depending on what the test needs.

Canonical link: <a href="https://commits.webkit.org/268622@main">https://commits.webkit.org/268622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee9f2e2a37ccf4be28046fcad115462b0108568

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20787 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22939 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18347 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22580 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19109 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18313 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4843 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->