### PR TITLE
[scroll-anchoring] Contract owning scroller rect for scroll padding

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-affects-anchoring-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-affects-anchoring-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL scroll anchoring accounts for scroll-padding assert_equals: Shouldn't anchor to #changer, since it's covered by scroll-padding expected 150 but got 50
+PASS scroll anchoring accounts for scroll-padding
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -169,6 +169,15 @@ CandidateExaminationResult ScrollAnchoringController::examineCandidate(Element& 
     auto containingRect = boundingRectForScrollableArea(m_owningScrollableArea);
     auto* document = frameView().frame().document();
 
+    if (auto* element = elementForScrollableArea(m_owningScrollableArea)) {
+        if (auto* box = element->renderBox()) {
+            LayoutRect paddedLayerBounds(containingRect);
+            paddedLayerBounds.contract(box->scrollPaddingForViewportRect(paddedLayerBounds));
+            LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::examineCandidate() contracted rect: "<< IntRect(paddedLayerBounds));
+            containingRect = IntRect(paddedLayerBounds);
+        }
+    }
+
     if (auto renderer = element.renderer()) {
         // TODO: we need to think about position: absolute
         // TODO: figure out how to get scrollable area for renderer to check if it is maintaining scroll anchor


### PR DESCRIPTION
#### fd9841045cff01fad55cb6e8edd188eb595e14ea
<pre>
[scroll-anchoring] Contract owning scroller rect for scroll padding
<a href="https://bugs.webkit.org/show_bug.cgi?id=262342">https://bugs.webkit.org/show_bug.cgi?id=262342</a>
<a href="https://rdar.apple.com/116209834">rdar://116209834</a>

Reviewed by Simon Fraser.

Contract owning scroller rect for scroll padding.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/scroll-padding-affects-anchoring-expected.txt:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::examineCandidate):

Canonical link: <a href="https://commits.webkit.org/270483@main">https://commits.webkit.org/270483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cc9f0caefd125461782ef09febe7c8f0854eb54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23582 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28264 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29095 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26936 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2748 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1000 "An unexpected error occured. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4133 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6147 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->