### PR TITLE
Add smart pointers around DisplayList::ResourceHeap resources

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -54,7 +54,7 @@ template<class T>
 inline static std::optional<RenderingResourceIdentifier> applyImageBufferItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item)
 {
     auto resourceIdentifier = item.imageBufferIdentifier();
-    if (auto* imageBuffer = resourceHeap.getImageBuffer(resourceIdentifier)) {
+    if (RefPtr imageBuffer = resourceHeap.getImageBuffer(resourceIdentifier)) {
         item.apply(context, *imageBuffer);
         return std::nullopt;
     }
@@ -65,7 +65,7 @@ template<class T>
 inline static std::optional<RenderingResourceIdentifier> applyNativeImageItem(GraphicsContext& context, const ResourceHeap& resourceHeap, const T& item)
 {
     auto resourceIdentifier = item.imageIdentifier();
-    if (auto* image = resourceHeap.getNativeImage(resourceIdentifier)) {
+    if (RefPtr image = resourceHeap.getNativeImage(resourceIdentifier)) {
         item.apply(context, *image);
         return std::nullopt;
     }
@@ -111,7 +111,7 @@ inline static std::optional<RenderingResourceIdentifier> applySetStateItem(Graph
 inline static std::optional<RenderingResourceIdentifier> applyDrawGlyphs(GraphicsContext& context, const ResourceHeap& resourceHeap, const DrawGlyphs& item)
 {
     auto resourceIdentifier = item.fontIdentifier();
-    if (auto* font = resourceHeap.getFont(resourceIdentifier)) {
+    if (RefPtr font = resourceHeap.getFont(resourceIdentifier)) {
         item.apply(context, *font);
         return std::nullopt;
     }
@@ -121,12 +121,12 @@ inline static std::optional<RenderingResourceIdentifier> applyDrawGlyphs(Graphic
 inline static std::optional<RenderingResourceIdentifier> applyDrawDecomposedGlyphs(GraphicsContext& context, const ResourceHeap& resourceHeap, const DrawDecomposedGlyphs& item)
 {
     auto fontIdentifier = item.fontIdentifier();
-    auto* font = resourceHeap.getFont(fontIdentifier);
+    RefPtr font = resourceHeap.getFont(fontIdentifier);
     if (!font)
         return fontIdentifier;
 
     auto drawGlyphsIdentifier = item.decomposedGlyphsIdentifier();
-    auto* decomposedGlyphs = resourceHeap.getDecomposedGlyphs(drawGlyphsIdentifier);
+    RefPtr decomposedGlyphs = resourceHeap.getDecomposedGlyphs(drawGlyphsIdentifier);
     if (!decomposedGlyphs)
         return drawGlyphsIdentifier;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
@@ -92,15 +92,14 @@ public:
         add<FontCustomPlatformData>(renderingResourceIdentifier, WTFMove(customPlatformData), m_customPlatformDataCount);
     }
 
-    ImageBuffer* getImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier) const
+    RefPtr<ImageBuffer> getImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier) const
     {
         return get<ImageBuffer>(renderingResourceIdentifier);
     }
 
-    NativeImage* getNativeImage(RenderingResourceIdentifier renderingResourceIdentifier) const
+    RefPtr<NativeImage> getNativeImage(RenderingResourceIdentifier renderingResourceIdentifier) const
     {
-        auto* renderingResource = get<RenderingResource>(renderingResourceIdentifier);
-        return dynamicDowncast<NativeImage>(renderingResource);
+        return dynamicDowncast<NativeImage>(get<RenderingResource>(renderingResourceIdentifier));
     }
 
     std::optional<SourceImage> getSourceImage(RenderingResourceIdentifier renderingResourceIdentifier) const
@@ -114,30 +113,27 @@ public:
         return std::nullopt;
     }
 
-    DecomposedGlyphs* getDecomposedGlyphs(RenderingResourceIdentifier renderingResourceIdentifier) const
+    RefPtr<DecomposedGlyphs> getDecomposedGlyphs(RenderingResourceIdentifier renderingResourceIdentifier) const
     {
-        auto* renderingResource = get<RenderingResource>(renderingResourceIdentifier);
-        return dynamicDowncast<DecomposedGlyphs>(renderingResource);
+        return dynamicDowncast<DecomposedGlyphs>(get<RenderingResource>(renderingResourceIdentifier));
     }
 
-    Gradient* getGradient(RenderingResourceIdentifier renderingResourceIdentifier) const
+    RefPtr<Gradient> getGradient(RenderingResourceIdentifier renderingResourceIdentifier) const
     {
-        auto* renderingResource = get<RenderingResource>(renderingResourceIdentifier);
-        return dynamicDowncast<Gradient>(renderingResource);
+        return dynamicDowncast<Gradient>(get<RenderingResource>(renderingResourceIdentifier));
     }
 
-    Filter* getFilter(RenderingResourceIdentifier renderingResourceIdentifier) const
+    RefPtr<Filter> getFilter(RenderingResourceIdentifier renderingResourceIdentifier) const
     {
-        auto* renderingResource = get<RenderingResource>(renderingResourceIdentifier);
-        return dynamicDowncast<Filter>(renderingResource);
+        return dynamicDowncast<Filter>(get<RenderingResource>(renderingResourceIdentifier));
     }
 
-    Font* getFont(RenderingResourceIdentifier renderingResourceIdentifier) const
+    RefPtr<Font> getFont(RenderingResourceIdentifier renderingResourceIdentifier) const
     {
         return get<Font>(renderingResourceIdentifier);
     }
 
-    FontCustomPlatformData* getFontCustomPlatformData(RenderingResourceIdentifier renderingResourceIdentifier) const
+    RefPtr<FontCustomPlatformData> getFontCustomPlatformData(RenderingResourceIdentifier renderingResourceIdentifier) const
     {
         return get<FontCustomPlatformData>(renderingResourceIdentifier);
     }
@@ -225,7 +221,7 @@ private:
     }
 
     template <typename T>
-    T* get(RenderingResourceIdentifier renderingResourceIdentifier) const
+    RefPtr<T> get(RenderingResourceIdentifier renderingResourceIdentifier) const
     {
         checkInvariants();
 


### PR DESCRIPTION
#### 6b6ae3662daf8d849d635d967ed5fe8692a9e1cd
<pre>
Add smart pointers around DisplayList::ResourceHeap resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=262462">https://bugs.webkit.org/show_bug.cgi?id=262462</a>
rdar://problem/116322207

Reviewed by NOBODY (OOPS!).

Adding smart pointers as expected by clang static analyzer.

* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyImageBufferItem):
(WebCore::DisplayList::applyNativeImageItem):
(WebCore::DisplayList::applyDrawGlyphs):
(WebCore::DisplayList::applyDrawDecomposedGlyphs):
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
(WebCore::DisplayList::ResourceHeap::getImageBuffer const):
(WebCore::DisplayList::ResourceHeap::getNativeImage const):
(WebCore::DisplayList::ResourceHeap::getDecomposedGlyphs const):
(WebCore::DisplayList::ResourceHeap::getGradient const):
(WebCore::DisplayList::ResourceHeap::getFilter const):
(WebCore::DisplayList::ResourceHeap::getFont const):
(WebCore::DisplayList::ResourceHeap::getFontCustomPlatformData const):
(WebCore::DisplayList::ResourceHeap::get const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b6ae3662daf8d849d635d967ed5fe8692a9e1cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19079 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21049 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20479 "13 flakes 179 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23199 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24869 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22809 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16432 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->