### PR TITLE
Revert page load performance regression

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -128,10 +128,7 @@ public:
 
     // Cause a rendering update to happen as soon as possible.
     virtual void triggerRenderingUpdate() = 0;
-    // Cause a rendering update to happen at the next suitable time,
-    // as determined by the drawing area.
     virtual bool scheduleRenderingUpdate() { return false; }
-
     virtual void renderingUpdateFramesPerSecondChanged() { }
 
     virtual void willStartRenderingUpdateDisplay();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -146,7 +146,7 @@ void RemoteLayerTreeDrawingArea::setRootCompositingLayer(WebCore::Frame& frame, 
             rootLayer.contentLayer = rootGraphicsLayer;
     }
     updateRootLayers();
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    triggerRenderingUpdate();
 }
 
 void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, const std::optional<VisibleContentRectUpdateInfo>& info, bool flushSynchronously, const WTF::MachSendRight&, CompletionHandler<void()>&& completionHandler)
@@ -174,7 +174,7 @@ void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, const s
         size = contentSize;
     }
 
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    triggerRenderingUpdate();
     completionHandler();
 }
 
@@ -228,7 +228,7 @@ void RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen(bool isFrozen)
 
     if (!m_isRenderingSuspended && m_hasDeferredRenderingUpdate) {
         m_hasDeferredRenderingUpdate = false;
-        scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+        startRenderingUpdateTimer();
     }
 }
 
@@ -238,7 +238,7 @@ void RemoteLayerTreeDrawingArea::forceRepaint()
         return;
 
     m_webPage->corePage()->forceRepaintAllFrames();
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    updateRendering();
 }
 
 void RemoteLayerTreeDrawingArea::acceleratedAnimationDidStart(WebCore::PlatformLayerIdentifier layerID, const String& key, MonotonicTime startTime)
@@ -277,23 +277,24 @@ void RemoteLayerTreeDrawingArea::setExposedContentRect(const FloatRect& exposedC
         return;
 
     frameView->setExposedContentRect(exposedContentRect);
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    triggerRenderingUpdate();
 }
 
 void RemoteLayerTreeDrawingArea::startRenderingUpdateTimer()
 {
-    RELEASE_ASSERT(m_state != State::WaitingForDisplayDidRefresh);
-    if (m_updateRenderingTimer.isActive()) {
-        RELEASE_ASSERT(m_state == State::WaitingForUpdateRenderingTimer);
+    if (m_updateRenderingTimer.isActive())
         return;
-    }
-    m_state = State::WaitingForUpdateRenderingTimer;
     m_updateRenderingTimer.startOneShot(0_s);
 }
 
 void RemoteLayerTreeDrawingArea::triggerRenderingUpdate()
 {
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    if (m_isRenderingSuspended) {
+        m_hasDeferredRenderingUpdate = true;
+        return;
+    }
+
+    startRenderingUpdateTimer();
 }
 
 void RemoteLayerTreeDrawingArea::setNextRenderingUpdateRequiresSynchronousImageDecoding()
@@ -303,24 +304,23 @@ void RemoteLayerTreeDrawingArea::setNextRenderingUpdateRequiresSynchronousImageD
 
 void RemoteLayerTreeDrawingArea::updateRendering()
 {
-    RELEASE_ASSERT(m_updateRenderingIsPending);
-    RELEASE_ASSERT(m_state == State::WaitingForUpdateRenderingTimer);
-    m_updateRenderingIsPending = false;
-
     if (m_isRenderingSuspended) {
         m_hasDeferredRenderingUpdate = true;
         return;
     }
 
+    if (m_waitingForBackingStoreSwap) {
+        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
+        return;
+    }
+
     // This function is not reentrant, e.g. a rAF callback may force repaint.
-    RELEASE_ASSERT(!m_inUpdateRendering);
+    if (m_inUpdateRendering)
+        return;
 
     Ref webPage = m_webPage.get();
     if (auto* page = webPage->corePage(); page && !page->rootFrames().computeSize())
         return;
-
-    RELEASE_ASSERT(!m_updateRenderingTimer.isActive());
-    m_state = State::WaitingForDisplayDidRefresh;
 
     scaleViewToFitDocumentIfNeeded();
 
@@ -377,6 +377,8 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         
         willCommitLayerTree(layerTransaction);
 
+        m_waitingForBackingStoreSwap = true;
+
         send(Messages::RemoteLayerTreeDrawingAreaProxy::WillCommitLayerTree(layerTransaction.transactionID()));
 
         RemoteScrollingCoordinatorTransaction scrollingTransaction;
@@ -427,7 +429,7 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
     // FIXME: This should use a counted replacement for setLayerTreeStateIsFrozen, but
     // the callers of that function are not strictly paired.
 
-    RELEASE_ASSERT(m_state == State::WaitingForDisplayDidRefresh);
+    auto wasWaitingForBackingStoreSwap = std::exchange(m_waitingForBackingStoreSwap, false);
 
     if (!WebProcess::singleton().shouldUseRemoteRenderingFor(WebCore::RenderingPurpose::DOM)) {
         // This empty transaction serves to trigger CA's garbage collection of IOSurfaces. See <rdar://problem/16110687>
@@ -435,10 +437,12 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
         [CATransaction commit];
     }
 
-    m_state = State::Idle;
-    RELEASE_ASSERT(!m_updateRenderingTimer.isActive());
-    if (m_updateRenderingIsPending && !m_scheduleRenderingTimer.isActive())
-        startRenderingUpdateTimer();
+    if (m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap || (m_isScheduled && !m_scheduleRenderingTimer.isActive())) {
+        triggerRenderingUpdate();
+        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = false;
+        m_isScheduled = false;
+    } else if (wasWaitingForBackingStoreSwap && m_updateRenderingTimer.isActive())
+        m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
     else
         send(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTreeNotTriggered(nextTransactionID()));
 }
@@ -500,7 +504,7 @@ void RemoteLayerTreeDrawingArea::activityStateDidChange(OptionSet<WebCore::Activ
     if (activityStateChangeID != ActivityStateChangeAsynchronous) {
         m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding();
         m_activityStateChangeID = activityStateChangeID;
-        scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+        startRenderingUpdateTimer();
     }
 
     // FIXME: We may want to match behavior in TiledCoreAnimationDrawingArea by firing these callbacks after the next compositing flush, rather than immediately after
@@ -515,7 +519,7 @@ void RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing(IPC::AsyncReplyID 
     m_remoteLayerTreeContext->setNextRenderingUpdateRequiresSynchronousImageDecoding();
 
     m_pendingCallbackIDs.append(callbackID);
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    triggerRenderingUpdate();
 }
 
 void RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea(DrawingArea& oldDrawingArea)
@@ -529,45 +533,32 @@ void RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea(DrawingArea& oldDraw
 
 void RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired()
 {
-    if (m_state == State::WaitingForScheduleRenderingTimer)
-        startRenderingUpdateTimer();
-}
-
-void RemoteLayerTreeDrawingArea::scheduleRenderingUpdate(ScheduleRenderingUrgency urgency)
-{
-    if (m_updateRenderingIsPending && urgency != ScheduleRenderingUrgency::AsSoonAsPossible)
-        return;
-
-    tracePoint(RemoteLayerTreeScheduleRenderingUpdate, m_state == State::WaitingForDisplayDidRefresh);
-
-    m_updateRenderingIsPending = true;
-
-    if (m_preferredFramesPerSecond) {
-        if (m_state == State::WaitingForDisplayDidRefresh)
-            return;
-
-        if (urgency == ScheduleRenderingUrgency::AsSoonAsPossible)
-            startRenderingUpdateTimer();
-        else {
-            m_state = State::WaitingForCallOnMainRunLoop;
-            callOnMainRunLoop([self = WeakPtr { this }] () {
-                // It's possible that an ASAP request got ahead of this
-                // and started a rendering update already and we're no
-                // longer waiting for this callback.
-                if (self && self->m_state == State::WaitingForCallOnMainRunLoop)
-                    self->startRenderingUpdateTimer();
-            });
-        }
-    } else if (m_state == State::Idle || m_state == State::WaitingForDisplayDidRefresh) {
-        ASSERT(!m_scheduleRenderingTimer.isActive());
-        m_state = State::WaitingForScheduleRenderingTimer;
-        m_scheduleRenderingTimer.startOneShot(m_preferredRenderingUpdateInterval);
-    }
+    triggerRenderingUpdate();
+    m_isScheduled = false;
 }
 
 bool RemoteLayerTreeDrawingArea::scheduleRenderingUpdate()
 {
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::NextSuitableTime);
+    if (m_isScheduled)
+        return true;
+
+    tracePoint(RemoteLayerTreeScheduleRenderingUpdate, m_waitingForBackingStoreSwap);
+
+    m_isScheduled = true;
+
+    if (m_preferredFramesPerSecond) {
+        if (displayDidRefreshIsPending())
+            return true;
+
+        callOnMainRunLoop([self = WeakPtr { this }] () {
+            if (self) {
+                self->m_isScheduled = false;
+                self->triggerRenderingUpdate();
+            }
+        });
+    } else
+        m_scheduleRenderingTimer.startOneShot(m_preferredRenderingUpdateInterval);
+
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -79,8 +79,8 @@ void RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage(double scale, Float
     auto unscrolledOrigin = origin;
     FloatRect unobscuredContentRect = frameView->unobscuredContentRectIncludingScrollbars();
     unscrolledOrigin.moveBy(-unobscuredContentRect.location());
-    m_webPage->scalePage(scale / m_webPage->viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
-    scheduleRenderingUpdate(ScheduleRenderingUrgency::AsSoonAsPossible);
+    webPage->scalePage(scale / webPage->viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
+    updateRendering();
 }
 
 void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::FloatPoint origin)


### PR DESCRIPTION
#### e4de01c167748e15abeaf9c7ba7f525432772df6
<pre>
Revert page load performance regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=261932">https://bugs.webkit.org/show_bug.cgi?id=261932</a>
rdar://problem/116217509

Unreviewed revert of 267274@main.

* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::scheduleRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefreshIsPending const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::setRootCompositingLayer):
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen):
(WebKit::RemoteLayerTreeDrawingArea::forceRepaint):
(WebKit::RemoteLayerTreeDrawingArea::setExposedContentRect):
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer):
(WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
(WebKit::RemoteLayerTreeDrawingArea::activityStateDidChange):
(WebKit::RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired):
(WebKit::RemoteLayerTreeDrawingArea::scheduleRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage):

Canonical link: <a href="https://commits.webkit.org/268654@main">https://commits.webkit.org/268654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6da2c4f21164f940de89dcde902f4d21cfb4b94c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20855 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23005 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17550 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24668 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22641 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16282 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18377 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4878 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->