### PR TITLE
NativePromise should provide a safe way to pass some argument types

### DIFF
--- a/Source/WTF/wtf/CrossThreadCopier.cpp
+++ b/Source/WTF/wtf/CrossThreadCopier.cpp
@@ -44,11 +44,6 @@ static_assert((std::is_same<RefPtr<CopierThreadSafeRefCountedTest>, CrossThreadC
 static_assert((std::is_same<RefPtr<CopierThreadSafeRefCountedTest>, CrossThreadCopier<CopierThreadSafeRefCountedTest*>::Type>::value), "RawPointerTest");
 static_assert((std::is_same<Ref<CopierThreadSafeRefCountedTest>, CrossThreadCopier<Ref<CopierThreadSafeRefCountedTest>>::Type>::value), "RawPointerTest");
 
-// Add specializations for RefCounted types which will let us verify that no other template matches.
-template<typename T> struct CrossThreadCopierBase<false, false, RefPtr<T>> {
-    typedef int Type;
-};
-
 template<typename T> struct CrossThreadCopierBase<false, false, T*> {
     typedef int Type;
 };
@@ -57,7 +52,6 @@ template<typename T> struct CrossThreadCopierBase<false, false, T*> {
 class CopierRefCountedTest : public RefCounted<CopierRefCountedTest> {
 };
 
-static_assert((std::is_same<int, CrossThreadCopier<RefPtr<CopierRefCountedTest>>::Type>::value), "CrossThreadCopier specialization improperly applied to RefPtr<> of a RefCounted (but not ThreadSafeRefCounted) type");
 static_assert((std::is_same<int, CrossThreadCopier<CopierRefCountedTest*>::Type>::value), "CrossThreadCopier specialization improperly applied to raw pointer of a RefCounted (but not ThreadSafeRefCounted) type");
 
 } // namespace WTF

--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009, 2010 Google Inc. All rights reserved.
- * Copyright (C) 2014-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,13 +31,17 @@
 
 #pragma once
 
+#include <tuple>
 #include <type_traits>
+#include <variant>
 #include <wtf/Assertions.h>
+#include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/TypeTraits.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTF {
@@ -68,7 +72,9 @@ struct CrossThreadCopierBaseHelper {
 };
 
 template<typename T> struct CrossThreadCopierPassThrough {
-    typedef T Type;
+    static_assert(CrossThreadCopierBaseHelper::IsEnumOrConvertibleToInteger<T>::value, "CrossThreadCopierPassThrough only used for enums or integers");
+    using Type = T;
+    static constexpr bool IsNeeded = false;
     static Type copy(const T& parameter)
     {
         return parameter;
@@ -82,37 +88,89 @@ template<typename T> struct CrossThreadCopierBase<true, false, T> : public Cross
 };
 
 // Classes that have an isolatedCopy() method get a default specialization.
-template<class T> struct CrossThreadCopierBase<false, false, T> {
-    template<typename U> static auto copy(U&& value)
+template<typename T>
+struct CrossThreadCopierBase<false, false, T> {
+    using Type = T;
+    static constexpr bool IsNeeded = HasIsolatedCopy<T>::value;
+    template<typename U> static auto copy(U&& value) -> Type
     {
-        return std::forward<U>(value).isolatedCopy();
+        if constexpr (HasIsolatedCopy<U>::value)
+            return std::forward<U>(value).isolatedCopy();
+        else
+            return std::forward<U>(value);
     }
 };
 
 // Custom copy methods.
 template<typename T> struct CrossThreadCopierBase<false, true, T> {
-    typedef typename CrossThreadCopierBaseHelper::RemovePointer<T>::Type RefCountedType;
+    using RefCountedType = typename CrossThreadCopierBaseHelper::RemovePointer<T>::Type;
     static_assert(std::is_convertible<RefCountedType*, ThreadSafeRefCountedBase*>::value, "T is not convertible to ThreadSafeRefCounted!");
 
-    typedef RefPtr<RefCountedType> Type;
+    using Type = RefPtr<RefCountedType>;
+    static constexpr bool IsNeeded = false;
+
     static Type copy(const T& refPtr)
     {
         return refPtr;
+    }
+    static Type copy(T&& refPtr)
+    {
+        return WTFMove(refPtr);
+    }
+};
+
+// Can only be moved
+template<typename T> struct CrossThreadCopierBase<false, false, Ref<T>> {
+    using Type = Ref<T>;
+    static constexpr bool IsNeeded = false;
+    static Type copy(Type&& ref)
+    {
+        return WTFMove(ref);
+    }
+};
+
+// Can only be moved
+template<typename T> struct CrossThreadCopierBase<false, false, RefPtr<T>> {
+    using Type = RefPtr<T>;
+    static constexpr bool IsNeeded = false;
+    static Type copy(Type&& ref)
+    {
+        return WTFMove(ref);
     }
 };
 
 template<typename T> struct CrossThreadCopierBase<false, true, Ref<T>> {
     static_assert(std::is_convertible<T*, ThreadSafeRefCountedBase*>::value, "T is not convertible to ThreadSafeRefCounted!");
+    static constexpr bool IsNeeded = false;
 
-    typedef Ref<T> Type;
+    using Type = Ref<T>;
     static Type copy(const Type& ref)
     {
         return ref;
     }
+    static Type copy(Type&& ref)
+    {
+        return WTFMove(ref);
+    }
+};
+
+// Default specialization for AtomString of CrossThreadCopyable classes.
+template<> struct CrossThreadCopierBase<false, false, AtomString> {
+    using Type = String;
+    static constexpr bool IsNeeded = true;
+    static Type copy(const AtomString& source)
+    {
+        return source.string().isolatedCopy();
+    }
+    static Type copy(AtomString&& source)
+    {
+        return source.releaseString().isolatedCopy();
+    }
 };
 
 template<> struct CrossThreadCopierBase<false, false, WTF::ASCIILiteral> {
-    typedef WTF::ASCIILiteral Type;
+    using Type = WTF::ASCIILiteral;
+    static constexpr bool IsNeeded = false;
     static Type copy(const Type& source)
     {
         return source;
@@ -120,7 +178,8 @@ template<> struct CrossThreadCopierBase<false, false, WTF::ASCIILiteral> {
 };
 
 template<typename T, typename U> struct CrossThreadCopierBase<false, false, ObjectIdentifierGeneric<T, U>> {
-    typedef ObjectIdentifierGeneric<T, U> Type;
+    using Type = ObjectIdentifierGeneric<T, U>;
+    static constexpr bool IsNeeded = false;
     static Type copy(const Type& source)
     {
         return source;
@@ -134,6 +193,7 @@ struct CrossThreadCopier : public CrossThreadCopierBase<CrossThreadCopierBaseHel
 // Default specialization for Vectors of CrossThreadCopyable classes.
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity> struct CrossThreadCopierBase<false, false, Vector<T, inlineCapacity, OverflowHandler, minCapacity>> {
     using Type = Vector<T, inlineCapacity, OverflowHandler, minCapacity>;
+    static constexpr bool IsNeeded = CrossThreadCopier<T>::IsNeeded;
     static Type copy(const Type& source)
     {
         return WTF::map<inlineCapacity, OverflowHandler, minCapacity>(source, [](auto& object) {
@@ -147,10 +207,11 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
         return WTFMove(source);
     }
 };
-    
+
 // Default specialization for HashSets of CrossThreadCopyable classes
 template<typename T> struct CrossThreadCopierBase<false, false, HashSet<T> > {
-    typedef HashSet<T> Type;
+    using Type = HashSet<T>;
+    static constexpr bool IsNeeded = CrossThreadCopier<T>::IsNeeded;
     static Type copy(const Type& source)
     {
         Type destination;
@@ -171,7 +232,8 @@ template<typename T> struct CrossThreadCopierBase<false, false, HashSet<T> > {
 // Default specialization for HashMaps of CrossThreadCopyable classes
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
 struct CrossThreadCopierBase<false, false, HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>> {
-    typedef HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg> Type;
+    using Type = HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>;
+    static constexpr bool IsNeeded = CrossThreadCopier<KeyArg>::IsNeeded || CrossThreadCopier<MappedArg>::IsNeeded;
     static Type copy(const Type& source)
     {
         Type destination;
@@ -191,7 +253,8 @@ struct CrossThreadCopierBase<false, false, HashMap<KeyArg, MappedArg, HashArg, K
 
 // Default specialization for pairs of CrossThreadCopyable classes
 template<typename F, typename S> struct CrossThreadCopierBase<false, false, std::pair<F, S> > {
-    typedef std::pair<F, S> Type;
+    using Type = std::pair<F, S>;
+    static constexpr bool IsNeeded = CrossThreadCopier<F>::IsNeeded || CrossThreadCopier<S>::IsNeeded;
     template<typename U> static Type copy(U&& source)
     {
         return std::make_pair(CrossThreadCopier<F>::copy(std::get<0>(std::forward<U>(source))), CrossThreadCopier<S>::copy(std::get<1>(std::forward<U>(source))));
@@ -200,6 +263,8 @@ template<typename F, typename S> struct CrossThreadCopierBase<false, false, std:
 
 // Default specialization for std::optional of CrossThreadCopyable class.
 template<typename T> struct CrossThreadCopierBase<false, false, std::optional<T>> {
+    using Type = std::optional<T>;
+    static constexpr bool IsNeeded = CrossThreadCopier<T>::IsNeeded;
     template<typename U> static std::optional<T> copy(U&& source)
     {
         if (!source)
@@ -210,7 +275,9 @@ template<typename T> struct CrossThreadCopierBase<false, false, std::optional<T>
 
 // Default specialization for Markable of CrossThreadCopyable class.
 template<typename T, typename U> struct CrossThreadCopierBase<false, false, Markable<T, U>> {
-    template<typename V> static Markable<T, U> copy(V&& source)
+    using Type = Markable<T, U>;
+    static constexpr bool IsNeeded = CrossThreadCopier<T>::IsNeeded;
+    template<typename V> static Type copy(V&& source)
     {
         if (!source)
             return std::nullopt;
@@ -219,12 +286,14 @@ template<typename T, typename U> struct CrossThreadCopierBase<false, false, Mark
 };
 
 template<> struct CrossThreadCopierBase<false, false, std::nullptr_t> {
+    static constexpr bool IsNeeded = false;
     static std::nullptr_t copy(std::nullptr_t) { return nullptr; }
 };
 
 // Default specialization for std::variant of CrossThreadCopyable classes.
 template<typename... Types> struct CrossThreadCopierBase<false, false, std::variant<Types...>> {
     using Type = std::variant<Types...>;
+    static constexpr bool IsNeeded = (CrossThreadCopier<std::remove_cvref_t<Types>>::IsNeeded || ...);
     static std::variant<Types...> copy(const Type& source)
     {
         return std::visit([] (auto& type) -> std::variant<Types...> {
@@ -239,11 +308,61 @@ template<typename... Types> struct CrossThreadCopierBase<false, false, std::vari
     }
 };
 
+template<>
+struct CrossThreadCopierBase<false, false, void> {
+    static constexpr bool IsNeeded = false;
+    using Type = void;
+};
+
+template<typename T, typename U> struct CrossThreadCopierBase<false, false, Expected<T, U> > {
+    using Type = Expected<T, U>;
+    static constexpr bool IsNeeded = CrossThreadCopier<std::remove_cvref_t<T>>::IsNeeded || CrossThreadCopier<std::remove_cvref_t<U>>::IsNeeded;
+    static Type copy(const Type& source)
+    {
+        if (source.has_value()) {
+            if constexpr (std::is_void_v<T>)
+                return source;
+            else
+                return CrossThreadCopier<T>::copy(source.value());
+        }
+        return Unexpected<U>(CrossThreadCopier<U>::copy(source.error()));
+    }
+
+    static Type copy(Type&& source)
+    {
+        if (source.has_value()) {
+            if constexpr (std::is_void_v<T>)
+                return WTFMove(source);
+            else
+                return CrossThreadCopier<T>::copy(WTFMove(source.value()));
+        }
+        return Unexpected<U>(CrossThreadCopier<U>::copy(WTFMove(source.error())));
+    }
+};
+
+// Default specialization for std::tuple of CrossThreadCopyable classes.
+template<typename... Types> struct CrossThreadCopierBase<false, false, std::tuple<Types...>> {
+    using Type = std::tuple<Types...>;
+    static constexpr bool IsNeeded = (CrossThreadCopier<std::remove_cvref_t<Types>>::IsNeeded || ...);
+    static Type copy(const Type& source)
+    {
+        return std::apply([]<typename ...Ts>(Ts const&... ts) {
+            return std::make_tuple((CrossThreadCopier<std::remove_cvref_t<Ts>>::copy(ts), ...));
+        }, source);
+    }
+    static Type copy(Type&& source)
+    {
+        return std::apply([]<typename ...Ts>(Ts&&... ts) {
+            return std::make_tuple((CrossThreadCopier<std::remove_cvref_t<Ts>>::copy(WTFMove(ts)), ...));
+        }, WTFMove(source));
+    }
+};
+
 template<typename T> auto crossThreadCopy(T&& source)
 {
     return CrossThreadCopier<std::remove_cvref_t<T>>::copy(std::forward<T>(source));
 }
-    
+
 } // namespace WTF
 
 using WTF::CrossThreadCopierBaseHelper;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -122,7 +122,7 @@ template<typename Key, typename Value, typename Extractor, typename HashFunction
 template<typename Value, typename = DefaultHash<Value>, typename = HashTraits<Value>> class HashCountedSet;
 template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits> class HashMap;
 template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits> class HashSet;
-template<typename ResolveValueT, typename RejectValueT, bool IsExclusive> class NativePromise;
+template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> class NativePromise;
 
 }
 

--- a/Source/WTF/wtf/TypeTraits.h
+++ b/Source/WTF/wtf/TypeTraits.h
@@ -107,6 +107,19 @@ static auto HasRefCountMethodsTest(long) -> std::false_type;
 template<class T>
 struct HasRefCountMethods : decltype(detail::HasRefCountMethodsTest<T>(0)) { };
 
+// HasIsolatedCopy()
+namespace detail {
+
+template<class T>
+static auto HasIsolatedCopyTest(int) -> SFINAE1True<decltype(std::declval<T>().isolatedCopy())>;
+template<class>
+static auto HasIsolatedCopyTest(long) -> std::false_type;
+
+} // namespace detail
+
+template<class T>
+struct HasIsolatedCopy : decltype(detail::HasIsolatedCopyTest<T>(0)) { };
+
 // LooksLikeRCSerialDispatcher implementation
 namespace detail {
 

--- a/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp
@@ -47,7 +47,7 @@ Ref<DecodingTaskPromise> AsyncAudioDecoder::decodeAsync(Ref<ArrayBuffer>&& audio
         // The ArrayBuffer must be deleted on the main thread, send it back there to be derefed.
         callOnMainThread([audioData = WTFMove(audioData)] { });
         if (!audioBuffer)
-            return DecodingTaskPromise::createAndReject(EncodingError);
+            return DecodingTaskPromise::createAndReject(Exception { EncodingError, "Decoding failed"_s });
         return DecodingTaskPromise::createAndResolve(audioBuffer.releaseNonNull());
     });
 }

--- a/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.h
+++ b/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.h
@@ -24,7 +24,8 @@
 
 #pragma once
 
-#include "ExceptionCode.h"
+#include "Exception.h"
+#include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RunLoop.h>
 
@@ -32,18 +33,13 @@ namespace JSC {
 class ArrayBuffer;
 }
 
-namespace WTF {
-template<typename TypeResolve, typename TypeReject, bool IsExclusive>
-class NativePromise;
-}
-
 namespace WebCore {
 class AudioBuffer;
 
 // AsyncAudioDecoder asynchronously decodes audio file data from an ArrayBuffer in a worker thread.
 // Upon successful decoding, the DecodingTaskPromise will be resolved with the decoded AudioBuffer
-// otherwise an ExceptionCode will be returned.
-using DecodingTaskPromise = WTF::NativePromise<Ref<WebCore::AudioBuffer>, ExceptionCode, true /* isExclusive */>;
+// otherwise an Exception will be returned.
+using DecodingTaskPromise = WTF::NativePromise<Ref<WebCore::AudioBuffer>, Exception>;
 
 class AsyncAudioDecoder final {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -304,7 +304,7 @@ void BaseAudioContext::decodeAudioData(Ref<ArrayBuffer>&& audioData, RefPtr<Audi
         queueTaskKeepingObjectAlive(*this, TaskSource::InternalAsyncTask, [successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise), result = WTFMove(result)]() mutable {
             if (!result) {
                 if (promise)
-                    promise.value()->reject(Exception { result.error(), "Decoding failed"_s });
+                    promise.value()->reject(WTFMove(result.error()));
                 if (errorCallback)
                     errorCallback->handleEvent(nullptr);
                 return;

--- a/Source/WebCore/dom/ExceptionOr.h
+++ b/Source/WebCore/dom/ExceptionOr.h
@@ -202,7 +202,8 @@ template <typename T> using TypeOrExceptionOrUnderlyingType = typename TypeOrExc
 
 namespace WTF {
 template<typename T> struct CrossThreadCopierBase<false, false, WebCore::ExceptionOr<T> > {
-    typedef WebCore::ExceptionOr<T> Type;
+    using Type = WebCore::ExceptionOr<T>;
+    static constexpr bool IsNeeded = true;
     static Type copy(const Type& source)
     {
         if (source.hasException())
@@ -218,7 +219,8 @@ template<typename T> struct CrossThreadCopierBase<false, false, WebCore::Excepti
 };
 
 template<> struct CrossThreadCopierBase<false, false, WebCore::ExceptionOr<void> > {
-    typedef WebCore::ExceptionOr<void> Type;
+    using Type = WebCore::ExceptionOr<void>;
+    static constexpr bool IsNeeded = true;
     static Type copy(const Type& source)
     {
         if (source.hasException())

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -234,11 +234,11 @@ def message_to_struct_declaration(receiver, message):
         result.append('    using ReplyArguments = std::tuple<%s>;\n' % ', '.join([parameter.type for parameter in message.reply_parameters]))
         if not message.has_attribute(SYNCHRONOUS_ATTRIBUTE):
             if len(message.reply_parameters) == 0:
-                result.append('    using Promise = WTF::NativePromise<void, IPC::Error, true>;\n')
+                result.append('    using Promise = WTF::NativePromise<void, IPC::Error>;\n')
             elif len(message.reply_parameters) == 1:
-                result.append('    using Promise = WTF::NativePromise<%s, IPC::Error, true>;\n' % message.reply_parameters[0].type)
+                result.append('    using Promise = WTF::NativePromise<%s, IPC::Error>;\n' % message.reply_parameters[0].type)
             else:
-                result.append('    using Promise = WTF::NativePromise<std::tuple<%s>, IPC::Error, true>;\n' % ', '.join([parameter.type for parameter in message.reply_parameters]))
+                result.append('    using Promise = WTF::NativePromise<std::tuple<%s>, IPC::Error>;\n' % ', '.join([parameter.type for parameter in message.reply_parameters]))
 
     if len(function_parameters):
         result.append('    %s%s(%s)' % (len(function_parameters) == 1 and 'explicit ' or '', message.name, ', '.join([' '.join(x) for x in function_parameters])))

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
@@ -81,7 +81,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RetainPtr<CVPixelBufferRef>>;
-    using Promise = WTF::NativePromise<RetainPtr<CVPixelBufferRef>, IPC::Error, true>;
+    using Promise = WTF::NativePromise<RetainPtr<CVPixelBufferRef>, IPC::Error>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
@@ -76,7 +76,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithImageData_ReceiveImageDataReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RefPtr<WebCore::ImageData>>;
-    using Promise = WTF::NativePromise<RefPtr<WebCore::ImageData>, IPC::Error, true>;
+    using Promise = WTF::NativePromise<RefPtr<WebCore::ImageData>, IPC::Error>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -307,7 +307,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_CreatePluginReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
-    using Promise = WTF::NativePromise<bool, IPC::Error, true>;
+    using Promise = WTF::NativePromise<bool, IPC::Error>;
     CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
         : m_arguments(pluginInstanceID, parameters)
     {
@@ -334,7 +334,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    using Promise = WTF::NativePromise<void, IPC::Error, true>;
+    using Promise = WTF::NativePromise<void, IPC::Error>;
     RunJavaScriptAlert(uint64_t frameID, const String& message)
         : m_arguments(frameID, message)
     {
@@ -361,7 +361,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_GetPluginsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::PluginInfo>>;
-    using Promise = WTF::NativePromise<Vector<WebCore::PluginInfo>, IPC::Error, true>;
+    using Promise = WTF::NativePromise<Vector<WebCore::PluginInfo>, IPC::Error>;
     explicit GetPlugins(bool refresh)
         : m_arguments(refresh)
     {
@@ -528,7 +528,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEventReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::KeypressCommand>>;
-    using Promise = WTF::NativePromise<Vector<WebCore::KeypressCommand>, IPC::Error, true>;
+    using Promise = WTF::NativePromise<Vector<WebCore::KeypressCommand>, IPC::Error>;
     explicit InterpretKeyEvent(uint32_t type)
         : m_arguments(type)
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
@@ -75,7 +75,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Semaphore>;
-    using Promise = WTF::NativePromise<IPC::Semaphore, IPC::Error, true>;
+    using Promise = WTF::NativePromise<IPC::Semaphore, IPC::Error>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -81,7 +81,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_SendStringAsyncReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<int64_t>;
-    using Promise = WTF::NativePromise<int64_t, IPC::Error, true>;
+    using Promise = WTF::NativePromise<int64_t, IPC::Error>;
     explicit SendStringAsync(const String& url)
         : m_arguments(url)
     {
@@ -139,7 +139,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_CallWithIdentifierReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    using Promise = WTF::NativePromise<void, IPC::Error, true>;
+    using Promise = WTF::NativePromise<void, IPC::Error>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
@@ -81,7 +81,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::MainThread;
     using ReplyArguments = std::tuple<uint64_t>;
-    using Promise = WTF::NativePromise<uint64_t, IPC::Error, true>;
+    using Promise = WTF::NativePromise<uint64_t, IPC::Error>;
     explicit TestAsyncMessage(WebKit::TestTwoStateEnum twoStateEnum)
         : m_arguments(twoStateEnum)
     {
@@ -110,7 +110,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    using Promise = WTF::NativePromise<void, IPC::Error, true>;
+    using Promise = WTF::NativePromise<void, IPC::Error>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);
@@ -134,7 +134,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool, uint64_t>;
-    using Promise = WTF::NativePromise<std::tuple<bool, uint64_t>, IPC::Error, true>;
+    using Promise = WTF::NativePromise<std::tuple<bool, uint64_t>, IPC::Error>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);
@@ -158,7 +158,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
-    using Promise = WTF::NativePromise<bool, IPC::Error, true>;
+    using Promise = WTF::NativePromise<bool, IPC::Error>;
     explicit TestAsyncMessageWithConnection(const int& value)
         : m_arguments(value)
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -307,7 +307,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_CreatePluginReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
-    using Promise = WTF::NativePromise<bool, IPC::Error, true>;
+    using Promise = WTF::NativePromise<bool, IPC::Error>;
     CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
         : m_arguments(pluginInstanceID, parameters)
     {
@@ -334,7 +334,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlertReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    using Promise = WTF::NativePromise<void, IPC::Error, true>;
+    using Promise = WTF::NativePromise<void, IPC::Error>;
     RunJavaScriptAlert(uint64_t frameID, const String& message)
         : m_arguments(frameID, message)
     {
@@ -361,7 +361,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_GetPluginsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::PluginInfo>>;
-    using Promise = WTF::NativePromise<Vector<WebCore::PluginInfo>, IPC::Error, true>;
+    using Promise = WTF::NativePromise<Vector<WebCore::PluginInfo>, IPC::Error>;
     explicit GetPlugins(bool refresh)
         : m_arguments(refresh)
     {
@@ -528,7 +528,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_InterpretKeyEventReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::KeypressCommand>>;
-    using Promise = WTF::NativePromise<Vector<WebCore::KeypressCommand>, IPC::Error, true>;
+    using Promise = WTF::NativePromise<Vector<WebCore::KeypressCommand>, IPC::Error>;
     explicit InterpretKeyEvent(uint32_t type)
         : m_arguments(type)
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h
@@ -70,7 +70,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    using Promise = WTF::NativePromise<void, IPC::Error, true>;
+    using Promise = WTF::NativePromise<void, IPC::Error>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);
@@ -92,7 +92,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<String>;
-    using Promise = WTF::NativePromise<String, IPC::Error, true>;
+    using Promise = WTF::NativePromise<String, IPC::Error>;
     auto&& arguments()
     {
         return WTFMove(m_arguments);
@@ -137,7 +137,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReplyReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    using Promise = WTF::NativePromise<void, IPC::Error, true>;
+    using Promise = WTF::NativePromise<void, IPC::Error>;
     explicit MessageWithArgumentAndEmptyReply(const String& argument)
         : m_arguments(argument)
     {
@@ -164,7 +164,7 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgumentReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<String>;
-    using Promise = WTF::NativePromise<String, IPC::Error, true>;
+    using Promise = WTF::NativePromise<String, IPC::Error>;
     explicit MessageWithArgumentAndReplyWithArgument(const String& argument)
         : m_arguments(argument)
     {

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -65,7 +65,7 @@ struct MockTestMessageWithAsyncReply1 {
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
     std::tuple<> arguments() { return { }; }
     using ReplyArguments = std::tuple<uint64_t>;
-    using Promise = WTF::NativePromise<uint64_t, IPC::Error, true>;
+    using Promise = WTF::NativePromise<uint64_t, IPC::Error>;
 };
 
 class MockConnectionClient final : public IPC::Connection::Client {


### PR DESCRIPTION
#### 0345168e97b5e2c1fa074c8b5c9d721e23ae60ce
<pre>
NativePromise should provide a safe way to pass some argument types
<a href="https://bugs.webkit.org/show_bug.cgi?id=262437">https://bugs.webkit.org/show_bug.cgi?id=262437</a>
rdar://116274506

Reviewed by Youenn Fablet.

We expand the scope of CrossThreadCopier so that it can always deal with
r-values, including those without an isolatedCopy() method.
Add specialisation for void, std::tuple and AtomString.
We allow using non-threadsafe refcount when using only r-value as the object
can be safely moved around.

NativePromise aims to add a layer between the producer and the consumer such
that the producer doesn&apos;t have to know the threading model of the consumer.
To achieve this, we needed to have a way to guarantee that the object returned
by the producer is usable on any threads. By using this expanded CrossThreadCopier
in NativePromise we achieve that goal.
It is now safe to have NativePromise using Strings, AtomString and any
supported composite objects using those (tuple, variant, pair, expected,
Vector, optional, HashMap, HashSet)
Should more specialisation be needed, they should be added to CrossThreadCopier.

Non Exclusive NativePromise requires the programmer to explicitly define
the behaviour: that is always use CrossThreadCopy or never do.

Add API tests.

* Source/WTF/wtf/CrossThreadCopier.cpp:
* Source/WTF/wtf/CrossThreadCopier.h:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/NativePromise.h:
(WTF::operator|):
(WTF::operator&amp;):
* Source/WTF/wtf/TypeTraits.h:
* Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp: Make use of the ability of
rejecting with an Exception object.
(WebCore::AsyncAudioDecoder::decodeAsync):
* Source/WebCore/Modules/webaudio/AsyncAudioDecoder.h: Update definition of DecodingTaskPromise
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::decodeAudioData):
* Source/WebCore/dom/ExceptionOr.h:
* Source/WebKit/Scripts/webkit/messages.py:
(message_to_struct_declaration):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h:
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessages.h:
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268880@main">https://commits.webkit.org/268880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aa0100da64ba8d23dda382c6744c216e246e0c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20858 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19435 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20722 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23602 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/21045 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25220 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18168 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23130 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20280 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16719 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24268 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18929 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5026 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23258 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25530 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19503 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5589 "Passed tests") | 
<!--EWS-Status-Bubble-End-->