### PR TITLE
[UnifiedPDF] Make PDF plugin documents scrollable

### DIFF
--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -76,9 +76,9 @@ Ref<HTMLStyleElement> PluginDocumentParser::createStyleElement(Document& documen
     auto styleElement = HTMLStyleElement::create(document);
 
     constexpr auto styleSheetContents = R"CONTENTS(
-html { width: 100%; height: 100%; }
-body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
-embed { width: 100%; height: 100%; }
+html.plugin-fills-viewport, html.plugin-fills-viewport body, html.plugin-fills-viewport embed { width: 100%; height: 100%; }
+html.plugin-fills-viewport body { overflow: hidden; }
+body { margin: 0 }
 )CONTENTS"_s;
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -70,6 +70,8 @@ public:
     virtual bool isUnifiedPDFPlugin() const { return false; }
     virtual bool isLegacyPDFPlugin() const { return false; }
 
+    virtual bool pluginFillsViewport() const { return true; }
+
     virtual void setView(PluginView&);
 
     virtual void willDetachRenderer() { }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -42,6 +42,8 @@ private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
     bool isUnifiedPDFPlugin() const override { return true; }
 
+    bool pluginFillsViewport() const override { return false; }
+
     void teardown() override;
 
     void createPDFDocument() override;
@@ -80,6 +82,8 @@ private:
     id accessibilityHitTest(const WebCore::IntPoint&) const override;
     id accessibilityObject() const override;
     id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const override;
+
+    void sizeToFitContents();
 
     PDFDocumentLayout m_documentLayout;
 };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -28,8 +28,11 @@
 
 #if ENABLE(UNIFIED_PDF)
 
+#include "PluginView.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/HTMLNames.h>
+#include <WebCore/HTMLPlugInElement.h>
 #include <WebCore/ImageBuffer.h>
 
 namespace WebKit {
@@ -71,7 +74,17 @@ void UnifiedPDFPlugin::installPDFDocument()
     if (!m_view)
         return;
 
+    sizeToFitContents();
     invalidateRect({ IntPoint(), size() });
+}
+
+void UnifiedPDFPlugin::sizeToFitContents()
+{
+    auto contentsSize = expandedIntSize(m_documentLayout.layoutSize());
+
+    auto& pluginElement = m_view->pluginElement();
+    pluginElement.setInlineStyleProperty(CSSPropertyWidth, contentsSize.width(), CSSUnitType::CSS_PX);
+    pluginElement.setInlineStyleProperty(CSSPropertyHeight, contentsSize.height(), CSSUnitType::CSS_PX);
 }
 
 void UnifiedPDFPlugin::paint(GraphicsContext& context, const WebCore::IntRect& rect)
@@ -118,6 +131,8 @@ void UnifiedPDFPlugin::geometryDidChange(const IntSize& pluginSize, const Affine
 {
     if (size() == pluginSize)
         return;
+
+    // FIXME: Re-layout
 
     PDFPluginBase::geometryDidChange(pluginSize, pluginToRootViewTransform);
 }

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -52,6 +52,7 @@
 #include <WebCore/FrameLoadRequest.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/HTMLNames.h>
 #include <WebCore/HTMLPlugInElement.h>
 #include <WebCore/HTTPHeaderNames.h>
 #include <WebCore/HostWindow.h>
@@ -232,6 +233,7 @@ PluginView::PluginView(HTMLPlugInElement& element, const URL& mainResourceURL, c
     , m_pendingResourceRequestTimer(RunLoop::main(), this, &PluginView::pendingResourceRequestTimerFired)
 {
     m_webPage->addPluginView(*this);
+    updateDocumentForPluginSizingBehavior();
 }
 
 PluginView::~PluginView()
@@ -246,6 +248,16 @@ PluginView::~PluginView()
 LocalFrame* PluginView::frame() const
 {
     return m_pluginElement->document().frame();
+}
+
+void PluginView::updateDocumentForPluginSizingBehavior()
+{
+    if (!m_plugin->pluginFillsViewport())
+        return;
+
+    RefPtr documentElement = m_pluginElement->document().documentElement();
+    // The styles in PluginDocumentParser are constructed to respond to this class.
+    documentElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "plugin-fills-viewport"_s);
 }
 
 void PluginView::manualLoadDidReceiveResponse(const ResourceResponse& response)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -121,6 +121,8 @@ private:
 
     bool shouldCreateTransientPaintingSnapshot() const;
 
+    void updateDocumentForPluginSizingBehavior();
+
     // WebCore::PluginViewBase
     PlatformLayer* platformLayer() const final;
     bool scroll(WebCore::ScrollDirection, WebCore::ScrollGranularity) final;


### PR DESCRIPTION
#### d34e910dd2e203ec8fb4f1d734826e24063a534c
<pre>
[UnifiedPDF] Make PDF plugin documents scrollable
<a href="https://bugs.webkit.org/show_bug.cgi?id=262428">https://bugs.webkit.org/show_bug.cgi?id=262428</a>
rdar://116268851

Reviewed by Tim Horton.

The UnifiedPDFPlugin expands to the size of the PDF, and scrolling is handled by the enclosing HTML
document.

To support this, modify the CSS in `PluginDocumentParser::createStyleElement()` to conditionalize
the old 100% height/width behavior based on a class on the `&lt;html&gt;` element; this classname is added
by `PluginView::updateDocumentForPluginSizingBehavior()` based on the value returned by
`m_plugin-&gt;pluginFillViewport()`.

The UnifiedPDFPlugin then sets its height and width based on the PDF dimensions after laying out the
PDF, making the page scrollable if necessary. A future patch will refine this to ensure that for
PDFs smaller than the viewport the plugin still fills it.

* Source/WebCore/html/PluginDocument.cpp:
(WebCore::PluginDocumentParser::createStyleElement):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::pluginFillViewport const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::sizeToFitContents):
(WebKit::UnifiedPDFPlugin::geometryDidChange):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::PluginView):
(WebKit::PluginView::updateDocumentForPluginSizingBehavior):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/268697@main">https://commits.webkit.org/268697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd90d573d7503df4ffe9ba4368a3765fc0cf6c1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20384 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20424 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23133 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24814 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22751 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19285 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18500 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4904 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->