### PR TITLE
[css-grid] Resolve and set the row start, non-auto margins for subgrids with baseline aligned items.

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt
@@ -1,10 +1,6 @@
 X
 X
 
-FAIL .first-baseline 1 assert_equals:
-<div data-offset-y="31" class="first-baseline">X</div>
-offsetTop expected 31 but got 16
-FAIL .first-baseline 2 assert_equals:
-<div data-offset-y="31" class="first-baseline">X</div>
-offsetTop expected 31 but got 16
+PASS .first-baseline 1
+PASS .first-baseline 2
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt
@@ -6,31 +6,19 @@
 
 
 PASS .item 1
-FAIL .item 2 assert_equals:
-<div data-offset-y="85" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetTop expected 85 but got 93
-FAIL .item 3 assert_equals:
-<div data-offset-y="163" class="item first">
-        <span></span><br><span></span>
-      </div>
-offsetTop expected 163 but got 171
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div data-offset-y="218" class="item last">
         <span></span><br><span></span>
       </div>
-offsetTop expected 218 but got 233
-FAIL .item 5 assert_equals:
-<div data-offset-y="308" class="item first">
-      <span></span><br><span></span>
-    </div>
-offsetTop expected 308 but got 313
+offsetTop expected 218 but got 225
+PASS .item 5
 FAIL .item 6 assert_equals:
 <div data-offset-y="360" class="item last">
       <span></span><br><span></span>
     </div>
-offsetTop expected 360 but got 375
+offsetTop expected 360 but got 370
 FAIL .item 7 assert_equals:
 <div data-offset-y="41" class="item small first"></div>
 offsetTop expected 41 but got 3

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
@@ -6,31 +6,19 @@
 
 
 PASS .item 1
-FAIL .item 2 assert_equals:
-<div data-offset-x="465" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 465 but got 457
-FAIL .item 3 assert_equals:
-<div data-offset-x="387" class="item first">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 387 but got 379
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div data-offset-x="332" class="item last">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 332 but got 317
-FAIL .item 5 assert_equals:
-<div data-offset-x="242" class="item first">
-      <span></span><br><span></span>
-    </div>
-offsetLeft expected 242 but got 237
+offsetLeft expected 332 but got 325
+PASS .item 5
 FAIL .item 6 assert_equals:
 <div data-offset-x="190" class="item last">
       <span></span><br><span></span>
     </div>
-offsetLeft expected 190 but got 175
+offsetLeft expected 190 but got 180
 FAIL .item 7 assert_equals:
 <div data-offset-x="534" class="item small first"></div>
 offsetLeft expected 534 but got 567

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt
@@ -10,27 +10,27 @@ FAIL .item 2 assert_equals:
 <div data-offset-y="58" class="item last">
         <span></span><br><span></span>
       </div>
-offsetTop expected 58 but got 51
+offsetTop expected 58 but got 43
 FAIL .item 3 assert_equals:
 <div data-offset-y="151" class="item first">
         <span></span><br><span></span>
       </div>
-offsetTop expected 151 but got 129
+offsetTop expected 151 but got 121
 FAIL .item 4 assert_equals:
 <div data-offset-y="181" class="item last">
         <span></span><br><span></span>
       </div>
-offsetTop expected 181 but got 149
+offsetTop expected 181 but got 141
 FAIL .item 5 assert_equals:
 <div data-offset-y="291" class="item first">
       <span></span><br><span></span>
     </div>
-offsetTop expected 291 but got 229
+offsetTop expected 291 but got 224
 FAIL .item 6 assert_equals:
 <div data-offset-y="321" class="item last">
       <span></span><br><span></span>
     </div>
-offsetTop expected 321 but got 249
+offsetTop expected 321 but got 244
 FAIL .item 7 assert_equals:
 <div data-offset-y="11" class="item small first"></div>
 offsetTop expected 11 but got 3

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
@@ -10,27 +10,27 @@ FAIL .item 2 assert_equals:
 <div data-offset-x="428" class="item last">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 428 but got 407
+offsetLeft expected 428 but got 415
 FAIL .item 3 assert_equals:
 <div data-offset-x="325" class="item first">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 325 but got 329
+offsetLeft expected 325 but got 337
 FAIL .item 4 assert_equals:
 <div data-offset-x="234" class="item last">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 234 but got 217
+offsetLeft expected 234 but got 225
 FAIL .item 5 assert_equals:
 <div data-offset-x="131" class="item first">
       <span></span><br><span></span>
     </div>
-offsetLeft expected 131 but got 137
+offsetLeft expected 131 but got 142
 FAIL .item 6 assert_equals:
 <div data-offset-x="40" class="item last">
       <span></span><br><span></span>
     </div>
-offsetLeft expected 40 but got 25
+offsetLeft expected 40 but got 30
 FAIL .item 7 assert_equals:
 <div data-offset-x="524" class="item small first"></div>
 offsetLeft expected 524 but got 547

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -133,7 +133,7 @@ public:
     std::optional<LayoutUnit> gridAreaBreadthForChild(const RenderBox&, GridTrackSizingDirection) const;
     std::optional<LayoutUnit> estimatedGridAreaBreadthForChild(const RenderBox&, GridTrackSizingDirection) const;
 
-    void cacheBaselineAlignedItem(const RenderBox&, GridAxis);
+    void cacheBaselineAlignedItem(const RenderBox&, GridAxis, bool cachingRowSubgridsForRootGrid);
     void copyBaselineItemsCache(const GridTrackSizingAlgorithm&, GridAxis);
     void clearBaselineItemsCache();
 
@@ -255,6 +255,8 @@ private:
     typedef HashMap<const RenderBox*, bool> BaselineItemsCache;
     BaselineItemsCache m_columnBaselineItemsMap;
     BaselineItemsCache m_rowBaselineItemsMap;
+
+    WeakHashSet<RenderGrid> m_rowSubgridsWithBaselineAlignedItems;
 
     // This is a RAII class used to ensure that the track sizing algorithm is
     // executed as it is suppossed to be, i.e., first resolve columns and then

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -109,7 +109,7 @@ public:
     // Returns true if this grid is inheriting subgridded tracks for
     // the given direction from the specified ancestor. This handles
     // nested subgrids, where ancestor may not be our direct parent.
-    bool isSubgridOf(GridTrackSizingDirection, const RenderGrid& ancestor);
+    bool isSubgridOf(GridTrackSizingDirection, const RenderGrid& ancestor) const;
 
     bool isMasonry() const;
     bool isMasonry(GridTrackSizingDirection) const;


### PR DESCRIPTION
#### d28a4da714e84e52e8c59db1b828d7f601c34036
<pre>
[css-grid] Resolve and set the row start, non-auto margins for subgrids with baseline aligned items.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262508">https://bugs.webkit.org/show_bug.cgi?id=262508</a>
rdar://problem/116369419

Reviewed by Matt Woodrow.

Note: This patch focuses on when we are performing baseline alignment
in the block direction of a grid (i.e. align-self/align-items).

When subgrids baseline align their items as part of alignment in the
outer grid, the sum of the subgrid&apos;s margin, border, and padding are
treated as an extra layer of margin for the grid item. Since an item&apos;s
margin is part of what determines the ascent value for the purposes of
baseline alignment, we must have that information when it gets added
into a baseline alignment context.

This process occurs at the end of the GridTrackSizingAlgorithm&apos;s setup
phase by the call to computeBaselineAlignmentContext, but the issue is
that by the time we call computeBaselineAlignmentContext none of the
subgrids have their margins resolved as part of their m_marginBox. This
information gets set during the actual grid track sizing algorithm when
the subgrid goes through layout as we attempt to compute the min content
size of the subgridded item.

When we call cacheBaselineAlignedChildren on the &quot;root&quot; grid (the grid
that subgrids will share tracks with), we can keep track of a bool that
is initially set to true to represent this state in which we want to
cache row subgrids. After we cache a baseline aligned item in
cacheBaselineAlignedItem we can then check to see if this flag is true
and also cache the item&apos;s grid if it is a row subgrid of the root grid.

Later on we will go through these subgrids and resolve their
margins just before we start creating the baseline alignment context
for the GridColumnAxis. We will only do this as part of the first/second
iteration of the row track sizing since we will just have determined the
size of the columns in the previous step. The sizes of the columns are
needed so that we can get the available width from the grid area the
subgrid is contained in, which may be needed to resolve its margins in
certain cases.

The affected tests below are brought more in like with their non-iOS
counterparts which share the same expected results. The discrepancy
between the two platforms is because on macOS, for example, an
additional layout occurs via a call to LocalFrameView::adjustViewSize
that does not occur when running the tests on iOS. The second layout
then uses the margin box information for the subgrids that was set
previously.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/align-self-baseline-with-subgrid-mbp-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::computeGridSpanSize):
(WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForChild const):
(WebCore::GridTrackSizingAlgorithm::cacheBaselineAlignedItem):
(WebCore::GridTrackSizingAlgorithm::setup):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::cacheBaselineAlignedChildren):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
(WebCore::RenderGrid::isSubgridOf const):
(WebCore::RenderGrid::isSubgridOf): Deleted.
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/269424@main">https://commits.webkit.org/269424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c6bf8c0684e1732fe81acb3f0d233c84cbe1233

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21408 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24690 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26161 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19974 "Found 1 new API test failure: TestWebKitAPI.WebArchive.SaveResourcesBlobURL (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24026 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17606 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19905 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5366 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->