### PR TITLE
Move program.branch.Branch.branch_point to Repository

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -36,7 +36,6 @@ class Branch(Command):
     help = 'Create a local development branch from the current checkout state'
 
     PR_PREFIX = 'eng'
-    MERGE_BASE_SHARD_SIZE = 512  # Windows has a maximum of ~32K characters in a single command
 
     @classmethod
     def parser(cls, parser, loggers=None):
@@ -89,68 +88,6 @@ class Branch(Command):
                 if branch in repository.branches_for(remote=name, cached=True):
                     return False
         return True
-
-    @classmethod
-    def branch_point(cls, repository):
-        branches = repository.branches_for(remote=None)
-        production_branches = [
-            'remotes/{}/{}'.format(remote, branch)
-            for remote in repository.source_remotes()
-            for branch in branches[remote] if not repository.dev_branches.match(branch)
-        ]
-
-        head = run(
-            [repository.executable(), 'rev-parse', 'HEAD'],
-            cwd=repository.root_path,
-            capture_output=True,
-            encoding='utf-8',
-        ).stdout.strip()
-
-        partial_bases = set()
-        for shard in [
-            production_branches[cls.MERGE_BASE_SHARD_SIZE * i:cls.MERGE_BASE_SHARD_SIZE * (i + 1)]
-            for i in range(1 + len(production_branches) // cls.MERGE_BASE_SHARD_SIZE)
-        ]:
-            if not shard:
-                continue
-            result = run(
-                [repository.executable(), 'merge-base', head] + shard,
-                cwd=repository.root_path,
-                capture_output=True,
-                encoding='utf-8',
-            )
-            if result.returncode:
-                partial_bases = set()
-                break
-            partial_base = result.stdout.strip()
-            if partial_base == head:
-                # If the current commit is ever the merge-base, then the current commit will
-                # be the merge-base when we combine all shards.
-                return repository.commit(
-                    hash=head,
-                    include_log=False, include_identifier=False,
-                )
-            partial_bases.add(partial_base)
-
-        merge_base = None
-        if len(partial_bases) == 1:
-            merge_base = list(partial_bases)[0]
-        elif len(partial_bases) > 1:
-            result = run(
-                [repository.executable(), 'merge-base', head] + list(partial_bases),
-                cwd=repository.root_path,
-                capture_output=True,
-                encoding='utf-8',
-            )
-            if not result.returncode:
-                merge_base = result.stdout.strip()
-        if not merge_base:
-            sys.stderr.write('Failed to find intersection with production branch\n')
-            return None
-        return repository.commit(
-            hash=merge_base,
-            include_log=False, include_identifier=False,
-        )
 
     @classmethod
     def to_branch_name(cls, value):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py
@@ -52,7 +52,7 @@ class Pull(Command):
             return 1
 
         if isinstance(repository, local.Git):
-            branch_point = Branch.branch_point(repository)
+            branch_point = repository.branch_point()
             bp_remotes = set(repository.branches_for(hash=branch_point.hash, remote=None).keys())
             remote = None
             for rmt in repository.source_remotes():

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -213,7 +213,7 @@ class PullRequest(Command):
             sys.stderr.write("'--remote={}' is incompatible with '--redacted'\n".format(args.remote))
             return None
 
-        branch_point = Branch.branch_point(repository)
+        branch_point = repository.branch_point()
         if not branch_point:
             sys.stderr.write('Failed to determine where pull-request diverged from production branch\n')
             return None

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/squash.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/squash.py
@@ -138,7 +138,7 @@ class Squash(Command):
             sys.stderr.write("Can only '{}' on a native Git repository\n".format(cls.name))
             return 1
 
-        branch_point = Branch.branch_point(repository)
+        branch_point = repository.branch_point()
         if not branch_point:
             return 1
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -516,14 +516,14 @@ Created the local development branch 'eng/4'
                 )
             ]
             repo.head = repo.commits['eng/1234'][-1]
-            self.assertEqual(program.Branch.branch_point(local.Git(self.path)).hash, 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc')
+            self.assertEqual(local.Git(self.path).branch_point().hash, 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc')
         self.assertEqual(captured.root.log.getvalue(), '')
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')
 
     def test_branch_point_main(self):
         with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), mocks.local.Svn():
-            self.assertEqual(program.Branch.branch_point(local.Git(self.path)).hash, 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc')
+            self.assertEqual(local.Git(self.path).branch_point().hash, 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc')
         self.assertEqual(captured.root.log.getvalue(), '')
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')

--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -557,7 +557,7 @@ class Git(SCM, SVNRepository):
     def remote_branch_ref(self, find_branch=False):
         if find_branch:
             repository = local.Git(self.checkout_root)
-            branch_point = branch.Branch.branch_point(repository)
+            branch_point = repository.branch_point()
             if branch_point:
                 # First, look for a remote branch that contains the branch point
                 for remote in repository.source_remotes():


### PR DESCRIPTION
#### 77dd08dc75482c6a8b5afcc3e519df604f5cd2bb
<pre>
Move program.branch.Branch.branch_point to Repository
<a href="https://bugs.webkit.org/show_bug.cgi?id=262406">https://bugs.webkit.org/show_bug.cgi?id=262406</a>
rdar://problem/116256812

Reviewed by Jonathan Bedard.

Added branch_point() to git.py and refactored code to reflect change.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git):
(Git.branch_point):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.editable):
(Branch.branch_point): Deleted.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull.py:
(Pull.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.pull_request_branch_point):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/squash.py:
(Squash.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.remote_branch_ref):

Canonical link: <a href="https://commits.webkit.org/268734@main">https://commits.webkit.org/268734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e939a513a29ec83abcf26b5072684af071cf9665

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20523 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/20947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21595 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/22419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20756 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/24203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/21124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/22419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20742 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/24203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/23276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20709 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/24203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/18650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/23276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/24203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/23276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/21124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/20344 "Failed resultsdbpy unit tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/18629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/22968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2533 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/19234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->