### PR TITLE
Add template parameters to WTF::map() to specify resulting vector inlineCapacity / minCapacity

### DIFF
--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -136,11 +136,9 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
     using Type = Vector<T, inlineCapacity, OverflowHandler, minCapacity>;
     static Type copy(const Type& source)
     {
-        Type destination;
-        destination.reserveInitialCapacity(source.size());
-        for (auto& object : source)
-            destination.uncheckedAppend(CrossThreadCopier<T>::copy(object));
-        return destination;
+        return WTF::map<inlineCapacity, OverflowHandler, minCapacity>(source, [](auto& object) {
+            return CrossThreadCopier<T>::copy(object);
+        });
     }
     static Type copy(Type&& source)
     {

--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -230,23 +230,18 @@ private:
     mutable unsigned m_maxOperationCountWithoutCleanup { 0 };
 };
 
-template<typename MapFunction, typename T, typename WeakMapImpl>
-struct Mapper<MapFunction, const WeakHashSet<T, WeakMapImpl>&, void> {
-    using SourceItemType = T&;
-    using DestinationItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
-
-    static Vector<DestinationItemType> map(const WeakHashSet<T, WeakMapImpl>& source, const MapFunction& mapFunction)
+template<typename MapFunction, typename DestinationVectorType, typename T, typename WeakMapImpl>
+struct Mapper<MapFunction, DestinationVectorType, const WeakHashSet<T, WeakMapImpl>&, void> {
+    static void map(DestinationVectorType& result, const WeakHashSet<T, WeakMapImpl>& source, const MapFunction& mapFunction)
     {
-        Vector<DestinationItemType> result;
         result.reserveInitialCapacity(source.computeSize());
         for (auto& item : source)
             result.unsafeAppendWithoutCapacityCheck(mapFunction(item));
-        return result;
     }
 };
 
-template<typename MapFunction, typename T, typename WeakMapImpl>
-struct Mapper<MapFunction, WeakHashSet<T, WeakMapImpl>&, void> : Mapper<MapFunction, const WeakHashSet<T, WeakMapImpl> &, void> {
+template<typename MapFunction, typename DestinationVectorType, typename T, typename WeakMapImpl>
+struct Mapper<MapFunction, DestinationVectorType, WeakHashSet<T, WeakMapImpl>&, void> : Mapper<MapFunction, DestinationVectorType, const WeakHashSet<T, WeakMapImpl> &, void> {
 };
 
 template<typename T, typename WeakMapImpl>

--- a/Source/WTF/wtf/WeakListHashSet.h
+++ b/Source/WTF/wtf/WeakListHashSet.h
@@ -388,18 +388,13 @@ private:
     mutable unsigned m_maxOperationCountWithoutCleanup { 0 };
 };
 
-template<typename MapFunction, typename T, typename WeakMapImpl>
-struct Mapper<MapFunction, const WeakListHashSet<T, WeakMapImpl> &, void> {
-    using SourceItemType = T&;
-    using DestinationItemType = typename std::invoke_result<MapFunction, SourceItemType&>::type;
-
-    static Vector<DestinationItemType> map(const WeakListHashSet<T, WeakMapImpl>& source, const MapFunction& mapFunction)
+template<typename MapFunction, typename DestinationVectorType, typename T, typename WeakMapImpl>
+struct Mapper<MapFunction, DestinationVectorType, const WeakListHashSet<T, WeakMapImpl> &, void> {
+    static void map(DestinationVectorType& result, const WeakListHashSet<T, WeakMapImpl>& source, const MapFunction& mapFunction)
     {
-        Vector<DestinationItemType> result;
         result.reserveInitialCapacity(source.computeSize());
         for (auto& item : source)
             result.unsafeAppendWithoutCapacityCheck(mapFunction(item));
-        return result;
     }
 };
 


### PR DESCRIPTION
#### f35b23c8867e86725fdefb4f88d255c88f3cdccb
<pre>
Add template parameters to WTF::map() to specify resulting vector inlineCapacity / minCapacity
<a href="https://bugs.webkit.org/show_bug.cgi?id=262470">https://bugs.webkit.org/show_bug.cgi?id=262470</a>

Reviewed by Darin Adler.

Add template parameters to WTF::map() to specify resulting vector inlineCapacity / minCapacity.
This allows us to use WTF::map() in more cases (a few were included in this patch).

This is important as we want developers to be able to write efficient code without relying
directly on Vector::uncheckedAppend().

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitCCall):
* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WTF/wtf/Vector.h:
(WTF::Mapper::map):
(WTF::map):
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakListHashSet.h:

Canonical link: <a href="https://commits.webkit.org/268739@main">https://commits.webkit.org/268739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a832a3777030b2ffb560fcf273b7282a7a118f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21120 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23272 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17768 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18648 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17872 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18824 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19951 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16491 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23928 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18627 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5719 "Found 2 jsc stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.no-llint") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4928 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22966 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25186 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19232 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5542 "Passed tests") | 
<!--EWS-Status-Bubble-End-->