### PR TITLE
[CSS Fonts] The `from-font` value for CSS `font-size-adjust` is not computed correctly

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3880,7 +3880,6 @@ webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/variations/fon
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/variations/font-slant-2a.html [ ImageOnlyFailure ]
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/variations/font-slant-2c.html [ ImageOnlyFailure ]
 webkit.org/b/214300 imported/w3c/web-platform-tests/css/css-fonts/hiragana-katakana-kerning.html [ ImageOnlyFailure ]
-webkit.org/b/259551 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-014.html [ ImageOnlyFailure ]
 
 # Untriaged font-style/font-face @font-face descriptor bugs
 webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/font-face-style-auto-variable.html [ ImageOnlyFailure ]

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -358,7 +358,7 @@ static RefPtr<CSSValue> valueForNinePieceImage(CSSPropertyID propertyID, const N
 static Ref<CSSValue> fontSizeAdjustFromStyle(const RenderStyle& style)
 {
     auto fontSizeAdjust = style.fontSizeAdjust();
-    if (!fontSizeAdjust.value)
+    if (!fontSizeAdjust)
         return CSSPrimitiveValue::create(CSSValueNone);
 
     auto metric = fontSizeAdjust.metric;

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -319,7 +319,7 @@ private:
         return advancedTextRenderingMode();
     }
 
-    FontCascadeDescription m_fontDescription;
+    mutable FontCascadeDescription m_fontDescription;
     mutable RefPtr<FontCascadeFonts> m_fonts;
     float m_letterSpacing { 0 };
     float m_wordSpacing { 0 };

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -120,7 +120,7 @@ struct FontDescriptionKey {
         auto variantAlternates = description.variantAlternates();
         auto fontPalette = description.fontPalette();
         auto fontSizeAdjust = description.fontSizeAdjust();
-        if (!featureSettings.isEmpty() || !variationSettings.isEmpty() || !variantAlternates.isNormal() || fontPalette.type != FontPalette::Type::Normal || fontSizeAdjust.value)
+        if (!featureSettings.isEmpty() || !variationSettings.isEmpty() || !variantAlternates.isNormal() || fontPalette.type != FontPalette::Type::Normal || fontSizeAdjust)
             m_rareData = FontDescriptionKeyRareData::create(WTFMove(featureSettings), WTFMove(variationSettings), WTFMove(variantAlternates), WTFMove(fontPalette), WTFMove(fontSizeAdjust));
     }
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -22,6 +22,7 @@
 #define FontCascadeFonts_h
 
 #include "Font.h"
+#include "FontCascadeDescription.h"
 #include "FontRanges.h"
 #include "FontSelector.h"
 #include "GlyphPage.h"
@@ -38,7 +39,6 @@
 
 namespace WebCore {
 
-class FontCascadeDescription;
 class FontPlatformData;
 class FontSelector;
 class GraphicsContext;
@@ -72,7 +72,7 @@ public:
     WidthCache& widthCache() { return m_widthCache; }
     const WidthCache& widthCache() const { return m_widthCache; }
 
-    const Font& primaryFont(const FontCascadeDescription&);
+    const Font& primaryFont(FontCascadeDescription&);
     WEBCORE_EXPORT const FontRanges& realizeFallbackRangesAt(const FontCascadeDescription&, unsigned fallbackIndex);
 
     void pruneSystemFallbacks();
@@ -131,7 +131,7 @@ inline bool FontCascadeFonts::isFixedPitch(const FontCascadeDescription& descrip
     return m_pitch == FixedPitch;
 };
 
-inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& description)
+inline const Font& FontCascadeFonts::primaryFont(FontCascadeDescription& description)
 {
     ASSERT(m_thread ? m_thread->ptr() == &Thread::current() : isMainThread());
     if (!m_cachedPrimaryFont) {
@@ -150,6 +150,13 @@ inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& d
                     break;
                 }
             }
+        }
+
+        ASSERT(m_cachedPrimaryFont);
+        auto fontSizeAdjust = description.fontSizeAdjust();
+        if (fontSizeAdjust.isFromFont) {
+            auto aspectValue = fontSizeAdjust.resolve(description.computedSize(), m_cachedPrimaryFont->fontMetrics());
+            description.setFontSizeAdjust({ fontSizeAdjust.metric, fontSizeAdjust.isFromFont, aspectValue });
         }
     }
     return *m_cachedPrimaryFont;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -67,7 +67,6 @@
 #include "ScrollbarGutter.h"
 #include "Settings.h"
 #include "StyleBuilderState.h"
-#include "StyleFontSizeFunctions.h"
 #include "StyleReflection.h"
 #include "StyleScrollSnapPoints.h"
 #include "StyleTextBoxEdge.h"
@@ -1604,7 +1603,7 @@ inline FontVariationSettings BuilderConverter::convertFontVariationSettings(Buil
     return settings;
 }
 
-inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& builderState, const CSSValue& value)
+inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState&, const CSSValue& value)
 {
     if (is<CSSPrimitiveValue>(value)) {
         auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
@@ -1617,9 +1616,10 @@ inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& buil
             return { defaultMetric, false, primitiveValue.floatValue() };
 
         ASSERT(primitiveValue.valueID() == CSSValueFromFont);
-        // The primary font could be null in the current builder state where
-        // a fallback font is used. So, we use the parent style instead.
-        return { defaultMetric, true, aspectValueOfPrimaryFont(builderState.parentStyle(), defaultMetric) };
+        // We cannot determine the primary font here, so we defer resolving the
+        // aspect value for from-font to when the primary font is created.
+        // See FontCascadeFonts::primaryFont().
+        return { defaultMetric, true, std::nullopt };
     }
 
     ASSERT(value.isPair());
@@ -1631,7 +1631,7 @@ inline FontSizeAdjust BuilderConverter::convertFontSizeAdjust(BuilderState& buil
         return { metric, false, primitiveValue.floatValue() };
 
     ASSERT(primitiveValue.valueID() == CSSValueFromFont);
-    return { metric, true, aspectValueOfPrimaryFont(builderState.parentStyle(), metric) };
+    return { metric, true, std::nullopt };
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -214,36 +214,5 @@ float adjustedFontSize(float size, const FontSizeAdjust& sizeAdjust, const FontM
     ASSERT_NOT_REACHED();
 }
 
-std::optional<float> aspectValueOfPrimaryFont(const RenderStyle& style, FontSizeAdjust::Metric metric)
-{
-    const auto& metrics = style.metricsOfPrimaryFont();
-    std::optional<float> metricValue;
-    switch (metric) {
-    case FontSizeAdjust::Metric::CapHeight:
-        if (metrics.hasCapHeight())
-            metricValue = metrics.floatCapHeight();
-        break;
-    case FontSizeAdjust::Metric::ChWidth:
-        if (metrics.zeroWidth())
-            metricValue = metrics.zeroWidth();
-        break;
-    // FIXME: Are ic-height and ic-width the same? Gecko treats them the same.
-    case FontSizeAdjust::Metric::IcWidth:
-    case FontSizeAdjust::Metric::IcHeight:
-        if (metrics.ideogramWidth() > 0)
-            metricValue = metrics.ideogramWidth();
-        break;
-    case FontSizeAdjust::Metric::ExHeight:
-    default:
-        if (metrics.hasXHeight())
-            metricValue = metrics.xHeight();
-    }
-
-    float computedFontSize = style.computedFontSize();
-    return metricValue.has_value() && computedFontSize
-        ? std::make_optional(*metricValue / computedFontSize)
-        : std::nullopt;
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -43,7 +43,6 @@ float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize
 float computedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const RenderStyle*, const Document&);
 float computedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
 float adjustedFontSize(float size, const FontSizeAdjust&, const FontMetrics&);
-std::optional<float> aspectValueOfPrimaryFont(const RenderStyle&, FontSizeAdjust::Metric);
 
 // Given a CSS keyword id in the range (CSSValueXxSmall to CSSValueXxxLarge), this function will return
 // the correct font size scaled relative to the user's default (medium).


### PR DESCRIPTION
#### 89bdb0336c3b32a4130822ed976d858538e0d596
<pre>
[CSS Fonts] The `from-font` value for CSS `font-size-adjust` is not computed correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=259551">https://bugs.webkit.org/show_bug.cgi?id=259551</a>

Reviewed by Tim Nguyen.

When resolving styles, we used the parent-style font to compute the aspect ratio
for font-size-adjust: from-font because the first available font could not be
determined at that moment. Unfortunately, this causes the failure of
font-size-adjust-014.html. To make the test happy, we should defer resolving
the aspect value after determining a primary font. Also, FontDescriptionKey
should consider if the font-size-adjust has from-font, not simply checking if
it has a valid value when looking up a proper FontCascadeFonts.

For minimizing performance regression, this patch is updated as follows.
1. The resolving place changed from FontCascadeFonts::glyphDataForCharacter() to
   FontCascadeFonts::primaryFont(). Font-size-adjust:from-font is resolved when
   the primary font is created the first time.
2. Copying FontCascadeDescription is avoided. Instead, the source font description
   is directly modified.

* LayoutTests/TestExpectations:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::fontSizeAdjustFromStyle):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeCache.h:
(WebCore::FontDescriptionKey::FontDescriptionKey):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::primaryFont):
* Source/WebCore/platform/graphics/FontSizeAdjust.h:
(WebCore::FontSizeAdjust::operator bool const):
(WebCore::FontSizeAdjust::resolve const):
(WebCore::add):
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertFontSizeAdjust):
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
(WebCore::Style::aspectValueOfPrimaryFont): Deleted.
* Source/WebCore/style/StyleFontSizeFunctions.h:

Canonical link: <a href="https://commits.webkit.org/269041@main">https://commits.webkit.org/269041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/583b4bd84cf99c4379db283d7b0cea448bc9df28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21040 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24128 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25724 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23572 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17110 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19415 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5118 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->