### PR TITLE
Introduce new Vector constructor that takes in a length and a lambda to generate vector items

### DIFF
--- a/Source/JavaScriptCore/API/APICallbackFunction.h
+++ b/Source/JavaScriptCore/API/APICallbackFunction.h
@@ -49,10 +49,9 @@ EncodedJSValue APICallbackFunction::callImpl(JSGlobalObject* globalObject, CallF
     JSObjectRef thisObjRef = toRef(jsCast<JSObject*>(callFrame->thisValue().toThis(globalObject, ECMAMode::sloppy())));
 
     int argumentCount = static_cast<int>(callFrame->argumentCount());
-    Vector<JSValueRef, 16> arguments;
-    arguments.reserveInitialCapacity(argumentCount);
-    for (int i = 0; i < argumentCount; i++)
-        arguments.uncheckedAppend(toRef(globalObject, callFrame->uncheckedArgument(i)));
+    Vector<JSValueRef, 16> arguments(argumentCount, [&](size_t i) {
+        return toRef(globalObject, callFrame->uncheckedArgument(i));
+    });
 
     JSValueRef exception = nullptr;
     JSValueRef result;
@@ -93,10 +92,9 @@ EncodedJSValue APICallbackFunction::constructImpl(JSGlobalObject* globalObject, 
         }
 
         size_t argumentCount = callFrame->argumentCount();
-        Vector<JSValueRef, 16> arguments;
-        arguments.reserveInitialCapacity(argumentCount);
-        for (size_t i = 0; i < argumentCount; ++i)
-            arguments.uncheckedAppend(toRef(globalObject, callFrame->uncheckedArgument(i)));
+        Vector<JSValueRef, 16> arguments(argumentCount, [&](size_t i) {
+            return toRef(globalObject, callFrame->uncheckedArgument(i));
+        });
 
         JSValueRef exception = nullptr;
         JSObjectRef result;

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -478,10 +478,9 @@ EncodedJSValue JSCallbackObject<Parent>::constructImpl(JSGlobalObject* globalObj
     for (JSClassRef jsClass = jsCast<JSCallbackObject<Parent>*>(constructor)->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (JSObjectCallAsConstructorCallback callAsConstructor = jsClass->callAsConstructor) {
             size_t argumentCount = callFrame->argumentCount();
-            Vector<JSValueRef, 16> arguments;
-            arguments.reserveInitialCapacity(argumentCount);
-            for (size_t i = 0; i < argumentCount; ++i)
-                arguments.uncheckedAppend(toRef(globalObject, callFrame->uncheckedArgument(i)));
+            Vector<JSValueRef, 16> arguments(argumentCount, [&](size_t i) {
+                return toRef(globalObject, callFrame->uncheckedArgument(i));
+            });
             JSValueRef exception = nullptr;
             JSObject* result;
             {
@@ -556,10 +555,10 @@ EncodedJSValue JSCallbackObject<Parent>::callImpl(JSGlobalObject* globalObject, 
     for (JSClassRef jsClass = jsCast<JSCallbackObject<Parent>*>(toJS(functionRef))->classRef(); jsClass; jsClass = jsClass->parentClass) {
         if (JSObjectCallAsFunctionCallback callAsFunction = jsClass->callAsFunction) {
             size_t argumentCount = callFrame->argumentCount();
-            Vector<JSValueRef, 16> arguments;
-            arguments.reserveInitialCapacity(argumentCount);
-            for (size_t i = 0; i < argumentCount; ++i)
-                arguments.uncheckedAppend(toRef(globalObject, callFrame->uncheckedArgument(i)));
+            Vector<JSValueRef, 16> arguments(argumentCount, [&](size_t i) {
+                return toRef(globalObject, callFrame->uncheckedArgument(i));
+            });
+
             JSValueRef exception = nullptr;
             JSValue result;
             {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -7512,10 +7512,7 @@ public:
 
             fallThrough.link(&m_jit);
         } else {
-            Vector<int64_t> cases;
-            cases.reserveInitialCapacity(targets.size());
-            for (size_t i = 0; i < targets.size(); ++i)
-                cases.uncheckedAppend(i);
+            Vector<int64_t> cases(targets.size(), [](size_t i) { return i; });
 
             BinarySwitch binarySwitch(wasmScratchGPR, cases, BinarySwitch::Int32);
             while (binarySwitch.advance(m_jit)) {

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -219,8 +219,9 @@ Worklist::Worklist()
     unsigned numberOfCompilationThreads = Options::useConcurrentJIT() ? Options::numberOfWasmCompilerThreads() : 1;
     m_threads.reserveInitialCapacity(numberOfCompilationThreads);
     Locker locker { *m_lock };
-    for (unsigned i = 0; i < numberOfCompilationThreads; ++i)
-        m_threads.uncheckedAppend(makeUnique<Worklist::Thread>(locker, *this));
+    m_threads = Vector<std::unique_ptr<Thread>>(numberOfCompilationThreads, [&](size_t) {
+        return makeUnique<Worklist::Thread>(locker, *this);
+    });
 }
 
 Worklist::~Worklist()

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -707,6 +707,17 @@ public:
             TypeOperations::uninitializedFill(begin(), end(), val);
     }
 
+    template<typename Functor, typename = typename std::enable_if_t<std::is_invocable_v<Functor, size_t>>>
+    Vector(size_t size, const Functor& valueGenerator)
+    {
+        reserveInitialCapacity(size);
+
+        asanSetInitialBufferSizeTo(size);
+
+        for (size_t i = 0; i < size; ++i)
+            unsafeAppendWithoutCapacityCheck(valueGenerator(i));
+    }
+
     template<typename U = T>
     Vector(const U* data, size_t dataSize)
         : Base(dataSize, dataSize)

--- a/Source/WTF/wtf/WorkQueue.cpp
+++ b/Source/WTF/wtf/WorkQueue.cpp
@@ -89,16 +89,13 @@ void ConcurrentWorkQueue::apply(size_t iterations, WTF::Function<void(size_t ind
     class ThreadPool {
     public:
         ThreadPool()
-        {
             // We don't need a thread for the current core.
-            unsigned threadCount = numberOfProcessorCores() - 1;
-
-            m_workers.reserveInitialCapacity(threadCount);
-            for (unsigned i = 0; i < threadCount; ++i) {
-                m_workers.uncheckedAppend(Thread::create("ThreadPool Worker", [this] {
+            : m_workers(numberOfProcessorCores() - 1, [this](size_t) {
+                return Thread::create("ThreadPool Worker", [this] {
                     threadBody();
-                }));
-            }
+                });
+            })
+        {
         }
 
         size_t workerCount() const { return m_workers.size(); }

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -64,14 +64,11 @@ RefPtr<StyleImage> CSSImageSetValue::createStyleImage(Style::BuilderState& state
 {
     size_t length = this->length();
 
-    Vector<ImageWithScale> images;
-    images.reserveInitialCapacity(length);
-
-    for (size_t i = 0; i < length; ++i) {
+    Vector<ImageWithScale> images(length, [&](size_t i) {
         ASSERT(is<CSSImageSetOptionValue>(item(i)));
         auto option = downcast<CSSImageSetOptionValue>(item(i));
-        images.uncheckedAppend(ImageWithScale { state.createStyleImage(option->image()), option->resolution()->floatValue(CSSUnitType::CSS_DPPX), option->type() });
-    }
+        return ImageWithScale { state.createStyleImage(option->image()), option->resolution()->floatValue(CSSUnitType::CSS_DPPX), option->type() };
+    });
 
     // Sort the images so that they are stored in order from lowest resolution to highest.
     // We want to maintain the authored order for serialization so we create a sorted indexing vector.

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -328,6 +328,17 @@ TEST(WTF_Vector, ConstructorOtherRawPointerTypeAndLength)
     EXPECT_EQ(vector[2], 'r');
 }
 
+TEST(WTF_Vector, ConstructorTakingLengthAndFunctor)
+{
+    Vector<size_t> vector(5, [](size_t i) { return i; });
+    EXPECT_EQ(vector.size(), 5U);
+    EXPECT_EQ(vector[0], 0U);
+    EXPECT_EQ(vector[1], 1U);
+    EXPECT_EQ(vector[2], 2U);
+    EXPECT_EQ(vector[3], 3U);
+    EXPECT_EQ(vector[4], 4U);
+}
+
 TEST(WTF_Vector, Reverse)
 {
     Vector<int> intVector;


### PR DESCRIPTION
#### ad5bc6db70f64c61cec477c458f7a921fc8e951e
<pre>
Introduce new Vector constructor that takes in a length and a lambda to generate vector items
<a href="https://bugs.webkit.org/show_bug.cgi?id=262523">https://bugs.webkit.org/show_bug.cgi?id=262523</a>

Reviewed by Darin Adler.

Introduce new Vector constructor that takes in a length and a lambda to generate vector items.
This allows us to construct vectors safely and more efficiently without the explicit use of
Vector::uncheckedAppend(), which recently became an alias for Vector::append().

Adopt this new constructor in a few places to get rid of some Vector::uncheckedAppend() calls.

* Source/JavaScriptCore/API/APICallbackFunction.h:
(JSC::APICallbackFunction::callImpl):
(JSC::APICallbackFunction::constructImpl):
* Source/JavaScriptCore/API/JSCallbackObjectFunctions.h:
(JSC::JSCallbackObject&lt;Parent&gt;::constructImpl):
(JSC::JSCallbackObject&lt;Parent&gt;::callImpl):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addSwitch):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
(JSC::Wasm::Worklist::Worklist):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::Vector):
* Source/WTF/wtf/WorkQueue.cpp:
(WTF::ConcurrentWorkQueue::apply):
* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::createStyleImage const):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268791@main">https://commits.webkit.org/268791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/658ea1aeb67e9449981baa326740766aa4bd0130

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20687 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21287 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23438 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18795 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18017 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23008 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20113 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19559 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24098 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18780 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5741 "Found 2 jsc stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.no-cjit-collect-continuously") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4966 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23117 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25359 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19377 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5566 "Passed tests") | 
<!--EWS-Status-Bubble-End-->