### PR TITLE
formAssociated=true shouldn’t cause custom element to become focusable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/focusability-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/focusability-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Focusability of form-associated custom elements
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/focusability.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/focusability.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<title>Focusability of form-associated custom elements</title>
+<link rel="author" title="Michael[tm] Smith" href="mailto:mike@w3.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<x-foo></x-foo>
+<x-bar tabindex=0></x-bar>
+<x-baz tabindex=0 disabled></x-baz>
+<script>
+  test(() => {
+    customElements.define(
+        'x-foo',
+        class Foo extends HTMLElement {
+            static formAssociated = true;
+        }
+    );
+    const foo = document.querySelector('x-foo');
+    foo.focus();
+    assert_false(document.activeElement === foo,
+      "FACE without tabindex is not focusable.");
+    customElements.define(
+        'x-bar',
+        class bar extends HTMLElement {
+            static formAssociated = true;
+        }
+    );
+    const bar = document.querySelector('x-bar');
+    bar.focus();
+    assert_true(document.activeElement === bar,
+      "FACE with tabindex is focusable.");
+    customElements.define(
+        'x-baz',
+        class baz extends HTMLElement {
+            static formAssociated = true;
+        }
+    );
+    const baz = document.querySelector('x-baz');
+    baz.focus();
+    assert_false(document.activeElement === baz,
+      "Disabled FACE with tabindex is not focusable.");
+  });
+</script>
+</html>

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
@@ -27,6 +27,7 @@
 #include "HTMLMaybeFormAssociatedCustomElement.h"
 
 #include "Document.h"
+#include "ElementRareData.h"
 #include "FormAssociatedCustomElement.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -106,7 +107,7 @@ bool HTMLMaybeFormAssociatedCustomElement::matchesUserInvalidPseudoClass() const
 
 bool HTMLMaybeFormAssociatedCustomElement::supportsFocus() const
 {
-    return isFormAssociatedCustomElement() ? !formAssociatedCustomElementUnsafe().isDisabled() : HTMLElement::supportsFocus();
+    return isFormAssociatedCustomElement() ? (shadowRoot() && shadowRoot()->delegatesFocus()) || (HTMLElement::supportsFocus() && !formAssociatedCustomElementUnsafe().isDisabled()) : HTMLElement::supportsFocus();
 }
 
 bool HTMLMaybeFormAssociatedCustomElement::isLabelable() const


### PR DESCRIPTION
#### 7e0cd07bab81cbd7cc043a2db4586136ca1d1307
<pre>
formAssociated=true shouldn’t cause custom element to become focusable
<a href="https://bugs.webkit.org/show_bug.cgi?id=261621">https://bugs.webkit.org/show_bug.cgi?id=261621</a>

Reviewed by Ryosuke Niwa.

This change fixes a bug that caused any custom element to become
focusable just by setting its formAssociated value to true — even if the
custom element doesn’t have a tabindex value.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/focusability-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/focusability.html: Added.
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp:
(WebCore::HTMLMaybeFormAssociatedCustomElement::supportsFocus const):

Canonical link: <a href="https://commits.webkit.org/268756@main">https://commits.webkit.org/268756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74d781edb91e1e269a5c5f806034685353cf291b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20718 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20520 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23238 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24903 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22843 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16466 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18450 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4939 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->