### PR TITLE
Sync 'TextMetrics' to web specification by changing from 'unrestricted float' to 'double'

### DIFF
--- a/Source/WebCore/html/TextMetrics.h
+++ b/Source/WebCore/html/TextMetrics.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,55 +34,55 @@ class TextMetrics : public RefCounted<TextMetrics> {
 public:
     static Ref<TextMetrics> create() { return adoptRef(*new TextMetrics); }
 
-    float width() const { return m_width; }
-    void setWidth(float w) { m_width = w; }
+    double width() const { return m_width; }
+    void setWidth(double w) { m_width = w; }
 
-    float actualBoundingBoxLeft() const { return m_actualBoundingBoxLeft; }
-    void setActualBoundingBoxLeft(float value) { m_actualBoundingBoxLeft = value; }
+    double actualBoundingBoxLeft() const { return m_actualBoundingBoxLeft; }
+    void setActualBoundingBoxLeft(double value) { m_actualBoundingBoxLeft = value; }
 
-    float actualBoundingBoxRight() const { return m_actualBoundingBoxRight; }
-    void setActualBoundingBoxRight(float value) { m_actualBoundingBoxRight = value; }
+    double actualBoundingBoxRight() const { return m_actualBoundingBoxRight; }
+    void setActualBoundingBoxRight(double value) { m_actualBoundingBoxRight = value; }
 
-    float fontBoundingBoxAscent() const { return m_fontBoundingBoxAscent; }
-    void setFontBoundingBoxAscent(float value) {  m_fontBoundingBoxAscent = value; }
+    double fontBoundingBoxAscent() const { return m_fontBoundingBoxAscent; }
+    void setFontBoundingBoxAscent(double value) { m_fontBoundingBoxAscent = value; }
 
-    float fontBoundingBoxDescent() const { return m_fontBoundingBoxDescent; }
-    void setFontBoundingBoxDescent(float value) {  m_fontBoundingBoxDescent = value; }
+    double fontBoundingBoxDescent() const { return m_fontBoundingBoxDescent; }
+    void setFontBoundingBoxDescent(double value) { m_fontBoundingBoxDescent = value; }
 
-    float actualBoundingBoxAscent() const { return m_actualBoundingBoxAscent; }
-    void setActualBoundingBoxAscent(float value) {  m_actualBoundingBoxAscent = value; }
+    double actualBoundingBoxAscent() const { return m_actualBoundingBoxAscent; }
+    void setActualBoundingBoxAscent(double value) { m_actualBoundingBoxAscent = value; }
 
-    float actualBoundingBoxDescent() const { return m_actualBoundingBoxDescent; }
-    void setActualBoundingBoxDescent(float value) {  m_actualBoundingBoxDescent = value; }
+    double actualBoundingBoxDescent() const { return m_actualBoundingBoxDescent; }
+    void setActualBoundingBoxDescent(double value) { m_actualBoundingBoxDescent = value; }
 
-    float emHeightAscent() const { return m_emHeightAscent; }
-    void setEmHeightAscent(float value) {  m_emHeightAscent = value; }
+    double emHeightAscent() const { return m_emHeightAscent; }
+    void setEmHeightAscent(double value) { m_emHeightAscent = value; }
 
-    float emHeightDescent() const { return m_emHeightDescent; }
-    void setEmHeightDescent(float value) {  m_emHeightDescent = value; }
+    double emHeightDescent() const { return m_emHeightDescent; }
+    void setEmHeightDescent(double value) { m_emHeightDescent = value; }
 
-    float hangingBaseline() const { return m_hangingBaseline; }
-    void setHangingBaseline(float value) {  m_hangingBaseline = value; }
+    double hangingBaseline() const { return m_hangingBaseline; }
+    void setHangingBaseline(double value) { m_hangingBaseline = value; }
 
-    float alphabeticBaseline() const { return m_alphabeticBaseline; }
-    void setAlphabeticBaseline(float value) {  m_alphabeticBaseline = value; }
+    double alphabeticBaseline() const { return m_alphabeticBaseline; }
+    void setAlphabeticBaseline(double value) { m_alphabeticBaseline = value; }
 
-    float ideographicBaseline() const { return m_ideographicBaseline; }
-    void setIdeographicBaseline(float value) {  m_ideographicBaseline = value; }
+    double ideographicBaseline() const { return m_ideographicBaseline; }
+    void setIdeographicBaseline(double value) { m_ideographicBaseline = value; }
 
 private:
-    float m_width { 0 };
-    float m_actualBoundingBoxLeft { 0 };
-    float m_actualBoundingBoxRight { 0 };
-    float m_fontBoundingBoxAscent { 0 };
-    float m_fontBoundingBoxDescent { 0 };
-    float m_actualBoundingBoxAscent { 0 };
-    float m_actualBoundingBoxDescent { 0 };
-    float m_emHeightAscent { 0 };
-    float m_emHeightDescent { 0 };
-    float m_hangingBaseline { 0 };
-    float m_alphabeticBaseline { 0 };
-    float m_ideographicBaseline { 0 };
+    double m_width { 0 };
+    double m_actualBoundingBoxLeft { 0 };
+    double m_actualBoundingBoxRight { 0 };
+    double m_fontBoundingBoxAscent { 0 };
+    double m_fontBoundingBoxDescent { 0 };
+    double m_actualBoundingBoxAscent { 0 };
+    double m_actualBoundingBoxDescent { 0 };
+    double m_emHeightAscent { 0 };
+    double m_emHeightDescent { 0 };
+    double m_hangingBaseline { 0 };
+    double m_alphabeticBaseline { 0 };
+    double m_ideographicBaseline { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/TextMetrics.idl
+++ b/Source/WebCore/html/TextMetrics.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,25 +23,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://html.spec.whatwg.org/multipage/canvas.html#textmetrics
+
 [
     Exposed=(Window,Worker),
 ] interface TextMetrics {
-    // FIXME: All the unrestricted float attributes below should be doubles.
-
     // x-direction
-    readonly attribute unrestricted float width; // advance width
-    readonly attribute unrestricted float actualBoundingBoxLeft;
-    readonly attribute unrestricted float actualBoundingBoxRight;
+    readonly attribute double width; // advance width
+    readonly attribute double actualBoundingBoxLeft;
+    readonly attribute double actualBoundingBoxRight;
 
     // y-direction
-    readonly attribute unrestricted float fontBoundingBoxAscent;
-    readonly attribute unrestricted float fontBoundingBoxDescent;
-    readonly attribute unrestricted float actualBoundingBoxAscent;
-    readonly attribute unrestricted float actualBoundingBoxDescent;
-    readonly attribute unrestricted float emHeightAscent;
-    readonly attribute unrestricted float emHeightDescent;
-    readonly attribute unrestricted float hangingBaseline;
-    readonly attribute unrestricted float alphabeticBaseline;
-    readonly attribute unrestricted float ideographicBaseline;
+    readonly attribute double fontBoundingBoxAscent;
+    readonly attribute double fontBoundingBoxDescent;
+    readonly attribute double actualBoundingBoxAscent;
+    readonly attribute double actualBoundingBoxDescent;
+    readonly attribute double emHeightAscent;
+    readonly attribute double emHeightDescent;
+    readonly attribute double hangingBaseline;
+    readonly attribute double alphabeticBaseline;
+    readonly attribute double ideographicBaseline;
 };
 


### PR DESCRIPTION
#### 79655bbc8d3b2056a180e69d44d9678722c93043
<pre>
Sync &apos;TextMetrics&apos; to web specification by changing from &apos;unrestricted float&apos; to &apos;double&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=262532">https://bugs.webkit.org/show_bug.cgi?id=262532</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Web-Specification [1] and address &apos;FIXME&apos; present.

[1] <a href="https://html.spec.whatwg.org/multipage/canvas.html#textmetrics">https://html.spec.whatwg.org/multipage/canvas.html#textmetrics</a>

* Source/WebCore/html/TextMetrics.h:
* Source/WebCore/html/TextMetrics.idl:

Canonical link: <a href="https://commits.webkit.org/268786@main">https://commits.webkit.org/268786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f3d3dbbdad1f701eab288a136a2e758b809125a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21271 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23422 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25045 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18964 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22991 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16607 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18765 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4960 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->