### PR TITLE
[UnifiedPDF] Implement two-up display mode

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -71,10 +71,10 @@ public:
     WebCore::FloatSize scaledContentsSize() const;
 
 private:
-    void layoutPages(float availableWidth, float maxPageWidth);
+    void layoutPages(float availableWidth, float maxRowWidth);
 
-    void layoutSingleColumn(float availableWidth, float maxPageWidth);
-    void layoutTwoUpColumn(float availableWidth);
+    void layoutSingleColumn(float availableWidth, float maxRowWidth);
+    void layoutTwoUpColumn(float availableWidth, float maxRowWidth);
 
     static FloatSize documentMargin();
     static FloatSize pageMargin();


### PR DESCRIPTION
#### 808bcd5e0a980840b1dd1fcbc6787aa654c79cb8
<pre>
[UnifiedPDF] Implement two-up display mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=262454">https://bugs.webkit.org/show_bug.cgi?id=262454</a>
rdar://116296737

Reviewed by Dan Glastonbury.

Implement two-up display mode, which displays pairs of pages side-by-side.

In this mode, the height of the pair of pages is the larger of the two heights, and pages with
unequal heights are vertically centered in the row. If there is a single page on the last row, it&apos;s
centered (which is also the case for a single page PDF).

Have `PDFDocumentLayout::updateLayout()` keep track of the width of page pairs when necessary, which
is passed to `layoutTwoUpColumn()`.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::layoutPages):
(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::layoutTwoUpColumn):

Canonical link: <a href="https://commits.webkit.org/268733@main">https://commits.webkit.org/268733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08ee198af58e19794bb851b5b7525985a35c141c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19093 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20493 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23213 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17719 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24882 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22822 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16445 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18575 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4924 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22915 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->