### PR TITLE
Add support for action, browserAction, and pageAction APIs.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -382,6 +382,7 @@ $(PROJECT_DIR)/WebProcess/Cache/WebCacheStorageConnection.messages.in
 $(PROJECT_DIR)/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in
 $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
 $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIAlarms.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -44,6 +44,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPCTesterReceiverMessagesReplies.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAction.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAction.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIAlarms.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIEvent.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -682,6 +682,7 @@ BINDINGS_SCRIPTS = \
 #
 
 EXTENSION_INTERFACES = \
+    WebExtensionAPIAction \
     WebExtensionAPIAlarms \
     WebExtensionAPIEvent \
     WebExtensionAPIExtension \

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -489,7 +489,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     if (tab)
         NSParameterAssert([tab conformsToProtocol:@protocol(_WKWebExtensionTab)]);
 
-    _webExtensionContext->performAction(toImplNullable(tab, *_webExtensionContext).get());
+    _webExtensionContext->performAction(toImplNullable(tab, *_webExtensionContext).get(), WebKit::WebExtensionContext::UserTriggered::Yes);
 }
 
 - (void)userGesturePerformedInTab:(id<_WKWebExtensionTab>)tab

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "WebExtensionAction.h"
+#import "WebExtensionContextProxyMessages.h"
+#import "WebExtensionUtilities.h"
+
+namespace WebKit {
+
+static RefPtr<WebExtensionAction> getActionWithIdentifiers(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, WebExtensionContext& context, NSString *apiName, std::optional<String>& error)
+{
+    RefPtr<WebExtensionAction> action;
+
+    if (windowIdentifier) {
+        auto window = context.getWindow(windowIdentifier.value());
+        if (!window) {
+            error = toErrorString(apiName, nil, @"window not found");
+            return nullptr;
+        }
+
+        return context.getAction(window.get()).ptr();
+    }
+
+    if (tabIdentifier) {
+        auto tab = context.getTab(tabIdentifier.value());
+        if (!tab) {
+            error = toErrorString(apiName, nil, @"tab not found");
+            return nullptr;
+        }
+
+        return context.getAction(tab.get()).ptr();
+    }
+
+    return &context.defaultAction();
+}
+
+static RefPtr<WebExtensionAction> getOrCreateActionWithIdentifiers(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, WebExtensionContext& context, NSString *apiName, std::optional<String>& error)
+{
+    RefPtr<WebExtensionAction> action;
+
+    if (windowIdentifier) {
+        auto window = context.getWindow(windowIdentifier.value());
+        if (!window) {
+            error = toErrorString(apiName, nil, @"window not found");
+            return nullptr;
+        }
+
+        return context.getOrCreateAction(window.get()).ptr();
+    }
+
+    if (tabIdentifier) {
+        auto tab = context.getTab(tabIdentifier.value());
+        if (!tab) {
+            error = toErrorString(apiName, nil, @"tab not found");
+            return nullptr;
+        }
+
+        return context.getOrCreateAction(tab.get()).ptr();
+    }
+
+    return &context.defaultAction();
+}
+
+void WebExtensionContext::actionGetTitle(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(std::optional<String>, std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.getTitle()";
+
+    std::optional<String> error;
+    auto action = getActionWithIdentifiers(windowIdentifier, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(std::nullopt, error);
+        return;
+    }
+
+    ASSERT(action);
+
+    completionHandler(action->displayLabel(WebExtensionAction::FallbackWhenEmpty::No), std::nullopt);
+}
+
+void WebExtensionContext::actionSetTitle(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& title, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.setTitle()";
+
+    std::optional<String> error;
+    auto action = getOrCreateActionWithIdentifiers(windowIdentifier, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(error);
+        return;
+    }
+
+    ASSERT(action);
+
+    action->setDisplayLabel(title);
+
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::actionSetIcon(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& iconDictionaryJSON, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.setIcon()";
+
+    std::optional<String> error;
+    auto action = getOrCreateActionWithIdentifiers(windowIdentifier, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(error);
+        return;
+    }
+
+    ASSERT(action);
+
+    action->setIconsDictionary(parseJSON(iconDictionaryJSON));
+
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::actionGetPopup(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(std::optional<String>, std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.getPopup()";
+
+    std::optional<String> error;
+    auto action = getActionWithIdentifiers(windowIdentifier, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(std::nullopt, error);
+        return;
+    }
+
+    ASSERT(action);
+
+    completionHandler(action->popupPath(), std::nullopt);
+}
+
+void WebExtensionContext::actionSetPopup(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& popupPath, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.setPopup()";
+
+    std::optional<String> error;
+    auto action = getOrCreateActionWithIdentifiers(windowIdentifier, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(error);
+        return;
+    }
+
+    ASSERT(action);
+
+    action->setPopupPath(popupPath);
+
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.openPopup()";
+
+    if (!defaultAction().canProgrammaticallyPresentPopup()) {
+        completionHandler(toErrorString(apiName, nil, @"it is not implemented"));
+        return;
+    }
+
+    if (windowIdentifier) {
+        auto window = getWindow(windowIdentifier.value());
+        if (!window) {
+            completionHandler(toErrorString(apiName, nil, @"window not found"));
+            return;
+        }
+
+        if (auto activeTab = window->activeTab()) {
+            if (getAction(activeTab.get())->hasPopup())
+                performAction(activeTab.get(), UserTriggered::No);
+
+            completionHandler(std::nullopt);
+            return;
+        }
+    }
+
+    if (tabIdentifier) {
+        auto tab = getTab(tabIdentifier.value());
+        if (!tab) {
+            completionHandler(toErrorString(apiName, nil, @"tab not found"));
+            return;
+        }
+
+        if (getAction(tab.get())->hasPopup())
+            performAction(tab.get(), UserTriggered::No);
+
+        completionHandler(std::nullopt);
+        return;
+    }
+
+    if (defaultAction().hasPopup())
+        performAction(nullptr, UserTriggered::No);
+
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::actionGetBadgeText(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(std::optional<String>, std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.getBadgeText()";
+
+    std::optional<String> error;
+    auto action = getActionWithIdentifiers(windowIdentifier, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(std::nullopt, error);
+        return;
+    }
+
+    ASSERT(action);
+
+    completionHandler(action->badgeText(), std::nullopt);
+}
+
+void WebExtensionContext::actionSetBadgeText(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, const String& text, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.setBadgeText()";
+
+    std::optional<String> error;
+    auto action = getOrCreateActionWithIdentifiers(windowIdentifier, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(error);
+        return;
+    }
+
+    ASSERT(action);
+
+    action->setBadgeText(text);
+
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::actionGetEnabled(std::optional<WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebExtensionTabIdentifier> tabIdentifier, CompletionHandler<void(std::optional<bool>, std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = @"action.isEnabled()";
+
+    std::optional<String> error;
+    auto action = getActionWithIdentifiers(windowIdentifier, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(std::nullopt, error);
+        return;
+    }
+
+    ASSERT(action);
+
+    completionHandler(action->isEnabled(), std::nullopt);
+}
+
+void WebExtensionContext::actionSetEnabled(std::optional<WebExtensionTabIdentifier> tabIdentifier, bool enabled, CompletionHandler<void(std::optional<String>)>&& completionHandler)
+{
+    static NSString * const apiName = enabled ? @"action.enable()" : @"action.disable()";
+
+    std::optional<String> error;
+    auto action = getOrCreateActionWithIdentifiers(std::nullopt, tabIdentifier, *this, apiName, error);
+    if (error) {
+        completionHandler(error);
+        return;
+    }
+
+    ASSERT(action);
+
+    action->setEnabled(enabled);
+
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::fireActionClickedEventIfNeeded(WebExtensionTab* tab)
+{
+    constexpr auto type = WebExtensionEventListenerType::ActionOnClicked;
+    wakeUpBackgroundContentIfNecessaryToFireEvents({ type }, [&] {
+        sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchActionClickedEvent(tab ? std::optional(tab->parameters()) : std::nullopt));
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -44,6 +44,7 @@ namespace WebKit {
 
 class WebExtensionContext;
 class WebExtensionTab;
+class WebExtensionWindow;
 
 class WebExtensionAction : public API::ObjectImpl<API::Object::Type::WebExtensionAction>, public CanMakeWeakPtr<WebExtensionAction> {
     WTF_MAKE_NONCOPYABLE(WebExtensionAction);
@@ -57,20 +58,23 @@ public:
 
     explicit WebExtensionAction(WebExtensionContext&);
     explicit WebExtensionAction(WebExtensionContext&, WebExtensionTab&);
+    explicit WebExtensionAction(WebExtensionContext&, WebExtensionWindow&);
 
     enum class LoadOnFirstAccess { No, Yes };
+    enum class FallbackWhenEmpty { No, Yes };
 
     bool operator==(const WebExtensionAction&) const;
 
     WebExtensionContext* extensionContext() const;
     WebExtensionTab* tab() { return m_tab.get(); }
+    WebExtensionWindow* window() { return m_window.get(); }
 
     void propertiesDidChange();
 
     CocoaImage *icon(CGSize);
     void setIconsDictionary(NSDictionary *);
 
-    String displayLabel() const;
+    String displayLabel(FallbackWhenEmpty = FallbackWhenEmpty::Yes) const;
     void setDisplayLabel(String);
 
     String badgeText() const;
@@ -80,6 +84,7 @@ public:
     void setEnabled(std::optional<bool>);
 
     bool hasPopup() const { return !popupPath().isEmpty(); }
+    bool canProgrammaticallyPresentPopup() const { return m_respondsToPresentPopup; }
 
     String popupPath() const;
     void setPopupPath(String);
@@ -98,6 +103,7 @@ public:
 private:
     WeakPtr<WebExtensionContext> m_extensionContext;
     RefPtr<WebExtensionTab> m_tab;
+    RefPtr<WebExtensionWindow> m_window;
 
     RetainPtr<_WKWebExtensionActionWebView> m_popupWebView;
     RetainPtr<_WKWebExtensionActionWebViewDelegate> m_popupWebViewDelegate;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -26,6 +26,18 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 messages -> WebExtensionContext {
+    // Action APIs
+    ActionGetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> title, std::optional<String> error);
+    ActionSetTitle(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String title) -> (std::optional<String> error);
+    ActionSetIcon(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String iconDictionaryJSON) -> (std::optional<String> error);
+    ActionGetPopup(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> popupPath, std::optional<String> error);
+    ActionSetPopup(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String popupPath) -> (std::optional<String> error);
+    ActionOpenPopup(WebKit::WebPageProxyIdentifier identifier, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> error);
+    ActionGetBadgeText(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<String> text, std::optional<String> error);
+    ActionSetBadgeText(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, String text) -> (std::optional<String> error);
+    ActionGetEnabled(std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<bool> enabled, std::optional<String> error);
+    ActionSetEnabled(std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, bool enabled) -> (std::optional<String> error);
+
     // Alarms APIs
     AlarmsCreate(String name, Seconds initialInterval, Seconds repeatInterval);
     AlarmsGet(String name) -> (std::optional<WebKit::WebExtensionAlarmParameters> alarmInfo);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -45,7 +45,7 @@ class WebExtensionTab;
 struct WebExtensionTabQueryParameters;
 struct WebExtensionWindowParameters;
 
-class WebExtensionWindow : public RefCounted<WebExtensionWindow> {
+class WebExtensionWindow : public RefCounted<WebExtensionWindow>, public CanMakeWeakPtr<WebExtensionWindow> {
     WTF_MAKE_NONCOPYABLE(WebExtensionWindow);
     WTF_MAKE_FAST_ALLOCATED;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -521,6 +521,11 @@
 		1CBBE4A019B66C53006B7D81 /* WebInspectorUIMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CBBE49E19B66C53006B7D81 /* WebInspectorUIMessageReceiver.cpp */; };
 		1CBBE4A119B66C53006B7D81 /* WebInspectorUIMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CBBE49F19B66C53006B7D81 /* WebInspectorUIMessages.h */; };
 		1CBEE27028F4DDA1006D1A02 /* WebExtensionControllerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1CC94E532AC92F190045F269 /* JSWebExtensionAPIAction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CC94E512AC92F190045F269 /* JSWebExtensionAPIAction.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1CC94E542AC92F190045F269 /* JSWebExtensionAPIAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CC94E522AC92F190045F269 /* JSWebExtensionAPIAction.h */; };
+		1CC94E562AC92F960045F269 /* WebExtensionAPIAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CC94E552AC92F960045F269 /* WebExtensionAPIAction.h */; };
+		1CC94E582AC92FA50045F269 /* WebExtensionAPIActionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CC94E572AC92FA50045F269 /* WebExtensionAPIActionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1CC94E5A2AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CC94E592AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1CF0C9462AC34BC600EC82F2 /* _WKWebExtensionAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF0C9452AC34BC600EC82F2 /* _WKWebExtensionAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1CF0C9482AC37FAD00EC82F2 /* _WKWebExtensionAction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CF0C9472AC37FAD00EC82F2 /* _WKWebExtensionAction.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1CF0C94A2AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF0C9492AC37FFA00EC82F2 /* _WKWebExtensionActionPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3977,6 +3982,12 @@
 		1CC23B1F288732F600D0A65A /* WebExtensionControllerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionControllerProxy.messages.in; sourceTree = "<group>"; };
 		1CC23B20288732F600D0A65A /* WebExtensionControllerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerProxy.h; sourceTree = "<group>"; };
 		1CC23B21288732F600D0A65A /* WebExtensionControllerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionControllerProxy.cpp; sourceTree = "<group>"; };
+		1CC94E502AC92E9F0045F269 /* WebExtensionAPIAction.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIAction.idl; sourceTree = "<group>"; };
+		1CC94E512AC92F190045F269 /* JSWebExtensionAPIAction.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIAction.mm; sourceTree = "<group>"; };
+		1CC94E522AC92F190045F269 /* JSWebExtensionAPIAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIAction.h; sourceTree = "<group>"; };
+		1CC94E552AC92F960045F269 /* WebExtensionAPIAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIAction.h; sourceTree = "<group>"; };
+		1CC94E572AC92FA50045F269 /* WebExtensionAPIActionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIActionCocoa.mm; sourceTree = "<group>"; };
+		1CC94E592AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIActionCocoa.mm; sourceTree = "<group>"; };
 		1CDA62A02925DA3700D90390 /* WebExtensionAPITest.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPITest.idl; sourceTree = "<group>"; };
 		1CDDFC7B2755860000C93C62 /* RemoteGPUProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteGPUProxy.messages.in; sourceTree = "<group>"; };
 		1CDDFC7D2755866D00C93C62 /* RemoteGPUProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGPUProxyMessageReceiver.cpp; sourceTree = "<group>"; };
@@ -8821,6 +8832,7 @@
 		1C1549802926E7CC001B9E5B /* API */ = {
 			isa = PBXGroup;
 			children = (
+				1CC94E592AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm */,
 				1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */,
 				B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */,
 				B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */,
@@ -8848,6 +8860,7 @@
 			isa = PBXGroup;
 			children = (
 				1C5DC4502908A9D00061EC62 /* Cocoa */,
+				1CC94E552AC92F960045F269 /* WebExtensionAPIAction.h */,
 				1C2B4D452A8199CC00C528A1 /* WebExtensionAPIAlarms.h */,
 				B6544F912937E45000034EB0 /* WebExtensionAPIEvent.h */,
 				1C5DC468290B239C0061EC62 /* WebExtensionAPIExtension.h */,
@@ -8871,6 +8884,7 @@
 		1C5DC4502908A9D00061EC62 /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				1CC94E572AC92FA50045F269 /* WebExtensionAPIActionCocoa.mm */,
 				1C2B4D432A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm */,
 				B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */,
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
@@ -9022,6 +9036,7 @@
 		1C9DD98F28FA19A30093BDB0 /* Interfaces */ = {
 			isa = PBXGroup;
 			children = (
+				1CC94E502AC92E9F0045F269 /* WebExtensionAPIAction.idl */,
 				1C2B4D472A819C4700C528A1 /* WebExtensionAPIAlarms.idl */,
 				B6544F7C29357B1B00034EB0 /* WebExtensionAPIEvent.idl */,
 				1C9DD99028FA19A30093BDB0 /* WebExtensionAPIExtension.idl */,
@@ -13686,6 +13701,8 @@
 				0F5562DE27EE28D000953585 /* GPUProcessMessages.h */,
 				0F5562E827EE28D200953585 /* GPUProcessProxyMessageReceiver.cpp */,
 				0F5562E427EE28D100953585 /* GPUProcessProxyMessages.h */,
+				1CC94E522AC92F190045F269 /* JSWebExtensionAPIAction.h */,
+				1CC94E512AC92F190045F269 /* JSWebExtensionAPIAction.mm */,
 				1C2B4D482A819D0C00C528A1 /* JSWebExtensionAPIAlarms.h */,
 				1C2B4D492A819D0C00C528A1 /* JSWebExtensionAPIAlarms.mm */,
 				B6114A7C2939498000380B1B /* JSWebExtensionAPIEvent.h */,
@@ -14853,6 +14870,7 @@
 				A31F60A425CC7DB900AF14F4 /* IPCSemaphore.h in Headers */,
 				7BE37F9327C7CA51007A6CD3 /* IPCStreamTesterIdentifier.h in Headers */,
 				9B47908F253151CC00EC11AB /* JSIPCBinding.h in Headers */,
+				1CC94E542AC92F190045F269 /* JSWebExtensionAPIAction.h in Headers */,
 				B61AFA4829510D0F008220B1 /* JSWebExtensionAPIPermissions.h in Headers */,
 				1C9A15CE2ABDF1E2002CC12A /* JSWebExtensionAPIPort.h in Headers */,
 				B63E9A6E2AAF2B2D005F4561 /* JSWebExtensionAPIScripting.h in Headers */,
@@ -15317,6 +15335,7 @@
 				F4CBF79E2A6ADF7E00C066BF /* WebEventType.h in Headers */,
 				1CF0C94E2AC380C400EC82F2 /* WebExtensionAction.h in Headers */,
 				1C2B4D422A817D7200C528A1 /* WebExtensionAlarmParameters.h in Headers */,
+				1CC94E562AC92F960045F269 /* WebExtensionAPIAction.h in Headers */,
 				1C2B4D462A8199CD00C528A1 /* WebExtensionAPIAlarms.h in Headers */,
 				B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */,
 				1C5DC46D290B271E0061EC62 /* WebExtensionAPIExtension.h in Headers */,
@@ -17643,6 +17662,7 @@
 				522F792928D50EBB0069B45B /* HidService.mm in Sources */,
 				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
 				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
+				1CC94E532AC92F190045F269 /* JSWebExtensionAPIAction.mm in Sources */,
 				1C2B4D4B2A819D0D00C528A1 /* JSWebExtensionAPIAlarms.mm in Sources */,
 				B6114A7F29394A1600380B1B /* JSWebExtensionAPIEvent.mm in Sources */,
 				1C5DC471290B33A20061EC62 /* JSWebExtensionAPIExtension.mm in Sources */,
@@ -17974,6 +17994,7 @@
 				E3866AE52397400400F88FE9 /* WebDeviceOrientationUpdateProviderProxy.mm in Sources */,
 				E3866B092399A2D500F88FE9 /* WebDeviceOrientationUpdateProviderProxyMessageReceiver.cpp in Sources */,
 				1CF0C9502AC380E900EC82F2 /* WebExtensionActionCocoa.mm in Sources */,
+				1CC94E582AC92FA50045F269 /* WebExtensionAPIActionCocoa.mm in Sources */,
 				1C2B4D442A8199C100C528A1 /* WebExtensionAPIAlarmsCocoa.mm in Sources */,
 				B6544F972937E46900034EB0 /* WebExtensionAPIEventCocoa.mm in Sources */,
 				1C5DC467290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm in Sources */,
@@ -17990,6 +18011,7 @@
 				1C5ACFB82A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm in Sources */,
 				1C5ACFB42A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm in Sources */,
 				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,
+				1CC94E5A2AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm in Sources */,
 				1C2B4D3F2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm in Sources */,
 				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,
 				B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -1,0 +1,570 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPIAction.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "CocoaHelpers.h"
+#import "Logging.h"
+#import "MessageSenderInlines.h"
+#import "WebExtensionAPINamespace.h"
+#import "WebExtensionAPITabs.h"
+#import "WebExtensionAPIWindows.h"
+#import "WebExtensionContextMessages.h"
+#import "WebExtensionContextProxy.h"
+#import "WebExtensionUtilities.h"
+#import "WebProcess.h"
+
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIKit.h>
+#endif
+
+static NSString * const tabIdKey = @"tabId";
+static NSString * const windowIdKey = @"windowId";
+
+static NSString * const imageDataKey = @"imageData";
+static NSString * const pathKey = @"path";
+static NSString * const popupKey = @"popup";
+static NSString * const textKey = @"text";
+static NSString * const titleKey = @"title";
+
+namespace WebKit {
+
+bool WebExtensionAPIAction::parseActionDetails(NSDictionary *details, std::optional<WebExtensionWindowIdentifier>& windowIdentifier, std::optional<WebExtensionTabIdentifier>& tabIdentifier, NSString **outExceptionString)
+{
+    static NSDictionary<NSString *, id> *types = @{
+        tabIdKey: NSNumber.class,
+        windowIdKey: NSNumber.class,
+    };
+
+    if (!validateDictionary(details, @"details", nil, types, outExceptionString))
+        return false;
+
+    if (details[tabIdKey] && details[windowIdKey]) {
+        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'tabId' and 'windowID'");
+        return false;
+    }
+
+    if (NSNumber *tabID = details[tabIdKey]) {
+        tabIdentifier = toWebExtensionTabIdentifier(tabID.doubleValue);
+        if (!isValid(tabIdentifier, outExceptionString))
+            return false;
+    }
+
+    if (NSNumber *windowID = details[windowIdKey]) {
+        windowIdentifier = toWebExtensionWindowIdentifier(windowID.doubleValue);
+        if (!isValid(windowIdentifier, outExceptionString))
+            return false;
+    }
+
+    return true;
+}
+
+void WebExtensionAPIAction::getTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getTitle
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetTitle(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> title, std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        ASSERT(title);
+
+        callback->call((NSString *)title.value());
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::setTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setTitle
+
+    static NSArray<NSString *> *requiredKeys = @[ titleKey ];
+
+    static NSDictionary<NSString *, id> *types = @{
+        titleKey: [NSOrderedSet orderedSetWithObjects:NSString.class, NSNull.class, nil],
+    };
+
+    if (!validateDictionary(details, @"details", requiredKeys, types, outExceptionString))
+        return;
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    String title = nullString();
+    if (NSString *string = objectForKey<NSString>(details, titleKey, false))
+        title = string;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetTitle(windowIdentifier, tabIdentifier, title), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::getBadgeText(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getBadgeText
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetBadgeText(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> badgeText, std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        ASSERT(badgeText);
+
+        callback->call((NSString *)badgeText.value());
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::setBadgeText(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setBadgeText
+
+    static NSArray<NSString *> *requiredKeys = @[ textKey ];
+
+    static NSDictionary<NSString *, id> *types = @{
+        textKey: [NSOrderedSet orderedSetWithObjects:NSString.class, NSNull.class, nil],
+    };
+
+    if (!validateDictionary(details, @"details", requiredKeys, types, outExceptionString))
+        return;
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    String text = nullString();
+    if (NSString *string = objectForKey<NSString>(details, textKey, false))
+        text = string;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetBadgeText(windowIdentifier, tabIdentifier, text), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::getBadgeBackgroundColor(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getBadgeBackgroundColor
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    // FIXME: <rdar://problem/57666368> Implement getting/setting the extension toolbar item's badge background color.
+
+    callback->call(@[ @255, @0, @0, @255 ]);
+}
+
+void WebExtensionAPIAction::setBadgeBackgroundColor(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setBadgeBackgroundColor
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    // FIXME: <rdar://problem/57666368> Implement getting/setting the extension toolbar item's badge background color.
+
+    callback->call();
+}
+
+void WebExtensionAPIAction::enable(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/enable
+
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
+        return;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetEnabled(tabIdentifer, true), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::disable(double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/disable
+
+    auto tabIdentifer = toWebExtensionTabIdentifier(tabID);
+    if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
+        return;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetEnabled(tabIdentifer, false), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::isEnabled(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/isEnabled
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetEnabled(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<bool> enabled, std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        ASSERT(enabled);
+
+        callback->call(@(enabled.value()));
+    }, extensionContext().identifier().toUInt64());
+}
+
+static NSString *dataURLFromImageData(JSValue *imageData, size_t *outWidth, NSString *sourceKey, NSString **outExceptionString)
+{
+    if (outWidth)
+        *outWidth = 0;
+
+    static NSString * const notImageDataError = @"it is not an ImageData object";
+
+    auto *imageDataConstructor = imageData.context[@"ImageData"];
+    if (![imageData isInstanceOf:imageDataConstructor]) {
+        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        return nil;
+    }
+
+    auto *dataObject = imageData[@"data"];
+    if (!dataObject.isObject) {
+        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        return nil;
+    }
+
+    auto context = imageData.context.JSGlobalContextRef;
+    auto dataObjectRef = JSValueToObject(context, dataObject.JSValueRef, nullptr);
+
+    auto dataArrayType = JSValueGetTypedArrayType(context, dataObjectRef, nullptr);
+    if (dataArrayType != kJSTypedArrayTypeUint8ClampedArray) {
+        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        return nil;
+    }
+
+    auto *pixelData = [[NSData alloc] initWithBytes:JSObjectGetTypedArrayBytesPtr(context, dataObjectRef, nullptr) length:JSObjectGetTypedArrayByteLength(context, dataObjectRef, nullptr)];
+    auto width = imageData[@"width"].toNumber.unsignedLongValue;
+    auto height = imageData[@"height"].toNumber.unsignedLongValue;
+    auto *colorSpaceString = imageData[@"colorSpace"].toString;
+
+    ASSERT([colorSpaceString isEqualToString:@"srgb"] || [colorSpaceString isEqualToString:@"display-p3"]);
+
+    constexpr size_t bitsPerComponent = 8;
+    constexpr size_t bitsPerPixel = 32;
+    const size_t bytesPerRow = 4 * width;
+    auto colorSpace = CGColorSpaceCreateWithName([colorSpaceString isEqualToString:@"display-p3"] ? kCGColorSpaceDisplayP3 : kCGColorSpaceSRGB);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
+    constexpr CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedLast;
+#pragma clang diagnostic pop
+
+    constexpr CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
+    constexpr CGFloat *decode = nullptr;
+    constexpr bool shouldInterpolate = YES;
+
+    auto dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)pixelData);
+    auto cgImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorSpace, bitmapInfo, dataProvider, decode, shouldInterpolate, renderingIntent);
+    CGDataProviderRelease(dataProvider);
+    CGColorSpaceRelease(colorSpace);
+
+    if (!cgImage) {
+        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        return nil;
+    }
+
+#if USE(APPKIT)
+    auto *imageRep = [[NSBitmapImageRep alloc] initWithCGImage:cgImage];
+    CGImageRelease(cgImage);
+
+    auto *pngData = [imageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
+#else
+    UIImage *image = [UIImage imageWithCGImage:cgImage];
+    CGImageRelease(cgImage);
+
+    auto *pngData = UIImagePNGRepresentation(image);
+#endif
+
+    if (!pngData.length) {
+        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        return nil;
+    }
+
+    auto *base64String = [pngData base64EncodedStringWithOptions:0];
+    if (!base64String.length) {
+        *outExceptionString = toErrorString(nil, sourceKey, notImageDataError);
+        return nil;
+    }
+
+    if (outWidth)
+        *outWidth = width;
+
+    return [NSString stringWithFormat:@"data:image/png;base64,%@", base64String];
+}
+
+static bool isValidDimensionKey(NSString *dimension)
+{
+    double value = dimension.doubleValue;
+    if (!value)
+        return false;
+
+    if (!std::isfinite(value) || value <= 0 || value >= static_cast<double>(std::numeric_limits<size_t>::max()))
+        return false;
+
+    double integral;
+    if (std::modf(value, &integral) != 0.0) {
+        // Only integral numbers can be used.
+        return false;
+    }
+
+    return true;
+}
+
+void WebExtensionAPIAction::setIcon(JSContextRef, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setIcon
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    static NSDictionary<NSString *, id> *types = @{
+        pathKey: [NSOrderedSet orderedSetWithObjects:NSString.class, NSDictionary.class, NSNull.class, nil],
+        imageDataKey: [NSOrderedSet orderedSetWithObjects:JSValue.class, NSDictionary.class, NSNull.class, nil],
+    };
+
+    if (!validateDictionary(details, @"details", nil, types, outExceptionString))
+        return;
+
+    if (details[pathKey] && details[imageDataKey]) {
+        *outExceptionString = toErrorString(nil, @"details", @"it cannot specify both 'path' and 'imageData'");
+        return;
+    }
+
+    NSDictionary *iconDictionary;
+
+    if (auto *imageData = objectForKey<JSValue>(details, imageDataKey)) {
+        size_t width;
+        auto *dataURLString = dataURLFromImageData(imageData, &width, imageDataKey, outExceptionString);
+        if (!dataURLString)
+            return;
+
+        iconDictionary = @{ @(width).stringValue: dataURLString };
+    }
+
+    if (auto *images = objectForKey<NSDictionary>(details, imageDataKey)) {
+        auto *mutableIconDictionary = [NSMutableDictionary dictionaryWithCapacity:images.count];
+
+        for (NSString *key in images) {
+            if (!isValidDimensionKey(key)) {
+                *outExceptionString = toErrorString(nil, imageDataKey, @"'%@' in not a valid dimension", key);
+                return;
+            }
+
+            if (!validateObject(images[key], key, JSValue.class, outExceptionString))
+                return;
+
+            JSValue *imageData = images[key];
+            auto *dataURLString = dataURLFromImageData(imageData, nullptr, key, outExceptionString);
+            if (!dataURLString)
+                return;
+
+            mutableIconDictionary[key] = dataURLString;
+        }
+
+        iconDictionary = [mutableIconDictionary copy];
+    }
+
+    if (auto *path = objectForKey<NSString>(details, pathKey)) {
+        // Chrome documentation states that 'details.path = foo' is equivalent to 'details.path = { '16': foo }'.
+        // Documentation: https://developer.chrome.com/docs/extensions/reference/action/#method-setIcon
+        iconDictionary = @{ @"16": path };
+    }
+
+    if (auto *paths = objectForKey<NSDictionary>(details, pathKey)) {
+        for (NSString *key in paths) {
+            if (!isValidDimensionKey(key)) {
+                *outExceptionString = toErrorString(nil, imageDataKey, @"'%@' in not a valid dimension", key);
+                return;
+            }
+
+            if (!validateObject(paths[key], key, NSString.class, outExceptionString))
+                return;
+        }
+
+        iconDictionary = paths;
+    }
+
+    auto *iconDictionaryJSON = encodeJSONString(iconDictionary);
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetIcon(windowIdentifier, tabIdentifier, iconDictionaryJSON), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::getPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getPopup
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionGetPopup(windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> popupPath, std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        ASSERT(popupPath);
+
+        callback->call((NSString *)popupPath.value());
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::setPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setPopup
+
+    static NSArray<NSString *> *requiredKeys = @[ popupKey ];
+
+    static NSDictionary<NSString *, id> *types = @{
+        popupKey: [NSOrderedSet orderedSetWithObjects:NSString.class, NSNull.class, nil],
+    };
+
+    if (!validateDictionary(details, @"details", requiredKeys, types, outExceptionString))
+        return;
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    String popup = nullString();
+    if (NSString *string = objectForKey<NSString>(details, popupKey, false))
+        popup = string;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionSetPopup(windowIdentifier, tabIdentifier, popup), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+void WebExtensionAPIAction::openPopup(WebPage* page, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    std::optional<WebExtensionTabIdentifier> tabIdentifier;
+    if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
+        return;
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionOpenPopup(page->webPageProxyIdentifier(), windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
+        if (error) {
+            callback->reportError(error.value());
+            return;
+        }
+
+        callback->call();
+    }, extensionContext().identifier().toUInt64());
+}
+
+WebExtensionAPIEvent& WebExtensionAPIAction::onClicked()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/onClicked
+
+    if (!m_onClicked)
+        m_onClicked = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::ActionOnClicked);
+
+    return *m_onClicked;
+}
+
+void WebExtensionContextProxy::dispatchActionClickedEvent(const std::optional<WebExtensionTabParameters>& tabParameters)
+{
+    auto *tab = tabParameters ? toWebAPI(tabParameters.value()) : nil;
+
+    enumerateNamespaceObjects([&](auto& namespaceObject) {
+        // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/onClicked
+        namespaceObject.action().onClicked().invokeListenersWithArgument(tab);
+    });
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -473,7 +473,7 @@ bool WebExtensionAPITabs::parseConnectOptions(NSDictionary *options, std::option
     return true;
 }
 
-static bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **outExceptionString)
+bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **outExceptionString)
 {
     if (UNLIKELY(!isValid(identifier))) {
         if (isNone(identifier))

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -595,7 +595,7 @@ inline WebExtensionAPIWindows::WindowTypeFilter toWindowTypeFilter(WebExtensionW
     }
 }
 
-void WebExtensionContextProxy::dispatchWindowsEvent(WebExtensionEventListenerType type, std::optional<WebExtensionWindowParameters> windowParameters)
+void WebExtensionContextProxy::dispatchWindowsEvent(WebExtensionEventListenerType type, const std::optional<WebExtensionWindowParameters>& windowParameters)
 {
     auto filter = windowParameters ? toWindowTypeFilter(windowParameters.value().type.value()) : WebExtensionAPIWindows::WindowTypeFilter::All;
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "JSWebExtensionAPIAction.h"
+#include "WebExtensionAPIEvent.h"
+#include "WebExtensionAPIObject.h"
+
+OBJC_CLASS NSDictionary;
+OBJC_CLASS NSString;
+
+namespace WebKit {
+
+class WebExtensionAPIAction : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIAction, action);
+
+public:
+#if PLATFORM(COCOA)
+    void getTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setTitle(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+
+    void getBadgeText(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setBadgeText(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+
+    void getBadgeBackgroundColor(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setBadgeBackgroundColor(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+
+    void enable(double tabIdentifier, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void disable(double tabIdentifier, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void isEnabled(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+
+    void setIcon(JSContextRef, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+
+    void getPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void openPopup(WebPage*, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+
+    WebExtensionAPIEvent& onClicked();
+private:
+    static bool parseActionDetails(NSDictionary *, std::optional<WebExtensionWindowIdentifier>&, std::optional<WebExtensionTabIdentifier>&, NSString **outExceptionString);
+
+    RefPtr<WebExtensionAPIEvent> m_onClicked;
+#endif
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "JSWebExtensionAPINamespace.h"
+#include "WebExtensionAPIAction.h"
 #include "WebExtensionAPIAlarms.h"
 #include "WebExtensionAPIExtension.h"
 #include "WebExtensionAPILocalization.h"
@@ -52,9 +53,12 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
+    WebExtensionAPIAction& action();
     WebExtensionAPIAlarms& alarms();
+    WebExtensionAPIAction& browserAction() { return action(); }
     WebExtensionAPIExtension& extension();
     WebExtensionAPILocalization& i18n();
+    WebExtensionAPIAction& pageAction() { return action(); }
     WebExtensionAPIPermissions& permissions();
     WebExtensionAPIRuntime& runtime() final;
     WebExtensionAPIScripting& scripting();
@@ -65,6 +69,7 @@ public:
 #endif
 
 private:
+    RefPtr<WebExtensionAPIAction> m_action;
     RefPtr<WebExtensionAPIAlarms> m_alarms;
     RefPtr<WebExtensionAPIExtension> m_extension;
     RefPtr<WebExtensionAPILocalization> m_i18n;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -108,6 +108,7 @@ private:
 #endif
 };
 
+bool isValid(std::optional<WebExtensionTabIdentifier>, NSString **outExceptionString);
 NSDictionary *toWebAPI(const WebExtensionTabParameters&);
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WK_WEB_EXTENSIONS,
+    MainWorldOnly,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIAction {
+
+    [RaisesException] void getTitle([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException] void setTitle([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void getBadgeText([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException] void setBadgeText([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void getBadgeBackgroundColor([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException] void setBadgeBackgroundColor([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void enable([Optional] double tabId, [Optional, CallbackHandler] function callback);
+    [RaisesException] void disable([Optional] double tabId, [Optional, CallbackHandler] function callback);
+    [RaisesException] void isEnabled([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+
+    [RaisesException, NeedsScriptContext] void setIcon([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+
+    [RaisesException] void setPopup([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException] void getPopup([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsPage] void openPopup([Optional, NSDictionary=NullAllowed] any options, [Optional, CallbackHandler] function callback);
+
+    readonly attribute WebExtensionAPIEvent onClicked;
+
+};

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
@@ -28,13 +28,19 @@
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPINamespace {
 
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction action;
+
     [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAlarms alarms;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction browserAction;
 
     readonly attribute WebExtensionAPIExtension extension;
 
     readonly attribute WebExtensionAPILocalization i18n;
 
     readonly attribute WebExtensionAPIRuntime runtime;
+
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIAction pageAction;
 
     [MainWorldOnly] readonly attribute WebExtensionAPIPermissions permissions;
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -103,6 +103,9 @@ public:
 private:
     explicit WebExtensionContextProxy(const WebExtensionContextParameters&);
 
+    // Action
+    void dispatchActionClickedEvent(const std::optional<WebExtensionTabParameters>&);
+
     // Alarms
     void dispatchAlarmsEvent(const WebExtensionAlarmParameters&);
 
@@ -134,7 +137,7 @@ private:
     void dispatchWebNavigationEvent(WebExtensionEventListenerType, WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);
 
     // Windows
-    void dispatchWindowsEvent(WebExtensionEventListenerType, std::optional<WebExtensionWindowParameters>);
+    void dispatchWindowsEvent(WebExtensionEventListenerType, const std::optional<WebExtensionWindowParameters>&);
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -26,6 +26,9 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 messages -> WebExtensionContextProxy {
+    // Action
+    DispatchActionClickedEvent(std::optional<WebKit::WebExtensionTabParameters> tabParameters)
+
     // Alarms
     DispatchAlarmsEvent(struct WebKit::WebExtensionAlarmParameters alarmInfo)
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -35,8 +35,8 @@ namespace TestWebKitAPI {
 static auto *actionPopupManifest = @{
     @"manifest_version": @3,
 
-    @"name": @"Tabs Test",
-    @"description": @"Tabs Test",
+    @"name": @"Action Test",
+    @"description": @"Action Test",
     @"version": @"1",
 
     @"background": @{
@@ -67,12 +67,12 @@ NSData *makePNGData(CGSize size, SEL colorSelector) {
     [image unlockFocus];
 
     auto cgImageRef = [image CGImageForProposedRect:NULL context:nil hints:nil];
-    auto newRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef]);
-    [newRep setSize:size];
+    auto newImageRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef]);
+    newImageRep.get().size = size;
 
-    return [newRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
+    return [newImageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
 #else
-    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
+    UIGraphicsBeginImageContextWithOptions(size, NO, 1.0);
 
     [[UIColor performSelector:colorSelector] setFill];
     UIRectFill(CGRectMake(0, 0, size.width, size.height));
@@ -83,6 +83,76 @@ NSData *makePNGData(CGSize size, SEL colorSelector) {
 
     return UIImagePNGRepresentation(image);
 #endif
+}
+
+TEST(WKWebExtensionAPIAction, Errors)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertThrows(() => browser.action.setTitle({tabId: 'bad', title: 'Test'}), /'tabId' is expected to be a number, but a string was provided/i)",
+        @"browser.test.assertThrows(() => browser.action.setTitle({windowId: 'bad', title: 'Test'}), /'windowId' is expected to be a number, but a string was provided/i)",
+        @"browser.test.assertThrows(() => browser.action.setIcon({path: 123}), /'path' is expected to be a string or an object or null, but a number was provided/i)",
+        @"browser.test.assertThrows(() => browser.action.setIcon({tabId: true, path: 'icon.png'}), /'tabId' is expected to be a number, but a boolean was provided/i)",
+        @"browser.test.assertThrows(() => browser.action.setIcon({windowId: true, path: 'icon.png'}), /'windowId' is expected to be a number, but a boolean was provided/i)",
+        @"browser.test.assertThrows(() => browser.action.setPopup({tabId: 'bad', popup: 'popup.html'}), /'tabId' is expected to be a number, but a string was provided/i)",
+        @"browser.test.assertThrows(() => browser.action.setPopup({windowId: 'bad', popup: 'popup.html'}), /'windowId' is expected to be a number, but a string was provided/i)",
+        @"browser.test.assertThrows(() => browser.action.setBadgeText({tabId: 1.2, text: '1'}), /'tabID' value is invalid, because it is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.action.setBadgeText({windowId: -3, text: '2'}), /'windowID' value is invalid, because it is not a window identifier/i)",
+        @"browser.test.assertThrows(() => browser.action.enable('bad'), /'tabId' value is invalid, because a number is expected/i)",
+        @"browser.test.assertThrows(() => browser.action.disable('bad'), /'tabId' value is invalid, because a number is expected/i)",
+        @"browser.test.assertThrows(() => browser.action.isEnabled({tabId: Infinity}), /'tabId' is expected to be a number, but Infinity was provided/i)",
+        @"browser.test.assertThrows(() => browser.action.isEnabled({windowId: NaN}), /'windowId' is expected to be a number, but NaN was provided/i)",
+
+        @"browser.test.assertThrows(() => browser.action.setTitle({tabId: 1}), /'details' value is invalid, because it is missing required keys: 'title'/i)",
+        @"browser.test.assertThrows(() => browser.action.setTitle({windowId: 1}), /'details' value is invalid, because it is missing required keys: 'title'/i)",
+        @"browser.test.assertThrows(() => browser.action.setPopup({tabId: 1}), /'details' value is invalid, because it is missing required keys: 'popup'/i)",
+        @"browser.test.assertThrows(() => browser.action.setPopup({windowId: 1}), /'details' value is invalid, because it is missing required keys: 'popup'/i)",
+        @"browser.test.assertThrows(() => browser.action.setBadgeText({tabId: 1}), /'details' value is invalid, because it is missing required keys: 'text'/i)",
+        @"browser.test.assertThrows(() => browser.action.setBadgeText({windowId: 1}), /'details' value is invalid, because it is missing required keys: 'text'/i)",
+
+        @"browser.test.assertThrows(() => browser.action.setTitle({tabId: 1, windowId: 1, title: null}), /'details' value is invalid, because it cannot specify both 'tabId' and 'windowID'/i)",
+        @"browser.test.assertThrows(() => browser.action.setIcon({tabId: 1, windowId: 1, path: null}), /'details' value is invalid, because it cannot specify both 'tabId' and 'windowID'/i)",
+        @"browser.test.assertThrows(() => browser.action.setPopup({tabId: 1, windowId: 1, popup: null}), /'details' value is invalid, because it cannot specify both 'tabId' and 'windowID'/i)",
+        @"browser.test.assertThrows(() => browser.action.setBadgeText({tabId: 1, windowId: 1, text: null}), /'details' value is invalid, because it cannot specify both 'tabId' and 'windowID'/i)",
+
+        @"await browser.test.assertRejects(browser.action.getTitle({tabId: 9999}), /tab not found/i)",
+        @"await browser.test.assertRejects(browser.action.getTitle({windowId: 9999}), /window not found/i)",
+        @"await browser.test.assertRejects(browser.action.getPopup({tabId: 9999}), /tab not found/i)",
+        @"await browser.test.assertRejects(browser.action.getPopup({windowId: 9999}), /window not found/i)",
+        @"await browser.test.assertRejects(browser.action.getBadgeText({tabId: 9999}), /tab not found/i)",
+        @"await browser.test.assertRejects(browser.action.getBadgeText({windowId: 9999}), /window not found/i)",
+        @"await browser.test.assertRejects(browser.action.isEnabled({tabId: 9999}), /tab not found/i)",
+        @"await browser.test.assertRejects(browser.action.isEnabled({windowId: 9999}), /window not found/i)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(actionPopupManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIAction, ClickedEvent)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.action.setPopup({ popup: '' })",
+
+        @"browser.action.onClicked.addListener((tab) => {",
+        @"  browser.test.assertEq(typeof tab, 'object', 'The tab should be an object')",
+
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"browser.test.yield('Test Action')"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Test Action");
+
+    [manager.get().context performActionForTab:manager.get().defaultTab];
+
+    [manager run];
 }
 
 TEST(WKWebExtensionAPIAction, PresentActionPopup)
@@ -136,6 +206,661 @@ TEST(WKWebExtensionAPIAction, PresentActionPopup)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Test Popup Action");
 
     [manager.get().context performActionForTab:manager.get().defaultTab];
+}
+
+TEST(WKWebExtensionAPIAction, SetDefaultActionProperties)
+{
+    auto *popupPage = @"<b>Hello World!</b>";
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.action.setTitle({ title: 'Modified Title' })",
+        @"await browser.action.setIcon({ path: 'toolbar-48.png' })",
+        @"await browser.action.setPopup({ popup: 'alt-popup.html' })",
+        @"await browser.action.setBadgeText({ text: '42' })",
+        @"await browser.action.disable()",
+
+        @"browser.action.openPopup()"
+    ]);
+
+    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"alt-popup.html": popupPage,
+        @"toolbar-48.png": extraLargeToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *defaultAction = [manager.get().context actionForTab:nil];
+
+        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_FALSE(defaultAction.isEnabled);
+        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(defaultAction.badgeText, @"42");
+
+        EXPECT_NULL(action.associatedTab);
+
+        EXPECT_FALSE(action.isEnabled);
+        EXPECT_NS_EQUAL(action.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(action.badgeText, @"42");
+
+        auto *icon = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
+
+        EXPECT_TRUE(action.hasPopup);
+        EXPECT_FALSE(action.isEnabled);
+
+        EXPECT_NOT_NULL(action.popupWebView);
+        EXPECT_FALSE(action.popupWebView.loading);
+
+        NSURL *webViewURL = action.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/alt-popup.html");
+
+        [action closePopupWebView];
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, TabSpecificActionProperties)
+{
+    auto *popupPage = @"<b>Hello World!</b>";
+    auto *altPopupPage = @"<b>Hello Alternate World!</b>";
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
+
+        @"browser.action.setTitle({ title: 'Tab Title', tabId: currentTab.id })",
+        @"browser.action.setIcon({ path: 'toolbar-48.png', tabId: currentTab.id })",
+        @"browser.action.setPopup({ popup: 'alt-popup.html', tabId: currentTab.id })",
+        @"browser.action.setBadgeText({ text: '42', tabId: currentTab.id })",
+        @"browser.action.disable(currentTab.id)",
+
+        @"browser.action.openPopup({ windowId: currentTab.windowId })"
+    ]);
+
+    auto *smallToolbarIcon = makePNGData(CGSizeMake(16, 16), @selector(redColor));
+    auto *largeToolbarIcon = makePNGData(CGSizeMake(32, 32), @selector(blueColor));
+    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": popupPage,
+        @"alt-popup.html": altPopupPage,
+        @"toolbar-16.png": smallToolbarIcon,
+        @"toolbar-32.png": largeToolbarIcon,
+        @"toolbar-48.png": extraLargeToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *defaultAction = [manager.get().context actionForTab:nil];
+
+        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_TRUE(defaultAction.isEnabled);
+        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Test Action");
+        EXPECT_NS_EQUAL(defaultAction.badgeText, @"");
+
+        auto *defaultIcon = [defaultAction iconForSize:CGSizeMake(32, 32)];
+        EXPECT_NOT_NULL(defaultIcon);
+        EXPECT_TRUE(CGSizeEqualToSize(defaultIcon.size, CGSizeMake(32, 32)));
+
+        EXPECT_FALSE(action.isEnabled);
+        EXPECT_NS_EQUAL(action.displayLabel, @"Tab Title");
+        EXPECT_NS_EQUAL(action.badgeText, @"42");
+
+        auto *icon = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
+
+        EXPECT_TRUE(action.hasPopup);
+        EXPECT_FALSE(action.isEnabled);
+
+        EXPECT_NOT_NULL(action.popupWebView);
+        EXPECT_FALSE(action.popupWebView.loading);
+
+        NSURL *webViewURL = action.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/alt-popup.html");
+
+        auto *secondTabAction = [manager.get().context actionForTab:manager.get().defaultWindow.tabs.lastObject];
+
+        EXPECT_EQ(secondTabAction.hasPopup, defaultAction.hasPopup);
+        EXPECT_EQ(secondTabAction.isEnabled, defaultAction.isEnabled);
+        EXPECT_NS_EQUAL(secondTabAction.displayLabel, defaultAction.displayLabel);
+        EXPECT_NS_EQUAL(secondTabAction.badgeText, defaultAction.badgeText);
+
+        icon = [secondTabAction iconForSize:CGSizeMake(32, 32)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, defaultIcon.size));
+
+        webViewURL = secondTabAction.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
+
+        auto *secondWindowAction = [manager.get().context actionForTab:manager.get().windows[1].tabs[0]];
+        EXPECT_EQ(secondWindowAction.hasPopup, defaultAction.hasPopup);
+        EXPECT_EQ(secondWindowAction.isEnabled, defaultAction.isEnabled);
+        EXPECT_NS_EQUAL(secondWindowAction.displayLabel, defaultAction.displayLabel);
+        EXPECT_NS_EQUAL(secondWindowAction.badgeText, defaultAction.badgeText);
+
+        icon = [secondWindowAction iconForSize:CGSizeMake(32, 32)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, defaultIcon.size));
+
+        webViewURL = secondWindowAction.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
+
+        [secondTabAction closePopupWebView];
+        [secondWindowAction closePopupWebView];
+        [action closePopupWebView];
+
+        [manager done];
+    };
+
+    [manager.get().defaultWindow openNewTab];
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, WindowSpecificActionProperties)
+{
+    auto *popupPage = @"<b>Hello World!</b>";
+    auto *windowPopupPage = @"<b>Window-Specific Popup!</b>";
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
+        @"const currentWindowId = currentTab.windowId",
+
+        @"browser.action.setTitle({ title: 'Window Title', windowId: currentWindowId })",
+        @"browser.action.setIcon({ path: 'window-toolbar-48.png', windowId: currentWindowId })",
+        @"browser.action.setPopup({ popup: 'window-popup.html', windowId: currentWindowId })",
+        @"browser.action.setBadgeText({ text: 'W', windowId: currentWindowId })",
+
+        @"browser.action.openPopup({ windowId: currentWindowId })"
+    ]);
+
+    auto *defaultToolbarIcon = makePNGData(CGSizeMake(32, 32), @selector(redColor));
+    auto *windowToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(greenColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"popup.html": popupPage,
+        @"window-popup.html": windowPopupPage,
+        @"toolbar-32.png": defaultToolbarIcon,
+        @"window-toolbar-48.png": windowToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *defaultAction = [manager.get().context actionForTab:nil];
+
+        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_TRUE(defaultAction.isEnabled);
+        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Test Action");
+        EXPECT_NS_EQUAL(defaultAction.badgeText, @"");
+
+        auto *defaultIcon = [defaultAction iconForSize:CGSizeMake(32, 32)];
+        EXPECT_NOT_NULL(defaultIcon);
+        EXPECT_TRUE(CGSizeEqualToSize(defaultIcon.size, CGSizeMake(32, 32)));
+
+        EXPECT_TRUE(action.isEnabled);
+        EXPECT_NS_EQUAL(action.displayLabel, @"Window Title");
+        EXPECT_NS_EQUAL(action.badgeText, @"W");
+
+        auto *windowIcon = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(windowIcon);
+        EXPECT_TRUE(CGSizeEqualToSize(windowIcon.size, CGSizeMake(48, 48)));
+
+        EXPECT_TRUE(action.hasPopup);
+        NSURL *webViewURL = action.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/window-popup.html");
+
+        auto *secondWindowAction = [manager.get().context actionForTab:manager.get().windows[1].tabs[0]];
+        EXPECT_EQ(secondWindowAction.hasPopup, defaultAction.hasPopup);
+        EXPECT_EQ(secondWindowAction.isEnabled, defaultAction.isEnabled);
+        EXPECT_NS_EQUAL(secondWindowAction.displayLabel, defaultAction.displayLabel);
+        EXPECT_NS_EQUAL(secondWindowAction.badgeText, defaultAction.badgeText);
+
+        auto *secondWindowIcon = [secondWindowAction iconForSize:CGSizeMake(32, 32)];
+        EXPECT_NOT_NULL(secondWindowIcon);
+        EXPECT_TRUE(CGSizeEqualToSize(secondWindowIcon.size, defaultIcon.size));
+
+        webViewURL = secondWindowAction.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
+
+        [secondWindowAction closePopupWebView];
+        [action closePopupWebView];
+
+        [manager done];
+    };
+
+    [manager openNewWindow];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, SetIconSinglePath)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.action.setIcon({ path: 'toolbar-48.png' })",
+
+        @"browser.action.openPopup()"
+    ]);
+
+    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"toolbar-48.png": extraLargeToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *icon = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.action.setIcon({ path: { '48': 'toolbar-48.png', '96': 'toolbar-96.png', '128': 'toolbar-128.png' } })",
+
+        @"browser.action.openPopup()"
+    ]);
+
+    auto *largeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(96, 96), @selector(greenColor));
+    auto *superExtraLargeToolbarIcon = makePNGData(CGSizeMake(128, 128), @selector(purpleColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"toolbar-48.png": largeToolbarIcon,
+        @"toolbar-96.png": extraLargeToolbarIcon,
+        @"toolbar-128.png": superExtraLargeToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
+        auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
+        auto *icon128 = [action iconForSize:CGSizeMake(128, 128)];
+
+        EXPECT_NOT_NULL(icon48);
+#if USE(APPKIT)
+        EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(48, 48)));
+#else
+        EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(128, 128)));
+#endif
+
+        EXPECT_NOT_NULL(icon96);
+#if USE(APPKIT)
+        EXPECT_TRUE(CGSizeEqualToSize(icon96.size, CGSizeMake(96, 96)));
+#else
+        EXPECT_TRUE(CGSizeEqualToSize(icon96.size, CGSizeMake(128, 128)));
+#endif
+
+        EXPECT_NOT_NULL(icon128);
+        EXPECT_TRUE(CGSizeEqualToSize(icon128.size, CGSizeMake(128, 128)));
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, SetIconWithImageData)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const context = new OffscreenCanvas(48, 48).getContext('2d')",
+        @"context.fillStyle = 'green'",
+        @"context.fillRect(0, 0, 48, 48)",
+
+        @"const imageData = context.getImageData(0, 0, 48, 48)",
+        @"await browser.action.setIcon({ imageData })",
+
+        @"browser.action.openPopup()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *icon = [action iconForSize:CGSizeMake(48, 48)];
+
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, SetIconWithMultipleImageDataSizes)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const createImageData = (size, color) => {",
+        @"  const context = new OffscreenCanvas(size, size).getContext('2d')",
+        @"  context.fillStyle = color",
+        @"  context.fillRect(0, 0, size, size)",
+
+        @"  return context.getImageData(0, 0, size, size)",
+        @"}",
+
+        @"const imageData48 = createImageData(48, 'green')",
+        @"const imageData96 = createImageData(96, 'blue')",
+        @"const imageData128 = createImageData(128, 'red')",
+
+        @"await browser.action.setIcon({ imageData: { '48': imageData48, '96': imageData96, '128': imageData128 } })",
+
+        @"browser.action.openPopup()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
+        auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
+        auto *icon128 = [action iconForSize:CGSizeMake(128, 128)];
+
+        EXPECT_NOT_NULL(icon48);
+#if USE(APPKIT)
+        EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(48, 48)));
+#else
+        EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(128, 128)));
+#endif
+
+        EXPECT_NOT_NULL(icon96);
+#if USE(APPKIT)
+        EXPECT_TRUE(CGSizeEqualToSize(icon96.size, CGSizeMake(96, 96)));
+#else
+        EXPECT_TRUE(CGSizeEqualToSize(icon96.size, CGSizeMake(128, 128)));
+#endif
+
+        EXPECT_NOT_NULL(icon128);
+        EXPECT_TRUE(CGSizeEqualToSize(icon128.size, CGSizeMake(128, 128)));
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, SetIconWithSVGDataURL)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const canvas = document.createElement('canvas')",
+        @"canvas.width = 48",
+        @"canvas.height = 48",
+
+        @"const context = canvas.getContext('2d')",
+        @"context.fillStyle = 'blue'",
+        @"context.fillRect(0, 0, 48, 48)",
+
+        @"const pngDataURL48 = canvas.toDataURL('image/png')",
+
+        @"await browser.action.setIcon({ path: pngDataURL48 })",
+
+        @"browser.action.openPopup()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *icon = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, SetIconWithMultipleDataURLs)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const canvas = document.createElement('canvas')",
+
+        @"canvas.width = 48",
+        @"canvas.height = 48",
+
+        @"let context = canvas.getContext('2d')",
+        @"context.fillStyle = 'blue'",
+        @"context.fillRect(0, 0, 48, 48)",
+
+        @"const pngDataURL48 = canvas.toDataURL('image/png')",
+
+        @"canvas.width = 96",
+        @"canvas.height = 96",
+
+        @"context = canvas.getContext('2d')",
+        @"context.fillStyle = 'red'",
+        @"context.fillRect(0, 0, 96, 96)",
+
+        @"const pngDataURL96 = canvas.toDataURL('image/png')",
+
+        @"await browser.action.setIcon({ path: { '48': pngDataURL48, '96': pngDataURL96 } })",
+
+        @"browser.action.openPopup();"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(icon48);
+#if USE(APPKIT)
+        EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(48, 48)));
+#else
+        EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(96, 96)));
+#endif
+
+        auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
+        EXPECT_NOT_NULL(icon96);
+        EXPECT_TRUE(CGSizeEqualToSize(icon96.size, CGSizeMake(96, 96)));
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, BrowserAction)
+{
+    auto *browserActionManifest = @{
+        @"manifest_version": @2,
+
+        @"name": @"Browser Action Test",
+        @"description": @"Browser Action Test",
+        @"version": @"1",
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+
+        @"browser_action": @{
+            @"default_title": @"Test Browser Action",
+            @"default_popup": @"popup.html",
+            @"default_icon": @{
+                @"16": @"toolbar-16.png",
+                @"32": @"toolbar-32.png",
+            },
+        },
+    };
+
+    auto *popupPage = @"<b>Hello World!</b>";
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.browserAction.setTitle({ title: 'Modified Title' })",
+        @"await browser.browserAction.setIcon({ path: 'toolbar-48.png' })",
+        @"await browser.browserAction.setPopup({ popup: 'alt-popup.html' })",
+        @"await browser.browserAction.setBadgeText({ text: '42' })",
+        @"await browser.browserAction.disable()",
+
+        @"browser.browserAction.openPopup()"
+    ]);
+
+    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"alt-popup.html": popupPage,
+        @"toolbar-48.png": extraLargeToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:browserActionManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *defaultAction = [manager.get().context actionForTab:nil];
+
+        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_FALSE(defaultAction.isEnabled);
+        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(defaultAction.badgeText, @"42");
+
+        EXPECT_NULL(action.associatedTab);
+
+        EXPECT_FALSE(action.isEnabled);
+        EXPECT_NS_EQUAL(action.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(action.badgeText, @"42");
+
+        auto *icon = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
+
+        EXPECT_TRUE(action.hasPopup);
+        EXPECT_FALSE(action.isEnabled);
+
+        EXPECT_NOT_NULL(action.popupWebView);
+        EXPECT_FALSE(action.popupWebView.loading);
+
+        NSURL *webViewURL = action.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/alt-popup.html");
+
+        [action closePopupWebView];
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, PageAction)
+{
+    auto *pageActionManifest = @{
+        @"manifest_version": @2,
+
+        @"name": @"Page Action Test",
+        @"description": @"Page Action Test",
+        @"version": @"1",
+
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+
+        @"page_action": @{
+            @"default_title": @"Test Page Action",
+            @"default_popup": @"popup.html",
+            @"default_icon": @{
+                @"16": @"toolbar-16.png",
+                @"32": @"toolbar-32.png",
+            },
+        },
+    };
+
+    auto *popupPage = @"<b>Hello World!</b>";
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.pageAction.setTitle({ title: 'Modified Title' })",
+        @"await browser.pageAction.setIcon({ path: 'toolbar-48.png' })",
+        @"await browser.pageAction.setPopup({ popup: 'alt-popup.html' })",
+        @"await browser.pageAction.setBadgeText({ text: '42' })",
+        @"await browser.pageAction.disable()",
+
+        @"browser.pageAction.openPopup()"
+    ]);
+
+    auto *extraLargeToolbarIcon = makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"alt-popup.html": popupPage,
+        @"toolbar-48.png": extraLargeToolbarIcon,
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:pageActionManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentActionPopup = ^(_WKWebExtensionAction *action) {
+        auto *defaultAction = [manager.get().context actionForTab:nil];
+
+        EXPECT_TRUE(defaultAction.hasPopup);
+        EXPECT_FALSE(defaultAction.isEnabled);
+        EXPECT_NS_EQUAL(defaultAction.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(defaultAction.badgeText, @"42");
+
+        EXPECT_NULL(action.associatedTab);
+
+        EXPECT_FALSE(action.isEnabled);
+        EXPECT_NS_EQUAL(action.displayLabel, @"Modified Title");
+        EXPECT_NS_EQUAL(action.badgeText, @"42");
+
+        auto *icon = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
+
+        EXPECT_TRUE(action.hasPopup);
+        EXPECT_FALSE(action.isEnabled);
+
+        EXPECT_NOT_NULL(action.popupWebView);
+        EXPECT_FALSE(action.popupWebView.loading);
+
+        NSURL *webViewURL = action.popupWebView.URL;
+        EXPECT_NS_EQUAL(webViewURL.scheme, @"webkit-extension");
+        EXPECT_NS_EQUAL(webViewURL.path, @"/alt-popup.html");
+
+        [action closePopupWebView];
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -61,6 +61,7 @@
 - (void)load;
 - (void)run;
 - (void)loadAndRun;
+- (void)done;
 
 @end
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -206,6 +206,11 @@
     [self run];
 }
 
+- (void)done
+{
+    _done = true;
+}
+
 - (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestAssertionResult:(BOOL)result withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
 {
     if (result)


### PR DESCRIPTION
#### f1eb252bd8272bd6c8aec0a89c37295ad8ede9af
<pre>
Add support for action, browserAction, and pageAction APIs.
<a href="https://webkit.org/b/260154">https://webkit.org/b/260154</a>
rdar://problem/114823241

Reviewed by Brian Weinstein.

Added support for the manifest v3 action API (and browserAction and pageAction APIs in v2).
Also added support for the windowId key, which is supported in Firefox by not Chrome.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext performActionForTab:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm: Added.
(WebKit::getActionWithIdentifiers):
(WebKit::getOrCreateActionWithIdentifiers):
(WebKit::WebExtensionContext::actionGetTitle):
(WebKit::WebExtensionContext::actionSetTitle):
(WebKit::WebExtensionContext::actionSetIcon):
(WebKit::WebExtensionContext::actionGetPopup):
(WebKit::WebExtensionContext::actionSetPopup):
(WebKit::WebExtensionContext::actionOpenPopup):
(WebKit::WebExtensionContext::actionGetBadgeText):
(WebKit::WebExtensionContext::actionSetBadgeText):
(WebKit::WebExtensionContext::actionGetEnabled):
(WebKit::WebExtensionContext::actionSetEnabled):
(WebKit::WebExtensionContext::fireActionClickedEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionWebView invalidateIntrinsicContentSize]):
(WebKit::WebExtensionAction::WebExtensionAction):
(WebKit::WebExtensionAction::operator== const):
(WebKit::WebExtensionAction::icon):
(WebKit::WebExtensionAction::setIconsDictionary):
(WebKit::WebExtensionAction::popupPath const):
(WebKit::WebExtensionAction::presentPopupWhenReady):
(WebKit::WebExtensionAction::readyToPresentPopup):
(WebKit::WebExtensionAction::displayLabel const):
(WebKit::WebExtensionAction::badgeText const):
(WebKit::WebExtensionAction::isEnabled const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::setInspectable):
(WebKit::WebExtensionContext::defaultAction):
(WebKit::WebExtensionContext::getAction):
(WebKit::WebExtensionContext::getOrCreateAction):
(WebKit::WebExtensionContext::performAction):
(WebKit::WebExtensionContext::relatedWebView):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
(WebKit::WebExtensionAction::window):
(WebKit::WebExtensionAction::canProgramaticlyPresentPopup const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm: Added.
(WebKit::WebExtensionAPIAction::parseActionDetails):
(WebKit::WebExtensionAPIAction::getTitle):
(WebKit::WebExtensionAPIAction::setTitle):
(WebKit::WebExtensionAPIAction::getBadgeText):
(WebKit::WebExtensionAPIAction::setBadgeText):
(WebKit::WebExtensionAPIAction::getBadgeBackgroundColor):
(WebKit::WebExtensionAPIAction::setBadgeBackgroundColor):
(WebKit::WebExtensionAPIAction::enable):
(WebKit::WebExtensionAPIAction::disable):
(WebKit::WebExtensionAPIAction::isEnabled):
(WebKit::dataURLFromImageData):
(WebKit::isValidDimensionKey):
(WebKit::WebExtensionAPIAction::setIcon):
(WebKit::WebExtensionAPIAction::getPopup):
(WebKit::WebExtensionAPIAction::setPopup):
(WebKit::WebExtensionAPIAction::openPopup):
(WebKit::WebExtensionAPIAction::onClicked):
(WebKit::WebExtensionContextProxy::dispatchActionClickedEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed):
(WebKit::WebExtensionAPINamespace::action):
(WebKit::WebExtensionAPINamespace::i18n):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::isValid): Removed static so other files can use this.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionContextProxy::dispatchWindowsEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h: Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
(WebKit::WebExtensionAPINamespace::browserAction):
(WebKit::WebExtensionAPINamespace::pageAction):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl: Added.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager done]): Added.

Canonical link: <a href="https://commits.webkit.org/268811@main">https://commits.webkit.org/268811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a41a5a4994b96742572c28d9957714bf7d9c722e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19345 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21332 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23481 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25143 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23037 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16650 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23156 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2560 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->