### PR TITLE
Use StringView in CSSParserToken and simplify its code

### DIFF
--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -261,15 +261,15 @@ String convertASCIICase(const CharacterType* input, unsigned length)
 String StringView::convertToASCIILowercase() const
 {
     if (m_is8Bit)
-        return convertASCIICase<ASCIICase::Lower>(static_cast<const LChar*>(m_characters), m_length);
-    return convertASCIICase<ASCIICase::Lower>(static_cast<const UChar*>(m_characters), m_length);
+        return convertASCIICase<ASCIICase::Lower>(static_cast<const LChar*>(m_characters.get()), m_length);
+    return convertASCIICase<ASCIICase::Lower>(static_cast<const UChar*>(m_characters.get()), m_length);
 }
 
 String StringView::convertToASCIIUppercase() const
 {
     if (m_is8Bit)
-        return convertASCIICase<ASCIICase::Upper>(static_cast<const LChar*>(m_characters), m_length);
-    return convertASCIICase<ASCIICase::Upper>(static_cast<const UChar*>(m_characters), m_length);
+        return convertASCIICase<ASCIICase::Upper>(static_cast<const LChar*>(m_characters.get()), m_length);
+    return convertASCIICase<ASCIICase::Upper>(static_cast<const UChar*>(m_characters.get()), m_length);
 }
 
 template<typename CharacterType>

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -48,7 +48,7 @@ template<typename CharacterType> void CSSVariableData::updateBackingStringsInTok
         if (!token.hasStringBacking())
             continue;
         unsigned length = token.value().length();
-        token.updateCharacters(currentOffset, length);
+        token.updateString({ currentOffset, length });
         currentOffset += length;
     }
     ASSERT(currentOffset == m_backingString.characters<CharacterType>() + m_backingString.length());

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -41,6 +41,14 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSParserToken);
 
+struct SameSizeAsCSSParserToken {
+    StringView value;
+    unsigned flags;
+    double unionValue;
+};
+
+static_assert(sizeof(CSSParserToken) == sizeof(SameSizeAsCSSParserToken), "CSSParserToken should stay small");
+
 template<typename CharacterType>
 CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned length)
 {
@@ -369,30 +377,30 @@ CSSParserToken::CSSParserToken(CSSParserTokenType type, UChar c)
 }
 
 CSSParserToken::CSSParserToken(CSSParserTokenType type, StringView value, BlockType blockType)
-    : m_type(type)
+    : m_value(value)
+    , m_type(type)
     , m_blockType(blockType)
 {
-    initValueFromStringView(value);
     m_id = -1;
 }
 
 CSSParserToken::CSSParserToken(double numericValue, NumericValueType numericValueType, NumericSign sign, StringView originalText)
-    : m_type(NumberToken)
+    : m_value(originalText)
+    , m_type(NumberToken)
     , m_blockType(NotBlock)
     , m_numericValueType(numericValueType)
     , m_numericSign(sign)
     , m_unit(static_cast<unsigned>(CSSUnitType::CSS_NUMBER))
     , m_numericValue(numericValue)
 {
-    initValueFromStringView(originalText);
 }
 
 CSSParserToken::CSSParserToken(HashTokenType type, StringView value)
-    : m_type(HashToken)
+    : m_value(value)
+    , m_type(HashToken)
     , m_blockType(NotBlock)
     , m_hashTokenType(type)
 {
-    initValueFromStringView(value);
 }
 
 static StringView mergeIfAdjacent(StringView a, StringView b)
@@ -422,7 +430,7 @@ void CSSParserToken::convertToDimensionWithUnit(StringView unit)
     m_type = DimensionToken;
     m_unit = static_cast<unsigned>(stringToUnitType(unit));
     m_nonUnitPrefixLength = string == unit ? 0 : originalNumberTextLength;
-    initValueFromStringView(string);
+    m_value = string;
 }
 
 void CSSParserToken::convertToPercentage()
@@ -540,7 +548,7 @@ CSSParserToken CSSParserToken::copyWithUpdatedString(StringView string) const
 {
     ASSERT(value() == string);
     CSSParserToken copy(*this);
-    copy.initValueFromStringView(string);
+    copy.m_value = string;
     return copy;
 }
 

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -117,7 +117,7 @@ public:
     void convertToPercentage();
 
     CSSParserTokenType type() const { return static_cast<CSSParserTokenType>(m_type); }
-    StringView value() const { return { m_valueDataCharRaw, m_valueLength, m_valueIs8Bit }; }
+    StringView value() const { return m_value; }
 
     UChar delimiter() const;
     NumericSign numericSign() const;
@@ -137,30 +137,18 @@ public:
 
     void serialize(StringBuilder&, const CSSParserToken* nextToken = nullptr) const;
 
-    template<typename CharacterType>
-    void updateCharacters(const CharacterType* characters, unsigned length);
-
+    void updateString(StringView string) { m_value = string; }
     CSSParserToken copyWithUpdatedString(StringView) const;
 
 private:
-    void initValueFromStringView(StringView string)
-    {
-        m_valueLength = string.length();
-        m_valueIs8Bit = string.is8Bit();
-        m_valueDataCharRaw = string.rawCharacters();
-    }
+    StringView m_value;
+
     unsigned m_type : 6; // CSSParserTokenType
     unsigned m_blockType : 2; // BlockType
     unsigned m_numericValueType : 1; // NumericValueType
     unsigned m_numericSign : 2; // NumericSign
     unsigned m_unit : 7; // CSSUnitType
     unsigned m_nonUnitPrefixLength : 4; // Only for DimensionType, only needs to be long enough for UnicodeRange parsing.
-
-    // m_value... is an unpacked StringView so that we can pack it
-    // tightly with the rest of this object for a smaller object size.
-    bool m_valueIs8Bit : 1;
-    unsigned m_valueLength;
-    const void* m_valueDataCharRaw; // Either LChar* or UChar*.
 
     union {
         UChar m_delimiter;
@@ -169,13 +157,5 @@ private:
         mutable int m_id;
     };
 };
-
-template<typename CharacterType>
-inline void CSSParserToken::updateCharacters(const CharacterType* characters, unsigned length)
-{
-    m_valueLength = length;
-    m_valueIs8Bit = (sizeof(CharacterType) == 1);
-    m_valueDataCharRaw = characters;
-}
 
 } // namespace WebCore


### PR DESCRIPTION
#### 855b9cf6ef5a2b8b5ead0d06314779d7fd1884fc
<pre>
Use StringView in CSSParserToken and simplify its code
<a href="https://bugs.webkit.org/show_bug.cgi?id=262498">https://bugs.webkit.org/show_bug.cgi?id=262498</a>

Reviewed by Darin Adler.

Use StringView in CSSParserToken and simplify its code.

Previously, CSSParserToken wasn&apos;t using StringView internally for better bit packing,
as the size of this object matters a lot. Instead, do better bit packing in StringView
so that CSSParserToken can use it without increasing its size (24 bits on my
macBookPro M1).

To better bit-pack StringView, we rely on PackedPtr to fit the is8Bit flag in the same
word as the character pointer.

This is performance neutral on Speedometer.

* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::convertToASCIILowercase const):
(WTF::StringView::convertToASCIIUppercase const):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::StringView):
(WTF::StringView::characters8 const):
(WTF::StringView::characters16 const):
* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::updateBackingStringsInTokens):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::CSSParserToken::CSSParserToken):
(WebCore::CSSParserToken::convertToDimensionWithUnit):
(WebCore::CSSParserToken::copyWithUpdatedString const):
* Source/WebCore/css/parser/CSSParserToken.h:
(WebCore::CSSParserToken::value const):
(WebCore::CSSParserToken::updateString):
(WebCore::CSSParserToken::initValueFromStringView): Deleted.
(WebCore::CSSParserToken::updateCharacters): Deleted.

Canonical link: <a href="https://commits.webkit.org/268760@main">https://commits.webkit.org/268760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03100cfa4c7077014c25c7b5aeb66f2e75ade67b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23342 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24985 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/17931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22926 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20015 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19470 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24003 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18690 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5730 "Found 4 jsc stress test failures: stress/sampling-profiler-microtasks.js.default, stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit, stress/sampling-profiler-microtasks.js.mini-mode, stress/sampling-profiler-microtasks.js.no-llint") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4942 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23026 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25261 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19289 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5555 "Passed tests") | 
<!--EWS-Status-Bubble-End-->