### PR TITLE
Regression(268511@main?) 3% PLT regression on some iOS devices

### DIFF
--- a/Source/WebCore/loader/FormState.h
+++ b/Source/WebCore/loader/FormState.h
@@ -41,7 +41,7 @@ enum FormSubmissionTrigger { SubmittedByJavaScript, NotSubmittedByJavaScript };
 
 using StringPairVector = Vector<std::pair<String, String>>;
 
-class FormState : public RefCounted<FormState>, public FrameDestructionObserver {
+class FormState : public RefCounted<FormState>, public CanMakeWeakPtr<FormState>, public FrameDestructionObserver {
 public:
     static Ref<FormState> create(HTMLFormElement&, StringPairVector&& textFieldValues, Document&, FormSubmissionTrigger);
     ~FormState();

--- a/Source/WebCore/page/FrameDestructionObserver.h
+++ b/Source/WebCore/page/FrameDestructionObserver.h
@@ -25,14 +25,13 @@
 
 #pragma once
 
-#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class LocalFrame;
 
-class FrameDestructionObserver : public CanMakeWeakPtr<FrameDestructionObserver> {
+class FrameDestructionObserver {
 public:
     WEBCORE_EXPORT explicit FrameDestructionObserver(LocalFrame*);
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -491,18 +491,20 @@ void LocalDOMWindow::willDestroyCachedFrame()
 {
     // It is necessary to copy m_observers to a separate vector because the Observer may
     // unregister themselves from the LocalDOMWindow as a result of the call to willDestroyGlobalObjectInCachedFrame.
-    m_observers.forEach([](auto& observer) {
-        observer.willDestroyGlobalObjectInCachedFrame();
-    });
+    for (auto* observer : copyToVector(m_observers)) {
+        if (m_observers.contains(observer))
+            observer->willDestroyGlobalObjectInCachedFrame();
+    }
 }
 
 void LocalDOMWindow::willDestroyDocumentInFrame()
 {
     // It is necessary to copy m_observers to a separate vector because the Observer may
     // unregister themselves from the LocalDOMWindow as a result of the call to willDestroyGlobalObjectInFrame.
-    m_observers.forEach([](auto& observer) {
-        observer.willDestroyGlobalObjectInFrame();
-    });
+    for (auto* observer : copyToVector(m_observers)) {
+        if (m_observers.contains(observer))
+            observer->willDestroyGlobalObjectInFrame();
+    }
 }
 
 void LocalDOMWindow::willDetachDocumentFromFrame()
@@ -514,9 +516,10 @@ void LocalDOMWindow::willDetachDocumentFromFrame()
 
     // It is necessary to copy m_observers to a separate vector because the Observer may
     // unregister themselves from the LocalDOMWindow as a result of the call to willDetachGlobalObjectFromFrame.
-    m_observers.forEach([](auto& observer) {
-        observer.willDetachGlobalObjectFromFrame();
-    });
+    for (auto& observer : copyToVector(m_observers)) {
+        if (m_observers.contains(observer))
+            observer->willDetachGlobalObjectFromFrame();
+    }
 
     if (m_performance)
         m_performance->clearResourceTimings();
@@ -547,12 +550,12 @@ void LocalDOMWindow::decrementGamepadEventListenerCount()
 
 void LocalDOMWindow::registerObserver(Observer& observer)
 {
-    m_observers.add(observer);
+    m_observers.add(&observer);
 }
 
 void LocalDOMWindow::unregisterObserver(Observer& observer)
 {
-    m_observers.remove(observer);
+    m_observers.remove(&observer);
 }
 
 void LocalDOMWindow::resetUnlessSuspendedForDocumentSuspension()
@@ -567,9 +570,10 @@ void LocalDOMWindow::suspendForBackForwardCache()
     SetForScope isSuspendingObservers(m_isSuspendingObservers, true);
     RELEASE_ASSERT(frame());
 
-    m_observers.forEach([](auto& observer) {
-        observer.suspendForBackForwardCache();
-    });
+    for (auto* observer : copyToVector(m_observers)) {
+        if (m_observers.contains(observer))
+            observer->suspendForBackForwardCache();
+    }
     RELEASE_ASSERT(frame());
 
     m_suspendedForDocumentSuspension = true;
@@ -577,9 +581,10 @@ void LocalDOMWindow::suspendForBackForwardCache()
 
 void LocalDOMWindow::resumeFromBackForwardCache()
 {
-    m_observers.forEach([](auto& observer) {
-        observer.resumeFromBackForwardCache();
-    });
+    for (auto* observer : copyToVector(m_observers)) {
+        if (m_observers.contains(observer))
+            observer->resumeFromBackForwardCache();
+    }
 
     m_suspendedForDocumentSuspension = false;
 }

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -124,7 +124,7 @@ public:
     // the network load. See also SecurityContext::isSecureTransitionTo.
     void didSecureTransitionTo(Document&);
 
-    class Observer : public CanMakeWeakPtr<Observer> {
+    class Observer {
     public:
         virtual ~Observer() { }
 
@@ -441,7 +441,7 @@ private:
     bool m_isSuspendingObservers { false };
     std::optional<bool> m_canShowModalDialogOverride;
 
-    WeakHashSet<Observer> m_observers;
+    HashSet<Observer*> m_observers; // FIXME: Should use WeakHashSet.
 
     mutable RefPtr<Crypto> m_crypto;
     mutable RefPtr<History> m_history;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -219,12 +219,12 @@ LocalFrame::~LocalFrame()
 
 void LocalFrame::addDestructionObserver(FrameDestructionObserver& observer)
 {
-    m_destructionObservers.add(observer);
+    m_destructionObservers.add(&observer);
 }
 
 void LocalFrame::removeDestructionObserver(FrameDestructionObserver& observer)
 {
-    m_destructionObservers.remove(observer);
+    m_destructionObservers.remove(&observer);
 }
 
 void LocalFrame::setView(RefPtr<LocalFrameView>&& view)
@@ -778,7 +778,7 @@ void LocalFrame::willDetachPage()
         parent->loader().checkLoadComplete();
 
     for (auto& observer : m_destructionObservers)
-        observer.willDetachPage();
+        observer->willDetachPage();
 
     // FIXME: It's unclear as to why this is called more than once, but it is,
     // so page() could be NULL.

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -301,7 +301,7 @@ private:
     FrameView* virtualView() const final;
     DOMWindow* virtualWindow() const final;
 
-    WeakHashSet<FrameDestructionObserver> m_destructionObservers;
+    HashSet<FrameDestructionObserver*> m_destructionObservers; // FIXME: Should use WeakHashSet.
 
     Vector<std::pair<Ref<DOMWrapperWorld>, UniqueRef<UserScript>>> m_userScriptsAwaitingNotification;
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1405,7 +1405,7 @@ RenderBox* LocalFrameView::embeddedContentBox() const
 void LocalFrameView::addEmbeddedObjectToUpdate(RenderEmbeddedObject& embeddedObject)
 {
     if (!m_embeddedObjectsToUpdate)
-        m_embeddedObjectsToUpdate = makeUnique<ListHashSet<CheckedPtr<RenderEmbeddedObject>>>();
+        m_embeddedObjectsToUpdate = makeUnique<ListHashSet<RenderEmbeddedObject*>>();
 
     auto& element = embeddedObject.frameOwnerElement();
     if (is<HTMLPlugInImageElement>(element))

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -944,7 +944,7 @@ private:
     std::unique_ptr<Display::View> m_displayView;
 
     HashSet<CheckedPtr<Widget>> m_widgetsInRenderTree;
-    std::unique_ptr<ListHashSet<CheckedPtr<RenderEmbeddedObject>>> m_embeddedObjectsToUpdate;
+    std::unique_ptr<ListHashSet<RenderEmbeddedObject*>> m_embeddedObjectsToUpdate; // FIXME: Should use CheckedPtr.
     std::unique_ptr<WeakHashSet<RenderElement>> m_slowRepaintObjects;
 
     RefPtr<ContainerNode> m_maintainScrollPositionAnchor;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -770,13 +770,13 @@ void Page::setNeedsRecalcStyleInAllFrames()
 
 void Page::refreshPlugins(bool reload)
 {
-    WeakHashSet<PluginInfoProvider> pluginInfoProviders;
+    HashSet<PluginInfoProvider*> pluginInfoProviders;
 
     for (auto& page : allPages())
-        pluginInfoProviders.add(page->pluginInfoProvider());
+        pluginInfoProviders.add(&page->pluginInfoProvider());
 
     for (auto& pluginInfoProvider : pluginInfoProviders)
-        pluginInfoProvider.refresh(reload);
+        pluginInfoProvider->refresh(reload);
 }
 
 PluginData& Page::pluginData()
@@ -3150,7 +3150,7 @@ void Page::addRelevantRepaintedObject(const RenderObject& object, const LayoutRe
 
     // If this object was previously counted as an unpainted object, remove it from that HashSet
     // and corresponding Region. FIXME: This doesn't do the right thing if the objects overlap.
-    if (m_relevantUnpaintedRenderObjects.remove(object))
+    if (m_relevantUnpaintedRenderObjects.remove(&object))
         m_relevantUnpaintedRegion.subtract(snappedPaintRect);
 
     // Split the relevantRect into a top half and a bottom half. Making sure we have coverage in
@@ -3201,7 +3201,7 @@ void Page::addRelevantUnpaintedObject(const RenderObject& object, const LayoutRe
     if (!objectPaintRect.intersects(snappedIntRect(relevantViewRect(&object.view()))))
         return;
 
-    m_relevantUnpaintedRenderObjects.add(object);
+    m_relevantUnpaintedRenderObjects.add(&object);
     m_relevantUnpaintedRegion.unite(snappedIntRect(objectPaintRect));
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1252,7 +1252,7 @@ private:
     int m_footerHeight { 0 };
 
     std::unique_ptr<RenderingUpdateScheduler> m_renderingUpdateScheduler;
-    WeakHashSet<const RenderObject> m_relevantUnpaintedRenderObjects;
+    HashSet<const RenderObject*> m_relevantUnpaintedRenderObjects; // FIXME: Should use WeakHashSet.
 
     Region m_topRelevantPaintedRegion;
     Region m_bottomRelevantPaintedRegion;

--- a/Source/WebCore/plugins/PluginInfoProvider.h
+++ b/Source/WebCore/plugins/PluginInfoProvider.h
@@ -27,11 +27,10 @@
 
 #include "PluginData.h"
 #include <wtf/WeakHashSet.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class WEBCORE_EXPORT PluginInfoProvider : public RefCounted<PluginInfoProvider>, public CanMakeWeakPtr<PluginInfoProvider> {
+class WEBCORE_EXPORT PluginInfoProvider : public RefCounted<PluginInfoProvider> {
 public:
     virtual ~PluginInfoProvider();
 


### PR DESCRIPTION
#### 16bd3223ce59037ae69266564dcb1ee22b73d8d7
<pre>
Regression(268511@main?) 3% PLT regression on some iOS devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=262484">https://bugs.webkit.org/show_bug.cgi?id=262484</a>
rdar://116345117

Unreviewed, revert 268511@main as it seems to be the cause of a
PLT regression on certain iOS devices.

* Source/WebCore/loader/FormState.h:
* Source/WebCore/page/FrameDestructionObserver.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::willDestroyCachedFrame):
(WebCore::LocalDOMWindow::willDestroyDocumentInFrame):
(WebCore::LocalDOMWindow::willDetachDocumentFromFrame):
(WebCore::LocalDOMWindow::suspendForBackForwardCache):
(WebCore::LocalDOMWindow::resumeFromBackForwardCache):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::willDetachPage):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::addEmbeddedObjectToUpdate):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::refreshPlugins):
* Source/WebCore/page/Page.h:
* Source/WebCore/plugins/PluginInfoProvider.h:

Canonical link: <a href="https://commits.webkit.org/268736@main">https://commits.webkit.org/268736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e9d15fcfd198aae12d2cd08d0b2a35e1deeea6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21109 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20533 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23260 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24927 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22866 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16485 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18618 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4927 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->