### PR TITLE
[IPInt] Add support for the exceptions proposal (except rethrow)

### DIFF
--- a/JSTests/wasm/stress/exception-simple-throw-catch.js
+++ b/JSTests/wasm/stress/exception-simple-throw-catch.js
@@ -141,6 +141,34 @@ function testSimpleTryCatchValue(){
     assert.eq(instance.exports.call(), 2, "catching an exported wasm tag thrown from JS should be possible");
 }
 
+function testSimpleTryCatchValue2(){
+    const b = new Builder();
+    b.Type().End()
+        .Function().End()
+        .Exception().Signature({ params: ["i32", "i32"]}).End()
+        .Export().Function("call")
+            .Exception("foo", 0)
+        .End()
+        .Code()
+            .Function("call", { params: [], ret: "i32" })
+            .Try("i32")
+                .I32Const(0)
+                .I32Const(42)
+                .Throw(0)
+            .Catch(0)
+                .I32DivU()
+            .End()
+            .End()
+        .End()
+
+
+    const bin = b.WebAssembly().get();
+    const module = new WebAssembly.Module(bin);
+    const instance = new WebAssembly.Instance(module, { });
+
+    assert.eq(instance.exports.call(), 0, "catching an exported wasm tag thrown from JS should be possible");
+}
+
 function testCallTryCatchValue(){
     const b = new Builder();
     b.Type().End()
@@ -368,7 +396,7 @@ function testUnifyTryNoCatch() {
     assert.eq(instance.exports.call(), 2, "catching an exported wasm tag thrown from JS should be possible");
 }
 
-function testNestedCatch (){
+function testNestedCatch() {
     const b = new Builder();
     b.Type().End()
         .Function().End()
@@ -400,6 +428,7 @@ function testNestedCatch (){
 testSimpleTryCatch();
 testSimpleTryCatchAll();
 testSimpleTryCatchValue();
+testSimpleTryCatchValue2();
 testCallTryCatch();
 testCallTryCatchAll();
 testCallTryCatchValue();

--- a/JSTests/wasm/stress/exception-throw-from-function-returning-tuple.js
+++ b/JSTests/wasm/stress/exception-throw-from-function-returning-tuple.js
@@ -79,5 +79,84 @@ function testCatchWithExceptionThrownFromFunctionReturningTuple2() {
         assert.eq(instance.exports.call(42, 5), 47, "catching an exported wasm tag thrown from JS should be possible");
 }
 
+function testCatchWithExceptionThrownFromFunctionReturningTuple3() {
+    const b = new Builder();
+    b.Type().End()
+        .Function().End()
+        .Exception().Signature({ params: ["i32", "i32"]}).End()
+        .Export().Function("call")
+            .Exception("foo", 0)
+        .End()
+        .Code()
+
+            .Function("call", { params: ["i32", "i32"], ret: "i32" })
+                .Try("i32")
+                    .GetLocal(0)
+                    .GetLocal(1)
+                    .Call(1)
+                    .Drop()
+                    .Drop()
+                .Catch(0)
+                    .I32DivU()
+                .End()
+            .End()
+
+            .Function("call2", { params: ["i32", "i32"], ret: ["i32", "i32", "i32"] })
+                .GetLocal(0)
+                .GetLocal(1)
+                .Throw(0)
+            .End()
+        .End();
+
+    const bin = b.WebAssembly().get();
+    const module = new WebAssembly.Module(bin);
+    const instance = new WebAssembly.Instance(module, { });
+
+    for (let i = 0; i < 1000; ++i)
+        assert.eq(instance.exports.call(0, 42), 0, "catching an exported wasm tag thrown from JS should be possible");
+}
+
+function testCatchWithExceptionThrownFromJSReturningTuple() {
+    const b = new Builder();
+    b.Type().End()
+        .Import().Function("context", "callback", { params: ["i32", "i32"], ret: ["i32", "i32", "i32"] }).End()
+        .Function().End()
+        .Exception().Signature({ params: ["i32", "i32"]}).End()
+        .Export().Function("call")
+            .Exception("foo", 0)
+        .End()
+        .Code()
+
+            .Function("call", { params: ["i32", "i32"], ret: "i32" })
+                .Try("i32")
+                    .GetLocal(0)
+                    .GetLocal(1)
+                    .Call(0)
+                    .Drop()
+                    .Drop()
+                .Catch(0)
+                    .I32DivU()
+                .End()
+            .End()
+        .End();
+
+    const bin = b.WebAssembly().get();
+    const module = new WebAssembly.Module(bin);
+    const instance = new WebAssembly.Instance(module, { context: { callback }});
+
+    let tag = instance.exports.foo;
+
+    function callback(a, b) {
+        assert.eq(a, 0);
+        assert.eq(b, 42);
+        throw new WebAssembly.Exception(tag, [a, b]);
+    }
+
+    for (let i = 0; i < 1000; ++i)
+        assert.eq(instance.exports.call(0, 42), 0, "catching an exported wasm tag thrown from JS should be possible");
+}
+
 testCatchWithExceptionThrownFromFunctionReturningTuple();
 testCatchWithExceptionThrownFromFunctionReturningTuple2();
+testCatchWithExceptionThrownFromFunctionReturningTuple3();
+testCatchWithExceptionThrownFromJSReturningTuple()

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -581,7 +581,10 @@ CatchInfo::CatchInfo(const Wasm::HandlerInfo* handler, const Wasm::Callee* calle
         m_catchPCForInterpreter = { static_cast<WasmInstruction*>(nullptr) };
         if (callee->compilationMode() == Wasm::CompilationMode::LLIntMode)
             m_catchPCForInterpreter = { static_cast<const Wasm::LLIntCallee*>(callee)->instructions().at(handler->m_target).ptr() };
-        else {
+        else if (callee->compilationMode() == Wasm::CompilationMode::IPIntMode) {
+            m_catchPCForInterpreter = handler->m_target;
+            m_catchMetadataPCForInterpreter = handler->m_targetMetadata;
+        } else {
 #if USE(JSVALUE64) && ENABLE(JIT)
             m_nativeCode = Wasm::Thunks::singleton().stub(Wasm::catchInWasmThunkGenerator).template retagged<ExceptionHandlerPtrTag>().code();
             m_nativeCodeForDispatchAndCatch = handler->m_nativeCode;

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -56,7 +56,7 @@ struct WasmOpcodeTraits;
 using JSInstruction = BaseInstruction<JSOpcodeTraits>;
 using WasmInstruction = BaseInstruction<WasmOpcodeTraits>;
 
-using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruction*>;
+using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruction*, uintptr_t /* IPIntOffset */>;
 
     class ArgList;
     class CachedCall;
@@ -115,6 +115,7 @@ using JSOrWasmInstruction = std::variant<const JSInstruction*, const WasmInstruc
         CodePtr<ExceptionHandlerPtrTag> m_nativeCodeForDispatchAndCatch;
 #endif
         JSOrWasmInstruction m_catchPCForInterpreter;
+        uintptr_t m_catchMetadataPCForInterpreter { 0 };
     };
 
     class Interpreter {

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -45,7 +45,7 @@ do { \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
     void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
     void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
-    RELEASE_ASSERT((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
 #define VALIDATE_IPINT_0xFC_OPCODE(opcode, name) \
@@ -54,7 +54,7 @@ do { \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
     void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
     void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
-    RELEASE_ASSERT((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
 #define VALIDATE_IPINT_SIMD_OPCODE(opcode, name) \
@@ -63,7 +63,7 @@ do { \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
     void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
     void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
-    RELEASE_ASSERT((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
 #define VALIDATE_IPINT_ATOMIC_OPCODE(opcode, name) \
@@ -72,7 +72,7 @@ do { \
     void* ptr = reinterpret_cast<void*>(ipint_ ## name ## _validate); \
     void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
     void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
-    RELEASE_ASSERT((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
 void initialize()

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -29,6 +29,8 @@
 
 extern "C" void ipint_entry();
 extern "C" void ipint_entry_simd();
+extern "C" void ipint_catch_entry();
+extern "C" void ipint_catch_all_entry();
 
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
     extern "C" void ipint_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
@@ -40,6 +42,9 @@ extern "C" void ipint_entry_simd();
     m(0x03, loop) \
     m(0x04, if) \
     m(0x05, else) \
+    m(0x06, try) \
+    m(0x07, catch) \
+    m(0x08, throw) \
     m(0x0b, end) \
     m(0x0c, br) \
     m(0x0d, br_if) \
@@ -47,6 +52,8 @@ extern "C" void ipint_entry_simd();
     m(0x0f, return) \
     m(0x10, call) \
     m(0x11, call_indirect) \
+    m(0x18, delegate) \
+    m(0x19, catch_all) \
     m(0x1a, drop) \
     m(0x1b, select) \
     m(0x1c, select_t) \

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -623,7 +623,7 @@ const FunctionCode = constexpr FunctionCode
 const ModuleCode = constexpr ModuleCode
 
 # The interpreter steals the tag word of the argument count.
-const LLIntReturnPC = ArgumentCountIncludingThis + TagOffset
+const CallSiteIndex = ArgumentCountIncludingThis + TagOffset
 
 # String flags.
 const isRopeInPointer = constexpr JSString::isRopeInPointer
@@ -1357,7 +1357,7 @@ macro getterSetterOSRExitReturnPoint(opName, size)
     defineReturnLabel(opName, size)
 
     restoreStackPointerAfterCall()
-    loadi LLIntReturnPC[cfr], PC
+    loadi CallSiteIndex[cfr], PC
 end
 
 macro arrayProfile(offset, cellAndIndexingType, metadata, scratch)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -24,11 +24,11 @@
 
 # Utilities.
 macro storePC()
-    storei PC, LLIntReturnPC[cfr]
+    storei PC, CallSiteIndex[cfr]
 end
 
 macro loadPC()
-    loadi LLIntReturnPC[cfr], PC
+    loadi CallSiteIndex[cfr], PC
 end
 
 macro getuOperandNarrow(opcodeStruct, fieldName, dst)
@@ -503,7 +503,7 @@ macro callTrapHandler(throwHandler)
     move PC, a1
     cCall2(_llint_slow_path_handle_traps)
     btpnz r0, throwHandler
-    loadi LLIntReturnPC[cfr], PC
+    loadi CallSiteIndex[cfr], PC
 end
 
 if JIT

--- a/Source/JavaScriptCore/offlineasm/arm64.rb
+++ b/Source/JavaScriptCore/offlineasm/arm64.rb
@@ -1120,7 +1120,7 @@ class Instruction
         when "move"
             if operands[0].immediate?
                 emitARM64MoveImmediate(operands[0].value, operands[1])
-            elsif operands[0] != operands[1]
+            elsif operands[0].arm64Operand(:quad) != operands[1].arm64Operand(:quad)
                 emitARM64("mov", operands, :quad)
             end
         when "moved"

--- a/Source/JavaScriptCore/offlineasm/x86.rb
+++ b/Source/JavaScriptCore/offlineasm/x86.rb
@@ -1023,7 +1023,7 @@ class Instruction
             else
                 $asm.puts "xor#{x86Suffix(:ptr)} #{operands[1].x86Operand(:ptr)}, #{operands[1].x86Operand(:ptr)}"
             end
-        elsif operands[0] != operands[1]
+        elsif operands[0].x86Operand(:quad) != operands[1].x86Operand(:quad)
             if isX64
                 $asm.puts "mov#{x86Suffix(:quad)} #{x86Operands(:quad, :quad)}"
             else

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -776,6 +776,7 @@ public:
     void* targetMachinePCForThrow;
     void* targetMachinePCAfterCatch;
     JSOrWasmInstruction targetInterpreterPCForThrow;
+    uintptr_t targetInterpreterMetadataPCForThrow;
 
     unsigned varargsLength;
     uint32_t osrExitIndex;

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "InPlaceInterpreter.h"
 #include "LLIntExceptions.h"
 #include "NativeCalleeRegistry.h"
 #include "WasmCallingConvention.h"
@@ -184,6 +185,28 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, size_t index
     , m_numArgumentsOnStack(generator.m_numArgumentsOnStack)
     , m_tierUpCounter(WTFMove(generator.m_tierUpCounter))
 {
+    if (size_t count = generator.m_exceptionHandlers.size()) {
+        m_exceptionHandlers = FixedVector<HandlerInfo>(count);
+        for (size_t i = 0; i < count; i++) {
+            const UnlinkedHandlerInfo& unlinkedHandler = generator.m_exceptionHandlers[i];
+            HandlerInfo& handler = m_exceptionHandlers[i];
+            void* ptr = reinterpret_cast<void*>(unlinkedHandler.m_type == HandlerType::Catch ? ipint_catch_entry : ipint_catch_all_entry);
+            void* untagged = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr();
+            void* retagged = nullptr;
+#if ENABLE(JIT_CAGE)
+            if (Options::useJITCage())
+#else
+            if (false)
+#endif
+                retagged = tagCodePtr<ExceptionHandlerPtrTag>(untagged);
+            else
+                retagged = WTF::tagNativeCodePtrImpl<ExceptionHandlerPtrTag>(untagged);
+            assertIsTaggedWith<ExceptionHandlerPtrTag>(retagged);
+
+            CodeLocationLabel<ExceptionHandlerPtrTag> target(retagged);
+            handler.initialize(unlinkedHandler, target);
+        }
+    }
 }
 
 void IPIntCallee::setEntrypoint(CodePtr<WasmEntryPtrTag> entrypoint)

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -113,6 +113,7 @@ private:
 
     Vector<const TypeDefinition*> m_signatures;
     HashMap<WasmInstructionStream::Offset, LLIntTierUpCounter::OSREntryData> m_tierUpCounter;
+    Vector<UnlinkedHandlerInfo> m_exceptionHandlers;
 
     // Optimization to skip large numbers of blocks
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -156,6 +156,14 @@ public:
     };
     bool localIsInitialized(uint32_t localIndex) { return m_localInitFlags.quickGet(localIndex); }
 
+    uint32_t getStackHeightInValues() const
+    {
+        uint32_t result = m_expressionStack.size();
+        for (const ControlEntry& entry : m_controlStack)
+            result += entry.enclosedExpressionStack.size();
+        return result;
+    }
+
 private:
     static constexpr bool verbose = false;
 

--- a/Source/JavaScriptCore/wasm/WasmHandlerInfo.cpp
+++ b/Source/JavaScriptCore/wasm/WasmHandlerInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@ void HandlerInfo::initialize(const UnlinkedHandlerInfo& unlinkedInfo, CodePtr<Ex
     m_start = unlinkedInfo.m_start;
     m_end = unlinkedInfo.m_end;
     m_target = unlinkedInfo.m_target;
+    m_targetMetadata = unlinkedInfo.m_targetMetadata;
     m_tryDepth = unlinkedInfo.m_tryDepth;
     m_nativeCode = label;
 

--- a/Source/JavaScriptCore/wasm/WasmHandlerInfo.h
+++ b/Source/JavaScriptCore/wasm/WasmHandlerInfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,6 +48,7 @@ struct HandlerInfoBase {
     uint32_t m_start;
     uint32_t m_end;
     uint32_t m_target;
+    uint32_t m_targetMetadata { 0 };
     uint32_t m_tryDepth;
     uint32_t m_exceptionIndexOrDelegateTarget;
 };
@@ -63,6 +64,17 @@ struct UnlinkedHandlerInfo : public HandlerInfoBase {
         m_start = start;
         m_end = end;
         m_target = target;
+        m_tryDepth = tryDepth;
+        m_exceptionIndexOrDelegateTarget = exceptionIndexOrDelegateTarget;
+    }
+
+    UnlinkedHandlerInfo(HandlerType handlerType, uint32_t start, uint32_t end, uint32_t target, uint32_t targetMetadata, uint32_t tryDepth, uint32_t exceptionIndexOrDelegateTarget)
+    {
+        m_type = handlerType;
+        m_start = start;
+        m_end = end;
+        m_target = target;
+        m_targetMetadata = targetMetadata;
         m_tryDepth = tryDepth;
         m_exceptionIndexOrDelegateTarget = exceptionIndexOrDelegateTarget;
     }

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -57,6 +57,9 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, u
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(epilogue_osr, CallFrame* callFrame);
 #endif
 
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_and_clear_exception, v128_t* stack);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_exception, CallFrame*, v128_t* stack, unsigned exceptionIndex);
+
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, unsigned);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value);


### PR DESCRIPTION
#### 1b97cb2b6e051d2f0ff0460714103eb4791a1832
<pre>
[IPInt] Add support for the exceptions proposal (except rethrow)
<a href="https://bugs.webkit.org/show_bug.cgi?id=262446">https://bugs.webkit.org/show_bug.cgi?id=262446</a>

Reviewed by Justin Michaud.

This patch adds support for the Wasm exceptions proposal, with the exception (pun intended) of rethrow.
Rethrow is suffiecently complicated in the IPInt that it should be in its own patch.

Exceptions work mostly as they do in the rest of JSC. When an exception is thrown we write the
target PC and the (newly added) MC to the VM. These tell us where to go once we&apos;ve reentered the
IPInt. There&apos;s also two new entrypoints to the IPInt, one for regular catch blocks and one
for catch_all blocks.

Like the Wasm LLInt, IPInt exception handling works based on PC ranges. The current PC is (now) stored
to the CallFrame&apos;s CallSiteIndex when making calls / performing operations. When an exception is thrown
we check that the PC from the CallFrame is inside the range from one of the function&apos;s HandlerInfo.

This patch also has a couple of other fixes/improvements:
    1) offlineasm self moves should actually be elided. Previously we were checking that the
       two ruby objects had the same address, which didn&apos;t work.
    2) Add a dump to the IPInt, which tells you what the PC and MC should be for each instruction.
    3) Move the _ipint_call_impl call label below the call interpreter macros so it&apos;s clear
       _ipint_call_impl can fall through to .ipint_call_common.
    4) Add a message to the IPInt validation so you know which opcodes are too big.
    5) Rename WasmCodeBlock to UnboxedWasmCalleeStackSlot.
    6) Rename LLIntReturnPC to CallSiteIndex to match CallFrame.

* JSTests/wasm/stress/exception-liveness-tier-up.js:
(assert.eq.): Deleted.
(assert.eq): Deleted.
* JSTests/wasm/stress/exception-simple-throw-catch.js:
(testSimpleTryCatchValue2):
(testNestedCatch):
* JSTests/wasm/stress/exception-throw-from-function-returning-tuple.js:
(testCatchWithExceptionThrownFromFunctionReturningTuple3):
(testCatchWithExceptionThrownFromJSReturningTuple.callback):
(testCatchWithExceptionThrownFromJSReturningTuple):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::CatchInfo::CatchInfo):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/jit/JITExceptions.cpp:
(JSC::genericUnwind):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/offlineasm/arm64.rb:
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::getStackHeightInValues const):
* Source/JavaScriptCore/wasm/WasmHandlerInfo.cpp:
(JSC::Wasm::HandlerInfo::initialize):
* Source/JavaScriptCore/wasm/WasmHandlerInfo.h:
(JSC::Wasm::UnlinkedHandlerInfo::UnlinkedHandlerInfo):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::condenseControlFlowInstructions):
(JSC::Wasm::IPIntGenerator::addTry):
(JSC::Wasm::IPIntGenerator::convertTryToCatch):
(JSC::Wasm::IPIntGenerator::addCatch):
(JSC::Wasm::IPIntGenerator::addCatchToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchAllToUnreachable):
(JSC::Wasm::IPIntGenerator::addDelegate):
(JSC::Wasm::IPIntGenerator::addDelegateToUnreachable):
(JSC::Wasm::IPIntGenerator::addThrow):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::IPIntGenerator::dump):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h: Removed.

Canonical link: <a href="https://commits.webkit.org/268872@main">https://commits.webkit.org/268872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96a48e7889fe4de1f9025c87e117e516bee7ba45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22806 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21501 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23662 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18976 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18227 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23179 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20346 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24326 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18986 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5768 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5016 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25588 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19558 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5593 "Passed tests") | 
<!--EWS-Status-Bubble-End-->