### PR TITLE
[EWS] Add WPE API testers for the EWS

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -35,6 +35,10 @@
     { "name": "igalia9-wpe-ews", "platform": "wpe" },
     { "name": "igalia10-wpe-ews", "platform": "wpe" },
     { "name": "igalia11-wpe-ews", "platform": "wpe" },
+    { "name": "igalia12-wpe-ews", "platform": "wpe" },
+    { "name": "igalia13-wpe-ews", "platform": "wpe" },
+    { "name": "igalia14-wpe-ews", "platform": "wpe" },
+    { "name": "igalia15-wpe-ews", "platform": "wpe" },
     { "name": "aperez-wpe-ews", "platform": "wpe" },
     { "name": "wincairo-ews-001", "platform": "wincairo" },
     { "name": "wincairo-ews-002", "platform": "wincairo" },
@@ -279,7 +283,7 @@
       "name": "WPE-Build-EWS", "shortname": "wpe", "icon": "buildOnly",
       "factory": "WPEBuildFactory", "platform": "wpe",
       "configuration": "release", "architectures": ["x86_64"],
-      "triggers": ["wpe-wk2-tests-ews"],
+      "triggers": ["wpe-wk2-tests-ews", "api-tests-wpe-ews"],
       "workernames": ["aperez-wpe-ews", "igalia-wpe-ews", "igalia2-wpe-ews", "igalia3-wpe-ews"]
     },
     {
@@ -369,6 +373,13 @@
       "configuration": "release", "architectures": ["x86_64"],
       "triggered_by": ["gtk-build-ews"],
       "workernames": ["igalia3-gtk-wk2-ews", "igalia4-gtk-wk2-ews", "igalia14-gtk-wk2-ews", "igalia15-gtk-wk2-ews"]
+    },
+    {
+      "name": "API-Tests-WPE-EWS", "shortname": "api-wpe", "icon": "testOnly",
+      "factory": "APITestsFactory", "platform": "wpe",
+      "configuration": "release", "architectures": ["x86_64"],
+      "triggered_by": ["wpe-build-ews"],
+      "workernames": ["igalia12-wpe-ews", "igalia13-wpe-ews", "igalia14-wpe-ews", "igalia15-wpe-ews"]
     },
     {
       "name": "Services-EWS", "shortname": "services", "icon": "testOnly",
@@ -499,6 +510,10 @@
     {
       "type": "Triggerable", "name": "wpe-wk2-tests-ews",
       "builderNames": ["WPE-WK2-Tests-EWS"]
+    },
+    {
+      "type": "Triggerable", "name": "api-tests-wpe-ews",
+      "builderNames": ["API-Tests-WPE-EWS"]
     },
     {
       "type": "Triggerable", "name": "jsc-tests-mipsel-tests-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -601,6 +601,23 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'kill-old-processes',
             'run-api-tests'
         ],
+        'API-Tests-WPE-EWS': [
+            'configure-build',
+            'validate-change',
+            'configuration',
+            'clean-up-git-repo',
+            'checkout-source',
+            'fetch-branch-references',
+            'checkout-specific-revision',
+            'show-identifier',
+            'apply-patch',
+            'checkout-pull-request',
+            'jhbuild',
+            'download-built-product',
+            'extract-built-product',
+            'kill-old-processes',
+            'run-api-tests'
+        ],
         'Services-EWS': [
             'configure-build',
             'check-change-relevance',


### PR DESCRIPTION
#### 84f4eb1e49007fdb0ca968308a73aef786021010
<pre>
[EWS] Add WPE API testers for the EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=262478">https://bugs.webkit.org/show_bug.cgi?id=262478</a>

Reviewed by Aakash Jain and Jonathan Bedard.

Add a new test queue to the EWS to run API tests
with the WPE port. It adds 4 new workers for this
new test queue like we already have for the GTK port.

This patch only adds the new testers on the EWS,
the changes on the UI to add the new status bubbles
will come on a follow-up patch later once we verify
that the new queue is running as expected.

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/269162@main">https://commits.webkit.org/269162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/337fae3aaa20eb73686a3e2be8375b7108702902

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21763 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/22007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23631 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22004 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22295 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21991 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24484 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/19703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/23855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/21573 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19727 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2701 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->