### PR TITLE
Hook up willStartRenderingUpdateDisplay/didCompleteRenderingUpdateDisplay for Coordinated Graphics

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -451,6 +451,10 @@ void LayerTreeHost::resize(const IntSize& size)
 
 void LayerTreeHost::willRenderFrame()
 {
+    RunLoop::main().dispatch([webPage = Ref { m_webPage }] {
+        if (auto* drawingArea = webPage->drawingArea())
+            drawingArea->willStartRenderingUpdateDisplay();
+    });
     m_surface->willRenderFrame();
 }
 
@@ -461,6 +465,10 @@ void LayerTreeHost::didRenderFrame()
     if (!m_didRenderFrameTimer.isActive())
         m_didRenderFrameTimer.startOneShot(0_s);
 #endif
+    RunLoop::main().dispatch([webPage = Ref { m_webPage }] {
+        if (auto* drawingArea = webPage->drawingArea())
+            drawingArea->didCompleteRenderingUpdateDisplay();
+    });
 }
 
 #if HAVE(DISPLAY_LINK)


### PR DESCRIPTION
#### fe9dc550d9a039a1c30493921322aa1b30383d97
<pre>
Hook up willStartRenderingUpdateDisplay/didCompleteRenderingUpdateDisplay for Coordinated Graphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=249786">https://bugs.webkit.org/show_bug.cgi?id=249786</a>

Reviewed by Alejandro G. Castro.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::willRenderFrame):
(WebKit::LayerTreeHost::didRenderFrame):

Canonical link: <a href="https://commits.webkit.org/268770@main">https://commits.webkit.org/268770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fa28413e1be3d136adcbf2b0b2b5a5c61de08cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19273 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20606 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23400 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17862 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25025 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22969 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16585 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18743 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23080 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2548 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->