### PR TITLE
GraphicsContextCG is instantiated redundantly to round rects

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -650,6 +650,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ca/cocoa/WebVideoContainerLayer.h
 
     platform/graphics/cg/CGContextStateSaver.h
+    platform/graphics/cg/CGUtilities.h
     platform/graphics/cg/ColorSpaceCG.h
     platform/graphics/cg/GradientRendererCG.h
     platform/graphics/cg/GraphicsContextCG.h

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -199,10 +199,6 @@ public:
 
     // Pixel Snapping
 
-    enum RoundingMode {
-        RoundAllSides,
-        RoundOriginAndDimensions
-    };
     WEBCORE_EXPORT static void adjustLineToPixelBoundaries(FloatPoint& p1, FloatPoint& p2, float strokeWidth, StrokeStyle);
 
     // Shapes

--- a/Source/WebCore/platform/graphics/cg/CGUtilities.h
+++ b/Source/WebCore/platform/graphics/cg/CGUtilities.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatRect.h"
+#include "GraphicsTypes.h"
+#include "IntRect.h"
+#include <CoreGraphics/CoreGraphics.h>
+#include <math.h>
+
+namespace WebCore {
+
+inline CGInterpolationQuality toCGInterpolationQuality(InterpolationQuality quality)
+{
+    switch (quality) {
+    case InterpolationQuality::Default:
+        return kCGInterpolationDefault;
+    case InterpolationQuality::DoNotInterpolate:
+        return kCGInterpolationNone;
+    case InterpolationQuality::Low:
+        return kCGInterpolationLow;
+    case InterpolationQuality::Medium:
+        return kCGInterpolationMedium;
+    case InterpolationQuality::High:
+        return kCGInterpolationHigh;
+    }
+    ASSERT_NOT_REACHED();
+    return kCGInterpolationDefault;
+}
+
+inline FloatRect cgRoundToDevicePixelsNonIdentity(CGAffineTransform deviceMatrix, FloatRect rect)
+{
+    // It is not enough just to round to pixels in device space. The rotation part of the
+    // affine transform matrix to device space can mess with this conversion if we have a
+    // rotating image like the hands of the world clock widget. We just need the scale, so
+    // we get the affine transform matrix and extract the scale.
+    auto deviceScaleX = hypot(deviceMatrix.a, deviceMatrix.b);
+    auto deviceScaleY = hypot(deviceMatrix.c, deviceMatrix.d);
+
+    CGPoint deviceOrigin = CGPointMake(rect.x() * deviceScaleX, rect.y() * deviceScaleY);
+    CGPoint deviceLowerRight = CGPointMake((rect.x() + rect.width()) * deviceScaleX,
+        (rect.y() + rect.height()) * deviceScaleY);
+
+    deviceOrigin.x = roundf(deviceOrigin.x);
+    deviceOrigin.y = roundf(deviceOrigin.y);
+    deviceLowerRight.x = roundf(deviceLowerRight.x);
+    deviceLowerRight.y = roundf(deviceLowerRight.y);
+
+    // Don't let the height or width round to 0 unless either was originally 0
+    if (deviceOrigin.y == deviceLowerRight.y && rect.height())
+        deviceLowerRight.y += 1;
+    if (deviceOrigin.x == deviceLowerRight.x && rect.width())
+        deviceLowerRight.x += 1;
+
+    FloatPoint roundedOrigin = FloatPoint(deviceOrigin.x / deviceScaleX, deviceOrigin.y / deviceScaleY);
+    FloatPoint roundedLowerRight = FloatPoint(deviceLowerRight.x / deviceScaleX, deviceLowerRight.y / deviceScaleY);
+    return FloatRect(roundedOrigin, roundedLowerRight - roundedOrigin);
+}
+
+inline FloatRect cgRoundToDevicePixels(CGAffineTransform deviceMatrix, FloatRect rect)
+{
+    if (CGAffineTransformIsIdentity(deviceMatrix))
+        return roundedIntRect(rect);
+    return cgRoundToDevicePixelsNonIdentity(deviceMatrix, rect);
+}
+
+inline IntRect cgImageRect(CGImageRef image)
+{
+    return { 0, 0, static_cast<int>(CGImageGetWidth(image)), static_cast<int>(CGImageGetHeight(image)) };
+}
+
+}

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -130,8 +130,7 @@ public:
 
     virtual bool canUseShadowBlur() const;
 
-    virtual std::optional<std::pair<float, float>> scaleForRoundingToDevicePixels() const;
-    FloatRect roundToDevicePixels(const FloatRect&, RoundingMode = RoundAllSides) const;
+    FloatRect roundToDevicePixels(const FloatRect&) const;
 
     // Returns the platform context for draws.
     CGContextRef contextForDraw();

--- a/Source/WebCore/platform/graphics/cg/PatternCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PatternCG.cpp
@@ -30,8 +30,8 @@
 #if USE(CG)
 
 #include "AffineTransform.h"
+#include "CGUtilities.h"
 #include "GraphicsContextCG.h"
-#include <CoreGraphics/CoreGraphics.h>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/MainThread.h>
 
@@ -42,9 +42,7 @@ static void patternCallback(void* info, CGContextRef context)
     CGImageRef platformImage = static_cast<CGImageRef>(info);
     if (!platformImage)
         return;
-
-    CGRect rect = GraphicsContextCG(context).roundToDevicePixels(
-        FloatRect(0, 0, CGImageGetWidth(platformImage), CGImageGetHeight(platformImage)));
+    auto rect = cgRoundToDevicePixels(CGContextGetUserSpaceToDeviceSpaceTransform(context), cgImageRect(platformImage));
     CGContextDrawImage(context, rect, platformImage);
 }
 

--- a/Source/WebCore/platform/ios/wak/WAKView.mm
+++ b/Source/WebCore/platform/ios/wak/WAKView.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "CGUtilities.h"
 #import "GraphicsContext.h"
 #import "WAKClipView.h"
 #import "WAKScrollView.h"
@@ -465,25 +466,6 @@ static void _WAKCopyWrapper(const void *value, void *context)
     ASSERT(context);
     CGContextRestoreGState(context);
     setGlobalFocusView(nil);
-}
-
-static CGInterpolationQuality toCGInterpolationQuality(WebCore::InterpolationQuality quality)
-{
-    switch (quality) {
-    case WebCore::InterpolationQuality::Default:
-        return kCGInterpolationDefault;
-    case WebCore::InterpolationQuality::DoNotInterpolate:
-        return kCGInterpolationNone;
-    case WebCore::InterpolationQuality::Low:
-        return kCGInterpolationLow;
-    case WebCore::InterpolationQuality::Medium:
-        return kCGInterpolationMedium;
-    case WebCore::InterpolationQuality::High:
-        return kCGInterpolationHigh;
-    default:
-        ASSERT_NOT_REACHED();
-        return kCGInterpolationLow;
-    }
 }
 
 + (void)_setInterpolationQuality:(int)quality


### PR DESCRIPTION
#### efab4b9bc302ea934c09eed6f7fff30a5dfddff5
<pre>
GraphicsContextCG is instantiated redundantly to round rects
<a href="https://bugs.webkit.org/show_bug.cgi?id=262364">https://bugs.webkit.org/show_bug.cgi?id=262364</a>
rdar://116233471

Reviewed by Tim Horton.

GraphicsContext construction does non-trivial work to ensure the context
state is constent. It shouldn&apos;t be called just to round rects.

Extract the rect rounding code to a freestanding function in
CGUtilities.h

Unduplicate interpolation quality enum conversion code to the file, too.

* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::drawPatternCallback):
(WebCore::GraphicsContextCG::roundToDevicePixels const):
(WebCore::cgInterpolationQuality): Deleted.
(WebCore::GraphicsContextCG::scaleForRoundingToDevicePixels const): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/cg/PatternCG.cpp:
(WebCore::patternCallback):
* Source/WebCore/platform/ios/wak/WAKView.mm:
(+[WAKView _setInterpolationQuality:]):
(toCGInterpolationQuality): Deleted.

Canonical link: <a href="https://commits.webkit.org/268841@main">https://commits.webkit.org/268841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53ef00525eebda9ece32e343027bddca430b028c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22738 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19429 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21432 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23592 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18916 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19083 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19098 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19680 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18921 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4996 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->