### PR TITLE
[Win] Fix -Wundef and -Wnonportable-include-path compiler warnings

### DIFF
--- a/Source/WTF/wtf/Brigand.h
+++ b/Source/WTF/wtf/Brigand.h
@@ -38,7 +38,7 @@
 #elif _MSC_VER == 1800
 #define BRIGAND_COMP_MSVC_2013
 #endif
-#elif __GNUC__
+#elif defined(__GNUC__)
 #ifndef __clang__
 #define BRIGAND_COMP_GCC
 #else

--- a/Source/WebCore/crypto/openssl/OpenSSLUtilities.h
+++ b/Source/WebCore/crypto/openssl/OpenSSLUtilities.h
@@ -30,7 +30,7 @@
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 #include <stdint.h>
-#include <wtf/NonCopyable.h>
+#include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
 
 #if ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/platform/network/curl/CookieJarDB.cpp
+++ b/Source/WebCore/platform/network/curl/CookieJarDB.cpp
@@ -24,7 +24,7 @@
 
 #include "config.h"
 #include "CookieJarDB.h"
-#include "cookieJar.h"
+#include "CookieJar.h"
 
 #include "CookieUtil.h"
 #include "Logging.h"

--- a/Source/WebCore/platform/win/HWndDC.h
+++ b/Source/WebCore/platform/win/HWndDC.h
@@ -27,7 +27,7 @@
 #define HWndDC_h
 
 #include <windows.h>
-#include <wtf/NonCopyable.h>
+#include <wtf/Noncopyable.h>
 
 namespace WebCore {
 

--- a/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
+++ b/Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp
@@ -29,8 +29,8 @@
 
 #include "Connection.h"
 #include "IPCUtilities.h"
-#include <WTF/RunLoop.h>
 #include <shlwapi.h>
+#include <wtf/RunLoop.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebKit {

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -109,13 +109,8 @@ if (COMPILER_IS_GCC_OR_CLANG)
     # we do not add -fno-rtti or -fno-exceptions for clang-cl
     if (COMPILER_IS_CLANG_CL)
         # FIXME: These warnings should be addressed
-        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-undef
-                                             -Wno-macro-redefined
-                                             -Wno-unknown-pragmas
-                                             -Wno-nonportable-include-path
-                                             -Wno-sign-compare
-                                             -Wno-deprecated-declarations
-                                             -Wno-unknown-argument)
+        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-sign-compare
+                                             -Wno-deprecated-declarations)
     else ()
         WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-exceptions)
         WEBKIT_APPEND_GLOBAL_CXX_FLAGS(-fno-rtti)

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2565,6 +2565,11 @@ sub shouldRemoveCMakeCache(@)
         return 1;
     }
 
+    my $compilerFlagsCMake = File::Spec->catdir(sourceDir(), "Source", "cmake", "WebKitCompilerFlags.cmake");
+    if ($cacheFileModifiedTime < stat($compilerFlagsCMake)->mtime) {
+        return 1;
+    }
+
     # FIXME: This probably does not work as expected, or the next block to
     # delete the images subdirectory would not be here. Directory mtime does not
     # percolate upwards when files are added or removed from subdirectories.

--- a/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
@@ -25,7 +25,7 @@
 
 #include "config.h"
 
-#include <PAL/crypto/CryptoDigest.h>
+#include <pal/crypto/CryptoDigest.h>
 #include <wtf/text/CString.h>
 
 namespace TestWebKitAPI {


### PR DESCRIPTION
#### fed6dd1cc3869b517a33f1f8a22df6c30a0e0a2d
<pre>
[Win] Fix -Wundef and -Wnonportable-include-path compiler warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=262473">https://bugs.webkit.org/show_bug.cgi?id=262473</a>

Reviewed by Ross Kirsling.

Fixed more clang-cl warnings.

&gt; wtf/Brigand.h(41,7): warning: &apos;__GNUC__&apos; is not defined, evaluates to 0 [-Wundef]
&gt; Source\WebCore\platform\network\curl\CookieJarDB.cpp(27,10): warning: non-portable path to file &apos;&quot;CookieJar.h&quot;&apos;;
&gt;   specified path differs in case from file name on disk [-Wnonportable-include-path]

* Source/WTF/wtf/Brigand.h:
* Source/WebCore/crypto/openssl/OpenSSLUtilities.h:
* Source/WebCore/platform/network/curl/CookieJarDB.cpp:
* Source/WebCore/platform/win/HWndDC.h:
* Source/WebKit/UIProcess/Launcher/win/ProcessLauncherWin.cpp:
* Source/cmake/WebKitCompilerFlags.cmake:
* Tools/Scripts/webkitdirs.pm:
(shouldRemoveCMakeCache): Remove CMakeCache.txt if WebKitCompilerFlags.cmake is modified.
* Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp:

Canonical link: <a href="https://commits.webkit.org/268748@main">https://commits.webkit.org/268748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d08928a8046e6b5026cb78573bd458a003b588e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22447 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21152 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23305 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18673 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/17898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18850 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/19979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23959 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18654 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5726 "Found 2 jsc stress test failures: stress/sampling-profiler-microtasks.js.mini-mode, stress/sampling-profiler-microtasks.js.no-cjit-collect-continuously") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22991 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25218 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2540 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/19255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5550 "Passed tests") | 
<!--EWS-Status-Bubble-End-->