### PR TITLE
[JSC] Account owner cell's color for extra memory allocation

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -735,7 +735,7 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
         dumpBytecode();
 
     if (m_metadata)
-        vm.heap.reportExtraMemoryAllocated(m_metadata->sizeInBytesForGC());
+        vm.heap.reportExtraMemoryAllocated(this, m_metadata->sizeInBytesForGC());
 
     initializeTemplateObjects(topLevelExecutable, templateObjectIndices);
     RETURN_IF_EXCEPTION(throwScope, false);

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -325,7 +325,7 @@ public:
     void setJITCode(Ref<JITCode>&& code)
     {
         if (!code->isShared())
-            heap()->reportExtraMemoryAllocated(code->size());
+            heap()->reportExtraMemoryAllocated(this, code->size());
 
         ConcurrentJSLocker locker(m_lock);
         WTF::storeStoreFence(); // This is probably not needed because the lock will also do something similar, but it's good to be paranoid.

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
@@ -157,7 +157,7 @@ void UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> i
             m_codeBlock->initializeLoopHintExecutionCounter();
     }
     m_vm.writeBarrier(m_codeBlock.get());
-    m_vm.heap.reportExtraMemoryAllocated(m_codeBlock->m_instructions->sizeInBytes() + m_codeBlock->metadataSizeInBytes());
+    m_vm.heap.reportExtraMemoryAllocated(m_codeBlock.get(), m_codeBlock->m_instructions->sizeInBytes() + m_codeBlock->metadataSizeInBytes());
 }
 
 UnlinkedHandlerInfo* UnlinkedCodeBlockGenerator::handlerForBytecodeIndex(BytecodeIndex bytecodeIndex, RequiredHandler requiredHandler)

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -388,8 +388,8 @@ public:
     // Use this API to report non-GC memory referenced by GC objects. Be sure to
     // call both of these functions: Calling only one may trigger catastropic
     // memory growth.
-    void reportExtraMemoryAllocated(size_t);
-    void reportExtraMemoryAllocated(GCDeferralContext*, size_t);
+    void reportExtraMemoryAllocated(const JSCell*, size_t);
+    void reportExtraMemoryAllocated(GCDeferralContext*, const JSCell*, size_t);
     JS_EXPORT_PRIVATE void reportExtraMemoryVisited(size_t);
 
 #if ENABLE(RESOURCE_USAGE)
@@ -614,7 +614,8 @@ private:
 
     Lock& lock() { return m_lock; }
 
-    JS_EXPORT_PRIVATE void reportExtraMemoryAllocatedSlowCase(GCDeferralContext*, size_t);
+    void reportExtraMemoryAllocatedPossiblyFromAlreadyMarkedCell(const JSCell*, size_t);
+    JS_EXPORT_PRIVATE void reportExtraMemoryAllocatedSlowCase(GCDeferralContext*, const JSCell*, size_t);
     JS_EXPORT_PRIVATE void deprecatedReportExtraMemorySlowCase(size_t);
     
     bool shouldCollectInCollectorThread(const AbstractLocker&);

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -210,16 +210,16 @@ inline HashSet<MarkedVectorBase*>& Heap::markListSet()
     return m_markListSet;
 }
 
-inline void Heap::reportExtraMemoryAllocated(size_t size)
+inline void Heap::reportExtraMemoryAllocated(const JSCell* cell, size_t size)
 {
     if (size > minExtraMemory)
-        reportExtraMemoryAllocatedSlowCase(nullptr, size);
+        reportExtraMemoryAllocatedSlowCase(nullptr, cell, size);
 }
 
-inline void Heap::reportExtraMemoryAllocated(GCDeferralContext* deferralContext, size_t size)
+inline void Heap::reportExtraMemoryAllocated(GCDeferralContext* deferralContext, const JSCell* cell, size_t size)
 {
     if (size > minExtraMemory)
-        reportExtraMemoryAllocatedSlowCase(deferralContext, size);
+        reportExtraMemoryAllocatedSlowCase(deferralContext, cell, size);
 }
 
 inline void Heap::deprecatedReportExtraMemory(size_t size)

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -464,7 +464,7 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::grow(VM& vm, size_t newByteLength
         return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
     auto result = shared->grow(vm, newByteLength);
     if (result && result.value() > 0)
-        vm.heap.reportExtraMemoryAllocated(result.value());
+        vm.heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), result.value());
     return result;
 }
 
@@ -558,7 +558,7 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
     }
 
     if (deltaByteLength > 0)
-        vm.heap.reportExtraMemoryAllocated(deltaByteLength);
+        vm.heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), deltaByteLength);
 
     return deltaByteLength;
 }

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -99,7 +99,7 @@ JSArrayBufferView::ConstructionContext::ConstructionContext(VM& vm, Structure* s
     if (!m_vector)
         return;
 
-    vm.heap.reportExtraMemoryAllocated(size.value());
+    vm.heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), size.value());
     
     m_structure = structure;
     m_mode = OversizeTypedArray;

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -179,7 +179,7 @@ AtomString JSRopeString::resolveRopeToAtomString(JSGlobalObject* globalObject) c
 
     // If we resolved a string that didn't previously exist, notify the heap that we've grown.
     if (atomString.impl()->hasOneRef())
-        vm.heap.reportExtraMemoryAllocated(atomString.impl()->cost());
+        vm.heap.reportExtraMemoryAllocated(this, atomString.impl()->cost());
 
     convertToNonRope(String { atomString });
 
@@ -243,7 +243,7 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
             outOfMemory(nullOrGlobalObjectForOOM);
             return nullString();
         }
-        vm.heap.reportExtraMemoryAllocated(newImpl->cost());
+        vm.heap.reportExtraMemoryAllocated(this, newImpl->cost());
 
         uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
         resolveRopeInternalNoSubstring(buffer, stackLimit);
@@ -257,7 +257,7 @@ const String& JSRopeString::resolveRopeWithFunction(JSGlobalObject* nullOrGlobal
         outOfMemory(nullOrGlobalObjectForOOM);
         return nullString();
     }
-    vm.heap.reportExtraMemoryAllocated(newImpl->cost());
+    vm.heap.reportExtraMemoryAllocated(this, newImpl->cost());
     
     uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
     resolveRopeInternalNoSubstring(buffer, stackLimit);

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -172,7 +172,7 @@ private:
         ASSERT_UNUSED(length, length > 0);
         ASSERT(!valueInternal().isNull());
         Base::finishCreation(vm);
-        vm.heap.reportExtraMemoryAllocated(cost);
+        vm.heap.reportExtraMemoryAllocated(this, cost);
     }
 
     void finishCreation(VM& vm, GCDeferralContext* deferralContext, unsigned length, size_t cost)
@@ -180,7 +180,7 @@ private:
         ASSERT_UNUSED(length, length > 0);
         ASSERT(!valueInternal().isNull());
         Base::finishCreation(vm);
-        vm.heap.reportExtraMemoryAllocated(deferralContext, cost);
+        vm.heap.reportExtraMemoryAllocated(deferralContext, this, cost);
     }
 
     static JSString* createEmptyString(VM&);

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -295,7 +295,7 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* st
     auto createFromRope = [&](VM& vm, auto& buffer) {
         auto impl = AtomStringImpl::add(buffer);
         if (impl->hasOneRef())
-            vm.heap.reportExtraMemoryAllocated(impl->cost());
+            vm.heap.reportExtraMemoryAllocated(ropeString, impl->cost());
         ropeString->convertToNonRope(String { WTFMove(impl) });
         return ropeString;
     };

--- a/Source/JavaScriptCore/runtime/PropertyTable.cpp
+++ b/Source/JavaScriptCore/runtime/PropertyTable.cpp
@@ -125,7 +125,7 @@ PropertyTable::PropertyTable(VM& vm, unsigned initialCapacity, const PropertyTab
 void PropertyTable::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
-    vm.heap.reportExtraMemoryAllocated(dataSize(isCompact()));
+    vm.heap.reportExtraMemoryAllocated(this, dataSize(isCompact()));
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -598,7 +598,7 @@ inline void PropertyTable::rehash(VM& vm, unsigned newCapacity, bool canStayComp
 
     size_t newDataSize = dataSize(this->isCompact());
     if (oldDataSize < newDataSize)
-        vm.heap.reportExtraMemoryAllocated(newDataSize - oldDataSize);
+        vm.heap.reportExtraMemoryAllocated(this, newDataSize - oldDataSize);
 }
 
 inline unsigned PropertyTable::tableCapacity() const { return m_indexSize >> 1; }

--- a/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
+++ b/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
@@ -73,7 +73,7 @@ SparseArrayValueMap::AddResult SparseArrayValueMap::add(JSObject* array, unsigne
         }
     }
     if (increasedCapacity)
-        Heap::heap(array)->reportExtraMemoryAllocated(increasedCapacity * sizeof(Map::KeyValuePairType));
+        Heap::heap(array)->reportExtraMemoryAllocated(array, increasedCapacity * sizeof(Map::KeyValuePairType));
     return result;
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -64,7 +64,7 @@ void JSWebAssemblyInstance::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-    vm.heap.reportExtraMemoryAllocated(m_instance->extraMemoryAllocated());
+    vm.heap.reportExtraMemoryAllocated(this, m_instance->extraMemoryAllocated());
 }
 
 void JSWebAssemblyInstance::destroy(JSCell* cell)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -173,14 +173,14 @@ void JSWebAssemblyMemory::growSuccessCallback(VM& vm, PageCount oldPageCount, Pa
     
     memory().check();
     
-    vm.heap.reportExtraMemoryAllocated(newPageCount.bytes() - oldPageCount.bytes());
+    vm.heap.reportExtraMemoryAllocated(this, newPageCount.bytes() - oldPageCount.bytes());
 }
 
 void JSWebAssemblyMemory::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-    vm.heap.reportExtraMemoryAllocated(memory().size());
+    vm.heap.reportExtraMemoryAllocated(this, memory().size());
 }
 
 void JSWebAssemblyMemory::destroy(JSCell* cell)

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -4975,7 +4975,7 @@ sub GenerateImplementation
         $hasNonTrivialFinishCreation = 1;
     }
     if ($interface->extendedAttributes->{ReportExtraMemoryCost}) {
-        push(@finishCreation, "    vm.heap.reportExtraMemoryAllocated(wrapped().memoryCost());\n");
+        push(@finishCreation, "    vm.heap.reportExtraMemoryAllocated(this, wrapped().memoryCost());\n");
         $hasNonTrivialFinishCreation = 1;
     }
     push(@finishCreation, "}\n");

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
@@ -130,7 +130,7 @@ void JSTestReportExtraMemoryCost::finishCreation(VM& vm)
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
-    vm.heap.reportExtraMemoryAllocated(wrapped().memoryCost());
+    vm.heap.reportExtraMemoryAllocated(this, wrapped().memoryCost());
 }
 
 JSObject* JSTestReportExtraMemoryCost::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -292,7 +292,7 @@ RefPtr<ImageBuffer> CanvasBase::setImageBuffer(RefPtr<ImageBuffer>&& buffer) con
         m_contextStateSaver = makeUnique<GraphicsContextStateSaver>(m_imageBuffer->context());
 
         JSC::JSLockHolder lock(scriptExecutionContext()->vm());
-        scriptExecutionContext()->vm().heap.reportExtraMemoryAllocated(memoryCost());
+        scriptExecutionContext()->vm().heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), memoryCost());
     }
 
     return returnBuffer;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -295,7 +295,7 @@ void XMLHttpRequest::changeState(State newState)
             if (auto* context = scriptExecutionContext()) {
                 JSC::VM& vm = context->vm();
                 JSC::JSLockHolder lock(vm);
-                vm.heap.reportExtraMemoryAllocated(memoryCost());
+                vm.heap.reportExtraMemoryAllocated(static_cast<JSCell*>(nullptr), memoryCost());
             }
         }
         callReadyStateChangeListener();


### PR DESCRIPTION
#### 96f8b42d219564ebc87ab37838f923dbee8b244a
<pre>
[JSC] Account owner cell&apos;s color for extra memory allocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=262393">https://bugs.webkit.org/show_bug.cgi?id=262393</a>
rdar://116251726

Reviewed by Keith Miller.

We report extra memory allocation via reportExtraMemoryAllocated, and it can invoke GC.
And reportExtraMemoryVisited will account the current total live size of extra memory through GC scan,
so GC can know the current shape well. However, consider the following case,

1. If the cell is already old region.
2. New reportExtraMemoryAllocated happens for this cell.
3. Eden GC is happening.

In this case, it is already marked. So we will not get the new allocated memory reporting via reportExtraMemoryVisited.
In this patch, we do reportExtraMemoryVisited from reportExtraMemoryAllocated when the cell will not report it again.
It is basically the same condition to WriteBarrier&apos;s remember-set addition.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finishCreation):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
(JSC::CodeBlock::setJITCode):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp:
(JSC::UnlinkedCodeBlockGenerator::finalize):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::reportExtraMemoryAllocatedPossiblyFromAlreadyMarkedCell):
(JSC::Heap::reportExtraMemoryAllocatedSlowCase):
(JSC::Heap::deprecatedReportExtraMemorySlowCase):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapInlines.h:
(JSC::Heap::reportExtraMemoryAllocated):
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::grow):
(JSC::ArrayBuffer::resize):
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::JSArrayBufferView::ConstructionContext::ConstructionContext):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::resolveRopeToAtomString const):
(JSC::JSRopeString::resolveRopeWithFunction const):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::JSString::finishCreation):
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::jsAtomString):
* Source/JavaScriptCore/runtime/PropertyTable.cpp:
(JSC::PropertyTable::finishCreation):
* Source/JavaScriptCore/runtime/PropertyTable.h:
(JSC::PropertyTable::rehash):
* Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp:
(JSC::SparseArrayValueMap::add):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::finishCreation):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::growSuccessCallback):
(JSC::JSWebAssemblyMemory::finishCreation):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateImplementation):
* Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp:
(WebCore::JSTestReportExtraMemoryCost::finishCreation):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::setImageBuffer const):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::changeState):

Canonical link: <a href="https://commits.webkit.org/268796@main">https://commits.webkit.org/268796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fa55b2eee1f88afc75b80c155c4f806292ccd4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20379 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23056 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24770 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17671 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22701 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19688 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16324 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23715 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18427 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5685 "Found 3 jsc stress test failures: stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.no-llint, wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-eager") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22767 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/24972 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2553 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19046 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5508 "Passed tests") | 
<!--EWS-Status-Bubble-End-->