### PR TITLE
[WPE] Timers are not being scheduled when animations take all the CPU

### DIFF
--- a/Source/WTF/wtf/glib/RunLoopSourcePriority.h
+++ b/Source/WTF/wtf/glib/RunLoopSourcePriority.h
@@ -84,8 +84,8 @@ enum RunLoopSourcePriority {
     JavascriptTimer = 10,
     MainThreadSharedTimer = 10,
 
-    LayerFlushTimer = 0,
-    DisplayRefreshMonitorTimer = 0,
+    LayerFlushTimer = 20,
+    DisplayRefreshMonitorTimer = 20,
 
     CompositingThreadUpdateTimer = 0,
 


### PR DESCRIPTION
#### 0ef6ff1932f9a0df7511d8f597d96e202772338a
<pre>
[WPE] Timers are not being scheduled when animations take all the CPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=262477">https://bugs.webkit.org/show_bug.cgi?id=262477</a>

Reviewed by NOBODY (OOPS!).

The ThreadedDisplayRefreshMonitor can take time (layout, ...) and has an higher priority
than the main SharedTimer.
This means that animations could prevent the timers from executing, if the JS relies on this
to stop the animation the page appears to be stuck.

This is the same as <a href="https://commits.webkit.org/226833@main">https://commits.webkit.org/226833@main</a> done for GTK.

* Source/WTF/wtf/glib/RunLoopSourcePriority.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ef6ff1932f9a0df7511d8f597d96e202772338a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22384 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19116 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21086 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20513 "20 flakes 173 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23237 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24902 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17837 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22842 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19915 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16464 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23893 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18598 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5716 "Found 3 jsc stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.default, stress/sampling-profiler-microtasks.js.dfg-eager") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22938 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25150 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19205 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5539 "Passed tests") | 
<!--EWS-Status-Bubble-End-->