### PR TITLE
REGRESSION(266247@main): PDF "Save" button does nothing, "Print" function also broken

### DIFF
--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -178,6 +178,12 @@ inline bool isSafelistedBlobProtocol(const URL& url)
     // except that assert gets hit on certain tests.
     return url.protocolIsInHTTPFamily()
         || url.protocolIsFile()
+#if PLATFORM(GTK) || PLATFORM(WPE)
+        || url.protocolIs("resource"_s)
+#endif
+#if ENABLE(PDFJS)
+        || url.protocolIs("webkit-pdfjs-viewer"_s)
+#endif
         || LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol());
 }
 


### PR DESCRIPTION
#### 58df23fe5ac509adc2117503127e97d53b02445b
<pre>
REGRESSION(266247@main): PDF &quot;Save&quot; button does nothing, &quot;Print&quot; function also broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=260771">https://bugs.webkit.org/show_bug.cgi?id=260771</a>

Reviewed by Chris Dumez.

The PDF.js viewer protocol and resource protocols both should be treated
the same as HTTP protocols and have access to blob URLs. The protocol is
an implementation detail that shouldn&apos;t affect how the web content
behaves and certainly should not restrict access to web platform
features.

* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::isSafelistedBlobProtocol):

Canonical link: <a href="https://commits.webkit.org/270274@main">https://commits.webkit.org/270274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1d53f2bbd478d15d099e60810d96348ee1eec45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22404 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23257 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24920 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22860 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16483 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18617 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5995 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->