### PR TITLE
Highlight test has a too long a defined wait.

### DIFF
--- a/LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt
@@ -2,4 +2,4 @@ Highlight this first and then this.
 (repaint rects
   (rect 8 8 784 37)
 )
-
+When run, the first "this" should be highlighted, followed by the second "this", and the first highlight should be removed.

--- a/LayoutTests/fast/repaint/highlight-paint-after-range-change.html
+++ b/LayoutTests/fast/repaint/highlight-paint-after-range-change.html
@@ -1,29 +1,29 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Test that highlights gets repainted properly when the underlying range is changed.</title>
-    <style>
-        html { 
-            font-size: 24pt;
-        }
-        ::highlight(yellowHighlight)  {
-            background-color: yellow;
-        }
-    </style>
+<style>
+html {
+    font-size: 24pt;
+}
+
+::highlight(yellowHighlight) {
+    background-color: yellow;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
 </head>
 <body>
-    <title>When run, the first "this" should be highlighted, followed by the second "this", and the first highlight should be removed.</title>
     <div id="highlight_area">Highlight this first and then this.</div>
     <pre id="result"></pre>
+    <p>When run, the first "this" should be highlighted, followed by the second "this", and the first highlight should be removed.</p>
 </body>
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 }
- 
-async function test() {   
 
+(async () => {
     if (window.internals)
         internals.startTrackingRepaints();
 
@@ -35,20 +35,18 @@ async function test() {
     highlightRange.setStart(highlightNode.firstChild, 11);
     highlightRange.setEnd(highlightNode.firstChild, 14);
 
-    setTimeout(() => {
+    await UIHelper.renderingUpdate();
 
-        highlightRange.setStart(highlightNode.firstChild, 25);
-        highlightRange.setEnd(highlightNode.firstChild, 29);
-        if (window.internals) {
-            let repaintRects = internals.repaintRectsAsText();
-            internals.stopTrackingRepaints();
-            result.textContent = repaintRects;
-        }
-        if (window.testRunner)
-            testRunner.notifyDone();
-     }, 100);
-    
-};
-test();
+    highlightRange.setStart(highlightNode.firstChild, 25);
+    highlightRange.setEnd(highlightNode.firstChild, 29);
+    if (window.internals) {
+        let repaintRects = internals.repaintRectsAsText();
+        internals.stopTrackingRepaints();
+        result.textContent = repaintRects;
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
 </script>
 </html>


### PR DESCRIPTION
#### 2ee8d3fa3d705cd2feff3719e4442454f7cdcf99
<pre>
Highlight test has a too long a defined wait.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262398">https://bugs.webkit.org/show_bug.cgi?id=262398</a>
rdar://116254079

Reviewed by Aditya Keerthi and Simon Fraser.

Responding to feedback that having a 100ms timeout is too long, rearchitecting the test to
instead await UIHelper.renderingUpdate() to wait the minimum amount of time needed.

* LayoutTests/fast/repaint/highlight-paint-after-range-change-expected.txt:
* LayoutTests/fast/repaint/highlight-paint-after-range-change.html:

Canonical link: <a href="https://commits.webkit.org/269114@main">https://commits.webkit.org/269114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c16364be98f0040cee33b094cffbf879affabb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21607 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23469 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/25300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/22148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21834 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/25300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24321 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/25300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/19575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/25300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23732 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/22148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/19587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/19392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5156 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->