### PR TITLE
[WK2] Extension targets' SUPPORTED_PLATFORMS setting uses quotes; Xcode does not parse it as a string list

### DIFF
--- a/Source/WebKit/Configurations/BaseExtension.xcconfig
+++ b/Source/WebKit/Configurations/BaseExtension.xcconfig
@@ -33,8 +33,8 @@ SWIFT_VERSION = 5.0;
 SWIFT_OPTIMIZATION_LEVEL = -O;
 SWIFT_OPTIMIZATION_LEVEL[config=Debug] = -Onone;
 PRODUCT_NAME = $(TARGET_NAME);
-SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
+SUPPORTED_PLATFORMS = appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator;
 SUPPORTS_MACCATALYST = NO;
 SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-TARGETED_DEVICE_FAMILY = "1,2";
+TARGETED_DEVICE_FAMILY = 1,2;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = Shared/AuxiliaryProcessExtensions/*


### PR DESCRIPTION
#### b0eaecf6d9e13180ae2b627c84b0a5a44427c21c
<pre>
[WK2] Extension targets&apos; SUPPORTED_PLATFORMS setting uses quotes; Xcode does not parse it as a string list
<a href="https://bugs.webkit.org/show_bug.cgi?id=262348">https://bugs.webkit.org/show_bug.cgi?id=262348</a>
rdar://116210374

Unreviewed build fix.

It&apos;s leading to issues like:

    warning: Did not find any platform for SUPPORTED_PLATFORMS &apos;appletvos appletvsimulator iphoneos iphonesimulator macosx watchos

and, in IDE builds (where we aren&apos;t using Make to set SDKROOT), appears
to be causing the appex targets to build against the macOS SDK.

Also fix quoting around TARGETED_DEVICE_FAMILY, which is emitting issues
like:

    warning: unexpected TARGETED_DEVICE_FAMILY item: `&quot;1`
    warning: unexpected TARGETED_DEVICE_FAMILY item: `2&quot;`

* Source/WebKit/Configurations/BaseExtension.xcconfig:

Canonical link: <a href="https://commits.webkit.org/268624@main">https://commits.webkit.org/268624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88ed2c08c729bd00c5f6ea4c32961dc59b612f72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18854 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20801 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22954 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22598 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18327 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4846 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->