### PR TITLE
[UnifiedPDF] Handle page rotation

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -29,6 +29,7 @@
 
 #include <CoreGraphics/CoreGraphics.h>
 #include <WebCore/FloatRect.h>
+#include <WebCore/IntDegrees.h>
 #include <wtf/RetainPtr.h>
 
 namespace WebCore {
@@ -60,6 +61,8 @@ public:
 
     RetainPtr<CGPDFPageRef> pageAtIndex(PageIndex) const;
     WebCore::FloatRect boundsForPageAtIndex(PageIndex) const;
+    // Returns 0, 90, 180, 270.
+    IntDegrees rotationForPageAtIndex(PageIndex) const;
 
     WebCore::FloatSize layoutSize() const { return m_documentBounds.size(); }
 
@@ -75,8 +78,13 @@ private:
     static FloatSize documentMargin();
     static FloatSize pageMargin();
 
+    struct PageGeometry {
+        WebCore::FloatRect normalizedBounds;
+        IntDegrees rotation { 0 };
+    };
+
     RetainPtr<CGPDFDocumentRef> m_pdfDocument;
-    Vector<WebCore::FloatRect> m_pageBounds;
+    Vector<PageGeometry> m_pageGeometry;
     WebCore::FloatRect m_documentBounds;
     DisplayMode m_displayMode { DisplayMode::Continuous };
 };


### PR DESCRIPTION
#### 7e3907d4cb77cae87cc983af5f2ec852508cc99e
<pre>
[UnifiedPDF] Handle page rotation
<a href="https://bugs.webkit.org/show_bug.cgi?id=262449">https://bugs.webkit.org/show_bug.cgi?id=262449</a>
rdar://116292055

Reviewed by Tim Horton and Richard Robinson.

PDFs have per-page metadata about page rotation, and we have to respect this when drawing.

Rename the bounds vector in PDFDocumentLayout to m_pageGeometry and have it store both
rotation and normalized page bounds. Normalize page rotation to multiples of 90deg,
and store normalized bounds for rotated pages.

When drawing, we can use `CGPDFPageGetDrawingTransform()` to compute the transform
from the page crop box to the destination rect, but we have to first transform the
context to the page destination origin and flip.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::updateGeometry):
(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::boundsForPageAtIndex const):
(WebKit::PDFDocumentLayout::rotationForPageAtIndex const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paint):

Canonical link: <a href="https://commits.webkit.org/268704@main">https://commits.webkit.org/268704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b08c170e292d79ee405dec2a6030443e7d45c28c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22324 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19056 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21026 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23176 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17685 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24848 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22788 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16411 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18541 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4909 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->