### PR TITLE
WebGPU should be exposed in DedicatedWorkers

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -23,7 +23,7 @@
         {
             "id": "ContextType",
             "type": "string",
-            "enum": ["canvas-2d", "offscreen-canvas-2d", "bitmaprenderer", "webgl", "webgl2"],
+            "enum": ["canvas-2d", "offscreen-canvas-2d", "bitmaprenderer", "webgl", "webgl2", "webgpu"],
             "description": "The type of rendering context backing the canvas element."
         },
         {

--- a/Source/WebCore/Modules/WebGPU/GPU.idl
+++ b/Source/WebCore/Modules/WebGPU/GPU.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPU {

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUAdapter {

--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUAdapterInfo {

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroup.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroup.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUBindGroup {

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUBindGroupLayout {

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
@@ -32,7 +32,7 @@ typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUBuffer {

--- a/Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUBufferUsage {

--- a/Source/WebCore/Modules/WebGPU/GPUColorWrite.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUColorWrite.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUColorWrite {

--- a/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUCommandBuffer {

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
@@ -33,7 +33,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUCommandEncoder {

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     Serializable,
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     Serializable,
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUComputePassEncoder {

--- a/Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUComputePipeline {

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.idl
@@ -28,7 +28,7 @@
 [
     EnabledBySetting=WebGPUEnabled,
     ActiveDOMObject,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUDevice : EventTarget {

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUDeviceLostInfo {

--- a/Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUExternalTexture {

--- a/Source/WebCore/Modules/WebGPU/GPUInternalError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUInternalError.idl
@@ -25,7 +25,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUInternalError {

--- a/Source/WebCore/Modules/WebGPU/GPUMapMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUMapMode.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUMapMode {

--- a/Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUOutOfMemoryError {

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUPipelineLayout {

--- a/Source/WebCore/Modules/WebGPU/GPUQuerySet.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQuerySet.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUQuerySet {

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.idl
@@ -33,7 +33,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUQueue {

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundle.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundle.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPURenderBundle {

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPURenderBundleEncoder {

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl
@@ -33,7 +33,7 @@ typedef (sequence<double> or GPUColorDict) GPUColor;
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPURenderPassEncoder {

--- a/Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPURenderPipeline {

--- a/Source/WebCore/Modules/WebGPU/GPUSampler.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSampler.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUSampler {

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModule.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModule.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUShaderModule {

--- a/Source/WebCore/Modules/WebGPU/GPUShaderStage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderStage.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUShaderStage {

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUSupportedFeatures {

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUSupportedLimits {

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUTexture {

--- a/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUTextureUsage {

--- a/Source/WebCore/Modules/WebGPU/GPUTextureView.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureView.idl
@@ -27,7 +27,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUTextureView {

--- a/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl
@@ -31,7 +31,7 @@ typedef (GPUOutOfMemoryError or GPUValidationError or GPUInternalError) GPUError
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUUncapturedErrorEvent : Event {

--- a/Source/WebCore/Modules/WebGPU/GPUValidationError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUValidationError.idl
@@ -25,7 +25,7 @@
 
 [
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext
 ]
 interface GPUValidationError {

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -53,6 +53,8 @@ namespace WebCore {
 
 class CanvasRenderingContext;
 class DeferredPromise;
+class GPU;
+class GPUCanvasContext;
 class HTMLCanvasElement;
 class ImageBitmap;
 class ImageBitmapRenderingContext;
@@ -67,6 +69,7 @@ using OffscreenRenderingContext = std::variant<
     RefPtr<WebGLRenderingContext>,
     RefPtr<WebGL2RenderingContext>,
 #endif
+    RefPtr<GPUCanvasContext>,
     RefPtr<ImageBitmapRenderingContext>,
     RefPtr<OffscreenCanvasRenderingContext2D>
 >;
@@ -111,7 +114,8 @@ public:
         _2d,
         Webgl,
         Webgl2,
-        Bitmaprenderer
+        Bitmaprenderer,
+        Webgpu
     };
 
     static bool enabledForContext(ScriptExecutionContext&);
@@ -175,6 +179,8 @@ private:
 #if ENABLE(WEBGL)
     void createContextWebGL(RenderingContextType, WebGLContextAttributes&& = { });
 #endif
+
+    GPUCanvasContext* createContextWebGPU(RenderingContextType, GPU*);
 
     void createImageBuffer() const final;
     std::unique_ptr<SerializedImageBuffer> takeImageBuffer() const;

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -28,6 +28,7 @@ typedef (
     WebGLRenderingContext or
     WebGL2RenderingContext or
 #endif
+    GPUCanvasContext or
     ImageBitmapRenderingContext or
     OffscreenCanvasRenderingContext2D) OffscreenRenderingContext;
 
@@ -42,7 +43,8 @@ enum OffscreenRenderingContextType
    "2d",
    "webgl",
    "webgl2",
-   "bitmaprenderer"
+   "bitmaprenderer",
+   "webgpu"
 };
 
 [

--- a/Source/WebCore/html/canvas/GPUCanvasContext.idl
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.idl
@@ -28,7 +28,7 @@
 [
     ActiveDOMObject,
     EnabledBySetting=WebGPUEnabled,
-    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    Exposed=(Window,DedicatedWorker),
     SecureContext,
     SkipVTableValidation,
 ]

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -65,9 +65,8 @@ public:
     PixelFormat pixelFormat() const override;
     void reshape(int width, int height) override;
 
-    // FIXME: implement these to allow for painting
-    void prepareForDisplayWithPaint() override { }
-    void paintRenderingResultsToCanvas() override { }
+    void prepareForDisplayWithPaint() override;
+    void paintRenderingResultsToCanvas() override;
     // GPUCanvasContext methods:
     CanvasType canvas() override;
     void configure(GPUCanvasConfiguration&&) override;
@@ -89,6 +88,8 @@ private:
     {
         return static_cast<bool>(m_configuration);
     }
+
+    CanvasType htmlOrOffscreenCanvas() const;
 
     struct Configuration {
         Ref<GPUDevice> device;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -132,13 +132,24 @@ static int getCanvasHeight(const GPUCanvasContext::CanvasType& canvas)
     );
 }
 
+GPUCanvasContextCocoa::CanvasType GPUCanvasContextCocoa::htmlOrOffscreenCanvas() const
+{
+    if (auto* c = htmlCanvas())
+        return c;
+
+    auto& base = canvasBase();
+    RELEASE_ASSERT(is<OffscreenCanvas>(base));
+
+    return &downcast<OffscreenCanvas>(base);
+}
+
 GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, GPU& gpu)
     : GPUCanvasContext(canvas)
     , m_layerContentsDisplayDelegate(GPUDisplayBufferDisplayDelegate::create())
     , m_compositorIntegration(gpu.createCompositorIntegration())
     , m_presentationContext(gpu.createPresentationContext(presentationContextDescriptor(m_compositorIntegration)))
-    , m_width(getCanvasWidth(htmlCanvas()))
-    , m_height(getCanvasHeight(htmlCanvas()))
+    , m_width(getCanvasWidth(htmlOrOffscreenCanvas()))
+    , m_height(getCanvasHeight(htmlOrOffscreenCanvas()))
 {
 }
 
@@ -165,9 +176,20 @@ void GPUCanvasContextCocoa::reshape(int width, int height)
     }
 }
 
+void GPUCanvasContextCocoa::prepareForDisplayWithPaint()
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=233622 - Support offscreen canvas with WebGPU
+    prepareForDisplay();
+}
+
+void GPUCanvasContextCocoa::paintRenderingResultsToCanvas()
+{
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=233622 - Support offscreen canvas with WebGPU
+}
+
 GPUCanvasContext::CanvasType GPUCanvasContextCocoa::canvas()
 {
-    return htmlCanvas();
+    return htmlOrOffscreenCanvas();
 }
 
 void GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& configuration)
@@ -259,26 +281,32 @@ void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
 
     bool canvasIsDirty = false;
 
-    if (auto* canvas = htmlCanvas()) {
-        auto* renderBox = canvas->renderBox();
+    auto canvas = htmlOrOffscreenCanvas();
+    CanvasBase *canvasBase = nullptr;
+    WTF::switchOn(canvas, [&](RefPtr<HTMLCanvasElement>& htmlCanvas) {
+        auto* renderBox = htmlCanvas->renderBox();
+        canvasBase = htmlCanvas.get();
         if (isAccelerated() && renderBox && renderBox->hasAcceleratedCompositing()) {
             canvasIsDirty = true;
-            canvas->clearCopiedImage();
+            htmlCanvas->clearCopiedImage();
             renderBox->contentChanged(CanvasChanged);
         }
-    }
+    }, [&](RefPtr<OffscreenCanvas>& offscreenCanvas) {
+        UNUSED_PARAM(offscreenCanvas);
+        canvasBase = offscreenCanvas.get();
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=233622 - [WebGPU] Hook it up to WorkerNavigator
+    });
 
     if (!canvasIsDirty)
-        canvasBase().didDraw({ });
+        this->canvasBase().didDraw({ });
 
     if (!isAccelerated())
         return;
 
-    auto* canvas = htmlCanvas();
-    if (!canvas)
+    if (!canvasBase)
         return;
 
-    canvas->notifyObserversCanvasChanged({ });
+    canvasBase->notifyObserversCanvasChanged({ });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -39,6 +39,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "FloatPoint.h"
+#include "GPUCanvasContext.h"
 #include "Gradient.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
@@ -892,6 +893,9 @@ Ref<Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(bool capture
         if (is<WebGL2RenderingContext>(m_context))
             return Protocol::Canvas::ContextType::WebGL2;
 #endif
+        if (is<GPUCanvasContext>(m_context))
+            return Protocol::Canvas::ContextType::WebGPU;
+
         ASSERT_NOT_REACHED();
         return Protocol::Canvas::ContextType::Canvas2D;
     }();

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -565,11 +565,12 @@ RefPtr<GraphicsContextGL> Chrome::createGraphicsContextGL(const GraphicsContextG
     return m_client->createGraphicsContextGL(attributes);
 }
 #endif
-
+#if HAVE(WEBGPU_IMPLEMENTATION)
 RefPtr<WebGPU::GPU> Chrome::createGPUForWebGPU() const
 {
     return m_client->createGPUForWebGPU();
 }
+#endif
 
 RefPtr<ShapeDetection::BarcodeDetector> Chrome::createBarcodeDetector(const ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions) const
 {

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -114,9 +114,9 @@ public:
 #if ENABLE(WEBGL)
     RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const override;
 #endif
-
-    RefPtr<WebGPU::GPU> createGPUForWebGPU() const;
-
+#if HAVE(WEBGPU_IMPLEMENTATION)
+    RefPtr<WebGPU::GPU> createGPUForWebGPU() const override;
+#endif
     RefPtr<ShapeDetection::BarcodeDetector> createBarcodeDetector(const ShapeDetection::BarcodeDetectorOptions&) const;
     void getBarcodeDetectorSupportedFormats(CompletionHandler<void(Vector<ShapeDetection::BarcodeFormat>&&)>&&) const;
     RefPtr<ShapeDetection::FaceDetector> createFaceDetector(const ShapeDetection::FaceDetectorOptions&) const;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -374,9 +374,9 @@ public:
 #if ENABLE(WEBGL)
     WEBCORE_EXPORT virtual RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const;
 #endif
-
+#if HAVE(WEBGPU_IMPLEMENTATION)
     virtual RefPtr<WebGPU::GPU> createGPUForWebGPU() const { return nullptr; }
-
+#endif
     virtual RefPtr<ShapeDetection::BarcodeDetector> createBarcodeDetector(const ShapeDetection::BarcodeDetectorOptions&) const { return nullptr; }
     virtual void getBarcodeDetectorSupportedFormats(CompletionHandler<void(Vector<ShapeDetection::BarcodeFormat>&&)>&& completionHandler) const { completionHandler({ }); }
     virtual RefPtr<ShapeDetection::FaceDetector> createFaceDetector(const ShapeDetection::FaceDetectorOptions&) const { return nullptr; }

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -367,6 +367,7 @@ bool Navigator::standalone() const
 
 GPU* Navigator::gpu()
 {
+#if HAVE(WEBGPU_IMPLEMENTATION)
     if (!m_gpuForWebGPU) {
         auto* frame = this->frame();
         if (!frame)
@@ -382,6 +383,7 @@ GPU* Navigator::gpu()
 
         m_gpuForWebGPU = GPU::create(*gpu);
     }
+#endif
 
     return m_gpuForWebGPU.get();
 }

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+class GPU;
+
 class WorkerNavigator final : public NavigatorBase, public Supplementable<WorkerNavigator> {
 public:
     static Ref<WorkerNavigator> create(ScriptExecutionContext& context, const String& userAgent, bool isOnline) { return adoptRef(*new WorkerNavigator(context, userAgent, isOnline)); }
@@ -52,6 +54,9 @@ private:
 
     String m_userAgent;
     bool m_isOnline;
+#if HAVE(WEBGPU_IMPLEMENTATION)
+    RefPtr<GPU> m_gpuForWebGPU;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/GraphicsClient.h
+++ b/Source/WebCore/platform/GraphicsClient.h
@@ -41,6 +41,10 @@ enum class PixelFormat : uint8_t;
 enum class RenderingMode : bool;
 enum class RenderingPurpose : uint8_t;
 
+namespace WebGPU {
+class GPU;
+}
+
 class GraphicsClient {
     WTF_MAKE_NONCOPYABLE(GraphicsClient); WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -51,6 +55,9 @@ public:
 
 #if ENABLE(WEBGL)
     virtual RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const = 0;
+#endif
+#if HAVE(WEBGPU_IMPLEMENTATION)
+    virtual RefPtr<WebCore::WebGPU::GPU> createGPUForWebGPU() const = 0;
 #endif
 
 private:

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -103,7 +103,6 @@ template: enum class WebKit::StorageNamespaceIdentifierType
 template: enum class WebKit::TrackPrivateRemoteIdentifierType
 template: enum class WebKit::WCLayerTreeHostIdentifierType
 template: enum class WebKit::WebExtensionControllerIdentifierType
-template: enum class WebKit::WebGPUIdentifierType
 template: enum class WebKit::XRDeviceIdentifierType
 template: struct WebCore::AttributedStringTextListIDType
 template: struct WebCore::AttributedStringTextTableIDType
@@ -181,6 +180,7 @@ template: enum class WebKit::RemoteVideoFrameIdentifierType
 template: enum class WebKit::VideoDecoderIdentifierType
 template: enum class WebKit::VideoEncoderIdentifierType
 template: enum class WebKit::WCContentBufferIdentifierType
+template: enum class WebKit::WebGPUIdentifierType
 template: struct IPC::AsyncReplyIDType
 template: struct WebCore::WebSocketFrame
 template: struct WebKit::ConnectionAsyncReplyHandler

--- a/Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h
@@ -32,7 +32,7 @@
 namespace WebKit {
 
 enum class WebGPUIdentifierType { };
-using WebGPUIdentifier = ObjectIdentifier<WebGPUIdentifierType>;
+using WebGPUIdentifier = AtomicObjectIdentifier<WebGPUIdentifierType>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -978,18 +978,18 @@ RefPtr<GraphicsContextGL> WebChromeClient::createGraphicsContextGL(const Graphic
 }
 #endif
 
+#if HAVE(WEBGPU_IMPLEMENTATION)
 RefPtr<WebCore::WebGPU::GPU> WebChromeClient::createGPUForWebGPU() const
 {
 #if ENABLE(GPU_PROCESS)
     return RemoteGPUProxy::create(WebProcess::singleton().ensureGPUProcessConnection(), WebGPU::DowncastConvertToBackingContext::create(), WebGPUIdentifier::generate(), protectedPage()->ensureRemoteRenderingBackendProxy().ensureBackendCreated());
-#elif HAVE(WEBGPU_IMPLEMENTATION)
+#else
     return WebCore::WebGPU::create([](WebCore::WebGPU::WorkItem&& workItem) {
         callOnMainRunLoop(WTFMove(workItem));
     });
-#else
-    return nullptr;
 #endif
 }
+#endif
 
 RefPtr<WebCore::ShapeDetection::BarcodeDetector> WebChromeClient::createBarcodeDetector(const WebCore::ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions) const
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -255,9 +255,9 @@ private:
 #if ENABLE(WEBGL)
     RefPtr<WebCore::GraphicsContextGL> createGraphicsContextGL(const WebCore::GraphicsContextGLAttributes&) const final;
 #endif
-
+#if HAVE(WEBGPU_IMPLEMENTATION)
     RefPtr<WebCore::WebGPU::GPU> createGPUForWebGPU() const final;
-
+#endif
     RefPtr<WebCore::ShapeDetection::BarcodeDetector> createBarcodeDetector(const WebCore::ShapeDetection::BarcodeDetectorOptions&) const final;
     void getBarcodeDetectorSupportedFormats(CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)>&&) const final;
     RefPtr<WebCore::ShapeDetection::FaceDetector> createFaceDetector(const WebCore::ShapeDetection::FaceDetectorOptions&) const final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -28,10 +28,16 @@
 #include "Connection.h"
 #include "RemoteRenderingBackendCreationParameters.h"
 #include "RemoteVideoFrameObjectHeapProxy.h"
+#include "WebGPUIdentifier.h"
 #include <WebCore/WorkerClient.h>
+
+namespace WebCore::WebGPU {
+class GPU;
+}
 
 namespace WebKit {
 
+class GPUProcessConnection;
 class WebPage;
 class RemoteRenderingBackendProxy;
 
@@ -50,7 +56,7 @@ public:
     // nested worker.
 #if ENABLE(GPU_PROCESS)
 #if ENABLE(VIDEO)
-    WebWorkerClient(IPC::Connection&, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&, Ref<RemoteVideoFrameObjectHeapProxy>&&);
+    WebWorkerClient(GPUProcessConnection&, IPC::Connection&, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&, Ref<RemoteVideoFrameObjectHeapProxy>&&);
 #else
     WebWorkerClient(IPC::Connection&, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&);
 #endif
@@ -68,6 +74,10 @@ public:
     RefPtr<WebCore::GraphicsContextGL> createGraphicsContextGL(const WebCore::GraphicsContextGLAttributes&) const final;
 #endif
 
+#if HAVE(WEBGPU_IMPLEMENTATION)
+    RefPtr<WebCore::WebGPU::GPU> createGPUForWebGPU() const final;
+#endif
+
 private:
 #if ENABLE(GPU_PROCESS)
     RemoteRenderingBackendProxy& ensureRenderingBackend() const;
@@ -75,6 +85,7 @@ private:
 
     SerialFunctionDispatcher& m_dispatcher;
 #if ENABLE(GPU_PROCESS)
+    GPUProcessConnection& m_gpuProcessConnection;
     Ref<IPC::Connection> m_connection;
     mutable std::unique_ptr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
     RemoteRenderingBackendCreationParameters m_creationParameters;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -252,9 +252,9 @@ private:
 #if PLATFORM(MAC)
     void changeUniversalAccessZoomFocus(const WebCore::IntRect&, const WebCore::IntRect&) final;
 #endif
-
+#if HAVE(WEBGPU_IMPLEMENTATION)
     RefPtr<WebCore::WebGPU::GPU> createGPUForWebGPU() const final;
-
+#endif
     RefPtr<WebCore::ShapeDetection::BarcodeDetector> createBarcodeDetector(const WebCore::ShapeDetection::BarcodeDetectorOptions&) const final;
     void getBarcodeDetectorSupportedFormats(CompletionHandler<void(Vector<WebCore::ShapeDetection::BarcodeFormat>&&)>&&) const final;
     RefPtr<WebCore::ShapeDetection::FaceDetector> createFaceDetector(const WebCore::ShapeDetection::FaceDetectorOptions&) const final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -1172,16 +1172,14 @@ void WebChromeClient::changeUniversalAccessZoomFocus(const WebCore::IntRect& vie
 }
 #endif
 
+#if HAVE(WEBGPU_IMPLEMENTATION)
 RefPtr<WebCore::WebGPU::GPU> WebChromeClient::createGPUForWebGPU() const
 {
-#if HAVE(WEBGPU_IMPLEMENTATION)
     return WebCore::WebGPU::create([](WebCore::WebGPU::WorkItem&& workItem) {
         callOnMainRunLoop(WTFMove(workItem));
     });
-#else
-    return nullptr;
-#endif
 }
+#endif
 
 RefPtr<WebCore::ShapeDetection::BarcodeDetector> WebChromeClient::createBarcodeDetector(const WebCore::ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions) const
 {


### PR DESCRIPTION
#### ff507241e7dd8c7bc6d01f11027c09e8e3f0dc1b
<pre>
WebGPU should be exposed in DedicatedWorkers
<a href="https://bugs.webkit.org/show_bug.cgi?id=232542">https://bugs.webkit.org/show_bug.cgi?id=232542</a>&gt;
&lt;radar://85108397&gt;

Reviewed by Tadeu Zagallo.

Allow WebGPU to render in a web worker.

This patch is mostly mechanical and doesn&apos;t implement copying
the buffer from OffscreenCavnas, so nothing is visible, but
GPU frame capture indicates the expected results are rendered.

* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/WebCore/Modules/WebGPU/GPU.idl:
* Source/WebCore/Modules/WebGPU/GPUAdapter.idl:
* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroup.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUBuffer.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl:
* Source/WebCore/Modules/WebGPU/GPUColorWrite.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl:
* Source/WebCore/Modules/WebGPU/GPUDevice.idl:
* Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl:
* Source/WebCore/Modules/WebGPU/GPUInternalError.idl:
* Source/WebCore/Modules/WebGPU/GPUMapMode.idl:
* Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUQuerySet.idl:
* Source/WebCore/Modules/WebGPU/GPUQueue.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundle.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl:
* Source/WebCore/Modules/WebGPU/GPUSampler.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderModule.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderStage.idl:
* Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl:
* Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl:
* Source/WebCore/Modules/WebGPU/GPUTexture.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureView.idl:
* Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl:
* Source/WebCore/Modules/WebGPU/GPUValidationError.idl:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::createContextWebGPU):
(WebCore::OffscreenCanvas::getContext):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/html/canvas/GPUCanvasContext.idl:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::htmlOrOffscreenCanvas const):
(WebCore::GPUCanvasContextCocoa::GPUCanvasContextCocoa):
(WebCore::GPUCanvasContextCocoa::prepareForDisplayWithPaint):
(WebCore::GPUCanvasContextCocoa::paintRenderingResultsToCanvas):
(WebCore::GPUCanvasContextCocoa::canvas):
(WebCore::GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::buildObjectForCanvas):
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::gpu):

* Source/WebCore/page/WorkerNavigator.h:
* Source/WebCore/platform/GraphicsClient.h:
* Source/WebKit/Shared/WebGPU/WebGPUIdentifier.h:
Changed to AtomicObjectIdentifier as workers will render off the main thread.

* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::WebWorkerClient):
(WebKit::WebWorkerClient::clone):
(WebKit::WebWorkerClient::createGraphicsContextGL const):
(WebKit::WebWorkerClient::createGPUForWebGPU const):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:

Canonical link: <a href="https://commits.webkit.org/268693@main">https://commits.webkit.org/268693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f0fbe1cf22797628d350884755d1732c51b1f7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18927 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20362 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23030 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24693 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17649 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22666 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19659 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16302 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23686 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18401 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5695 "Found 4 jsc stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.dfg-eager, stress/sampling-profiler-microtasks.js.no-llint, wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-eager") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4899 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22742 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24943 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19021 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5505 "Passed tests") | 
<!--EWS-Status-Bubble-End-->