### PR TITLE
AX: aria-description/ariaDescription IDL harness tests failing

### DIFF
--- a/LayoutTests/accessibility/ARIA-reflection-expected.txt
+++ b/LayoutTests/accessibility/ARIA-reflection-expected.txt
@@ -88,6 +88,13 @@ PASS element.getAttribute(currentAttribute) is ""
 element.setAttribute("aria-describedby", otherData);
 PASS element[currentProperty] is otherDataProperty
 
+Test ariaDescription < - > aria-description
+PASS element[currentProperty] is null
+PASS element.getAttribute(currentAttribute) is null
+PASS element.getAttribute(currentAttribute) is dataAttribute
+element.setAttribute("aria-description", otherData);
+PASS element[currentProperty] is otherDataProperty
+
 Test ariaDetailsElements < - > aria-details
 PASS element[currentProperty] is null
 PASS element.getAttribute(currentAttribute) is null
@@ -334,7 +341,7 @@ element.setAttribute("aria-valuetext", otherData);
 PASS element[currentProperty] is otherDataProperty
 
 
-PASS count is 46
+PASS count is 47
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/ARIA-reflection.html
+++ b/LayoutTests/accessibility/ARIA-reflection.html
@@ -129,7 +129,7 @@
         }
 
         debug("\n");
-        shouldBe("count", "46");
+        shouldBe("count", "47");
 
     } else {
         testFailed("Could not load accessibility controller");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-attribute-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-attribute-reflection-expected.txt
@@ -9,7 +9,7 @@ PASS aria-colcount attribute reflects.
 PASS aria-colindex attribute reflects.
 PASS aria-colspan attribute reflects.
 PASS aria-current attribute reflects.
-FAIL aria-description attribute reflects. assert_equals: expected (string) "cold as ice" but got (undefined) undefined
+PASS aria-description attribute reflects.
 PASS aria-disabled attribute reflects.
 PASS aria-expanded attribute reflects.
 PASS aria-haspopup attribute reflects.

--- a/LayoutTests/imported/w3c/web-platform-tests/wai-aria/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wai-aria/idlharness.window-expected.txt
@@ -16,7 +16,7 @@ PASS Element interface: attribute ariaColIndex
 FAIL Element interface: attribute ariaColIndexText assert_true: The prototype object must have a property "ariaColIndexText" expected true got false
 PASS Element interface: attribute ariaColSpan
 PASS Element interface: attribute ariaCurrent
-FAIL Element interface: attribute ariaDescription assert_true: The prototype object must have a property "ariaDescription" expected true got false
+PASS Element interface: attribute ariaDescription
 PASS Element interface: attribute ariaDisabled
 PASS Element interface: attribute ariaExpanded
 PASS Element interface: attribute ariaHasPopup
@@ -57,7 +57,7 @@ FAIL Element interface: element must inherit property "ariaColIndex" with the pr
 FAIL Element interface: element must inherit property "ariaColIndexText" with the proper type assert_inherits: property "ariaColIndexText" not found in prototype chain
 FAIL Element interface: element must inherit property "ariaColSpan" with the proper type assert_equals: expected "string" but got "object"
 FAIL Element interface: element must inherit property "ariaCurrent" with the proper type assert_equals: expected "string" but got "object"
-FAIL Element interface: element must inherit property "ariaDescription" with the proper type assert_inherits: property "ariaDescription" not found in prototype chain
+FAIL Element interface: element must inherit property "ariaDescription" with the proper type assert_equals: expected "string" but got "object"
 FAIL Element interface: element must inherit property "ariaDisabled" with the proper type assert_equals: expected "string" but got "object"
 FAIL Element interface: element must inherit property "ariaExpanded" with the proper type assert_equals: expected "string" but got "object"
 FAIL Element interface: element must inherit property "ariaHasPopup" with the proper type assert_equals: expected "string" but got "object"

--- a/Source/WebCore/accessibility/AriaAttributes.idl
+++ b/Source/WebCore/accessibility/AriaAttributes.idl
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/aom/spec/aria-reflection.html#AriaAttributes
+// https://w3c.github.io/aria/#idl-interface
 interface mixin AriaAttributes {
     [CEReactions=Needed, Reflect=aria_activedescendant, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute Element? ariaActiveDescendantElement;
     [CEReactions=Needed, Reflect=aria_atomic]           attribute DOMString? ariaAtomic;
@@ -36,6 +36,7 @@ interface mixin AriaAttributes {
     [CEReactions=Needed, CustomGetter, Reflect=aria_controls, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaControlsElements;
     [CEReactions=Needed, Reflect=aria_current]          attribute DOMString? ariaCurrent;
     [CEReactions=Needed, CustomGetter, Reflect=aria_describedby, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaDescribedByElements;
+    [CEReactions=Needed, Reflect=aria_description]      attribute DOMString? ariaDescription;
     [CEReactions=Needed, CustomGetter, Reflect=aria_details, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaDetailsElements;
     [CEReactions=Needed, Reflect=aria_disabled]         attribute DOMString? ariaDisabled;
     [CEReactions=Needed, CustomGetter, Reflect=aria_errormessage, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaErrorMessageElements;


### PR DESCRIPTION
#### 127b493dc96160d84b6fc59b22eb14468129f93a
<pre>
AX: aria-description/ariaDescription IDL harness tests failing

<a href="https://bugs.webkit.org/show_bug.cgi?id=257141">https://bugs.webkit.org/show_bug.cgi?id=257141</a>
rdar://problem/109668891

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Blink / Chromium, Gecko / Firefox and Web-Specification [1].

[1] <a href="https://w3c.github.io/aria/#idl-interface">https://w3c.github.io/aria/#idl-interface</a>

This PR is to add missing &apos;ariaDescription&apos; in IDL file to fix failing tests.

* Source/WebCore/accessibility/AriaAttributes.idl:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/aria-attribute-reflection-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/wai-aria/idlharness.window-expected.txt: Rebaselined
* LayoutTests/accessibility/ARIA-reflection.html: Rebaselined
* LayoutTests/accessibility/ARIA-reflection-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/268657@main">https://commits.webkit.org/268657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4d0aa487e3a2792f737e1e8680c07febdec68ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22164 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20865 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23014 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24674 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22648 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18260 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4879 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->