### PR TITLE
[WebGPU] CompositorIntegrationImpl should store WebCore::IOSurface instances not IOSurfaceRef directly

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -30,6 +30,7 @@
 
 #include "WebGPUConvertToBackingContext.h"
 #include <CoreFoundation/CoreFoundation.h>
+#include <WebCore/IOSurface.h>
 #include <WebGPU/WebGPUExt.h>
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
 
@@ -50,57 +51,25 @@ void CompositorIntegrationImpl::prepareForDisplay(CompletionHandler<void()>&& co
 }
 
 #if PLATFORM(COCOA)
-static RetainPtr<CFNumberRef> toCFNumber(int x)
-{
-    return adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &x));
-}
-
 Vector<MachSendRight> CompositorIntegrationImpl::recreateRenderBuffers(int width, int height)
 {
     m_renderBuffers.clear();
 
-    auto createIOSurface = [&]() -> RetainPtr<IOSurfaceRef> {
-        unsigned bytesPerElement = 4;
-        unsigned bytesPerPixel = 4;
-
-        size_t bytesPerRow = IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, width * bytesPerPixel);
-        ASSERT(bytesPerRow);
-
-        size_t totalBytes = IOSurfaceAlignProperty(kIOSurfaceAllocSize, height * bytesPerRow);
-        ASSERT(totalBytes);
-
-        unsigned pixelFormat = 'BGRA';
-
-        auto options = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 8, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-        CFDictionaryAddValue(options.get(), kIOSurfaceWidth, toCFNumber(width).get());
-        CFDictionaryAddValue(options.get(), kIOSurfaceHeight, toCFNumber(height).get());
-        CFDictionaryAddValue(options.get(), kIOSurfacePixelFormat, toCFNumber(pixelFormat).get());
-        CFDictionaryAddValue(options.get(), kIOSurfaceBytesPerElement, toCFNumber(bytesPerElement).get());
-        CFDictionaryAddValue(options.get(), kIOSurfaceBytesPerRow, toCFNumber(bytesPerRow).get());
-        CFDictionaryAddValue(options.get(), kIOSurfaceAllocSize, toCFNumber(totalBytes).get());
-#if PLATFORM(IOS_FAMILY)
-        CFDictionaryAddValue(options.get(), kIOSurfaceCacheMode, toCFNumber(kIOMapWriteCombineCache).get());
-#endif
-        CFDictionaryAddValue(options.get(), kIOSurfaceElementHeight, toCFNumber(1).get());
-
-        return adoptCF(IOSurfaceCreate(options.get()));
-    };
-
     static_cast<PresentationContext*>(m_presentationContext.get())->unconfigure();
     m_presentationContext->setSize(width, height);
 
-    m_renderBuffers.append(createIOSurface());
-    m_renderBuffers.append(createIOSurface());
+    m_renderBuffers.append(WebCore::IOSurface::create(nullptr, WebCore::IntSize(width, height), WebCore::DestinationColorSpace::SRGB()));
+    m_renderBuffers.append(WebCore::IOSurface::create(nullptr, WebCore::IntSize(width, height), WebCore::DestinationColorSpace::SRGB()));
 
     {
         auto renderBuffers = adoptCF(CFArrayCreateMutable(kCFAllocatorDefault, 2, &kCFTypeArrayCallBacks));
-        for (auto ioSurface : m_renderBuffers)
-            CFArrayAppendValue(renderBuffers.get(), ioSurface.get());
+        for (auto& ioSurface : m_renderBuffers)
+            CFArrayAppendValue(renderBuffers.get(), ioSurface->surface());
         m_renderBuffersWereRecreatedCallback(static_cast<CFArrayRef>(renderBuffers));
     }
 
     return m_renderBuffers.map([](const auto& renderBuffer) {
-        return MachSendRight::adopt(IOSurfaceCreateMachPort(renderBuffer.get()));
+        return renderBuffer->createSendRight();
     });
 }
 #endif

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
@@ -30,6 +30,7 @@
 #include "WebGPUCompositorIntegration.h"
 
 #include "WebGPUPresentationContextImpl.h"
+#include <WebCore/IOSurface.h>
 #include <WebGPU/WebGPU.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
@@ -84,7 +85,7 @@ private:
 #if PLATFORM(COCOA)
     Vector<MachSendRight> recreateRenderBuffers(int width, int height) override;
 
-    Vector<RetainPtr<IOSurfaceRef>> m_renderBuffers;
+    Vector<std::unique_ptr<WebCore::IOSurface>> m_renderBuffers;
     WTF::Function<void(CFArrayRef)> m_renderBuffersWereRecreatedCallback;
 #endif
 


### PR DESCRIPTION
#### 912e5b85f7e31b14718f25987cb965789148a334
<pre>
[WebGPU] CompositorIntegrationImpl should store WebCore::IOSurface instances not IOSurfaceRef directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=262397">https://bugs.webkit.org/show_bug.cgi?id=262397</a>
&lt;radar://116253806&gt;

Reviewed by Dan Glastonbury.

Now that we are in WebCore and not PAL, we can use WebCore::IOSurface instead of IOSurfaceRef.

This will be used in a followup patch to support WebGPU in OffscreenCanvas.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::recreateRenderBuffers):
(WebCore::WebGPU::toCFNumber): Deleted.
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h:

Canonical link: <a href="https://commits.webkit.org/268691@main">https://commits.webkit.org/268691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/496c0f5d270d7d240f7f3def2c9ac3b479b57434

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20388 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23077 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24773 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22705 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16337 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18448 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4900 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->