### PR TITLE
[WebGPU][WGSL] Support @interpolate

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTInterpolateAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTInterpolateAttribute.h
@@ -47,17 +47,17 @@ public:
 
     NodeKind kind() const override;
     Type type() const { return m_type; }
-    Sampling sampling() const { return m_sampling; }
+    std::optional<Sampling> sampling() const { return m_sampling; }
 
 private:
-    InterpolateAttribute(SourceSpan span, Type type, Sampling sampling)
+    InterpolateAttribute(SourceSpan span, Type type, std::optional<Sampling> sampling)
         : Attribute(span)
         , m_type(type)
-        , m_sampling(sampling)
+        , m_sampling(WTFMove(sampling))
     { }
 
     Type m_type;
-    Sampling m_sampling;
+    std::optional<Sampling> m_sampling;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -133,8 +133,9 @@ void Visitor::visit(AST::IdAttribute& attribute)
     visit(attribute.value());
 }
 
-void Visitor::visit(AST::InterpolateAttribute&)
+void Visitor::visit(AST::InterpolateAttribute& attribute)
 {
+    visit(attribute.type(), attribute.sampling());
 }
 
 void Visitor::visit(AST::InvariantAttribute&)

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ASTForward.h"
+#include "ASTInterpolateAttribute.h"
 #include "CompilationMessage.h"
 
 #include <wtf/Expected.h>
@@ -111,6 +112,8 @@ public:
 
     virtual void visit(AST::Variable&);
     virtual void visit(AST::VariableQualifier&);
+
+    virtual void visit(AST::InterpolateAttribute::Type, std::optional<AST::InterpolateAttribute::Sampling>) { }
 
     bool hasError() const;
     Result<void> result();

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -616,6 +616,29 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
         RETURN_ARENA_NODE(AlignAttribute, WTFMove(alignment));
     }
 
+    if (ident.ident == "interpolate"_s) {
+        CONSUME_TYPE(ParenLeft);
+        PARSE(interpolate, Identifier);
+        AST::InterpolateAttribute::Type interpolationType { AST::InterpolateAttribute::Type::Flat };
+        if (interpolate == "perspective"_s)
+            interpolationType = AST::InterpolateAttribute::Type::Perspective;
+        else if (interpolate == "linear"_s)
+            interpolationType = AST::InterpolateAttribute::Type::Linear;
+        AST::InterpolateAttribute::Sampling sampleType { AST::InterpolateAttribute::Sampling::Center };
+        if (current().type == TokenType::Comma) {
+            consume();
+            PARSE(sampling, Identifier);
+            UNUSED_PARAM(sampling);
+            if (sampling == "centroid"_s)
+                sampleType = AST::InterpolateAttribute::Sampling::Centroid;
+            else if (sampling == "sample"_s)
+                sampleType = AST::InterpolateAttribute::Sampling::Sample;
+        }
+        CONSUME_TYPE(ParenRight);
+        UNUSED_PARAM(interpolate);
+        RETURN_ARENA_NODE(InterpolateAttribute, interpolationType, sampleType);
+    }
+
     if (ident.ident == "size"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(size, Expression);


### PR DESCRIPTION
#### 93cfb0d7485895eebe72c136501b709572ada15c
<pre>
[WebGPU][WGSL] Support @interpolate
<a href="https://bugs.webkit.org/show_bug.cgi?id=262509">https://bugs.webkit.org/show_bug.cgi?id=262509</a>
&lt;radar://113987505&gt;

Reviewed by Dan Glastonbury.

Support @interpolate which allows for flat shading, linear / non-perspective
interpolation, along with sample, center, and centroid sampling.

* Source/WebGPU/WGSL/AST/ASTInterpolateAttribute.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::convertToSampleMode):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/268762@main">https://commits.webkit.org/268762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9c61d60dedc020b20a2b24771541ae06aa04057

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19199 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20566 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23324 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17803 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24966 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22905 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18672 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4945 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23008 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19271 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->