### PR TITLE
Fix build without ITP

### DIFF
--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -620,7 +620,7 @@ public:
     IntPoint savedLayerScrollPosition() const;
     void setSavedLayerScrollPosition(const IntPoint&);
 
-    bool dispatchMouseEvent(const PlatformMouseEvent&, const AtomString& eventType, int clickCount = 0, Element* relatedTarget = nullptr, IsSyntheticClick isSyntethicClick = IsSyntheticClick::No);
+    bool dispatchMouseEvent(const PlatformMouseEvent&, const AtomString& eventType, int clickCount = 0, Element* relatedTarget = nullptr, IsSyntheticClick isSyntheticClick = IsSyntheticClick::No);
     bool dispatchWheelEvent(const PlatformWheelEvent&, OptionSet<EventHandling>&, EventIsCancelable = EventIsCancelable::Yes);
     bool dispatchKeyEvent(const PlatformKeyboardEvent&);
     bool dispatchSimulatedClick(Event* underlyingEvent, SimulatedClickMouseEventOptions = SendNoEvents, SimulatedClickVisualOptions = ShowPressedLook);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1226,6 +1226,7 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
     UNUSED_PARAM(eventType);
     UNUSED_PARAM(detail);
     UNUSED_PARAM(relatedTarget);
+    UNUSED_PARAM(isSyntheticClick);
 #endif
     return Quirks::StorageAccessResult::ShouldNotCancelEvent;
 }

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -334,6 +334,7 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     UNUSED_PARAM(frameID);
     UNUSED_PARAM(pageID);
     UNUSED_PARAM(applyTrackingPrevention);
+    UNUSED_PARAM(relaxThirdPartyCookieBlocking);
 #endif
 
     auto origin = urlToSoupURI(url);
@@ -573,6 +574,7 @@ bool NetworkStorageSession::getRawCookies(const URL& firstParty, const SameSiteI
     UNUSED_PARAM(frameID);
     UNUSED_PARAM(pageID);
     UNUSED_PARAM(applyTrackingPrevention);
+    UNUSED_PARAM(relaxThirdPartyCookieBlocking);
 #endif
 
     auto uri = urlToSoupURI(url);
@@ -613,6 +615,7 @@ static std::pair<String, bool> cookiesForSession(const NetworkStorageSession& se
     UNUSED_PARAM(frameID);
     UNUSED_PARAM(pageID);
     UNUSED_PARAM(applyTrackingPrevention);
+    UNUSED_PARAM(relaxThirdPartyCookieBlocking);
 #endif
 
     auto uri = urlToSoupURI(url);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -54,6 +54,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/WebSocketIdentifier.h>
 #include <optional>
+#include <wtf/HashCountedSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/URLHash.h>

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -155,12 +155,16 @@ void WebSWServerToContextConnection::fireNotificationEvent(ServiceWorkerIdentifi
         if (!--weakThis->m_processingFunctionalEventCount)
             weakThis->m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { weakThis->webProcessIdentifier() }, 0);
 
+#if ENABLE(TRACKING_PREVENTION)
         auto* session = weakThis->m_connection.networkSession();
         if (auto* resourceLoadStatistics = session ? session->resourceLoadStatistics() : nullptr; resourceLoadStatistics && wasProcessed && eventType == NotificationEventType::Click) {
             return resourceLoadStatistics->setMostRecentWebPushInteractionTime(RegistrableDomain(weakThis->registrableDomain()), [callback = WTFMove(callback), wasProcessed] () mutable {
                 callback(wasProcessed);
             });
         }
+#else
+        UNUSED_PARAM(eventType);
+#endif
 
         callback(wasProcessed);
     });

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -33,6 +33,7 @@
 #include "NetworkCacheStorage.h"
 #include "NetworkProcess.h"
 #include "NetworkSession.h"
+#include "WebsiteDataType.h"
 #include <WebCore/CacheValidation.h>
 #include <WebCore/HTTPHeaderNames.h>
 #include <WebCore/LowPowerModeNotifier.h>

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4664,6 +4664,8 @@ struct WebCore::MessageWithMessagePorts {
     Vector<WebCore::TransferredMessagePort> transferredPorts;
 };
 
+#if ENABLE(TRACKING_PREVENTION)
+
 enum class WebCore::StorageAccessWasGranted : bool
 
 enum class WebCore::StorageAccessPromptWasShown : bool
@@ -4680,6 +4682,8 @@ header: <WebCore/DocumentStorageAccess.h>
     WebCore::RegistrableDomain topFrameDomain;
     WebCore::RegistrableDomain subFrameDomain;
 };
+
+#endif // ENABLE(TRACKING_PREVENTION)
 
 class WebCore::Exception {
     WebCore::ExceptionCode code();


### PR DESCRIPTION
#### a6bbf5eb1b30d0966a4888c6ad963405854462f4
<pre>
Fix build without ITP
<a href="https://bugs.webkit.org/show_bug.cgi?id=262533">https://bugs.webkit.org/show_bug.cgi?id=262533</a>

Reviewed by Michael Catanzaro.

* Source/WebCore/dom/Element.h:
Drive-by typo fix to rename isSyntheticClick variable as isSyntheticClick

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
Flag isSyntheticClick usage added in 238929@main (98bc1318d160)

* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::setCookiesFromDOM const):
(WebCore::NetworkStorageSession::getRawCookies const):
(WebCore::cookiesForSession):
Flag shouldRelaxThirdPartyCookieBlocking usage added in 225134@main (664f22663e8d)

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
Include HashCountedSet.h to fix build of MessageReceiver objects without ITP

* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::fireNotificationEvent):
Flag resourceLoadStatistics() usage added in 255816@main (9404eeeb89ae)

* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
Include WebsiteDataType.h for WebsiteDataType::DiskCache usage

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Flag RequestStorageAccessResult struct moved in 259893@main (cbe22e46962f)

Canonical link: <a href="https://commits.webkit.org/268975@main">https://commits.webkit.org/268975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaa8ac01936612c32c6a8ee9ab22cfd381c657f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20655 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22549 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20612 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23405 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25031 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18947 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22977 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19528 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16590 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18748 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5078 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->