### PR TITLE
[WGSL] Implement constant function for subtraction

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -74,10 +74,8 @@ struct ConstantValue : BaseValue {
 
     void dump(PrintStream&) const;
 
-    bool isNumber() const
-    {
-        return std::holds_alternative<int64_t>(*this) || std::holds_alternative<double>(*this);
-    }
+    bool isInt() const { return std::holds_alternative<int64_t>(*this); }
+    bool isNumber() const { return isInt() || std::holds_alternative<double>(*this); }
 
     bool toBool() const { return std::get<bool>(*this); }
     int64_t toInt() const

--- a/Source/WebGPU/WGSL/tests/valid/reordering.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/reordering.wgsl
@@ -1,6 +1,6 @@
 // RUN: %metal-compile main
 
-const x = y * 2;
+const x = y - 2;
 const y = 3;
 
 struct T {


### PR DESCRIPTION
#### 4239b6239ca6e22e94255f22781077ca0fd720b6
<pre>
[WGSL] Implement constant function for subtraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=262507">https://bugs.webkit.org/show_bug.cgi?id=262507</a>
rdar://116368320

Reviewed by Dan Glastonbury.

On 268726@main we made the constant rewriter stricter, which can cause the compilation
to fail if we can&apos;t evaluate a constant. This broke the imageBlur sample, since it has
constants with negative numbers, and we didn&apos;t yet support the unary minus operator
(or binary for that matter), but this patch adds support for both and fixes the sample.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::scalarOrVector):
(WGSL::constantPow):
(WGSL::constantMinus):
(WGSL::constantVector):
(WGSL::constantVector2):
(WGSL::constantVector3):
(WGSL::constantVector4):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantValue::isInt const):
(WGSL::ConstantValue::isNumber const):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/tests/valid/reordering.wgsl:

Canonical link: <a href="https://commits.webkit.org/268764@main">https://commits.webkit.org/268764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/684864dcb250d402c38726904ee64fae289aa378

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19190 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20560 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23319 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17802 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24965 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22904 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16531 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18667 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4947 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->