### PR TITLE
[SVG] Repaint bounding box computation should not be super costly

### DIFF
--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -134,6 +134,7 @@ public:
     void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = nullptr) const override;
     
     FloatRect repaintRectInLocalCoordinates() const override { return borderBoxRect(); }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const override { return borderBoxRect(); }
     FloatRect objectBoundingBox() const override { return borderBoxRect(); }
 
     // Note these functions are not equivalent of childrenOfType<RenderBox>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2089,6 +2089,12 @@ FloatRect RenderObject::repaintRectInLocalCoordinates() const
     return FloatRect();
 }
 
+FloatRect RenderObject::repaintRectInLocalCoordinatesForHitTesting() const
+{
+    ASSERT_NOT_REACHED();
+    return FloatRect();
+}
+
 AffineTransform RenderObject::localTransform() const
 {
     return AffineTransform();

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -507,6 +507,10 @@ public:
     // respecting clipping, masking, filters, opacity, stroke-width and markers
     virtual FloatRect repaintRectInLocalCoordinates() const;
 
+    // repaintRectInLocalCoordinates, but more precise, "sensitive to hit detection".
+    // https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__checkIntersection
+    virtual FloatRect repaintRectInLocalCoordinatesForHitTesting() const;
+
     // This only returns the transform="" value from the element
     // most callsites want localToParentTransform() instead.
     virtual AffineTransform localTransform() const;

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -46,6 +46,7 @@ public:
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
     FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
     FloatRect repaintRectInLocalCoordinates() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
 protected:
     RenderSVGContainer(Type, Document&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -47,6 +47,7 @@ public:
     FloatRect objectBoundingBox() const final { return m_viewport; }
     FloatRect strokeBoundingBox() const final { return m_viewport; }
     FloatRect repaintRectInLocalCoordinates() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
 private:
     void graphicsElement() const = delete;

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.h
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.h
@@ -49,6 +49,7 @@ private:
     FloatRect objectBoundingBox() const override { return FloatRect(); }
     FloatRect strokeBoundingBox() const override { return FloatRect(); }
     FloatRect repaintRectInLocalCoordinates() const override { return FloatRect(); }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const override { return FloatRect(); }
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint&, HitTestAction) override { return false; }
 
     ASCIILiteral renderName() const override { return "RenderSVGGradientStop"_s; }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -58,6 +58,7 @@ private:
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect strokeBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect repaintRectInLocalCoordinates() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
     void imageChanged(WrappedImagePtr, const IntRect* = nullptr) final;
 

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -73,6 +73,11 @@ FloatRect RenderSVGInline::repaintRectInLocalCoordinates() const
     return FloatRect();
 }
 
+FloatRect RenderSVGInline::repaintRectInLocalCoordinatesForHitTesting() const
+{
+    return repaintRectInLocalCoordinates();
+}
+
 LayoutRect RenderSVGInline::clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext context) const
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -49,6 +49,7 @@ private:
     FloatRect objectBoundingBox() const final;
     FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates() const final;
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const final;
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     LayoutPoint currentSVGLayoutLocation() const final { return { }; }

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -224,7 +224,7 @@ bool RenderSVGModelObject::checkIntersection(RenderElement* renderer, const Floa
     SVGElement* svgElement = downcast<SVGElement>(renderer->element());
     ASSERT(is<SVGGraphicsElement>(svgElement));
     auto ctm = downcast<SVGGraphicsElement>(*svgElement).getCTM(SVGLocatable::DisallowStyleUpdate);
-    return intersectsAllowingEmpty(rect, ctm.mapRect(renderer->repaintRectInLocalCoordinates()));
+    return intersectsAllowingEmpty(rect, ctm.mapRect(renderer->repaintRectInLocalCoordinatesForHitTesting()));
 }
 
 bool RenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
@@ -236,7 +236,7 @@ bool RenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRe
     SVGElement* svgElement = downcast<SVGElement>(renderer->element());
     ASSERT(is<SVGGraphicsElement>(svgElement));
     auto ctm = downcast<SVGGraphicsElement>(*svgElement).getCTM(SVGLocatable::DisallowStyleUpdate);
-    return rect.contains(ctm.mapRect(renderer->repaintRectInLocalCoordinates()));
+    return rect.contains(ctm.mapRect(renderer->repaintRectInLocalCoordinatesForHitTesting()));
 }
 
 LayoutSize RenderSVGModelObject::cachedSizeForOverflowClip() const

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -68,6 +68,7 @@ public:
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
     FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
     FloatRect repaintRectInLocalCoordinates() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
     LayoutRect visualOverflowRectEquivalent() const { return SVGBoundingBoxComputation::computeVisualOverflowRect(*this); }
 

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -79,6 +79,7 @@ public:
     FloatRect objectBoundingBox() const final { return m_fillBoundingBox; }
     FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
     FloatRect repaintRectInLocalCoordinates() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
     FloatRect computeMarkerBoundingBox(const SVGBoundingBoxComputation::DecorationOptions&) const;
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -605,6 +605,11 @@ FloatRect RenderSVGText::repaintRectInLocalCoordinates() const
     return repaintRect;
 }
 
+FloatRect RenderSVGText::repaintRectInLocalCoordinatesForHitTesting() const
+{
+    return repaintRectInLocalCoordinates();
+}
+
 void RenderSVGText::updatePositionAndOverflow(const FloatRect& boundaries)
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -63,6 +63,7 @@ public:
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates() const final;
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const final;
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     LayoutRect visualOverflowRectEquivalent() const { return SVGBoundingBoxComputation::computeVisualOverflowRect(*this); }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -61,7 +61,8 @@ public:
     // Determines whether the passed point lies in a clipping area
     static bool pointInClippingArea(const RenderElement&, const FloatPoint&);
 
-    static void computeContainerBoundingBoxes(const RenderElement& container, FloatRect& objectBoundingBox, bool& objectBoundingBoxValid, FloatRect& strokeBoundingBox, FloatRect& repaintBoundingBox);
+    static void computeContainerBoundingBoxes(const RenderElement& container, FloatRect& objectBoundingBox, bool& objectBoundingBoxValid, FloatRect& repaintBoundingBox);
+    static void computeContainerStrokeBoundingBox(const RenderElement& container, FloatRect& strokeBoundingBox);
     static bool paintInfoIntersectsRepaintRect(const FloatRect& localRepaintRect, const AffineTransform& localTransform, const PaintInfo&);
 
     // Important functions used by nearly all SVG renderers centralizing coordinate transformations / repaint rect calculations

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -28,6 +28,7 @@
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
 #include "LayoutRepainter.h"
+#include "LegacyRenderSVGShape.h"
 #include "RenderIterator.h"
 #include "RenderSVGResourceFilter.h"
 #include "RenderTreeBuilder.h"
@@ -154,8 +155,23 @@ void LegacyRenderSVGContainer::addFocusRingRects(Vector<LayoutRect>& rects, cons
 
 void LegacyRenderSVGContainer::updateCachedBoundaries()
 {
-    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_strokeBoundingBox, m_repaintBoundingBox);
+    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_repaintBoundingBox);
     SVGRenderSupport::intersectRepaintRectWithResources(*this, m_repaintBoundingBox);
+    m_strokeBoundingBox = FloatRect::nanRect();
+}
+
+FloatRect LegacyRenderSVGContainer::repaintRectInLocalCoordinatesForHitTesting() const
+{
+    FloatRect strokeBoundingBox = this->strokeBoundingBox();
+    SVGRenderSupport::intersectRepaintRectWithResources(*this, strokeBoundingBox);
+    return strokeBoundingBox;
+}
+
+FloatRect LegacyRenderSVGContainer::strokeBoundingBox() const
+{
+    if (m_strokeBoundingBox.isNaN())
+        SVGRenderSupport::computeContainerStrokeBoundingBox(*this, m_strokeBoundingBox);
+    return m_strokeBoundingBox;
 }
 
 bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, HitTestResult& result, const FloatPoint& pointInParent, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -51,8 +51,9 @@ protected:
     void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = 0) const final;
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
-    FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
+    FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates() const final { return m_repaintBoundingBox; }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const final;
 
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
 
@@ -73,8 +74,8 @@ private:
     bool isLegacySVGContainer() const final { return true; }
 
     FloatRect m_objectBoundingBox;
-    FloatRect m_strokeBoundingBox;
     FloatRect m_repaintBoundingBox;
+    mutable FloatRect m_strokeBoundingBox { FloatRect::nanRect() };
 
     bool m_objectBoundingBoxValid { false };
     bool m_needsBoundariesUpdate { true };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.h
@@ -39,7 +39,7 @@ public:
 private:
     ASCIILiteral renderName() const override { return "RenderSVGEllipse"_s; }
 
-    void updateShapeFromElement() override;
+    FloatRect updateShapeFromElement() override;
     bool isEmpty() const override { return hasPath() ? LegacyRenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
     bool isRenderingDisabled() const override;
     void fillShape(GraphicsContext&) const override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
@@ -45,6 +45,7 @@ public:
     FloatRect objectBoundingBox() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
     FloatRect strokeBoundingBox() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
     FloatRect repaintRectInLocalCoordinates() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const override { return FloatRect(FloatPoint(), m_viewport.size()); }
 
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -65,6 +65,7 @@ private:
     FloatRect objectBoundingBox() const override { return m_objectBoundingBox; }
     FloatRect strokeBoundingBox() const override { return m_objectBoundingBox; }
     FloatRect repaintRectInLocalCoordinates() const override { return m_repaintBoundingBox; }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const override { return m_repaintBoundingBox; }
 
     void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = 0) const override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -177,7 +177,7 @@ bool LegacyRenderSVGModelObject::checkIntersection(RenderElement* renderer, cons
     SVGElement* svgElement = downcast<SVGElement>(renderer->element());
     getElementCTM(svgElement, ctm);
     ASSERT(svgElement->renderer());
-    return intersectsAllowingEmpty(rect, ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinates()));
+    return intersectsAllowingEmpty(rect, ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinatesForHitTesting()));
 }
 
 bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
@@ -190,7 +190,7 @@ bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const F
     SVGElement* svgElement = downcast<SVGElement>(renderer->element());
     getElementCTM(svgElement, ctm);
     ASSERT(svgElement->renderer());
-    return rect.contains(ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinates()));
+    return rect.contains(ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinatesForHitTesting()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
@@ -35,11 +35,15 @@ public:
     LegacyRenderSVGPath(SVGGraphicsElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGPath();
 
+    FloatRect updateMarkerBounds(const FloatRect&) const;
+    void drawMarkers(PaintInfo&) const;
+
 private:
     ASCIILiteral renderName() const override { return "RenderSVGPath"_s; }
 
-    void updateShapeFromElement() override;
-    FloatRect calculateUpdatedStrokeBoundingBox() const;
+    FloatRect updateShapeFromElement() override;
+    void processMarkerPositions();
+    FloatRect markerRect(float strokeWidth) const;
 
     void strokeShape(GraphicsContext&) const override;
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;
@@ -49,10 +53,12 @@ private:
     FloatRect zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();
     void strokeZeroLengthSubpaths(GraphicsContext&) const;
+    bool shouldGenerateMarkerPositions() const;
 
     bool isRenderingDisabled() const override;
 
     Vector<FloatPoint> m_zeroLengthLinecapLocations;
+    Vector<MarkerPosition> m_markerPositions;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h
@@ -45,7 +45,7 @@ private:
 
     ASCIILiteral renderName() const override { return "RenderSVGRect"_s; }
 
-    void updateShapeFromElement() override;
+    FloatRect updateShapeFromElement() override;
     bool isEmpty() const override { return hasPath() ? LegacyRenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
     bool isRenderingDisabled() const override;
     void fillShape(GraphicsContext&) const override;
@@ -53,9 +53,8 @@ private:
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;
     bool shapeDependentFillContains(const FloatPoint&, const WindRule) const override;
 
-private:
-    FloatRect m_innerStrokeRect;
-    FloatRect m_outerStrokeRect;
+    bool definitelyHasSimpleStroke() const;
+    bool canUseStrokeHitTestFastPath() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -28,6 +28,7 @@
 #include "HitTestResult.h"
 #include "LayoutRepainter.h"
 #include "LegacyRenderSVGResourceContainer.h"
+#include "LegacyRenderSVGShape.h"
 #include "LocalFrame.h"
 #include "Page.h"
 #include "RenderBoxInlines.h"
@@ -414,9 +415,24 @@ const RenderObject* LegacyRenderSVGRoot::pushMappingToContainer(const RenderLaye
 
 void LegacyRenderSVGRoot::updateCachedBoundaries()
 {
-    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_strokeBoundingBox, m_repaintBoundingBox);
+    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_repaintBoundingBox);
     SVGRenderSupport::intersectRepaintRectWithResources(*this, m_repaintBoundingBox);
     m_repaintBoundingBox.inflate(horizontalBorderAndPaddingExtent());
+    m_strokeBoundingBox = FloatRect::nanRect();
+}
+
+FloatRect LegacyRenderSVGRoot::repaintRectInLocalCoordinatesForHitTesting() const
+{
+    FloatRect strokeBoundingBox = this->strokeBoundingBox();
+    SVGRenderSupport::intersectRepaintRectWithResources(*this, strokeBoundingBox);
+    return strokeBoundingBox;
+}
+
+FloatRect LegacyRenderSVGRoot::strokeBoundingBox() const
+{
+    if (m_strokeBoundingBox.isNaN())
+        SVGRenderSupport::computeContainerStrokeBoundingBox(*this, m_strokeBoundingBox);
+    return m_strokeBoundingBox;
 }
 
 bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -86,8 +86,9 @@ private:
     const AffineTransform& localToParentTransform() const override;
 
     FloatRect objectBoundingBox() const override { return m_objectBoundingBox; }
-    FloatRect strokeBoundingBox() const override { return m_strokeBoundingBox; }
+    FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates() const override { return m_repaintBoundingBox; }
+    FloatRect repaintRectInLocalCoordinatesForHitTesting() const override;
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 
@@ -108,13 +109,13 @@ private:
 
     IntSize m_containerSize;
     FloatRect m_objectBoundingBox;
-    bool m_objectBoundingBoxValid { false };
-    bool m_inLayout { false };
-    FloatRect m_strokeBoundingBox;
     FloatRect m_repaintBoundingBox;
+    mutable FloatRect m_strokeBoundingBox { FloatRect::nanRect() };
     mutable AffineTransform m_localToParentTransform;
     AffineTransform m_localToBorderBoxTransform;
     WeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
+    bool m_objectBoundingBoxValid { false };
+    bool m_inLayout { false };
     bool m_isLayoutSizeChanged : 1;
     bool m_needsBoundariesOrTransformUpdate : 1;
     bool m_hasBoxDecorations : 1;


### PR DESCRIPTION
#### 9c0dad05c5114d23e2d211555d8796b739909dbe
<pre>
[SVG] Repaint bounding box computation should not be super costly
<a href="https://bugs.webkit.org/show_bug.cgi?id=262409">https://bugs.webkit.org/show_bug.cgi?id=262409</a>
rdar://116141498

Reviewed by NOBODY (OOPS!).

Computing precise stroke-bounding-box is super costly operation. It creates GraphicsContext, applying all styles,
and actually drawing strokes in CoreGraphics and get the bounding box.
While we need this precise bounding box information sometimes, we don&apos;t need to have this for repainting.
If we can get approximate stroke-bounding-box, which is always larger than the precise one, then it is enough.

This patch implements calculateApproximateDecoratedBoundingBox mechanism. We import blink&apos;s idea and implementations[1],
and adjusting it to our SVG implementation. Based on stroke&apos;s style information, we compute approximate repainting box
super quickly for SVG path and use it for repainting. Precise stroke-bounding-box is computed on-demand when some requires
this (e.g. checkEnclosure requires it). We add repaintRectInLocalCoordinatesForHitTesting for that purpose, and using
approximate bounding box for repaintRectInLocalCoordinates.

To make it possible to adopt optimizations done in blink, we refactor LegacyRenderSVGShape etc. We recognize ShapeType,
and based on that, we do fast path when we can take (Moving marker related code to LegacyRenderSVGPath, reorganize layout function).

This wipes very costly stroke-bounding-box computation from Speedometer3.0/React-Stockcharts-SVG and offers 6% progression
on that subtest, contributing overall 0.5% progression.

This patch includes rebaseline of SVG tests since it now changes repainting rect for path / rect / ellipse.

[1]: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=435097">https://bugs.chromium.org/p/chromium/issues/detail?id=435097</a>

* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::repaintRectInLocalCoordinatesForHitTesting const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/svg/RenderSVGContainer.h:
* Source/WebCore/rendering/svg/RenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/RenderSVGGradientStop.h:
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::repaintRectInLocalCoordinatesForHitTesting const):
* Source/WebCore/rendering/svg/RenderSVGInline.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::checkIntersection):
(WebCore::RenderSVGModelObject::checkEnclosure):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::repaintRectInLocalCoordinatesForHitTesting const):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeContainerBoundingBoxes):
(WebCore::SVGRenderSupport::computeContainerStrokeBoundingBox):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::updateCachedBoundaries):
(WebCore::LegacyRenderSVGContainer::repaintRectInLocalCoordinatesForHitTesting const):
(WebCore::LegacyRenderSVGContainer::strokeBoundingBox const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
(WebCore::LegacyRenderSVGEllipse::updateShapeFromElement):
(WebCore::LegacyRenderSVGEllipse::shapeDependentStrokeContains):
(WebCore::LegacyRenderSVGEllipse::shapeDependentFillContains const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::checkIntersection):
(WebCore::LegacyRenderSVGModelObject::checkEnclosure):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::updateShapeFromElement):
(WebCore::LegacyRenderSVGPath::shouldGenerateMarkerPositions const):
(WebCore::LegacyRenderSVGPath::processMarkerPositions):
(WebCore::markerForType):
(WebCore::LegacyRenderSVGPath::markerRect const):
(WebCore::LegacyRenderSVGPath::updateMarkerBounds const):
(WebCore::LegacyRenderSVGPath::drawMarkers const):
(WebCore::LegacyRenderSVGPath::calculateUpdatedStrokeBoundingBox const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
(WebCore::LegacyRenderSVGRect::definitelyHasSimpleStroke const):
(WebCore::LegacyRenderSVGRect::updateShapeFromElement):
(WebCore::LegacyRenderSVGRect::canUseStrokeHitTestFastPath const):
(WebCore::LegacyRenderSVGRect::shapeDependentStrokeContains):
(WebCore::LegacyRenderSVGRect::shapeDependentFillContains const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::updateCachedBoundaries):
(WebCore::LegacyRenderSVGRoot::repaintRectInLocalCoordinatesForHitTesting const):
(WebCore::LegacyRenderSVGRoot::strokeBoundingBox const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::canUseSimpleStrokeApproximation):
(WebCore::LegacyRenderSVGShape::strokeContains):
(WebCore::LegacyRenderSVGShape::layout):
(WebCore::LegacyRenderSVGShape::fillStrokeMarkers):
(WebCore::LegacyRenderSVGShape::calculateApproximateDecoratedBoundingBox const):
(WebCore::LegacyRenderSVGShape::calculateDecoratedBoundingBox const):
(WebCore::LegacyRenderSVGShape::calculateNonScalingDecoratedBoundingBox const):
(WebCore::LegacyRenderSVGShape::repaintRectInLocalCoordinatesForHitTesting const):
(WebCore::LegacyRenderSVGShape::strokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::calculateStrokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::ensurePath const):
(WebCore::LegacyRenderSVGShape::updateShapeFromElement): Deleted.
(WebCore::LegacyRenderSVGShape::shouldGenerateMarkerPositions const): Deleted.
(WebCore::markerForType): Deleted.
(WebCore::LegacyRenderSVGShape::markerRect const): Deleted.
(WebCore::LegacyRenderSVGShape::calculateObjectBoundingBox const): Deleted.
(WebCore::LegacyRenderSVGShape::updateRepaintBoundingBox): Deleted.
(WebCore::LegacyRenderSVGShape::drawMarkers): Deleted.
(WebCore::LegacyRenderSVGShape::processMarkerPositions): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
(WebCore::LegacyRenderSVGShape::shapeType const):
(WebCore::LegacyRenderSVGShape::decoratedBoundingBox const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c0dad05c5114d23e2d211555d8796b739909dbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19494 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21146 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20911 "Found 1 new test failure: svg/custom/shape-rendering.svg (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23670 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18073 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18982 "Found 1 new test failure: svg/custom/shape-rendering.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25276 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19158 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19174 "Found 1 new test failure: svg/custom/shape-rendering.svg (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19743 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16773 "Found 1 new test failure: svg/custom/shape-rendering.svg (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19565 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->