### PR TITLE
Inline nullQName() function

### DIFF
--- a/Source/WebCore/dom/QualifiedName.cpp
+++ b/Source/WebCore/dom/QualifiedName.cpp
@@ -64,6 +64,7 @@ QualifiedName::QualifiedNameImpl::~QualifiedNameImpl()
 
 // Global init routines
 LazyNeverDestroyed<const QualifiedName> anyName;
+LazyNeverDestroyed<const QualifiedName> nullName;
 
 void QualifiedName::init()
 {
@@ -72,13 +73,8 @@ void QualifiedName::init()
         return;
 
     anyName.construct(nullAtom(), starAtom(), starAtom(), Namespace::Unknown, NodeName::Unknown);
+    nullName.construct(nullAtom(), nullAtom(), nullAtom(), Namespace::None, NodeName::Unknown);
     initialized = true;
-}
-
-const QualifiedName& nullQName()
-{
-    static NeverDestroyed<QualifiedName> nullName(nullAtom(), nullAtom(), nullAtom(), Namespace::None, NodeName::Unknown);
-    return nullName;
 }
 
 const AtomString& QualifiedName::localNameUppercase() const

--- a/Source/WebCore/dom/QualifiedName.h
+++ b/Source/WebCore/dom/QualifiedName.h
@@ -132,7 +132,8 @@ inline void add(Hasher& hasher, const QualifiedName& name)
 extern LazyNeverDestroyed<const QualifiedName> anyName;
 inline const QualifiedName& anyQName() { return anyName; }
 
-const QualifiedName& nullQName();
+extern LazyNeverDestroyed<const QualifiedName> nullName;
+inline const QualifiedName& nullQName() { return nullName; }
 
 inline bool operator==(const AtomString& a, const QualifiedName& q) { return a == q.localName(); }
 inline bool operator==(const QualifiedName& q, const AtomString& a) { return a == q.localName(); }


### PR DESCRIPTION
#### 422472ab0e3cbddaee4e93f2e97e818b3f766ce0
<pre>
Inline nullQName() function
<a href="https://bugs.webkit.org/show_bug.cgi?id=262404">https://bugs.webkit.org/show_bug.cgi?id=262404</a>

Reviewed by Darin Adler.

Inline nullQName() function since it shows in profiles.

* Source/WebCore/dom/QualifiedName.cpp:
(WebCore::QualifiedName::init):
(WebCore::nullQName): Deleted.
* Source/WebCore/dom/QualifiedName.h:
(WebCore::nullQName):

Canonical link: <a href="https://commits.webkit.org/268695@main">https://commits.webkit.org/268695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d25372e30c31a03a382f0c5c172bcddaabdde26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20390 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23075 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24777 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22709 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19235 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16336 "16 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18446 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4902 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22783 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->