### PR TITLE
Add support for `showPicker()` to `HTMLSelectElement`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6741,11 +6741,6 @@ imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-f
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-002.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-003.html [ Pass Failure ]
 
-webkit.org/b/261814 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-disabled.tentative.html [ Skip ]
-webkit.org/b/261814 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-size.tentative.html [ Skip ]
-webkit.org/b/261814 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-multiple.tentative.html [ Skip ]
-webkit.org/b/261814 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-user-gesture.tentative.html [ Skip ]
-
 webkit.org/b/245032 imported/w3c/web-platform-tests/css/compositing/root-element-background-image-transparency-004.html [ ImageOnlyFailure ]
 
 webkit.org/b/261916 media/video-pause-while-seeking.html [ Pass Failure ]

--- a/LayoutTests/fast/forms/select/select-show-picker-expected.txt
+++ b/LayoutTests/fast/forms/select/select-show-picker-expected.txt
@@ -1,0 +1,4 @@
+
+Is showing popup? true
+
+This test verifies that the popup is presented when calling showPicker on a select.

--- a/LayoutTests/fast/forms/select/select-show-picker.html
+++ b/LayoutTests/fast/forms/select/select-show-picker.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+
+body {
+    margin: 0;
+}
+</style>
+<head>
+<body onload="runTest()">
+<select name="select" id="select">
+    <option value="one">One</option>
+    <option value="two">Two</option>
+</select>
+<pre>Is showing popup? <span id="before"></span></pre>
+<br>
+<div>This test verifies that the popup is presented when calling showPicker on a select.</div>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+async function runTest() {
+    await UIHelper.activateAt(0, 0);
+    select.showPicker();
+
+    before.textContent = internals.isSelectPopupVisible(select);
+
+    testRunner.notifyDone();
+}
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-cross-origin-iframe.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-cross-origin-iframe.tentative-expected.txt
@@ -1,0 +1,10 @@
+CONSOLE MESSAGE: SecurityError: Attempted to use a non-registrable domain.
+
+
+Harness Error (TIMEOUT), message = null
+
+PASS Test showPicker() called from cross-origin iframe
+PASS Test showPicker() called from cross-origin iframe 1
+PASS Test showPicker() called from cross-origin iframe 2
+TIMEOUT Test showPicker() called from cross-origin iframe 3 Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-disabled.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-disabled.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS select showPicker() throws when disabled
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-multiple.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-multiple.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS select showPicker() does not throw when called on a <select multiple>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-size.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-size.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS select showPicker() does not throw when called on a <select size="4">
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-user-gesture.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-user-gesture.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS select showPicker() requires a user gesture
+PASS select showPicker() does not throw when user activation is active
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3276,6 +3276,9 @@ fast/forms/datetimelocal/datetimelocal-show-hide-picker.html [ Skip ]
 fast/forms/date/date-show-picker.html [ Skip ]
 fast/forms/datetimelocal/datetimelocal-show-picker.html [ Skip ]
 
+# showPicker not yet implemented for iOS
+webkit.org/b/261703 fast/forms/select/select-show-picker.html [ Skip ]
+
 # <rdar://problem/59636115> REGRESSION: [ iOS & macOS ] two imported/w3c/web-platform-tests/WebCryptoAPI are failing
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.worker.html [ Failure ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2667,6 +2667,8 @@ imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-pa
 
 webkit.org/b/261305 [ Monterey+ Debug ] editing/inserting/break-out-of-nested-lists.html [ Crash ]
 
+fast/forms/select/select-show-picker.html [ Skip ]
+
 # webkit.org/b/261304 Batch mark expectations for flaky media tests
 [ Monterey+ ] http/tests/media/fairplay/legacy-fairplay-hls.html [ Pass Failure ]
 
@@ -2695,6 +2697,3 @@ webkit.org/b/262340 [ Sonoma ] compositing/repaint/iframes/compositing-iframe-wi
 
 # rdar://113991102 (REGRESSION ( Sonoma ): [ Sonoma ] 10 fast/text/canvas-color-fonts/..COLR tests are a consistent image failure)
 [ Sonoma+ ] fast/text/canvas-color-fonts/stroke-gradient-COLR.html [ ImageOnlyFailure ]
-
-fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html [ Failure ]
-fast/events/cancel-mousedown-and-drag-to-frame.html [ Failure ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5838,6 +5838,20 @@ SecureContextChecksEnabled:
     WebCore:
       default: true
 
+SelectShowPickerEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "<select> showPicker() method"
+  humanReadableDescription: "Enable showPicker() method on <select>"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 SelectTrailingWhitespaceEnabled:
   type: bool

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -84,6 +84,8 @@ public:
     ExceptionOr<void> setItem(unsigned index, HTMLOptionElement*);
     ExceptionOr<void> setLength(unsigned);
 
+    ExceptionOr<void> showPicker();
+
     WEBCORE_EXPORT HTMLOptionElement* namedItem(const AtomString& name);
     WEBCORE_EXPORT HTMLOptionElement* item(unsigned index);
     bool isSupportedPropertyIndex(unsigned index);

--- a/Source/WebCore/html/HTMLSelectElement.idl
+++ b/Source/WebCore/html/HTMLSelectElement.idl
@@ -52,6 +52,7 @@
     boolean checkValidity();
     [EnabledBySetting=InteractiveFormValidationEnabled] boolean reportValidity();
     undefined setCustomValidity(DOMString error);
+    [EnabledBySetting=SelectShowPickerEnabled] undefined showPicker();
 
     readonly attribute NodeList labels;
 };


### PR DESCRIPTION
#### 5df7cdc4a1ec1cfef6b892665536af6eefe925e2
<pre>
Add support for `showPicker()` to `HTMLSelectElement`
<a href="https://bugs.webkit.org/show_bug.cgi?id=261814">https://bugs.webkit.org/show_bug.cgi?id=261814</a>

Reviewed by Aditya Keerthi.

At whatwg/html#9754, it&apos;s proposed to add a
new HTMLSelectElement::showPicker() method to show the popup for
select elements.

This patch introduces this functionality, for non-iOS platforms in WK2.

* LayoutTests/fast/forms/select/select-show-picker-expected.txt: Added.
* LayoutTests/fast/forms/select/select-show-picker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-cross-origin-iframe.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-disabled.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-multiple.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-size.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-user-gesture.tentative-expected.txt: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::showPicker):
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/html/HTMLSelectElement.idl:
* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269420@main">https://commits.webkit.org/269420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/803aebbd3f94149a192e2a15bcc52028c65ba19e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24397 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23024 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22732 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25249 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26637 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19596 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24478 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21861 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/80 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17945 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25910 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/59 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20188 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6083 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5360 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/98 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27189 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/95 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5910 "Passed tests") | 
<!--EWS-Status-Bubble-End-->