### PR TITLE
REGRESSION(268723@main): Broke pyOpenSSL & Twisted

### DIFF
--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -30,9 +30,14 @@ AutoInstall.install(Package('constantly', Version(15, 1, 0), pypi_name='constant
 if sys.version_info >= (3, 0):
     AutoInstall.install(Package('hyperlink', Version(21, 0, 0), pypi_name='hyperlink'))
     AutoInstall.install(Package('incremental', Version(21, 3, 0), pypi_name='incremental'))
-    AutoInstall.install(Package('twisted', Version(23, 8, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
 
-    AutoInstall.install(Package('pyOpenSSL', Version(23, 2, 0)))
+    if sys.version_info >= (3, 11):
+        AutoInstall.install(Package('twisted', Version(23, 8, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
+        AutoInstall.install(Package('pyOpenSSL', Version(23, 2, 0)))
+    else:
+        AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
+        AutoInstall.install(Package('pyOpenSSL', Version(20, 0, 0)))
+
     # There are no prebuilt binaries for arm-32 of 'bcrypt' and building it requires cargo/rust
     # Since this dep is not really needed for the current arm-32 bots we skip it instead of
     # adding the overhead of a cargo/rust toolchain into the yocto-based image the bots run.


### PR DESCRIPTION
#### c199bf81ac72e278d5b97f47c782bfc67fbb245e
<pre>
REGRESSION(268723@main): Broke pyOpenSSL &amp; Twisted
<a href="https://bugs.webkit.org/show_bug.cgi?id=262512">https://bugs.webkit.org/show_bug.cgi?id=262512</a>
rdar://problem/116373366

Reviewed by Jonathan Bedard.

pyOpenSSL requires on cryptography&gt;=38.0.0,&lt;42,!=40.0.0,!=40.0.1,
whereas we AutoInstall 36.0.2. It&apos;s unclear how this works on the WPE
bots, but I leave that as an exercise for those who maintain those bots.

Twisted 23.8.0 cannot be installed by the AutoInstaller, because we
don&apos;t support PEP 517 builders. Again, unclear how this works on the WPE
bots.

This does in principle leave this broken on all configurations on Python
3.11 or later, but should hopefully avoid re-breaking the WPE bots.

* Tools/Scripts/webkitpy/autoinstalled/twisted.py:

Canonical link: <a href="https://commits.webkit.org/268757@main">https://commits.webkit.org/268757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d204a53770ce2b3f3ad5b6b204dee1ce62006fb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19206 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21180 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20643 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23331 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20770 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18700 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22914 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19459 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18679 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23015 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2544 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->