### PR TITLE
Adopt more smart pointers in editing code

### DIFF
--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -217,11 +217,11 @@ static TriState stateTextWritingDirection(LocalFrame& frame, WritingDirection di
 
 static unsigned verticalScrollDistance(LocalFrame& frame)
 {
-    Element* focusedElement = frame.document()->focusedElement();
+    RefPtr focusedElement = frame.document()->focusedElement();
     if (!focusedElement)
         return 0;
-    auto* renderer = focusedElement->renderer();
-    if (!is<RenderBox>(renderer))
+    CheckedPtr renderer = focusedElement->renderer();
+    if (!is<RenderBox>(renderer.get()))
         return 0;
     const RenderStyle& style = renderer->style();
     if (!(style.overflowY() == Overflow::Scroll || style.overflowY() == Overflow::Auto || focusedElement->hasEditableStyle()))
@@ -503,7 +503,7 @@ static bool executeInsertLineBreak(LocalFrame& frame, Event* event, EditorComman
 
 static bool executeInsertNewline(LocalFrame& frame, Event* event, EditorCommandSource, const String&)
 {
-    LocalFrame* targetFrame = WebCore::targetFrame(frame, event);
+    RefPtr targetFrame = WebCore::targetFrame(frame, event);
     return targetFrame->eventHandler().handleTextInputEvent("\n"_s, event, targetFrame->editor().canEditRichly() ? TextEventInputKeyboard : TextEventInputLineBreak);
 }
 
@@ -1616,7 +1616,7 @@ static String valueFormatBlock(LocalFrame& frame, Event*)
     const VisibleSelection& selection = frame.selection().selection();
     if (selection.isNoneOrOrphaned() || !selection.isContentEditable())
         return emptyString();
-    auto* formatBlockElement = FormatBlockCommand::elementForFormatBlockCommand(selection.firstRange());
+    RefPtr formatBlockElement = FormatBlockCommand::elementForFormatBlockCommand(selection.firstRange());
     if (!formatBlockElement)
         return emptyString();
     return formatBlockElement->localName();

--- a/Source/WebCore/editing/FormatBlockCommand.h
+++ b/Source/WebCore/editing/FormatBlockCommand.h
@@ -46,7 +46,7 @@ public:
     
     bool preservesTypingStyle() const override { return true; }
 
-    static Element* elementForFormatBlockCommand(const std::optional<SimpleRange>&);
+    static RefPtr<Element> elementForFormatBlockCommand(const std::optional<SimpleRange>&);
     bool didApply() const { return m_didApply; }
 
 private:

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -251,7 +251,7 @@ public:
     enum class TextRectangleHeight : bool { TextHeight, SelectionHeight };
     WEBCORE_EXPORT void getClippedVisibleTextRectangles(Vector<FloatRect>&, TextRectangleHeight = TextRectangleHeight::SelectionHeight) const;
 
-    WEBCORE_EXPORT HTMLFormElement* currentForm() const;
+    WEBCORE_EXPORT RefPtr<HTMLFormElement> currentForm() const;
 
     WEBCORE_EXPORT void revealSelection(SelectionRevealMode = SelectionRevealMode::Reveal, const ScrollAlignment& = ScrollAlignment::alignCenterIfNeeded, RevealExtentOption = RevealExtentOption::DoNotRevealExtent, ScrollBehavior = ScrollBehavior::Instant);
     WEBCORE_EXPORT void setSelectionFromNone();
@@ -320,6 +320,7 @@ private:
     void caretAnimationDidUpdate(CaretAnimator&) final;
 
     Document* document() final;
+    RefPtr<Document> protectedDocument() const { return m_document.get(); }
 
     Node* caretNode() final;
 

--- a/Source/WebCore/editing/InsertIntoTextNodeCommand.cpp
+++ b/Source/WebCore/editing/InsertIntoTextNodeCommand.cpp
@@ -58,38 +58,42 @@ void InsertIntoTextNodeCommand::doApply()
     if (passwordEchoEnabled)
         document().updateLayoutIgnorePendingStylesheets();
 
-    if (!m_node->hasEditableStyle())
+    auto node = protectedNode();
+    if (!node->hasEditableStyle())
         return;
 
     if (passwordEchoEnabled) {
-        if (RenderText* renderText = m_node->renderer())
+        if (CheckedPtr renderText = node->renderer())
             renderText->momentarilyRevealLastTypedCharacter(m_offset + m_text.length());
     }
     
-    m_node->insertData(m_offset, m_text);
+    node->insertData(m_offset, m_text);
 }
 
 void InsertIntoTextNodeCommand::doReapply()
 {
-    if (!m_node->hasEditableStyle())
+    auto node = protectedNode();
+    if (!node->hasEditableStyle())
         return;
 
-    m_node->insertData(m_offset, m_text);
+    node->insertData(m_offset, m_text);
 }
 
 void InsertIntoTextNodeCommand::doUnapply()
 {
-    if (!m_node->hasEditableStyle())
+    auto node = protectedNode();
+    if (!node->hasEditableStyle())
         return;
 
-    m_node->deleteData(m_offset, m_text.length());
+    node->deleteData(m_offset, m_text.length());
 }
 
 #ifndef NDEBUG
 
 void InsertIntoTextNodeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
 {
-    addNodeAndDescendants(m_node.ptr(), nodes);
+    auto node = protectedNode();
+    addNodeAndDescendants(node.ptr(), nodes);
 }
 
 #endif

--- a/Source/WebCore/editing/InsertIntoTextNodeCommand.h
+++ b/Source/WebCore/editing/InsertIntoTextNodeCommand.h
@@ -47,6 +47,8 @@ private:
     void doApply() override;
     void doUnapply() override;
     void doReapply() override;
+
+    Ref<Text> protectedNode() const { return m_node.get(); }
     
 #ifndef NDEBUG
     void getNodesInCommand(HashSet<Ref<Node>>&) override;

--- a/Source/WebCore/editing/InsertLineBreakCommand.cpp
+++ b/Source/WebCore/editing/InsertLineBreakCommand.cpp
@@ -136,9 +136,8 @@ void InsertLineBreakCommand::doApply()
                 insertTextIntoNode(textNode, 0, nonBreakingSpaceString());
             else {
                 auto nbspNode = document->createTextNode(String { nonBreakingSpaceString() });
-                auto* nbspNodePtr = nbspNode.ptr();
-                insertNodeAt(WTFMove(nbspNode), positionBeforeTextNode);
-                endingPosition = firstPositionInNode(nbspNodePtr);
+                insertNodeAt(nbspNode.copyRef(), positionBeforeTextNode);
+                endingPosition = firstPositionInNode(nbspNode.ptr());
             }
         }
         

--- a/Source/WebCore/editing/InsertNodeBeforeCommand.cpp
+++ b/Source/WebCore/editing/InsertNodeBeforeCommand.cpp
@@ -48,20 +48,21 @@ InsertNodeBeforeCommand::InsertNodeBeforeCommand(Ref<Node>&& insertChild, Node& 
 
 void InsertNodeBeforeCommand::doApply()
 {
-    ContainerNode* parent = m_refChild->parentNode();
+    RefPtr parent = m_refChild->parentNode();
     if (!parent || (m_shouldAssumeContentIsAlwaysEditable == DoNotAssumeContentIsAlwaysEditable && !isEditableNode(*parent)))
         return;
     ASSERT(isEditableNode(*parent));
 
-    parent->insertBefore(m_insertChild, m_refChild.copyRef());
+    parent->insertBefore(protectedInsertChild(), m_refChild.copyRef());
 }
 
 void InsertNodeBeforeCommand::doUnapply()
 {
-    if (!isEditableNode(m_insertChild))
+    auto insertChild = protectedInsertChild();
+    if (!isEditableNode(insertChild))
         return;
 
-    m_insertChild->remove();
+    insertChild->remove();
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/InsertNodeBeforeCommand.h
+++ b/Source/WebCore/editing/InsertNodeBeforeCommand.h
@@ -48,6 +48,8 @@ private:
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif
 
+    Ref<Node> protectedInsertChild() const { return m_insertChild; }
+
     Ref<Node> m_insertChild;
     Ref<Node> m_refChild;
     ShouldAssumeContentIsAlwaysEditable m_shouldAssumeContentIsAlwaysEditable;

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.h
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.h
@@ -52,6 +52,8 @@ private:
 
     bool preservesTypingStyle() const override;
 
+    RefPtr<EditingStyle> protectedStyle() const { return m_style; }
+
     RefPtr<EditingStyle> m_style;
 
     bool m_mustUseDefaultParagraphElement;

--- a/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
+++ b/Source/WebCore/editing/MergeIdenticalElementsCommand.cpp
@@ -40,38 +40,42 @@ MergeIdenticalElementsCommand::MergeIdenticalElementsCommand(Ref<Element>&& firs
 
 void MergeIdenticalElementsCommand::doApply()
 {
-    if (m_element1->nextSibling() != m_element2.ptr() || !m_element1->hasEditableStyle() || !m_element2->hasEditableStyle())
+    Ref element1 = protectedElement1();
+    Ref element2 = protectedElement2();
+    if (element1->nextSibling() != element2.ptr() || !element1->hasEditableStyle() || !element2->hasEditableStyle())
         return;
 
-    m_atChild = m_element2->firstChild();
+    m_atChild = element2->firstChild();
 
     Vector<Ref<Node>> children;
-    for (Node* child = m_element1->firstChild(); child; child = child->nextSibling())
+    for (Node* child = element1->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
     for (auto& child : children)
-        m_element2->insertBefore(child, m_atChild.copyRef());
+        element2->insertBefore(child, m_atChild.copyRef());
 
-    m_element1->remove();
+    element1->remove();
 }
 
 void MergeIdenticalElementsCommand::doUnapply()
 {
     RefPtr<Node> atChild = WTFMove(m_atChild);
 
-    auto* parent = m_element2->parentNode();
+    Ref element2 = protectedElement2();
+    RefPtr parent = element2->parentNode();
     if (!parent || !parent->hasEditableStyle())
         return;
 
-    if (parent->insertBefore(m_element1, m_element2.copyRef()).hasException())
+    Ref element1 = protectedElement1();
+    if (parent->insertBefore(element1, element2.copyRef()).hasException())
         return;
 
     Vector<Ref<Node>> children;
-    for (Node* child = m_element2->firstChild(); child && child != atChild; child = child->nextSibling())
+    for (Node* child = element2->firstChild(); child && child != atChild; child = child->nextSibling())
         children.append(*child);
 
     for (auto& child : children)
-        m_element1->appendChild(child);
+        element1->appendChild(child);
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/MergeIdenticalElementsCommand.h
+++ b/Source/WebCore/editing/MergeIdenticalElementsCommand.h
@@ -45,6 +45,9 @@ private:
 #ifndef NDEBUG
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif
+
+    Ref<Element> protectedElement1() const { return m_element1; }
+    Ref<Element> protectedElement2() const { return m_element2; }
     
     Ref<Element> m_element1;
     Ref<Element> m_element2;

--- a/Source/WebCore/editing/MoveSelectionCommand.cpp
+++ b/Source/WebCore/editing/MoveSelectionCommand.cpp
@@ -87,7 +87,7 @@ void MoveSelectionCommand::doApply()
         options.add(ReplaceSelectionCommand::SmartReplace);
 
     {
-        auto replaceSelection = ReplaceSelectionCommand::create(document(), WTFMove(m_fragment), options, EditAction::InsertFromDrop);
+        auto replaceSelection = ReplaceSelectionCommand::create(document(), m_fragment.copyRef(), options, EditAction::InsertFromDrop);
         replaceSelection->setParent(this);
         replaceSelection->apply();
         m_commands.append(WTFMove(replaceSelection));

--- a/Source/WebCore/editing/RemoveFormatCommand.cpp
+++ b/Source/WebCore/editing/RemoveFormatCommand.cpp
@@ -89,14 +89,13 @@ void RemoveFormatCommand::doApply()
 
     // Get the default style for this editable root, it's the style that we'll give the
     // content that we're operating on.
-    Node* root = endingSelection().rootEditableElement();
-    auto defaultStyle = EditingStyle::create(root);
+    auto defaultStyle = EditingStyle::create(endingSelection().rootEditableElement());
 
     // We want to remove everything but transparent background.
     // FIXME: We shouldn't access style().
     defaultStyle->style()->setProperty(CSSPropertyBackgroundColor, CSSValueTransparent);
 
-    applyCommandToComposite(ApplyStyleCommand::create(document(), defaultStyle.ptr(), isElementForRemoveFormatCommand, editingAction()));
+    applyCommandToComposite(ApplyStyleCommand::create(protectedDocument(), defaultStyle.ptr(), isElementForRemoveFormatCommand, editingAction()));
 }
 
 }

--- a/Source/WebCore/editing/RemoveNodeCommand.cpp
+++ b/Source/WebCore/editing/RemoveNodeCommand.cpp
@@ -43,16 +43,17 @@ RemoveNodeCommand::RemoveNodeCommand(Ref<Node>&& node, ShouldAssumeContentIsAlwa
 
 void RemoveNodeCommand::doApply()
 {
-    ContainerNode* parent = m_node->parentNode();
+    auto node = protectedNode();
+    RefPtr parent = node->parentNode();
     if (!parent || (m_shouldAssumeContentIsAlwaysEditable == DoNotAssumeContentIsAlwaysEditable
         && !isEditableNode(*parent) && parent->renderer()))
         return;
     ASSERT(isEditableNode(*parent) || !parent->renderer());
 
-    m_parent = parent;
-    m_refChild = m_node->nextSibling();
+    m_parent = WTFMove(parent);
+    m_refChild = node->nextSibling();
 
-    m_node->remove();
+    node->remove();
 }
 
 void RemoveNodeCommand::doUnapply()
@@ -62,7 +63,7 @@ void RemoveNodeCommand::doUnapply()
     if (!parent || !parent->hasEditableStyle())
         return;
 
-    parent->insertBefore(m_node, WTFMove(refChild));
+    parent->insertBefore(protectedNode(), WTFMove(refChild));
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/RemoveNodeCommand.h
+++ b/Source/WebCore/editing/RemoveNodeCommand.h
@@ -46,6 +46,8 @@ private:
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif
 
+    Ref<Node> protectedNode() const { return m_node; }
+
     Ref<Node> m_node;
     RefPtr<ContainerNode> m_parent;
     RefPtr<Node> m_refChild;

--- a/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp
+++ b/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp
@@ -42,20 +42,21 @@ RemoveNodePreservingChildrenCommand::RemoveNodePreservingChildrenCommand(Ref<Nod
 void RemoveNodePreservingChildrenCommand::doApply()
 {
     Vector<Ref<Node>> children;
-    RefPtr parent { m_node->parentNode() };
+    auto node = protectedNode();
+    RefPtr parent { node->parentNode() };
     if (!parent || (m_shouldAssumeContentIsAlwaysEditable == DoNotAssumeContentIsAlwaysEditable && !isEditableNode(*parent)))
         return;
 
-    for (Node* child = m_node->firstChild(); child; child = child->nextSibling())
+    for (Node* child = node->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
     size_t size = children.size();
     for (size_t i = 0; i < size; ++i) {
         auto child = WTFMove(children[i]);
         removeNode(child, m_shouldAssumeContentIsAlwaysEditable);
-        insertNodeBefore(WTFMove(child), m_node, m_shouldAssumeContentIsAlwaysEditable);
+        insertNodeBefore(WTFMove(child), node, m_shouldAssumeContentIsAlwaysEditable);
     }
-    removeNode(m_node, m_shouldAssumeContentIsAlwaysEditable);
+    removeNode(node, m_shouldAssumeContentIsAlwaysEditable);
 }
 
 }

--- a/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.h
+++ b/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.h
@@ -40,6 +40,7 @@ private:
     explicit RemoveNodePreservingChildrenCommand(Ref<Node>&&, ShouldAssumeContentIsAlwaysEditable, EditAction);
 
     void doApply() override;
+    Ref<Node> protectedNode() const { return m_node; }
 
     Ref<Node> m_node;
     ShouldAssumeContentIsAlwaysEditable m_shouldAssumeContentIsAlwaysEditable;

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 static inline const RenderObject* rendererFromPosition(const Position& position)
 {
     ASSERT(position.isNotNull());
-    Node* rendererNode = nullptr;
+    RefPtr<Node> rendererNode;
     switch (position.anchorType()) {
     case Position::PositionIsOffsetInAnchor:
         rendererNode = position.computeNodeAfterPosition();
@@ -206,9 +206,9 @@ Position RenderedPosition::positionAtLeftBoundaryOfBiDiRun() const
     ASSERT(atLeftBoundaryOfBidiRun());
 
     if (atLeftmostOffsetInBox())
-        return makeDeprecatedLegacyPosition(m_renderer->node(), m_offset);
+        return makeDeprecatedLegacyPosition(m_renderer->protectedNode().get(), m_offset);
 
-    return makeDeprecatedLegacyPosition(nextLeafOnLine()->renderer().node(), nextLeafOnLine()->leftmostCaretOffset());
+    return makeDeprecatedLegacyPosition(nextLeafOnLine()->renderer().protectedNode().get(), nextLeafOnLine()->leftmostCaretOffset());
 }
 
 Position RenderedPosition::positionAtRightBoundaryOfBiDiRun() const
@@ -216,9 +216,9 @@ Position RenderedPosition::positionAtRightBoundaryOfBiDiRun() const
     ASSERT(atRightBoundaryOfBidiRun());
 
     if (atRightmostOffsetInBox())
-        return makeDeprecatedLegacyPosition(m_renderer->node(), m_offset);
+        return makeDeprecatedLegacyPosition(m_renderer->protectedNode().get(), m_offset);
 
-    return makeDeprecatedLegacyPosition(previousLeafOnLine()->renderer().node(), previousLeafOnLine()->rightmostCaretOffset());
+    return makeDeprecatedLegacyPosition(previousLeafOnLine()->renderer().protectedNode().get(), previousLeafOnLine()->rightmostCaretOffset());
 }
 
 IntRect RenderedPosition::absoluteRect(CaretRectMode caretRectMode) const

--- a/Source/WebCore/editing/RenderedPosition.h
+++ b/Source/WebCore/editing/RenderedPosition.h
@@ -81,7 +81,7 @@ private:
     bool atLeftBoundaryOfBidiRun(ShouldMatchBidiLevel, unsigned char bidiLevelOfRun) const;
     bool atRightBoundaryOfBidiRun(ShouldMatchBidiLevel, unsigned char bidiLevelOfRun) const;
 
-    const RenderObject* m_renderer { nullptr };
+    CheckedPtr<const RenderObject> m_renderer;
     InlineIterator::LeafBoxIterator m_box;
     unsigned m_offset { 0 };
 

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
@@ -45,7 +45,7 @@ ReplaceNodeWithSpanCommand::ReplaceNodeWithSpanCommand(Ref<HTMLElement>&& elemen
 static void swapInNodePreservingAttributesAndChildren(Ref<HTMLElement> newNode, HTMLElement& nodeToReplace)
 {
     ASSERT(nodeToReplace.isConnected());
-    RefPtr<ContainerNode> parentNode = nodeToReplace.parentNode();
+    RefPtr parentNode = nodeToReplace.parentNode();
 
     // FIXME: Fix this to send the proper MutationRecords when MutationObservers are present.
     newNode->cloneDataFromElement(nodeToReplace);
@@ -64,15 +64,15 @@ void ReplaceNodeWithSpanCommand::doApply()
         return;
     if (!m_spanElement)
         m_spanElement = HTMLSpanElement::create(m_elementToReplace->document());
-    swapInNodePreservingAttributesAndChildren(*m_spanElement, m_elementToReplace);
+    swapInNodePreservingAttributesAndChildren(protectedSpanElement().releaseNonNull(), protectedElementToReplace());
 }
 
 void ReplaceNodeWithSpanCommand::doUnapply()
 {
-    RefPtr spanElement = m_spanElement;
+    RefPtr spanElement = protectedSpanElement();
     if (!spanElement || !spanElement->isConnected())
         return;
-    swapInNodePreservingAttributesAndChildren(m_elementToReplace, *spanElement);
+    swapInNodePreservingAttributesAndChildren(protectedElementToReplace(), *spanElement);
 }
 
 #ifndef NDEBUG

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.h
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.h
@@ -51,6 +51,9 @@ private:
 
     void doApply() override;
     void doUnapply() override;
+
+    RefPtr<HTMLElement> protectedSpanElement() const { return m_spanElement; }
+    Ref<HTMLElement> protectedElementToReplace() const { return m_elementToReplace; }
     
 #ifndef NDEBUG
     void getNodesInCommand(HashSet<Ref<Node>>&) override;

--- a/Source/WebCore/editing/ReplaceRangeWithTextCommand.cpp
+++ b/Source/WebCore/editing/ReplaceRangeWithTextCommand.cpp
@@ -64,7 +64,7 @@ void ReplaceRangeWithTextCommand::doApply()
         return;
 
     applyCommandToComposite(SetSelectionCommand::create(selection, FrameSelection::defaultSetSelectionOptions()));
-    applyCommandToComposite(ReplaceSelectionCommand::create(document(), WTFMove(m_textFragment), ReplaceSelectionCommand::MatchStyle, EditAction::Paste));
+    applyCommandToComposite(ReplaceSelectionCommand::create(document(), m_textFragment.copyRef(), ReplaceSelectionCommand::MatchStyle, EditAction::Paste));
 }
 
 String ReplaceRangeWithTextCommand::inputEventData() const
@@ -78,7 +78,7 @@ String ReplaceRangeWithTextCommand::inputEventData() const
 RefPtr<DataTransfer> ReplaceRangeWithTextCommand::inputEventDataTransfer() const
 {
     if (!isEditingTextAreaOrTextInput())
-        return DataTransfer::createForInputEvent(m_text, serializeFragment(*m_textFragment, SerializedNodes::SubtreeIncludingNode));
+        return DataTransfer::createForInputEvent(m_text, serializeFragment(*protectedTextFragment(), SerializedNodes::SubtreeIncludingNode));
 
     return CompositeEditCommand::inputEventDataTransfer();
 }

--- a/Source/WebCore/editing/ReplaceRangeWithTextCommand.h
+++ b/Source/WebCore/editing/ReplaceRangeWithTextCommand.h
@@ -46,6 +46,8 @@ private:
     RefPtr<DataTransfer> inputEventDataTransfer() const final;
     Vector<RefPtr<StaticRange>> targetRanges() const final;
 
+    RefPtr<DocumentFragment> protectedTextFragment() const { return m_textFragment; }
+
     SimpleRange m_rangeToBeReplaced;
     RefPtr<DocumentFragment> m_textFragment;
     String m_text;

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -92,7 +92,7 @@ private:
         RefPtr<Node> m_lastNodeInserted;
     };
 
-    Node* insertAsListItems(HTMLElement& listElement, Node* insertionNode, const Position&, InsertedNodes&);
+    RefPtr<Node> insertAsListItems(HTMLElement& listElement, Node* insertionNode, const Position&, InsertedNodes&);
 
     void updateNodesInserted(Node*);
     bool shouldRemoveEndBR(Node*, const VisiblePosition&);

--- a/Source/WebCore/editing/SpellingCorrectionCommand.cpp
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.cpp
@@ -116,7 +116,7 @@ void SpellingCorrectionCommand::doApply()
     applyCommandToComposite(SpellingCorrectionRecordUndoCommand::create(document(), m_corrected, m_correction));
 #endif
 
-    applyCommandToComposite(ReplaceSelectionCommand::create(document(), WTFMove(m_correctionFragment), ReplaceSelectionCommand::MatchStyle, EditAction::Paste));
+    applyCommandToComposite(ReplaceSelectionCommand::create(document(), m_correctionFragment.copyRef(), ReplaceSelectionCommand::MatchStyle, EditAction::Paste));
 }
 
 String SpellingCorrectionCommand::inputEventData() const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -610,6 +610,7 @@ public:
             return nullptr;
         return m_node.ptr();
     }
+    RefPtr<Node> protectedNode() const { return node(); }
 
     Node* nonPseudoNode() const { return isPseudoElement() ? nullptr : node(); }
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -321,7 +321,7 @@ static HTMLInputElement* inputElementFromDOMElement(DOMElement* element)
 
 - (DOMElement *)currentForm
 {
-    return kit(core([_private->dataSource webFrame])->selection().currentForm());
+    return kit(core([_private->dataSource webFrame])->selection().currentForm().get());
 }
 
 - (NSArray *)controlsInForm:(DOMElement *)form


### PR DESCRIPTION
#### d3c6d562070aae58ed3422466e1cb518c57acb01
<pre>
Adopt more smart pointers in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=262452">https://bugs.webkit.org/show_bug.cgi?id=262452</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::identifierForStyleProperty):
(WebCore::fontWeightValueIsBold):
(WebCore::EditingStyle::extractFontSizeDelta):
(WebCore::EditingStyle::conflictsWithInlineStyleOfElement const):
(WebCore::EditingStyle::prepareToApplyAt):
(WebCore::EditingStyle::styleAtSelectionStart):
(WebCore::EditingStyle::inverseTransformColorIfNeeded):
(WebCore::StyleChange::StyleChange):
(WebCore::backgroundColorInEffect):
* Source/WebCore/editing/Editor.cpp:
(WebCore::imageElementFromImageDocument):
(WebCore::Editor::canPaste const):
(WebCore::Editor::shouldInsertText const):
(WebCore::Editor::hasBidiSelection const):
(WebCore::Editor::postTextStateChangeNotificationForCut):
(WebCore::Editor::quoteFragmentForPasting):
(WebCore::Editor::baseWritingDirectionForSelectionStart const):
(WebCore::Editor::setComposition):
(WebCore::Editor::markMisspellingsAfterTypingToWord):
(WebCore::Editor::markMisspellingsOrBadGrammar):
(WebCore::Editor::rangeForPoint):
(WebCore::isFrameInRange):
(WebCore::editableTextListsAtPositionInDescendingOrder):
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::verticalScrollDistance):
(WebCore::executeInsertNewline):
(WebCore::valueFormatBlock):
* Source/WebCore/editing/FormatBlockCommand.cpp:
(WebCore::FormatBlockCommand::formatRange):
(WebCore::FormatBlockCommand::elementForFormatBlockCommand):
* Source/WebCore/editing/FormatBlockCommand.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::DragCaretController::caretRectInRootViewCoordinates const):
(WebCore::DragCaretController::editableElementRectInRootViewCoordinates const):
(WebCore::DragCaretController::setCaretPosition):
(WebCore::FrameSelection::setSelectionWithoutUpdatingAppearance):
(WebCore::FrameSelection::setSelection):
(WebCore::FrameSelection::updateSelectionAppearanceNow):
(WebCore::FrameSelection::respondToNodeModification):
(WebCore::adjustPositionForUserSelectAll):
(WebCore::repaintCaretForLocalRect):
(WebCore::FrameSelection::recomputeCaretRect):
(WebCore::CaretBase::invalidateCaretRect):
(WebCore::CaretBase::paintCaret const):
(WebCore::FrameSelection::contains const):
(WebCore::FrameSelection::selectFrameElementInParentIfFullySelected):
(WebCore::FrameSelection::selectAll):
(WebCore::FrameSelection::focusedOrActiveStateChanged):
(WebCore::FrameSelection::updateAppearance):
(WebCore::FrameSelection::selectionBounds):
(WebCore::scanForForm):
(WebCore::FrameSelection::currentForm const):
(WebCore::FrameSelection::setSelectionFromNone):
(WebCore::FrameSelection::dispatchSelectStart):
(WebCore::FrameSelection::setShouldShowBlockCursor):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/InsertIntoTextNodeCommand.cpp:
(WebCore::InsertIntoTextNodeCommand::doApply):
(WebCore::InsertIntoTextNodeCommand::doReapply):
(WebCore::InsertIntoTextNodeCommand::doUnapply):
(WebCore::InsertIntoTextNodeCommand::getNodesInCommand):
* Source/WebCore/editing/InsertIntoTextNodeCommand.h:
(WebCore::InsertIntoTextNodeCommand::protectedNode const):
* Source/WebCore/editing/InsertLineBreakCommand.cpp:
(WebCore::InsertLineBreakCommand::doApply):
* Source/WebCore/editing/InsertNodeBeforeCommand.cpp:
(WebCore::InsertNodeBeforeCommand::doApply):
(WebCore::InsertNodeBeforeCommand::doUnapply):
* Source/WebCore/editing/InsertNodeBeforeCommand.h:
(WebCore::InsertNodeBeforeCommand::protectedInsertChild const):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::highestVisuallyEquivalentDivBelowRoot):
(WebCore::InsertParagraphSeparatorCommand::calculateStyleBeforeInsertion):
(WebCore::InsertParagraphSeparatorCommand::applyStyleAfterInsertion):
(WebCore::InsertParagraphSeparatorCommand::doApply):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.h:
(WebCore::InsertParagraphSeparatorCommand::protectedStyle const):
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::insertTab):
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::serializeNodesWithNamespaces):
(WebCore::MarkupAccumulator::entityMaskForText const):
(WebCore::MarkupAccumulator::xmlAttributeSerialization):
* Source/WebCore/editing/MergeIdenticalElementsCommand.cpp:
(WebCore::MergeIdenticalElementsCommand::doApply):
(WebCore::MergeIdenticalElementsCommand::doUnapply):
* Source/WebCore/editing/MergeIdenticalElementsCommand.h:
(WebCore::MergeIdenticalElementsCommand::protectedElement1 const):
(WebCore::MergeIdenticalElementsCommand::protectedElement2 const):
* Source/WebCore/editing/RemoveFormatCommand.cpp:
(WebCore::RemoveFormatCommand::doApply):
* Source/WebCore/editing/RemoveNodeCommand.cpp:
(WebCore::RemoveNodeCommand::doApply):
(WebCore::RemoveNodeCommand::doUnapply):
* Source/WebCore/editing/RemoveNodeCommand.h:
(WebCore::RemoveNodeCommand::protectedNode const):
* Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp:
(WebCore::RemoveNodePreservingChildrenCommand::doApply):
* Source/WebCore/editing/RemoveNodePreservingChildrenCommand.h:
(WebCore::RemoveNodePreservingChildrenCommand::portectedNode const):
* Source/WebCore/editing/RenderedPosition.cpp:
(WebCore::rendererFromPosition):
(WebCore::RenderedPosition::positionAtLeftBoundaryOfBiDiRun const):
(WebCore::RenderedPosition::positionAtRightBoundaryOfBiDiRun const):
* Source/WebCore/editing/RenderedPosition.h:
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp:
(WebCore::swapInNodePreservingAttributesAndChildren):
(WebCore::ReplaceNodeWithSpanCommand::doApply):
(WebCore::ReplaceNodeWithSpanCommand::doUnapply):
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.h:
(WebCore::ReplaceNodeWithSpanCommand::protectedSpanElement const):
(WebCore::ReplaceNodeWithSpanCommand::protectedElementToReplace const):
* Source/WebCore/editing/ReplaceRangeWithTextCommand.cpp:
(WebCore::ReplaceRangeWithTextCommand::inputEventDataTransfer const):
* Source/WebCore/editing/ReplaceRangeWithTextCommand.h:
(WebCore::ReplaceRangeWithTextCommand::protectedTextFragment const):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::protectedFragment const):
(WebCore::positionAvoidingPrecedingNodes):
(WebCore::ReplacementFragment::ReplacementFragment):
(WebCore::ReplacementFragment::removeNode):
(WebCore::ReplacementFragment::insertNodeBefore):
(WebCore::ReplacementFragment::insertFragmentForTestRendering):
(WebCore::ReplacementFragment::restoreAndRemoveTestRenderingNodesToFragment):
(WebCore::ReplaceSelectionCommand::ReplaceSelectionCommand):
(WebCore::fragmentNeedsColorTransformed):
(WebCore::ReplaceSelectionCommand::moveNodeOutOfAncestor):
(WebCore::ReplaceSelectionCommand::removeUnrenderedTextNodesAtEnds):
(WebCore::handleStyleSpansBeforeInsertion):
(WebCore::isInlineNodeWithStyle):
(WebCore::ReplaceSelectionCommand::doApply):
(WebCore::ReplaceSelectionCommand::addSpacesForSmartReplace):
(WebCore::ReplaceSelectionCommand::mergeTextNodesAroundPosition):
(WebCore::singleChildList):
(WebCore::deepestSingleChildList):
(WebCore::ReplaceSelectionCommand::insertAsListItems):
(WebCore::ReplaceSelectionCommand::ensureReplacementFragment):
* Source/WebCore/editing/ReplaceSelectionCommand.h:
* Source/WebCore/editing/markup.cpp:
(WebCore::createPageForSanitizingWebContent):
(WebCore::styleFromMatchedRulesAndInlineDecl):
(WebCore::collectElementsToRemoveFromFragment):
(WebCore::replaceChildrenWithFragment):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::protectedNode const):
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(-[WebHTMLRepresentation currentForm]):

Canonical link: <a href="https://commits.webkit.org/268709@main">https://commits.webkit.org/268709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d5f10083c93a0e75cbf9f220b62c4a08b5a8917

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20465 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23183 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24856 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22796 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16418 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18547 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4912 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->