### PR TITLE
[GTK][WPE] Gardening fast/text/emphasis expectations after 267729@main

### DIFF
--- a/LayoutTests/platform/glib/fast/text/emphasis-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/emphasis-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x705
-  RenderView at (0,0) size 785x600
-layer at (0,0) size 785x705
-  RenderBlock {HTML} at (0,0) size 785x705
-    RenderBody {BODY} at (8,8) size 769x0
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x552
+  RenderBlock {HTML} at (0,0) size 800x552
+    RenderBody {BODY} at (8,8) size 784x0
       RenderBlock (floating) {DIV} at (8,8) size 366x139 [border: (3px solid #000000)]
         RenderText {#text} at (3,3) size 276x26
           text run at (3,3) width 276: "Lorem ipsum dolor sit amet,"
@@ -95,67 +95,67 @@ layer at (0,0) size 785x705
           text run at (199,98) width 7: " "
           text run at (205,98) width 136: "eu iaculis vel,"
           text run at (3,125) width 210: "scelerisque nec dolor."
-      RenderBlock (floating) {DIV} at (390,163) size 366x153 [border: (3px solid #000000)]
-        RenderText {#text} at (3,3) size 71x26
-          text run at (3,3) width 71: "Lorem "
+      RenderBlock (floating) {DIV} at (390,163) size 366x155 [border: (3px solid #000000)]
+        RenderText {#text} at (3,4) size 71x26
+          text run at (3,4) width 71: "Lorem "
         RenderInline {SPAN} at (0,0) size 59x26
-          RenderText {#text} at (74,3) size 59x26
-            text run at (74,3) width 59: "ipsum"
-        RenderText {#text} at (132,3) size 7x26
-          text run at (132,3) width 7: " "
+          RenderText {#text} at (74,4) size 59x26
+            text run at (74,4) width 59: "ipsum"
+        RenderText {#text} at (132,4) size 7x26
+          text run at (132,4) width 7: " "
         RenderInline {SPAN} at (0,0) size 52x26
-          RenderText {#text} at (138,3) size 52x26
-            text run at (138,3) width 52: "dolor"
-        RenderText {#text} at (189,3) size 7x26
-          text run at (189,3) width 7: " "
+          RenderText {#text} at (138,4) size 52x26
+            text run at (138,4) width 52: "dolor"
+        RenderText {#text} at (189,4) size 7x26
+          text run at (189,4) width 7: " "
         RenderInline {SPAN} at (0,0) size 24x26
-          RenderText {#text} at (195,3) size 24x26
-            text run at (195,3) width 24: "sit"
-        RenderText {#text} at (218,3) size 7x26
-          text run at (218,3) width 7: " "
+          RenderText {#text} at (195,4) size 24x26
+            text run at (195,4) width 24: "sit"
+        RenderText {#text} at (218,4) size 7x26
+          text run at (218,4) width 7: " "
         RenderInline {SPAN} at (0,0) size 49x26
-          RenderText {#text} at (224,3) size 49x26
-            text run at (224,3) width 49: "amet"
-        RenderText {#text} at (272,3) size 7x26
-          text run at (272,3) width 7: ","
+          RenderText {#text} at (224,4) size 49x26
+            text run at (224,4) width 49: "amet"
+        RenderText {#text} at (272,4) size 7x26
+          text run at (272,4) width 7: ","
         RenderInline {SPAN} at (0,0) size 111x26
-          RenderText {#text} at (3,43) size 111x26
-            text run at (3,43) width 111: "consectetur"
-        RenderText {#text} at (113,43) size 7x26
-          text run at (113,43) width 7: " "
+          RenderText {#text} at (3,44) size 111x26
+            text run at (3,44) width 111: "consectetur"
+        RenderText {#text} at (113,44) size 7x26
+          text run at (113,44) width 7: " "
         RenderInline {SPAN} at (0,0) size 101x26
-          RenderText {#text} at (119,43) size 101x26
-            text run at (119,43) width 101: "adipiscing"
-        RenderText {#text} at (219,43) size 7x26
-          text run at (219,43) width 7: " "
+          RenderText {#text} at (119,44) size 101x26
+            text run at (119,44) width 101: "adipiscing"
+        RenderText {#text} at (219,44) size 7x26
+          text run at (219,44) width 7: " "
         RenderInline {SPAN} at (0,0) size 33x26
-          RenderText {#text} at (225,43) size 33x26
-            text run at (225,43) width 33: "elit"
-        RenderText {#text} at (257,43) size 13x26
-          text run at (257,43) width 13: ". "
+          RenderText {#text} at (225,44) size 33x26
+            text run at (225,44) width 33: "elit"
+        RenderText {#text} at (257,44) size 13x26
+          text run at (257,44) width 13: ". "
         RenderInline {SPAN} at (0,0) size 86x26
-          RenderText {#text} at (269,43) size 86x26
-            text run at (269,43) width 86: "Aliquam"
-        RenderText {#text} at (354,43) size 7x26
-          text run at (354,43) width 7: ","
+          RenderText {#text} at (269,44) size 86x26
+            text run at (269,44) width 86: "Aliquam"
+        RenderText {#text} at (354,44) size 7x26
+          text run at (354,44) width 7: ","
         RenderInline {SPAN} at (0,0) size 43x26
-          RenderText {#text} at (3,83) size 43x26
-            text run at (3,83) width 43: "odio"
-        RenderText {#text} at (45,83) size 7x26
-          text run at (45,83) width 7: " "
+          RenderText {#text} at (3,85) size 43x26
+            text run at (3,85) width 43: "odio"
+        RenderText {#text} at (45,85) size 7x26
+          text run at (45,85) width 7: " "
         RenderInline {SPAN} at (0,0) size 63x26
-          RenderText {#text} at (51,83) size 63x26
-            text run at (51,83) width 63: "sapien"
-        RenderText {#text} at (113,83) size 13x26
-          text run at (113,83) width 13: ", "
+          RenderText {#text} at (51,85) size 63x26
+            text run at (51,85) width 63: "sapien"
+        RenderText {#text} at (113,85) size 13x26
+          text run at (113,85) width 13: ", "
         RenderInline {SPAN} at (0,0) size 75x26
-          RenderText {#text} at (125,83) size 75x26
-            text run at (125,83) width 75: "lobortis"
-        RenderText {#text} at (199,83) size 338x66
-          text run at (199,83) width 7: " "
-          text run at (205,83) width 136: "eu iaculis vel,"
-          text run at (3,123) width 210: "scelerisque nec dolor."
-      RenderBlock (floating) {DIV} at (390,332) size 366x202 [border: (3px solid #000000)]
+          RenderText {#text} at (125,85) size 75x26
+            text run at (125,85) width 75: "lobortis"
+        RenderText {#text} at (199,85) size 338x67
+          text run at (199,85) width 7: " "
+          text run at (205,85) width 136: "eu iaculis vel,"
+          text run at (3,126) width 210: "scelerisque nec dolor."
+      RenderBlock (floating) {DIV} at (8,334) size 366x202 [border: (3px solid #000000)]
         RenderText {#text} at (3,14) size 276x26
           text run at (3,14) width 276: "Lorem ipsum dolor sit amet,"
         RenderInline {SPAN} at (0,0) size 217x26
@@ -171,7 +171,7 @@ layer at (0,0) size 785x705
           text run at (113,112) width 13: ", "
           text run at (125,112) width 216: "lobortis eu iaculis vel,"
           text run at (3,162) width 210: "scelerisque nec dolor."
-      RenderBlock (floating) {DIV} at (8,550) size 366x139 [border: (3px solid #000000)]
+      RenderBlock (floating) {DIV} at (390,334) size 366x139 [border: (3px solid #000000)]
         RenderText {#text} at (3,3) size 276x26
           text run at (3,3) width 276: "Lorem ipsum dolor sit amet,"
         RenderInline {SPAN} at (0,0) size 217x26

--- a/LayoutTests/platform/glib/fast/text/emphasis-overlap-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/emphasis-overlap-expected.txt
@@ -52,7 +52,7 @@ layer at (0,0) size 800x600
             text run at (0,128) width 128: "4444"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,176) size 784x176
-        RenderBlock {DIV} at (0,24) size 128x144
+        RenderBlock {DIV} at (0,8) size 128x144
           RenderText {#text} at (0,0) size 128x32
             text run at (0,0) width 128: "1111"
           RenderBR {BR} at (128,0) size 0x32
@@ -66,9 +66,9 @@ layer at (0,0) size 800x600
           RenderBR {BR} at (128,80) size 0x32
           RenderText {#text} at (0,112) size 128x32
             text run at (0,112) width 128: "4444"
-        RenderText {#text} at (128,139) size 4x17
-          text run at (128,139) width 4: " "
-        RenderBlock {DIV} at (132,24) size 128x144
+        RenderText {#text} at (128,11) size 4x17
+          text run at (128,11) width 4: " "
+        RenderBlock {DIV} at (132,8) size 128x144
           RenderText {#text} at (0,0) size 128x32
             text run at (0,0) width 128: "1111"
           RenderBR {BR} at (128,0) size 0x32
@@ -82,8 +82,8 @@ layer at (0,0) size 800x600
           RenderBR {BR} at (128,80) size 0x32
           RenderText {#text} at (0,112) size 128x32
             text run at (0,112) width 128: "4444"
-        RenderText {#text} at (260,139) size 4x17
-          text run at (260,139) width 4: " "
+        RenderText {#text} at (260,11) size 4x17
+          text run at (260,11) width 4: " "
         RenderBlock {DIV} at (264,8) size 128x160
           RenderText {#text} at (0,0) size 128x32
             text run at (0,0) width 128: "1111"


### PR DESCRIPTION
#### 0950b86a6bf624ef2c47ffa490d6d63899bb2e32
<pre>
[GTK][WPE] Gardening fast/text/emphasis expectations after 267729@main

Unreviewed test gardening

When we worked on IFC writing-mode in 267729@main, we updated these test
expectations for higher level LayoutTests and for mac-specific ports, but
we didn&apos;t update them for GTK and WPE. Updating, as tests were failing
in bots since 267729@main.

* LayoutTests/platform/glib/fast/text/emphasis-expected.txt:
* LayoutTests/platform/glib/fast/text/emphasis-overlap-expected.txt:

Canonical link: <a href="https://commits.webkit.org/268818@main">https://commits.webkit.org/268818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ae08bbffe8745e6bb20ed7f0514705b62617400

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22402 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19133 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20530 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23255 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24917 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22857 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16482 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18616 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4983 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->