### PR TITLE
Add _WKWebExtensionAction API to support web extension actions.

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2119,6 +2119,16 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionAction {
+    header "_WKWebExtensionAction.h"
+    export *
+  }
+
+  explicit module _WKWebExtensionActionPrivate {
+    header "_WKWebExtensionActionPrivate.h"
+    export *
+  }
+
   explicit module _WKWebExtensionContext {
     header "_WKWebExtensionContext.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3021,6 +3021,16 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionAction {
+    header "_WKWebExtensionAction.h"
+    export *
+  }
+
+  explicit module _WKWebExtensionActionPrivate {
+    header "_WKWebExtensionActionPrivate.h"
+    export *
+  }
+
   explicit module _WKWebExtensionContext {
     header "_WKWebExtensionContext.h"
     export *

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -176,6 +176,7 @@ public:
         VisitedLinkStore,
 #if ENABLE(WK_WEB_EXTENSIONS)
         WebExtension,
+        WebExtensionAction,
         WebExtensionContext,
         WebExtensionController,
         WebExtensionControllerConfiguration,
@@ -437,6 +438,7 @@ template<> struct EnumTraits<API::Object::Type> {
         API::Object::Type::VisitedLinkStore,
 #if ENABLE(WK_WEB_EXTENSIONS)
         API::Object::Type::WebExtension,
+        API::Object::Type::WebExtensionAction,
         API::Object::Type::WebExtensionContext,
         API::Object::Type::WebExtensionController,
         API::Object::Type::WebExtensionControllerConfiguration,

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -104,6 +104,7 @@
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+#import "_WKWebExtensionActionInternal.h"
 #import "_WKWebExtensionContextInternal.h"
 #import "_WKWebExtensionControllerConfigurationInternal.h"
 #import "_WKWebExtensionControllerInternal.h"
@@ -402,6 +403,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     case Type::WebExtensionContext:
         wrapper = [_WKWebExtensionContext alloc];
+        break;
+
+    case Type::WebExtensionAction:
+        wrapper = [_WKWebExtensionAction alloc];
         break;
 
     case Type::WebExtensionController:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -150,7 +150,12 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 /*! @abstract The localized extension description. Returns `nil` if there was no description specified. */
 @property (nonatomic, nullable, readonly, copy) NSString *displayDescription;
 
-/*! @abstract The localized extension action label. Returns `nil` if there was no action label specified. */
+/*!
+ @abstract The default localized extension action label.
+ @result The action label, or `nil` if there was no default action label specified.
+ @discussion This label serves as a default and should be used to represent the extension in contexts like action sheets or toolbars prior to
+ the extension being loaded into an extension context. Once the extension is loaded, use the `actionForTab:` API to get the tab-specific label.
+ */
 @property (nonatomic, nullable, readonly, copy) NSString *displayActionLabel;
 
 /*! @abstract The extension version. Returns `nil` if there was no version specified. */
@@ -171,11 +176,13 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 #endif
 
 /*!
- @abstract Returns the action icon for the specified size.
+ @abstract Returns the default action icon for the specified size.
  @param size The size to use when looking up the action icon.
  @result The action icon, or `nil` if the icon was unable to be loaded.
- @discussion This icon should represent the extension in action sheets or toolbars. The returned image will be the best match for the specified
- size that is available in the extension's action icon set. If no matching icon is available, the method will fall back to the extension's icon.
+ @discussion This icon serves as a default and should be used to represent the extension in contexts like action sheets or toolbars prior to
+ the extension being loaded into an extension context. Once the extension is loaded, use the `actionForTab:` API to get the tab-specific icon.
+ The returned image will be the best match for the specified size that is available in the extension's action icon set. If no matching icon is available,
+ the method will fall back to the extension's icon.
  @seealso iconForSize:
  */
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+#import <Foundation/Foundation.h>
+
+@class WKWebView;
+@class _WKWebExtensionContext;
+@protocol _WKWebExtensionTab;
+
+#if TARGET_OS_IPHONE
+@class UIImage;
+#else
+@class NSImage;
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @abstract This notification is sent whenever a @link WKWebExtensionAction has changed properties. */
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionActionPropertiesDidChangeNotification NS_SWIFT_NAME(_WKWebExtensionAction.propertiesDidChangeNotification);
+
+/*! @abstract This notification is sent when the `intrinsicContentSize` of the popup web view associated with a @link WKWebExtensionAction changes. */
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionActionPopupWebViewContentSizeDidChangeNotification NS_SWIFT_NAME(_WKWebExtensionAction.popupWebViewContentSizeDidChangeNotification);
+
+/*! @abstract This notification is sent when the popup web view associated with a @link WKWebExtensionAction is closed. */
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN NSNotificationName const _WKWebExtensionActionPopupWebViewDidCloseNotification NS_SWIFT_NAME(_WKWebExtensionAction.popupWebViewDidCloseNotification);
+
+/*!
+ @abstract A `WKWebExtensionAction` object encapsulates the properties for an individual web extension action.
+ @discussion Provides access to action properties such as popup, icon, and title, with tab-specific values.
+ */
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+NS_SWIFT_NAME(_WKWebExtension.Action)
+@interface _WKWebExtensionAction : NSObject
+
+/*! @abstract The extension context to which this action is related. */
+@property (nonatomic, readonly, weak) _WKWebExtensionContext *webExtensionContext;
+
+/*!
+ @abstract The tab that this action is associated with, or `nil` if it is the default action.
+ @discussion When this property is `nil`, it indicates that the action is the default action and not associated with a specific tab.
+ */
+@property (nonatomic, readonly, nullable, weak) id <_WKWebExtensionTab> associatedTab;
+
+/*!
+ @abstract Returns the action icon for the specified size.
+ @param size The size to use when looking up the action icon.
+ @result The action icon, or `nil` if the icon was unable to be loaded.
+ @discussion This icon should represent the extension in action sheets or toolbars. The returned image will be the best match for the specified
+ size that is available in the extension's action icon set. If no matching icon is available, the method will fall back to the extension's icon.
+ */
+#if TARGET_OS_IPHONE
+- (nullable UIImage *)iconForSize:(CGSize)size;
+#else
+- (nullable NSImage *)iconForSize:(CGSize)size;
+#endif
+
+/*! @abstract The localized display label for the action. */
+@property (nonatomic, readonly, copy) NSString *displayLabel;
+
+/*! @abstract The badge text for the action. */
+@property (nonatomic, nullable, readonly, copy) NSString *badgeText;
+
+/*! @abstract A Boolean value indicating whether the action is enabled. */
+@property (nonatomic, readonly, getter=isEnabled) BOOL enabled;
+
+/*!
+ @abstract A Boolean value indicating whether the action has a popup.
+ @discussion Use this property to check if the action has a popup before attempting to access the `popupWebView` property.
+ @seealso popupWebView
+ */
+@property (nonatomic, readonly) BOOL hasPopup;
+
+/*!
+ @abstract A web view loaded with the popup page for this action, or `nil` if no popup is specified.
+ @discussion The web view will be preloaded with the popup page upon first access or after it has been closed. Use the `hasPopup`
+ property to determine whether a popup should be displayed before accessing this property.
+ @seealso hasPopup
+ */
+@property (nonatomic, readonly, nullable) WKWebView *popupWebView;
+
+/*!
+ @abstract Should be called by the app to close the popup's web view.
+ @discussion This method should be called when the popup web view is no longer presented to the user, indicating that it can safely be closed.
+ */
+- (void)closePopupWebView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionActionInternal.h"
+
+#import "CocoaImage.h"
+#import "WebExtensionAction.h"
+#import "WebExtensionContext.h"
+#import "WebExtensionTab.h"
+#import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/CompletionHandler.h>
+
+NSNotificationName const _WKWebExtensionActionPropertiesDidChangeNotification = @"_WKWebExtensionActionPropertiesDidChange";
+NSNotificationName const _WKWebExtensionActionPopupWebViewContentSizeDidChangeNotification = @"_WKWebExtensionActionPopupWebViewContentSizeDidChange";
+NSNotificationName const _WKWebExtensionActionPopupWebViewDidCloseNotification = @"_WKWebExtensionActionPopupWebViewDidClose";
+
+@implementation _WKWebExtensionAction
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKWebExtensionAction.class, self))
+        return;
+
+    _webExtensionAction->~WebExtensionAction();
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+        return YES;
+
+    auto *other = dynamic_objc_cast<_WKWebExtensionAction>(object);
+    if (!other)
+        return NO;
+
+    return *_webExtensionAction == *other->_webExtensionAction;
+}
+
+- (_WKWebExtensionContext *)webExtensionContext
+{
+    if (auto *context = _webExtensionAction->extensionContext())
+        return context->wrapper();
+    return nil;
+}
+
+- (id<_WKWebExtensionTab>)associatedTab
+{
+    if (auto *tab = _webExtensionAction->tab())
+        return tab->delegate();
+    return nil;
+}
+
+- (CocoaImage *)iconForSize:(CGSize)size
+{
+    return _webExtensionAction->icon(size);
+}
+
+- (NSString *)displayLabel
+{
+    return _webExtensionAction->displayLabel();
+}
+
+- (NSString *)badgeText
+{
+    return _webExtensionAction->badgeText();
+}
+
+- (BOOL)isEnabled
+{
+    return _webExtensionAction->isEnabled();
+}
+
+- (BOOL)hasPopup
+{
+    return _webExtensionAction->hasPopup();
+}
+
+- (WKWebView *)popupWebView
+{
+    return _webExtensionAction->popupWebView();
+}
+
+- (void)closePopupWebView
+{
+    _webExtensionAction->closePopupWebView();
+}
+
+#pragma mark WKObject protocol implementation
+
+- (API::Object&)_apiObject
+{
+    return *_webExtensionAction;
+}
+
+- (WebKit::WebExtensionAction&)_webExtensionAction
+{
+    return *_webExtensionAction;
+}
+
+#else // ENABLE(WK_WEB_EXTENSIONS)
+
+- (_WKWebExtensionContext *)webExtensionContext
+{
+    return nil;
+}
+
+- (id<_WKWebExtensionTab>)associatedTab
+{
+    return nil;
+}
+
+- (CocoaImage *)iconForSize:(CGSize)size
+{
+    return nil;
+}
+
+- (NSString *)displayLabel
+{
+    return nil;
+}
+
+- (NSString *)badgeText
+{
+    return nil;
+}
+
+- (BOOL)isEnabled
+{
+    return NO;
+}
+
+- (BOOL)hasPopup
+{
+    return NO;
+}
+
+- (WKWebView *)popupWebView
+{
+    return nil;
+}
+
+- (void)closePopupWebView
+{
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionActionInternal.h
@@ -23,22 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
+#import "_WKWebExtensionActionPrivate.h"
 
-#import "PlatformUtilities.h"
-#import "Test.h"
-#import <WebKit/WKWebViewPrivate.h>
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-TEST(WKWebViewInspection, UseInspectionAPIAfterClose)
-{
-    auto webView = adoptNS([[WKWebView alloc] init]);
+#import "WKObject.h"
+#import "WebExtensionAction.h"
 
-    [webView setInspectable:YES];
-
-    [webView _close];
-
-    EXPECT_FALSE([webView isInspectable]);
-    [webView setInspectable:NO];
-    EXPECT_WK_STREQ("", [webView _remoteInspectionNameOverride]);
-    [webView _setRemoteInspectionNameOverride:@"Somebody"];
+namespace WebKit {
+template<> struct WrapperTraits<WebExtensionAction> {
+    using WrapperClass = _WKWebExtensionAction;
+};
 }
+
+@interface _WKWebExtensionAction () <WKObject> {
+@package
+    API::ObjectStorage<WebKit::WebExtensionAction> _webExtensionAction;
+}
+
+@property (nonatomic, readonly) WebKit::WebExtensionAction& _webExtensionAction;
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionActionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionActionPrivate.h
@@ -23,22 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
+#import <WebKit/_WKWebExtensionAction.h>
 
-#import "PlatformUtilities.h"
-#import "Test.h"
-#import <WebKit/WKWebViewPrivate.h>
+@interface _WKWebExtensionAction ()
 
-TEST(WKWebViewInspection, UseInspectionAPIAfterClose)
-{
-    auto webView = adoptNS([[WKWebView alloc] init]);
-
-    [webView setInspectable:YES];
-
-    [webView _close];
-
-    EXPECT_FALSE([webView isInspectable]);
-    [webView setInspectable:NO];
-    EXPECT_WK_STREQ("", [webView _remoteInspectionNameOverride]);
-    [webView _setRemoteInspectionNameOverride:@"Somebody"];
-}
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -32,6 +32,7 @@
 #import <WebKit/_WKWebExtensionTab.h>
 
 @class _WKWebExtension;
+@class _WKWebExtensionAction;
 @class _WKWebExtensionController;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -448,10 +449,52 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 - (void)setPermissionStatus:(_WKWebExtensionContextPermissionStatus)status forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(nullable NSDate *)expirationDate NS_SWIFT_NAME(setPermissionStatus(_:for:expirationDate:));
 
 /*!
- @abstract Returns a Boolean value indicating if a user gesture has been noted for the specified tab.
- @param tab The tab in which to return the user gesture status.
-*/
+ @abstract Retrieves the extension action for a given tab, or the default action if `nil` is passed.
+ @param tab The tab for which to retrieve the extension action, or `nil` to get the default action.
+ @discussion The returned object represents the action specific to the tab when provided; otherwise, it returns the default action. The default
+ action is useful when the context is unrelated to a specific tab. When possible, specify the tab to get the most context-relevant action.
+ */
+- (_WKWebExtensionAction *)actionForTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(action(for:));
+
+/*!
+ @abstract Performs the extension action associated with the specified tab or performs the default action if `nil` is passed.
+ @param tab The tab for which to perform the extension action, or `nil` to perform the default action.
+ @discussion Performing the action will mark the tab, if specified, as having an active user gesture. When the `tab` parameter is `nil`,
+ the default action is performed. The action can either trigger an event or display a popup, depending on how the extension is configured.
+ If the action is configured to display a popup, implementing the appropriate web extension controller delegate method is required; otherwise,
+ no action is performed for popup actions.
+ */
+- (void)performActionForTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(performAction(for:));
+
+/*!
+ @abstract Should be called by the app when a user gesture is performed in a specific tab.
+ @param tab The tab in which the user gesture was performed.
+ @discussion When a user gesture is performed in a tab, this method should be called to update the extension context.
+ This enables the extension to be aware of the user gesture, potentially granting it access to features that require user interaction,
+ such as `activeTab`. Not required if using `performActionForTab:`.
+ @seealso hasActiveUserGestureInTab:
+ */
+- (void)userGesturePerformedInTab:(id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(userGesturePerformed(in:));
+
+/*!
+ @abstract Indicates if a user gesture is currently active in the specified tab.
+ @param tab The tab for which to check for an active user gesture.
+ @discussion An active user gesture may influence the availability of certain permissions, such as `activeTab`. User gestures can
+ be triggered by various user interactions with the web extension, including clicking on extension menu items, executing extension commands,
+ or interacting with extension actions. A tab as having an active user gesture enables the extension to access features that require user interaction.
+ @seealso userGesturePerformedInTab:
+ */
 - (BOOL)hasActiveUserGestureInTab:(id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(hasActiveUserGesture(in:));
+
+/*!
+ @abstract Should be called by the app to clear a user gesture in a specific tab.
+ @param tab The tab from which the user gesture should be cleared.
+ @discussion When a user gesture is no longer relevant in a tab, this method should be called to update the extension context.
+ This will revoke the extension's access to features that require active user interaction, such as `activeTab`. User gestures are
+ automatically cleared during navigation in certain scenarios; this method is needed if the app intends to clear the gesture more aggressively.
+ @seealso userGesturePerformedInTab:
+ */
+- (void)clearUserGestureInTab:(id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(clearUserGesture(in:));
 
 /*!
  @abstract An array of open windows that are exposed to this extension.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
@@ -29,6 +29,7 @@
 
 #import <WebKit/_WKWebExtensionPermission.h>
 
+@class _WKWebExtensionAction;
 @class _WKWebExtensionContext;
 @class _WKWebExtensionController;
 @class _WKWebExtensionMatchPattern;
@@ -136,6 +137,19 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  the request is assumed to have been denied.
  */
 - (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionMatchPatterns:in:for:completionHandler:));
+
+/*!
+ @abstract Called when a popup is requested to be displayed for a specific action.
+ @param controller The web extension controller initiating the request.
+ @param action The action for which the popup is requested.
+ @param context The context within which the web extension is running.
+ @param completionHandler A block to be called once the popup display operation is completed.
+ @discussion This method is called in response to the extension's scripts or when invoking `performActionForTab:` if the action has a popup.
+ The associated tab, if applicable, can be located through the `associatedTab` property of the `action` parameter. This delegate method is
+ called when the web view for the popup is fully loaded and ready to display. Implementing this method is needed if the app intends to support
+ programmatically showing the popup by the extension, although it is recommended for handling both programmatic and user-initiated cases.
+ */
+- (void)webExtensionController:(_WKWebExtensionController *)controller presentActionPopup:(_WKWebExtensionAction *)action forExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 /*!
  @abstract Called when an extension context wants to send a one-time message to an application.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -1,0 +1,392 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAction.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WKNavigationActionPrivate.h"
+#import "WKNavigationDelegatePrivate.h"
+#import "WKUIDelegatePrivate.h"
+#import "WKWebViewConfigurationPrivate.h"
+#import "WKWebViewPrivate.h"
+#import "WebExtensionContext.h"
+#import "_WKWebExtensionActionInternal.h"
+#import "_WKWebExtensionControllerDelegatePrivate.h"
+#import <wtf/BlockPtr.h>
+
+#if USE(APPKIT)
+constexpr CGFloat popoverMaximumWidth = 800;
+constexpr CGFloat popoverMaximumHeight = 600;
+#endif
+
+constexpr CGFloat popoverMinimumWidth = 50;
+constexpr CGFloat popoverMinimumHeight = 50;
+constexpr NSTimeInterval popoverShowTimeout = 1;
+
+@interface _WKWebExtensionActionWebViewDelegate : NSObject <WKNavigationDelegatePrivate, WKUIDelegatePrivate>
+@end
+
+@implementation _WKWebExtensionActionWebViewDelegate {
+    WeakPtr<WebKit::WebExtensionAction> _webExtensionAction;
+}
+
+- (instancetype)initWithWebExtensionAction:(WebKit::WebExtensionAction&)action
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _webExtensionAction = action;
+
+    return self;
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
+{
+    NSURL *targetURL = navigationAction.request.URL;
+
+    if (!navigationAction.targetFrame) {
+        // FIXME: Handle new tab/window navigation.
+        decisionHandler(WKNavigationActionPolicyCancel);
+        return;
+    }
+
+    // Allow subframes to load any URL.
+    if (!navigationAction.targetFrame.isMainFrame) {
+        decisionHandler(WKNavigationActionPolicyAllow);
+        return;
+    }
+
+    ASSERT(navigationAction.targetFrame.mainFrame);
+
+    // Require an extension URL for the main frame.
+    if (!_webExtensionAction->extensionContext()->isURLForThisExtension(targetURL)) {
+        decisionHandler(WKNavigationActionPolicyCancel);
+        return;
+    }
+
+    decisionHandler(WKNavigationActionPolicyAllow);
+}
+
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
+{
+    _webExtensionAction->popupDidClose();
+}
+
+- (void)webViewDidClose:(WKWebView *)webView
+{
+    _webExtensionAction->popupDidClose();
+}
+
+@end
+
+@interface _WKWebExtensionActionWebView : WKWebView
+@end
+
+@implementation _WKWebExtensionActionWebView {
+    WeakPtr<WebKit::WebExtensionAction> _webExtensionAction;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration webExtensionAction:(WebKit::WebExtensionAction&)action
+{
+    if (!(self = [super initWithFrame:frame configuration:configuration]))
+        return nil;
+
+    _webExtensionAction = action;
+
+    return self;
+}
+
+- (void)invalidateIntrinsicContentSize
+{
+    auto intrinsicContentSize = self.intrinsicContentSize;
+
+    [super invalidateIntrinsicContentSize];
+
+    _webExtensionAction->popupSizeDidChange();
+
+    if (intrinsicContentSize.width >= popoverMinimumWidth && intrinsicContentSize.height >= popoverMinimumHeight)
+        _webExtensionAction->readyToPresentPopup();
+}
+
+@end
+
+namespace WebKit {
+
+WebExtensionAction::WebExtensionAction(WebExtensionContext& extensionContext)
+    : m_extensionContext(extensionContext)
+{
+    auto delegate = extensionContext.extensionController()->delegate();
+    m_respondsToPresentPopup = [delegate respondsToSelector:@selector(webExtensionController:presentActionPopup:forExtensionContext:completionHandler:)];
+
+    if (!m_respondsToPresentPopup)
+        RELEASE_LOG_ERROR(Extensions, "%{public}@ does not implement the webExtensionController:presentActionPopup:forExtensionContext:completionHandler: method", delegate.debugDescription);
+}
+
+WebExtensionAction::WebExtensionAction(WebExtensionContext& extensionContext, WebExtensionTab& tab)
+    : m_extensionContext(extensionContext)
+    , m_tab(&tab)
+{
+    auto delegate = extensionContext.extensionController()->delegate();
+    m_respondsToPresentPopup = [delegate respondsToSelector:@selector(webExtensionController:presentActionPopup:forExtensionContext:completionHandler:)];
+
+    if (!m_respondsToPresentPopup)
+        RELEASE_LOG_ERROR(Extensions, "%{public}@ does not implement the webExtensionController:presentActionPopup:forExtensionContext:completionHandler: method", delegate.debugDescription);
+}
+
+bool WebExtensionAction::operator==(const WebExtensionAction& other) const
+{
+    return this == &other || (m_extensionContext == other.m_extensionContext && m_tab == other.m_tab);
+}
+
+WebExtensionContext* WebExtensionAction::extensionContext() const
+{
+    return m_extensionContext.get();
+}
+
+void WebExtensionAction::propertiesDidChange()
+{
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
+        [NSNotificationCenter.defaultCenter postNotificationName:_WKWebExtensionActionPropertiesDidChangeNotification object:wrapper() userInfo:nil];
+    }).get());
+}
+
+CocoaImage *WebExtensionAction::icon(CGSize idealSize)
+{
+    if (!extensionContext())
+        return nil;
+
+    if (m_customIcons)
+        return extensionContext()->extension().bestImageInIconsDictionary(m_customIcons.get(), idealSize.width > idealSize.height ? idealSize.width : idealSize.height);
+
+    if (m_tab)
+        return extensionContext()->defaultAction().icon(idealSize);
+
+    return extensionContext()->extension().actionIcon(idealSize);
+}
+
+void WebExtensionAction::setIconsDictionary(NSDictionary *icons)
+{
+    m_customIcons = icons;
+
+    propertiesDidChange();
+}
+
+String WebExtensionAction::popupPath() const
+{
+    if (!extensionContext())
+        return emptyString();
+
+    if (!m_customPopupPath.isNull())
+        return m_customPopupPath;
+
+    if (m_tab)
+        return extensionContext()->defaultAction().popupPath();
+
+    return extensionContext()->extension().actionPopupPath();
+}
+
+void WebExtensionAction::setPopupPath(String path)
+{
+    m_customPopupPath = path;
+
+    propertiesDidChange();
+}
+
+WKWebView *WebExtensionAction::popupWebView(LoadOnFirstAccess loadOnFirstAccess)
+{
+    if (!hasPopup())
+        return nil;
+
+    if (m_popupWebView || loadOnFirstAccess == LoadOnFirstAccess::No)
+        return m_popupWebView.get();
+
+    auto *webViewConfiguration = extensionContext()->webViewConfiguration();
+    webViewConfiguration.suppressesIncrementalRendering = YES;
+
+    m_popupWebViewDelegate = [[_WKWebExtensionActionWebViewDelegate alloc] initWithWebExtensionAction:*this];
+
+    m_popupWebView = [[_WKWebExtensionActionWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration webExtensionAction:*this];
+    m_popupWebView.get().navigationDelegate = m_popupWebViewDelegate.get();
+    m_popupWebView.get().UIDelegate = m_popupWebViewDelegate.get();
+
+    m_popupWebView.get().inspectable = extensionContext()->isInspectable();
+
+    m_popupWebView.get().accessibilityLabel = extensionContext()->extension().displayName();
+
+#if USE(APPKIT)
+    m_popupWebView.get().accessibilityRole = NSAccessibilityPopoverRole;
+
+    m_popupWebView.get()._sizeToContentAutoSizeMaximumSize = CGSizeMake(popoverMaximumWidth, popoverMaximumHeight);
+    m_popupWebView.get()._useSystemAppearance = YES;
+
+    [m_popupWebView setContentHuggingPriority:NSLayoutPriorityDefaultHigh forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [m_popupWebView setContentHuggingPriority:NSLayoutPriorityDefaultHigh forOrientation:NSLayoutConstraintOrientationVertical];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [m_popupWebView.get().widthAnchor constraintGreaterThanOrEqualToConstant:popoverMinimumWidth],
+        [m_popupWebView.get().widthAnchor constraintLessThanOrEqualToConstant:popoverMaximumWidth],
+        [m_popupWebView.get().heightAnchor constraintGreaterThanOrEqualToConstant:popoverMinimumHeight],
+        [m_popupWebView.get().heightAnchor constraintLessThanOrEqualToConstant:popoverMaximumHeight]
+    ]];
+#endif // USE(APPKIT)
+
+    auto url = URL { extensionContext()->baseURL(), popupPath() };
+    [m_popupWebView loadRequest:[NSURLRequest requestWithURL:url]];
+
+    return m_popupWebView.get();
+}
+
+void WebExtensionAction::presentPopupWhenReady()
+{
+    if (!extensionContext() || !m_respondsToPresentPopup)
+        return;
+
+    m_popupPresented = false;
+
+    if (m_popupWebView) {
+        readyToPresentPopup();
+        return;
+    }
+
+    // Delay showing the popup until a minimum size or a timeout is reached.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(popoverShowTimeout * NSEC_PER_SEC)), dispatch_get_main_queue(), makeBlockPtr([protectecThis = Ref { *this }] {
+        protectecThis->readyToPresentPopup();
+    }).get());
+
+    popupWebView(LoadOnFirstAccess::Yes);
+}
+
+void WebExtensionAction::readyToPresentPopup()
+{
+    if (m_popupPresented || !m_respondsToPresentPopup)
+        return;
+
+    m_popupPresented = true;
+
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
+        auto* extensionController = extensionContext()->extensionController();
+        auto delegate = extensionController->delegate();
+
+        [delegate webExtensionController:extensionController->wrapper() presentActionPopup:wrapper() forExtensionContext:extensionContext()->wrapper() completionHandler:makeBlockPtr([protectecThis = Ref { *this }](NSError *error) {
+            if (error)
+                protectecThis->closePopupWebView();
+        }).get()];
+    }).get());
+}
+
+void WebExtensionAction::popupSizeDidChange()
+{
+    [NSNotificationCenter.defaultCenter postNotificationName:_WKWebExtensionActionPopupWebViewContentSizeDidChangeNotification object:wrapper() userInfo:nil];
+}
+
+void WebExtensionAction::popupDidClose()
+{
+    m_popupWebView = nil;
+    m_popupPresented = false;
+}
+
+void WebExtensionAction::closePopupWebView()
+{
+    [m_popupWebView _close];
+    m_popupWebView = nil;
+    m_popupPresented = false;
+}
+
+String WebExtensionAction::displayLabel() const
+{
+    if (!extensionContext())
+        return emptyString();
+
+    if (!m_customLabel.isEmpty())
+        return m_customLabel;
+
+    if (m_tab)
+        return extensionContext()->defaultAction().displayLabel();
+
+    if (auto *defaultLabel = extensionContext()->extension().displayActionLabel())
+        return defaultLabel;
+
+    return extensionContext()->extension().displayName();
+}
+
+void WebExtensionAction::setDisplayLabel(String label)
+{
+    m_customLabel = label;
+
+    propertiesDidChange();
+}
+
+String WebExtensionAction::badgeText() const
+{
+    if (!extensionContext())
+        return emptyString();
+
+    if (!m_customBadgeText.isNull())
+        return m_customBadgeText;
+
+    if (m_tab)
+        return extensionContext()->defaultAction().badgeText();
+
+    return emptyString();
+}
+
+void WebExtensionAction::setBadgeText(String badgeText)
+{
+    m_customBadgeText = badgeText;
+
+    propertiesDidChange();
+}
+
+bool WebExtensionAction::isEnabled() const
+{
+    if (!extensionContext())
+        return false;
+
+    if (m_customEnabled)
+        return m_customEnabled.value();
+
+    if (m_tab)
+        return extensionContext()->defaultAction().isEnabled();
+
+    return true;
+}
+
+void WebExtensionAction::setEnabled(std::optional<bool> enabled)
+{
+    m_customEnabled = enabled;
+
+    propertiesDidChange();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -239,8 +239,7 @@ bool WebExtensionTab::matches(const WebExtensionTabQueryParameters& parameters, 
 
 bool WebExtensionTab::extensionHasAccess() const
 {
-    auto url = this->url();
-    return extensionContext()->hasPermission(url, delegate());
+    return extensionContext()->hasPermission(url(), const_cast<WebExtensionTab*>(this));
 }
 
 RefPtr<WebExtensionWindow> WebExtensionTab::window(SkipContainsCheck skipCheck) const

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -46,6 +46,7 @@ OBJC_CLASS NSMutableArray;
 OBJC_CLASS NSMutableDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
+OBJC_CLASS UTType;
 OBJC_CLASS _WKWebExtension;
 OBJC_CLASS _WKWebExtensionLocalization;
 OBJC_CLASS _WKWebExtensionMatchPattern;
@@ -158,6 +159,8 @@ public:
     bool isAccessibleResourcePath(NSString *, NSURL *frameDocumentURL);
 
     NSURL *resourceFileURLForPath(NSString *);
+
+    UTType *resourceTypeForPath(NSString *);
 
     NSString *resourceStringForPath(NSString *, CacheResult = CacheResult::No);
     NSData *resourceDataForPath(NSString *, CacheResult = CacheResult::No);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "APIObject.h"
+#include "CocoaImage.h"
+#include <wtf/Forward.h>
+#include <wtf/WeakObjCPtr.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/WTFString.h>
+
+OBJC_CLASS NSError;
+OBJC_CLASS WKWebView;
+OBJC_CLASS _WKWebExtensionAction;
+OBJC_CLASS _WKWebExtensionActionWebView;
+OBJC_CLASS _WKWebExtensionActionWebViewDelegate;
+
+namespace WebKit {
+
+class WebExtensionContext;
+class WebExtensionTab;
+
+class WebExtensionAction : public API::ObjectImpl<API::Object::Type::WebExtensionAction>, public CanMakeWeakPtr<WebExtensionAction> {
+    WTF_MAKE_NONCOPYABLE(WebExtensionAction);
+
+public:
+    template<typename... Args>
+    static Ref<WebExtensionAction> create(Args&&... args)
+    {
+        return adoptRef(*new WebExtensionAction(std::forward<Args>(args)...));
+    }
+
+    explicit WebExtensionAction(WebExtensionContext&);
+    explicit WebExtensionAction(WebExtensionContext&, WebExtensionTab&);
+
+    enum class LoadOnFirstAccess { No, Yes };
+
+    bool operator==(const WebExtensionAction&) const;
+
+    WebExtensionContext* extensionContext() const;
+    WebExtensionTab* tab() { return m_tab.get(); }
+
+    void propertiesDidChange();
+
+    CocoaImage *icon(CGSize);
+    void setIconsDictionary(NSDictionary *);
+
+    String displayLabel() const;
+    void setDisplayLabel(String);
+
+    String badgeText() const;
+    void setBadgeText(String);
+
+    bool isEnabled() const;
+    void setEnabled(std::optional<bool>);
+
+    bool hasPopup() const { return !popupPath().isEmpty(); }
+
+    String popupPath() const;
+    void setPopupPath(String);
+
+    WKWebView *popupWebView(LoadOnFirstAccess = LoadOnFirstAccess::Yes);
+    void presentPopupWhenReady();
+    void readyToPresentPopup();
+    void popupSizeDidChange();
+    void popupDidClose();
+    void closePopupWebView();
+
+#ifdef __OBJC__
+    _WKWebExtensionAction *wrapper() const { return (_WKWebExtensionAction *)API::ObjectImpl<API::Object::Type::WebExtensionAction>::wrapper(); }
+#endif
+
+private:
+    WeakPtr<WebExtensionContext> m_extensionContext;
+    RefPtr<WebExtensionTab> m_tab;
+
+    RetainPtr<_WKWebExtensionActionWebView> m_popupWebView;
+    RetainPtr<_WKWebExtensionActionWebViewDelegate> m_popupWebViewDelegate;
+    String m_customPopupPath;
+
+    RetainPtr<NSDictionary> m_customIcons;
+    String m_customLabel;
+    String m_customBadgeText;
+    std::optional<bool> m_customEnabled;
+    bool m_popupPresented { false };
+    bool m_respondsToPresentPopup { false };
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -47,7 +47,7 @@ class WebProcessProxy;
 struct WebExtensionTabParameters;
 struct WebExtensionTabQueryParameters;
 
-class WebExtensionTab : public RefCounted<WebExtensionTab> {
+class WebExtensionTab : public RefCounted<WebExtensionTab>, public CanMakeWeakPtr<WebExtensionTab> {
     WTF_MAKE_NONCOPYABLE(WebExtensionTab);
     WTF_MAKE_FAST_ALLOCATED;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -521,6 +521,12 @@
 		1CBBE4A019B66C53006B7D81 /* WebInspectorUIMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CBBE49E19B66C53006B7D81 /* WebInspectorUIMessageReceiver.cpp */; };
 		1CBBE4A119B66C53006B7D81 /* WebInspectorUIMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CBBE49F19B66C53006B7D81 /* WebInspectorUIMessages.h */; };
 		1CBEE27028F4DDA1006D1A02 /* WebExtensionControllerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1CF0C9462AC34BC600EC82F2 /* _WKWebExtensionAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF0C9452AC34BC600EC82F2 /* _WKWebExtensionAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1CF0C9482AC37FAD00EC82F2 /* _WKWebExtensionAction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CF0C9472AC37FAD00EC82F2 /* _WKWebExtensionAction.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1CF0C94A2AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF0C9492AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1CF0C94C2AC3801400EC82F2 /* _WKWebExtensionActionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF0C94B2AC3801400EC82F2 /* _WKWebExtensionActionInternal.h */; };
+		1CF0C94E2AC380C400EC82F2 /* WebExtensionAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF0C94D2AC380C400EC82F2 /* WebExtensionAction.h */; };
+		1CF0C9502AC380E900EC82F2 /* WebExtensionActionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CF0C94F2AC380E900EC82F2 /* WebExtensionActionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1CF7FFA62AA7AD66003609F0 /* WebExtensionTabQueryParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF7FFA52AA7AD66003609F0 /* WebExtensionTabQueryParameters.h */; };
 		1D4D737023A9E54700717A25 /* RemoteMediaResourceManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1D4D736B23A9DF5500717A25 /* RemoteMediaResourceManagerMessageReceiver.cpp */; };
 		1D4D737123A9E56200717A25 /* RemoteMediaResourceManagerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D4D736C23A9DF6000717A25 /* RemoteMediaResourceManagerMessages.h */; };
@@ -3978,6 +3984,12 @@
 		1CDDFC7E2755866D00C93C62 /* RemoteGPUProxyMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGPUProxyMessages.h; sourceTree = "<group>"; };
 		1CEF45BB27BCA46A00C3A6BC /* WebGPUShaderModuleCompilationHint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebGPUShaderModuleCompilationHint.cpp; sourceTree = "<group>"; };
 		1CEF45BC27BCA46A00C3A6BC /* WebGPUShaderModuleCompilationHint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUShaderModuleCompilationHint.h; sourceTree = "<group>"; };
+		1CF0C9452AC34BC600EC82F2 /* _WKWebExtensionAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionAction.h; sourceTree = "<group>"; };
+		1CF0C9472AC37FAD00EC82F2 /* _WKWebExtensionAction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionAction.mm; sourceTree = "<group>"; };
+		1CF0C9492AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionActionPrivate.h; sourceTree = "<group>"; };
+		1CF0C94B2AC3801400EC82F2 /* _WKWebExtensionActionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionActionInternal.h; sourceTree = "<group>"; };
+		1CF0C94D2AC380C400EC82F2 /* WebExtensionAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAction.h; sourceTree = "<group>"; };
+		1CF0C94F2AC380E900EC82F2 /* WebExtensionActionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionActionCocoa.mm; sourceTree = "<group>"; };
 		1CF18F3E26BB5D90004B1722 /* LogInitialization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogInitialization.cpp; sourceTree = "<group>"; };
 		1CF7FFA52AA7AD66003609F0 /* WebExtensionTabQueryParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionTabQueryParameters.h; sourceTree = "<group>"; };
 		1D0B66192624C11800F9712F /* WebMediaKeySystemClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebMediaKeySystemClient.cpp; sourceTree = "<group>"; };
@@ -8913,6 +8925,7 @@
 			isa = PBXGroup;
 			children = (
 				1C1549802926E7CC001B9E5B /* API */,
+				1CF0C94F2AC380E900EC82F2 /* WebExtensionActionCocoa.mm */,
 				1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */,
 				1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */,
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
@@ -9331,6 +9344,7 @@
 			children = (
 				1C627476288A1DDE00CED3A2 /* Cocoa */,
 				1C3BEB5E2888710500E66E38 /* WebExtension.h */,
+				1CF0C94D2AC380C400EC82F2 /* WebExtensionAction.h */,
 				1C2B4D3C2A8091FF00C528A1 /* WebExtensionAlarm.cpp */,
 				1C2B4D3D2A8091FF00C528A1 /* WebExtensionAlarm.h */,
 				1C0234C128A00E7D00AC1E5B /* WebExtensionContext.cpp */,
@@ -10367,6 +10381,10 @@
 				574728D3234570AE001700AF /* _WKWebAuthenticationPanelInternal.h */,
 				1C3BEB6C288883E200E66E38 /* _WKWebExtension.h */,
 				1C3BEB6E288883E200E66E38 /* _WKWebExtension.mm */,
+				1CF0C9452AC34BC600EC82F2 /* _WKWebExtensionAction.h */,
+				1CF0C9472AC37FAD00EC82F2 /* _WKWebExtensionAction.mm */,
+				1CF0C94B2AC3801400EC82F2 /* _WKWebExtensionActionInternal.h */,
+				1CF0C9492AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h */,
 				1C04983A289AFF9B0010308B /* _WKWebExtensionContext.h */,
 				1C0234D328A0135600AC1E5B /* _WKWebExtensionContext.mm */,
 				1C0234D628A013D900AC1E5B /* _WKWebExtensionContextInternal.h */,
@@ -14533,6 +14551,9 @@
 				5790A6532565DED30077C5A7 /* _WKWebAuthenticationPanelForTesting.h in Headers */,
 				574728D4234570AE001700AF /* _WKWebAuthenticationPanelInternal.h in Headers */,
 				1C3BEB702888842400E66E38 /* _WKWebExtension.h in Headers */,
+				1CF0C9462AC34BC600EC82F2 /* _WKWebExtensionAction.h in Headers */,
+				1CF0C94C2AC3801400EC82F2 /* _WKWebExtensionActionInternal.h in Headers */,
+				1CF0C94A2AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h in Headers */,
 				1C04983E289AFF9B0010308B /* _WKWebExtensionContext.h in Headers */,
 				1C0234D828A013D900AC1E5B /* _WKWebExtensionContextInternal.h in Headers */,
 				1C0234D728A013D900AC1E5B /* _WKWebExtensionContextPrivate.h in Headers */,
@@ -15298,6 +15319,7 @@
 				BC111B5D112F629800337BAB /* WebEventFactory.h in Headers */,
 				86DD519028EF28E800DF2A58 /* WebEventModifier.h in Headers */,
 				F4CBF79E2A6ADF7E00C066BF /* WebEventType.h in Headers */,
+				1CF0C94E2AC380C400EC82F2 /* WebExtensionAction.h in Headers */,
 				1C2B4D422A817D7200C528A1 /* WebExtensionAlarmParameters.h in Headers */,
 				1C2B4D462A8199CD00C528A1 /* WebExtensionAPIAlarms.h in Headers */,
 				B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */,
@@ -17581,6 +17603,7 @@
 				49FBEFFF239B012F00BD032F /* _WKResourceLoadStatisticsThirdParty.mm in Sources */,
 				99E7189A21F79D9E0055E975 /* _WKTouchEventGenerator.mm in Sources */,
 				1C627479288B2F7400CED3A2 /* _WKWebExtension.mm in Sources */,
+				1CF0C9482AC37FAD00EC82F2 /* _WKWebExtensionAction.mm in Sources */,
 				1C0234D428A0135600AC1E5B /* _WKWebExtensionContext.mm in Sources */,
 				1C62747A288B2F7400CED3A2 /* _WKWebExtensionController.mm in Sources */,
 				1C1549D729381DFF001B9E5B /* _WKWebExtensionControllerConfiguration.mm in Sources */,
@@ -17954,6 +17977,7 @@
 				E3866B0B2399A2DD00F88FE9 /* WebDeviceOrientationUpdateProviderMessageReceiver.cpp in Sources */,
 				E3866AE52397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm in Sources */,
 				E3866B092399A2D500F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp in Sources */,
+				1CF0C9502AC380E900EC82F2 /* WebExtensionActionCocoa.mm in Sources */,
 				1C2B4D442A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm in Sources */,
 				B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */,
 				1C5DC467290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm in Sources */,

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -286,6 +286,7 @@ Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-leaks.mm
 Tests/WebKitCocoa/WKWebExtension.mm
+Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
 Tests/WebKitCocoa/WKWebExtensionAPIAlarms.mm
 Tests/WebKitCocoa/WKWebExtensionAPIEvent.mm
 Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2116,6 +2116,7 @@
 		1CC4C74B28890C5400A3B23D /* SVGFont.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = SVGFont.html; sourceTree = "<group>"; };
 		1CC4C74C28890CE100A3B23D /* Helvetica_light.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Helvetica_light.svg; sourceTree = "<group>"; };
 		1CC80CE92474F1F7004DC489 /* idempotent-mode-autosizing-only-honors-percentages.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "idempotent-mode-autosizing-only-honors-percentages.html"; sourceTree = "<group>"; };
+		1CC94E3D2AC75AB10045F269 /* WKWebExtensionAPIAction.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIAction.mm; sourceTree = "<group>"; };
 		1CE6FAC12320264F00E48F6E /* rich-color-filtered.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "rich-color-filtered.html"; sourceTree = "<group>"; };
 		1CF087D725ED7F73004148CB /* MobileAssetSandboxCheck.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MobileAssetSandboxCheck.mm; sourceTree = "<group>"; };
 		1CF0D3781BBF2F3D00B4EF54 /* WKRetainPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKRetainPtr.cpp; sourceTree = "<group>"; };
@@ -4226,6 +4227,7 @@
 				51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */,
 				5182C22D1F2BCB410059BA7C /* WKURLSchemeHandler-leaks.mm */,
 				1CFAA40828947999009F894D /* WKWebExtension.mm */,
+				1CC94E3D2AC75AB10045F269 /* WKWebExtensionAPIAction.mm */,
 				1C2B4D4C2A81F42800C528A1 /* WKWebExtensionAPIAlarms.mm */,
 				B6E1E1E02942B0DD00F314D2 /* WKWebExtensionAPIEvent.mm */,
 				1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "TestWebExtensionsDelegate.h"
+#import "WebExtensionUtilities.h"
+
+namespace TestWebKitAPI {
+
+static auto *actionPopupManifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"Tabs Test",
+    @"description": @"Tabs Test",
+    @"version": @"1",
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+
+    @"action": @{
+        @"default_title": @"Test Action",
+        @"default_popup": @"popup.html",
+        @"default_icon": @{
+            @"16": @"toolbar-16.png",
+            @"32": @"toolbar-32.png",
+        },
+    },
+};
+
+NSData *makePNGData(CGSize size, SEL colorSelector) {
+#if USE(APPKIT)
+    auto image = adoptNS([[NSImage alloc] initWithSize:size]);
+
+    [image lockFocus];
+
+    [[NSColor performSelector:colorSelector] setFill];
+    NSRectFill(NSMakeRect(0, 0, size.width, size.height));
+
+    [image unlockFocus];
+
+    auto cgImageRef = [image CGImageForProposedRect:NULL context:nil hints:nil];
+    auto newRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef]);
+    [newRep setSize:size];
+
+    return [newRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
+#else
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
+
+    [[UIColor performSelector:colorSelector] setFill];
+    UIRectFill(CGRectMake(0, 0, size.width, size.height));
+
+    auto *image = UIGraphicsGetImageFromCurrentImageContext();
+
+    UIGraphicsEndImageContext();
+
+    return UIImagePNGRepresentation(image);
+#endif
+}
+
+TEST(WKWebExtensionAPIAction, PresentActionPopup)
+{
+    auto *popupPage = @"<b>Hello World!</b>";
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.yield('Test Popup Action')"
+    ]);
+
+    auto *smallToolbarIcon = makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    auto *largeToolbarIcon = makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": popupPage,
+        @"toolbar-16.png": smallToolbarIcon,
+        @"toolbar-32.png": largeToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        EXPECT_TRUE(action.hasPopup);
+        EXPECT_TRUE(action.isEnabled);
+        EXPECT_NULL(action.badgeText);
+
+        EXPECT_NS_EQUAL(action.displayLabel, @"Test Action");
+
+        auto *smallIcon = [action iconForSize:CGSizeMake(16, 16)];
+        EXPECT_NOT_NULL(smallIcon);
+        EXPECT_TRUE(CGSizeEqualToSize(smallIcon.size, CGSizeMake(16, 16)));
+
+        auto *largeIcon = [action iconForSize:CGSizeMake(32, 32)];
+        EXPECT_NOT_NULL(largeIcon);
+        EXPECT_TRUE(CGSizeEqualToSize(largeIcon.size, CGSizeMake(32, 32)));
+
+        EXPECT_NOT_NULL(action.popupWebView);
+        EXPECT_FALSE(action.popupWebView.loading);
+
+        NSURL *webViewURL = action.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
+
+        [action closePopupWebView];
+    };
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Test Popup Action");
+
+    [manager.get().context performActionForTab:manager.get().defaultTab];
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -28,9 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "HTTPServer.h"
-#import "TestWebExtensionsDelegate.h"
 #import "WebExtensionUtilities.h"
-#import <WebKit/_WKWebExtensionTabCreationOptions.h>
 
 namespace TestWebKitAPI {
 

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -25,13 +25,21 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#import <WebKit/WebKit.h>
+#ifdef __OBJC__
 
-#import <WebKit/_WKWebExtensionControllerDelegate.h>
+#import <WebKit/WebKit.h>
+#import <WebKit/_WKWebExtensionAction.h>
+#import <WebKit/_WKWebExtensionContextPrivate.h>
+#import <WebKit/_WKWebExtensionControllerConfigurationPrivate.h>
+#import <WebKit/_WKWebExtensionControllerDelegatePrivate.h>
+#import <WebKit/_WKWebExtensionControllerPrivate.h>
 #import <WebKit/_WKWebExtensionMatchPattern.h>
 #import <WebKit/_WKWebExtensionMessagePort.h>
 #import <WebKit/_WKWebExtensionPermission.h>
+#import <WebKit/_WKWebExtensionPrivate.h>
 #import <WebKit/_WKWebExtensionTab.h>
+#import <WebKit/_WKWebExtensionTabCreationOptions.h>
+#import <WebKit/_WKWebExtensionWindow.h>
 
 @interface TestWebExtensionsDelegate : NSObject <_WKWebExtensionControllerDelegate>
 
@@ -47,6 +55,10 @@
 @property (nonatomic, copy) void (^sendMessage)(id message, NSString *applicationIdentifier, void (^)(id replyMessage, NSError *));
 @property (nonatomic, copy) void (^connectUsingMessagePort)(_WKWebExtensionMessagePort *);
 
+@property (nonatomic, copy) void (^presentActionPopup)(_WKWebExtensionAction *);
+
 @end
+
+#endif // __OBJC__
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -113,6 +113,15 @@
         completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.connectNative() not implemneted" }]);
 }
 
+- (void)webExtensionController:(_WKWebExtensionController *)controller presentActionPopup:(_WKWebExtensionAction *)action forExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
+{
+    if (_presentActionPopup) {
+        _presentActionPopup(action);
+        completionHandler(nil);
+    } else
+        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"action.showPopup() not implemneted" }]);
+}
+
 @end
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -28,15 +28,9 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "TestCocoa.h"
+#include "TestWebExtensionsDelegate.h"
 #include "Utilities.h"
 #include "WTFTestUtilities.h"
-#include <WebKit/_WKWebExtensionContextPrivate.h>
-#include <WebKit/_WKWebExtensionControllerConfigurationPrivate.h>
-#include <WebKit/_WKWebExtensionControllerDelegatePrivate.h>
-#include <WebKit/_WKWebExtensionControllerPrivate.h>
-#include <WebKit/_WKWebExtensionPrivate.h>
-#include <WebKit/_WKWebExtensionTab.h>
-#include <WebKit/_WKWebExtensionWindow.h>
 
 #ifdef __OBJC__
 
@@ -127,6 +121,7 @@
 OBJC_CLASS TestWebExtensionManager;
 OBJC_CLASS TestWebExtensionTab;
 OBJC_CLASS TestWebExtensionWindow;
+OBJC_CLASS TestWebExtensionsDelegate;
 
 #endif // __OBJC__
 


### PR DESCRIPTION
#### d206d1764428e6838dd3240c7868c0762cd5541d
<pre>
Add _WKWebExtensionAction API to support web extension actions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262388">https://bugs.webkit.org/show_bug.cgi?id=262388</a>

Reviewed by Brady Eidson.

Added the initial support for action via _WKWebExtensionAction. This supports
popups and all the properties of action that are supported by Safari. Only
manifest dat is used currently, but support for per-tab action changes is
supported and will be followed up by the JS API in <a href="https://webkit.org/b/260154.">https://webkit.org/b/260154.</a>

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm: Added.
(-[_WKWebExtensionAction dealloc]):
(-[_WKWebExtensionAction isEqual:]):
(-[_WKWebExtensionAction webExtensionContext]):
(-[_WKWebExtensionAction associatedTab]):
(-[_WKWebExtensionAction iconForSize:]):
(-[_WKWebExtensionAction displayLabel]):
(-[_WKWebExtensionAction badgeText]):
(-[_WKWebExtensionAction isEnabled]):
(-[_WKWebExtensionAction hasPopup]):
(-[_WKWebExtensionAction popupWebView]):
(-[_WKWebExtensionAction closePopupWebView]):
(-[_WKWebExtensionAction _apiObject]):
(-[_WKWebExtensionAction _webExtensionAction]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionActionInternal.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionActionPrivate.h: Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext hasPermission:inTab:]):
(-[_WKWebExtensionContext hasAccessToURL:inTab:]):
(-[_WKWebExtensionContext permissionStatusForPermission:inTab:]):
(-[_WKWebExtensionContext permissionStatusForURL:inTab:]):
(-[_WKWebExtensionContext permissionStatusForMatchPattern:inTab:]):
(-[_WKWebExtensionContext actionForTab:]):
(-[_WKWebExtensionContext performActionForTab:]):
(-[_WKWebExtensionContext userGesturePerformedInTab:]):
(-[_WKWebExtensionContext hasActiveUserGestureInTab:]):
(-[_WKWebExtensionContext clearUserGestureInTab:]):
(toImplNullable):
(-[_WKWebExtensionContext didActivateTab:previousActiveTab:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm: Added.
(-[_WKWebExtensionActionWebViewDelegate initWithWebExtensionAction:]):
(-[_WKWebExtensionActionWebViewDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(-[_WKWebExtensionActionWebViewDelegate webViewWebContentProcessDidTerminate:]):
(-[_WKWebExtensionActionWebViewDelegate webViewDidClose:]):
(-[_WKWebExtensionActionWebView initWithFrame:configuration:webExtensionAction:]):
(-[_WKWebExtensionActionWebView invalidateIntrinsicContentSize]):
(WebKit::WebExtensionAction::WebExtensionAction):
(WebKit::WebExtensionAction::operator== const):
(WebKit::WebExtensionAction::extensionContext const):
(WebKit::WebExtensionAction::propertiesDidChange):
(WebKit::WebExtensionAction::icon):
(WebKit::WebExtensionAction::setIconsDictionary):
(WebKit::WebExtensionAction::popupPath const):
(WebKit::WebExtensionAction::setPopupPath):
(WebKit::WebExtensionAction::popupWebView):
(WebKit::WebExtensionAction::presentPopupWhenReady):
(WebKit::WebExtensionAction::readyToPresentPopup):
(WebKit::WebExtensionAction::popupSizeDidChange):
(WebKit::WebExtensionAction::popupDidClose):
(WebKit::WebExtensionAction::closePopupWebView):
(WebKit::WebExtensionAction::displayLabel const):
(WebKit::WebExtensionAction::setDisplayLabel):
(WebKit::WebExtensionAction::badgeText const):
(WebKit::WebExtensionAction::setBadgeText):
(WebKit::WebExtensionAction::isEnabled const):
(WebKit::WebExtensionAction::setEnabled):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceTypeForPath):
(WebKit::WebExtension::resourceDataForPath):
(WebKit::WebExtension::imageForPath):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::setInspectable):
(WebKit::WebExtensionContext::hasPermission):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::defaultAction):
(WebKit::WebExtensionContext::getOrCreateAction):
(WebKit::WebExtensionContext::performAction):
(WebKit::WebExtensionContext::userGesturePerformed):
(WebKit::WebExtensionContext::hasActiveUserGesture const):
(WebKit::WebExtensionContext::clearUserGesture):
(WebKit::WebExtensionContext::relatedWebView):
(WebKit::WebExtensionContext::removeInjectedContent):
(WebKit::WebExtensionContext::cancelUserGesture): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::extensionHasAccess const):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h: Added.
(WebKit::WebExtensionAction::create):
(WebKit::WebExtensionAction::tab):
(WebKit::WebExtensionAction::hasPopup const):
(WebKit::WebExtensionAction::wrapper const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::hasPermission):
(WebKit::WebExtensionContext::permissionState):
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm: Added.
(TestWebKitAPI::makePNGData):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewInspection.mm:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate webExtensionController:presentActionPopup:forExtensionContext:completionHandler:]):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:

Canonical link: <a href="https://commits.webkit.org/268677@main">https://commits.webkit.org/268677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91557be7552cad3e1761ed9f887b800cfa71fdf8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20326 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22224 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18964 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20928 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23074 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18482 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22704 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19234 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18445 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22782 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2520 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/19059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->