### PR TITLE
Update audio and video WebCodec decoders and encoders close algorithms according latest spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
@@ -9,12 +9,8 @@ PASS Test that AudioDecoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioDecoder.configure() rejects invalid config: Empty codec
 PASS Test that AudioDecoder.configure() rejects invalid config: Missing sampleRate
 PASS Test that AudioDecoder.configure() rejects invalid config: Missing numberOfChannels
-FAIL Test that AudioDecoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero sampleRate assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero channels assert_unreached: unexpected error Reached unreachable code
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Unrecognized codec
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Video codec
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Ambiguous codec

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js
@@ -150,7 +150,7 @@ validButUnsupportedConfigs.forEach(entry => {
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
               assert_true(e instanceof DOMException);
-              assert_equals(e.name, 'InvalidStateError');
+              assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');
             }));
       },

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
@@ -9,12 +9,8 @@ PASS Test that AudioDecoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioDecoder.configure() rejects invalid config: Empty codec
 PASS Test that AudioDecoder.configure() rejects invalid config: Missing sampleRate
 PASS Test that AudioDecoder.configure() rejects invalid config: Missing numberOfChannels
-FAIL Test that AudioDecoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioDecoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero sampleRate assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero channels assert_unreached: unexpected error Reached unreachable code
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Unrecognized codec
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Video codec
 PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Ambiguous codec

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
@@ -13,45 +13,35 @@ PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus fra
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Invalid Opus frameDuration
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_unreached: unexpected error Reached unreachable code
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus complexity too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus packetlossperc too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too small
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Invalid Opus frameDuration
-FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Bitrate is too low assert_false: expected false got true
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Bitrate is too low
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Unrecognized codec
-FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too small assert_false: expected false got true
-FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too large assert_false: expected false got true
-FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Way too many channels assert_false: expected false got true
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too small
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too large
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Way too many channels
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future opus codec string
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future aac codec string
-FAIL Test that AudioEncoder.configure() doesn't support config: Bitrate is too low assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Bitrate is too low
 PASS Test that AudioEncoder.configure() doesn't support config: Unrecognized codec
-FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too small assert_unreached: flush succeeded unexpectedly Reached unreachable code
-FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too large assert_unreached: flush succeeded unexpectedly Reached unreachable code
-FAIL Test that AudioEncoder.configure() doesn't support config: Way too many channels assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Sample rate is too small
+PASS Test that AudioEncoder.configure() doesn't support config: Sample rate is too large
+PASS Test that AudioEncoder.configure() doesn't support config: Way too many channels
 PASS Test that AudioEncoder.configure() doesn't support config: Possible future opus codec string
 PASS Test that AudioEncoder.configure() doesn't support config: Possible future aac codec string
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":8000,"numberOfChannels":1}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"constant","bogus":123}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"variable","bogus":123}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"complexity":5,"frameDuration":20000,"packetlossperc":10,"useinbandfec":true}}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"format":"opus","complexity":10,"frameDuration":60000,"packetlossperc":20,"usedtx":true,"bogus":456}}
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":8000,"numberOfChannels":1} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"constant","bogus":123} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"variable","bogus":123} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"complexity":5,"frameDuration":20000,"packetlossperc":10,"useinbandfec":true}} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"format":"opus","complexity":10,"frameDuration":60000,"packetlossperc":20,"usedtx":true,"bogus":456}} assert_true: expected true got false
 FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{}} assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js
@@ -228,7 +228,7 @@ validButUnsupportedConfigs.forEach(entry => {
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
               assert_true(e instanceof DOMException);
-              assert_equals(e.name, 'InvalidStateError');
+              assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');
             }));
       },

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
@@ -13,45 +13,35 @@ PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus fra
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Invalid Opus frameDuration
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_unreached: unexpected error Reached unreachable code
+FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_unreached: unexpected error Reached unreachable code
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus complexity too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus packetlossperc too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too small
 PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too big
 PASS Test that AudioEncoder.configure() rejects invalid config: Invalid Opus frameDuration
-FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Bitrate is too low assert_false: expected false got true
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Bitrate is too low
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Unrecognized codec
-FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too small assert_false: expected false got true
-FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too large assert_false: expected false got true
-FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Way too many channels assert_false: expected false got true
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too small
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too large
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Way too many channels
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future opus codec string
 PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future aac codec string
-FAIL Test that AudioEncoder.configure() doesn't support config: Bitrate is too low assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Bitrate is too low
 PASS Test that AudioEncoder.configure() doesn't support config: Unrecognized codec
-FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too small assert_unreached: flush succeeded unexpectedly Reached unreachable code
-FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too large assert_unreached: flush succeeded unexpectedly Reached unreachable code
-FAIL Test that AudioEncoder.configure() doesn't support config: Way too many channels assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Sample rate is too small
+PASS Test that AudioEncoder.configure() doesn't support config: Sample rate is too large
+PASS Test that AudioEncoder.configure() doesn't support config: Way too many channels
 PASS Test that AudioEncoder.configure() doesn't support config: Possible future opus codec string
 PASS Test that AudioEncoder.configure() doesn't support config: Possible future aac codec string
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":8000,"numberOfChannels":1}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"constant","bogus":123}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"variable","bogus":123}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"complexity":5,"frameDuration":20000,"packetlossperc":10,"useinbandfec":true}}
-PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"format":"opus","complexity":10,"frameDuration":60000,"packetlossperc":20,"usedtx":true,"bogus":456}}
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":8000,"numberOfChannels":1} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"constant","bogus":123} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"variable","bogus":123} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"complexity":5,"frameDuration":20000,"packetlossperc":10,"useinbandfec":true}} assert_true: expected true got false
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"format":"opus","complexity":10,"frameDuration":60000,"packetlossperc":20,"usedtx":true,"bogus":456}} assert_true: expected true got false
 FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{}} assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt
@@ -19,8 +19,8 @@ PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
 PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
-FAIL Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future AV1 codec string
 PASS Test VideoDecoder construction

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js
@@ -111,7 +111,7 @@ validButUnsupportedConfigs.forEach(entry => {
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
               assert_true(e instanceof DOMException);
-              assert_equals(e.name, 'InvalidStateError');
+              assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');
             }));
       },

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt
@@ -19,8 +19,8 @@ PASS Test that VideoDecoder.configure() doesn't support config: Audio codec
 PASS Test that VideoDecoder.configure() doesn't support config: Ambiguous codec
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with bad casing
 PASS Test that VideoDecoder.configure() doesn't support config: Codec with MIME type
-FAIL Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoDecoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoDecoder.configure() doesn't support config: Possible future AV1 codec string
 PASS Test VideoDecoder construction

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -25,12 +25,12 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible
 PASS Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode
 PASS Test that VideoEncoder.configure() doesn't support config: Unrecognized codec
 PASS Test that VideoEncoder.configure() doesn't support config: Codec with bad casing
-FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Width is too large
+PASS Test that VideoEncoder.configure() doesn't support config: Height is too large
+PASS Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
@@ -204,7 +204,7 @@ validButUnsupportedConfigs.forEach(entry => {
             .then(t.unreached_func('flush succeeded unexpectedly'))
             .catch(t.step_func(e => {
               assert_true(e instanceof DOMException);
-              assert_equals(e.name, 'InvalidStateError');
+              assert_equals(e.name, 'NotSupportedError');
               assert_equals(codec.state, 'closed', 'state');
             }));
       },

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -25,12 +25,12 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible
 PASS Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode
 PASS Test that VideoEncoder.configure() doesn't support config: Unrecognized codec
 PASS Test that VideoEncoder.configure() doesn't support config: Codec with bad casing
-FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Width is too large
+PASS Test that VideoEncoder.configure() doesn't support config: Height is too large
+PASS Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js
@@ -418,7 +418,7 @@ promise_test(async t => {
 
   await promise_rejects_dom(t, "EncodingError",
     decoder.flush().catch((e) => {
-      assert_equals(errors, 0);
+      assert_equals(errors, 1);
       throw e;
     })
   );
@@ -453,7 +453,7 @@ promise_test(async t => {
 
   await promise_rejects_dom(t, "EncodingError",
     decoder.flush().catch((e) => {
-      assert_equals(errors, 0);
+      assert_equals(errors, 1);
       throw e;
     })
   );

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt
@@ -1,0 +1,32 @@
+
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Empty codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing sampleRate
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing numberOfChannels
+FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing codec
+PASS Test that AudioDecoder.configure() rejects invalid config: Empty codec
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing sampleRate
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing numberOfChannels
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Video codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Ambiguous codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Codec with MIME type
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future opus codec string
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future aac codec string
+PASS Test that AudioDecoder.configure() doesn't support config: Unrecognized codec
+PASS Test that AudioDecoder.configure() doesn't support config: Video codec
+PASS Test that AudioDecoder.configure() doesn't support config: Ambiguous codec
+PASS Test that AudioDecoder.configure() doesn't support config: Codec with MIME type
+PASS Test that AudioDecoder.configure() doesn't support config: Possible future opus codec string
+PASS Test that AudioDecoder.configure() doesn't support config: Possible future aac codec string
+PASS Test AudioDecoder construction
+PASS Verify unconfigured AudioDecoder operations
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt
@@ -1,0 +1,32 @@
+
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Empty codec
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing sampleRate
+PASS Test that AudioDecoder.isConfigSupported() rejects invalid config: Missing numberOfChannels
+FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioDecoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing codec
+PASS Test that AudioDecoder.configure() rejects invalid config: Empty codec
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing sampleRate
+PASS Test that AudioDecoder.configure() rejects invalid config: Missing numberOfChannels
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioDecoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Unrecognized codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Video codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Ambiguous codec
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Codec with MIME type
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future opus codec string
+PASS Test that AudioDecoder.isConfigSupported() doesn't support config: Possible future aac codec string
+PASS Test that AudioDecoder.configure() doesn't support config: Unrecognized codec
+PASS Test that AudioDecoder.configure() doesn't support config: Video codec
+PASS Test that AudioDecoder.configure() doesn't support config: Ambiguous codec
+PASS Test that AudioDecoder.configure() doesn't support config: Codec with MIME type
+PASS Test that AudioDecoder.configure() doesn't support config: Possible future opus codec string
+PASS Test that AudioDecoder.configure() doesn't support config: Possible future aac codec string
+PASS Test AudioDecoder construction
+PASS Verify unconfigured AudioDecoder operations
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
@@ -1,0 +1,57 @@
+
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing codec
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Empty codec
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Bit rate too big assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus complexity too big
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus packetlossperc too big
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus frame duration too small
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus frame duration too big
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Invalid Opus frameDuration
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
+PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
+FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+PASS Test that AudioEncoder.configure() rejects invalid config: Opus complexity too big
+PASS Test that AudioEncoder.configure() rejects invalid config: Opus packetlossperc too big
+PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too small
+PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too big
+PASS Test that AudioEncoder.configure() rejects invalid config: Invalid Opus frameDuration
+FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Bitrate is too low assert_false: expected false got true
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Unrecognized codec
+FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too small assert_false: expected false got true
+FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too large assert_false: expected false got true
+FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Way too many channels assert_false: expected false got true
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future opus codec string
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future aac codec string
+FAIL Test that AudioEncoder.configure() doesn't support config: Bitrate is too low assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Unrecognized codec
+FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too small assert_unreached: flush succeeded unexpectedly Reached unreachable code
+FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too large assert_unreached: flush succeeded unexpectedly Reached unreachable code
+FAIL Test that AudioEncoder.configure() doesn't support config: Way too many channels assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Possible future opus codec string
+PASS Test that AudioEncoder.configure() doesn't support config: Possible future aac codec string
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":8000,"numberOfChannels":1}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"constant","bogus":123}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"variable","bogus":123}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"complexity":5,"frameDuration":20000,"packetlossperc":10,"useinbandfec":true}}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"format":"opus","complexity":10,"frameDuration":60000,"packetlossperc":20,"usedtx":true,"bogus":456}}
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{}} assert_true: expected true got false
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
@@ -1,0 +1,57 @@
+
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing codec
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Empty codec
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Bit rate too big assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus complexity too big
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus packetlossperc too big
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus frame duration too small
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus frame duration too big
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Invalid Opus frameDuration
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
+PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
+FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_throws_js: function "() => {
+          codec.configure(entry.config);
+        }" did not throw
+PASS Test that AudioEncoder.configure() rejects invalid config: Opus complexity too big
+PASS Test that AudioEncoder.configure() rejects invalid config: Opus packetlossperc too big
+PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too small
+PASS Test that AudioEncoder.configure() rejects invalid config: Opus frame duration too big
+PASS Test that AudioEncoder.configure() rejects invalid config: Invalid Opus frameDuration
+FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Bitrate is too low assert_false: expected false got true
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Unrecognized codec
+FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too small assert_false: expected false got true
+FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Sample rate is too large assert_false: expected false got true
+FAIL Test that AudioEncoder.isConfigSupported() doesn't support config: Way too many channels assert_false: expected false got true
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future opus codec string
+PASS Test that AudioEncoder.isConfigSupported() doesn't support config: Possible future aac codec string
+FAIL Test that AudioEncoder.configure() doesn't support config: Bitrate is too low assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Unrecognized codec
+FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too small assert_unreached: flush succeeded unexpectedly Reached unreachable code
+FAIL Test that AudioEncoder.configure() doesn't support config: Sample rate is too large assert_unreached: flush succeeded unexpectedly Reached unreachable code
+FAIL Test that AudioEncoder.configure() doesn't support config: Way too many channels assert_unreached: flush succeeded unexpectedly Reached unreachable code
+PASS Test that AudioEncoder.configure() doesn't support config: Possible future opus codec string
+PASS Test that AudioEncoder.configure() doesn't support config: Possible future aac codec string
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":8000,"numberOfChannels":1}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"constant","bogus":123}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"bitrate":128000,"bitrateMode":"variable","bogus":123}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"complexity":5,"frameDuration":20000,"packetlossperc":10,"useinbandfec":true}}
+PASS AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{"format":"opus","complexity":10,"frameDuration":60000,"packetlossperc":20,"usedtx":true,"bogus":456}}
+FAIL AudioEncoder.isConfigSupported() supports: {"codec":"opus","sampleRate":48000,"numberOfChannels":2,"opus":{}} assert_true: expected true got false
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -25,12 +25,12 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible
 PASS Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode
 PASS Test that VideoEncoder.configure() doesn't support config: Unrecognized codec
 PASS Test that VideoEncoder.configure() doesn't support config: Codec with bad casing
-FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Width is too large
+PASS Test that VideoEncoder.configure() doesn't support config: Height is too large
+PASS Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -25,12 +25,12 @@ PASS Test that VideoEncoder.isConfigSupported() doesn't support config: Possible
 PASS Test that VideoEncoder.configure() doesn't support config: Invalid scalability mode
 PASS Test that VideoEncoder.configure() doesn't support config: Unrecognized codec
 PASS Test that VideoEncoder.configure() doesn't support config: Codec with bad casing
-FAIL Test that VideoEncoder.configure() doesn't support config: Width is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Height is too large assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+PASS Test that VideoEncoder.configure() doesn't support config: Width is too large
+PASS Test that VideoEncoder.configure() doesn't support config: Height is too large
+PASS Test that VideoEncoder.configure() doesn't support config: Too strenuous accelerated encoding parameters
 PASS Test that VideoEncoder.configure() doesn't support config: Odd sized frames for H264
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
-FAIL Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string assert_equals: expected "InvalidStateError" but got "NotSupportedError"
+FAIL Test that VideoEncoder.configure() doesn't support config: Possible future H264 codec string assert_equals: expected "NotSupportedError" but got "InvalidStateError"
+PASS Test that VideoEncoder.configure() doesn't support config: Possible future HEVC codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future VP9 codec string
 PASS Test that VideoEncoder.configure() doesn't support config: Possible future AV1 codec string
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -237,11 +237,9 @@ ExceptionOr<void> WebCodecsAudioDecoder::closeDecoder(Exception&& exception)
         return result;
     m_state = WebCodecsCodecState::Closed;
     m_internalDecoder = nullptr;
-    if (exception.code() != AbortError) {
-        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, exception = WTFMove(exception)]() mutable {
-            m_error->handleEvent(DOMException::create(WTFMove(exception)));
-        });
-    }
+    if (exception.code() != AbortError)
+        m_error->handleEvent(DOMException::create(WTFMove(exception)));
+
     return { };
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -356,11 +356,9 @@ ExceptionOr<void> WebCodecsAudioEncoder::closeEncoder(Exception&& exception)
         return result;
     m_state = WebCodecsCodecState::Closed;
     m_internalEncoder = nullptr;
-    if (exception.code() != AbortError) {
-        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, exception = WTFMove(exception)]() mutable {
-            m_error->handleEvent(DOMException::create(WTFMove(exception)));
-        });
-    }
+    if (exception.code() != AbortError)
+        m_error->handleEvent(DOMException::create(WTFMove(exception)));
+
     return { };
 }
 
@@ -376,9 +374,6 @@ ExceptionOr<void> WebCodecsAudioEncoder::resetEncoder(const Exception& exception
     if (m_encodeQueueSize) {
         m_encodeQueueSize = 0;
         scheduleDequeueEvent();
-        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, exception = Exception { exception }]() mutable {
-            m_error->handleEvent(DOMException::create(WTFMove(exception)));
-        });
     }
     ++m_clearFlushPromiseCount;
     while (!m_pendingFlushPromises.isEmpty())

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -269,11 +269,9 @@ ExceptionOr<void> WebCodecsVideoDecoder::closeDecoder(Exception&& exception)
         return result;
     m_state = WebCodecsCodecState::Closed;
     m_internalDecoder = nullptr;
-    if (exception.code() != AbortError) {
-        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, exception = WTFMove(exception)]() mutable {
-            m_error->handleEvent(DOMException::create(WTFMove(exception)));
-        });
-    }
+    if (exception.code() != AbortError)
+        m_error->handleEvent(DOMException::create(WTFMove(exception)));
+
     return { };
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -330,11 +330,9 @@ ExceptionOr<void> WebCodecsVideoEncoder::closeEncoder(Exception&& exception)
         return result;
     m_state = WebCodecsCodecState::Closed;
     m_internalEncoder = nullptr;
-    if (exception.code() != AbortError) {
-        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, exception = WTFMove(exception)]() mutable {
-            m_error->handleEvent(DOMException::create(WTFMove(exception)));
-        });
-    }
+    if (exception.code() != AbortError)
+        m_error->handleEvent(DOMException::create(WTFMove(exception)));
+
     return { };
 }
 
@@ -350,9 +348,6 @@ ExceptionOr<void> WebCodecsVideoEncoder::resetEncoder(const Exception& exception
     if (m_encodeQueueSize) {
         m_encodeQueueSize = 0;
         scheduleDequeueEvent();
-        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, exception = Exception { exception }]() mutable {
-            m_error->handleEvent(DOMException::create(WTFMove(exception)));
-        });
     }
     ++m_clearFlushPromiseCount;
     while (!m_pendingFlushPromises.isEmpty())


### PR DESCRIPTION
#### abfc1105e4fe1c6242da40378a91c24da0d285d1
<pre>
Update audio and video WebCodec decoders and encoders close algorithms according latest spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=262486">https://bugs.webkit.org/show_bug.cgi?id=262486</a>
rdar://116346725

Reviewed by Eric Carlson.

Update implementation according <a href="https://github.com/w3c/webcodecs/commit/3856bbf7091a292b18ac32e703f18ae666a6e17c.">https://github.com/w3c/webcodecs/commit/3856bbf7091a292b18ac32e703f18ae666a6e17c.</a>
We are now firing the error event synchronously after setting the codec state to closed.

Resynced WPT webcodecs up to WPT ToT.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-decoder.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.worker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::closeDecoder):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::closeEncoder):
(WebCore::WebCodecsAudioEncoder::resetEncoder):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::closeDecoder):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::closeEncoder):
(WebCore::WebCodecsVideoEncoder::resetEncoder):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/268781@main">https://commits.webkit.org/268781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce2c70ac6a7007bf89c64bb7e3ed4b3747a530b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23394 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25017 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22961 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16580 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18737 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4955 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->