### PR TITLE
Fix cue ordering affected by TextTrackCue property mutation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt
@@ -1,4 +1,4 @@
 
 PASS VTTCue.snapToLines, script-created cue
-FAIL VTTCue.snapToLines, parsed cue assert_true: expected true got false
+PASS VTTCue.snapToLines, parsed cue
 

--- a/LayoutTests/media/track/texttrackcue/texttrackcue-order-expected.txt
+++ b/LayoutTests/media/track/texttrackcue/texttrackcue-order-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS VTTCue order, cue order should change only when start time or end time is changed
+

--- a/LayoutTests/media/track/texttrackcue/texttrackcue-order.html
+++ b/LayoutTests/media/track/texttrackcue/texttrackcue-order.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<title>VTTCue order</title>
+<script src=../../../resources/testharness.js></script>
+<script src=../../../resources/testharnessreport.js></script>
+<div>  </div>
+<script>
+function make_vtt_track(contents, test) {
+    var track_blob = new Blob([contents], { type: 'text/vtt' });
+    var track_url = URL.createObjectURL(track_blob);
+    test.add_cleanup(function() {
+        URL.revokeObjectURL(track_url);
+    });
+    return track_url;
+}
+
+setup(function(){
+    window.internals.setCaptionDisplayMode("automatic");
+    window.video = document.createElement('video');
+    window.t1 = video.addTextTrack('subtitles');
+    document.body.appendChild(video);
+});
+
+var t_parsed = async_test(document.title+', cue order should change only when start time or end time is changed');
+t_parsed.step(function(){
+    var t = document.createElement('track');
+    t.onload = this.step_func(function(){
+        assert_equals(t.track.cues[0].id, '0');
+        assert_equals(t.track.cues[1].id, '1');
+        assert_equals(t.track.cues[2].id, '2');
+        assert_equals(t.track.cues[3].id, '3');
+
+        t.track.cues[1].line = 10;
+        t.track.cues[1].snapToLines = false;
+        t.track.cues[1].size = 50;
+        t.track.cues[1].align = 'right';
+        t.track.cues[1].position = 10;
+        t.track.cues[1].positionAlign = "center";
+        assert_equals(t.track.cues[0].id, '0');
+        assert_equals(t.track.cues[1].id, '1');
+        assert_equals(t.track.cues[2].id, '2');
+        assert_equals(t.track.cues[3].id, '3');
+
+        t.track.cues[1].startTime = 1;
+        assert_equals(t.track.cues[0].id, '0');
+        assert_equals(t.track.cues[1].id, '2');
+        assert_equals(t.track.cues[2].id, '3');
+        assert_equals(t.track.cues[3].id, '1');
+
+        t.track.cues[2].endTime = 2;
+        assert_equals(t.track.cues[0].id, '3');
+        assert_equals(t.track.cues[1].id, '0');
+        assert_equals(t.track.cues[2].id, '2');
+        assert_equals(t.track.cues[3].id, '1');
+
+        this.done();
+    });
+    t.onerror = this.step_func(function() {
+      assert_unreached('got error event');
+    });
+    t.src = make_vtt_track('WEBVTT\n\n'+
+                            '0\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                            '1\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                            '2\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                            '3\n00:00:00.000 --> 00:00:00.001\ntest', this);
+    t.track.mode = 'showing';
+    video.appendChild(t);
+});
+</script>

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -437,10 +437,11 @@ void TextTrack::cueWillChange(TextTrackCue& cue)
     });
 }
 
-void TextTrack::cueDidChange(TextTrackCue& cue)
+void TextTrack::cueDidChange(TextTrackCue& cue, bool updateCueOrder)
 {
     // Make sure the TextTrackCueList order is up-to-date.
-    ensureTextTrackCueList().updateCueIndex(cue);
+    if (updateCueOrder)
+        ensureTextTrackCueList().updateCueIndex(cue);
 
     // ... and add it back again.
     m_clients.forEach([&] (auto& client) {

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -89,7 +89,7 @@ public:
     VTTRegionList* regions();
 
     void cueWillChange(TextTrackCue&);
-    void cueDidChange(TextTrackCue&);
+    void cueDidChange(TextTrackCue&, bool);
 
     enum TextTrackType { TrackElement, AddTrack, InBand };
     TextTrackType trackType() const { return m_trackType; }

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -246,7 +246,7 @@ void TextTrackCue::willChange()
         m_track->cueWillChange(*this);
 }
 
-void TextTrackCue::didChange()
+void TextTrackCue::didChange(bool affectOrder)
 {
     ASSERT(m_processingCueChanges);
     if (--m_processingCueChanges)
@@ -255,7 +255,7 @@ void TextTrackCue::didChange()
     m_displayTreeNeedsUpdate = true;
 
     if (m_track)
-        m_track->cueDidChange(*this);
+        m_track->cueDidChange(*this, affectOrder);
 }
 
 TextTrack* TextTrackCue::track() const
@@ -290,7 +290,7 @@ void TextTrackCue::setStartTime(const MediaTime& value)
 {
     willChange();
     m_startTime = value;
-    didChange();
+    didChange(true);
 }
 
 void TextTrackCue::setEndTime(double value)
@@ -305,7 +305,7 @@ void TextTrackCue::setEndTime(const MediaTime& value)
 {
     willChange();
     m_endTime = value;
-    didChange();
+    didChange(true);
 }
 
 void TextTrackCue::setPauseOnExit(bool value)

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -107,7 +107,7 @@ public:
     bool isEqual(const TextTrackCue&, CueMatchRules) const;
 
     void willChange();
-    virtual void didChange();
+    virtual void didChange(bool = false);
 
     virtual RefPtr<TextTrackCueBox> getDisplayTree();
     virtual void removeDisplayTree();

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -329,9 +329,9 @@ VTTCueBox* VTTCue::displayTreeInternal()
     return m_displayTree.get();
 }
 
-void VTTCue::didChange()
+void VTTCue::didChange(bool affectOrder)
 {
-    TextTrackCue::didChange();
+    TextTrackCue::didChange(affectOrder);
     m_displayTreeShouldChange = true;
 }
 

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -199,7 +199,7 @@ public:
     CueType cueType() const override { return WebVTT; }
     bool isRenderable() const final { return !m_content.isEmpty(); }
 
-    void didChange() final;
+    void didChange(bool = false) final;
 
     double calculateComputedTextPosition() const;
     PositionAlignSetting calculateComputedPositionAlignment() const;


### PR DESCRIPTION
#### 1e25aac1511ac92e723d32ba4554cd36a55ba669
<pre>
Fix cue ordering affected by TextTrackCue property mutation
<a href="https://bugs.webkit.org/show_bug.cgi?id=262474">https://bugs.webkit.org/show_bug.cgi?id=262474</a>

Reviewed by Eric Carlson.

The ordering of the cues in TextTrack is defined as follows:

&gt; ... cues must be sorted by their start time, earliest first;
&gt; then, any cues with the same start time must be sorted by their end time,
&gt; latest first; and finally, any cues with identical end times must be sorted
&gt; in the order they were last added ...
&gt; <a href="https://html.spec.whatwg.org/multipage/media.html#text-track-cue-order">https://html.spec.whatwg.org/multipage/media.html#text-track-cue-order</a>

However, there is a current issue where mutating a property of a TextTrackCue/
VTTCue (except for .startTime/.endTime) results in a rearrangement of cues,
causing cues with identical start/end time to be resorted, then deviating from
the intended order.

This change fix the issue by updating to the ordering of cues only when changes
are made to the .startTime or .endTime properties.

* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/snapToLines-expected.txt:
* LayoutTests/media/track/texttrackcue/texttrackcue-order-expected.txt: Added.
* LayoutTests/media/track/texttrackcue/texttrackcue-order.html: Added.
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::cueDidChange):
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::didChange):
(WebCore::TextTrackCue::setStartTime):
(WebCore::TextTrackCue::setEndTime):
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::didChange):
* Source/WebCore/html/track/VTTCue.h:

Canonical link: <a href="https://commits.webkit.org/268857@main">https://commits.webkit.org/268857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce21de223df07a970e11e4245f804a6fbf5121c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20508 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23231 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24898 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22838 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16458 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5009 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22932 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->