### PR TITLE
[MMS] MSE-related properties in VideoTrack and AudioTrack are not enabled with MMS

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-idl-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-idl-expected.txt
@@ -1,0 +1,23 @@
+
+RUN(source = new ManagedMediaSource())
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(videoSourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(audioSourceBuffer = source.addSourceBuffer("audio/mock; codecs=mock"))
+RUN(videoSourceBuffer.appendBuffer(initVideoSegment))
+RUN(audioSourceBuffer.appendBuffer(initAudioSegment))
+EXPECTED (source.sourceBuffers.length == '2') OK
+EXPECTED (videoSourceBuffer.updating == 'true') OK
+EXPECTED (audioSourceBuffer.updating == 'true') OK
+got all updateend
+EXPECTED (videoSourceBuffer.updating == 'false') OK
+EXPECTED (audioSourceBuffer.updating == 'false') OK
+EXPECTED (videoSourceBuffer.videoTracks.length == '1') OK
+EXPECTED (audioSourceBuffer.audioTracks.length == '1') OK
+EXPECTED (source.activeSourceBuffers.length == '2') OK
+EXPECTED (video.videoTracks.length == '1') OK
+EXPECTED (video.audioTracks.length == '1') OK
+EXPECTED (video.videoTracks[0].sourceBuffer == '[object ManagedSourceBuffer]') OK
+EXPECTED (video.audioTracks[0].sourceBuffer == '[object ManagedSourceBuffer]') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-idl.html
+++ b/LayoutTests/media/media-source/media-managedmse-idl.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=false] -->
+<html>
+<head>
+    <title>ManagedMSE track IDL check</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../utilities.js"></script>
+    <script>
+
+    var source;
+    var videoSourceBuffer;
+    var audioSourceBuffer;
+    var initVideoSegment;
+    var initAudioSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    async function runTest() {
+        findMediaElement();
+        video.disableRemotePlayback = true;
+        run('source = new ManagedMediaSource()');
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run('videoSourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        run('audioSourceBuffer = source.addSourceBuffer("audio/mock; codecs=mock")');
+
+        initVideoSegment = makeAInit(100, [
+            makeATrack(1, 'mock', TRACK_KIND.VIDEO),
+        ]);
+        initAudioSegment = makeAInit(101, [
+            makeATrack(1, 'mock', TRACK_KIND.AUDIO),
+        ]);
+        run('videoSourceBuffer.appendBuffer(initVideoSegment)');
+        run('audioSourceBuffer.appendBuffer(initAudioSegment)');
+        testExpected('source.sourceBuffers.length', 2);
+        testExpected('videoSourceBuffer.updating', true);
+        testExpected('audioSourceBuffer.updating', true);
+        await Promise.all([waitFor(videoSourceBuffer, 'updateend', true), waitFor(audioSourceBuffer, 'updateend', true)]);
+        consoleWrite('got all updateend');
+
+        testExpected('videoSourceBuffer.updating', false);
+        testExpected('audioSourceBuffer.updating', false);
+        testExpected('videoSourceBuffer.videoTracks.length', 1);
+        testExpected('audioSourceBuffer.audioTracks.length', 1);
+        testExpected('source.activeSourceBuffers.length', 2);
+
+        testExpected('video.videoTracks.length', 1);
+        testExpected('video.audioTracks.length', 1);
+
+        testExpected('video.videoTracks[0].sourceBuffer', videoSourceBuffer);
+        testExpected('video.audioTracks[0].sourceBuffer', audioSourceBuffer);
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -249,8 +249,9 @@ media/video-size-intrinsic-scale.html [ WontFix ]
 media/video-element-fullscreen-not-in-dom-accelerated-iphone.html [ Pass ]
 
 # MediaSource is not currently supported on iOS.
-media/media-source/media-managedmse-airplay.html [ Pass ]
 media/media-source
+media/media-source/media-managedmse-airplay.html [ Pass ]
+media/media-source/media-managedmse-idl.html [ Pass ]
 http/tests/media/media-source [ Skip ]
 imported/w3c/web-platform-tests/media-source/ [ Skip ]
 fast/history/page-cache-media-source-closed-2.html [ Skip ]

--- a/Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl
@@ -26,7 +26,7 @@
 // https://w3c.github.io/media-source/#audio-track-extensions
 [
     Conditional=MEDIA_SOURCE,
-    EnabledBySetting=MediaSourceEnabled,
+    EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled,
     ImplementedBy=AudioTrackMediaSource
 ] partial interface AudioTrack {
     readonly attribute SourceBuffer? sourceBuffer;

--- a/Source/WebCore/Modules/mediasource/SourceBufferList.idl
+++ b/Source/WebCore/Modules/mediasource/SourceBufferList.idl
@@ -32,7 +32,7 @@
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
     GenerateIsReachable=Impl,
-    EnabledBySetting=MediaSourceEnabled,
+    EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled,
     Exposed=Window
 ] interface SourceBufferList : EventTarget {
     readonly attribute unsigned long length;

--- a/Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl
@@ -26,7 +26,7 @@
 // https://w3c.github.io/media-source/#text-track-extensions
 [
     Conditional=MEDIA_SOURCE,
-    EnabledBySetting=MediaSourceEnabled,
+    EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled,
     ImplementedBy=TextTrackMediaSource
 ] partial interface TextTrack {
     readonly attribute SourceBuffer? sourceBuffer;

--- a/Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl
@@ -25,7 +25,7 @@
 
 [
     Conditional=MEDIA_SOURCE,
-    EnabledBySetting=MediaSourceEnabled,
+    EnabledBySetting=MediaSourceEnabled|ManagedMediaSourceEnabled ,
     ImplementedBy=VideoTrackMediaSource
 ] partial interface VideoTrack {
     readonly attribute SourceBuffer? sourceBuffer;


### PR DESCRIPTION
#### 325f73e7161ec5fbe3574e0f25c736be584cc09f
<pre>
[MMS] MSE-related properties in VideoTrack and AudioTrack are not enabled with MMS
<a href="https://bugs.webkit.org/show_bug.cgi?id=262438">https://bugs.webkit.org/show_bug.cgi?id=262438</a>
rdar://116158362

Reviewed by Eric Carlson.

The IDL extensions were only enabled according to the MediaSourceEnabled
flag, which on iPhone is false.
Amend IDL CodeGenerator to supports an | (or) operator (it only supported &amp;).

Add test.

* LayoutTests/media/media-source/media-managedmse-idl-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-idl.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/Modules/mediasource/AudioTrack+MediaSource.idl:
* Source/WebCore/Modules/mediasource/SourceBufferList.idl:
* Source/WebCore/Modules/mediasource/TextTrack+MediaSource.idl:
* Source/WebCore/Modules/mediasource/VideoTrack+MediaSource.idl:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm: Add support for | (or) operator.
(GenerateRuntimeEnableConditionalString):

Canonical link: <a href="https://commits.webkit.org/268711@main">https://commits.webkit.org/268711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/482e2cb4f1ec7174923b9d7107a471e1188dcef6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22304 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20439 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20625 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20503 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23155 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24828 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22768 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19306 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16391 "12 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18376 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4913 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->