### PR TITLE
Implement full showPicker() support on iOS

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-show-picker.html
+++ b/LayoutTests/fast/forms/datalist/datalist-show-picker.html
@@ -31,11 +31,20 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 
+function waitForDataListSuggestionsToChangeVisibility(visible)
+{
+    return new Promise(async resolve => {
+        while (visible != await UIHelper.isShowingDataListSuggestions())
+            continue;
+        resolve();
+    });
+}
+
 async function runTest() {
     await UIHelper.activateAt(0, 0);
 
     input.showPicker();
-
+    await waitForDataListSuggestionsToChangeVisibility(true);
     before.textContent = await UIHelper.isShowingDataListSuggestions();
 
     testRunner.notifyDone();

--- a/LayoutTests/fast/forms/date/date-show-picker.html
+++ b/LayoutTests/fast/forms/date/date-show-picker.html
@@ -26,12 +26,30 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 
+function getFormControlInteractionScript()
+{
+    return `
+    (function() {
+        uiController.didStartFormControlInteractionCallback(function () {
+            uiController.uiScriptComplete();
+        })
+    })();`
+}
+
 async function runTest() {
     await UIHelper.activateAt(0, 0);
     input.showPicker();
 
-    before.textContent = await UIHelper.isShowingDateTimePicker();
-
+    if (UIHelper.isIOSFamily()) {
+        await new Promise((resolve) => {
+            testRunner.runUIScript(getFormControlInteractionScript(), function () {
+                resolve();
+            });
+        });
+        before.textContent = 'true';
+    } else {
+        before.textContent = await UIHelper.isShowingDateTimePicker();
+    }
     testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker.html
@@ -26,12 +26,30 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 
+function getFormControlInteractionScript()
+{
+    return `
+    (function() {
+        uiController.didStartFormControlInteractionCallback(function () {
+            uiController.uiScriptComplete();
+        })
+    })();`
+}
+
 async function runTest() {
     await UIHelper.activateAt(0, 0);
     input.showPicker();
 
-    before.textContent = await UIHelper.isShowingDateTimePicker();
-
+    if (UIHelper.isIOSFamily()) {
+        await new Promise((resolve) => {
+            testRunner.runUIScript(getFormControlInteractionScript(), function () {
+                resolve();
+            });
+        });
+        before.textContent = 'true';
+    } else {
+        before.textContent = await UIHelper.isShowingDateTimePicker();
+    }
     testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/fast/forms/ios/color-show-picker-expected.txt
+++ b/LayoutTests/fast/forms/ios/color-show-picker-expected.txt
@@ -1,0 +1,4 @@
+
+Is showing color picker? true
+
+This test verifies that a color picker is presented when calling showPicker on a color input.

--- a/LayoutTests/fast/forms/ios/color-show-picker.html
+++ b/LayoutTests/fast/forms/ios/color-show-picker.html
@@ -15,13 +15,10 @@ body {
 </style>
 <head>
 <body onload="runTest()">
-<select name="select" id="select">
-    <option value="one">One</option>
-    <option value="two">Two</option>
-</select>
-<pre>Is showing popup? <span id="before"></span></pre>
+<input id="input" type="color"/>
+<pre>Is showing color picker? <span id="before"></span></pre>
 <br>
-<div>This test verifies that the popup is presented when calling showPicker on a select.</div>
+<div>This test verifies that a color picker is presented when calling showPicker on a color input.</div>
 </body>
 <script>
 if (window.testRunner) {
@@ -41,17 +38,11 @@ function getFormControlInteractionScript()
 
 async function runTest() {
     await UIHelper.activateAt(0, 0);
-    select.showPicker();
-
-    if (UIHelper.isIOSFamily()) {
-        await new Promise((resolve) => {
-            testRunner.runUIScript(getFormControlInteractionScript(), resolve);
-        });
-        before.textContent = 'true';
-    } else {
-        before.textContent = internals.isSelectPopupVisible(select);
-    }
-
+    input.showPicker();
+    await new Promise((resolve) => {
+        testRunner.runUIScript(getFormControlInteractionScript(), resolve);
+    });
+    before.textContent = 'true';
     testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3292,14 +3292,6 @@ fast/text/canceled-mousemove-does-not-prevent-selectionchange.html [ Failure ]
 # FIXME: These tests require UIScriptControllerIOS additions to know when a date/time picker is presented
 fast/forms/date/date-show-hide-picker.html [ Skip ]
 fast/forms/datetimelocal/datetimelocal-show-hide-picker.html [ Skip ]
-fast/forms/date/date-show-picker.html [ Skip ]
-fast/forms/datetimelocal/datetimelocal-show-picker.html [ Skip ]
-
-# showPicker not yet implemented for iOS
-webkit.org/b/261703 fast/forms/select/select-show-picker.html [ Skip ]
-
-# showPicker not yet implemented for iOS
-webkit.org/b/261703 fast/forms/datalist/datalist-show-picker.html [ Skip ]
 
 # <rdar://problem/59636115> REGRESSION: [ iOS & macOS ] two imported/w3c/web-platform-tests/WebCryptoAPI are failing
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.worker.html [ Failure ]

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -314,6 +314,9 @@ void BaseDateAndTimeInputType::showPicker()
     if (!element()->document().page())
         return;
 
+#if PLATFORM(IOS_FAMILY)
+    element()->focus();
+#else
     DateTimeChooserParameters parameters;
     if (!setupDateTimeChooserParameters(parameters))
         return;
@@ -323,6 +326,7 @@ void BaseDateAndTimeInputType::showPicker()
         if (m_dateTimeChooser)
             m_dateTimeChooser->showChooser(parameters);
     }
+#endif
 }
 
 void BaseDateAndTimeInputType::createShadowSubtree()

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -197,12 +197,16 @@ void ColorInputType::handleDOMActivateEvent(Event& event)
 
 void ColorInputType::showPicker() 
 {
+#if PLATFORM(IOS_FAMILY)
+    element()->focus();
+#else
     if (Chrome* chrome = this->chrome()) {
         if (!m_chooser)
             m_chooser = chrome->createColorChooser(*this, valueAsColor());
         else
             m_chooser->reattachColorChooser(valueAsColor());
     }
+#endif
 }
 
 bool ColorInputType::allowsShowPickerAcrossFrames()

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1686,7 +1686,9 @@ ExceptionOr<void> HTMLSelectElement::showPicker()
     if (!window || !window->hasTransientActivation())
         return Exception { ExceptionCode::NotAllowedError, "Select showPicker() requires a user gesture."_s };
 
-#if !PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY)
+    focus();
+#else
     auto* renderer = this->renderer();
     if (auto* renderMenuList = dynamicDowncast<RenderMenuList>(renderer))
         renderMenuList->showPopup();

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -134,6 +134,15 @@ void MonthInputType::handleDOMActivateEvent(Event&)
 
 void MonthInputType::showPicker()
 {
+    if (!element()->renderer())
+        return;
+
+    if (!element()->document().page())
+        return;
+
+#if PLATFORM(IOS_FAMILY)
+    element()->focus();
+#endif
 }
 
 bool MonthInputType::isValidFormat(OptionSet<DateTimeFormatValidationResults> results) const

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -190,10 +190,11 @@ void TextFieldInputType::handleClickEvent(MouseEvent&)
 
 void TextFieldInputType::showPicker()
 {
-#if !PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY)
+    element()->focus();
+#endif
     if (element()->list())
         displaySuggestions(DataListSuggestionActivationType::ControlClicked);
-#endif
 }
 #endif
 

--- a/Source/WebCore/html/TimeInputType.cpp
+++ b/Source/WebCore/html/TimeInputType.cpp
@@ -109,6 +109,15 @@ void TimeInputType::handleDOMActivateEvent(Event&)
 
 void TimeInputType::showPicker()
 {
+    if (!element()->renderer())
+        return;
+
+    if (!element()->document().page())
+        return;
+
+#if PLATFORM(IOS_FAMILY)
+    element()->focus();
+#endif
 }
 
 bool TimeInputType::isValidFormat(OptionSet<DateTimeFormatValidationResults> results) const


### PR DESCRIPTION
#### 9d6d668d9c5a66f000e3dbfb9f0436535ba74565
<pre>
Implement full showPicker() support on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=261703">https://bugs.webkit.org/show_bug.cgi?id=261703</a>

Reviewed by NOBODY (OOPS!).

Currently only file input works with showPicker on iOS.
This patch expands that to all inputs with a picker UI.
It also adds support for select on iOS.
This is done by calling element()-&gt;focus() where needed.

* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::showPicker):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::showPicker):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::showPicker):
* Source/WebCore/html/MonthInputType.cpp:
(WebCore::MonthInputType::showPicker):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::showPicker):
* Source/WebCore/html/TimeInputType.cpp:
(WebCore::TimeInputType::showPicker):
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/fast/forms/datalist/datalist-show-picker.html:
* LayoutTests/fast/forms/date/date-show-picker.html:
* LayoutTests/fast/forms/datetimelocal/datetimelocal-show-picker.html:
* LayoutTests/fast/forms/ios/color-show-picker-expected.txt: Added.
* LayoutTests/fast/forms/ios/color-show-picker.html: Added.
* LayoutTests/fast/forms/select/select-show-picker.html:
* LayoutTests/platform/ios/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d6d668d9c5a66f000e3dbfb9f0436535ba74565

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38435 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32149 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30925 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36255 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12377 "Found 3 new test failures: fast/dynamic/anchor-lock.html, fast/forms/datalist/datalist-show-picker.html, fast/forms/ios/color-show-picker.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10874 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10877 "Exiting early after 10 failures. 40 tests run. 2 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39682 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32441 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36830 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34916 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31571 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->