### PR TITLE
More smart pointers in webcore/platform/graphics

### DIFF
--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -139,6 +139,7 @@ public:
     
     LocalFrame* frame() const; // Can be null
     Document* document() const { return m_document.get(); } // Can be null
+    RefPtr<Document> protectedDocument() const { return document(); }
     void setDocument(Document* document) { m_document = document; }
     void clearDocumentLoader(); 
     void loadDone(LoadCompletionType, bool shouldPerformPostLoadActions = true);

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -373,7 +373,7 @@ void BitmapImage::drawPattern(GraphicsContext& ctxt, const FloatRect& destRect, 
     }
 
     ctxt.setDrawLuminanceMask(false);
-    ctxt.drawPattern(*m_cachedImage, destRect, tileRect, transform, phase, spacing, { options, ImageOrientation::Orientation::FromImage });
+    ctxt.drawPattern(Ref { *m_cachedImage }, destRect, tileRect, transform, phase, spacing, { options, ImageOrientation::Orientation::FromImage });
 }
 
 bool BitmapImage::shouldAnimate() const

--- a/Source/WebCore/platform/graphics/GradientImage.cpp
+++ b/Source/WebCore/platform/graphics/GradientImage.cpp
@@ -92,7 +92,7 @@ void GradientImage::drawPattern(GraphicsContext& destContext, const FloatRect& d
     }
 
     destContext.setDrawLuminanceMask(false);
-    destContext.drawPattern(*m_cachedImage, destRect, adjustedSrcRect, adjustedPatternCTM, phase, spacing, options);
+    destContext.drawPattern(Ref { *m_cachedImage }, destRect, adjustedSrcRect, adjustedPatternCTM, phase, spacing, options);
 
 }
 

--- a/Source/WebCore/platform/graphics/WebMResourceClient.cpp
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.cpp
@@ -39,10 +39,9 @@ RefPtr<WebMResourceClient> WebMResourceClient::create(WebMResourceClientParent& 
     auto resource = loader.requestResource(WTFMove(request), PlatformMediaResourceLoader::LoadOption::DisallowCaching);
     if (!resource)
         return nullptr;
-    auto* resourcePointer = resource.get();
-    auto client = adoptRef(*new WebMResourceClient { parent, resource.releaseNonNull() });
+    auto client = adoptRef(*new WebMResourceClient { parent, Ref { *resource } });
     auto result = client.copyRef();
-    resourcePointer->setClient(WTFMove(client));
+    resource->setClient(WTFMove(client));
     return result;
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2770,7 +2770,7 @@ void MediaPlayerPrivateAVFoundationObjC::paintWithVideoOutput(GraphicsContext& c
     INFO_LOG(LOGIDENTIFIER);
 
     FloatRect imageRect { FloatPoint::zero(), m_lastImage->size() };
-    context.drawNativeImage(*m_lastImage, imageRect.size(), outputRect, imageRect);
+    context.drawNativeImage(Ref { *m_lastImage }, imageRect.size(), outputRect, imageRect);
 
     // If we have created an AVAssetImageGenerator in the past due to m_videoOutput not having an available
     // video frame, destroy it now that it is no longer needed.

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -171,11 +171,10 @@ WeakPtr<PlatformResourceMediaLoader> PlatformResourceMediaLoader::create(WebCore
     auto resource = loader.requestResource(WTFMove(request), PlatformMediaResourceLoader::LoadOption::DisallowCaching);
     if (!resource)
         return nullptr;
-    auto* resourcePointer = resource.get();
-    auto client = adoptRef(*new PlatformResourceMediaLoader { parent, resource.releaseNonNull() });
+    auto client = adoptRef(*new PlatformResourceMediaLoader { parent, Ref { *resource } });
     WeakPtr result = client;
 
-    resourcePointer->setClient(WTFMove(client));
+    resource->setClient(WTFMove(client));
     return result;
 }
 

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.cpp
@@ -91,7 +91,7 @@ void ReferenceFilterOperation::loadExternalDocumentIfNeeded(CachedResourceLoader
 {
     if (m_cachedSVGDocumentReference)
         return;
-    if (!SVGURIReference::isExternalURIReference(m_url, *cachedResourceLoader.document()))
+    if (!SVGURIReference::isExternalURIReference(m_url, *cachedResourceLoader.protectedDocument()))
         return;
     m_cachedSVGDocumentReference = makeUnique<CachedSVGDocumentReference>(m_url);
     m_cachedSVGDocumentReference->load(cachedResourceLoader, options);

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -329,7 +329,7 @@ void FELightingSoftwareApplier::applyPlatform(const LightingData& data)
     auto [r, g, b, a] = data.lightingColor.toResolvedColorComponentsInColorSpace(*data.operatingColorSpace);
     paintingData.initialLightingData.colorVector = FloatPoint3D(r, g, b);
 
-    data.lightSource->initPaintingData(*data.filter, *data.result, paintingData);
+    data.lightSource->initPaintingData(Ref { *data.filter }, Ref { *data.result }, paintingData);
 
     // Top left.
     int offset = 0;


### PR DESCRIPTION
#### c7333154762b59d651bcf94a5fafde7606ff747d
<pre>
More smart pointers in webcore/platform/graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=262463">https://bugs.webkit.org/show_bug.cgi?id=262463</a>
rdar://116322384

Reviewed by Chris Dumez.

Adding smart pointers as expected by clang static analyzer.

* Source/WebCore/loader/cache/CachedResourceLoader.h:
(WebCore::CachedResourceLoader::protectedDocument const):
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::drawPattern):
* Source/WebCore/platform/graphics/GradientImage.cpp:
(WebCore::GradientImage::drawPattern):
* Source/WebCore/platform/graphics/WebMResourceClient.cpp:
(WebCore::WebMResourceClient::create):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::paintWithVideoOutput):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::PlatformResourceMediaLoader::create):
* Source/WebCore/platform/graphics/filters/FilterOperation.cpp:
(WebCore::ReferenceFilterOperation::loadExternalDocumentIfNeeded):
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp:
(WebCore::FELightingSoftwareApplier::applyPlatform):

Canonical link: <a href="https://commits.webkit.org/268763@main">https://commits.webkit.org/268763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1df604b9b693786722f2c119e66f8a24ec55d586

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22476 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20572 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23333 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24980 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22920 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16539 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18681 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4946 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->