### PR TITLE
[webkitpy] Update twisted and pyopenssl autoinstalled versions (fix issues with python-3.11 and WPE ARM32 perf bots)

### DIFF
--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -30,9 +30,9 @@ AutoInstall.install(Package('constantly', Version(15, 1, 0), pypi_name='constant
 if sys.version_info >= (3, 0):
     AutoInstall.install(Package('hyperlink', Version(21, 0, 0), pypi_name='hyperlink'))
     AutoInstall.install(Package('incremental', Version(21, 3, 0), pypi_name='incremental'))
-    AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
+    AutoInstall.install(Package('twisted', Version(23, 8, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
 
-    AutoInstall.install(Package('pyOpenSSL', Version(20, 0, 0)))
+    AutoInstall.install(Package('pyOpenSSL', Version(23, 2, 0)))
     # There are no prebuilt binaries for arm-32 of 'bcrypt' and building it requires cargo/rust
     # Since this dep is not really needed for the current arm-32 bots we skip it instead of
     # adding the overhead of a cargo/rust toolchain into the yocto-based image the bots run.


### PR DESCRIPTION
#### 4ae17ef2311b9532fdcbe9549844b883801cff28
<pre>
[webkitpy] Update twisted and pyopenssl autoinstalled versions (fix issues with python-3.11 and WPE ARM32 perf bots)
<a href="https://bugs.webkit.org/show_bug.cgi?id=262369">https://bugs.webkit.org/show_bug.cgi?id=262369</a>

Reviewed by Philippe Normand.

Update the pyopensl and twisted versions to fix an issue that is happening on the WPE Perf ARM32 bots.
The issue is related to the new python version this bot use (python-3.11) and also related with the
fact that this bots have to actually build most of the python dependencies because there aren&apos;t much
pre-built pip packages for ARM32. See the linked bugzilla bug for more details about the issue.

* Tools/Scripts/webkitpy/autoinstalled/twisted.py:

Canonical link: <a href="https://commits.webkit.org/268723@main">https://commits.webkit.org/268723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5df5b60d1a311b488ebeb157b95b95a7a94d15c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18905 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20345 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23007 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20443 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24669 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22642 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16285 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18379 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4920 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22720 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->