### PR TITLE
[css-grid] Start considering subgrid's margin, border, and padding for align-self baseline items.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt
@@ -1,0 +1,6 @@
+X
+X
+
+PASS .first-baseline 1
+PASS .first-baseline 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<meta name="assert" content="Margin, border, and padding of subgrids should influence the offset of items in the same baseline alignment context">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#subgrid-item-contribution">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+html,body {
+  color:black; background-color:white;  padding:0; margin:0;
+}
+.grid {
+    font:16px/1 Ahem;
+    display: inline-grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+}
+.subgrid {
+    display: grid;
+    grid-template-rows: subgrid;
+    border: 9px solid blue;
+    margin-top: 15px;
+    padding-top: 6px;
+}
+.first-baseline {
+    align-self: baseline;
+}
+</style>
+</head>
+<body onload="checkLayout('.first-baseline')">
+<div id="target" class="grid">
+    <div data-offset-y="31" class="first-baseline">X</div>
+    <div class="subgrid">
+        <div data-offset-y="31"  class="first-baseline">X</div>
+    </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt
@@ -13,7 +13,7 @@ PASS .item 5
 PASS .item 6
 FAIL .item 7 assert_equals:
 <div data-offset-y="41" class="item small first"></div>
-offsetTop expected 41 but got 8
+offsetTop expected 41 but got 21
 FAIL .item 8 assert_equals:
 <div data-offset-y="110" class="item small last"></div>
 offsetTop expected 110 but got 120

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
@@ -9,7 +9,7 @@ FAIL .item 1 assert_equals:
 <div data-offset-x="514" class="item first">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 514 but got 499
+offsetLeft expected 514 but got 512
 PASS .item 2
 FAIL .item 3 assert_equals:
 <div data-offset-x="387" class="item first">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt
@@ -9,48 +9,42 @@ FAIL .item 1 assert_equals:
 <div data-offset-y="36" class="item first">
         <span></span><br><span></span>
       </div>
-offsetTop expected 36 but got 61
+offsetTop expected 36 but got 48
 FAIL .item 2 assert_equals:
 <div data-offset-y="58" class="item last">
         <span></span><br><span></span>
       </div>
-offsetTop expected 58 but got 61
-FAIL .item 3 assert_equals:
-<div data-offset-y="151" class="item first">
-        <span></span><br><span></span>
-      </div>
-offsetTop expected 151 but got 164
+offsetTop expected 58 but got 48
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div data-offset-y="181" class="item last">
         <span></span><br><span></span>
       </div>
-offsetTop expected 181 but got 164
+offsetTop expected 181 but got 151
 FAIL .item 5 assert_equals:
 <div data-offset-y="291" class="item first">
       <span></span><br><span></span>
     </div>
-offsetTop expected 291 but got 279
+offsetTop expected 291 but got 266
 FAIL .item 6 assert_equals:
 <div data-offset-y="321" class="item last">
       <span></span><br><span></span>
     </div>
-offsetTop expected 321 but got 279
+offsetTop expected 321 but got 266
 FAIL .item 7 assert_equals:
 <div data-offset-y="11" class="item small first"></div>
 offsetTop expected 11 but got 3
-FAIL .item 8 assert_equals:
-<div data-offset-y="3" class="item small last"></div>
-offsetTop expected 3 but got 16
+PASS .item 8
 FAIL .item 9 assert_equals:
 <div data-offset-y="126" class="item small first"></div>
-offsetTop expected 126 but got 129
+offsetTop expected 126 but got 116
 FAIL .item 10 assert_equals:
 <div data-offset-y="126" class="item small last"></div>
-offsetTop expected 126 but got 136
+offsetTop expected 126 but got 123
 FAIL .item 11 assert_equals:
 <div data-offset-y="266" class="item small first"></div>
-offsetTop expected 266 but got 249
+offsetTop expected 266 but got 236
 FAIL .item 12 assert_equals:
 <div data-offset-y="266" class="item small last"></div>
-offsetTop expected 266 but got 259
+offsetTop expected 266 but got 246
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
@@ -9,43 +9,43 @@ FAIL .item 1 assert_equals:
 <div data-offset-x="514" class="item first">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 514 but got 479
+offsetLeft expected 514 but got 492
 FAIL .item 2 assert_equals:
 <div data-offset-x="428" class="item last">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 428 but got 412
+offsetLeft expected 428 but got 421
 FAIL .item 3 assert_equals:
 <div data-offset-x="325" class="item first">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 325 but got 299
+offsetLeft expected 325 but got 308
 FAIL .item 4 assert_equals:
 <div data-offset-x="234" class="item last">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 234 but got 232
+offsetLeft expected 234 but got 236
 FAIL .item 5 assert_equals:
 <div data-offset-x="131" class="item first">
       <span></span><br><span></span>
     </div>
-offsetLeft expected 131 but got 107
+offsetLeft expected 131 but got 111
 PASS .item 6
 FAIL .item 7 assert_equals:
 <div data-offset-x="524" class="item small first"></div>
 offsetLeft expected 524 but got 547
 FAIL .item 8 assert_equals:
 <div data-offset-x="393" class="item small last"></div>
-offsetLeft expected 393 but got 417
+offsetLeft expected 393 but got 426
 FAIL .item 9 assert_equals:
 <div data-offset-x="335" class="item small first"></div>
-offsetLeft expected 335 but got 344
+offsetLeft expected 335 but got 353
 FAIL .item 10 assert_equals:
 <div data-offset-x="199" class="item small last"></div>
-offsetLeft expected 199 but got 220
+offsetLeft expected 199 but got 224
 FAIL .item 11 assert_equals:
 <div data-offset-x="141" class="item small first"></div>
-offsetLeft expected 141 but got 147
+offsetLeft expected 141 but got 151
 FAIL .item 12 assert_equals:
 <div data-offset-x="5" class="item small last"></div>
 offsetLeft expected 5 but got 20

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt
@@ -1,0 +1,10 @@
+X
+X
+
+FAIL .first-baseline 1 assert_equals:
+<div data-offset-y="31" class="first-baseline">X</div>
+offsetTop expected 31 but got 16
+FAIL .first-baseline 2 assert_equals:
+<div data-offset-y="31" class="first-baseline">X</div>
+offsetTop expected 31 but got 16
+


### PR DESCRIPTION
#### d935079e09c41c82bd1e9f3b5cd4f7d38bda6972
<pre>
[css-grid] Start considering subgrid&apos;s margin, border, and padding for align-self baseline items.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262336">https://bugs.webkit.org/show_bug.cgi?id=262336</a>
rdar://problem/116206243

Reviewed by Matt Woodrow.

For baseline alignment we currently do not consider the extra layer of
margin imposed by a subgrid&apos;s margin, border, and padding on a subgrid
item. For the purposes of baseline alignment this extra layer can
influence the ascent of a subgrid item.

This patch is a first step in towards considering these values for the
purposes of baseline alignment. We start with the most simple case where
we have a non-orthogonal and one level deep subgrid. We will want to
add additional patches to consider the scenarios where subgrids start
nesting and possibly even switch writing modes.

We can compute this &quot;subgrid offset,&quot; when we compute the ascent value
for a grid item by checking to see if its parent is a subgrid in
ascentForChild. As a result, this means that the ascent value for a
subgrid item will always be relative to parent (non-subgrid) grid.

We will bail out of this computation and ultimately fall back to the old
behavior in any of the following conditions:
- The subgrid is orthogonal to its parent
- The baseline axis is the row axis (e.g. justify-self: baseline)
- The alignment is last baseline alignment

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt: Added.
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::ascentForChild const):

Canonical link: <a href="https://commits.webkit.org/268804@main">https://commits.webkit.org/268804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/919a83cbd214095039a73483d2a1b79eb96976c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20580 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23341 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24983 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22924 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19469 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16547 "9 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4971 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->