### PR TITLE
[Hardening] Make Vector::uncheckedAppend() an alias to Vector::append()

### DIFF
--- a/Source/JavaScriptCore/API/JSObjectRef.cpp
+++ b/Source/JavaScriptCore/API/JSObjectRef.cpp
@@ -809,10 +809,9 @@ JSPropertyNameArrayRef JSObjectCopyPropertyNames(JSContextRef ctx, JSObjectRef o
     PropertyNameArray array(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
     jsObject->getPropertyNames(globalObject, array, DontEnumPropertiesMode::Exclude);
 
-    size_t size = array.size();
-    propertyNames->array.reserveInitialCapacity(size);
-    for (size_t i = 0; i < size; ++i)
-        propertyNames->array.uncheckedAppend(OpaqueJSString::tryCreate(array[i].string()).releaseNonNull());
+    propertyNames->array = WTF::map(array, [](auto& item) {
+        return OpaqueJSString::tryCreate(item.string()).releaseNonNull();
+    });
 
     return JSPropertyNameArrayRetain(propertyNames);
 }

--- a/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp
@@ -154,8 +154,7 @@ private:
         ASSERT(!m_workset->isEmpty());
 
         liveAtHead.reserveCapacity(liveAtHead.size() + m_workset->size());
-        for (unsigned newValue : *m_workset)
-            liveAtHead.uncheckedAppend(newValue);
+        liveAtHead.appendRange(m_workset->begin(), m_workset->end());
 
         bool changedPredecessor = false;
         for (BasicBlock* predecessor : block->predecessors) {

--- a/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
@@ -462,13 +462,12 @@ public:
             unsigned entrypointIndex = pair.key;
             BasicBlock* oldRoot = pair.value;
             ArgumentsVector& arguments = m_graph.m_rootToArguments.find(oldRoot)->value;
-            Vector<FlushFormat> argumentFormats;
-            argumentFormats.reserveInitialCapacity(arguments.size());
-            for (unsigned i = 0; i < arguments.size(); ++i) {
-                Node* node = m_argumentMapping.get(arguments[i]);
+            auto argumentFormats = arguments.map([&](auto& argument) {
+                Node* node = m_argumentMapping.get(argument);
                 RELEASE_ASSERT(node);
-                argumentFormats.uncheckedAppend(node->stackAccessData()->format);
-            }
+                return node->stackAccessData()->format;
+            });
+
             m_graph.m_argumentFormats[entrypointIndex] = WTFMove(argumentFormats);
         }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2723,16 +2723,14 @@ void SpeculativeJIT::linkOSREntries(LinkBuffer& linkBuffer)
             continue;
         if (block->isCatchEntrypoint) {
             auto& argumentsVector = m_graph.m_rootToArguments.find(block)->value;
-            Vector<FlushFormat> argumentFormats;
-            argumentFormats.reserveInitialCapacity(argumentsVector.size());
-            for (Node* setArgument : argumentsVector) {
+            auto argumentFormats = argumentsVector.map([](auto* setArgument) {
                 if (setArgument) {
                     FlushFormat flushFormat = setArgument->variableAccessData()->flushFormat();
                     ASSERT(flushFormat == FlushedInt32 || flushFormat == FlushedCell || flushFormat == FlushedBoolean || flushFormat == FlushedJSValue);
-                    argumentFormats.uncheckedAppend(flushFormat);
-                } else
-                    argumentFormats.uncheckedAppend(DeadFlush);
-            }
+                    return flushFormat;
+                }
+                return DeadFlush;
+            });
             noticeCatchEntrypoint(*block, m_osrEntryHeads[osrEntryIndex++], linkBuffer, WTFMove(argumentFormats));
         } else {
             ASSERT(block->isOSRTarget);

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -100,15 +100,10 @@ Vector<String> IntlCollator::sortLocaleData(const String& locale, RelevantExtens
         break;
     }
     case RelevantExtensionKey::Kf:
-        keyLocaleData.reserveInitialCapacity(3);
-        keyLocaleData.uncheckedAppend("false"_s);
-        keyLocaleData.uncheckedAppend("lower"_s);
-        keyLocaleData.uncheckedAppend("upper"_s);
+        keyLocaleData = Vector<String>::from("false"_str, "lower"_str, "upper"_str);
         break;
     case RelevantExtensionKey::Kn:
-        keyLocaleData.reserveInitialCapacity(2);
-        keyLocaleData.uncheckedAppend("false"_s);
-        keyLocaleData.uncheckedAppend("true"_s);
+        keyLocaleData = Vector<String>::from("false"_str, "true"_str);
         break;
     default:
         ASSERT_NOT_REACHED();
@@ -127,15 +122,10 @@ Vector<String> IntlCollator::searchLocaleData(const String&, RelevantExtensionKe
         keyLocaleData.append({ });
         break;
     case RelevantExtensionKey::Kf:
-        keyLocaleData.reserveInitialCapacity(3);
-        keyLocaleData.uncheckedAppend("false"_s);
-        keyLocaleData.uncheckedAppend("lower"_s);
-        keyLocaleData.uncheckedAppend("upper"_s);
+        keyLocaleData = Vector<String>::from("false"_str, "lower"_str, "upper"_str);
         break;
     case RelevantExtensionKey::Kn:
-        keyLocaleData.reserveInitialCapacity(2);
-        keyLocaleData.uncheckedAppend("false"_s);
-        keyLocaleData.uncheckedAppend("true"_s);
+        keyLocaleData = Vector<String>::from("false"_str, "true"_str);
         break;
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -324,8 +324,7 @@ protected:
                     continue;
 
                 liveAtHead.reserveCapacity(liveAtHead.size() + m_workset.size());
-                for (unsigned newValue : m_workset)
-                    liveAtHead.uncheckedAppend(newValue);
+                liveAtHead.appendRange(m_workset.begin(), m_workset.end());
                 
                 m_workset.sort();
                 

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -240,7 +240,7 @@ struct Mapper<MapFunction, const WeakHashSet<T, WeakMapImpl>&, void> {
         Vector<DestinationItemType> result;
         result.reserveInitialCapacity(source.computeSize());
         for (auto& item : source)
-            result.uncheckedAppend(mapFunction(item));
+            result.unsafeAppendWithoutCapacityCheck(mapFunction(item));
         return result;
     }
 };

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -398,7 +398,7 @@ struct Mapper<MapFunction, const WeakListHashSet<T, WeakMapImpl> &, void> {
         Vector<DestinationItemType> result;
         result.reserveInitialCapacity(source.computeSize());
         for (auto& item : source)
-            result.uncheckedAppend(mapFunction(item));
+            result.unsafeAppendWithoutCapacityCheck(mapFunction(item));
         return result;
     }
 };

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -180,8 +180,7 @@ Vector<UChar> String::charactersWithoutNullTermination() const
 
         if (is8Bit()) {
             const LChar* characters8 = m_impl->characters8();
-            for (unsigned i = 0; i < length(); ++i)
-                result.uncheckedAppend(characters8[i]);
+            result.append(characters8, m_impl->length());
         } else {
             const UChar* characters16 = m_impl->characters16();
             result.append(characters16, m_impl->length());

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -360,14 +360,15 @@ RefPtr<IDBKey> maybeCreateIDBKeyFromScriptValueAndKeyPath(JSGlobalObject& lexica
 {
     if (std::holds_alternative<Vector<String>>(keyPath)) {
         auto& array = std::get<Vector<String>>(keyPath);
-        Vector<RefPtr<IDBKey>> result;
-        result.reserveInitialCapacity(array.size());
-        for (auto& string : array) {
-            RefPtr<IDBKey> key = internalCreateIDBKeyFromScriptValueAndKeyPath(lexicalGlobalObject, value, string);
+        bool hasNullKey = false;
+        auto result = WTF::map(array, [&](auto& string) -> RefPtr<IDBKey> {
+            auto key = internalCreateIDBKeyFromScriptValueAndKeyPath(lexicalGlobalObject, value, string);
             if (!key)
-                return nullptr;
-            result.uncheckedAppend(WTFMove(key));
-        }
+                hasNullKey = true;
+            return key;
+        });
+        if (hasNullKey)
+            return nullptr;
         return IDBKey::createArray(WTFMove(result));
     }
 

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -279,13 +279,10 @@ void CSSFontFace::setUnicodeRange(CSSValueList& list)
 {
     mutableProperties().setProperty(CSSPropertyUnicodeRange, &list);
 
-    Vector<UnicodeRange> ranges;
-    ranges.reserveInitialCapacity(list.length());
-
-    for (auto& rangeValue : list) {
+    auto ranges = WTF::map(list, [](auto& rangeValue) {
         auto& range = downcast<CSSUnicodeRangeValue>(rangeValue);
-        ranges.uncheckedAppend({ range.from(), range.to() });
-    }
+        return UnicodeRange { range.from(), range.to() };
+    });
 
     if (ranges == m_ranges)
         return;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8103,13 +8103,11 @@ void Document::didAssociateFormControl(Element& element)
 
 void Document::didAssociateFormControlsTimerFired()
 {
-    Vector<RefPtr<Element>> controls;
-    controls.reserveInitialCapacity(m_associatedFormControls.computeSize());
-    for (auto& element : std::exchange(m_associatedFormControls, { })) {
+    auto controls = WTF::compactMap(std::exchange(m_associatedFormControls, { }), [](auto&& element) -> std::optional<RefPtr<Element>> {
         if (element.isConnected())
-            controls.uncheckedAppend(&element);
-    }
-    controls.shrinkToFit();
+            return RefPtr { &element };
+        return std::nullopt;
+    });
 
     if (auto page = this->page(); page && !controls.isEmpty()) {
         ASSERT(m_frame);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2263,11 +2263,7 @@ void Element::setElementsArrayAttribute(const QualifiedName& attributeName, std:
 
     setAttribute(attributeName, emptyAtom());
 
-    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> newElements;
-    newElements.reserveInitialCapacity(elements->size());
-    for (auto element : elements.value()) {
-        newElements.uncheckedAppend(element);
-    }
+    auto newElements = copyToVectorOf<WeakPtr<Element, WeakPtrImplWithEventTargetData>>(*elements);
     explicitlySetAttrElementsMap().set(attributeName, WTFMove(newElements));
     
     if (auto* cache = document().existingAXObjectCache()) {

--- a/Source/WebCore/html/URLSearchParams.cpp
+++ b/Source/WebCore/html/URLSearchParams.cpp
@@ -116,14 +116,11 @@ void URLSearchParams::append(const String& name, const String& value)
 
 Vector<String> URLSearchParams::getAll(const String& name) const
 {
-    Vector<String> values;
-    values.reserveInitialCapacity(m_pairs.size());
-    for (const auto& pair : m_pairs) {
+    return WTF::compactMap(m_pairs, [&](auto& pair) -> std::optional<String> {
         if (pair.key == name)
-            values.uncheckedAppend(pair.value);
-    }
-    values.shrinkToFit();
-    return values;
+            return pair.value;
+        return std::nullopt;
+    });
 }
 
 void URLSearchParams::remove(const String& name, const String& value)

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -221,18 +221,16 @@ inline void AtomHTMLToken::initializeAttributes(const HTMLToken::AttributeList& 
 
     HashSet<AtomString> addedAttributes;
     addedAttributes.reserveInitialCapacity(size);
-    m_attributes.reserveInitialCapacity(size);
-    for (auto& attribute : attributes) {
+    m_attributes = WTF::compactMap(attributes, [&](auto& attribute) -> std::optional<Attribute> {
         if (attribute.name.isEmpty())
-            continue;
+            return std::nullopt;
 
         auto qualifiedName = HTMLNameCache::makeAttributeQualifiedName(attribute.name);
-
         if (addedAttributes.add(qualifiedName.localName()).isNewEntry)
-            m_attributes.uncheckedAppend(Attribute(WTFMove(qualifiedName), HTMLNameCache::makeAttributeValue(attribute.value)));
-        else
-            m_hasDuplicateAttribute = true;
-    }
+            return Attribute(WTFMove(qualifiedName), HTMLNameCache::makeAttributeValue(attribute.value));
+        m_hasDuplicateAttribute = true;
+        return std::nullopt;
+    });
 }
 
 inline AtomHTMLToken::AtomHTMLToken(HTMLToken& token)

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -247,8 +247,7 @@ void MemoryCache::forEachResource(const Function<void(CachedResource&)>& functio
     Vector<WeakPtr<CachedResource>> allResources;
     for (auto& lruList : m_allResources) {
         allResources.reserveCapacity(allResources.size() + lruList->computeSize());
-        for (auto& resource : *lruList)
-            allResources.uncheckedAppend(resource);
+        allResources.appendRange(lruList->begin(), lruList->end());
     }
     for (auto& resource : allResources) {
         if (CachedResourceHandle resourceHandle = resource.get())

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2228,14 +2228,12 @@ static Vector<FloatRect> absoluteRectsForRangeInText(const SimpleRange& range, T
 
     if (behavior.contains(RenderObject::BoundingRectBehavior::RespectClipping)) {
         auto absoluteClippedOverflowRect = renderer->absoluteClippedOverflowRectForRepaint();
-        Vector<FloatRect> clippedRects;
-        clippedRects.reserveInitialCapacity(textQuads.size());
-        for (auto& quad : textQuads) {
+        return WTF::compactMap(textQuads, [&](auto& quad) -> std::optional<FloatRect> {
             auto clippedRect = intersection(quad.boundingBox(), absoluteClippedOverflowRect);
             if (!clippedRect.isEmpty())
-                clippedRects.uncheckedAppend(clippedRect);
-        }
-        return clippedRects;
+                return clippedRect;
+            return std::nullopt;
+        });
     }
 
     return boundingBoxes(textQuads);
@@ -2258,12 +2256,9 @@ Vector<IntRect> RenderObject::absoluteTextRects(const SimpleRange& range, Option
         }
     }
 
-    Vector<IntRect> result;
-    result.reserveInitialCapacity(rects.size());
-    for (auto& layoutRect : rects)
-        result.uncheckedAppend(enclosingIntRect(layoutRect));
-
-    return result;
+    return WTF::map(rects, [](auto& layoutRect) {
+        return enclosingIntRect(layoutRect);
+    });
 }
 
 static RefPtr<Node> nodeBefore(const BoundaryPoint& point)


### PR DESCRIPTION
#### 1b624bea4bbbf7cf1c9a7b8fc65e9fa6d153d32c
<pre>
[Hardening] Make Vector::uncheckedAppend() an alias to Vector::append()
<a href="https://bugs.webkit.org/show_bug.cgi?id=262431">https://bugs.webkit.org/show_bug.cgi?id=262431</a>

Reviewed by Ryosuke Niwa.

Make Vector::uncheckedAppend() an alias to Vector::append() so that bounds
checking always happens. This hardening is part of our effort to make our code
safer.

This tested as performance neutral on Speedometer, MotionMark and JetStream on
various A/B bots (I tried to cover various configurations). However, I plan to
monitor the bots after landing to be safe. If it sticks, I&apos;ll follow-up to get
rid of Vector::uncheckedAppend() entirely.

Note that in order to avoid regressions on benchmarks, WTF::map(), Vector::map(),
copyToVector() &amp; copyToVectorOf() still rely on a private
unsafeAppendWithoutCapacityCheck() function.

* Source/JavaScriptCore/API/JSObjectRef.cpp:
(JSObjectCopyPropertyNames):
* Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp:
(JSC::DFG::SSAConversionPhase::run):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::linkOSREntries):
* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::IntlCollator::sortLocaleData):
(JSC::IntlCollator::searchLocaleData):
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::compute):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::Vector):
(WTF::Vector::append):
(WTF::Vector::uncheckedAppend):
(WTF::Vector::uncheckedConstructAndAppend):
(WTF::Vector::unsafeAppendWithoutCapacityCheck):
(WTF::Malloc&gt;::unsafeAppendWithoutCapacityCheck):
(WTF::Malloc&gt;::appendVector):
(WTF::Malloc&gt;::map const const):
(WTF::Mapper::map):
(WTF::copyToVectorSpecialization):
(WTF::Malloc&gt;::uncheckedAppend): Deleted.
(WTF::Malloc&gt;::uncheckedConstructAndAppend): Deleted.
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::charactersWithoutNullTermination const):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::maybeCreateIDBKeyFromScriptValueAndKeyPath):
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::setUnicodeRange):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::didAssociateFormControlsTimerFired):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setElementsArrayAttribute):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::convertNodesOrStringsIntoNode):
* Source/WebCore/html/URLSearchParams.cpp:
(WebCore::URLSearchParams::getAll const):
* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::initializeAttributes):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::forEachResource):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::absoluteRectsForRangeInText):
(WebCore::RenderObject::absoluteTextRects):

Canonical link: <a href="https://commits.webkit.org/268700@main">https://commits.webkit.org/268700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f5fb93af5f1b9bb3ea97c83c66373a66bae5a83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19040 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20441 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23157 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24830 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17763 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22770 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19809 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16394 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23815 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18523 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5702 "Found 4 jsc stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.dfg-eager, stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.mini-mode") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4906 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22860 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25072 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19132 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5525 "Found 1 jsc stress test failure: microbenchmarks/array-from-object.js.lockdown") | 
<!--EWS-Status-Bubble-End-->