### PR TITLE
REGRESSION (267023@main): The language switching menu is broken on English Wikipedia

### DIFF
--- a/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task-expected.txt
@@ -1,0 +1,10 @@
+This tests that requestIdleCallback will execute the function even when there is a pending task for a suspended document
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didExecuteIdleCallback is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html><!-- webkit-test-runner [ RequestIdleCallbackEnabled=true UsesBackForwardCache=true ] -->
+<html>
+<body>
+<script src="../resources/js-test.js"></script>
+<script>
+
+description('This tests that requestIdleCallback will execute the function even when there is a pending task for a suspended document');
+jsTestIsAsync = true;
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+
+window.addEventListener("pagehide", function(event) {
+    requestIdleCallback(() => console.log('FAIL - idle callback executed'));
+    iframe.contentWindow.requestIdleCallback(() => console.log('FAIL - idle callback in iframe executed'));
+    internals.queueTask('DOMManipulation', () => { });
+});
+
+onload = () => {
+    setTimeout(() => {
+        window.location = 'resources/page-cache-with-pending-task.html';
+    }, 0);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/requestidlecallback/resources/page-cache-with-pending-task.html
+++ b/LayoutTests/requestidlecallback/resources/page-cache-with-pending-task.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests that requestIdleCallback will execute the function even when there is a pending task for a suspended document');
+
+jsTestIsAsync = true;
+didExecuteIdleCallback = false;
+
+window.onload = () => {
+    setTimeout(() => {
+        shouldBeTrue('didExecuteIdleCallback');
+        finishJSTest();
+    }, 100);
+    requestIdleCallback(() => {
+        didExecuteIdleCallback = true;
+    });
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -346,6 +346,14 @@ void EventLoop::clearAllTasks()
     m_groupsWithSuspendedTasks.clear();
 }
 
+bool EventLoop::hasTasksForFullyActiveDocument() const
+{
+    return m_tasks.containsIf([](auto& task) {
+        auto group = task->group();
+        return group && !group->isStoppedPermanently() && !group->isSuspended();
+    });
+}
+
 void EventLoop::forEachAssociatedContext(const Function<void(ScriptExecutionContext&)>& apply)
 {
     m_associatedContexts.forEach(apply);

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -135,8 +135,7 @@ protected:
     void run(std::optional<ApproximateTime> deadline = std::nullopt);
     void clearAllTasks();
 
-    // FIXME: Account for fully-activeness of each document.
-    bool hasTasksForFullyActiveDocument() const { return !m_tasks.isEmpty(); }
+    bool hasTasksForFullyActiveDocument() const;
 
 private:
     virtual void scheduleToRun() = 0;


### PR DESCRIPTION
#### ffd8a014dd114d2dd7f2fba65c372ba2cc45b233
<pre>
REGRESSION (267023@main): The language switching menu is broken on English Wikipedia
<a href="https://bugs.webkit.org/show_bug.cgi?id=262358">https://bugs.webkit.org/show_bug.cgi?id=262358</a>

Reviewed by Wenson Hsieh.

The bug was caused by EventLoop::hasTasksForFullyActiveDocument returning true when there are pending tasks
for suspended documents (in back-forward cache). This resulted in WindowEventLoop::didReachTimeToRun() to
exit early before running idle callbacks. Fixed the bug by making hasTasksForFullyActiveDocument return true
only when there are pending tasks for non-suspended task groups.

* LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task-expected.txt: Added.
* LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task.html: Added.
* LayoutTests/requestidlecallback/resources/page-cache-with-pending-task.html: Added.

* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoop::hasTasksForFullyActiveDocument const): Fixed the bug.
* Source/WebCore/dom/EventLoop.h:
(WebCore::EventLoop::hasTasksForFullyActiveDocument const): Moved to the cpp file above.

Canonical link: <a href="https://commits.webkit.org/268782@main">https://commits.webkit.org/268782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45759aa36ebd8fb429aac32206ba903790574d0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19241 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20589 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23363 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25000 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18905 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22943 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16561 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18564 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23046 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2551 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->