### PR TITLE
Unreviewed, revert 267869@main, potential MotionMark regression

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -458,9 +458,6 @@ private:
 #define FINALIZE_CODE(linkBufferReference, resultPtrTag, ...)  \
     FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly()), linkBufferReference, resultPtrTag, __VA_ARGS__)
 
-#define FINALIZE_BASELINE_CODE(linkBufferReference, resultPtrTag, ...)  \
-    FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpBaselineDisassembly()), linkBufferReference, resultPtrTag, __VA_ARGS__)
-
 #define FINALIZE_DFG_CODE(linkBufferReference, resultPtrTag, ...)  \
     FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpDFGDisassembly()), linkBufferReference, resultPtrTag, __VA_ARGS__)
 

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -760,7 +760,7 @@ std::tuple<std::unique_ptr<LinkBuffer>, RefPtr<BaselineJITCode>> JIT::compileAnd
             m_stringSwitchJumpTables = FixedVector<StringJumpTable>(m_unlinkedCodeBlock->numberOfUnlinkedStringSwitchJumpTables());
     }
 
-    if (UNLIKELY(Options::dumpDisassembly() || Options::dumpBaselineDisassembly() || (m_vm->m_perBytecodeProfiler && Options::disassembleBaselineForProfiler()))) {
+    if (UNLIKELY(Options::dumpDisassembly() || (m_vm->m_perBytecodeProfiler && Options::disassembleBaselineForProfiler()))) {
         // FIXME: build a disassembler off of UnlinkedCodeBlock.
         m_disassembler = makeUnique<JITDisassembler>(m_profiledCodeBlock);
     }
@@ -988,7 +988,7 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
             jitCodeMapBuilder.append(BytecodeIndex(bytecodeOffset), patchBuffer.locationOf<JSEntryPtrTag>(m_labels[bytecodeOffset]));
     }
 
-    if (UNLIKELY(Options::dumpDisassembly() || Options::dumpBaselineDisassembly())) {
+    if (UNLIKELY(Options::dumpDisassembly())) {
         m_disassembler->dump(patchBuffer);
         patchBuffer.didAlreadyDisassemble();
     }
@@ -1005,7 +1005,7 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
         pcToCodeOriginMap = makeUnique<PCToCodeOriginMap>(WTFMove(m_pcToCodeOriginMapBuilder), patchBuffer);
     
     // FIXME: Make a version of CodeBlockWithJITType that knows about UnlinkedCodeBlock.
-    CodeRef<JSEntryPtrTag> result = FINALIZE_BASELINE_CODE(
+    CodeRef<JSEntryPtrTag> result = FINALIZE_CODE(
         patchBuffer, JSEntryPtrTag,
         "Baseline JIT code for %s", toCString(CodeBlockWithJITType(m_profiledCodeBlock, JITType::BaselineJIT)).data());
     

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -339,7 +339,6 @@ namespace JSC {
         ECMAMode ecmaMode(Op);
 
         void emitGetVirtualRegister(VirtualRegister src, JSValueRegs dst);
-        void emitGetVirtualRegisters(std::initializer_list<std::tuple<VirtualRegister, JSValueRegs>>);
         void emitGetVirtualRegisterPayload(VirtualRegister src, RegisterID dst);
         void emitPutVirtualRegister(VirtualRegister dst, JSValueRegs src);
 

--- a/Source/JavaScriptCore/jit/JITArithmetic.cpp
+++ b/Source/JavaScriptCore/jit/JITArithmetic.cpp
@@ -268,10 +268,8 @@ ALWAYS_INLINE void JIT::emit_compareImpl(VirtualRegister op1, VirtualRegister op
     if (handleConstantIntOperand(op2, op1, jsRegT10, commute(condition)))
         return;
 
-    emitGetVirtualRegisters({
-        { op1, jsRegT10 },
-        { op2, jsRegT32 }
-    });
+    emitGetVirtualRegister(op1, jsRegT10);
+    emitGetVirtualRegister(op2, jsRegT32);
     emitJumpSlowCaseIfNotInt(jsRegT10);
     emitJumpSlowCaseIfNotInt(jsRegT32);
 
@@ -384,10 +382,8 @@ void JIT::emit_compareSlowImpl(VirtualRegister op1, VirtualRegister op2, size_t 
         constexpr JSValueRegs arg1JSR = preferredArgumentJSR<SlowOperation, 1>();
         constexpr JSValueRegs arg2JSR = preferredArgumentJSR<SlowOperation, 2>();
 
-        emitGetVirtualRegisters({
-            { op1, arg1JSR },
-            { op2, arg2JSR }
-        });
+        emitGetVirtualRegister(op1, arg1JSR);
+        emitGetVirtualRegister(op2, arg2JSR);
         loadGlobalObject(globalObjectGPR);
         callOperation(operation, globalObjectGPR, arg1JSR, arg2JSR);
         handleReturnValueGPR();
@@ -499,10 +495,8 @@ void JIT::emit_op_mod(const JSInstruction* currentInstruction)
     ASSERT(regT4 != edx);
     ASSERT(regT4 != ecx);
 
-    emitGetVirtualRegisters({
-        { op1, JSValueRegs { regT4 } },
-        { op2, JSValueRegs { ecx } }
-    });
+    emitGetVirtualRegister(op1, regT4);
+    emitGetVirtualRegister(op2, ecx);
     emitJumpSlowCaseIfNotInt(regT4);
     emitJumpSlowCaseIfNotInt(ecx);
 
@@ -557,10 +551,8 @@ void JIT::emit_op_pow(const JSInstruction* currentInstruction)
     constexpr JSValueRegs resultRegs = leftRegs;
     constexpr GPRReg scratchGPR = regT4;
 
-    emitGetVirtualRegisters({
-        { op1, leftRegs },
-        { op2, rightRegs }
-    });
+    emitGetVirtualRegister(op1, leftRegs);
+    emitGetVirtualRegister(op2, rightRegs);
     emitJumpSlowCaseIfNotInt(rightRegs);
 
     addSlowCase(branch32(LessThan, rightRegs.payloadGPR(), TrustedImm32(0)));
@@ -647,17 +639,10 @@ void JIT::emitBitBinaryOpFastPath(const JSInstruction* currentInstruction)
 
     RELEASE_ASSERT(!leftOperand.isConst() || !rightOperand.isConst());
 
-    if (!leftOperand.isConst() && !rightOperand.isConst()) {
-        emitGetVirtualRegisters({
-            { op1, leftRegs },
-            { op2, rightRegs }
-        });
-    } else {
-        if (!leftOperand.isConst())
-            emitGetVirtualRegister(op1, leftRegs);
-        if (!rightOperand.isConst())
-            emitGetVirtualRegister(op2, rightRegs);
-    }
+    if (!leftOperand.isConst())
+        emitGetVirtualRegister(op1, leftRegs);
+    if (!rightOperand.isConst())
+        emitGetVirtualRegister(op2, rightRegs);
 
     SnippetGenerator gen(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs, scratchGPR);
 
@@ -729,17 +714,10 @@ void JIT::emitRightShiftFastPath(const JSInstruction* currentInstruction, JITRig
 
     RELEASE_ASSERT(!leftOperand.isConst() || !rightOperand.isConst());
 
-    if (!leftOperand.isConst() && !rightOperand.isConst()) {
-        emitGetVirtualRegisters({
-            { op1, leftRegs },
-            { op2, rightRegs }
-        });
-    } else {
-        if (!leftOperand.isConst())
-            emitGetVirtualRegister(op1, leftRegs);
-        if (!rightOperand.isConst())
-            emitGetVirtualRegister(op2, rightRegs);
-    }
+    if (!leftOperand.isConst())
+        emitGetVirtualRegister(op1, leftRegs);
+    if (!rightOperand.isConst())
+        emitGetVirtualRegister(op2, rightRegs);
 
     JITRightShiftGenerator gen(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs, fpRegT0, scratchGPR, snippetShiftType);
 
@@ -854,17 +832,10 @@ void JIT::emitMathICFast(JITBinaryMathIC<Generator>* mathIC, const JSInstruction
     
     ASSERT(!(Generator::isLeftOperandValidConstant(leftOperand) && Generator::isRightOperandValidConstant(rightOperand)));
     
-    if (!Generator::isLeftOperandValidConstant(leftOperand) && !Generator::isRightOperandValidConstant(rightOperand)) {
-        emitGetVirtualRegisters({
-            { op1, leftRegs },
-            { op2, rightRegs }
-        });
-    } else {
-        if (!Generator::isLeftOperandValidConstant(leftOperand))
-            emitGetVirtualRegister(op1, leftRegs);
-        if (!Generator::isRightOperandValidConstant(rightOperand))
-            emitGetVirtualRegister(op2, rightRegs);
-    }
+    if (!Generator::isLeftOperandValidConstant(leftOperand))
+        emitGetVirtualRegister(op1, leftRegs);
+    if (!Generator::isRightOperandValidConstant(rightOperand))
+        emitGetVirtualRegister(op2, rightRegs);
 
 #if ENABLE(MATH_IC_STATS)
     auto inlineStart = label();
@@ -874,17 +845,10 @@ void JIT::emitMathICFast(JITBinaryMathIC<Generator>* mathIC, const JSInstruction
 
     bool generatedInlineCode = mathIC->generateInline(*this, mathICGenerationState);
     if (!generatedInlineCode) {
-        if (!leftOperand.isConst() && !rightOperand.isConst()) {
-            emitGetVirtualRegisters({
-                { op1, leftRegs },
-                { op2, rightRegs }
-            });
-        } else {
-            if (leftOperand.isConst())
-                emitGetVirtualRegister(op1, leftRegs);
-            else if (rightOperand.isConst())
-                emitGetVirtualRegister(op2, rightRegs);
-        }
+        if (leftOperand.isConst())
+            emitGetVirtualRegister(op1, leftRegs);
+        else if (rightOperand.isConst())
+            emitGetVirtualRegister(op2, rightRegs);
         BinaryArithProfile* arithProfile = mathIC->arithProfile();
         loadGlobalObject(globalObjectGPR);
         if (arithProfile && shouldEmitProfiling())
@@ -974,17 +938,10 @@ void JIT::emitMathICSlow(JITBinaryMathIC<Generator>* mathIC, const JSInstruction
 
     ASSERT(!(Generator::isLeftOperandValidConstant(leftOperand) && Generator::isRightOperandValidConstant(rightOperand)));
 
-    if (!Generator::isLeftOperandValidConstant(leftOperand) && !Generator::isRightOperandValidConstant(rightOperand)) {
-        emitGetVirtualRegisters({
-            { op1, leftRegs },
-            { op2, rightRegs }
-        });
-    } else {
-        if (Generator::isLeftOperandValidConstant(leftOperand))
-            emitGetVirtualRegister(op1, leftRegs);
-        else if (Generator::isRightOperandValidConstant(rightOperand))
-            emitGetVirtualRegister(op2, rightRegs);
-    }
+    if (Generator::isLeftOperandValidConstant(leftOperand))
+        emitGetVirtualRegister(op1, leftRegs);
+    else if (Generator::isRightOperandValidConstant(rightOperand))
+        emitGetVirtualRegister(op2, rightRegs);
 
 #if ENABLE(MATH_IC_STATS)
     auto slowPathStart = label();
@@ -1051,17 +1008,10 @@ void JIT::emit_op_div(const JSInstruction* currentInstruction)
 
     RELEASE_ASSERT(!leftOperand.isConst() || !rightOperand.isConst());
 
-    if (!leftOperand.isConst() && !rightOperand.isConst()) {
-        emitGetVirtualRegisters({
-            { op1, leftRegs },
-            { op2, rightRegs }
-        });
-    } else {
-        if (!leftOperand.isConst())
-            emitGetVirtualRegister(op1, leftRegs);
-        if (!rightOperand.isConst())
-            emitGetVirtualRegister(op2, rightRegs);
-    }
+    if (!leftOperand.isConst())
+        emitGetVirtualRegister(op1, leftRegs);
+    if (!rightOperand.isConst())
+        emitGetVirtualRegister(op2, rightRegs);
 
     JITDivGenerator gen(leftOperand, rightOperand, resultRegs, leftRegs, rightRegs,
         fpRegT0, fpRegT1, scratchGPR, scratchFPR, arithProfile);

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -189,15 +189,8 @@ void JIT::compileCallDirectEval(const OpCallDirectEval& bytecode)
 
     resetSP();
 
-#if USE(JSVALUE32_64)
     emitGetVirtualRegister(bytecode.m_thisValue, thisValueJSR);
     emitGetVirtualRegisterPayload(bytecode.m_scope, scopeGPR);
-#else
-    emitGetVirtualRegisters({
-        { bytecode.m_thisValue, thisValueJSR },
-        { bytecode.m_scope, JSValueRegs { scopeGPR } }
-    });
-#endif
     callOperation(bytecode.m_ecmaMode.isStrict() ? operationCallDirectEvalStrict : operationCallDirectEvalSloppy, calleeFrameGPR, scopeGPR, thisValueJSR);
     addSlowCase(branchIfEmpty(returnValueJSR));
 

--- a/Source/JavaScriptCore/jit/JITCode.cpp
+++ b/Source/JavaScriptCore/jit/JITCode.cpp
@@ -164,7 +164,7 @@ JITCodeWithCodeRef::JITCodeWithCodeRef(CodeRef<JSEntryPtrTag> ref, JITType jitTy
 
 JITCodeWithCodeRef::~JITCodeWithCodeRef()
 {
-    if ((Options::dumpDisassembly() || ((jitType() == JITType::BaselineJIT) && Options::dumpBaselineDisassembly()) || (isOptimizingJIT(jitType()) && Options::dumpDFGDisassembly()))
+    if ((Options::dumpDisassembly() || (isOptimizingJIT(jitType()) && Options::dumpDFGDisassembly()))
         && m_executableMemory)
         dataLog("Destroying JIT code at ", pointerDump(m_executableMemory.get()), "\n");
 }

--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -158,10 +158,8 @@ void JIT::emit_op_instanceof(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::Instanceof::protoJSR;
     using BaselineJITRegisters::Instanceof::stubInfoGPR;
 
-    emitGetVirtualRegisters({
-        { value, valueJSR },
-        { proto, protoJSR }
-    });
+    emitGetVirtualRegister(value, valueJSR);
+    emitGetVirtualRegister(proto, protoJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -421,15 +419,8 @@ void JIT::emit_op_set_function_name(const JSInstruction* currentInstruction)
     constexpr GPRReg functionGPR = preferredArgumentGPR<SlowOperation, 1>();
     constexpr JSValueRegs nameJSR = preferredArgumentJSR<SlowOperation, 2>();
 
-#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(bytecode.m_function, functionGPR);
     emitGetVirtualRegister(bytecode.m_name, nameJSR);
-#else
-    emitGetVirtualRegisters({
-        { bytecode.m_function, JSValueRegs { functionGPR } },
-        { bytecode.m_name, nameJSR }
-    });
-#endif
     loadGlobalObject(globalObjectGPR);
     callOperation(operationSetFunctionName, globalObjectGPR, functionGPR, nameJSR);
 }
@@ -611,10 +602,8 @@ void JIT::emit_op_jneq_ptr(const JSInstruction* currentInstruction)
 void JIT::emit_op_eq(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpEq>();
-    emitGetVirtualRegisters({
-        { bytecode.m_lhs, JSValueRegs { regT0 } },
-        { bytecode.m_rhs, JSValueRegs { regT1 } }
-    });
+    emitGetVirtualRegister(bytecode.m_lhs, regT0);
+    emitGetVirtualRegister(bytecode.m_rhs, regT1);
     emitJumpSlowCaseIfNotInt(regT0, regT1, regT2);
     compare32(Equal, regT1, regT0, regT0);
     boxBoolean(regT0, jsRegT10);
@@ -625,10 +614,8 @@ void JIT::emit_op_jeq(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpJeq>();
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
-    emitGetVirtualRegisters({
-        { bytecode.m_lhs, JSValueRegs { regT0 } },
-        { bytecode.m_rhs, JSValueRegs { regT1 } }
-    });
+    emitGetVirtualRegister(bytecode.m_lhs, regT0);
+    emitGetVirtualRegister(bytecode.m_rhs, regT1);
     emitJumpSlowCaseIfNotInt(regT0, regT1, regT2);
     addJump(branch32(Equal, regT0, regT1), target);
 }
@@ -681,10 +668,8 @@ MacroAssemblerCodeRef<JITThunkPtrTag> JIT::valueIsTruthyGenerator(VM& vm)
 void JIT::emit_op_neq(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpNeq>();
-    emitGetVirtualRegisters({
-        { bytecode.m_lhs, JSValueRegs { regT0 } },
-        { bytecode.m_rhs, JSValueRegs { regT1 } }
-    });
+    emitGetVirtualRegister(bytecode.m_lhs, regT0);
+    emitGetVirtualRegister(bytecode.m_rhs, regT1);
     emitJumpSlowCaseIfNotInt(regT0, regT1, regT2);
     compare32(NotEqual, regT1, regT0, regT0);
     boxBoolean(regT0, jsRegT10);
@@ -696,10 +681,8 @@ void JIT::emit_op_jneq(const JSInstruction* currentInstruction)
 {
     auto bytecode = currentInstruction->as<OpJneq>();
     unsigned target = jumpTarget(currentInstruction, bytecode.m_targetLabel);
-    emitGetVirtualRegisters({
-        { bytecode.m_lhs, JSValueRegs { regT0 } },
-        { bytecode.m_rhs, JSValueRegs { regT1 } }
-    });
+    emitGetVirtualRegister(bytecode.m_lhs, regT0);
+    emitGetVirtualRegister(bytecode.m_rhs, regT1);
     emitJumpSlowCaseIfNotInt(regT0, regT1, regT2);
     addJump(branch32(NotEqual, regT0, regT1), target);
 }
@@ -760,10 +743,8 @@ void JIT::compileOpStrictEq(const JSInstruction* currentInstruction)
     VirtualRegister src1 = bytecode.m_lhs;
     VirtualRegister src2 = bytecode.m_rhs;
 
-    emitGetVirtualRegisters({
-        { src1, JSValueRegs { regT0 } },
-        { src2, JSValueRegs { regT1 } }
-    });
+    emitGetVirtualRegister(src1, regT0);
+    emitGetVirtualRegister(src2, regT1);
 
 #if USE(BIGINT32)
     /* At a high level we do (assuming 'type' to be StrictEq):
@@ -848,10 +829,8 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
     VirtualRegister src1 = bytecode.m_lhs;
     VirtualRegister src2 = bytecode.m_rhs;
 
-    emitGetVirtualRegisters({
-        { src1, JSValueRegs { regT0 } },
-        { src2, JSValueRegs { regT1 } }
-    });
+    emitGetVirtualRegister(src1, regT0);
+    emitGetVirtualRegister(src2, regT1);
 
 #if USE(BIGINT32)
     /* At a high level we do (assuming 'type' to be StrictEq):
@@ -1855,15 +1834,8 @@ void JIT::emit_op_log_shadow_chicken_tail(const JSInstruction* currentInstructio
         GPRReg scratch2Reg = regT2;
         ensureShadowChickenPacket(vm(), shadowPacketReg, scratch1Reg, scratch2Reg);
     }
-#if USE(JSVALUE32_64)
     emitGetVirtualRegister(bytecode.m_thisValue, jsRegT32);
     emitGetVirtualRegisterPayload(bytecode.m_scope, regT4);
-#else
-    emitGetVirtualRegisters({
-        { bytecode.m_thisValue, jsRegT32 },
-        { bytecode.m_scope, JSValueRegs { regT4 } }
-    });
-#endif
     loadPtr(addressFor(CallFrameSlot::codeBlock), regT1);
     logShadowChickenTailPacket(shadowPacketReg, jsRegT32, regT4, regT1, CallSiteIndex(m_bytecodeIndex));
 }

--- a/Source/JavaScriptCore/jit/JITOpcodes32_64.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes32_64.cpp
@@ -44,10 +44,8 @@ namespace JSC {
 
 void JIT::compileOpEqCommon(VirtualRegister src1, VirtualRegister src2)
 {
-    emitGetVirtualRegisters({
-        { src1, jsRegT10 },
-        { src2, jsRegT32 }
-    });
+    emitGetVirtualRegister(src1, jsRegT10);
+    emitGetVirtualRegister(src2, jsRegT32);
     addSlowCase(branch32(NotEqual, jsRegT10.tagGPR(), jsRegT32.tagGPR()));
     addSlowCase(branchIfCell(jsRegT10));
     addSlowCase(branch32(Below, jsRegT10.tagGPR(), TrustedImm32(JSValue::LowestTag)));
@@ -162,10 +160,8 @@ void JIT::emitSlow_op_jneq(const JSInstruction* currentInstruction, Vector<SlowC
 
 void JIT::compileOpStrictEqCommon(VirtualRegister src1,  VirtualRegister src2)
 {
-    emitGetVirtualRegisters({
-        { src1, jsRegT10 },
-        { src2, jsRegT32 }
-    });
+    emitGetVirtualRegister(src1, jsRegT10);
+    emitGetVirtualRegister(src2, jsRegT32);
 
     // Bail if the tags differ, or are double.
     addSlowCase(branch32(NotEqual, jsRegT10.tagGPR(), jsRegT32.tagGPR()));

--- a/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
+++ b/Source/JavaScriptCore/jit/JITPropertyAccess.cpp
@@ -60,10 +60,8 @@ void JIT::emit_op_get_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByVal::profileGPR;
     using BaselineJITRegisters::GetByVal::scratch1GPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { property, propertyJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(property, propertyJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -120,10 +118,8 @@ void JIT::emit_op_get_private_name(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByVal::resultJSR;
     using BaselineJITRegisters::GetByVal::stubInfoGPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { property, propertyJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(property, propertyJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -163,10 +159,8 @@ void JIT::emit_op_set_private_brand(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PrivateBrand::propertyJSR;
     using BaselineJITRegisters::PrivateBrand::stubInfoGPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { brand, propertyJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(brand, propertyJSR);
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
 
@@ -206,10 +200,8 @@ void JIT::emit_op_check_private_brand(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PrivateBrand::propertyJSR;
     using BaselineJITRegisters::PrivateBrand::stubInfoGPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { brand, propertyJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(brand, propertyJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -249,11 +241,9 @@ void JIT::emit_op_put_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PutByVal::stubInfoGPR;
     using BaselineJITRegisters::PutByVal::scratch1GPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { property, propertyJSR },
-        { value, valueJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(property, propertyJSR);
+    emitGetVirtualRegister(value, valueJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -328,11 +318,9 @@ void JIT::emit_op_put_private_name(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PutByVal::valueJSR;
     using BaselineJITRegisters::PutByVal::stubInfoGPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { property, propertyJSR },
-        { value, valueJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(property, propertyJSR);
+    emitGetVirtualRegister(value, valueJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -404,18 +392,10 @@ void JIT::emit_op_put_getter_by_val(const JSInstruction* currentInstruction)
     // Attributes in argument 3
     constexpr GPRReg setterGPR = preferredArgumentGPR<SlowOperation, 4>();
 
-    int32_t attributes = bytecode.m_attributes;
-#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(bytecode.m_base, baseGPR);
     emitGetVirtualRegister(bytecode.m_property, propertyJSR);
+    int32_t attributes = bytecode.m_attributes;
     emitGetVirtualRegisterPayload(bytecode.m_accessor, setterGPR);
-#else
-    emitGetVirtualRegisters({
-        { bytecode.m_base, JSValueRegs { baseGPR } },
-        { bytecode.m_property, propertyJSR },
-        { bytecode.m_accessor, JSValueRegs { setterGPR } }
-    });
-#endif
     loadGlobalObject(globalObjectGRP);
     callOperation(operationPutGetterByVal, globalObjectGRP, baseGPR, propertyJSR, attributes, setterGPR);
 }
@@ -431,18 +411,10 @@ void JIT::emit_op_put_setter_by_val(const JSInstruction* currentInstruction)
     // Attributes in argument 3
     constexpr GPRReg setterGPR = preferredArgumentGPR<SlowOperation, 4>();
 
-    int32_t attributes = bytecode.m_attributes;
-#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(bytecode.m_base, baseGPR);
     emitGetVirtualRegister(bytecode.m_property, propertyJSR);
+    int32_t attributes = bytecode.m_attributes;
     emitGetVirtualRegisterPayload(bytecode.m_accessor, setterGPR);
-#else
-    emitGetVirtualRegisters({
-        { bytecode.m_base, JSValueRegs { baseGPR } },
-        { bytecode.m_property, propertyJSR },
-        { bytecode.m_accessor, JSValueRegs { setterGPR } }
-    });
-#endif
     loadGlobalObject(globalObjectGRP);
     callOperation(operationPutSetterByVal, globalObjectGRP, baseGPR, propertyJSR, attributes, setterGPR);
 }
@@ -507,10 +479,8 @@ void JIT::emit_op_del_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::DelByVal::resultJSR;
     using BaselineJITRegisters::DelByVal::stubInfoGPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { property, propertyJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(property, propertyJSR);
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
 
@@ -692,10 +662,8 @@ void JIT::emit_op_get_by_id_with_this(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByIdWithThis::resultJSR;
     using BaselineJITRegisters::GetByIdWithThis::stubInfoGPR;
 
-    emitGetVirtualRegisters({
-        { baseVReg, baseJSR },
-        { thisVReg, thisJSR }
-    });
+    emitGetVirtualRegister(baseVReg, baseJSR);
+    emitGetVirtualRegister(thisVReg, thisJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -744,10 +712,8 @@ void JIT::emit_op_put_by_id(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::PutById::stubInfoGPR;
     using BaselineJITRegisters::PutById::scratch1GPR;
 
-    emitGetVirtualRegisters({
-        { baseVReg, baseJSR },
-        { valueVReg, valueJSR }
-    });
+    emitGetVirtualRegister(baseVReg, baseJSR);
+    emitGetVirtualRegister(valueVReg, valueJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -832,10 +798,8 @@ void JIT::emit_op_in_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::InByVal::profileGPR;
     using BaselineJITRegisters::InByVal::scratch1GPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { property, propertyJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(property, propertyJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -872,10 +836,8 @@ void JIT::emitHasPrivate(VirtualRegister dst, VirtualRegister base, VirtualRegis
     using BaselineJITRegisters::InByVal::resultJSR;
     using BaselineJITRegisters::InByVal::stubInfoGPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { propertyOrBrand, propertyJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(propertyOrBrand, propertyJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -1454,15 +1416,8 @@ void JIT::emit_op_put_to_scope(const JSInstruction* currentInstruction)
             loadPtrFromMetadata(bytecode, OpPutToScope::Metadata::offsetOfWatchpointSet(), regT3);
             loadPtrFromMetadata(bytecode, OpPutToScope::Metadata::offsetOfOperand(), regT2);
             emitNotifyWriteWatchpoint(regT3);
-#if USE(JSVALUE32_64)
             emitGetVirtualRegister(value, jsRegT10);
             emitGetVirtualRegisterPayload(scope, regT3);
-#else
-            emitGetVirtualRegisters({
-                { value, jsRegT10 },
-                { scope, JSValueRegs { regT3 } }
-            });
-#endif
             storeValue(jsRegT10, BaseIndex(regT3, regT2, TimesEight, JSLexicalEnvironment::offsetOfVariables()));
 
             emitWriteBarrier(scope, value, ShouldFilterValue);
@@ -1608,15 +1563,8 @@ void JIT::emit_op_put_to_arguments(const JSInstruction* currentInstruction)
     VirtualRegister value = bytecode.m_value;
 
     static_assert(noOverlap(regT2, jsRegT10));
-#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(arguments, regT2);
     emitGetVirtualRegister(value, jsRegT10);
-#else
-    emitGetVirtualRegisters({
-        { arguments, JSValueRegs { regT2 } },
-        { value, jsRegT10 }
-    });
-#endif
     storeValue(jsRegT10, Address(regT2, DirectArguments::storageOffset() + index * sizeof(WriteBarrier<Unknown>)));
 
     emitWriteBarrier(arguments, value, ShouldFilterValue);
@@ -1644,15 +1592,8 @@ void JIT::emit_op_put_internal_field(const JSInstruction* currentInstruction)
     unsigned index = bytecode.m_index;
 
     static_assert(noOverlap(regT2, jsRegT10));
-#if USE(JSVALUE32_64)
     emitGetVirtualRegisterPayload(base, regT2);
     emitGetVirtualRegister(value, jsRegT10);
-#else
-    emitGetVirtualRegisters({
-        { base, JSValueRegs { regT2 } },
-        { value, jsRegT10 }
-    });
-#endif
     storeValue(jsRegT10, Address(regT2, JSInternalFieldObjectImpl<>::offsetOfInternalField(index)));
     emitWriteBarrier(base, value, ShouldFilterValue);
 }
@@ -1675,11 +1616,9 @@ void JIT::emit_op_get_by_val_with_this(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::GetByValWithThis::profileGPR;
     using BaselineJITRegisters::GetByValWithThis::scratch1GPR;
 
-    emitGetVirtualRegisters({
-        { base, baseJSR },
-        { property, propertyJSR },
-        { thisValue, thisJSR }
-    });
+    emitGetVirtualRegister(base, baseJSR);
+    emitGetVirtualRegister(property, propertyJSR);
+    emitGetVirtualRegister(thisValue, thisJSR);
 
     auto [ stubInfo, stubInfoIndex ] = addUnlinkedStructureStubInfo();
     loadConstant(stubInfoIndex, stubInfoGPR);
@@ -1770,11 +1709,9 @@ void JIT::emit_op_enumerator_next(const JSInstruction* currentInstruction)
     if (bytecode.metadata(m_profiledCodeBlock).m_enumeratorMetadata == JSPropertyNameEnumerator::OwnStructureMode) {
         GPRReg enumeratorGPR = regT3;
         GPRReg scratch1GPR = regT4;
-        emitGetVirtualRegisters({
-            { enumerator, JSValueRegs { enumeratorGPR } },
-            { base, JSValueRegs { baseGPR } }
-        });
+        emitGetVirtualRegister(enumerator, enumeratorGPR);
         operationCases.append(branchTest32(NonZero, Address(enumeratorGPR, JSPropertyNameEnumerator::flagsOffset()), TrustedImm32((~JSPropertyNameEnumerator::OwnStructureMode) & JSPropertyNameEnumerator::enumerationModeMask)));
+        emitGetVirtualRegister(base, baseGPR);
 
         load8FromMetadata(bytecode, OpEnumeratorNext::Metadata::offsetOfEnumeratorMetadata(), scratch1GPR);
         or32(TrustedImm32(JSPropertyNameEnumerator::OwnStructureMode), scratch1GPR);
@@ -1783,10 +1720,8 @@ void JIT::emit_op_enumerator_next(const JSInstruction* currentInstruction)
         load32(Address(enumeratorGPR, JSPropertyNameEnumerator::cachedStructureIDOffset()), indexGPR);
         operationCases.append(branch32(NotEqual, indexGPR, Address(baseGPR, JSCell::structureIDOffset())));
 
-        emitGetVirtualRegisters({
-            { mode, JSValueRegs { modeGPR } },
-            { index, JSValueRegs { indexGPR } }
-        });
+        emitGetVirtualRegister(mode, modeGPR);
+        emitGetVirtualRegister(index, indexGPR);
         Jump notInit = branchTest32(Zero, modeGPR);
         // Need to use add64 since this is a JSValue int32.
         add64(TrustedImm32(1), indexGPR);
@@ -1826,18 +1761,18 @@ void JIT::emit_enumerator_has_propertyImpl(const Bytecode& bytecode, SlowPathFun
 
     JumpList slowCases;
 
-    emitGetVirtualRegisters({
-        { base, JSValueRegs { regT0 } },
-        { enumerator, JSValueRegs { regT1 } },
-        { mode, JSValueRegs { regT2 } }
-    });
-    load8FromMetadata(bytecode, Bytecode::Metadata::offsetOfEnumeratorMetadata(), regT3);
-    or32(regT2, regT3);
-    store8ToMetadata(regT3, bytecode, Bytecode::Metadata::offsetOfEnumeratorMetadata());
+    emitGetVirtualRegister(mode, regT0);
+    load8FromMetadata(bytecode, Bytecode::Metadata::offsetOfEnumeratorMetadata(), regT1);
+    or32(regT0, regT1);
+    store8ToMetadata(regT1, bytecode, Bytecode::Metadata::offsetOfEnumeratorMetadata());
 
-    slowCases.append(branchTest32(Zero, regT2, TrustedImm32(JSPropertyNameEnumerator::OwnStructureMode)));
+    slowCases.append(branchTest32(Zero, regT0, TrustedImm32(JSPropertyNameEnumerator::OwnStructureMode)));
+
+    emitGetVirtualRegister(base, regT0);
+
     slowCases.append(branchIfNotCell(regT0));
 
+    emitGetVirtualRegister(enumerator, regT1);
     load32(Address(regT0, JSCell::structureIDOffset()), regT0);
     slowCases.append(branch32(NotEqual, regT0, Address(regT1, JSPropertyNameEnumerator::cachedStructureIDOffset())));
 
@@ -1886,11 +1821,9 @@ void JIT::emit_op_enumerator_get_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::EnumeratorGetByVal::scratch2GPR;
     using BaselineJITRegisters::EnumeratorGetByVal::scratch3GPR;
 
-    emitGetVirtualRegisters({
-        { base, JSValueRegs { baseGPR } },
-        { mode, JSValueRegs { scratch3GPR } },
-        { propertyName, JSValueRegs { propertyGPR } }
-    });
+    emitGetVirtualRegister(base, baseGPR);
+    emitGetVirtualRegister(mode, scratch3GPR);
+    emitGetVirtualRegister(propertyName, propertyGPR);
 
     load8FromMetadata(bytecode, OpEnumeratorGetByVal::Metadata::offsetOfEnumeratorMetadata(), scratch2GPR);
     or32(scratch3GPR, scratch2GPR);
@@ -1981,13 +1914,12 @@ void JIT::emit_op_enumerator_put_by_val(const JSInstruction* currentInstruction)
     using BaselineJITRegisters::EnumeratorPutByVal::scratch2GPR;
 
     // These four registers need to be set up before jumping to SlowPath code.
-    emitGetVirtualRegisters({
-        { base, JSValueRegs { baseGPR } },
-        { value, JSValueRegs { valueGPR } },
-        { propertyName, JSValueRegs { propertyGPR } },
-        { mode, JSValueRegs { scratch2GPR } }
-    });
+    emitGetVirtualRegister(base, baseGPR);
+    emitGetVirtualRegister(value, valueGPR);
+    emitGetVirtualRegister(propertyName, propertyGPR);
     materializePointerIntoMetadata(bytecode, OpEnumeratorPutByVal::Metadata::offsetOfArrayProfile(), profileGPR);
+
+    emitGetVirtualRegister(mode, scratch2GPR);
 
     load8FromMetadata(bytecode, OpEnumeratorPutByVal::Metadata::offsetOfEnumeratorMetadata(), scratch1GPR);
     or32(scratch2GPR, scratch1GPR);

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -607,7 +607,6 @@ static inline void disableAllJITOptions()
 
     Options::dumpDisassembly() = false;
     Options::asyncDisassembly() = false;
-    Options::dumpBaselineDisassembly() = false;
     Options::dumpDFGDisassembly() = false;
     Options::dumpFTLDisassembly() = false;
     Options::dumpRegExpDisassembly() = false;
@@ -707,7 +706,6 @@ void Options::notifyOptionsChanged()
 
         if (Options::dumpDisassembly()
             || Options::asyncDisassembly()
-            || Options::dumpBaselineDisassembly()
             || Options::dumpDFGDisassembly()
             || Options::dumpFTLDisassembly()
             || Options::dumpRegExpDisassembly()

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -134,7 +134,6 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, dumpDisassembly, false, Normal, "dumps disassembly of all JIT compiled code upon compilation") \
     v(Bool, asyncDisassembly, false, Normal, nullptr) \
     v(Bool, logJIT, false, Normal, nullptr) \
-    v(Bool, dumpBaselineDisassembly, false, Normal, "dumps disassembly of Baseline function upon compilation") \
     v(Bool, dumpDFGDisassembly, false, Normal, "dumps disassembly of DFG function upon compilation") \
     v(Bool, dumpFTLDisassembly, false, Normal, "dumps disassembly of FTL function upon compilation") \
     v(Bool, dumpRegExpDisassembly, false, Normal, "dumps disassembly of RegExp upon compilation") \


### PR DESCRIPTION
#### c091a2ca3805926207ef25922e76a5a1edf57fcc
<pre>
Unreviewed, revert 267869@main, potential MotionMark regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=262493">https://bugs.webkit.org/show_bug.cgi?id=262493</a>
rdar://116198459

* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::compileAndLinkWithoutFinalizing):
(JSC::JIT::link):
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITArithmetic.cpp:
(JSC::JIT::emit_compareImpl):
(JSC::JIT::emit_compareSlowImpl):
(JSC::JIT::emit_op_mod):
(JSC::JIT::emit_op_pow):
(JSC::JIT::emitBitBinaryOpFastPath):
(JSC::JIT::emitRightShiftFastPath):
(JSC::JIT::emitMathICFast):
(JSC::JIT::emitMathICSlow):
(JSC::JIT::emit_op_div):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileCallDirectEval):
* Source/JavaScriptCore/jit/JITCode.cpp:
(JSC::JITCodeWithCodeRef::~JITCodeWithCodeRef):
* Source/JavaScriptCore/jit/JITInlines.h:
(JSC::JIT::emitGetVirtualRegisters): Deleted.
* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::emit_op_instanceof):
(JSC::JIT::emit_op_set_function_name):
(JSC::JIT::emit_op_eq):
(JSC::JIT::emit_op_jeq):
(JSC::JIT::emit_op_neq):
(JSC::JIT::emit_op_jneq):
(JSC::JIT::compileOpStrictEq):
(JSC::JIT::compileOpStrictEqJump):
(JSC::JIT::emit_op_log_shadow_chicken_tail):
* Source/JavaScriptCore/jit/JITOpcodes32_64.cpp:
(JSC::JIT::compileOpEqCommon):
(JSC::JIT::compileOpStrictEqCommon):
* Source/JavaScriptCore/jit/JITPropertyAccess.cpp:
(JSC::JIT::emit_op_get_by_val):
(JSC::JIT::emit_op_get_private_name):
(JSC::JIT::emit_op_set_private_brand):
(JSC::JIT::emit_op_check_private_brand):
(JSC::JIT::emit_op_put_by_val):
(JSC::JIT::emit_op_put_private_name):
(JSC::JIT::emit_op_put_getter_by_val):
(JSC::JIT::emit_op_put_setter_by_val):
(JSC::JIT::emit_op_del_by_val):
(JSC::JIT::emit_op_get_by_id_with_this):
(JSC::JIT::emit_op_put_by_id):
(JSC::JIT::emit_op_in_by_val):
(JSC::JIT::emitHasPrivate):
(JSC::JIT::emit_op_put_to_scope):
(JSC::JIT::emit_op_put_to_arguments):
(JSC::JIT::emit_op_put_internal_field):
(JSC::JIT::emit_op_get_by_val_with_this):
(JSC::JIT::emit_op_enumerator_next):
(JSC::JIT::emit_enumerator_has_propertyImpl):
(JSC::JIT::emit_op_enumerator_get_by_val):
(JSC::JIT::emit_op_enumerator_put_by_val):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::disableAllJITOptions):
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/268741@main">https://commits.webkit.org/268741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/181ed65dd35d655fc559b328f0f108931227e53d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19151 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21132 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23285 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18658 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17880 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22877 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/19959 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16501 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/23940 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18636 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5720 "Found 1 jsc stress test failure: stress/sampling-profiler-microtasks.js.dfg-eager") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22975 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25198 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2537 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19240 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5543 "Passed tests") | 
<!--EWS-Status-Bubble-End-->