### PR TITLE
[update-test-expectations-from-bugzilla] move to parse_args

### DIFF
--- a/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py
@@ -69,10 +69,11 @@ def configure_logging(debug=False):
 
 def argument_parser():
     description = """Update expected.txt files from patches submitted by EWS bots on bugzilla. Given id refers to a bug id by default."""
-    parser = argparse.ArgumentParser(prog='importupdate-test-expectations-from-bugzilla bugzilla_id', description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-a', '--is-attachment-id', dest='is_bug_id', action='store_false', default=True, help='Whether the given id is a bugzilla attachment and not a bug id')
     parser.add_argument('-b', '--bot-filter', dest='bot_filter_name', action='store', default=None, help='Only process EWS results for bots where BOT_FILTER_NAME its part of the name')
     parser.add_argument('-d', '--debug', dest='debug', action='store_true', default=False, help='Log debug messages')
+    parser.add_argument('bugzilla_id', help='Bugzilla ID to lookup')
     return parser
 
 
@@ -168,14 +169,9 @@ class TestExpectationUpdater(object):
 
 def main(_argv, _stdout, _stderr):
     parser = argument_parser()
-    options, args = parser.parse_known_args(_argv)
-
-    if not args:
-        msg = 'Please provide a bug id or use -a option'
-        raise Exception(msg)
+    options = parser.parse_args(_argv)
 
     configure_logging(options.debug)
 
-    bugzilla_id = args[0]
-    updater = TestExpectationUpdater(Host(), bugzilla_id, options.is_bug_id, options.bot_filter_name)
+    updater = TestExpectationUpdater(Host(), options.bugzilla_id, options.is_bug_id, options.bot_filter_name)
     updater.do_update()


### PR DESCRIPTION
#### 5610a2924300060bd87e8c1a2e4c4c314ad791e7
<pre>
[update-test-expectations-from-bugzilla] move to parse_args
<a href="https://bugs.webkit.org/show_bug.cgi?id=262421">https://bugs.webkit.org/show_bug.cgi?id=262421</a>
rdar://problem/116264336

Reviewed by Jonathan Bedard.

There&apos;s no reason for us to re-implement our own argument parsing after
calling the argument parser, so just move from parse_known_args to
parse_args.

* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater.py:
(argument_parser):
(main):

Canonical link: <a href="https://commits.webkit.org/268738@main">https://commits.webkit.org/268738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ca8aeecbd6fba0e72e14cf0ca12ff0aafc035a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20408 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23107 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20545 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17630 "6 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24795 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16359 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22810 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2535 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->