### PR TITLE
Add WKWebViewConfiguration to _WKWebExtensionControllerConfiguration.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h
@@ -29,6 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class WKWebViewConfiguration;
 @class _WKWebExtensionController;
 
 /*!
@@ -69,8 +70,11 @@ NS_SWIFT_NAME(_WKWebExtensionController.Configuration)
 /*! @abstract A Boolean value indicating if this context will write data to the the file system. */
 @property (nonatomic, readonly, getter=isPersistent) BOOL persistent;
 
-/*! @abstract A unique identifier used for persistent configuration storage, or `nil` when it is the default or not persistent. */
-@property (nonatomic, nullable, readonly) NSUUID *identifier;
+/*! @abstract The unique identifier used for persistent configuration storage, or `nil` when it is the default or not persistent. */
+@property (nonatomic, nullable, readonly, copy) NSUUID *identifier;
+
+/*! @abstract The web view configuration to be used as a basis for configuring web views in extension contexts. */
+@property (nonatomic, null_resettable, copy) WKWebViewConfiguration *webViewConfiguration;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
@@ -30,11 +30,14 @@
 #import "config.h"
 #import "_WKWebExtensionControllerConfigurationInternal.h"
 
+#import "APIPageConfiguration.h"
+#import "WKWebViewConfigurationPrivate.h"
 #import "WebExtensionControllerConfiguration.h"
 #import <WebCore/WebCoreObjCExtras.h>
 
 static NSString * const persistentCodingKey = @"persistent";
 static NSString * const identifierCodingKey = @"identifier";
+static NSString * const webViewConfigurationCodingKey = @"webViewConfiguration";
 
 @implementation _WKWebExtensionControllerConfiguration
 
@@ -70,6 +73,7 @@ static NSString * const identifierCodingKey = @"identifier";
 
     [coder encodeObject:self.identifier forKey:identifierCodingKey];
     [coder encodeBool:self.persistent forKey:persistentCodingKey];
+    [coder encodeObject:self.webViewConfiguration forKey:webViewConfigurationCodingKey];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder
@@ -89,6 +93,8 @@ static NSString * const identifierCodingKey = @"identifier";
         API::Object::constructInWrapper<WebKit::WebExtensionControllerConfiguration>(self, *uuid);
     else
         API::Object::constructInWrapper<WebKit::WebExtensionControllerConfiguration>(self, persistent ? IsPersistent::Yes : IsPersistent::No);
+
+    self.webViewConfiguration = [coder decodeObjectOfClass:WKWebViewConfiguration.class forKey:webViewConfigurationCodingKey];
 
     return self;
 }
@@ -133,6 +139,16 @@ static NSString * const identifierCodingKey = @"identifier";
 - (BOOL)isPersistent
 {
     return _webExtensionControllerConfiguration->storageIsPersistent();
+}
+
+- (WKWebViewConfiguration *)webViewConfiguration
+{
+    return _webExtensionControllerConfiguration->webViewConfiguration();
+}
+
+- (void)setWebViewConfiguration:(WKWebViewConfiguration *)configuration
+{
+    _webExtensionControllerConfiguration->setWebViewConfiguration(configuration);
 }
 
 #pragma mark WKObject protocol implementation
@@ -186,6 +202,15 @@ static NSString * const identifierCodingKey = @"identifier";
 - (BOOL)isPersistent
 {
     return NO;
+}
+
+- (WKWebViewConfiguration *)webViewConfiguration
+{
+    return nil;
+}
+
+- (void)setWebViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration
+{
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
@@ -163,7 +163,7 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  If not implemented, the default behavior is to pass the messages to the app extension handler within the extension's bundle,
  if the extension was loaded from an app extension bundle; otherwise, no action is performed if not implemented.
  */
-- (void)webExtensionController:(_WKWebExtensionController *)controller connectUsingMessagePort:(_WKWebExtensionMessagePort *)port forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError * _Nullable error))replyHandler NS_SWIFT_NAME(webExtensionController(_:connectUsingMessagePort:for:completionHandler:));
+- (void)webExtensionController:(_WKWebExtensionController *)controller connectUsingMessagePort:(_WKWebExtensionMessagePort *)port forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(webExtensionController(_:connectUsingMessagePort:for:completionHandler:));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h
@@ -78,9 +78,9 @@ NS_SWIFT_NAME(_WKWebExtension.MessagePort)
 /*!
  @abstract Sends a message to the connected web extension.
  @param message The message that needs to be sent, which must be JSON-serializable.
- @param completionHandler A block to be invoked after the message is sent, taking a boolean and an optional error object as parameters.
+ @param completionHandler An optional block to be invoked after the message is sent, taking a boolean and an optional error object as parameters.
  */
-- (void)sendMessage:(id)message completionHandler:(void (^)(BOOL success, NSError * _Nullable error))completionHandler;
+- (void)sendMessage:(id)message completionHandler:(void (^ _Nullable)(BOOL success, NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Disconnects the port, terminating all further messages.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
@@ -77,6 +77,9 @@ NSErrorDomain const _WKWebExtensionMessagePortErrorDomain = @"_WKWebExtensionMes
 {
     NSParameterAssert(message);
 
+    if (!completionHandler)
+        completionHandler = ^(BOOL, NSError *) { };
+
     _webExtensionMessagePort->sendMessage(message, [completionHandler = makeBlockPtr(completionHandler)] (WebKit::WebExtensionMessagePort::Error error) {
         if (error) {
             completionHandler(NO, toAPI(error.value()));

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
@@ -33,6 +33,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "SandboxUtilities.h"
+#import "WKWebViewConfiguration.h"
 #import <wtf/FileSystem.h>
 
 namespace WebKit {
@@ -60,6 +61,29 @@ String WebExtensionControllerConfiguration::createStorageDirectoryPath(std::opti
     });
 
     return defaultStoragePath.get();
+}
+
+Ref<WebExtensionControllerConfiguration> WebExtensionControllerConfiguration::copy() const
+{
+    RefPtr<WebExtensionControllerConfiguration> result;
+
+    if (m_identifier)
+        result = create(m_identifier.value());
+    else if (storageIsPersistent())
+        result = createDefault();
+    else
+        result = createNonPersistent();
+
+    result->setWebViewConfiguration([m_webViewConfiguration copy]);
+
+    return result.releaseNonNull();
+}
+
+WKWebViewConfiguration *WebExtensionControllerConfiguration::webViewConfiguration()
+{
+    if (!m_webViewConfiguration)
+        m_webViewConfiguration = [[WKWebViewConfiguration alloc] init];
+    return m_webViewConfiguration.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -28,14 +28,13 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "APIObject.h"
+#include "CocoaImage.h"
 #include "WebExtensionMatchPattern.h"
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
-
-#import "CocoaImage.h"
 
 OBJC_CLASS NSArray;
 OBJC_CLASS NSBundle;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -284,6 +284,9 @@ public:
     void addInjectedContent(WebUserContentControllerProxy&);
     void removeInjectedContent(WebUserContentControllerProxy&);
 
+    WKWebView *relatedWebView();
+    WKWebViewConfiguration *webViewConfiguration();
+
     void wakeUpBackgroundContentIfNecessaryToFireEvents(EventListenerTypeSet, CompletionHandler<void()>&&);
 
     HashSet<Ref<WebProcessProxy>> processes(WebExtensionEventListenerType, WebExtensionContentWorldType) const;
@@ -320,8 +323,6 @@ private:
 
     PermissionsMap& removeExpired(PermissionsMap&, WallTime& nextExpirationDate, NSString *notificationName = nil);
     PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, WallTime& nextExpirationDate, NSString *notificationName = nil);
-
-    WKWebViewConfiguration *webViewConfiguration();
 
     void populateWindowsAndTabs();
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -67,7 +67,7 @@ public:
 
     using WebExtensionContextSet = HashSet<Ref<WebExtensionContext>>;
     using WebExtensionSet = HashSet<Ref<WebExtension>>;
-    using WebExtensionContextBaseURLMap = HashMap<URL, Ref<WebExtensionContext>>;
+    using WebExtensionContextBaseURLMap = HashMap<String, Ref<WebExtensionContext>>;
     using WebExtensionURLSchemeHandlerMap = HashMap<String, Ref<WebExtensionURLSchemeHandler>>;
 
     using WebProcessProxySet = WeakHashSet<WebProcessProxy>;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp
@@ -41,27 +41,9 @@ WebExtensionControllerConfiguration::WebExtensionControllerConfiguration(const W
 {
 }
 
-Ref<WebExtensionControllerConfiguration> WebExtensionControllerConfiguration::copy() const
-{
-    if (m_identifier)
-        return create(m_identifier.value());
-    if (storageIsPersistent())
-        return createDefault();
-    return createNonPersistent();
-}
-
 bool WebExtensionControllerConfiguration::operator==(const WebExtensionControllerConfiguration& other) const
 {
-    if (this == &other)
-        return true;
-
-    if (m_storageDirectory != other.m_storageDirectory)
-        return false;
-
-    if (m_identifier != other.m_identifier)
-        return false;
-
-    return true;
+    return this == &other || (m_identifier == other.m_identifier && m_storageDirectory == other.m_storageDirectory && m_webViewConfiguration == other.m_webViewConfiguration);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -30,8 +30,10 @@
 #include "APIObject.h"
 #include <wtf/Forward.h>
 #include <wtf/Markable.h>
+#include <wtf/RetainPtr.h>
 #include <wtf/UUID.h>
 
+OBJC_CLASS WKWebViewConfiguration;
 OBJC_CLASS _WKWebExtensionControllerConfiguration;
 
 namespace WebKit {
@@ -56,6 +58,9 @@ public:
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
     String storageDirectory() const { return m_storageDirectory; }
 
+    WKWebViewConfiguration *webViewConfiguration();
+    void setWebViewConfiguration(WKWebViewConfiguration *configuration) { m_webViewConfiguration = configuration; }
+
     bool operator==(const WebExtensionControllerConfiguration&) const;
 
 #ifdef __OBJC__
@@ -67,6 +72,7 @@ private:
 
     Markable<WTF::UUID> m_identifier;
     String m_storageDirectory;
+    RetainPtr<WKWebViewConfiguration> m_webViewConfiguration;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -664,10 +664,8 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     m_pageGroup->addPage(*this);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    if (m_webExtensionController)
-        m_webExtensionController->addPage(*this);
-    if (m_weakWebExtensionController)
-        m_weakWebExtensionController->addPage(*this);
+    if (auto *webExtensionController = this->webExtensionController())
+        webExtensionController->addPage(*this);
 #endif
 
     m_inspector = WebInspectorUIProxy::create(*this);
@@ -789,6 +787,13 @@ bool WebPageProxy::modelElementEnabled()
 {
     return preferences().modelElementEnabled();
 }
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+WebExtensionController* WebPageProxy::webExtensionController()
+{
+    return m_webExtensionController.get() ?: m_weakWebExtensionController.get();
+}
+#endif
 
 // FIXME: Should return a const PageClient& and add a separate non-const
 // version of this function, but several PageClient methods will need to become

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -607,6 +607,10 @@ public:
 
     WebUserContentControllerProxy& userContentController() { return m_userContentController.get(); }
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+    WebExtensionController* webExtensionController();
+#endif
+
     bool hasSleepDisabler() const;
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -400,7 +400,7 @@
 		1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1549842926F091001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1C1549D229381BA0001B9E5B /* WebExtensionControllerConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549D129381B9F001B9E5B /* WebExtensionControllerConfiguration.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C1549D229381BA0001B9E5B /* WebExtensionControllerConfigurationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549D129381B9F001B9E5B /* WebExtensionControllerConfigurationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549D429381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1549D829382062001B9E5B /* _WKWebExtensionControllerConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1549D329381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C1549D92938206A001B9E5B /* _WKWebExtensionControllerConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1549D629381DFF001B9E5B /* _WKWebExtensionControllerConfigurationPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3493,7 +3493,7 @@
 		1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerDelegatePrivate.h; sourceTree = "<group>"; };
 		1C1549CE293812F8001B9E5B /* WebExtensionControllerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerConfiguration.h; sourceTree = "<group>"; };
 		1C1549CF293817FE001B9E5B /* WebExtensionControllerConfiguration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionControllerConfiguration.cpp; sourceTree = "<group>"; };
-		1C1549D129381B9F001B9E5B /* WebExtensionControllerConfiguration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionControllerConfiguration.mm; sourceTree = "<group>"; };
+		1C1549D129381B9F001B9E5B /* WebExtensionControllerConfigurationCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionControllerConfigurationCocoa.mm; sourceTree = "<group>"; };
 		1C1549D329381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerConfiguration.h; sourceTree = "<group>"; };
 		1C1549D429381DFE001B9E5B /* _WKWebExtensionControllerConfiguration.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionControllerConfiguration.mm; sourceTree = "<group>"; };
 		1C1549D529381DFF001B9E5B /* _WKWebExtensionControllerConfigurationInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerConfigurationInternal.h; sourceTree = "<group>"; };
@@ -8912,7 +8912,7 @@
 				1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */,
 				1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */,
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
-				1C1549D129381B9F001B9E5B /* WebExtensionControllerConfiguration.mm */,
+				1C1549D129381B9F001B9E5B /* WebExtensionControllerConfigurationCocoa.mm */,
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
 				1C73167E2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm */,
 				1C66BDE02A8C282F009D4452 /* WebExtensionTabCocoa.mm */,
@@ -17979,7 +17979,7 @@
 				330A30E52951112200F84419 /* WebExtensionContextProxyCocoa.mm in Sources */,
 				1C0234CE28A00FE600AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp in Sources */,
 				1CBEE27028F4DDA1006D1A02 /* WebExtensionControllerCocoa.mm in Sources */,
-				1C1549D229381BA0001B9E5B /* WebExtensionControllerConfiguration.mm in Sources */,
+				1C1549D229381BA0001B9E5B /* WebExtensionControllerConfigurationCocoa.mm in Sources */,
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,
 				1C3D0AC1291AE6210093F67E /* WebExtensionControllerProxyCocoa.mm in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -80,12 +80,13 @@ void WebExtensionAPIPort::add()
 
 void WebExtensionAPIPort::remove()
 {
+    disconnect();
+
     auto entry = webExtensionPorts().find(channelIdentifier());
-    RELEASE_ASSERT(entry != webExtensionPorts().end());
+    if (entry == webExtensionPorts().end())
+        return;
 
     entry->value.remove(this);
-
-    disconnect();
 
     if (!entry->value.isEmpty())
         return;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
@@ -58,7 +58,7 @@ Ref<WebExtensionControllerProxy> WebExtensionControllerProxy::getOrCreate(WebExt
 
         for (auto& contextParameters : parameters.contextParameters) {
             auto context = WebExtensionContextProxy::getOrCreate(contextParameters);
-            baseURLMap.add(contextParameters.baseURL, context);
+            baseURLMap.add(contextParameters.baseURL.protocolHostAndPort(), context);
             contexts.add(context);
         }
 
@@ -93,7 +93,7 @@ WebExtensionControllerProxy::~WebExtensionControllerProxy()
 void WebExtensionControllerProxy::load(const WebExtensionContextParameters& contextParameters)
 {
     auto context = WebExtensionContextProxy::getOrCreate(contextParameters);
-    m_extensionContextBaseURLMap.add(contextParameters.baseURL, context);
+    m_extensionContextBaseURLMap.add(contextParameters.baseURL.protocolHostAndPort(), context);
     m_extensionContexts.add(context);
 }
 
@@ -120,7 +120,7 @@ RefPtr<WebExtensionContextProxy> WebExtensionControllerProxy::extensionContext(c
 
 RefPtr<WebExtensionContextProxy> WebExtensionControllerProxy::extensionContext(const URL& url) const
 {
-    return m_extensionContextBaseURLMap.get(url.truncatedForUseAsBase());
+    return m_extensionContextBaseURLMap.get(url.protocolHostAndPort());
 }
 
 RefPtr<WebExtensionContextProxy> WebExtensionControllerProxy::extensionContext(WebFrame& frame, DOMWrapperWorld& world) const

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -53,7 +53,7 @@ public:
     ~WebExtensionControllerProxy();
 
     using WebExtensionContextProxySet = HashSet<Ref<WebExtensionContextProxy>>;
-    using WebExtensionContextProxyBaseURLMap = HashMap<URL, Ref<WebExtensionContextProxy>>;
+    using WebExtensionContextProxyBaseURLMap = HashMap<String, Ref<WebExtensionContextProxy>>;
 
     WebExtensionControllerIdentifier identifier() { return m_identifier; }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm
@@ -39,23 +39,29 @@ TEST(WKWebExtensionControllerConfiguration, Initialization)
 
     EXPECT_TRUE(configuration.persistent);
     EXPECT_NULL(configuration.identifier);
+    EXPECT_NOT_NULL(configuration.webViewConfiguration);
     EXPECT_NE(configuration, _WKWebExtensionControllerConfiguration.defaultConfiguration);
-    EXPECT_NS_EQUAL(configuration, _WKWebExtensionControllerConfiguration.defaultConfiguration);
+    EXPECT_FALSE([configuration isEqual:_WKWebExtensionControllerConfiguration.defaultConfiguration]);
+    EXPECT_FALSE([configuration.webViewConfiguration isEqual:_WKWebExtensionControllerConfiguration.defaultConfiguration.webViewConfiguration]);
 
     configuration = _WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
 
     EXPECT_FALSE(configuration.persistent);
     EXPECT_NULL(configuration.identifier);
+    EXPECT_NOT_NULL(configuration.webViewConfiguration);
     EXPECT_NE(configuration, _WKWebExtensionControllerConfiguration.nonPersistentConfiguration);
-    EXPECT_NS_EQUAL(configuration, _WKWebExtensionControllerConfiguration.nonPersistentConfiguration);
+    EXPECT_FALSE([configuration isEqual:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration]);
+    EXPECT_FALSE([configuration.webViewConfiguration isEqual:_WKWebExtensionControllerConfiguration.nonPersistentConfiguration.webViewConfiguration]);
 
     auto *identifier = [NSUUID UUID];
     configuration = [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
 
     EXPECT_TRUE(configuration.persistent);
     EXPECT_NS_EQUAL(configuration.identifier, identifier);
+    EXPECT_NOT_NULL(configuration.webViewConfiguration);
     EXPECT_NE(configuration, [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier]);
-    EXPECT_NS_EQUAL(configuration, [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier]);
+    EXPECT_FALSE([configuration isEqual:[_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier]]);
+    EXPECT_FALSE([configuration.webViewConfiguration isEqual:[_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier].webViewConfiguration]);
 }
 
 TEST(WKWebExtensionControllerConfiguration, SecureCoding)
@@ -68,8 +74,10 @@ TEST(WKWebExtensionControllerConfiguration, SecureCoding)
     EXPECT_NULL(error);
     EXPECT_TRUE(result.persistent);
     EXPECT_NULL(result.identifier);
+    EXPECT_NOT_NULL(result.webViewConfiguration);
     EXPECT_NE(configuration, result);
-    EXPECT_NS_EQUAL(configuration, result);
+    EXPECT_FALSE([result isEqual:configuration]);
+    EXPECT_FALSE([result.webViewConfiguration isEqual:configuration.webViewConfiguration]);
 
     configuration = _WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
     data = [NSKeyedArchiver archivedDataWithRootObject:configuration requiringSecureCoding:YES error:&error];
@@ -78,8 +86,10 @@ TEST(WKWebExtensionControllerConfiguration, SecureCoding)
     EXPECT_NULL(error);
     EXPECT_FALSE(result.persistent);
     EXPECT_NULL(result.identifier);
+    EXPECT_NOT_NULL(result.webViewConfiguration);
     EXPECT_NE(configuration, result);
-    EXPECT_NS_EQUAL(configuration, result);
+    EXPECT_FALSE([result isEqual:configuration]);
+    EXPECT_FALSE([result.webViewConfiguration isEqual:configuration.webViewConfiguration]);
 
     auto *identifier = [NSUUID UUID];
     configuration = [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
@@ -88,9 +98,11 @@ TEST(WKWebExtensionControllerConfiguration, SecureCoding)
 
     EXPECT_NULL(error);
     EXPECT_TRUE(result.persistent);
+    EXPECT_NOT_NULL(result.webViewConfiguration);
     EXPECT_NS_EQUAL(result.identifier, identifier);
     EXPECT_NE(configuration, result);
-    EXPECT_NS_EQUAL(configuration, result);
+    EXPECT_FALSE([result isEqual:configuration]);
+    EXPECT_FALSE([result.webViewConfiguration isEqual:configuration.webViewConfiguration]);
 }
 
 TEST(WKWebExtensionControllerConfiguration, Copying)
@@ -100,16 +112,20 @@ TEST(WKWebExtensionControllerConfiguration, Copying)
 
     EXPECT_TRUE(copy.persistent);
     EXPECT_NULL(copy.identifier);
+    EXPECT_NOT_NULL(copy.webViewConfiguration);
     EXPECT_NE(configuration, copy);
-    EXPECT_NS_EQUAL(configuration, copy);
+    EXPECT_FALSE([copy isEqual:configuration]);
+    EXPECT_FALSE([copy.webViewConfiguration isEqual:configuration.webViewConfiguration]);
 
     configuration = _WKWebExtensionControllerConfiguration.nonPersistentConfiguration;
     copy = [configuration copy];
 
     EXPECT_FALSE(copy.persistent);
     EXPECT_NULL(copy.identifier);
+    EXPECT_NOT_NULL(copy.webViewConfiguration);
     EXPECT_NE(configuration, copy);
-    EXPECT_NS_EQUAL(configuration, copy);
+    EXPECT_FALSE([copy isEqual:configuration]);
+    EXPECT_FALSE([copy.webViewConfiguration isEqual:configuration.webViewConfiguration]);
 
     auto *identifier = [NSUUID UUID];
     configuration = [_WKWebExtensionControllerConfiguration configurationWithIdentifier:identifier];
@@ -117,8 +133,10 @@ TEST(WKWebExtensionControllerConfiguration, Copying)
 
     EXPECT_TRUE(copy.persistent);
     EXPECT_NS_EQUAL(copy.identifier, identifier);
+    EXPECT_NOT_NULL(copy.webViewConfiguration);
     EXPECT_NE(configuration, copy);
-    EXPECT_NS_EQUAL(configuration, copy);
+    EXPECT_FALSE([copy isEqual:configuration]);
+    EXPECT_FALSE([copy.webViewConfiguration isEqual:configuration.webViewConfiguration]);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 11a9133692954ea702fcef2e32bd890b4ae8a3a3
<pre>
Add WKWebViewConfiguration to _WKWebExtensionControllerConfiguration.
<a href="https://webkit.org/b/262381">https://webkit.org/b/262381</a>
rdar://problem/116243665

Reviewed by Brian Weinstein.

Clients will need to provide some base defaults for extension web views, like what
process pool to use. This is best to do via a WKWebViewConfiguration property
on _WKWebExtensionControllerConfiguration.

Also fix some small drive-by issues.
* Use protocolHostAndPort() instead of truncatedForUseAsBase() for the baseURL maps
  since truncatedForUseAsBase() will include the path still and this breaks some
  extensions that use directories in their paths.
* Added relatedWebView to the configuration in prep for action popups.
* Added a webExtensionController() helper method to WebPageProxy to return the strong
  or weak controller as a convenience.
* Fixed an ASSERT in WebExtensionAPIPort that would fire on garbage collect if the
  port was already disconnected and removed.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm:
(-[_WKWebExtensionControllerConfiguration encodeWithCoder:]): Encode webViewConfiguration.
(-[_WKWebExtensionControllerConfiguration initWithCoder:]): Set webViewConfiguration.
(-[_WKWebExtensionControllerConfiguration webViewConfiguration]): Added.
(-[_WKWebExtensionControllerConfiguration setWebViewConfiguration:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm:
(-[_WKWebExtensionMessagePort sendMessage:completionHandler:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
(WebKit::WebExtensionController::unload):
(WebKit::WebExtensionController::extensionContext const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
Renamed from WebExtensionControllerConfiguration.mm to match conventions.
(WebKit::WebExtensionControllerConfiguration::createStorageDirectoryPath):
(WebKit::WebExtensionControllerConfiguration::copy const):
(WebKit::WebExtensionControllerConfiguration::webViewConfiguration): Added.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.cpp:
(WebKit::WebExtensionControllerConfiguration::operator== const):
(WebKit::WebExtensionControllerConfiguration::copy const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
(WebKit::WebExtensionControllerConfiguration::setWebViewConfiguration): Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::webExtensionController): Added.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
(WebKit::WebExtensionControllerProxy::getOrCreate):
(WebKit::WebExtensionControllerProxy::load):
(WebKit::WebExtensionControllerProxy::extensionContext const):
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionControllerConfiguration.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268667@main">https://commits.webkit.org/268667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cec545a0fcca8352d71e9ed9b5365e9cc2b4e6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20892 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23040 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18446 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22673 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19206 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22752 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2512 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->