### PR TITLE
Partial Sync 'CSSRule.idl' and 'CSSStyleRule.idl' to Web Specification

### DIFF
--- a/LayoutTests/fast/dom/css-element-attribute-js-null-expected.txt
+++ b/LayoutTests/fast/dom/css-element-attribute-js-null-expected.txt
@@ -2,7 +2,7 @@ This test setting various attributes of a CSSOM elements to JavaScript null.
 
 TEST SUCCEEDED: The value was the string '.foo { color: black; }'. [tested CSSRule.cssText]
 
-TEST SUCCEEDED: The value was the string '.foo'. [tested CSSStyleRule.selectorText]
+TEST SUCCEEDED: The value was the string 'null'. [tested CSSStyleRule.selectorText]
 
 TEST SUCCEEDED: The value was the empty string. [tested CSSStyleDeclaration.cssText]
 

--- a/LayoutTests/fast/dom/css-element-attribute-js-null.html
+++ b/LayoutTests/fast/dom/css-element-attribute-js-null.html
@@ -47,12 +47,13 @@
             if (window.testRunner)
                 testRunner.dumpAsText();
 
-            var rules = document.getElementsByTagName('style')[1].sheet.cssRules;
+            var rules = document.styleSheets[1].cssRules;
 
-            var rule = rules.item(0);            
+            var rule = rules[0];
+            var mediaRule = rules[1];            
             var style = rule.style;
             var value = style.getPropertyCSSValue('color');
-            var mediaList = rules.item(1).media;
+            var mediaList = mediaRule.media;
 
 
             var listing = [
@@ -60,8 +61,7 @@
                     type: 'CSSRule',
                     elementToUse: rule,
                     attributes: [
-                         // for now, setting cssText does not doing anything. When it gets implemented, the expectedNull
-                         // should become the empty string. 
+                        // 'null' is not a valid rule, so the setter does nothing.
                         {name: 'cssText', expectedNull: '.foo { color: black; }'}
                     ]
                 },
@@ -69,9 +69,7 @@
                     type: 'CSSStyleRule',
                     elementToUse: rule,
                     attributes: [
-                         // for now, setting selectorText does not doing anything. When it gets implemented, the expectedNull
-                         // should become the empty string. 
-                        {name: 'selectorText', expectedNull: '.foo'}
+                         {name: 'selectorText', expectedNull: 'null'}
                     ]
                 },
                 {

--- a/Source/WebCore/css/CSSRule.idl
+++ b/Source/WebCore/css/CSSRule.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -18,6 +18,8 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://drafts.csswg.org/cssom/#the-cssrule-interface
+
 [
     CustomToJSObject,
     ExportToWrappedFunction,
@@ -27,7 +29,7 @@
     JSCustomMarkFunction,
     ConstantsEnum=StyleRuleType
 ] interface CSSRule {
-    attribute DOMString? cssText;
+    attribute DOMString cssText;
     readonly attribute CSSRule? parentRule;
     readonly attribute CSSStyleSheet? parentStyleSheet;
 

--- a/Source/WebCore/css/CSSStyleRule.idl
+++ b/Source/WebCore/css/CSSStyleRule.idl
@@ -18,12 +18,14 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://drafts.csswg.org/cssom/#the-cssstylerule-interface
+
 typedef USVString CSSOMString;
 
 [
     Exposed=Window
 ] interface CSSStyleRule : CSSRule {
-    attribute DOMString? selectorText;
+    attribute DOMString selectorText;
     [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 
     // https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects


### PR DESCRIPTION
#### a8eba40b3bd441ff8c612d86ab28ce90857f9baa
<pre>
Partial Sync &apos;CSSRule.idl&apos; and &apos;CSSStyleRule.idl&apos; to Web Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=262033">https://bugs.webkit.org/show_bug.cgi?id=262033</a>
rdar://problem/116340666

Reviewed by Chris Dumez.

This patch is to align WebKit with Gecko/Firefox, Blink/Chromium and Web Specification [1] and [2].

[1] <a href="https://drafts.csswg.org/cssom/#the-cssrule-interface">https://drafts.csswg.org/cssom/#the-cssrule-interface</a>
[2] <a href="https://drafts.csswg.org/cssom/#the-cssstylerule-interface">https://drafts.csswg.org/cssom/#the-cssstylerule-interface</a>

In following PR, &apos;cssText&apos; and &apos;selectorText&apos; are changed to be &apos;DOMString&apos; rather than &apos;DOMString?&apos;
aligning with web-specification.

* Source/WebCore/css/CSSRule.idl:
* Source/WebCore/css/CSSStyleRule.idl:
* LayoutTests/fast/dom/css-element-attribute-js-null.html: Rebaselined
* LayoutTests/fast/dom/css-element-attribute-js-null-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/268783@main">https://commits.webkit.org/268783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d16f81be41b72f17b4bcfdc4ac050dec728ef73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22556 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21261 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23412 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25035 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22981 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16599 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18605 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4959 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->