### PR TITLE
Optimize LocalFrameView::incrementVisuallyNonEmptyCharacterCount()

### DIFF
--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -757,6 +757,8 @@ private:
     bool isVerticalDocument() const final;
     bool isFlippedDocument() const final;
 
+    void incrementVisuallyNonEmptyCharacterCountSlowCase(const String&);
+
     void reset();
     void init();
 
@@ -1081,6 +1083,14 @@ inline void LocalFrameView::incrementVisuallyNonEmptyPixelCount(const IntSize& s
         m_visuallyNonEmptyPixelCount = std::numeric_limits<decltype(m_visuallyNonEmptyPixelCount)>::max();
     else
         m_visuallyNonEmptyPixelCount = area;
+}
+
+inline void LocalFrameView::incrementVisuallyNonEmptyCharacterCount(const String& inlineText)
+{
+    if (m_visuallyNonEmptyCharacterCount > visualCharacterThreshold && m_hasReachedSignificantRenderedTextThreshold)
+        return;
+
+    incrementVisuallyNonEmptyCharacterCountSlowCase(inlineText);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const LocalFrameView&);


### PR DESCRIPTION
#### 38d1d72e3b8a4123450e4f2c2a2966bf83a66c01
<pre>
Optimize LocalFrameView::incrementVisuallyNonEmptyCharacterCount()
<a href="https://bugs.webkit.org/show_bug.cgi?id=262368">https://bugs.webkit.org/show_bug.cgi?id=262368</a>

Reviewed by Ryosuke Niwa.

Optimize LocalFrameView::incrementVisuallyNonEmptyCharacterCount():
- Add inline fast path when we&apos;ve already reached the threshold.
- Templatize nonWhitespaceLength() to avoid repeated branching on
  is8Bit() inside String::operator[].

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::nonWhitespaceLength):
(WebCore::LocalFrameView::incrementVisuallyNonEmptyCharacterCountSlowCase):
(WebCore::LocalFrameView::incrementVisuallyNonEmptyCharacterCount): Deleted.
* Source/WebCore/page/LocalFrameView.h:
(WebCore::LocalFrameView::incrementVisuallyNonEmptyCharacterCount):

Canonical link: <a href="https://commits.webkit.org/268659@main">https://commits.webkit.org/268659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd0c9f8e12be1d6e8ec9ab407f6b2d8c5dbeedd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20870 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23019 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24679 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22653 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16292 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18390 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4883 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->