### PR TITLE
[visionOS] Mute button has the wrong shape on audio-only controls

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js
@@ -374,6 +374,7 @@ class VisionInlineMediaControls extends VisionMediaControls
         this.skipForwardButton.style = Button.Styles.Bar;
         this.playPauseButton.style = Button.Styles.Bar;
         this.muteButton.style = Button.Styles.Bar;
+        this.muteButton.circular = true;
         this.overflowButton.style = Button.Styles.Bar;
 
         this.timeControl.timeLabelsAttachment = TimeControl.TimeLabelsAttachment.Side;


### PR DESCRIPTION
#### bb655c10c05022354156e6e5d1c2304433f62797
<pre>
[visionOS] Mute button has the wrong shape on audio-only controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=262534">https://bugs.webkit.org/show_bug.cgi?id=262534</a>
&lt;rdar://116373077&gt;

Reviewed by Richard Robinson.

The mute button was not marked as &quot;circular&quot; when using the audio
layout.

* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js:
(VisionInlineMediaControls.prototype._performSingleBarLayout):
(VisionInlineMediaControls):
Set `circular = true` on the `muteButton`.

Canonical link: <a href="https://commits.webkit.org/268774@main">https://commits.webkit.org/268774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c7774c04210acd55c991a95520da890ec3c085b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21255 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20611 "13 flakes 182 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23406 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25029 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22975 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16591 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18749 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4952 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->