### PR TITLE
[scroll-anchoring] Have ExamineCandidate properly handle non-atomic inline boxes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-001-expected.txt
@@ -1,4 +1,4 @@
 abcd efg def ghi
 
-FAIL Anchoring with text wrapping changes. assert_equals: expected 250 but got 150
+PASS Anchoring with text wrapping changes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-002-expected.txt
@@ -1,4 +1,4 @@
 abcd efg def ghi
 
-FAIL Anchoring with text wrapping changes. assert_equals: expected 250 but got 150
+PASS Anchoring with text wrapping changes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-003-expected.txt
@@ -1,4 +1,4 @@
 abcd efg def ghi
 
-FAIL Anchoring with text wrapping changes. assert_equals: expected 250 but got 150
+PASS Anchoring with text wrapping changes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/text-anchor-in-vertical-rl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/text-anchor-in-vertical-rl-expected.txt
@@ -6,5 +6,5 @@ FAIL
 FAIL
 line
 
-FAIL Line at edge of scrollport shouldn't jump visually when content is inserted before assert_equals: expected -400 but got -300
+PASS Line at edge of scrollport shouldn't jump visually when content is inserted before
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/wrapped-text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/wrapped-text-expected.txt
@@ -1,4 +1,4 @@
 abcd efg def ghi
 
-FAIL Anchoring with text wrapping changes. assert_equals: expected 250 but got 150
+PASS Anchoring with text wrapping changes.
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -174,7 +174,7 @@ CandidateExaminationResult ScrollAnchoringController::examineCandidate(Element& 
         // TODO: figure out how to get scrollable area for renderer to check if it is maintaining scroll anchor
         if (renderer->style().overflowAnchor() == OverflowAnchor::None || renderer->isStickilyPositioned() || renderer->isFixedPositioned() || renderer->isPseudoElement() || renderer->isAnonymousBlock())
             return CandidateExaminationResult::Exclude;
-        if (&element == document->bodyOrFrameset() || is<HTMLHtmlElement>(&element) || (renderer->isInline() && !renderer->isAtomicInlineLevelBox()))
+        if (&element == document->bodyOrFrameset() || is<HTMLHtmlElement>(&element) || (is<RenderBox>(renderer) && renderer->isInline() && !renderer->isAtomicInlineLevelBox()))
             return CandidateExaminationResult::Skip;
         auto boxRect = renderer->absoluteBoundingBoxRect();
         if (!boxRect.width() || !boxRect.height())


### PR DESCRIPTION
#### 3e618b4b37deef32e5eaa1daf79cd2c2d218d705
<pre>
[scroll-anchoring] Have ExamineCandidate properly handle non-atomic inline boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=262511">https://bugs.webkit.org/show_bug.cgi?id=262511</a>
<a href="https://rdar.apple.com/116370324">rdar://116370324</a>

Reviewed by NOBODY (OOPS!).

We should only check if a renderer is a non-atomic inline box for boxes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/text-anchor-in-vertical-rl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/wrapped-text-expected.txt:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::examineCandidate):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e618b4b37deef32e5eaa1daf79cd2c2d218d705

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27681 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23581 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28263 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22997 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29098 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scroll-anchoring/text-anchor-in-vertical-rl.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/998 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4132 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3206 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->