### PR TITLE
Synthetic FetchResponse should populate their expected content length

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/xhr-content-length.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/xhr-content-length.https.window-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Setup
 PASS Synthetic response without Content-Length header
-FAIL Synthetic response with Content-Length header with value larger than response body length assert_true: expected true got false
-FAIL Synthetic response with two Content-Length headers value larger than response body length assert_true: expected true got false
+PASS Synthetic response with Content-Length header with value larger than response body length
+PASS Synthetic response with two Content-Length headers value larger than response body length
 PASS Synthetic response with bogus Content-Length header
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -114,6 +114,9 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::create(ScriptExecutionContext& co
     r->m_internalResponse.setMimeType(mimeType.isEmpty() ? AtomString { defaultMIMEType() } : mimeType);
     r->m_internalResponse.setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
 
+    if (auto expectedContentLength = parseContentLength(r->m_headers->fastGet(HTTPHeaderName::ContentLength)))
+        r->m_internalResponse.setExpectedContentLength(*expectedContentLength);
+
     // 3. Set response’s response’s status to init["status"].
     r->m_internalResponse.setHTTPStatusCode(init.status);
     // 4. Set response’s response’s status message to init["statusText"].

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -798,6 +798,21 @@ size_t parseHTTPRequestBody(const uint8_t* data, size_t length, Vector<uint8_t>&
     return length;
 }
 
+std::optional<uint64_t> parseContentLength(StringView contentLengthValue)
+{
+    // Based on https://www.rfc-editor.org/rfc/rfc9110#field.content-length, we allow ',' values if they are all the same.
+    std::optional<uint64_t> value;
+    for (auto token : contentLengthValue.split(',')) {
+        if (auto expectedContentLength = parseInteger<uint64_t>(token)) {
+            if (value && *value != *expectedContentLength)
+                return { };
+            value = expectedContentLength;
+        } else if (value)
+            return { };
+    }
+    return value;
+}
+
 // Implements <https://fetch.spec.whatwg.org/#forbidden-header-name>.
 bool isForbiddenHeaderName(const String& name)
 {

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -106,6 +106,8 @@ ContentTypeOptionsDisposition parseContentTypeOptionsHeader(StringView header);
 size_t parseHTTPHeader(const uint8_t* data, size_t length, String& failureReason, StringView& nameStr, String& valueStr, bool strict = true);
 size_t parseHTTPRequestBody(const uint8_t* data, size_t length, Vector<uint8_t>& body);
 
+std::optional<uint64_t> parseContentLength(StringView);
+
 // HTTP Header routine as per https://fetch.spec.whatwg.org/#terminology-headers
 bool isForbiddenHeader(const String& name, StringView value);
 bool isForbiddenHeaderName(const String&);


### PR DESCRIPTION
#### 2bf8d40cc4077d9b6aad416b58e48ee2ea97893b
<pre>
Synthetic FetchResponse should populate their expected content length
<a href="https://bugs.webkit.org/show_bug.cgi?id=262530">https://bugs.webkit.org/show_bug.cgi?id=262530</a>
rdar://116388101

Reviewed by Chris Dumez.

We are now parsing the Content-Length header for synthetic responses to properly set ResourceResponse expectedContentLength.
This aligns with responses coming from the network.
This is useful for XHR and will be useful for downloads as well.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/xhr-content-length.https.window-expected.txt:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::create):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseContentLength):
* Source/WebCore/platform/network/HTTPParsers.h:

Canonical link: <a href="https://commits.webkit.org/268780@main">https://commits.webkit.org/268780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c8f9e54aaee6335cc5bd129f80a169219c75bad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19259 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20600 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23386 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25012 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22956 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16574 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18729 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4958 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->