### PR TITLE
Expose WKSnapshotConfiguration._usesTransparentBackground as SPI

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm
@@ -30,6 +30,7 @@
 #if PLATFORM(MAC)
     BOOL _includesSelectionHighlighting;
 #endif
+    BOOL _usesTransparentBackground;
 }
 
 - (instancetype)init
@@ -65,12 +66,12 @@
 #if PLATFORM(MAC)
     snapshotConfiguration._includesSelectionHighlighting = self._includesSelectionHighlighting;
 #endif
+    snapshotConfiguration._usesTransparentBackground = self._usesTransparentBackground;
 
     return snapshotConfiguration;
 }
 
 #if PLATFORM(MAC)
-
 - (BOOL)_includesSelectionHighlighting
 {
     return _includesSelectionHighlighting;
@@ -80,7 +81,16 @@
 {
     _includesSelectionHighlighting = includesSelectionHighlighting;
 }
+#endif // PLATFORM(MAC)
 
-#endif
+- (BOOL)_usesTransparentBackground
+{
+    return _usesTransparentBackground;
+}
+
+- (void)_setUsesTransparentBackground:(BOOL)usesTransparentBackground
+{
+    _usesTransparentBackground = usesTransparentBackground;
+}
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfigurationPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,16 +25,16 @@
 
 #import <WebKit/WKSnapshotConfiguration.h>
 
-#if !TARGET_OS_IPHONE
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WKSnapshotConfiguration (WKPrivate)
 
+#if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setIncludesSelectionHighlighting:) BOOL _includesSelectionHighlighting WK_API_AVAILABLE(macos(13.3));
+#endif
+
+@property (nonatomic, setter=_setUsesTransparentBackground:) BOOL _usesTransparentBackground WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1240,6 +1240,8 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
     WebKit::SnapshotOptions snapshotOptions = WebKit::SnapshotOptionsInViewCoordinates;
     if (!snapshotConfiguration._includesSelectionHighlighting)
         snapshotOptions |= WebKit::SnapshotOptionsExcludeSelectionHighlighting;
+    if (snapshotConfiguration._usesTransparentBackground)
+        snapshotOptions |= WebKit::SnapshotOptionsTransparentBackground;
 
     // Software snapshot will not capture elements rendered with hardware acceleration (WebGL, video, etc).
     // This code doesn't consider snapshotConfiguration.afterScreenUpdates since the software snapshot always


### PR DESCRIPTION
#### 602025fdc4dc982b18d8ac3e040296ff13b06ff6
<pre>
Expose WKSnapshotConfiguration._usesTransparentBackground as SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=262501">https://bugs.webkit.org/show_bug.cgi?id=262501</a>
&lt;rdar://116260533&gt;

Reviewed by Timothy Hatcher and Patrick Angle.

To help clients move away from `-[WKWebProcessPlugInNodeHandle renderedImageWithOptions:]`,
make it possible to snapshot page contents with transparency by compositing on a transparent
background color. Transparent backgrounds are always used by WebPage::snapshotNode(), but
not the generic viewport snapshot method. Make it possible to do the same with WKWebView API.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView takeSnapshotWithConfiguration:completionHandler:]):
Add in `SnapshotOptionsTransparentBackground` if `-_usesTransparentBackground` is YES.

* Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfigurationPrivate.h:
Add `_usesTransparentBackground` / `_setUsesTransparentBackground`.

* Source/WebKit/UIProcess/API/Cocoa/WKSnapshotConfiguration.mm:
(-[WKSnapshotConfiguration init]):
(-[WKSnapshotConfiguration copyWithZone:]):
Add new field to `-copyWithZone:`.

(-[WKSnapshotConfiguration _usesTransparentBackground]):
(-[WKSnapshotConfiguration _setUsesTransparentBackground:]):
Added.

Canonical link: <a href="https://commits.webkit.org/268759@main">https://commits.webkit.org/268759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28bf5eaa27fb3697ac9f795691b9346cade6e4b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22464 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19195 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21170 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23321 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17806 "Passed tests") | | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22901 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16529 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18669 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4941 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->