### PR TITLE
imported/w3c/web-platform-tests/css/css-nesting/cssom.html is failing in WebKit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -13,7 +13,7 @@ PASS Simple CSSOM manipulation of subrules 5
 PASS Simple CSSOM manipulation of subrules 6
 PASS Simple CSSOM manipulation of subrules 7
 PASS Simple CSSOM manipulation of subrules 8
-FAIL Simple CSSOM manipulation of subrules 9 assert_equals: selectorText and insertRule expected ".a {\n  color: red;\n  div & { }\n  div.b .c & { color: green; }\n  .c div.b &, div & { color: blue; }\n}" but got ".a {\n  color: olivedrab;\n  div & { }\n  div.b .c & { color: green; }\n  .c div.b &, div & { color: blue; }\n}"
+PASS Simple CSSOM manipulation of subrules 9
 PASS Simple CSSOM manipulation of subrules 10
 PASS Mutating the selectorText of outer rule invalidates inner rules
 

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -27,6 +27,7 @@
 #include "ElementTraversal.h"
 #include "EventNames.h"
 #include "FrameSelection.h"
+#include "HTMLStyleElement.h"
 #include "InspectorInstrumentation.h"
 #include "MutationEvent.h"
 #include "MutationObserverInterestGroup.h"
@@ -50,7 +51,7 @@ static bool canUseSetDataOptimization(const CharacterData& node)
 {
     auto& document = node.document();
     return !document.hasListenerType(Document::ListenerType::DOMCharacterDataModified) && !document.hasMutationObserversOfType(MutationObserverOptionType::CharacterData)
-        && !document.hasListenerType(Document::ListenerType::DOMSubtreeModified);
+        && !document.hasListenerType(Document::ListenerType::DOMSubtreeModified) && !is<HTMLStyleElement>(node.parentNode());
 }
 
 void CharacterData::setData(const String& data)


### PR DESCRIPTION
#### 060f71cc967fca2975152a97cb8472a06926b031
<pre>
imported/w3c/web-platform-tests/css/css-nesting/cssom.html is failing in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=262459">https://bugs.webkit.org/show_bug.cgi?id=262459</a>

Reviewed by Ryosuke Niwa.

We have an optimization in CharacterData::setData() that avoids doing some work
when the JS cannot observe it. This optimization was breaking the test.

The test sets the innerHTML of a &lt;style&gt; element, which ends up calling setData()
on the child Text node (as an optimization) and then takes the optimized code
path in CharacterData::setData(). The optimized code path fails to notify the
ancestors that the text has changed. However, HTMLStyleElement::childrenChanged()
has code that needs to run in such case.

As a result, I am now disabling the optimization in CharacterData::setData() if
the parent node is an HTMLStyleElement.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::canUseSetDataOptimization):

Canonical link: <a href="https://commits.webkit.org/268707@main">https://commits.webkit.org/268707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dddec4a557a508ee89a1112a017038d40f608f59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22330 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21032 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23182 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24854 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22794 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19332 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18546 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4911 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22884 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->