### PR TITLE
Skip non-text svg elements in Position [upstream | downstream]

### DIFF
--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2015-2018 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,6 +52,8 @@
 #include "RenderIterator.h"
 #include "RenderLineBreak.h"
 #include "RenderText.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGTextElement.h"
 #include "Text.h"
 #include "TextIterator.h"
 #include "VisiblePosition.h"
@@ -717,6 +719,10 @@ Position Position::upstream(EditingBoundaryCrossingRule rule) const
             lastNode = &currentNode;
         }
 
+        // There is no caret position in non-text svg elements.
+        if (currentNode.isSVGElement() && !is<SVGTextElement>(currentNode))
+            continue;
+
         // If we've moved to a position that is visually distinct, return the last saved position. There 
         // is code below that terminates early if we're *about* to move to a visually distinct position.
         if (endsOfNodeAreVisuallyDistinctPositions(&currentNode) && &currentNode != boundary)
@@ -824,6 +830,10 @@ Position Position::downstream(EditingBoundaryCrossingRule rule) const
         // return the last visible streamer position
         if (is<HTMLBodyElement>(currentNode) && currentPosition.atEndOfNode())
             break;
+
+        // There is no caret position in non-text svg elements.
+        if (currentNode.isSVGElement() && !is<SVGTextElement>(currentNode))
+            continue;
 
         // Do not move to a visually distinct position.
         if (endsOfNodeAreVisuallyDistinctPositions(&currentNode) && &currentNode != boundary)


### PR DESCRIPTION
#### 13274cf68d90652bf43b4b3205403b2d9d78a6d6
<pre>
Skip non-text svg elements in Position [upstream | downstream]

<a href="https://bugs.webkit.org/show_bug.cgi?id=261984">https://bugs.webkit.org/show_bug.cgi?id=261984</a>
rdar://problem/116261189

Reviewed by Ryosuke Niwa and Wenson Hsieh.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/8e793a18ec6358414ffc337b336c93d4f6061c91">https://chromium.googlesource.com/chromium/src.git/+/8e793a18ec6358414ffc337b336c93d4f6061c91</a>

There is no caret position in non-text svg elements. Hence, this patch
skips such elements in the two functions for performance optimization.

Manually tested on test case from the bug and noticed that the local build
with patch is performing significantly better.

* Source/WebCore/dom/Position.cpp:
(Position::upstream):
(Position::downstream):

Canonical link: <a href="https://commits.webkit.org/268699@main">https://commits.webkit.org/268699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39cf238223fb7dcb30a50d6b5ec605c8422b263f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20431 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23146 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24820 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22759 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16384 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18513 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4905 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22848 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->