### PR TITLE
[WebGPU] https://webgpu.github.io/webgpu-samples/samples/worker does not load

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.h
+++ b/Source/WebCore/Modules/WebGPU/GPU.h
@@ -40,6 +40,8 @@ namespace WebCore {
 class GPUCompositorIntegration;
 class GPUPresentationContext;
 struct GPUPresentationContextDescriptor;
+class GraphicsContext;
+class NativeImage;
 
 class GPU : public RefCounted<GPU> {
 public:
@@ -57,6 +59,8 @@ public:
     Ref<GPUPresentationContext> createPresentationContext(const GPUPresentationContextDescriptor&);
 
     Ref<GPUCompositorIntegration> createCompositorIntegration();
+
+    void paintToCanvas(NativeImage&, const IntSize&, GraphicsContext&);
 
 private:
     GPU(Ref<WebGPU::GPU>&&);

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp
@@ -40,4 +40,9 @@ void GPUCompositorIntegration::prepareForDisplay(CompletionHandler<void()>&& com
     m_backing->prepareForDisplay(WTFMove(completionHandler));
 }
 
+void GPUCompositorIntegration::paintCompositedResultsToCanvas(WebCore::ImageBuffer& imageBuffer, uint32_t bufferIndex)
+{
+    m_backing->paintCompositedResultsToCanvas(imageBuffer, bufferIndex);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h
@@ -34,6 +34,8 @@
 
 namespace WebCore {
 
+class ImageBuffer;
+
 class GPUCompositorIntegration : public RefCounted<GPUCompositorIntegration> {
 public:
     static Ref<GPUCompositorIntegration> create(Ref<WebGPU::CompositorIntegration>&& backing)
@@ -49,6 +51,8 @@ public:
 
     WebGPU::CompositorIntegration& backing() { return m_backing; }
     const WebGPU::CompositorIntegration& backing() const { return m_backing; }
+
+    void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t);
 
 private:
     GPUCompositorIntegration(Ref<WebGPU::CompositorIntegration>&& backing)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
@@ -42,6 +42,10 @@
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
 #endif
 
+namespace WebCore {
+class NativeImage;
+}
+
 namespace WebCore::WebGPU {
 
 class ConvertToBackingContext;
@@ -69,6 +73,9 @@ public:
         ASSERT(!m_onSubmittedWorkScheduledCallback);
         m_onSubmittedWorkScheduledCallback = WTFMove(onSubmittedWorkScheduledCallback);
     }
+
+    void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage&)>) final;
+    void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t) final;
 
 private:
     friend class DowncastConvertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp
@@ -33,6 +33,9 @@
 #include "WebGPUDowncastConvertToBackingContext.h"
 #include "WebGPUPresentationContextDescriptor.h"
 #include "WebGPUPresentationContextImpl.h"
+#include <WebCore/GraphicsContext.h>
+#include <WebCore/IntSize.h>
+#include <WebCore/NativeImage.h>
 #include <WebGPU/WebGPUExt.h>
 #include <wtf/BlockPtr.h>
 
@@ -108,6 +111,15 @@ Ref<PresentationContext> GPUImpl::createPresentationContext(const PresentationCo
 Ref<CompositorIntegration> GPUImpl::createCompositorIntegration()
 {
     return CompositorIntegrationImpl::create(m_convertToBackingContext);
+}
+
+void GPUImpl::paintToCanvas(WebCore::NativeImage& image, const WebCore::IntSize& canvasSize, WebCore::GraphicsContext& context)
+{
+    auto imageSize = image.size();
+    FloatRect canvasRect(FloatPoint(), canvasSize);
+    GraphicsContextStateSaver stateSaver(context);
+    context.setImageInterpolationQuality(InterpolationQuality::DoNotInterpolate);
+    context.drawNativeImage(image, imageSize, canvasRect, FloatRect(FloatPoint(), imageSize), { CompositeOperator::Copy });
 }
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
@@ -34,6 +34,12 @@
 #include <wtf/Deque.h>
 #include <wtf/Function.h>
 
+namespace WebCore {
+class GraphicsContext;
+class IntSize;
+class NativeImage;
+}
+
 namespace WebCore::WebGPU {
 
 class ConvertToBackingContext;
@@ -50,6 +56,8 @@ public:
 
     void ref() const final { RefCounted<GPUImpl>::ref(); }
     void deref() const final { RefCounted<GPUImpl>::deref(); }
+
+    void paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&) final;
 
 private:
     friend class DowncastConvertToBackingContext;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
@@ -31,10 +31,18 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
+namespace WebCore {
+class NativeImage;
+class IntSize;
+class GraphicsContext;
+}
+
 namespace WebCore::WebGPU {
 
 class Adapter;
 class CompositorIntegration;
+class GraphicsContext;
+class NativeImage;
 class PresentationContext;
 struct PresentationContextDescriptor;
 
@@ -49,6 +57,7 @@ public:
     virtual Ref<PresentationContext> createPresentationContext(const PresentationContextDescriptor&) = 0;
 
     virtual Ref<CompositorIntegration> createCompositorIntegration() = 0;
+    virtual void paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&) = 0;
 
 protected:
     GPU() = default;

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
@@ -27,6 +27,7 @@
 
 #include <optional>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Function.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
@@ -35,6 +36,11 @@
 #include <wtf/MachSendRight.h>
 #include <wtf/Vector.h>
 #endif
+
+namespace WebCore {
+class ImageBuffer;
+class NativeImage;
+}
 
 namespace WebCore::WebGPU {
 
@@ -47,6 +53,8 @@ public:
 #endif
 
     virtual void prepareForDisplay(CompletionHandler<void()>&&) = 0;
+    virtual void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage&)>) = 0;
+    virtual void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t bufferIndex) = 0;
 
 protected:
     CompositorIntegration() = default;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -178,13 +178,17 @@ void GPUCanvasContextCocoa::reshape(int width, int height)
 
 void GPUCanvasContextCocoa::prepareForDisplayWithPaint()
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=233622 - Support offscreen canvas with WebGPU
     prepareForDisplay();
 }
 
 void GPUCanvasContextCocoa::paintRenderingResultsToCanvas()
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=233622 - Support offscreen canvas with WebGPU
+    auto& base = canvasBase();
+    base.clearCopiedImage();
+    if (auto buffer = base.buffer()) {
+        buffer->flushDrawingContext();
+        m_compositorIntegration->paintCompositedResultsToCanvas(*buffer, m_configuration->frameCount);
+    }
 }
 
 GPUCanvasContext::CanvasType GPUCanvasContextCocoa::canvas()
@@ -292,9 +296,7 @@ void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
             renderBox->contentChanged(CanvasChanged);
         }
     }, [&](RefPtr<OffscreenCanvas>& offscreenCanvas) {
-        UNUSED_PARAM(offscreenCanvas);
         canvasBase = offscreenCanvas.get();
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=233622 - [WebGPU] Hook it up to WorkerNavigator
     });
 
     if (!canvasIsDirty)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in
@@ -28,6 +28,7 @@ messages -> RemoteCompositorIntegration NotRefCounted Stream {
 void RecreateRenderBuffers(int width, int height) -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodableReply
 #endif
 void PrepareForDisplay() -> (bool dummy) Synchronous NotStreamEncodableReply // Because CanvasRenderingContext::prepareForDisplay() requires the layer contents synchronously, this needs to be Synchronous.
+void PaintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBuffer, uint32_t bufferIndex) -> () Synchronous
 void Destruct()
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -38,6 +38,7 @@
 #include "WebGPUSupportedLimits.h"
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
+#include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadAssertions.h>
@@ -53,6 +54,7 @@ class StreamServerConnection;
 
 namespace WebCore {
 class MediaPlayer;
+class NativeImage;
 class VideoFrame;
 }
 
@@ -79,6 +81,8 @@ public:
     virtual ~RemoteGPU();
 
     void stopListeningForIPC();
+
+    void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);
 
 private:
     friend class WebGPU::ObjectHeap;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -31,6 +31,7 @@
 #include "RemoteCompositorIntegrationMessages.h"
 #include "RemoteGPUProxy.h"
 #include "WebGPUConvertToBackingContext.h"
+#include <WebCore/ImageBuffer.h>
 
 namespace WebKit::WebGPU {
 
@@ -67,6 +68,18 @@ void RemoteCompositorIntegrationProxy::prepareForDisplay(CompletionHandler<void(
     m_presentationContext->present();
 
     completionHandler();
+}
+
+void RemoteCompositorIntegrationProxy::paintCompositedResultsToCanvas(WebCore::ImageBuffer& buffer, uint32_t bufferIndex)
+{
+    buffer.flushDrawingContext();
+    auto sendResult = sendSync(Messages::RemoteCompositorIntegration::PaintCompositedResultsToCanvas(buffer.renderingResourceIdentifier(), bufferIndex));
+    UNUSED_VARIABLE(sendResult);
+}
+
+void RemoteCompositorIntegrationProxy::withDisplayBufferAsNativeImage(uint32_t, Function<void(WebCore::NativeImage&)>)
+{
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -32,6 +32,11 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUCompositorIntegration.h>
 
+namespace WebCore {
+class ImageBuffer;
+class NativeImage;
+}
+
 namespace WebKit::WebGPU {
 
 class ConvertToBackingContext;
@@ -54,6 +59,9 @@ public:
         ASSERT(!m_presentationContext);
         m_presentationContext = &presentationContext;
     }
+
+    void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t) final;
+    void withDisplayBufferAsNativeImage(uint32_t, Function<void(WebCore::NativeImage&)>) final;
 
 private:
     friend class DowncastConvertToBackingContext;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -220,6 +220,11 @@ Ref<WebCore::WebGPU::CompositorIntegration> RemoteGPUProxy::createCompositorInte
     return WebGPU::RemoteCompositorIntegrationProxy::create(*this, m_convertToBackingContext, identifier);
 }
 
+void RemoteGPUProxy::paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&)
+{
+    ASSERT_NOT_REACHED();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -39,6 +39,12 @@ namespace WebKit {
 class GPUProcessConnection;
 }
 
+namespace WebCore {
+class IntSize;
+class GraphicsContext;
+class NativeImage;
+}
+
 namespace WebKit {
 
 namespace WebGPU {
@@ -60,6 +66,7 @@ public:
     void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteGPUProxy>::ref(); }
     void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteGPUProxy>::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteGPUProxy>::controlBlock(); }
+    void paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&) final;
 
 private:
     friend class WebGPU::DowncastConvertToBackingContext;


### PR DESCRIPTION
#### 81820fabe5cd04e9cb4f1c3c7fb2bb303a620046
<pre>
[WebGPU] <a href="https://webgpu.github.io/webgpu-samples/samples/worker">https://webgpu.github.io/webgpu-samples/samples/worker</a> does not load
<a href="https://bugs.webkit.org/show_bug.cgi?id=260241">https://bugs.webkit.org/show_bug.cgi?id=260241</a>
&lt;radar://113940893&gt;

Reviewed by Dan Glastonbury and Kimmo Kinnunen.

Mirror what WebGL does for OffscreenCanvas which enables the github
web worker sample to function.

* Source/WebCore/Modules/WebGPU/GPU.cpp:
* Source/WebCore/Modules/WebGPU/GPU.h:
* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.cpp:
(WebCore::GPUCompositorIntegration::paintCompositedResultsToCanvas):
* Source/WebCore/Modules/WebGPU/GPUCompositorIntegration.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp:
(WebCore::WebGPU::CompositorIntegrationImpl::recreateRenderBuffers):
(WebCore::WebGPU::CompositorIntegrationImpl::withDisplayBufferAsNativeImage):
(WebCore::WebGPU::CompositorIntegrationImpl::paintCompositedResultsToCanvas):
(WebCore::WebGPU::toCFNumber): Deleted.
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.cpp:
(WebCore::WebGPU::GPUImpl::paintToCanvas):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::prepareForDisplayWithPaint):
(WebCore::GPUCanvasContextCocoa::paintRenderingResultsToCanvas):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp:
(WebKit::RemoteCompositorIntegration::RemoteCompositorIntegration):
(WebKit::RemoteCompositorIntegration::paintCompositedResultsToCanvas):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::createCompositorIntegration):
(WebKit::RemoteGPU::paintNativeImageToImageBuffer):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::paintCompositedResultsToCanvas):
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::withDisplayBufferAsNativeImage):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::paintToCanvas):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:

Canonical link: <a href="https://commits.webkit.org/268745@main">https://commits.webkit.org/268745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54bc81bc9f24fd3d5aa2ad2dc763cc9f2de8846d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19156 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21137 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23290 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18661 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24951 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22889 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16505 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18639 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4932 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->