### PR TITLE
Stop using Vector::uncheckedAppend() in ISO8601.cpp

### DIFF
--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -598,10 +598,7 @@ static std::optional<std::variant<Vector<LChar>, int64_t>> parseTimeZoneBrackete
         if (!isValidComponent(currentNameComponentStartIndex, nameLength))
             return std::nullopt;
 
-        Vector<LChar> result;
-        result.reserveInitialCapacity(nameLength);
-        for (unsigned index = 0; index < nameLength; ++index)
-            result.uncheckedAppend(buffer[index]);
+        Vector<LChar> result(buffer.position(), nameLength);
         buffer.advanceBy(nameLength);
 
         if (buffer.atEnd())
@@ -739,10 +736,7 @@ static std::optional<CalendarRecord> parseCalendar(StringParsingBuffer<Character
     if (!isValidComponent(currentNameComponentStartIndex, nameLength))
         return std::nullopt;
 
-    Vector<LChar, maxCalendarLength> result;
-    result.reserveInitialCapacity(nameLength);
-    for (unsigned index = 0; index < nameLength; ++index)
-        result.uncheckedAppend(buffer[index]);
+    Vector<LChar, maxCalendarLength> result(buffer.position(), nameLength);
     buffer.advanceBy(nameLength);
 
     if (buffer.atEnd())

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -707,13 +707,14 @@ public:
             TypeOperations::uninitializedFill(begin(), end(), val);
     }
 
-    Vector(const T* data, size_t dataSize)
+    template<typename U = T>
+    Vector(const U* data, size_t dataSize)
         : Base(dataSize, dataSize)
     {
         asanSetInitialBufferSizeTo(dataSize);
 
         if (begin())
-            TypeOperations::uninitializedCopy(data, data + dataSize, begin());
+            VectorCopier<std::is_trivial<T>::value, U>::uninitializedCopy(data, data + dataSize, begin());
     }
 
     Vector(std::span<const T> span)
@@ -1985,6 +1986,8 @@ inline Vector<typename CopyOrMoveToVectorResult<Collection>::Type> moveToVector(
 {
     return moveToVectorOf<typename CopyOrMoveToVectorResult<Collection>::Type>(collection);
 }
+
+template<typename U> Vector(const U*, size_t) -> Vector<U>;
 
 } // namespace WTF
 

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -318,6 +318,16 @@ TEST(WTF_Vector, CopyFromOtherMinCapacity)
     EXPECT_FALSE(vector != vectorCopy);
 }
 
+TEST(WTF_Vector, ConstructorOtherRawPointerTypeAndLength)
+{
+    const UChar uchars[] = { 'b', 'a', 'r' };
+    Vector<LChar> vector(uchars, 3);
+    EXPECT_EQ(vector.size(), 3U);
+    EXPECT_EQ(vector[0], 'b');
+    EXPECT_EQ(vector[1], 'a');
+    EXPECT_EQ(vector[2], 'r');
+}
+
 TEST(WTF_Vector, Reverse)
 {
     Vector<int> intVector;


### PR DESCRIPTION
#### cc80dcc17dc52a2ec37475a278cc2717c006a9fe
<pre>
Stop using Vector::uncheckedAppend() in ISO8601.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=262464">https://bugs.webkit.org/show_bug.cgi?id=262464</a>

Reviewed by Ryosuke Niwa.

Stop using Vector::uncheckedAppend() in ISO8601.cpp. Vector::uncheckedAppend()
has recently become an alias to Vector::append(), which does bounds checking.

Introduce a more efficient Vector constructor and use it instead. We used to
have a `Vector(const T*, size_t length)` constructor. However, in this case
we want to construct a Vector&lt;LChar&gt; and the input raw pointer may be a UChar*.
To support this, I templated the constructor to make it `Vector(const U*, size_t)`
instead. Note that this matches what we already do for `Vector::append(const U*, size_t)`.

* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseTimeZoneBracketedAnnotation):
(JSC::ISO8601::parseCalendar):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::Vector):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268731@main">https://commits.webkit.org/268731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93667402b3368fd16b69bfa8dfa860bc5379d854

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22400 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21102 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23253 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18630 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17853 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18831 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22856 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19933 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16481 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23909 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18614 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5717 "Found 2 jsc stress test failures: stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.no-llint") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4922 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22954 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25166 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19221 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5540 "Passed tests") | 
<!--EWS-Status-Bubble-End-->