### PR TITLE
[content-visibility] Improve performance of grid based perf tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-100-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-100-expected.txt
@@ -1,0 +1,3 @@
+
+PASS getComputedStyle works in hidden c-v subtree when grid is the container
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-100.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-100.html
@@ -1,0 +1,24 @@
+<!doctype HTML>
+<meta charset="utf8">
+<title>CSS Content Visibility: getComputedStyle works in hidden c-v subtree when grid is the container</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<meta name="assert" content="getComputedStyle works in hidden c-v subtree when grid is the container">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#container { display:grid; content-visibility: hidden }
+</style>
+
+<div id=container style="width:200px">
+<div id=target style="width:50%"></div>
+</div>
+
+<script>
+test(() => {
+  const computedStyle = getComputedStyle(target);
+  assert_equals(computedStyle.width, "100px");
+}, "getComputedStyle works in hidden c-v subtree when grid is the container");
+</script>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1696,6 +1696,9 @@ void GridTrackSizingAlgorithm::run()
     if (m_renderGrid->isSubgrid(m_direction) && copyUsedTrackSizesForSubgrid())
         return;
 
+    if (m_renderGrid->isSkippedContentRoot())
+        return;
+
     // Step 1.
     const std::optional<LayoutUnit> initialFreeSpace = freeSpace(m_direction);
     initializeTrackSizes();


### PR DESCRIPTION
#### 324b1bf4b75f0f8916f982084ef49cfb34a957fb
<pre>
[content-visibility] Improve performance of grid based perf tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=261825">https://bugs.webkit.org/show_bug.cgi?id=261825</a>

Reviewed by NOBODY (OOPS!).

Improve performance of grid based perf tests by skipping parts of the track sizing algorithm.
As an example, on my mbp grid-item-width-changes.html results change from 738ms to 16ms.

To verify that the optimization does not break getComputedStyle on grid items content-visibility-100.html is added.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-100-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-100.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::run):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/324b1bf4b75f0f8916f982084ef49cfb34a957fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/37003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33905 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14528 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40314 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38683 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35534 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->