### PR TITLE
HighlightRegister should be renamed to HighlightRegistry.

### DIFF
--- a/LayoutTests/highlight/highlight-interfaces-expected.txt
+++ b/LayoutTests/highlight/highlight-interfaces-expected.txt
@@ -1,4 +1,4 @@
-Tests the interfaces of the highlight API, which include Highlight, HighlightRegister, and extensions to the CSS namespace.
+Tests the interfaces of the highlight API, which include Highlight, HighlightRegistry, and extensions to the CSS namespace.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -8,10 +8,10 @@ PASS Highlight instanceof Function is true
 PASS typeof Highlight is "function"
 PASS new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})) instanceof Highlight is true
 PASS Highlight.prototype[Symbol.iterator] is Highlight.prototype.values
-PASS HighlightRegister instanceof Function is true
-PASS typeof HighlightRegister is "function"
-PASS new HighlightRegister() instanceof HighlightRegister is true
-PASS new HighlightRegister().set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2}))) is defined.
+PASS HighlightRegistry instanceof Function is true
+PASS typeof HighlightRegistry is "function"
+PASS new HighlightRegistry() instanceof HighlightRegistry is true
+PASS new HighlightRegistry().set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2}))) is defined.
 PASS CSS.highlights is defined.
 PASS CSS.highlights.set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2}))) is CSS.highlights
 PASS successfullyParsed is true

--- a/LayoutTests/highlight/highlight-interfaces.html
+++ b/LayoutTests/highlight/highlight-interfaces.html
@@ -4,17 +4,17 @@
 <script src="../resources/js-test.js"></script>
 <script>
 
-description("Tests the interfaces of the highlight API, which include Highlight, HighlightRegister, and extensions to the CSS namespace.");
+description("Tests the interfaces of the highlight API, which include Highlight, HighlightRegistry, and extensions to the CSS namespace.");
 
 debug("Testing Highlight:");
 shouldBeTrue("Highlight instanceof Function");
 shouldBeEqualToString("typeof Highlight", "function");
 shouldBeTrue("new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})) instanceof Highlight");
 shouldBe("Highlight.prototype[Symbol.iterator]", "Highlight.prototype.values");
-shouldBeTrue("HighlightRegister instanceof Function");
-shouldBeEqualToString("typeof HighlightRegister", "function");
-shouldBeTrue("new HighlightRegister() instanceof HighlightRegister");
-shouldBeDefined('new HighlightRegister().set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})))');
+shouldBeTrue("HighlightRegistry instanceof Function");
+shouldBeEqualToString("typeof HighlightRegistry", "function");
+shouldBeTrue("new HighlightRegistry() instanceof HighlightRegistry");
+shouldBeDefined('new HighlightRegistry().set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})))');
 shouldBeDefined('CSS.highlights');
 shouldBe('CSS.highlights.set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})))', 'CSS.highlights');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL HighlightRegistry initializes as it should. assert_not_equals: HighlightRegistry is in window got disallowed value undefined
+FAIL HighlightRegistry initializes as it should. assert_throws_js: HighlightRegistry constructor throws function "function () { var x = new HighlightRegistry(); }" did not throw
 PASS HighlightRegistry has a maplike interface.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-tampered-Map-prototype.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-tampered-Map-prototype.html
@@ -29,33 +29,33 @@ test(() => {
   tamperMapPrototype();
 
   const highlight = new Highlight(new StaticRange({startContainer: document.body, endContainer: document.body, startOffset: 0, endOffset: 0}));
-  const highlightRegister = new HighlightRegister();
+  const highlightRegistry = new HighlightRegistry();
 
-  assert_equals(highlightRegister.size, 0);
-  highlightRegister.set("foo", highlight);
-  assert_equals(highlightRegister.size, 1);
+  assert_equals(highlightRegistry.size, 0);
+  highlightRegistry.set("foo", highlight);
+  assert_equals(highlightRegistry.size, 1);
 
-  assert_true(highlightRegister.has("foo"));
-  assert_equals([...highlightRegister.entries()][0][0], "foo");
+  assert_true(highlightRegistry.has("foo"));
+  assert_equals([...highlightRegistry.entries()][0][0], "foo");
 
-  highlightRegister.clear();
-  assert_equals(highlightRegister.size, 0);
-  assert_equals(highlightRegister.get("foo"), undefined);
+  highlightRegistry.clear();
+  assert_equals(highlightRegistry.size, 0);
+  assert_equals(highlightRegistry.get("foo"), undefined);
 
-  highlightRegister.set("bar", highlight);
-  assert_equals(highlightRegister.get("bar"), highlight);
-  assert_equals([...highlightRegister][0][1], highlight);
+  highlightRegistry.set("bar", highlight);
+  assert_equals(highlightRegistry.get("bar"), highlight);
+  assert_equals([...highlightRegistry][0][1], highlight);
 
-  highlightRegister.delete("bar");
-  assert_equals(highlightRegister.size, 0);
-  assert_false(highlightRegister.has("bar"));
+  highlightRegistry.delete("bar");
+  assert_equals(highlightRegistry.size, 0);
+  assert_false(highlightRegistry.has("bar"));
 
-  highlightRegister.set("baz", highlight);
-  assert_equals([...highlightRegister.keys()][0], "baz");
-  assert_equals([...highlightRegister.values()][0], highlight);
+  highlightRegistry.set("baz", highlight);
+  assert_equals([...highlightRegistry.keys()][0], "baz");
+  assert_equals([...highlightRegistry.values()][0], highlight);
 
   let callbackCalled = false;
-  highlightRegister.forEach(() => { callbackCalled = true; });
+  highlightRegistry.forEach(() => { callbackCalled = true; });
   assert_true(callbackCalled);
 }, "HighlightRegistry is a maplike interface that works as expected even if Map.prototype is tampered.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
@@ -16,15 +16,17 @@ PASS Highlight must be primary interface of new Highlight(new Range())
 PASS Stringification of new Highlight(new Range())
 PASS Highlight interface: new Highlight(new Range()) must inherit property "priority" with the proper type
 PASS Highlight interface: new Highlight(new Range()) must inherit property "type" with the proper type
-FAIL HighlightRegistry interface: existence and properties of interface object assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
-FAIL HighlightRegistry interface object length assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
-FAIL HighlightRegistry interface object name assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
-FAIL HighlightRegistry interface: existence and properties of interface prototype object assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
-FAIL HighlightRegistry interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
-FAIL HighlightRegistry interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
-FAIL HighlightRegistry interface: maplike<DOMString, Highlight> undefined is not an object (evaluating 'this.get_interface_object().prototype')
-FAIL HighlightRegistry must be primary interface of CSS.highlights assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
-FAIL Stringification of CSS.highlights assert_class_string: class string of CSS.highlights expected "[object HighlightRegistry]" but got "[object HighlightRegister]"
+FAIL HighlightRegistry interface: existence and properties of interface object assert_throws_js: interface object didn't throw TypeError when called as a constructor function "function() {
+                new interface_object();
+            }" did not throw
+PASS HighlightRegistry interface object length
+PASS HighlightRegistry interface object name
+PASS HighlightRegistry interface: existence and properties of interface prototype object
+PASS HighlightRegistry interface: existence and properties of interface prototype object's "constructor" property
+PASS HighlightRegistry interface: existence and properties of interface prototype object's @@unscopables property
+PASS HighlightRegistry interface: maplike<DOMString, Highlight>
+PASS HighlightRegistry must be primary interface of CSS.highlights
+PASS Stringification of CSS.highlights
 PASS CSS namespace: operation escape(CSSOMString)
 PASS CSS namespace: attribute highlights
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -369,7 +369,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/geolocation/PositionOptions.idl
 
     Modules/highlight/Highlight.idl
-    Modules/highlight/HighlightRegister.idl
+    Modules/highlight/HighlightRegistry.idl
 
     Modules/indexeddb/IDBCursor.idl
     Modules/indexeddb/IDBCursorDirection.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -498,7 +498,7 @@ $(PROJECT_DIR)/Modules/geolocation/PositionError.idl
 $(PROJECT_DIR)/Modules/geolocation/PositionErrorCallback.idl
 $(PROJECT_DIR)/Modules/geolocation/PositionOptions.idl
 $(PROJECT_DIR)/Modules/highlight/Highlight.idl
-$(PROJECT_DIR)/Modules/highlight/HighlightRegister.idl
+$(PROJECT_DIR)/Modules/highlight/HighlightRegistry.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursor.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorDirection.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorWithValue.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1583,8 +1583,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHdrMetadataType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHdrMetadataType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHighlight.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHighlight.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHighlightRegister.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHighlightRegister.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHighlightRegistry.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHighlightRegistry.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHistory.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHistory.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSHkdfParams.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -370,7 +370,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/geolocation/PositionCallback.idl \
     $(WebCore)/Modules/geolocation/PositionErrorCallback.idl \
     $(WebCore)/Modules/geolocation/PositionOptions.idl \
-    $(WebCore)/Modules/highlight/HighlightRegister.idl \
+    $(WebCore)/Modules/highlight/HighlightRegistry.idl \
     $(WebCore)/Modules/highlight/Highlight.idl \
     $(WebCore)/Modules/indexeddb/IDBCursor.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorDirection.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -391,7 +391,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/highlight/AppHighlight.h
     Modules/highlight/Highlight.h
-    Modules/highlight/HighlightRegister.h
+    Modules/highlight/HighlightRegistry.h
     Modules/highlight/HighlightVisibility.h
 
     Modules/indexeddb/IDBActiveDOMObject.h

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
@@ -36,7 +36,7 @@
 #include "Editor.h"
 #include "ElementInlines.h"
 #include "HTMLBodyElement.h"
-#include "HighlightRegister.h"
+#include "HighlightRegistry.h"
 #include "Node.h"
 #include "Position.h"
 #include "RenderedDocumentMarker.h"
@@ -264,7 +264,7 @@ bool AppHighlightStorage::attemptToRestoreHighlightAndScroll(AppHighlightRangeDa
     if (!range)
         return false;
     
-    strongDocument->appHighlightRegister().addAnnotationHighlightWithRange(StaticRange::create(*range));
+    strongDocument->appHighlightRegistry().addAnnotationHighlightWithRange(StaticRange::create(*range));
     
     if (scroll == ScrollToHighlight::Yes) {
         auto textIndicator = TextIndicator::createWithRange(range.value(), { TextIndicatorOption::DoNotClipToVisibleRect }, WebCore::TextIndicatorPresentationTransition::Bounce);

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "HighlightRegister.h"
+#include "HighlightRegistry.h"
 
 #include "IDLTypes.h"
 #include "JSDOMMapLike.h"
@@ -32,13 +32,13 @@
 
 namespace WebCore {
     
-void HighlightRegister::initializeMapLike(DOMMapAdapter& map)
+void HighlightRegistry::initializeMapLike(DOMMapAdapter& map)
 {
     for (auto& keyValue : m_map)
         map.set<IDLDOMString, IDLInterface<Highlight>>(keyValue.key, keyValue.value);
 }
 
-void HighlightRegister::setFromMapLike(AtomString&& key, Ref<Highlight>&& value)
+void HighlightRegistry::setFromMapLike(AtomString&& key, Ref<Highlight>&& value)
 {
     auto addResult = m_map.set(key, WTFMove(value));
     if (addResult.isNewEntry) {
@@ -47,19 +47,19 @@ void HighlightRegister::setFromMapLike(AtomString&& key, Ref<Highlight>&& value)
     }
 }
 
-void HighlightRegister::clear()
+void HighlightRegistry::clear()
 {
     m_map.clear();
     m_highlightNames.clear();
 }
 
-bool HighlightRegister::remove(const AtomString& key)
+bool HighlightRegistry::remove(const AtomString& key)
 {
     m_highlightNames.removeFirst(key);
     return m_map.remove(key);
 }
 #if ENABLE(APP_HIGHLIGHTS)
-void HighlightRegister::setHighlightVisibility(HighlightVisibility highlightVisibility)
+void HighlightRegistry::setHighlightVisibility(HighlightVisibility highlightVisibility)
 {
     if (m_highlightVisibility == highlightVisibility)
         return;
@@ -75,7 +75,7 @@ static ASCIILiteral annotationHighlightKey()
     return "annotationHighlightKey"_s;
 }
 
-void HighlightRegister::addAnnotationHighlightWithRange(Ref<StaticRange>&& value)
+void HighlightRegistry::addAnnotationHighlightWithRange(Ref<StaticRange>&& value)
 {
     if (m_map.contains(annotationHighlightKey()))
         m_map.get(annotationHighlightKey())->addToSetLike(value);

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.h
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.h
@@ -38,9 +38,9 @@ class DOMString;
 class Highlight;
 class StaticRange;
 
-class HighlightRegister : public RefCounted<HighlightRegister> {
+class HighlightRegistry : public RefCounted<HighlightRegistry> {
 public:
-    static Ref<HighlightRegister> create() { return adoptRef(*new HighlightRegister); }
+    static Ref<HighlightRegistry> create() { return adoptRef(*new HighlightRegistry); }
 
     void initializeMapLike(DOMMapAdapter&);
     void setFromMapLike(AtomString&&, Ref<Highlight>&&);
@@ -58,7 +58,7 @@ public:
     const Vector<AtomString>& highlightNames() const { return m_highlightNames; }
     
 private:
-    HighlightRegister() = default;
+    HighlightRegistry() = default;
     HashMap<AtomString, Ref<Highlight>> m_map;
     Vector<AtomString> m_highlightNames;
 

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.idl
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.idl
@@ -26,7 +26,7 @@
 [
     EnabledByDeprecatedGlobalSetting=HighlightAPIEnabled,
     Exposed=Window
-] interface HighlightRegister {
+] interface HighlightRegistry {
     constructor();
 
     maplike<[AtomString] DOMString, Highlight>;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -143,7 +143,7 @@ Modules/geolocation/GeolocationCoordinates.cpp
 Modules/geolocation/NavigatorGeolocation.cpp
 Modules/highlight/AppHighlightRangeData.cpp
 Modules/highlight/AppHighlightStorage.cpp
-Modules/highlight/HighlightRegister.cpp
+Modules/highlight/HighlightRegistry.cpp
 Modules/highlight/Highlight.cpp
 Modules/indexeddb/IDBCursor.cpp
 Modules/indexeddb/IDBCursorWithValue.cpp
@@ -3743,7 +3743,7 @@ JSHTMLVideoElement.cpp
 JSHardwareAcceleration.cpp
 JSHashChangeEvent.cpp
 JSHdrMetadataType.cpp
-JSHighlightRegister.cpp
+JSHighlightRegistry.cpp
 JSHighlight.cpp
 JSHistory.cpp
 JSHkdfParams.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -242,7 +242,7 @@ namespace WebCore {
     macro(GamepadButton) \
     macro(GamepadEvent) \
     macro(GamepadHapticActuator) \
-    macro(HighlightRegister) \
+    macro(HighlightRegistry) \
     macro(Highlight) \
     macro(HTMLAttachmentElement) \
     macro(HTMLAudioElement) \

--- a/Source/WebCore/css/DOMCSSNamespace.cpp
+++ b/Source/WebCore/css/DOMCSSNamespace.cpp
@@ -36,7 +36,7 @@
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
 #include "Document.h"
-#include "HighlightRegister.h"
+#include "HighlightRegistry.h"
 #include "MutableStyleProperties.h"
 #include "StyleProperties.h"
 #include <wtf/text/StringBuilder.h>
@@ -88,9 +88,9 @@ String DOMCSSNamespace::escape(const String& ident)
     return builder.toString();
 }
 
-HighlightRegister& DOMCSSNamespace::highlights(Document& document)
+HighlightRegistry& DOMCSSNamespace::highlights(Document& document)
 {
-    return document.highlightRegister();
+    return document.highlightRegistry();
 }
 
 }

--- a/Source/WebCore/css/DOMCSSNamespace.h
+++ b/Source/WebCore/css/DOMCSSNamespace.h
@@ -37,7 +37,7 @@
 namespace WebCore {
 
 class Document;
-class HighlightRegister;
+class HighlightRegistry;
 class Highlight;
 
 class DOMCSSNamespace final : public RefCounted<DOMCSSNamespace>, public Supplementable<DOMCSSNamespace> {
@@ -45,7 +45,7 @@ public:
     static bool supports(Document&, const String& property, const String& value);
     static bool supports(Document&, const String& conditionText);
     static String escape(const String& ident);
-    static HighlightRegister& highlights(Document&);
+    static HighlightRegistry& highlights(Document&);
 };
 
 }

--- a/Source/WebCore/css/DOMCSSNamespace.idl
+++ b/Source/WebCore/css/DOMCSSNamespace.idl
@@ -34,5 +34,5 @@
     [CallWith=CurrentDocument] boolean supports(DOMString property, DOMString value);
     [CallWith=CurrentDocument] boolean supports(DOMString conditionText);
     DOMString escape(DOMString ident);
-    [EnabledByDeprecatedGlobalSetting=HighlightAPIEnabled, CallWith=CurrentDocument] readonly attribute HighlightRegister highlights;
+    [EnabledByDeprecatedGlobalSetting=HighlightAPIEnabled, CallWith=CurrentDocument] readonly attribute HighlightRegistry highlights;
 };

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -151,7 +151,7 @@ class HTMLMediaElement;
 class HTMLMetaElement;
 class HTMLVideoElement;
 class HighlightRange;
-class HighlightRegister;
+class HighlightRegistry;
 class HitTestLocation;
 class HitTestRequest;
 class HitTestResult;
@@ -1722,16 +1722,16 @@ public:
     TextManipulationController* textManipulationControllerIfExists() { return m_textManipulationController.get(); }
 
     bool hasHighlight() const;
-    HighlightRegister* highlightRegisterIfExists() { return m_highlightRegister.get(); }
-    HighlightRegister& highlightRegister();
+    HighlightRegistry* highlightRegistryIfExists() { return m_highlightRegistry.get(); }
+    HighlightRegistry& highlightRegistry();
     void updateHighlightPositions();
 
-    HighlightRegister* fragmentHighlightRegisterIfExists() { return m_fragmentHighlightRegister.get(); }
-    HighlightRegister& fragmentHighlightRegister();
+    HighlightRegistry* fragmentHighlightRegistryIfExists() { return m_fragmentHighlightRegistry.get(); }
+    HighlightRegistry& fragmentHighlightRegistry();
         
 #if ENABLE(APP_HIGHLIGHTS)
-    HighlightRegister* appHighlightRegisterIfExists() { return m_appHighlightRegister.get(); }
-    WEBCORE_EXPORT HighlightRegister& appHighlightRegister();
+    HighlightRegistry* appHighlightRegistryIfExists() { return m_appHighlightRegistry.get(); }
+    WEBCORE_EXPORT HighlightRegistry& appHighlightRegistry();
 
     WEBCORE_EXPORT AppHighlightStorage& appHighlightStorage();
     AppHighlightStorage* appHighlightStorageIfExists() const { return m_appHighlightStorage.get(); };
@@ -1914,7 +1914,7 @@ private:
 
     void platformSuspendOrStopActiveDOMObjects();
 
-    void collectHighlightRangesFromRegister(Vector<WeakPtr<HighlightRange>>&, const HighlightRegister&);
+    void collectHighlightRangesFromRegister(Vector<WeakPtr<HighlightRange>>&, const HighlightRegistry&);
 
     bool isBodyPotentiallyScrollable(HTMLBodyElement&);
 
@@ -2143,10 +2143,10 @@ private:
     std::unique_ptr<TextAutoSizing> m_textAutoSizing;
 #endif
         
-    RefPtr<HighlightRegister> m_highlightRegister;
-    RefPtr<HighlightRegister> m_fragmentHighlightRegister;
+    RefPtr<HighlightRegistry> m_highlightRegistry;
+    RefPtr<HighlightRegistry> m_fragmentHighlightRegistry;
 #if ENABLE(APP_HIGHLIGHTS)
-    RefPtr<HighlightRegister> m_appHighlightRegister;
+    RefPtr<HighlightRegistry> m_appHighlightRegistry;
     std::unique_ptr<AppHighlightStorage> m_appHighlightStorage;
 #endif
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -63,7 +63,7 @@
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
 #include "HTMLPlugInImageElement.h"
-#include "HighlightRegister.h"
+#include "HighlightRegistry.h"
 #include "ImageDocument.h"
 #include "InspectorClient.h"
 #include "InspectorController.h"
@@ -2321,7 +2321,7 @@ bool LocalFrameView::scrollToFragment(const URL& url)
             
             auto highlightRanges = FragmentDirectiveRangeFinder::findRangesFromTextDirectives(parsedTextDirectives, document);
             for (auto range : highlightRanges)
-                document->fragmentHighlightRegister().addAnnotationHighlightWithRange(StaticRange::create(range));
+                document->fragmentHighlightRegistry().addAnnotationHighlightWithRange(StaticRange::create(range));
             
             if (highlightRanges.size()) {
                 auto range = highlightRanges.first();

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -31,7 +31,7 @@
 #include "DocumentMarkerController.h"
 #include "Editor.h"
 #include "ElementRuleCollector.h"
-#include "HighlightRegister.h"
+#include "HighlightRegistry.h"
 #include "RenderBoxModelObject.h"
 #include "RenderHighlight.h"
 #include "RenderStyleInlines.h"
@@ -112,14 +112,14 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
     if (DeprecatedGlobalSettings::highlightAPIEnabled()) {
         auto& parentRenderer = *renderer.parent();
         auto& parentStyle = parentRenderer.style();
-        if (auto highlightRegister = renderer.document().highlightRegisterIfExists()) {
-            for (auto& highlightName : highlightRegister->highlightNames()) {
+        if (auto highlightRegistry = renderer.document().highlightRegistryIfExists()) {
+            for (auto& highlightName : highlightRegistry->highlightNames()) {
                 auto renderStyle = parentRenderer.getUncachedPseudoStyle({ PseudoId::Highlight, highlightName }, &parentStyle);
                 if (!renderStyle)
                     continue;
                 if (renderStyle->textDecorationsInEffect().isEmpty() && phase == PaintPhase::Decoration)
                     continue;
-                for (auto& highlightRange : highlightRegister->map().get(highlightName)->highlightRanges()) {
+                for (auto& highlightRange : highlightRegistry->map().get(highlightName)->highlightRanges()) {
                     if (!renderHighlight.setRenderRange(highlightRange))
                         continue;
                     if (auto* staticRange = dynamicDowncast<StaticRange>(highlightRange->range()); staticRange
@@ -140,7 +140,7 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
                     auto [highlightStart, highlightEnd] = renderHighlight.rangeForTextBox(renderer, selectableRange);
 
                     if (highlightStart < highlightEnd) {
-                        int currentPriority = highlightRegister->map().get(highlightName)->priority();
+                        int currentPriority = highlightRegistry->map().get(highlightName)->priority();
                         // If we can just append it to the end, do that instead.
                         if (markedTexts.isEmpty() || markedTexts.last().priority <= currentPriority)
                             markedTexts.append({ highlightStart, highlightEnd, MarkedText::Type::Highlight, nullptr, highlightName, currentPriority });
@@ -161,8 +161,8 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
     }
     
     if (renderer.document().settings().scrollToTextFragmentEnabled()) {
-        if (auto fragmentHighlightRegister = renderer.document().fragmentHighlightRegisterIfExists()) {
-            for (auto& highlight : fragmentHighlightRegister->map()) {
+        if (auto fragmentHighlightRegistry = renderer.document().fragmentHighlightRegistryIfExists()) {
+            for (auto& highlight : fragmentHighlightRegistry->map()) {
                 for (auto& highlightRange : highlight.value->highlightRanges()) {
                     if (!renderHighlight.setRenderRange(highlightRange))
                         continue;
@@ -176,9 +176,9 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
     }
     
 #if ENABLE(APP_HIGHLIGHTS)
-    if (auto appHighlightRegister = renderer.document().appHighlightRegisterIfExists()) {
-        if (appHighlightRegister->highlightsVisibility() == HighlightVisibility::Visible) {
-            for (auto& highlight : appHighlightRegister->map()) {
+    if (auto appHighlightRegistry = renderer.document().appHighlightRegistryIfExists()) {
+        if (appHighlightRegistry->highlightsVisibility() == HighlightVisibility::Visible) {
+            for (auto& highlight : appHighlightRegistry->map()) {
                 for (auto& highlightRange : highlight.value->highlightRanges()) {
                     if (!renderHighlight.setRenderRange(highlightRange))
                         continue;

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -34,7 +34,7 @@
 #include "HTMLElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLParserIdioms.h"
-#include "HighlightRegister.h"
+#include "HighlightRegistry.h"
 #include "InlineIteratorBox.h"
 #include "InlineIteratorLineBoxInlines.h"
 #include "LayoutRepainter.h"
@@ -156,9 +156,9 @@ Color RenderReplaced::calculateHighlightColor() const
 {
     RenderHighlight renderHighlight;
 #if ENABLE(APP_HIGHLIGHTS)
-    if (auto appHighlightRegister = document().appHighlightRegisterIfExists()) {
-        if (appHighlightRegister->highlightsVisibility() == HighlightVisibility::Visible) {
-            for (auto& highlight : appHighlightRegister->map()) {
+    if (auto appHighlightRegistry = document().appHighlightRegistryIfExists()) {
+        if (appHighlightRegistry->highlightsVisibility() == HighlightVisibility::Visible) {
+            for (auto& highlight : appHighlightRegistry->map()) {
                 for (auto& highlightRange : highlight.value->highlightRanges()) {
                     if (!renderHighlight.setRenderRange(highlightRange))
                         continue;
@@ -175,8 +175,8 @@ Color RenderReplaced::calculateHighlightColor() const
     }
 #endif
     if (DeprecatedGlobalSettings::highlightAPIEnabled()) {
-        if (auto highlightRegister = document().highlightRegisterIfExists()) {
-            for (auto& highlight : highlightRegister->map()) {
+        if (auto highlightRegistry = document().highlightRegistryIfExists()) {
+            for (auto& highlight : highlightRegistry->map()) {
                 for (auto& highlightRange : highlight.value->highlightRanges()) {
                     if (!renderHighlight.setRenderRange(highlightRange))
                         continue;
@@ -192,8 +192,8 @@ Color RenderReplaced::calculateHighlightColor() const
         }
     }
     if (document().settings().scrollToTextFragmentEnabled()) {
-        if (auto highlightRegister = document().fragmentHighlightRegisterIfExists()) {
-            for (auto& highlight : highlightRegister->map()) {
+        if (auto highlightRegistry = document().fragmentHighlightRegistryIfExists()) {
+            for (auto& highlight : highlightRegistry->map()) {
                 for (auto& highlightRange : highlight.value->highlightRanges()) {
                     if (!renderHighlight.setRenderRange(highlightRange))
                         continue;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -106,7 +106,7 @@
 #include "HTMLSelectElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HTMLVideoElement.h"
-#include "HighlightRegister.h"
+#include "HighlightRegistry.h"
 #include "HistoryController.h"
 #include "HistoryItem.h"
 #include "HitTestResult.h"
@@ -6748,11 +6748,11 @@ unsigned Internals::numberOfAppHighlights()
     Document* document = contextDocument();
     if (!document)
         return 0;
-    auto appHighlightRegister = document->appHighlightRegisterIfExists();
-    if (!appHighlightRegister)
+    auto appHighlightRegistry = document->appHighlightRegistryIfExists();
+    if (!appHighlightRegistry)
         return 0;
     unsigned numHighlights = 0;
-    for (auto& highlight : appHighlightRegister->map())
+    for (auto& highlight : appHighlightRegistry->map())
         numHighlights += highlight.value->highlightRanges().size();
     return numHighlights;
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -221,7 +221,7 @@
 #include <WebCore/HTTPParsers.h>
 #include <WebCore/HandleMouseEventResult.h>
 #include <WebCore/Highlight.h>
-#include <WebCore/HighlightRegister.h>
+#include <WebCore/HighlightRegistry.h>
 #include <WebCore/HistoryController.h>
 #include <WebCore/HistoryItem.h>
 #include <WebCore/HitTestResult.h>
@@ -8628,7 +8628,7 @@ bool WebPage::createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighli
     if (!selectionRange)
         return false;
 
-    document->appHighlightRegister().addAnnotationHighlightWithRange(StaticRange::create(selectionRange.value()));
+    document->appHighlightRegistry().addAnnotationHighlightWithRange(StaticRange::create(selectionRange.value()));
     document->appHighlightStorage().storeAppHighlight(StaticRange::create(selectionRange.value()));
 
     return true;
@@ -8657,7 +8657,7 @@ void WebPage::setAppHighlightsVisibility(WebCore::HighlightVisibility appHighlig
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->appHighlightRegister().setHighlightVisibility(appHighlightVisibility);
+            document->appHighlightRegistry().setHighlightVisibility(appHighlightVisibility);
     }
 }
 


### PR DESCRIPTION
#### 5c10221be14f825562feca679a0c80ccb1e513c2
<pre>
HighlightRegister should be renamed to HighlightRegistry.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262522">https://bugs.webkit.org/show_bug.cgi?id=262522</a>
rdar://116262991

Reviewed by Aditya Keerthi and Richard Robinson.

HighlightRegister is the old version, need to rename to HighlightRegistry
to be compliant with he current spec.

* Source/WebCore/Modules/highlight/HighlightRegistry.cpp: Renamed from Source/WebCore/Modules/highlight/HighlightRegister.cpp.
(WebCore::HighlightRegistry::initializeMapLike):
(WebCore::HighlightRegistry::setFromMapLike):
(WebCore::HighlightRegistry::clear):
(WebCore::HighlightRegistry::remove):
(WebCore::HighlightRegistry::setHighlightVisibility):
(WebCore::annotationHighlightKey):
(WebCore::HighlightRegistry::addAnnotationHighlightWithRange):
* Source/WebCore/Modules/highlight/HighlightRegistry.h: Renamed from Source/WebCore/Modules/highlight/HighlightRegister.h.
(WebCore::HighlightRegistry::create):
(WebCore::HighlightRegistry::isEmpty const):
(WebCore::HighlightRegistry::highlightsVisibility const):
(WebCore::HighlightRegistry::map const):
(WebCore::HighlightRegistry::highlightNames const):
* Source/WebCore/Modules/highlight/HighlightRegistry.idl: Renamed from Source/WebCore/Modules/highlight/HighlightRegister.idl.

Canonical link: <a href="https://commits.webkit.org/268873@main">https://commits.webkit.org/268873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cbdeb77b9469e2695ca10e392cc895f0a3a0779

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22797 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19480 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21492 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23653 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18972 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23176 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16762 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18804 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5020 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23302 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->