### PR TITLE
[UnifiedPDF] Get basic PDF page layout working

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -670,6 +670,7 @@ WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
 WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
 
 WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
 WebProcess/WebCoreSupport/WebValidationMessageClient.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3007,6 +3007,8 @@
 		0F3157A928F4EDD800D79D05 /* RemoteLayerTreeDrawingAreaProxyIOS.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerTreeDrawingAreaProxyIOS.mm; sourceTree = "<group>"; };
 		0F3C7257196F5F5000AEDD0C /* WKInspectorHighlightView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKInspectorHighlightView.mm; sourceTree = "<group>"; };
 		0F3C7259196F5F6800AEDD0C /* WKInspectorHighlightView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKInspectorHighlightView.h; sourceTree = "<group>"; };
+		0F3D56722AC651390086D64E /* PDFDocumentLayout.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PDFDocumentLayout.mm; sourceTree = "<group>"; };
+		0F3D56732AC651390086D64E /* PDFDocumentLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PDFDocumentLayout.h; sourceTree = "<group>"; };
 		0F4000FD2527D69D00E91DA7 /* WebWheelEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebWheelEvent.h; sourceTree = "<group>"; };
 		0F4000FE2527D6C300E91DA7 /* WebMouseEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebMouseEvent.h; sourceTree = "<group>"; };
 		0F4000FF2527D6F700E91DA7 /* WebKeyboardEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebKeyboardEvent.h; sourceTree = "<group>"; };
@@ -7985,6 +7987,8 @@
 		0FFACF022AC2453300ED8DB6 /* UnifiedPDF */ = {
 			isa = PBXGroup;
 			children = (
+				0F3D56732AC651390086D64E /* PDFDocumentLayout.h */,
+				0F3D56722AC651390086D64E /* PDFDocumentLayout.mm */,
 				0FFACF042AC2453300ED8DB6 /* UnifiedPDFPlugin.h */,
 				0FFACF032AC2453300ED8DB6 /* UnifiedPDFPlugin.mm */,
 			);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -144,6 +144,8 @@ protected:
     void ensureDataBufferLength(uint64_t);
     void addArchiveResource();
 
+    void invalidateRect(const WebCore::IntRect&);
+
     WeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -153,6 +153,14 @@ void PDFPluginBase::geometryDidChange(const IntSize& pluginSize, const AffineTra
     m_size = pluginSize;
 }
 
+void PDFPluginBase::invalidateRect(const IntRect& rect)
+{
+    if (!m_view)
+        return;
+
+    m_view->invalidateRect(rect);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(PDFKIT_PLUGIN) || ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_PDF)
+
+#include <CoreGraphics/CoreGraphics.h>
+#include <WebCore/FloatRect.h>
+#include <wtf/RetainPtr.h>
+
+namespace WebCore {
+class GraphicsContext;
+class IntRect;
+}
+
+namespace WebKit {
+
+class PDFDocumentLayout {
+public:
+    using PageIndex = size_t; // This is a zero-based index.
+
+    enum class DisplayMode : uint8_t {
+        SinglePage,
+        Continuous,
+        TwoUp,
+        TwoUpContinuous,
+    };
+
+    PDFDocumentLayout();
+    ~PDFDocumentLayout();
+
+    void setPDFDocument(RetainPtr<CGPDFDocumentRef>&&);
+    CGPDFDocumentRef pdfDocument() const { return m_pdfDocument.get(); }
+
+    bool hasPDFDocument() const;
+    size_t pageCount() const;
+
+    RetainPtr<CGPDFPageRef> pageAtIndex(PageIndex) const;
+    WebCore::FloatRect boundsForPageAtIndex(PageIndex) const;
+
+    WebCore::FloatSize layoutSize() const { return m_documentBounds.size(); }
+
+private:
+
+    void updateGeometry();
+
+    void layoutPages(float availableWidth);
+
+    void layoutSingleColumn(float availableWidth);
+    void layoutTwoUpColumn(float availableWidth);
+
+    static FloatSize documentMargin();
+    static FloatSize pageMargin();
+
+    RetainPtr<CGPDFDocumentRef> m_pdfDocument;
+    Vector<WebCore::FloatRect> m_pageBounds;
+    WebCore::FloatRect m_documentBounds;
+    DisplayMode m_displayMode { DisplayMode::Continuous };
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PDFDocumentLayout.h"
+
+#if ENABLE(UNIFIED_PDF)
+
+#include <CoreGraphics/CoreGraphics.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+FloatSize PDFDocumentLayout::documentMargin()
+{
+    return { 20, 20 };
+}
+
+FloatSize PDFDocumentLayout::pageMargin()
+{
+    return { 10, 10 };
+}
+
+PDFDocumentLayout::PDFDocumentLayout() = default;
+PDFDocumentLayout::~PDFDocumentLayout() = default;
+
+void PDFDocumentLayout::setPDFDocument(RetainPtr<CGPDFDocumentRef>&& pdfDocument)
+{
+    m_pdfDocument = WTFMove(pdfDocument);
+    updateGeometry();
+}
+
+bool PDFDocumentLayout::hasPDFDocument() const
+{
+    return !!m_pdfDocument;
+}
+
+RetainPtr<CGPDFPageRef> PDFDocumentLayout::pageAtIndex(PageIndex index) const
+{
+    RetainPtr page = CGPDFDocumentGetPage(m_pdfDocument.get(), index + 1); // CG Page index is 1-based
+    return page;
+}
+
+void PDFDocumentLayout::updateGeometry()
+{
+    auto pageCount = this->pageCount();
+    m_pageBounds.clear();
+    m_documentBounds = { };
+
+    for (PageIndex i = 0; i < pageCount; ++i) {
+        auto page = pageAtIndex(i);
+        if (!page) {
+            m_pageBounds.append({ });
+            continue;
+        }
+
+        auto pageCropBox = FloatRect { CGPDFPageGetBoxRect(page.get(), kCGPDFCropBox) };
+
+        // FIXME: Handle page rotation
+        m_pageBounds.append(pageCropBox);
+    }
+
+    float availableWidth = 1000; // FIXME: Fixed for now, but should use plugin width, maybe with a second layout pass when horizontal scrolling is required.
+    layoutPages(availableWidth);
+
+    // FIXME: Update plugin size here.
+}
+
+void PDFDocumentLayout::layoutPages(float availableWidth)
+{
+    // We always lay out in a continuous mode. We handle non-continuous mode via scroll snap.
+    switch (m_displayMode) {
+    case DisplayMode::SinglePage:
+    case DisplayMode::Continuous:
+        layoutSingleColumn(availableWidth);
+        break;
+
+    case DisplayMode::TwoUp:
+    case DisplayMode::TwoUpContinuous:
+        layoutTwoUpColumn(availableWidth);
+        break;
+    }
+}
+
+void PDFDocumentLayout::layoutSingleColumn(float availableWidth)
+{
+    auto documentMargin = PDFDocumentLayout::documentMargin();
+    auto pageMargin = PDFDocumentLayout::documentMargin();
+
+    float currentYOffset = documentMargin.height();
+    float maxPageWidth = 0;
+    auto pageCount = this->pageCount();
+
+    for (PageIndex i = 0; i < pageCount; ++i) {
+        auto pageBounds = m_pageBounds[i];
+
+        auto pageLeft = std::max<float>(std::floor((availableWidth - pageBounds.width()) / 2), 0);
+        pageBounds.setLocation({ pageLeft, currentYOffset });
+
+        currentYOffset += pageBounds.height() + pageMargin.height();
+        maxPageWidth = std::max(maxPageWidth, pageBounds.width());
+
+        m_pageBounds[i] = pageBounds;
+    }
+
+    // Subtract the last page's bottom margin.
+    currentYOffset -= pageMargin.height();
+    currentYOffset += documentMargin.height();
+
+    m_documentBounds = FloatRect { 0, 0, std::max(maxPageWidth, availableWidth), currentYOffset };
+}
+
+void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth)
+{
+    // FIMXE: Not implemented yet.
+}
+
+size_t PDFDocumentLayout::pageCount() const
+{
+    if (!hasPDFDocument())
+        return 0;
+
+    return CGPDFDocumentGetNumberOfPages(m_pdfDocument.get());
+}
+
+WebCore::FloatRect PDFDocumentLayout::boundsForPageAtIndex(PageIndex index) const
+{
+    if (index >= m_pageBounds.size())
+        return { };
+
+    return m_pageBounds[index];
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(UNIFIED_PDF)
 
+#include "PDFDocumentLayout.h"
 #include "PDFPluginBase.h"
 
 namespace WebKit {
@@ -80,7 +81,7 @@ private:
     id accessibilityObject() const override;
     id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
 
-    RetainPtr<CGPDFDocumentRef> m_pdfDocument;
+    PDFDocumentLayout m_documentLayout;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -101,6 +101,8 @@ public:
     
     bool isUsingUISideCompositing() const;
 
+    void invalidateRect(const WebCore::IntRect&) final;
+
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);
     virtual ~PluginView();
@@ -132,7 +134,6 @@ private:
     // WebCore::Widget
     void setFrameRect(const WebCore::IntRect&) final;
     void paint(WebCore::GraphicsContext&, const WebCore::IntRect&, WebCore::Widget::SecurityOriginPaintPolicy, WebCore::RegionContext*) final;
-    void invalidateRect(const WebCore::IntRect&) final;
     void frameRectsChanged() final;
     void setParent(WebCore::ScrollView*) final;
     void handleEvent(WebCore::Event&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include "WebPage.h"
 #include <WebCore/EditorClient.h>
 #include <WebCore/TextCheckerClient.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 enum class DOMPasteAccessCategory : uint8_t;


### PR DESCRIPTION
#### 53ed985286a97c4ae32b699699de9eb7ff10b869
<pre>
[UnifiedPDF] Get basic PDF page layout working
<a href="https://bugs.webkit.org/show_bug.cgi?id=262389">https://bugs.webkit.org/show_bug.cgi?id=262389</a>
rdar://116249928

Reviewed by Tim Horton and Richard Robinson.

Introduce PDFDocumentLayout for UnifiedPDF, which contains the logic to lay out the PDF
pages, taking page size, rotation and the layout mode into account. Implement basic
single column layout.

Fix PDF page drawing to flip the context when drawing pages.

Hook up an invalidate code path, so that we can repaint the plugin when the PDF loads.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::invalidateRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h: Added.
(WebKit::PDFDocumentLayout::pdfDocument const):
(WebKit::PDFDocumentLayout::layoutSize const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm: Added.
(WebKit::PDFDocumentLayout::documentMargin):
(WebKit::PDFDocumentLayout::pageMargin):
(WebKit::PDFDocumentLayout::setPDFDocument):
(WebKit::PDFDocumentLayout::hasPDFDocument const):
(WebKit::PDFDocumentLayout::pageAtIndex const):
(WebKit::PDFDocumentLayout::updateGeometry):
(WebKit::PDFDocumentLayout::layoutPages):
(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::layoutTwoUpColumn):
(WebKit::PDFDocumentLayout::pageCount const):
(WebKit::PDFDocumentLayout::boundsForPageAtIndex const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::createPDFDocument):
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::paint):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:

Canonical link: <a href="https://commits.webkit.org/268670@main">https://commits.webkit.org/268670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0157e45fe7d6b3901862142e1ab13ce6eec9a14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20905 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23051 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17587 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24706 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22679 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16318 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18422 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4887 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->