### PR TITLE
[iOS] Date picker is clipped in landscape mode on some narrower iPhone models

### DIFF
--- a/LayoutTests/fast/forms/ios/show-and-dismiss-date-input-in-landscape-expected.txt
+++ b/LayoutTests/fast/forms/ios/show-and-dismiss-date-input-in-landscape-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that presenting a date picker in landscape orientation on an iPhone does not cause the Done button to be clipped.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Presented date picker
+PASS Dismissed date picker
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/show-and-dismiss-date-input-in-landscape.html
+++ b/LayoutTests/fast/forms/ios/show-and-dismiss-date-input-in-landscape.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+        body, html {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+
+        input {
+            width: 200px;
+            height: 44px;
+            position: absolute;
+            left: calc(50% - 100px);
+            top: calc(50% - 22px);
+        }
+    </style>
+</head>
+<body>
+    <input type="datetime-local"></input>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        description("This test verifies that presenting a date picker in landscape orientation on an iPhone does not cause the Done button to be clipped.");
+
+        await UIHelper.rotateDevice("landscape-right", true);
+        await UIHelper.ensurePresentationUpdate();
+
+        await UIHelper.activateElement(document.querySelector("input"));
+        await UIHelper.waitForContextMenuToShow();
+        testPassed("Presented date picker");
+
+        await UIHelper.dismissFormAccessoryView();
+        await UIHelper.waitForContextMenuToHide();
+        testPassed("Dismissed date picker");
+
+        await UIHelper.rotateDevice("portrait", true);
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/ios/time-picker-value-change.html
+++ b/LayoutTests/fast/forms/ios/time-picker-value-change.html
@@ -17,11 +17,13 @@ async function runTest() {
     if (!window.testRunner)
         return;
 
-    await UIHelper.activateElementAndWaitForInputSession(time);
+    await UIHelper.activateElement(time);
+    await UIHelper.waitForContextMenuToShow();
     await UIHelper.setTimePickerValue(9, 41);
     await UIHelper.dismissFormAccessoryView();
     await UIHelper.waitForInputSessionToDismiss();
-    await UIHelper.activateElementAndWaitForInputSession(time);
+    await UIHelper.activateElement(time);
+    await UIHelper.waitForContextMenuToShow();
     pickerValues = await UIHelper.timerPickerValues();
 
     shouldBe("pickerValues.hour", "9");

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12060,7 +12060,7 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
 - (void)dismissFormAccessoryView
 {
 #if !PLATFORM(WATCHOS)
-    if (auto dateInput = self.dateTimeInputControl; [dateInput dismissWithAnimation])
+    if (auto dateInput = self.dateTimeInputControl; [dateInput dismissWithAnimationForTesting])
         return;
 #endif
     [self accessoryDone];

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h
@@ -40,6 +40,7 @@
 - (instancetype)initWithDatePicker:(UIDatePicker *)datePicker delegate:(id<WKDatePickerPopoverControllerDelegate>)delegate;
 - (void)presentInView:(UIView *)view sourceRect:(CGRect)rect completion:(void(^)())completion;
 - (void)dismissDatePicker;
+- (void)assertAccessoryViewCanBeHitTestedForTesting;
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.h
@@ -38,7 +38,7 @@
 @property (nonatomic, readonly) double timePickerValueHour;
 @property (nonatomic, readonly) double timePickerValueMinute;
 - (void)setTimePickerHour:(NSInteger)hour minute:(NSInteger)minute;
-- (BOOL)dismissWithAnimation;
+- (BOOL)dismissWithAnimationForTesting;
 @end
 
 #endif // PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -345,9 +345,10 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
     return -1;
 }
 
-- (BOOL)dismissWithAnimation
+- (BOOL)dismissWithAnimationForTesting
 {
     if (auto picker = dynamic_objc_cast<WKDateTimePicker>(self.control)) {
+        [picker.datePickerController assertAccessoryViewCanBeHitTestedForTesting];
         [picker.datePickerController dismissDatePicker];
         return YES;
     }


### PR DESCRIPTION
#### 297cfba751db9ceee51fe4459c55fcc0b8365e8c
<pre>
[iOS] Date picker is clipped in landscape mode on some narrower iPhone models
<a href="https://bugs.webkit.org/show_bug.cgi?id=262451">https://bugs.webkit.org/show_bug.cgi?id=262451</a>
rdar://116317686

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

On iPhone models where the screen is narrower than 400 pt, focusing a date input while in landscape
orientation causes the bottom of the date picker (along with the accessory view containing &quot;Done&quot;
and &quot;Reset&quot; buttons) to become clipped. This is because, despite the fact that the date picker
popover lays out in undocked (arrow-less) mode in the center of the window, the window still isn&apos;t
tall enough to accomodate the full height of the date picker, whose layout is unable to compress
vertically to fit within the height of the window. This means that even if we adjust the height
constraint of the date picker and its containing view to be contained within the window, the date
picker will just clip itself to fit within the new height.

`_UIDatePickerOverlayPresentation` (which we stopped using in 268069@main) solved this problem by
scaling the entire content view in the popover to fit within the new size by setting a transform on
the content view containing the date picker and accessory view. We adopt a similar solution here,
and apply a transform to the `WKDatePickerPopoverView` if needed during view layout to fit within
the bounds of the view.

Note that we also need to add a new width constraint that fits the popover container view to the
content view to scale alongside the new `targetScale`; otherwise, the popover&apos;s view will be wider
than the content view itself, which leads to unnecessary left and right margins.

To test this, we:

1.  Add a layout test to rotate the device to landscape orientation and tap on a date input.
2.  Add a release assertion when simulating date picker dismissal by tapping on the Done button, to
    crash if the accessory view can&apos;t be hit-tested to (e.g. clipped).

Without this fix, we&apos;ll crash in the new release assert in `-assertAccessoryViewCanBeHitTested`.

* LayoutTests/fast/forms/ios/show-and-dismiss-date-input-in-landscape-expected.txt: Added.
* LayoutTests/fast/forms/ios/show-and-dismiss-date-input-in-landscape.html: Added.
* LayoutTests/fast/forms/ios/time-picker-value-change.html:

Adjust an existing layout test to wait for the context menu to finish presenting before interacting
with the accessory view&apos;s &quot;Done&quot; button, in order to avoid hitting the new assertion under
`-dismissWithAnimation`.

* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.h:
* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverView estimatedMaximumPopoverSize]):

Drive-by fix: increase the extra padding before falling back to arrow-less presentation to 80 pt; I
discovered that on an iPhone 12 with 60 pt, it&apos;s still possible to end up squishing (but not quite
totally clipping) the accessory view in some cases.

(-[WKDatePickerPopoverController assertAccessoryViewCanBeHitTestedForTesting]):

Add some logic to sanity check that the accessory view can actually be hit-tested (relative to the
popover&apos;s content view) when simulating tapping the &quot;Done&quot; button to dismiss the date picker.

(-[WKDatePickerPopoverController viewDidLoad]):
(-[WKDatePickerPopoverController viewWillLayoutSubviews]):
(-[WKDatePickerPopoverController _scaleDownToFitHeightIfNeeded]):

This is the main fix; see above for more details.

* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.h:
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimeInputControl dismissWithAnimationForTesting]):
(-[WKDateTimeInputControl dismissWithAnimation]): Deleted.

Add a `ForTesting` suffix to this testing-only method.

Canonical link: <a href="https://commits.webkit.org/268753@main">https://commits.webkit.org/268753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d797ab19f7bcf784ef661034ece962f8d1ec45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22452 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19178 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21157 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23310 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18678 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18855 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19440 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18514 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4937 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->