### PR TITLE
[build.webkit.org] download-built-product step fails on uat instances

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -572,8 +572,7 @@ class DownloadBuiltProduct(shell.ShellCommandNewStyle):
         # Only try to download from S3 on the official deployment <https://webkit.org/b/230006>
         if CURRENT_HOSTNAME != BUILD_WEBKIT_HOSTNAME:
             self.build.addStepsAfterCurrentStep([DownloadBuiltProductFromMaster()])
-            self.finished(SKIPPED)
-            defer.returnValue(SUCCESS)
+            defer.returnValue(SKIPPED)
 
         rc = yield super().run()
         if rc == FAILURE:


### PR DESCRIPTION
#### a4c5c55d46c169e9e4aa886d5d3591bda93a28bf
<pre>
[build.webkit.org] download-built-product step fails on uat instances
<a href="https://bugs.webkit.org/show_bug.cgi?id=262371">https://bugs.webkit.org/show_bug.cgi?id=262371</a>

Reviewed by Ryan Haddad.

finished() was used in old-style steps. This step was changed to new-style step
in 264202@main.

* Tools/CISupport/build-webkit-org/steps.py:
(DownloadBuiltProduct.run):

Canonical link: <a href="https://commits.webkit.org/268652@main">https://commits.webkit.org/268652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c634e1a8aae09b9f17b811609f4e3cc1a16deb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20260 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/20693 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/21333 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22161 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18909 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/20492 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Skipping applying patch since patch_id isn't provided; Checked out pull request; bindings-tests (cancelled)") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/23950 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/20862 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20348 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20480 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/23950 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/21333 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23011 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/23950 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/21333 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24672 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/23950 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/21333 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22646 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19177 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/20862 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/20083 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18383 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/21333 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22724 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2498 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->