### PR TITLE
Fix build issue

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
@@ -6,14 +6,14 @@
 	<dict>
 		<key>EXExtensionPointIdentifier</key>
 		<string>com.apple.webkit.networking.extension</string>
-		<key>CFBundleIdentifier</key>
-		<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-		<key>CFBundleExecutable</key>
-		<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
-		<key>CFBundleVersion</key>
-		<string>${PRODUCT_BUNDLE_VERSION}</string>
-		<key>CFBundleName</key>
-		<string>${PRODUCT_BUNDLE_NAME}</string>
 	</dict>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleExecutable</key>
+	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<key>CFBundleVersion</key>
+	<string>${PRODUCT_BUNDLE_VERSION}</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_BUNDLE_NAME}</string>
 </dict>
 </plist>


### PR DESCRIPTION
#### 260ad484d4197a1ac3c8849c8fdb966276009e45
<pre>
Fix build issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=262503">https://bugs.webkit.org/show_bug.cgi?id=262503</a>
rdar://116140701

Reviewed by Sihui Liu.

Some items in the plist were incorrectly put inside a dictionary.

* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist:

Canonical link: <a href="https://commits.webkit.org/268755@main">https://commits.webkit.org/268755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a38be2a3dc2ccebfeac7ef87ca2f7d6a6fee7bf4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19170 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21154 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23307 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17791 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18869 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22894 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16521 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18656 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4938 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->