### PR TITLE
Drop early-outs for "no boxes" in SVGTextQuery entrypoints

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -108,8 +108,6 @@ void SVGTextQuery::collectTextBoxesInFlowBox(LegacyInlineFlowBox* flowBox)
 
 bool SVGTextQuery::executeQuery(Data* queryData, ProcessTextFragmentCallback fragmentCallback) const
 {
-    ASSERT(!m_textBoxes.isEmpty());
-
     unsigned processedCharacters = 0;
     unsigned textBoxCount = m_textBoxes.size();
 
@@ -244,9 +242,6 @@ bool SVGTextQuery::numberOfCharactersCallback(Data*, const SVGTextFragment&) con
 
 unsigned SVGTextQuery::numberOfCharacters() const
 {
-    if (m_textBoxes.isEmpty())
-        return 0;
-
     Data data;
     executeQuery(&data, &SVGTextQuery::numberOfCharactersCallback);
     return data.processedCharacters;
@@ -310,9 +305,6 @@ bool SVGTextQuery::subStringLengthCallback(Data* queryData, const SVGTextFragmen
 
 float SVGTextQuery::subStringLength(unsigned startPosition, unsigned length) const
 {
-    if (m_textBoxes.isEmpty())
-        return 0;
-
     SubStringLengthData data(startPosition, length);
     executeQuery(&data, &SVGTextQuery::subStringLengthCallback);
     return data.subStringLength;
@@ -359,9 +351,6 @@ bool SVGTextQuery::startPositionOfCharacterCallback(Data* queryData, const SVGTe
 
 FloatPoint SVGTextQuery::startPositionOfCharacter(unsigned position) const
 {
-    if (m_textBoxes.isEmpty())
-        return { };
-
     StartPositionOfCharacterData data(position);
     executeQuery(&data, &SVGTextQuery::startPositionOfCharacterCallback);
     return data.startPosition;
@@ -406,9 +395,6 @@ bool SVGTextQuery::endPositionOfCharacterCallback(Data* queryData, const SVGText
 
 FloatPoint SVGTextQuery::endPositionOfCharacter(unsigned position) const
 {
-    if (m_textBoxes.isEmpty())
-        return { };
-
     EndPositionOfCharacterData data(position);
     executeQuery(&data, &SVGTextQuery::endPositionOfCharacterCallback);
     return data.endPosition;
@@ -449,9 +435,6 @@ bool SVGTextQuery::rotationOfCharacterCallback(Data* queryData, const SVGTextFra
 
 float SVGTextQuery::rotationOfCharacter(unsigned position) const
 {
-    if (m_textBoxes.isEmpty())
-        return 0;
-
     RotationOfCharacterData data(position);
     executeQuery(&data, &SVGTextQuery::rotationOfCharacterCallback);
     return data.rotation;
@@ -509,9 +492,6 @@ bool SVGTextQuery::extentOfCharacterCallback(Data* queryData, const SVGTextFragm
 
 FloatRect SVGTextQuery::extentOfCharacter(unsigned position) const
 {
-    if (m_textBoxes.isEmpty())
-        return FloatRect();
-
     ExtentOfCharacterData data(position);
     executeQuery(&data, &SVGTextQuery::extentOfCharacterCallback);
     return data.extent;
@@ -554,9 +534,6 @@ bool SVGTextQuery::characterNumberAtPositionCallback(Data* queryData, const SVGT
 
 int SVGTextQuery::characterNumberAtPosition(const FloatPoint& position) const
 {
-    if (m_textBoxes.isEmpty())
-        return -1;
-
     CharacterNumberAtPositionData data(position);
     if (!executeQuery(&data, &SVGTextQuery::characterNumberAtPositionCallback))
         return -1;


### PR DESCRIPTION
#### da2a3ce347f88ab0f3fae1a26a67ce51bc102ba0
<pre>
Drop early-outs for &quot;no boxes&quot; in SVGTextQuery entrypoints

<a href="https://bugs.webkit.org/show_bug.cgi?id=262382">https://bugs.webkit.org/show_bug.cgi?id=262382</a>

Reviewed by Nikolas Zimmermann.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=177149

All entrypoints in SVGTextQuery start with check if the text content
element has any boxes. If it doesn&apos;t, a value representing &quot;empty&quot; is
returned. In all cases this value is the same as the default value of the
corresponding query-data. SVGTextQuery::executeQuery itself has no
problems handling this case (and will return &apos;false&apos; as expected.)
Removing these early-outs means a few more cycles is needed in these
&quot;degenerate&quot; cases, although that seems like a small (and hopefully
reasonable) price to pay for less code (and duplication/exit-paths).

* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(SVGTextQuery::executeQuery):
(SVGTextQuery::numberOfCharacters):
(SVGTextQuery::subStringLength):
(SVGTextQuery::startPositionOfCharacter):
(SVGTextQuery::endPositionOfCharacter):
(SVGTextQuery::rotationOfCharacter):
(SVGTextQuery::extentOfCharacter):
(SVGTextQuery::characterNumberAtPosition):

Canonical link: <a href="https://commits.webkit.org/268702@main">https://commits.webkit.org/268702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0da5ababa4bd86eda5945e4bc6cb7be21d44dbcc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20395 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23083 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24778 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18692 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22710 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16342 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18454 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4908 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22791 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->