### PR TITLE
[UnifiedPDF] Scale pages to fix the available width

### DIFF
--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -78,7 +78,8 @@ Ref<HTMLStyleElement> PluginDocumentParser::createStyleElement(Document& documen
     constexpr auto styleSheetContents = R"CONTENTS(
 html.plugin-fills-viewport, html.plugin-fills-viewport body, html.plugin-fills-viewport embed { width: 100%; height: 100%; }
 html.plugin-fills-viewport body { overflow: hidden; }
-body { margin: 0 }
+body { margin: 0; }
+embed { width: 100%; }
 )CONTENTS"_s;
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -248,7 +248,6 @@ private:
 
     NSEvent *nsEventForWebMouseEvent(const WebMouseEvent&);
     WebCore::IntPoint convertFromPluginToPDFView(const WebCore::IntPoint&) const;
-    WebCore::IntPoint convertFromRootViewToPlugin(const WebCore::IntPoint&) const;
     WebCore::IntPoint convertFromPDFViewToRootView(const WebCore::IntPoint&) const;
     WebCore::IntRect convertFromPDFViewToRootView(const WebCore::IntRect&) const;
     WebCore::IntRect frameForHUD() const;
@@ -289,12 +288,10 @@ private:
     RefPtr<PDFPluginPasswordField> m_passwordField;
     RefPtr<WebCore::Element> m_annotationContainer;
 
-    WebCore::AffineTransform m_rootViewToPluginTransform;
     std::optional<WebMouseEvent> m_lastMouseEvent;
     WebCore::IntPoint m_lastMousePositionInPluginCoordinates;
 
     String m_temporaryPDFUUID;
-
     String m_lastFoundString;
 
     RetainPtr<WKPDFLayerControllerDelegate> m_pdfLayerControllerDelegate;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1935,11 +1935,6 @@ IntPoint PDFPlugin::convertFromPluginToPDFView(const IntPoint& point) const
     return IntPoint(point.x(), size().height() - point.y());
 }
 
-IntPoint PDFPlugin::convertFromRootViewToPlugin(const IntPoint& point) const
-{
-    return m_rootViewToPluginTransform.mapPoint(point);
-}
-
 IntPoint PDFPlugin::convertFromPDFViewToRootView(const IntPoint& point) const
 {
     IntPoint pointInPluginCoordinates(point.x(), size().height() - point.y());
@@ -2008,9 +2003,9 @@ void PDFPlugin::geometryDidChange(const IntSize& pluginSize, const AffineTransfo
     if (size() == pluginSize && m_view->pageScaleFactor() == [m_pdfLayerController contentScaleFactor])
         return;
 
+    LOG_WITH_STREAM(Plugins, stream << "PDFPlugin::geometryDidChange - size " << pluginSize << " pluginToRootViewTransform " << pluginToRootViewTransform);
     PDFPluginBase::geometryDidChange(pluginSize, pluginToRootViewTransform);
 
-    m_rootViewToPluginTransform = valueOrDefault(pluginToRootViewTransform.inverse());
     [m_pdfLayerController setFrameSize:pluginSize];
 
     [CATransaction begin];

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -130,6 +130,8 @@ public:
     void streamDidFinishLoading();
     void streamDidFail();
 
+    WebCore::IntPoint convertFromRootViewToPlugin(const WebCore::IntPoint&) const;
+
 protected:
     explicit PDFPluginBase(WebCore::HTMLPlugInElement&);
 
@@ -157,6 +159,7 @@ protected:
     uint64_t m_streamedBytes { 0 };
 
     WebCore::IntSize m_size;
+    WebCore::AffineTransform m_rootViewToPluginTransform;
 
     bool m_documentFinishedLoading { false };
     bool m_isBeingDestroyed { false };

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -151,6 +151,7 @@ void PDFPluginBase::addArchiveResource()
 void PDFPluginBase::geometryDidChange(const IntSize& pluginSize, const AffineTransform& pluginToRootViewTransform)
 {
     m_size = pluginSize;
+    m_rootViewToPluginTransform = valueOrDefault(pluginToRootViewTransform.inverse());
 }
 
 void PDFPluginBase::invalidateRect(const IntRect& rect)
@@ -159,6 +160,11 @@ void PDFPluginBase::invalidateRect(const IntRect& rect)
         return;
 
     m_view->invalidateRect(rect);
+}
+
+IntPoint PDFPluginBase::convertFromRootViewToPlugin(const IntPoint& point) const
+{
+    return m_rootViewToPluginTransform.mapPoint(point);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -64,15 +64,16 @@ public:
     // Returns 0, 90, 180, 270.
     IntDegrees rotationForPageAtIndex(PageIndex) const;
 
-    WebCore::FloatSize layoutSize() const { return m_documentBounds.size(); }
+    // This is the scale that scales the largest page or pair of pages up or down to fit the available width.
+    float scale() const { return m_scale; }
+
+    void updateLayout(WebCore::IntSize pluginSize);
+    WebCore::FloatSize scaledContentsSize() const;
 
 private:
+    void layoutPages(float availableWidth, float maxPageWidth);
 
-    void updateGeometry();
-
-    void layoutPages(float availableWidth);
-
-    void layoutSingleColumn(float availableWidth);
+    void layoutSingleColumn(float availableWidth, float maxPageWidth);
     void layoutTwoUpColumn(float availableWidth);
 
     static FloatSize documentMargin();
@@ -86,6 +87,7 @@ private:
     RetainPtr<CGPDFDocumentRef> m_pdfDocument;
     Vector<PageGeometry> m_pageGeometry;
     WebCore::FloatRect m_documentBounds;
+    float m_scale { 1 };
     DisplayMode m_displayMode { DisplayMode::Continuous };
 };
 


### PR DESCRIPTION
#### e7a5da73d9c204ec7d0b965794a722d63e42342b
<pre>
[UnifiedPDF] Scale pages to fix the available width
<a href="https://bugs.webkit.org/show_bug.cgi?id=262453">https://bugs.webkit.org/show_bug.cgi?id=262453</a>
rdar://116295967

Reviewed by Tim Horton and Richard Robinson.

PDFs are always scaled so that the widest page (or pair of pages) fits the available width.
So we set the width of the `embed` in `PluginDocumentParser::createStyleElement()` to always
be 100%, and stop setting the width in inline style in `UnifiedPDFPlugin::sizeToFitContents()`.

`PDFDocumentLayout::updateLayout()` now lays out pages to the available width, and we compute
the scale factor afterwards. This scale is applied when drawing.

This PR also moves `convertFromRootViewToPlugin()` to the base class, since this will be
shared by both PDFPlugin implementations, and a future PR will use it for point mapping.

* Source/WebCore/html/PluginDocument.cpp:
(WebCore::PluginDocumentParser::createStyleElement):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::geometryDidChange):
(WebKit::PDFPlugin::convertFromRootViewToPlugin const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::geometryDidChange):
(WebKit::PDFPluginBase::convertFromRootViewToPlugin const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::scale const):
(WebKit::PDFDocumentLayout::layoutSize const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::setPDFDocument):
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::layoutPages):
(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::scaledContentsSize const):
(WebKit::PDFDocumentLayout::updateGeometry): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::sizeToFitContents):
(WebKit::UnifiedPDFPlugin::paint):
(WebKit::UnifiedPDFPlugin::geometryDidChange):

Canonical link: <a href="https://commits.webkit.org/268715@main">https://commits.webkit.org/268715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a124c328a0be11c0ac144df56dabfa57b6ccc86b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20473 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23192 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24864 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22804 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16426 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18556 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4914 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->