### PR TITLE
Follow-up: Clean up libwebrtc Xcode project

### DIFF
--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -5380,25 +5380,25 @@
 		41009206242E3A4500C5EDA2 /* RTCVideoEncoderH265.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCVideoEncoderH265.mm; sourceTree = "<group>"; };
 		41009207242E3A4500C5EDA2 /* RTCVideoDecoderH265.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCVideoDecoderH265.mm; sourceTree = "<group>"; };
 		41009208242E3A4600C5EDA2 /* RTCCodecSpecificInfoH265.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCCodecSpecificInfoH265.mm; sourceTree = "<group>"; };
-		4100CDE521CACFD000F9B87D /* LPC_fit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LPC_fit.c; path = silk/LPC_fit.c; sourceTree = "<group>"; };
-		4100CDE821CAD03300F9B87D /* vq_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vq_sse.h; path = x86/vq_sse.h; sourceTree = "<group>"; };
-		4100CDEB21CAD1F500F9B87D /* pitch_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pitch_sse4_1.c; path = x86/pitch_sse4_1.c; sourceTree = "<group>"; };
-		4100CDED21CAD1F500F9B87D /* vq_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vq_sse2.c; path = x86/vq_sse2.c; sourceTree = "<group>"; };
-		4100CDEE21CAD1F600F9B87D /* pitch_sse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pitch_sse.c; path = x86/pitch_sse.c; sourceTree = "<group>"; };
-		4100CDEF21CAD1F600F9B87D /* pitch_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pitch_sse2.c; path = x86/pitch_sse2.c; sourceTree = "<group>"; };
-		4100CDF021CAD1F600F9B87D /* celt_lpc_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = celt_lpc_sse.h; path = x86/celt_lpc_sse.h; sourceTree = "<group>"; };
-		4100CDF121CAD1F700F9B87D /* pitch_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pitch_sse.h; path = x86/pitch_sse.h; sourceTree = "<group>"; };
+		4100CDE521CACFD000F9B87D /* LPC_fit.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LPC_fit.c; sourceTree = "<group>"; };
+		4100CDE821CAD03300F9B87D /* vq_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vq_sse.h; sourceTree = "<group>"; };
+		4100CDEB21CAD1F500F9B87D /* pitch_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pitch_sse4_1.c; sourceTree = "<group>"; };
+		4100CDED21CAD1F500F9B87D /* vq_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vq_sse2.c; sourceTree = "<group>"; };
+		4100CDEE21CAD1F600F9B87D /* pitch_sse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pitch_sse.c; sourceTree = "<group>"; };
+		4100CDEF21CAD1F600F9B87D /* pitch_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pitch_sse2.c; sourceTree = "<group>"; };
+		4100CDF021CAD1F600F9B87D /* celt_lpc_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = celt_lpc_sse.h; sourceTree = "<group>"; };
+		4100CDF121CAD1F700F9B87D /* pitch_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pitch_sse.h; sourceTree = "<group>"; };
 		4102F69721273260006AE8D7 /* remix_resample.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = remix_resample.cc; sourceTree = "<group>"; };
 		4102F69821273260006AE8D7 /* audio_level.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_level.h; sourceTree = "<group>"; };
 		4102F69A21273261006AE8D7 /* audio_level.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_level.cc; sourceTree = "<group>"; };
 		4102F69D21273261006AE8D7 /* remix_resample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remix_resample.h; sourceTree = "<group>"; };
-		4102F6AA212732B0006AE8D7 /* rtp_payload_params.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_payload_params.cc; path = call/rtp_payload_params.cc; sourceTree = "<group>"; };
+		4102F6AA212732B0006AE8D7 /* rtp_payload_params.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_payload_params.cc; sourceTree = "<group>"; };
 		4102F6AC212732E6006AE8D7 /* expand_uma_logger.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = expand_uma_logger.cc; sourceTree = "<group>"; };
 		4102F6AD212732E7006AE8D7 /* expand_uma_logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = expand_uma_logger.h; sourceTree = "<group>"; };
-		4102F6B521273381006AE8D7 /* packet_receiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = packet_receiver.h; path = call/packet_receiver.h; sourceTree = "<group>"; };
-		4102F6B621273381006AE8D7 /* audio_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_receive_stream.cc; path = call/audio_receive_stream.cc; sourceTree = "<group>"; };
-		4102F6B721273381006AE8D7 /* degraded_call.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = degraded_call.cc; path = call/degraded_call.cc; sourceTree = "<group>"; };
-		4102F6B821273381006AE8D7 /* flexfec_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = flexfec_receive_stream.cc; path = call/flexfec_receive_stream.cc; sourceTree = "<group>"; };
+		4102F6B521273381006AE8D7 /* packet_receiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = packet_receiver.h; sourceTree = "<group>"; };
+		4102F6B621273381006AE8D7 /* audio_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_receive_stream.cc; sourceTree = "<group>"; };
+		4102F6B721273381006AE8D7 /* degraded_call.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = degraded_call.cc; sourceTree = "<group>"; };
+		4102F6B821273381006AE8D7 /* flexfec_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = flexfec_receive_stream.cc; sourceTree = "<group>"; };
 		4102F6BE212733B5006AE8D7 /* video_send_stream_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_send_stream_impl.h; sourceTree = "<group>"; };
 		4102F6C0212733B6006AE8D7 /* video_stream_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_stream_encoder.h; sourceTree = "<group>"; };
 		4102F6C2212733B6006AE8D7 /* video_send_stream_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_send_stream_impl.cc; sourceTree = "<group>"; };
@@ -5424,13 +5424,13 @@
 		4105EB9D212E02CC008C0C20 /* vpx_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vpx_config.h; sourceTree = "<group>"; };
 		4105EB9E212E02CC008C0C20 /* vp9_rtcd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp9_rtcd.h; sourceTree = "<group>"; };
 		4105EB9F212E02CC008C0C20 /* vpx_config.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = vpx_config.asm; sourceTree = "<group>"; };
-		4105EBB1212E035C008C0C20 /* onyxd_if.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = onyxd_if.c; path = decoder/onyxd_if.c; sourceTree = "<group>"; };
-		4105EBB2212E035C008C0C20 /* decodeframe.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = decodeframe.c; path = decoder/decodeframe.c; sourceTree = "<group>"; };
-		4105EBB3212E035C008C0C20 /* threading.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = threading.c; path = decoder/threading.c; sourceTree = "<group>"; };
-		4105EBB4212E035D008C0C20 /* detokenize.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = detokenize.c; path = decoder/detokenize.c; sourceTree = "<group>"; };
-		4105EBB5212E035D008C0C20 /* dboolhuff.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = dboolhuff.c; path = decoder/dboolhuff.c; sourceTree = "<group>"; };
-		4105EBB6212E035D008C0C20 /* treereader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = treereader.h; path = decoder/treereader.h; sourceTree = "<group>"; };
-		4105EBB7212E035D008C0C20 /* decoderthreading.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = decoderthreading.h; path = decoder/decoderthreading.h; sourceTree = "<group>"; };
+		4105EBB1212E035C008C0C20 /* onyxd_if.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = onyxd_if.c; sourceTree = "<group>"; };
+		4105EBB2212E035C008C0C20 /* decodeframe.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = decodeframe.c; sourceTree = "<group>"; };
+		4105EBB3212E035C008C0C20 /* threading.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = threading.c; sourceTree = "<group>"; };
+		4105EBB4212E035D008C0C20 /* detokenize.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = detokenize.c; sourceTree = "<group>"; };
+		4105EBB5212E035D008C0C20 /* dboolhuff.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dboolhuff.c; sourceTree = "<group>"; };
+		4105EBB6212E035D008C0C20 /* treereader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = treereader.h; sourceTree = "<group>"; };
+		4105EBB7212E035D008C0C20 /* decoderthreading.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = decoderthreading.h; sourceTree = "<group>"; };
 		4106D56C216C2BA9001E3C40 /* string_view.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_view.h; sourceTree = "<group>"; };
 		410B34E2292B6DB70003E515 /* aom_codec_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aom_codec_internal.h; sourceTree = "<group>"; };
 		410B34E3292B6DB70003E515 /* aom_image_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aom_image_internal.h; sourceTree = "<group>"; };
@@ -5517,114 +5517,114 @@
 		410B3547292B6E3D0003E515 /* intrapred_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = intrapred_common.h; sourceTree = "<group>"; };
 		410B3548292B6E3E0003E515 /* odintrin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = odintrin.c; sourceTree = "<group>"; };
 		410B3549292B6E3F0003E515 /* aom_convolve.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aom_convolve.c; sourceTree = "<group>"; };
-		410B3590292B6E690003E515 /* blend_a64_mask_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = blend_a64_mask_neon.c; path = arm/blend_a64_mask_neon.c; sourceTree = "<group>"; };
-		410B3591292B6E690003E515 /* avg_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = avg_neon.c; path = arm/avg_neon.c; sourceTree = "<group>"; };
-		410B3592292B6E6A0003E515 /* highbd_variance_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_variance_neon.c; path = arm/highbd_variance_neon.c; sourceTree = "<group>"; };
-		410B3593292B6E6A0003E515 /* subpel_variance_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = subpel_variance_neon.c; path = arm/subpel_variance_neon.c; sourceTree = "<group>"; };
-		410B3594292B6E6A0003E515 /* intrapred_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = intrapred_neon.c; path = arm/intrapred_neon.c; sourceTree = "<group>"; };
-		410B3595292B6E6B0003E515 /* sad4d_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = sad4d_neon.c; path = arm/sad4d_neon.c; sourceTree = "<group>"; };
-		410B3596292B6E6B0003E515 /* subtract_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = subtract_neon.c; path = arm/subtract_neon.c; sourceTree = "<group>"; };
-		410B3597292B6E6D0003E515 /* sum_neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = sum_neon.h; path = arm/sum_neon.h; sourceTree = "<group>"; };
-		410B3598292B6E6E0003E515 /* variance_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = variance_neon.c; path = arm/variance_neon.c; sourceTree = "<group>"; };
-		410B3599292B6E6F0003E515 /* mem_neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = mem_neon.h; path = arm/mem_neon.h; sourceTree = "<group>"; };
-		410B359A292B6E6F0003E515 /* highbd_loopfilter_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_loopfilter_neon.c; path = arm/highbd_loopfilter_neon.c; sourceTree = "<group>"; };
-		410B359B292B6E6F0003E515 /* highbd_intrapred_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_intrapred_neon.c; path = arm/highbd_intrapred_neon.c; sourceTree = "<group>"; };
-		410B359C292B6E700003E515 /* sse_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = sse_neon.c; path = arm/sse_neon.c; sourceTree = "<group>"; };
-		410B359D292B6E710003E515 /* sum_squares_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = sum_squares_neon.c; path = arm/sum_squares_neon.c; sourceTree = "<group>"; };
-		410B359E292B6E720003E515 /* loopfilter_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = loopfilter_neon.c; path = arm/loopfilter_neon.c; sourceTree = "<group>"; };
-		410B359F292B6E720003E515 /* fwd_txfm_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = fwd_txfm_neon.c; path = arm/fwd_txfm_neon.c; sourceTree = "<group>"; };
-		410B35A0292B6E730003E515 /* sad_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = sad_neon.c; path = arm/sad_neon.c; sourceTree = "<group>"; };
-		410B35A1292B6E740003E515 /* transpose_neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = transpose_neon.h; path = arm/transpose_neon.h; sourceTree = "<group>"; };
-		410B35A2292B6E740003E515 /* aom_convolve_copy_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = aom_convolve_copy_neon.c; path = arm/aom_convolve_copy_neon.c; sourceTree = "<group>"; };
-		410B35A3292B6E740003E515 /* hadamard_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = hadamard_neon.c; path = arm/hadamard_neon.c; sourceTree = "<group>"; };
-		410B35A4292B6E750003E515 /* highbd_quantize_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_quantize_neon.c; path = arm/highbd_quantize_neon.c; sourceTree = "<group>"; };
-		410B35A5292B6E880003E515 /* aom_subpixel_bilinear_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = aom_subpixel_bilinear_sse2.asm; path = x86/aom_subpixel_bilinear_sse2.asm; sourceTree = "<group>"; };
-		410B35A6292B6E880003E515 /* aom_convolve_copy_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = aom_convolve_copy_sse2.c; path = x86/aom_convolve_copy_sse2.c; sourceTree = "<group>"; };
-		410B35A7292B6E880003E515 /* highbd_intrapred_asm_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = highbd_intrapred_asm_sse2.asm; path = x86/highbd_intrapred_asm_sse2.asm; sourceTree = "<group>"; };
-		410B35A8292B6E880003E515 /* intrapred_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = intrapred_sse4.c; path = x86/intrapred_sse4.c; sourceTree = "<group>"; };
-		410B35A9292B6E8B0003E515 /* blend_mask_sse4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = blend_mask_sse4.h; path = x86/blend_mask_sse4.h; sourceTree = "<group>"; };
-		410B35AA292B6E8B0003E515 /* highbd_variance_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_variance_sse2.c; path = x86/highbd_variance_sse2.c; sourceTree = "<group>"; };
-		410B35AB292B6E8B0003E515 /* aom_asm_stubs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = aom_asm_stubs.c; path = x86/aom_asm_stubs.c; sourceTree = "<group>"; };
-		410B35AC292B6E8C0003E515 /* fwd_txfm_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fwd_txfm_sse2.h; path = x86/fwd_txfm_sse2.h; sourceTree = "<group>"; };
-		410B35AD292B6E8C0003E515 /* blend_a64_hmask_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = blend_a64_hmask_sse4.c; path = x86/blend_a64_hmask_sse4.c; sourceTree = "<group>"; };
-		410B35AE292B6E8C0003E515 /* highbd_variance_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_variance_avx2.c; path = x86/highbd_variance_avx2.c; sourceTree = "<group>"; };
-		410B35AF292B6E8D0003E515 /* intrapred_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = intrapred_ssse3.c; path = x86/intrapred_ssse3.c; sourceTree = "<group>"; };
-		410B35B0292B6E8F0003E515 /* masked_variance_intrin_ssse3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = masked_variance_intrin_ssse3.h; path = x86/masked_variance_intrin_ssse3.h; sourceTree = "<group>"; };
-		410B35B1292B6E900003E515 /* aom_high_subpixel_bilinear_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = aom_high_subpixel_bilinear_sse2.asm; path = x86/aom_high_subpixel_bilinear_sse2.asm; sourceTree = "<group>"; };
-		410B35B2292B6E920003E515 /* highbd_sad4d_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = highbd_sad4d_sse2.asm; path = x86/highbd_sad4d_sse2.asm; sourceTree = "<group>"; };
-		410B35B3292B6E920003E515 /* intrapred_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = intrapred_utils.h; path = x86/intrapred_utils.h; sourceTree = "<group>"; };
-		410B35B4292B6E930003E515 /* convolve_common_intrin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = convolve_common_intrin.h; path = x86/convolve_common_intrin.h; sourceTree = "<group>"; };
-		410B35B5292B6E940003E515 /* highbd_sad_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_sad_avx2.c; path = x86/highbd_sad_avx2.c; sourceTree = "<group>"; };
-		410B35B6292B6E940003E515 /* aom_subpixel_8t_intrin_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = aom_subpixel_8t_intrin_ssse3.c; path = x86/aom_subpixel_8t_intrin_ssse3.c; sourceTree = "<group>"; };
-		410B35B7292B6E950003E515 /* obmc_sad_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = obmc_sad_avx2.c; path = x86/obmc_sad_avx2.c; sourceTree = "<group>"; };
-		410B35B8292B6E950003E515 /* highbd_loopfilter_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_loopfilter_avx2.c; path = x86/highbd_loopfilter_avx2.c; sourceTree = "<group>"; };
-		410B35BA292B6E990003E515 /* highbd_variance_impl_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = highbd_variance_impl_sse2.asm; path = x86/highbd_variance_impl_sse2.asm; sourceTree = "<group>"; };
-		410B35BB292B6E990003E515 /* highbd_intrapred_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_intrapred_sse2.c; path = x86/highbd_intrapred_sse2.c; sourceTree = "<group>"; };
-		410B35BC292B6E990003E515 /* blend_sse4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = blend_sse4.h; path = x86/blend_sse4.h; sourceTree = "<group>"; };
-		410B35BD292B6E9A0003E515 /* fft_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = fft_avx2.c; path = x86/fft_avx2.c; sourceTree = "<group>"; };
-		410B35BE292B6E9B0003E515 /* highbd_variance_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_variance_sse4.c; path = x86/highbd_variance_sse4.c; sourceTree = "<group>"; };
-		410B35BF292B6E9B0003E515 /* aom_subpixel_8t_intrin_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = aom_subpixel_8t_intrin_avx2.c; path = x86/aom_subpixel_8t_intrin_avx2.c; sourceTree = "<group>"; };
-		410B35C0292B6E9C0003E515 /* highbd_loopfilter_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_loopfilter_sse2.c; path = x86/highbd_loopfilter_sse2.c; sourceTree = "<group>"; };
-		410B35C1292B6E9D0003E515 /* highbd_quantize_intrin_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_quantize_intrin_avx2.c; path = x86/highbd_quantize_intrin_avx2.c; sourceTree = "<group>"; };
-		410B35C2292B6E9D0003E515 /* convolve_avx2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = convolve_avx2.h; path = x86/convolve_avx2.h; sourceTree = "<group>"; };
-		410B35C3292B6EA00003E515 /* mem_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = mem_sse2.h; path = x86/mem_sse2.h; sourceTree = "<group>"; };
-		410B35C4292B6EA00003E515 /* obmc_variance_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = obmc_variance_avx2.c; path = x86/obmc_variance_avx2.c; sourceTree = "<group>"; };
-		410B35C5292B6EA00003E515 /* fwd_txfm_ssse3_x86_64.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = fwd_txfm_ssse3_x86_64.asm; path = x86/fwd_txfm_ssse3_x86_64.asm; sourceTree = "<group>"; };
-		410B35C6292B6EA10003E515 /* obmc_variance_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = obmc_variance_sse4.c; path = x86/obmc_variance_sse4.c; sourceTree = "<group>"; };
-		410B35C7292B6EA10003E515 /* inv_wht_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = inv_wht_sse2.asm; path = x86/inv_wht_sse2.asm; sourceTree = "<group>"; };
-		410B35C8292B6EA10003E515 /* aom_subpixel_8t_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = aom_subpixel_8t_sse2.asm; path = x86/aom_subpixel_8t_sse2.asm; sourceTree = "<group>"; };
-		410B35C9292B6EA10003E515 /* common_avx2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = common_avx2.h; path = x86/common_avx2.h; sourceTree = "<group>"; };
-		410B35CA292B6EA20003E515 /* fft_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = fft_sse2.c; path = x86/fft_sse2.c; sourceTree = "<group>"; };
-		410B35CB292B6EAE0003E515 /* aom_subpixel_8t_intrin_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = aom_subpixel_8t_intrin_sse2.c; path = x86/aom_subpixel_8t_intrin_sse2.c; sourceTree = "<group>"; };
-		410B35CC292B6EAE0003E515 /* fwd_txfm_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = fwd_txfm_sse2.c; path = x86/fwd_txfm_sse2.c; sourceTree = "<group>"; };
-		410B35CD292B6EAE0003E515 /* blk_sse_sum_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = blk_sse_sum_sse2.c; path = x86/blk_sse_sum_sse2.c; sourceTree = "<group>"; };
-		410B35CE292B6EAE0003E515 /* convolve.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = convolve.h; path = x86/convolve.h; sourceTree = "<group>"; };
-		410B35CF292B6EAF0003E515 /* adaptive_quantize_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = adaptive_quantize_avx2.c; path = x86/adaptive_quantize_avx2.c; sourceTree = "<group>"; };
-		410B35D0292B6EAF0003E515 /* highbd_subtract_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_subtract_sse2.c; path = x86/highbd_subtract_sse2.c; sourceTree = "<group>"; };
-		410B35D1292B6EAF0003E515 /* convolve_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = convolve_sse2.h; path = x86/convolve_sse2.h; sourceTree = "<group>"; };
-		410B35D2292B6EB00003E515 /* masked_sad_intrin_ssse3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = masked_sad_intrin_ssse3.h; path = x86/masked_sad_intrin_ssse3.h; sourceTree = "<group>"; };
-		410B35D3292B6EB10003E515 /* avg_intrin_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = avg_intrin_avx2.c; path = x86/avg_intrin_avx2.c; sourceTree = "<group>"; };
-		410B35D4292B6EB90003E515 /* fwd_txfm_impl_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fwd_txfm_impl_sse2.h; path = x86/fwd_txfm_impl_sse2.h; sourceTree = "<group>"; };
-		410B35D5292B6EB90003E515 /* adaptive_quantize_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = adaptive_quantize_sse2.c; path = x86/adaptive_quantize_sse2.c; sourceTree = "<group>"; };
-		410B35D6292B6EB90003E515 /* avg_intrin_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = avg_intrin_sse2.c; path = x86/avg_intrin_sse2.c; sourceTree = "<group>"; };
-		410B35D7292B6EB90003E515 /* aom_convolve_copy_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = aom_convolve_copy_avx2.c; path = x86/aom_convolve_copy_avx2.c; sourceTree = "<group>"; };
-		410B35D8292B6EBA0003E515 /* convolve_sse4_1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = convolve_sse4_1.h; path = x86/convolve_sse4_1.h; sourceTree = "<group>"; };
-		410B35D9292B6EBA0003E515 /* highbd_subpel_variance_impl_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = highbd_subpel_variance_impl_sse2.asm; path = x86/highbd_subpel_variance_impl_sse2.asm; sourceTree = "<group>"; };
-		410B35DA292B6EBA0003E515 /* loopfilter_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = loopfilter_avx2.c; path = x86/loopfilter_avx2.c; sourceTree = "<group>"; };
-		410B35DB292B6EBA0003E515 /* aom_quantize_avx.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = aom_quantize_avx.c; path = x86/aom_quantize_avx.c; sourceTree = "<group>"; };
-		410B35DC292B6EBB0003E515 /* masked_sad_intrin_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = masked_sad_intrin_avx2.c; path = x86/masked_sad_intrin_avx2.c; sourceTree = "<group>"; };
-		410B35DD292B6EBB0003E515 /* masked_sad_intrin_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = masked_sad_intrin_ssse3.c; path = x86/masked_sad_intrin_ssse3.c; sourceTree = "<group>"; };
-		410B35DE292B6EBB0003E515 /* highbd_adaptive_quantize_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_adaptive_quantize_sse2.c; path = x86/highbd_adaptive_quantize_sse2.c; sourceTree = "<group>"; };
-		410B35DF292B6EBB0003E515 /* masked_variance_intrin_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = masked_variance_intrin_ssse3.c; path = x86/masked_variance_intrin_ssse3.c; sourceTree = "<group>"; };
-		410B35E0292B6EBC0003E515 /* intrapred_x86.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = intrapred_x86.h; path = x86/intrapred_x86.h; sourceTree = "<group>"; };
-		410B35E1292B6EBD0003E515 /* highbd_convolve_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_convolve_ssse3.c; path = x86/highbd_convolve_ssse3.c; sourceTree = "<group>"; };
-		410B35E2292B6EBD0003E515 /* blend_a64_mask_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = blend_a64_mask_sse4.c; path = x86/blend_a64_mask_sse4.c; sourceTree = "<group>"; };
-		410B35E3292B6EBD0003E515 /* aom_high_subpixel_8t_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = aom_high_subpixel_8t_sse2.asm; path = x86/aom_high_subpixel_8t_sse2.asm; sourceTree = "<group>"; };
-		410B35E4292B6EBE0003E515 /* intrapred_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = intrapred_avx2.c; path = x86/intrapred_avx2.c; sourceTree = "<group>"; };
-		410B35E5292B6EBF0003E515 /* bitdepth_conversion_avx2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = bitdepth_conversion_avx2.h; path = x86/bitdepth_conversion_avx2.h; sourceTree = "<group>"; };
-		410B35E6292B6EC00003E515 /* lpf_common_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = lpf_common_sse2.h; path = x86/lpf_common_sse2.h; sourceTree = "<group>"; };
-		410B35E7292B6EC00003E515 /* highbd_quantize_intrin_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_quantize_intrin_sse2.c; path = x86/highbd_quantize_intrin_sse2.c; sourceTree = "<group>"; };
-		410B35E8292B6EC20003E515 /* masked_sad4d_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = masked_sad4d_ssse3.c; path = x86/masked_sad4d_ssse3.c; sourceTree = "<group>"; };
-		410B35E9292B6EC20003E515 /* obmc_intrinsic_sse4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = obmc_intrinsic_sse4.h; path = x86/obmc_intrinsic_sse4.h; sourceTree = "<group>"; };
-		410B35EA292B6EC20003E515 /* obmc_intrinsic_ssse3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = obmc_intrinsic_ssse3.h; path = x86/obmc_intrinsic_ssse3.h; sourceTree = "<group>"; };
-		410B35EB292B6EC20003E515 /* obmc_sad_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = obmc_sad_sse4.c; path = x86/obmc_sad_sse4.c; sourceTree = "<group>"; };
-		410B35EC292B6EC40003E515 /* intrapred_asm_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = intrapred_asm_sse2.asm; path = x86/intrapred_asm_sse2.asm; sourceTree = "<group>"; };
-		410B35ED292B6EC40003E515 /* jnt_variance_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jnt_variance_ssse3.c; path = x86/jnt_variance_ssse3.c; sourceTree = "<group>"; };
-		410B35EE292B6EC50003E515 /* highbd_sad_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = highbd_sad_sse2.asm; path = x86/highbd_sad_sse2.asm; sourceTree = "<group>"; };
-		410B35EF292B6EC60003E515 /* intrapred_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = intrapred_sse2.c; path = x86/intrapred_sse2.c; sourceTree = "<group>"; };
-		410B35F0292B6EC70003E515 /* highbd_convolve_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_convolve_avx2.c; path = x86/highbd_convolve_avx2.c; sourceTree = "<group>"; };
-		410B35F2292B6EC90003E515 /* highbd_convolve_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_convolve_sse2.c; path = x86/highbd_convolve_sse2.c; sourceTree = "<group>"; };
+		410B3590292B6E690003E515 /* blend_a64_mask_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = blend_a64_mask_neon.c; sourceTree = "<group>"; };
+		410B3591292B6E690003E515 /* avg_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = avg_neon.c; sourceTree = "<group>"; };
+		410B3592292B6E6A0003E515 /* highbd_variance_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_variance_neon.c; sourceTree = "<group>"; };
+		410B3593292B6E6A0003E515 /* subpel_variance_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = subpel_variance_neon.c; sourceTree = "<group>"; };
+		410B3594292B6E6A0003E515 /* intrapred_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = intrapred_neon.c; sourceTree = "<group>"; };
+		410B3595292B6E6B0003E515 /* sad4d_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sad4d_neon.c; sourceTree = "<group>"; };
+		410B3596292B6E6B0003E515 /* subtract_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = subtract_neon.c; sourceTree = "<group>"; };
+		410B3597292B6E6D0003E515 /* sum_neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sum_neon.h; sourceTree = "<group>"; };
+		410B3598292B6E6E0003E515 /* variance_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = variance_neon.c; sourceTree = "<group>"; };
+		410B3599292B6E6F0003E515 /* mem_neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mem_neon.h; sourceTree = "<group>"; };
+		410B359A292B6E6F0003E515 /* highbd_loopfilter_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_loopfilter_neon.c; sourceTree = "<group>"; };
+		410B359B292B6E6F0003E515 /* highbd_intrapred_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_intrapred_neon.c; sourceTree = "<group>"; };
+		410B359C292B6E700003E515 /* sse_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sse_neon.c; sourceTree = "<group>"; };
+		410B359D292B6E710003E515 /* sum_squares_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sum_squares_neon.c; sourceTree = "<group>"; };
+		410B359E292B6E720003E515 /* loopfilter_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loopfilter_neon.c; sourceTree = "<group>"; };
+		410B359F292B6E720003E515 /* fwd_txfm_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fwd_txfm_neon.c; sourceTree = "<group>"; };
+		410B35A0292B6E730003E515 /* sad_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sad_neon.c; sourceTree = "<group>"; };
+		410B35A1292B6E740003E515 /* transpose_neon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = transpose_neon.h; sourceTree = "<group>"; };
+		410B35A2292B6E740003E515 /* aom_convolve_copy_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aom_convolve_copy_neon.c; sourceTree = "<group>"; };
+		410B35A3292B6E740003E515 /* hadamard_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = hadamard_neon.c; sourceTree = "<group>"; };
+		410B35A4292B6E750003E515 /* highbd_quantize_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_quantize_neon.c; sourceTree = "<group>"; };
+		410B35A5292B6E880003E515 /* aom_subpixel_bilinear_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = aom_subpixel_bilinear_sse2.asm; sourceTree = "<group>"; };
+		410B35A6292B6E880003E515 /* aom_convolve_copy_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aom_convolve_copy_sse2.c; sourceTree = "<group>"; };
+		410B35A7292B6E880003E515 /* highbd_intrapred_asm_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = highbd_intrapred_asm_sse2.asm; sourceTree = "<group>"; };
+		410B35A8292B6E880003E515 /* intrapred_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = intrapred_sse4.c; sourceTree = "<group>"; };
+		410B35A9292B6E8B0003E515 /* blend_mask_sse4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = blend_mask_sse4.h; sourceTree = "<group>"; };
+		410B35AA292B6E8B0003E515 /* highbd_variance_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_variance_sse2.c; sourceTree = "<group>"; };
+		410B35AB292B6E8B0003E515 /* aom_asm_stubs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aom_asm_stubs.c; sourceTree = "<group>"; };
+		410B35AC292B6E8C0003E515 /* fwd_txfm_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fwd_txfm_sse2.h; sourceTree = "<group>"; };
+		410B35AD292B6E8C0003E515 /* blend_a64_hmask_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = blend_a64_hmask_sse4.c; sourceTree = "<group>"; };
+		410B35AE292B6E8C0003E515 /* highbd_variance_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_variance_avx2.c; sourceTree = "<group>"; };
+		410B35AF292B6E8D0003E515 /* intrapred_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = intrapred_ssse3.c; sourceTree = "<group>"; };
+		410B35B0292B6E8F0003E515 /* masked_variance_intrin_ssse3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = masked_variance_intrin_ssse3.h; sourceTree = "<group>"; };
+		410B35B1292B6E900003E515 /* aom_high_subpixel_bilinear_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = aom_high_subpixel_bilinear_sse2.asm; sourceTree = "<group>"; };
+		410B35B2292B6E920003E515 /* highbd_sad4d_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = highbd_sad4d_sse2.asm; sourceTree = "<group>"; };
+		410B35B3292B6E920003E515 /* intrapred_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = intrapred_utils.h; sourceTree = "<group>"; };
+		410B35B4292B6E930003E515 /* convolve_common_intrin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = convolve_common_intrin.h; sourceTree = "<group>"; };
+		410B35B5292B6E940003E515 /* highbd_sad_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_sad_avx2.c; sourceTree = "<group>"; };
+		410B35B6292B6E940003E515 /* aom_subpixel_8t_intrin_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aom_subpixel_8t_intrin_ssse3.c; sourceTree = "<group>"; };
+		410B35B7292B6E950003E515 /* obmc_sad_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = obmc_sad_avx2.c; sourceTree = "<group>"; };
+		410B35B8292B6E950003E515 /* highbd_loopfilter_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_loopfilter_avx2.c; sourceTree = "<group>"; };
+		410B35BA292B6E990003E515 /* highbd_variance_impl_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = highbd_variance_impl_sse2.asm; sourceTree = "<group>"; };
+		410B35BB292B6E990003E515 /* highbd_intrapred_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_intrapred_sse2.c; sourceTree = "<group>"; };
+		410B35BC292B6E990003E515 /* blend_sse4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = blend_sse4.h; sourceTree = "<group>"; };
+		410B35BD292B6E9A0003E515 /* fft_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fft_avx2.c; sourceTree = "<group>"; };
+		410B35BE292B6E9B0003E515 /* highbd_variance_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_variance_sse4.c; sourceTree = "<group>"; };
+		410B35BF292B6E9B0003E515 /* aom_subpixel_8t_intrin_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aom_subpixel_8t_intrin_avx2.c; sourceTree = "<group>"; };
+		410B35C0292B6E9C0003E515 /* highbd_loopfilter_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_loopfilter_sse2.c; sourceTree = "<group>"; };
+		410B35C1292B6E9D0003E515 /* highbd_quantize_intrin_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_quantize_intrin_avx2.c; sourceTree = "<group>"; };
+		410B35C2292B6E9D0003E515 /* convolve_avx2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = convolve_avx2.h; sourceTree = "<group>"; };
+		410B35C3292B6EA00003E515 /* mem_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mem_sse2.h; sourceTree = "<group>"; };
+		410B35C4292B6EA00003E515 /* obmc_variance_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = obmc_variance_avx2.c; sourceTree = "<group>"; };
+		410B35C5292B6EA00003E515 /* fwd_txfm_ssse3_x86_64.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = fwd_txfm_ssse3_x86_64.asm; sourceTree = "<group>"; };
+		410B35C6292B6EA10003E515 /* obmc_variance_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = obmc_variance_sse4.c; sourceTree = "<group>"; };
+		410B35C7292B6EA10003E515 /* inv_wht_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = inv_wht_sse2.asm; sourceTree = "<group>"; };
+		410B35C8292B6EA10003E515 /* aom_subpixel_8t_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = aom_subpixel_8t_sse2.asm; sourceTree = "<group>"; };
+		410B35C9292B6EA10003E515 /* common_avx2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = common_avx2.h; sourceTree = "<group>"; };
+		410B35CA292B6EA20003E515 /* fft_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fft_sse2.c; sourceTree = "<group>"; };
+		410B35CB292B6EAE0003E515 /* aom_subpixel_8t_intrin_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aom_subpixel_8t_intrin_sse2.c; sourceTree = "<group>"; };
+		410B35CC292B6EAE0003E515 /* fwd_txfm_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = fwd_txfm_sse2.c; sourceTree = "<group>"; };
+		410B35CD292B6EAE0003E515 /* blk_sse_sum_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = blk_sse_sum_sse2.c; sourceTree = "<group>"; };
+		410B35CE292B6EAE0003E515 /* convolve.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = convolve.h; sourceTree = "<group>"; };
+		410B35CF292B6EAF0003E515 /* adaptive_quantize_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = adaptive_quantize_avx2.c; sourceTree = "<group>"; };
+		410B35D0292B6EAF0003E515 /* highbd_subtract_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_subtract_sse2.c; sourceTree = "<group>"; };
+		410B35D1292B6EAF0003E515 /* convolve_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = convolve_sse2.h; sourceTree = "<group>"; };
+		410B35D2292B6EB00003E515 /* masked_sad_intrin_ssse3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = masked_sad_intrin_ssse3.h; sourceTree = "<group>"; };
+		410B35D3292B6EB10003E515 /* avg_intrin_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = avg_intrin_avx2.c; sourceTree = "<group>"; };
+		410B35D4292B6EB90003E515 /* fwd_txfm_impl_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fwd_txfm_impl_sse2.h; sourceTree = "<group>"; };
+		410B35D5292B6EB90003E515 /* adaptive_quantize_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = adaptive_quantize_sse2.c; sourceTree = "<group>"; };
+		410B35D6292B6EB90003E515 /* avg_intrin_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = avg_intrin_sse2.c; sourceTree = "<group>"; };
+		410B35D7292B6EB90003E515 /* aom_convolve_copy_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aom_convolve_copy_avx2.c; sourceTree = "<group>"; };
+		410B35D8292B6EBA0003E515 /* convolve_sse4_1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = convolve_sse4_1.h; sourceTree = "<group>"; };
+		410B35D9292B6EBA0003E515 /* highbd_subpel_variance_impl_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = highbd_subpel_variance_impl_sse2.asm; sourceTree = "<group>"; };
+		410B35DA292B6EBA0003E515 /* loopfilter_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loopfilter_avx2.c; sourceTree = "<group>"; };
+		410B35DB292B6EBA0003E515 /* aom_quantize_avx.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = aom_quantize_avx.c; sourceTree = "<group>"; };
+		410B35DC292B6EBB0003E515 /* masked_sad_intrin_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = masked_sad_intrin_avx2.c; sourceTree = "<group>"; };
+		410B35DD292B6EBB0003E515 /* masked_sad_intrin_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = masked_sad_intrin_ssse3.c; sourceTree = "<group>"; };
+		410B35DE292B6EBB0003E515 /* highbd_adaptive_quantize_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_adaptive_quantize_sse2.c; sourceTree = "<group>"; };
+		410B35DF292B6EBB0003E515 /* masked_variance_intrin_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = masked_variance_intrin_ssse3.c; sourceTree = "<group>"; };
+		410B35E0292B6EBC0003E515 /* intrapred_x86.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = intrapred_x86.h; sourceTree = "<group>"; };
+		410B35E1292B6EBD0003E515 /* highbd_convolve_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_convolve_ssse3.c; sourceTree = "<group>"; };
+		410B35E2292B6EBD0003E515 /* blend_a64_mask_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = blend_a64_mask_sse4.c; sourceTree = "<group>"; };
+		410B35E3292B6EBD0003E515 /* aom_high_subpixel_8t_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = aom_high_subpixel_8t_sse2.asm; sourceTree = "<group>"; };
+		410B35E4292B6EBE0003E515 /* intrapred_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = intrapred_avx2.c; sourceTree = "<group>"; };
+		410B35E5292B6EBF0003E515 /* bitdepth_conversion_avx2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bitdepth_conversion_avx2.h; sourceTree = "<group>"; };
+		410B35E6292B6EC00003E515 /* lpf_common_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lpf_common_sse2.h; sourceTree = "<group>"; };
+		410B35E7292B6EC00003E515 /* highbd_quantize_intrin_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_quantize_intrin_sse2.c; sourceTree = "<group>"; };
+		410B35E8292B6EC20003E515 /* masked_sad4d_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = masked_sad4d_ssse3.c; sourceTree = "<group>"; };
+		410B35E9292B6EC20003E515 /* obmc_intrinsic_sse4.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = obmc_intrinsic_sse4.h; sourceTree = "<group>"; };
+		410B35EA292B6EC20003E515 /* obmc_intrinsic_ssse3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = obmc_intrinsic_ssse3.h; sourceTree = "<group>"; };
+		410B35EB292B6EC20003E515 /* obmc_sad_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = obmc_sad_sse4.c; sourceTree = "<group>"; };
+		410B35EC292B6EC40003E515 /* intrapred_asm_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = intrapred_asm_sse2.asm; sourceTree = "<group>"; };
+		410B35ED292B6EC40003E515 /* jnt_variance_ssse3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = jnt_variance_ssse3.c; sourceTree = "<group>"; };
+		410B35EE292B6EC50003E515 /* highbd_sad_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = highbd_sad_sse2.asm; sourceTree = "<group>"; };
+		410B35EF292B6EC60003E515 /* intrapred_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = intrapred_sse2.c; sourceTree = "<group>"; };
+		410B35F0292B6EC70003E515 /* highbd_convolve_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_convolve_avx2.c; sourceTree = "<group>"; };
+		410B35F2292B6EC90003E515 /* highbd_convolve_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_convolve_sse2.c; sourceTree = "<group>"; };
 		410B35F3292B6ECA0003E515 /* aom_mem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aom_mem.c; sourceTree = "<group>"; };
-		410B35F4292B6ECA0003E515 /* aom_subpixel_bilinear_ssse3.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = aom_subpixel_bilinear_ssse3.asm; path = x86/aom_subpixel_bilinear_ssse3.asm; sourceTree = "<group>"; };
-		410B35F5292B6ECB0003E515 /* highbd_adaptive_quantize_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = highbd_adaptive_quantize_avx2.c; path = x86/highbd_adaptive_quantize_avx2.c; sourceTree = "<group>"; };
+		410B35F4292B6ECA0003E515 /* aom_subpixel_bilinear_ssse3.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = aom_subpixel_bilinear_ssse3.asm; sourceTree = "<group>"; };
+		410B35F5292B6ECB0003E515 /* highbd_adaptive_quantize_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_adaptive_quantize_avx2.c; sourceTree = "<group>"; };
 		410B35F6292B6ECB0003E515 /* aom_mem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aom_mem.h; sourceTree = "<group>"; };
-		410B35F7292B6ECB0003E515 /* aom_subpixel_8t_ssse3.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; name = aom_subpixel_8t_ssse3.asm; path = x86/aom_subpixel_8t_ssse3.asm; sourceTree = "<group>"; };
-		410B35FA292B6ECC0003E515 /* blend_a64_vmask_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = blend_a64_vmask_sse4.c; path = x86/blend_a64_vmask_sse4.c; sourceTree = "<group>"; };
-		410B35FB292B6ECD0003E515 /* blk_sse_sum_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = blk_sse_sum_avx2.c; path = x86/blk_sse_sum_avx2.c; sourceTree = "<group>"; };
-		410B35FC292B6ED30003E515 /* convolve_ssse3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = convolve_ssse3.h; path = x86/convolve_ssse3.h; sourceTree = "<group>"; };
-		410B35FD292B6ED30003E515 /* blend_a64_mask_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = blend_a64_mask_avx2.c; path = x86/blend_a64_mask_avx2.c; sourceTree = "<group>"; };
-		410B35FE292B6ED50003E515 /* loopfilter_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = loopfilter_sse2.c; path = x86/loopfilter_sse2.c; sourceTree = "<group>"; };
-		410B35FF292B6ED50003E515 /* bitdepth_conversion_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = bitdepth_conversion_sse2.h; path = x86/bitdepth_conversion_sse2.h; sourceTree = "<group>"; };
+		410B35F7292B6ECB0003E515 /* aom_subpixel_8t_ssse3.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = aom_subpixel_8t_ssse3.asm; sourceTree = "<group>"; };
+		410B35FA292B6ECC0003E515 /* blend_a64_vmask_sse4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = blend_a64_vmask_sse4.c; sourceTree = "<group>"; };
+		410B35FB292B6ECD0003E515 /* blk_sse_sum_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = blk_sse_sum_avx2.c; sourceTree = "<group>"; };
+		410B35FC292B6ED30003E515 /* convolve_ssse3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = convolve_ssse3.h; sourceTree = "<group>"; };
+		410B35FD292B6ED30003E515 /* blend_a64_mask_avx2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = blend_a64_mask_avx2.c; sourceTree = "<group>"; };
+		410B35FE292B6ED50003E515 /* loopfilter_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = loopfilter_sse2.c; sourceTree = "<group>"; };
+		410B35FF292B6ED50003E515 /* bitdepth_conversion_sse2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bitdepth_conversion_sse2.h; sourceTree = "<group>"; };
 		410B3600292B6ED80003E515 /* aom_mem_intrnl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aom_mem_intrnl.h; sourceTree = "<group>"; };
 		410B3602292B6F080003E515 /* aom_scale_rtcd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aom_scale_rtcd.c; sourceTree = "<group>"; };
 		410B3603292B6F080003E515 /* yv12config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yv12config.h; sourceTree = "<group>"; };
@@ -6020,8 +6020,8 @@
 		410BA1262570F6A5002E2F8A /* libaom_av1_decoder_absent.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libaom_av1_decoder_absent.cc; sourceTree = "<group>"; };
 		410BA12B2570F6E3002E2F8A /* libaom_av1_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libaom_av1_encoder.h; sourceTree = "<group>"; };
 		410BA12C2570F6E4002E2F8A /* libaom_av1_encoder_absent.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libaom_av1_encoder_absent.cc; sourceTree = "<group>"; };
-		41109AA71E5FA19200C0955A /* video_frame_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_frame_buffer.h; path = include/video_frame_buffer.h; sourceTree = "<group>"; };
-		41109AA91E5FA19200C0955A /* bitrate_adjuster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitrate_adjuster.h; path = include/bitrate_adjuster.h; sourceTree = "<group>"; };
+		41109AA71E5FA19200C0955A /* video_frame_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_frame_buffer.h; sourceTree = "<group>"; };
+		41109AA91E5FA19200C0955A /* bitrate_adjuster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitrate_adjuster.h; sourceTree = "<group>"; };
 		411521D32169821F000ABAF7 /* helpers.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = helpers.cc; sourceTree = "<group>"; };
 		411521D42169821F000ABAF7 /* RTCH264ProfileLevelId.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCH264ProfileLevelId.h; sourceTree = "<group>"; };
 		411521D521698220000ABAF7 /* nalu_rewriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nalu_rewriter.h; sourceTree = "<group>"; };
@@ -6035,20 +6035,20 @@
 		4119276C2A375C47007C09F6 /* extensions.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = extensions.cc; sourceTree = "<group>"; };
 		411927702A375C93007C09F6 /* evp_do_all.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = evp_do_all.c; sourceTree = "<group>"; };
 		411927722A375CB6007C09F6 /* posix_time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = posix_time.c; sourceTree = "<group>"; };
-		411927752A375D70007C09F6 /* p_hkdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_hkdf.c; path = evp/p_hkdf.c; sourceTree = "<group>"; };
+		411927752A375D70007C09F6 /* p_hkdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_hkdf.c; sourceTree = "<group>"; };
 		411927772A375E0F007C09F6 /* e_des.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = e_des.c; sourceTree = "<group>"; };
 		4119277A2A375E3F007C09F6 /* siphash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = siphash.c; sourceTree = "<group>"; };
-		4119277C2A375E8A007C09F6 /* name_print.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = name_print.c; path = x509/name_print.c; sourceTree = "<group>"; };
+		4119277C2A375E8A007C09F6 /* name_print.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = name_print.c; sourceTree = "<group>"; };
 		4119277F2A375ED6007C09F6 /* des.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = des.c; sourceTree = "<group>"; };
-		411927812A375EF8007C09F6 /* policy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = policy.c; path = x509/policy.c; sourceTree = "<group>"; };
+		411927812A375EF8007C09F6 /* policy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = policy.c; sourceTree = "<group>"; };
 		411927842A3770C1007C09F6 /* common_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = common_data.c; sourceTree = "<group>"; };
 		411927862A377100007C09F6 /* nonrd_opt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = nonrd_opt.c; sourceTree = "<group>"; };
 		411927882A37714D007C09F6 /* temporal_filter_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = temporal_filter_neon.c; sourceTree = "<group>"; };
 		411927892A37714D007C09F6 /* av1_k_means_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = av1_k_means_neon.c; sourceTree = "<group>"; };
 		4119278A2A37714D007C09F6 /* wedge_utils_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wedge_utils_neon.c; sourceTree = "<group>"; };
-		4119278E2A3771BA007C09F6 /* masked_sad_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = masked_sad_neon.c; path = arm/masked_sad_neon.c; sourceTree = "<group>"; };
-		4119278F2A3771BA007C09F6 /* obmc_variance_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = obmc_variance_neon.c; path = arm/obmc_variance_neon.c; sourceTree = "<group>"; };
-		411927902A3771BA007C09F6 /* avg_pred_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = avg_pred_neon.c; path = arm/avg_pred_neon.c; sourceTree = "<group>"; };
+		4119278E2A3771BA007C09F6 /* masked_sad_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = masked_sad_neon.c; sourceTree = "<group>"; };
+		4119278F2A3771BA007C09F6 /* obmc_variance_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = obmc_variance_neon.c; sourceTree = "<group>"; };
+		411927902A3771BA007C09F6 /* avg_pred_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = avg_pred_neon.c; sourceTree = "<group>"; };
 		411ED02F212E04BD004320BA /* quant_common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant_common.c; sourceTree = "<group>"; };
 		411ED031212E04CC004320BA /* vp8_cx_iface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp8_cx_iface.c; sourceTree = "<group>"; };
 		411ED032212E04CC004320BA /* vp8_dx_iface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp8_dx_iface.c; sourceTree = "<group>"; };
@@ -6062,18 +6062,18 @@
 		41239B0A214757AE00396F81 /* yv12extend.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yv12extend.c; sourceTree = "<group>"; };
 		41239B0B214757AE00396F81 /* gen_scalers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gen_scalers.c; sourceTree = "<group>"; };
 		41239B3A21476AE500396F81 /* systemdependent.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = systemdependent.c; sourceTree = "<group>"; };
-		412455421EF87C0900F11809 /* dot_product_with_scale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dot_product_with_scale.h; path = signal_processing/dot_product_with_scale.h; sourceTree = "<group>"; };
-		412455431EF87C0F00F11809 /* dot_product_with_scale.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = dot_product_with_scale.cc; path = signal_processing/dot_product_with_scale.cc; sourceTree = "<group>"; };
+		412455421EF87C0900F11809 /* dot_product_with_scale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dot_product_with_scale.h; sourceTree = "<group>"; };
+		412455431EF87C0F00F11809 /* dot_product_with_scale.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dot_product_with_scale.cc; sourceTree = "<group>"; };
 		4124554A1EF8874300F11809 /* video_frame_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_frame_buffer.cc; sourceTree = "<group>"; };
 		4129408E212E128B00AD95E7 /* libvpx_vp8_encoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libvpx_vp8_encoder.cc; sourceTree = "<group>"; };
 		4129408F212E128C00AD95E7 /* libvpx_vp8_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libvpx_vp8_encoder.h; sourceTree = "<group>"; };
 		41294090212E128C00AD95E7 /* libvpx_vp8_decoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libvpx_vp8_decoder.cc; sourceTree = "<group>"; };
 		41294091212E128C00AD95E7 /* libvpx_vp8_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libvpx_vp8_decoder.h; sourceTree = "<group>"; };
-		41299B8E2127367A00B3414B /* isac_vad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = isac_vad.c; path = source/isac_vad.c; sourceTree = "<group>"; };
-		41299B8F2127367B00B3414B /* isac_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = isac_vad.h; path = source/isac_vad.h; sourceTree = "<group>"; };
-		41299B902127367B00B3414B /* pitch_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pitch_filter.h; path = source/pitch_filter.h; sourceTree = "<group>"; };
-		41299B942127369000B3414B /* fake_network_pipe.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fake_network_pipe.cc; path = call/fake_network_pipe.cc; sourceTree = "<group>"; };
-		41299B952127369100B3414B /* fake_network_pipe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_network_pipe.h; path = call/fake_network_pipe.h; sourceTree = "<group>"; };
+		41299B8E2127367A00B3414B /* isac_vad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = isac_vad.c; sourceTree = "<group>"; };
+		41299B8F2127367B00B3414B /* isac_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = isac_vad.h; sourceTree = "<group>"; };
+		41299B902127367B00B3414B /* pitch_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pitch_filter.h; sourceTree = "<group>"; };
+		41299B942127369000B3414B /* fake_network_pipe.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_network_pipe.cc; sourceTree = "<group>"; };
+		41299B952127369100B3414B /* fake_network_pipe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_network_pipe.h; sourceTree = "<group>"; };
 		41299B99212736DE00B3414B /* pitch_search_internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pitch_search_internal.h; sourceTree = "<group>"; };
 		41299B9A212736DE00B3414B /* pitch_search_internal.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = pitch_search_internal.cc; sourceTree = "<group>"; };
 		41299B9C212736DE00B3414B /* rnn.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = rnn.cc; sourceTree = "<group>"; };
@@ -6082,15 +6082,15 @@
 		412FF9332539B3C9001DF036 /* RTCVideoDecoderVTBVP9.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCVideoDecoderVTBVP9.h; sourceTree = "<group>"; };
 		412FF935253D8F0A001DF036 /* VTVideoDecoderSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VTVideoDecoderSPI.h; sourceTree = "<group>"; };
 		412FF936253D8F0A001DF036 /* CMBaseObjectSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMBaseObjectSPI.h; sourceTree = "<group>"; };
-		412FF942254B10A5001DF036 /* curve25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = curve25519.c; path = curve25519/curve25519.c; sourceTree = "<group>"; };
-		412FF943254B10A5001DF036 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal.h; path = curve25519/internal.h; sourceTree = "<group>"; };
-		412FF944254B10A5001DF036 /* curve25519_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = curve25519_tables.h; path = curve25519/curve25519_tables.h; sourceTree = "<group>"; };
+		412FF942254B10A5001DF036 /* curve25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = curve25519.c; sourceTree = "<group>"; };
+		412FF943254B10A5001DF036 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+		412FF944254B10A5001DF036 /* curve25519_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = curve25519_tables.h; sourceTree = "<group>"; };
 		412FF948254B10EE001DF036 /* fork_detect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fork_detect.c; sourceTree = "<group>"; };
 		412FF949254B10EF001DF036 /* fork_detect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fork_detect.h; sourceTree = "<group>"; };
 		412FF94C254B1109001DF036 /* p256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p256.c; sourceTree = "<group>"; };
-		412FF94E254B3340001DF036 /* echo_canceller3_config_json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = echo_canceller3_config_json.h; path = audio/echo_canceller3_config_json.h; sourceTree = "<group>"; };
-		412FF94F254B3341001DF036 /* echo_detector_creator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = echo_detector_creator.cc; path = audio/echo_detector_creator.cc; sourceTree = "<group>"; };
-		412FF950254B3341001DF036 /* echo_detector_creator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = echo_detector_creator.h; path = audio/echo_detector_creator.h; sourceTree = "<group>"; };
+		412FF94E254B3340001DF036 /* echo_canceller3_config_json.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_canceller3_config_json.h; sourceTree = "<group>"; };
+		412FF94F254B3341001DF036 /* echo_detector_creator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = echo_detector_creator.cc; sourceTree = "<group>"; };
+		412FF950254B3341001DF036 /* echo_detector_creator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_detector_creator.h; sourceTree = "<group>"; };
 		412FF954254B3BF2001DF036 /* degradation_preference_provider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = degradation_preference_provider.h; sourceTree = "<group>"; };
 		412FF955254B3BF2001DF036 /* video_stream_input_state_provider.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_stream_input_state_provider.cc; sourceTree = "<group>"; };
 		412FF956254B3BF2001DF036 /* adaptation_constraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adaptation_constraint.h; sourceTree = "<group>"; };
@@ -6161,20 +6161,20 @@
 		412FF9E9254B3FF8001DF036 /* video_stream_encoder_resource_manager.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_stream_encoder_resource_manager.cc; sourceTree = "<group>"; };
 		412FF9EA254B3FF8001DF036 /* quality_rampup_experiment_helper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = quality_rampup_experiment_helper.cc; sourceTree = "<group>"; };
 		412FF9EB254B3FF9001DF036 /* video_stream_encoder_resource_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_stream_encoder_resource_manager.h; sourceTree = "<group>"; };
-		412FF9FA254B406B001DF036 /* network_constants.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = network_constants.cc; path = rtc_base/network_constants.cc; sourceTree = "<group>"; };
-		412FF9FC254B406B001DF036 /* network_route.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = network_route.cc; path = rtc_base/network_route.cc; sourceTree = "<group>"; };
-		412FF9FD254B406B001DF036 /* network_monitor_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = network_monitor_factory.h; path = rtc_base/network_monitor_factory.h; sourceTree = "<group>"; };
-		412FF9FE254B406C001DF036 /* network_monitor_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = network_monitor_factory.cc; path = rtc_base/network_monitor_factory.cc; sourceTree = "<group>"; };
-		412FFA06254B40A7001DF036 /* audio_frame_view.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_frame_view.h; path = include/audio_frame_view.h; sourceTree = "<group>"; };
-		412FFA07254B40A7001DF036 /* audio_frame_proxies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_frame_proxies.h; path = include/audio_frame_proxies.h; sourceTree = "<group>"; };
+		412FF9FA254B406B001DF036 /* network_constants.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network_constants.cc; sourceTree = "<group>"; };
+		412FF9FC254B406B001DF036 /* network_route.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network_route.cc; sourceTree = "<group>"; };
+		412FF9FD254B406B001DF036 /* network_monitor_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network_monitor_factory.h; sourceTree = "<group>"; };
+		412FF9FE254B406C001DF036 /* network_monitor_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network_monitor_factory.cc; sourceTree = "<group>"; };
+		412FFA06254B40A7001DF036 /* audio_frame_view.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_frame_view.h; sourceTree = "<group>"; };
+		412FFA07254B40A7001DF036 /* audio_frame_proxies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_frame_proxies.h; sourceTree = "<group>"; };
 		412FFA0A254B40DF001DF036 /* mutex_abseil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_abseil.h; sourceTree = "<group>"; };
 		412FFA0C254B40E0001DF036 /* mutex_critical_section.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_critical_section.h; sourceTree = "<group>"; };
 		412FFA0D254B40E0001DF036 /* yield.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = yield.cc; sourceTree = "<group>"; };
 		412FFA0E254B40E0001DF036 /* mutex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex.h; sourceTree = "<group>"; };
 		412FFA0F254B40E0001DF036 /* yield.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yield.h; sourceTree = "<group>"; };
 		412FFA10254B40E1001DF036 /* mutex_pthread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex_pthread.h; sourceTree = "<group>"; };
-		412FFA18254B4112001DF036 /* dependency_descriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dependency_descriptor.h; path = rtp/dependency_descriptor.h; sourceTree = "<group>"; };
-		412FFA19254B4112001DF036 /* dependency_descriptor.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = dependency_descriptor.cc; path = rtp/dependency_descriptor.cc; sourceTree = "<group>"; };
+		412FFA18254B4112001DF036 /* dependency_descriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dependency_descriptor.h; sourceTree = "<group>"; };
+		412FFA19254B4112001DF036 /* dependency_descriptor.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dependency_descriptor.cc; sourceTree = "<group>"; };
 		412FFA1C254B4136001DF036 /* audio_processing_builder_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_processing_builder_impl.cc; sourceTree = "<group>"; };
 		412FFA1E254B41BA001DF036 /* string_format.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_format.cc; sourceTree = "<group>"; };
 		412FFA1F254B41BB001DF036 /* string_format.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_format.h; sourceTree = "<group>"; };
@@ -6191,9 +6191,9 @@
 		412FFA35254B42A9001DF036 /* optionally_built_submodule_creators.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = optionally_built_submodule_creators.cc; sourceTree = "<group>"; };
 		412FFA39254B42EC001DF036 /* resource.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = resource.cc; sourceTree = "<group>"; };
 		412FFA3A254B42EC001DF036 /* resource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resource.h; sourceTree = "<group>"; };
-		412FFA3D254B4313001DF036 /* audio_frame_proxies.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_frame_proxies.cc; path = include/audio_frame_proxies.cc; sourceTree = "<group>"; };
-		412FFA3F254B4344001DF036 /* analog_agc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = analog_agc.cc; path = agc/legacy/analog_agc.cc; sourceTree = "<group>"; };
-		412FFA40254B4344001DF036 /* digital_agc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = digital_agc.cc; path = agc/legacy/digital_agc.cc; sourceTree = "<group>"; };
+		412FFA3D254B4313001DF036 /* audio_frame_proxies.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_frame_proxies.cc; sourceTree = "<group>"; };
+		412FFA3F254B4344001DF036 /* analog_agc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = analog_agc.cc; sourceTree = "<group>"; };
+		412FFA40254B4344001DF036 /* digital_agc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = digital_agc.cc; sourceTree = "<group>"; };
 		412FFA45254B438A001DF036 /* ooura_fft.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ooura_fft.cc; sourceTree = "<group>"; };
 		412FFA46254B438A001DF036 /* ooura_fft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ooura_fft.h; sourceTree = "<group>"; };
 		412FFA47254B438A001DF036 /* ooura_fft_tables_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ooura_fft_tables_common.h; sourceTree = "<group>"; };
@@ -6202,35 +6202,35 @@
 		412FFA4D254B43F5001DF036 /* video_rtp_depacketizer_av1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_rtp_depacketizer_av1.h; sourceTree = "<group>"; };
 		412FFA53254B44C6001DF036 /* fft4g.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fft4g.h; sourceTree = "<group>"; };
 		412FFA54254B44C7001DF036 /* fft4g.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fft4g.cc; sourceTree = "<group>"; };
-		412FFA57254B44FF001DF036 /* transient_suppressor_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = transient_suppressor_impl.cc; path = transient/transient_suppressor_impl.cc; sourceTree = "<group>"; };
-		412FFA58254B44FF001DF036 /* transient_suppressor_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = transient_suppressor_impl.h; path = transient/transient_suppressor_impl.h; sourceTree = "<group>"; };
+		412FFA57254B44FF001DF036 /* transient_suppressor_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transient_suppressor_impl.cc; sourceTree = "<group>"; };
+		412FFA58254B44FF001DF036 /* transient_suppressor_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transient_suppressor_impl.h; sourceTree = "<group>"; };
 		412FFA5C254B4530001DF036 /* active_decode_targets_helper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = active_decode_targets_helper.cc; sourceTree = "<group>"; };
 		412FFA5D254B4530001DF036 /* active_decode_targets_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = active_decode_targets_helper.h; sourceTree = "<group>"; };
 		412FFA62254B45A5001DF036 /* video_rtp_depacketizer_av1.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_rtp_depacketizer_av1.cc; sourceTree = "<group>"; };
 		412FFA64254B4DAA001DF036 /* vp9_uncompressed_header_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vp9_uncompressed_header_parser.cc; sourceTree = "<group>"; };
 		412FFA65254B4DAA001DF036 /* vp9_uncompressed_header_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp9_uncompressed_header_parser.h; sourceTree = "<group>"; };
 		412FFA68254B4DCA001DF036 /* ooura_fft_sse2.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ooura_fft_sse2.cc; sourceTree = "<group>"; };
-		413091F91EF8CFF300757C55 /* builtin_audio_encoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = builtin_audio_encoder_factory.cc; path = audio_codecs/builtin_audio_encoder_factory.cc; sourceTree = "<group>"; };
-		413091FA1EF8CFF800757C55 /* builtin_audio_encoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = builtin_audio_encoder_factory.h; path = audio_codecs/builtin_audio_encoder_factory.h; sourceTree = "<group>"; };
+		413091F91EF8CFF300757C55 /* builtin_audio_encoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = builtin_audio_encoder_factory.cc; sourceTree = "<group>"; };
+		413091FA1EF8CFF800757C55 /* builtin_audio_encoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = builtin_audio_encoder_factory.h; sourceTree = "<group>"; };
 		413091FD1EF8D06D00757C55 /* receive_side_congestion_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = receive_side_congestion_controller.cc; sourceTree = "<group>"; };
-		413091FF1EF8D0A400757C55 /* rtp_demuxer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_demuxer.h; path = call/rtp_demuxer.h; sourceTree = "<group>"; };
-		413092001EF8D0A600757C55 /* rtp_demuxer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_demuxer.cc; path = call/rtp_demuxer.cc; sourceTree = "<group>"; };
-		413092101EF8D50C00757C55 /* aec_dump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = aec_dump.h; path = include/aec_dump.h; sourceTree = "<group>"; };
-		413092111EF8D51000757C55 /* aec_dump.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = aec_dump.cc; path = include/aec_dump.cc; sourceTree = "<group>"; };
-		413092161EF8D63400757C55 /* rtp_transport_controller_send.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_transport_controller_send.h; path = call/rtp_transport_controller_send.h; sourceTree = "<group>"; };
-		413092171EF8D63900757C55 /* rtp_transport_controller_send_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_transport_controller_send_interface.h; path = call/rtp_transport_controller_send_interface.h; sourceTree = "<group>"; };
-		413092181EF8D63F00757C55 /* rtp_transport_controller_send.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_transport_controller_send.cc; path = call/rtp_transport_controller_send.cc; sourceTree = "<group>"; };
-		4130922B1EF8D76100757C55 /* aec_dump_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = aec_dump_impl.cc; path = Source/webrtc/modules/audio_processing/aec_dump/aec_dump_impl.cc; sourceTree = SOURCE_ROOT; };
-		4130922C1EF8D76A00757C55 /* aec_dump_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = aec_dump_impl.h; path = Source/webrtc/modules/audio_processing/aec_dump/aec_dump_impl.h; sourceTree = SOURCE_ROOT; };
-		4130922D1EF8D77100757C55 /* aec_dump_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = aec_dump_factory.h; path = Source/webrtc/modules/audio_processing/aec_dump/aec_dump_factory.h; sourceTree = SOURCE_ROOT; };
+		413091FF1EF8D0A400757C55 /* rtp_demuxer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_demuxer.h; sourceTree = "<group>"; };
+		413092001EF8D0A600757C55 /* rtp_demuxer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_demuxer.cc; sourceTree = "<group>"; };
+		413092101EF8D50C00757C55 /* aec_dump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_dump.h; sourceTree = "<group>"; };
+		413092111EF8D51000757C55 /* aec_dump.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = aec_dump.cc; sourceTree = "<group>"; };
+		413092161EF8D63400757C55 /* rtp_transport_controller_send.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_transport_controller_send.h; sourceTree = "<group>"; };
+		413092171EF8D63900757C55 /* rtp_transport_controller_send_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_transport_controller_send_interface.h; sourceTree = "<group>"; };
+		413092181EF8D63F00757C55 /* rtp_transport_controller_send.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_transport_controller_send.cc; sourceTree = "<group>"; };
+		4130922B1EF8D76100757C55 /* aec_dump_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = aec_dump_impl.cc; sourceTree = "<group>"; };
+		4130922C1EF8D76A00757C55 /* aec_dump_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_dump_impl.h; sourceTree = "<group>"; };
+		4130922D1EF8D77100757C55 /* aec_dump_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aec_dump_factory.h; sourceTree = "<group>"; };
 		413111C12552A1EF001B9D95 /* limiter_db_gain_curve.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = limiter_db_gain_curve.cc; sourceTree = "<group>"; };
 		413111C22552A1EF001B9D95 /* limiter_db_gain_curve.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = limiter_db_gain_curve.h; sourceTree = "<group>"; };
-		413111C52552A266001B9D95 /* neteq_input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = neteq_input.cc; path = tools/neteq_input.cc; sourceTree = "<group>"; };
-		413111CA2552A36B001B9D95 /* pcm16b_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pcm16b_common.cc; path = pcm16b/pcm16b_common.cc; sourceTree = "<group>"; };
-		413111CB2552A36C001B9D95 /* pcm16b_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pcm16b_common.h; path = pcm16b/pcm16b_common.h; sourceTree = "<group>"; };
-		4131BE74234B85590028A615 /* hrss.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = hrss.c; path = hrss/hrss.c; sourceTree = "<group>"; };
-		4131BE76234B85A90028A615 /* p_x25519_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_x25519_asn1.c; path = evp/p_x25519_asn1.c; sourceTree = "<group>"; };
-		4131BE77234B85A90028A615 /* p_x25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_x25519.c; path = evp/p_x25519.c; sourceTree = "<group>"; };
+		413111C52552A266001B9D95 /* neteq_input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = neteq_input.cc; sourceTree = "<group>"; };
+		413111CA2552A36B001B9D95 /* pcm16b_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pcm16b_common.cc; sourceTree = "<group>"; };
+		413111CB2552A36C001B9D95 /* pcm16b_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pcm16b_common.h; sourceTree = "<group>"; };
+		4131BE74234B85590028A615 /* hrss.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hrss.c; sourceTree = "<group>"; };
+		4131BE76234B85A90028A615 /* p_x25519_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_x25519_asn1.c; sourceTree = "<group>"; };
+		4131BE77234B85A90028A615 /* p_x25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_x25519.c; sourceTree = "<group>"; };
 		4131BE7D234B880C0028A615 /* webrtc_session_description_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_session_description_factory.h; sourceTree = "<group>"; };
 		4131BE7E234B880D0028A615 /* stream_collection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stream_collection.h; sourceTree = "<group>"; };
 		4131BE7F234B880D0028A615 /* webrtc_session_description_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = webrtc_session_description_factory.cc; sourceTree = "<group>"; };
@@ -6312,224 +6312,224 @@
 		4131BEEE234B881F0028A615 /* peer_connection.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = peer_connection.cc; sourceTree = "<group>"; };
 		4131BEEF234B881F0028A615 /* external_hmac.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = external_hmac.cc; sourceTree = "<group>"; };
 		4131BEF1234B881F0028A615 /* media_protocol_names.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = media_protocol_names.cc; sourceTree = "<group>"; };
-		4131BF66234B88A00028A615 /* media_engine.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = media_engine.cc; path = base/media_engine.cc; sourceTree = "<group>"; };
-		4131BF67234B88A00028A615 /* video_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_adapter.h; path = base/video_adapter.h; sourceTree = "<group>"; };
-		4131BF68234B88A00028A615 /* codec.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = codec.cc; path = base/codec.cc; sourceTree = "<group>"; };
-		4131BF69234B88A00028A615 /* turn_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = turn_utils.h; path = base/turn_utils.h; sourceTree = "<group>"; };
-		4131BF6A234B88A00028A615 /* media_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = media_constants.h; path = base/media_constants.h; sourceTree = "<group>"; };
-		4131BF6B234B88A10028A615 /* adapted_video_track_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = adapted_video_track_source.cc; path = base/adapted_video_track_source.cc; sourceTree = "<group>"; };
-		4131BF6C234B88A10028A615 /* video_source_base.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_source_base.cc; path = base/video_source_base.cc; sourceTree = "<group>"; };
-		4131BF6D234B88A10028A615 /* rtp_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_utils.cc; path = base/rtp_utils.cc; sourceTree = "<group>"; };
-		4131BF6F234B88A10028A615 /* rid_description.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rid_description.h; path = base/rid_description.h; sourceTree = "<group>"; };
-		4131BF70234B88A20028A615 /* rtp_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_utils.h; path = base/rtp_utils.h; sourceTree = "<group>"; };
-		4131BF71234B88A20028A615 /* video_broadcaster.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_broadcaster.cc; path = base/video_broadcaster.cc; sourceTree = "<group>"; };
-		4131BF72234B88A20028A615 /* video_source_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_source_base.h; path = base/video_source_base.h; sourceTree = "<group>"; };
-		4131BF74234B88A20028A615 /* stream_params.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = stream_params.cc; path = base/stream_params.cc; sourceTree = "<group>"; };
-		4131BF76234B88A30028A615 /* adapted_video_track_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = adapted_video_track_source.h; path = base/adapted_video_track_source.h; sourceTree = "<group>"; };
-		4131BF78234B88A30028A615 /* codec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = codec.h; path = base/codec.h; sourceTree = "<group>"; };
-		4131BF7A234B88A30028A615 /* media_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = media_engine.h; path = base/media_engine.h; sourceTree = "<group>"; };
-		4131BF7B234B88A30028A615 /* video_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_adapter.cc; path = base/video_adapter.cc; sourceTree = "<group>"; };
-		4131BF7C234B88A40028A615 /* rid_description.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rid_description.cc; path = base/rid_description.cc; sourceTree = "<group>"; };
-		4131BF7D234B88A40028A615 /* audio_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_source.h; path = base/audio_source.h; sourceTree = "<group>"; };
-		4131BF7E234B88A40028A615 /* video_broadcaster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_broadcaster.h; path = base/video_broadcaster.h; sourceTree = "<group>"; };
-		4131BF7F234B88A40028A615 /* media_constants.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = media_constants.cc; path = base/media_constants.cc; sourceTree = "<group>"; };
-		4131BF80234B88A40028A615 /* stream_params.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stream_params.h; path = base/stream_params.h; sourceTree = "<group>"; };
-		4131BF81234B88A40028A615 /* video_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_common.cc; path = base/video_common.cc; sourceTree = "<group>"; };
-		4131BF82234B88A50028A615 /* delayable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = delayable.h; path = base/delayable.h; sourceTree = "<group>"; };
-		4131BF83234B88A50028A615 /* media_channel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = media_channel.h; path = base/media_channel.h; sourceTree = "<group>"; };
-		4131BF86234B88A50028A615 /* media_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = media_config.h; path = base/media_config.h; sourceTree = "<group>"; };
-		4131BF87234B88A50028A615 /* video_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_common.h; path = base/video_common.h; sourceTree = "<group>"; };
-		4131BF88234B88A60028A615 /* turn_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = turn_utils.cc; path = base/turn_utils.cc; sourceTree = "<group>"; };
-		4131BFAE234B89770028A615 /* fake_ssl_identity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_ssl_identity.h; path = rtc_base/fake_ssl_identity.h; sourceTree = "<group>"; };
-		4131BFAF234B89770028A615 /* async_socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = async_socket.cc; path = rtc_base/async_socket.cc; sourceTree = "<group>"; };
-		4131BFB0234B89780028A615 /* log_sinks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = log_sinks.h; path = rtc_base/log_sinks.h; sourceTree = "<group>"; };
-		4131BFB2234B89780028A615 /* data_rate_limiter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = data_rate_limiter.cc; path = rtc_base/data_rate_limiter.cc; sourceTree = "<group>"; };
-		4131BFB3234B89780028A615 /* async_udp_socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = async_udp_socket.cc; path = rtc_base/async_udp_socket.cc; sourceTree = "<group>"; };
-		4131BFB5234B89780028A615 /* network_monitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = network_monitor.h; path = rtc_base/network_monitor.h; sourceTree = "<group>"; };
-		4131BFB6234B89780028A615 /* network_monitor.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = network_monitor.cc; path = rtc_base/network_monitor.cc; sourceTree = "<group>"; };
-		4131BFB7234B89790028A615 /* async_udp_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = async_udp_socket.h; path = rtc_base/async_udp_socket.h; sourceTree = "<group>"; };
-		4131BFB8234B89790028A615 /* checks.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = checks.cc; path = rtc_base/checks.cc; sourceTree = "<group>"; };
-		4131BFB9234B89790028A615 /* memory_usage.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = memory_usage.cc; path = rtc_base/memory_usage.cc; sourceTree = "<group>"; };
-		4131BFBA234B89790028A615 /* cpu_time.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cpu_time.cc; path = rtc_base/cpu_time.cc; sourceTree = "<group>"; };
-		4131BFBB234B89790028A615 /* copy_on_write_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = copy_on_write_buffer.cc; path = rtc_base/copy_on_write_buffer.cc; sourceTree = "<group>"; };
-		4131BFBD234B897A0028A615 /* event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event.h; path = rtc_base/event.h; sourceTree = "<group>"; };
-		4131BFBE234B897A0028A615 /* async_packet_socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = async_packet_socket.cc; path = rtc_base/async_packet_socket.cc; sourceTree = "<group>"; };
-		4131BFBF234B897A0028A615 /* nat_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = nat_server.h; path = rtc_base/nat_server.h; sourceTree = "<group>"; };
-		4131BFC0234B897A0028A615 /* net_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = net_helpers.h; path = rtc_base/net_helpers.h; sourceTree = "<group>"; };
-		4131BFC1234B897A0028A615 /* crypt_string.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = crypt_string.cc; path = rtc_base/crypt_string.cc; sourceTree = "<group>"; };
-		4131BFC2234B897A0028A615 /* null_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = null_socket_server.h; path = rtc_base/null_socket_server.h; sourceTree = "<group>"; };
-		4131BFC4234B897B0028A615 /* network_route.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = network_route.h; path = rtc_base/network_route.h; sourceTree = "<group>"; };
-		4131BFC5234B897B0028A615 /* fake_network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_network.h; path = rtc_base/fake_network.h; sourceTree = "<group>"; };
-		4131BFC7234B897B0028A615 /* event_tracer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = event_tracer.cc; path = rtc_base/event_tracer.cc; sourceTree = "<group>"; };
-		4131BFC9234B897B0028A615 /* bit_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = bit_buffer.cc; path = rtc_base/bit_buffer.cc; sourceTree = "<group>"; };
-		4131BFCA234B897C0028A615 /* async_tcp_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = async_tcp_socket.h; path = rtc_base/async_tcp_socket.h; sourceTree = "<group>"; };
-		4131BFCB234B897C0028A615 /* nat_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = nat_server.cc; path = rtc_base/nat_server.cc; sourceTree = "<group>"; };
-		4131BFCC234B897C0028A615 /* dscp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dscp.h; path = rtc_base/dscp.h; sourceTree = "<group>"; };
-		4131BFCD234B897C0028A615 /* network.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = network.cc; path = rtc_base/network.cc; sourceTree = "<group>"; };
-		4131BFCE234B897C0028A615 /* crc32.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = crc32.cc; path = rtc_base/crc32.cc; sourceTree = "<group>"; };
-		4131BFCF234B897C0028A615 /* byte_order.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = byte_order.h; path = rtc_base/byte_order.h; sourceTree = "<group>"; };
-		4131BFD0234B897C0028A615 /* file_rotating_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = file_rotating_stream.cc; path = rtc_base/file_rotating_stream.cc; sourceTree = "<group>"; };
-		4131BFD1234B897D0028A615 /* buffer_queue.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = buffer_queue.cc; path = rtc_base/buffer_queue.cc; sourceTree = "<group>"; };
-		4131BFD2234B897D0028A615 /* bit_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bit_buffer.h; path = rtc_base/bit_buffer.h; sourceTree = "<group>"; };
-		4131BFD3234B897D0028A615 /* byte_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = byte_buffer.cc; path = rtc_base/byte_buffer.cc; sourceTree = "<group>"; };
-		4131BFD5234B897D0028A615 /* null_socket_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = null_socket_server.cc; path = rtc_base/null_socket_server.cc; sourceTree = "<group>"; };
-		4131BFD6234B897D0028A615 /* ifaddrs_android.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ifaddrs_android.cc; path = rtc_base/ifaddrs_android.cc; sourceTree = "<group>"; };
-		4131BFD7234B897D0028A615 /* ip_address.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ip_address.cc; path = rtc_base/ip_address.cc; sourceTree = "<group>"; };
-		4131BFD9234B897E0028A615 /* DEPS */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = DEPS; path = rtc_base/DEPS; sourceTree = "<group>"; };
-		4131BFDA234B897E0028A615 /* event.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = event.cc; path = rtc_base/event.cc; sourceTree = "<group>"; };
-		4131BFDC234B897E0028A615 /* cpu_time.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cpu_time.h; path = rtc_base/cpu_time.h; sourceTree = "<group>"; };
-		4131BFDD234B897E0028A615 /* memory_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = memory_stream.cc; path = rtc_base/memory_stream.cc; sourceTree = "<group>"; };
-		4131BFDE234B897E0028A615 /* crypt_string.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crypt_string.h; path = rtc_base/crypt_string.h; sourceTree = "<group>"; };
-		4131BFE0234B897F0028A615 /* ifaddrs_android.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ifaddrs_android.h; path = rtc_base/ifaddrs_android.h; sourceTree = "<group>"; };
-		4131BFE1234B897F0028A615 /* event_tracer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_tracer.h; path = rtc_base/event_tracer.h; sourceTree = "<group>"; };
-		4131BFE2234B897F0028A615 /* arraysize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = arraysize.h; path = rtc_base/arraysize.h; sourceTree = "<group>"; };
-		4131BFE3234B897F0028A615 /* nat_socket_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = nat_socket_factory.h; path = rtc_base/nat_socket_factory.h; sourceTree = "<group>"; };
-		4131BFE4234B897F0028A615 /* nat_socket_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = nat_socket_factory.cc; path = rtc_base/nat_socket_factory.cc; sourceTree = "<group>"; };
-		4131BFE5234B897F0028A615 /* buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = buffer.h; path = rtc_base/buffer.h; sourceTree = "<group>"; };
-		4131BFE6234B89800028A615 /* net_helper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = net_helper.cc; path = rtc_base/net_helper.cc; sourceTree = "<group>"; };
-		4131BFE7234B89800028A615 /* logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = logging.h; path = rtc_base/logging.h; sourceTree = "<group>"; };
-		4131BFE8234B89800028A615 /* async_resolver_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = async_resolver_interface.h; path = rtc_base/async_resolver_interface.h; sourceTree = "<group>"; };
-		4131BFE9234B89800028A615 /* data_rate_limiter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = data_rate_limiter.h; path = rtc_base/data_rate_limiter.h; sourceTree = "<group>"; };
-		4131BFEA234B89800028A615 /* async_tcp_socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = async_tcp_socket.cc; path = rtc_base/async_tcp_socket.cc; sourceTree = "<group>"; };
-		4131BFEC234B89800028A615 /* ifaddrs_converter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ifaddrs_converter.cc; path = rtc_base/ifaddrs_converter.cc; sourceTree = "<group>"; };
-		4131BFED234B89810028A615 /* buffer_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = buffer_queue.h; path = rtc_base/buffer_queue.h; sourceTree = "<group>"; };
-		4131BFEE234B89810028A615 /* ifaddrs_converter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ifaddrs_converter.h; path = rtc_base/ifaddrs_converter.h; sourceTree = "<group>"; };
-		4131BFEF234B89810028A615 /* network_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = network_constants.h; path = rtc_base/network_constants.h; sourceTree = "<group>"; };
-		4131BFF0234B89810028A615 /* fake_clock.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fake_clock.cc; path = rtc_base/fake_clock.cc; sourceTree = "<group>"; };
-		4131BFF1234B89810028A615 /* log_sinks.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = log_sinks.cc; path = rtc_base/log_sinks.cc; sourceTree = "<group>"; };
-		4131BFF3234B89810028A615 /* ignore_wundef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ignore_wundef.h; path = rtc_base/ignore_wundef.h; sourceTree = "<group>"; };
-		4131BFF4234B89820028A615 /* checks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = checks.h; path = rtc_base/checks.h; sourceTree = "<group>"; };
-		4131BFF6234B89820028A615 /* message_digest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = message_digest.cc; path = rtc_base/message_digest.cc; sourceTree = "<group>"; };
-		4131BFF7234B89820028A615 /* net_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = net_helper.h; path = rtc_base/net_helper.h; sourceTree = "<group>"; };
-		4131BFF8234B89820028A615 /* helpers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = helpers.cc; path = rtc_base/helpers.cc; sourceTree = "<group>"; };
-		4131BFFB234B89830028A615 /* logging.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = logging.cc; path = rtc_base/logging.cc; sourceTree = "<group>"; };
-		4131BFFC234B89830028A615 /* nat_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = nat_types.h; path = rtc_base/nat_types.h; sourceTree = "<group>"; };
-		4131BFFD234B89830028A615 /* memory_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = memory_stream.h; path = rtc_base/memory_stream.h; sourceTree = "<group>"; };
-		4131BFFE234B89830028A615 /* memory_usage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = memory_usage.h; path = rtc_base/memory_usage.h; sourceTree = "<group>"; };
-		4131BFFF234B89830028A615 /* net_helpers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = net_helpers.cc; path = rtc_base/net_helpers.cc; sourceTree = "<group>"; };
-		4131C001234B89880028A615 /* http_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = http_common.cc; path = rtc_base/http_common.cc; sourceTree = "<group>"; };
-		4131C002234B89880028A615 /* compile_assert_c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = compile_assert_c.h; path = rtc_base/compile_assert_c.h; sourceTree = "<group>"; };
-		4131C003234B89880028A615 /* copy_on_write_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = copy_on_write_buffer.h; path = rtc_base/copy_on_write_buffer.h; sourceTree = "<group>"; };
-		4131C005234B89890028A615 /* byte_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = byte_buffer.h; path = rtc_base/byte_buffer.h; sourceTree = "<group>"; };
-		4131C006234B89890028A615 /* mdns_responder_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mdns_responder_interface.h; path = rtc_base/mdns_responder_interface.h; sourceTree = "<group>"; };
-		4131C007234B89890028A615 /* fake_clock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_clock.h; path = rtc_base/fake_clock.h; sourceTree = "<group>"; };
-		4131C008234B89890028A615 /* async_resolver_interface.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = async_resolver_interface.cc; path = rtc_base/async_resolver_interface.cc; sourceTree = "<group>"; };
-		4131C009234B89890028A615 /* file_rotating_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = file_rotating_stream.h; path = rtc_base/file_rotating_stream.h; sourceTree = "<group>"; };
-		4131C00A234B89890028A615 /* BUILD.gn */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = BUILD.gn; path = rtc_base/BUILD.gn; sourceTree = "<group>"; };
-		4131C00E234B898A0028A615 /* ip_address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ip_address.h; path = rtc_base/ip_address.h; sourceTree = "<group>"; };
-		4131C00F234B898A0028A615 /* fake_ssl_identity.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fake_ssl_identity.cc; path = rtc_base/fake_ssl_identity.cc; sourceTree = "<group>"; };
-		4131C011234B898B0028A615 /* mac_ifaddrs_converter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mac_ifaddrs_converter.cc; path = rtc_base/mac_ifaddrs_converter.cc; sourceTree = "<group>"; };
-		4131C012234B898B0028A615 /* fake_mdns_responder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_mdns_responder.h; path = rtc_base/fake_mdns_responder.h; sourceTree = "<group>"; };
-		4131C013234B898B0028A615 /* http_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = http_common.h; path = rtc_base/http_common.h; sourceTree = "<group>"; };
-		4131C014234B898B0028A615 /* firewall_socket_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = firewall_socket_server.cc; path = rtc_base/firewall_socket_server.cc; sourceTree = "<group>"; };
-		4131C015234B898B0028A615 /* firewall_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = firewall_socket_server.h; path = rtc_base/firewall_socket_server.h; sourceTree = "<group>"; };
-		4131C016234B898B0028A615 /* async_packet_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = async_packet_socket.h; path = rtc_base/async_packet_socket.h; sourceTree = "<group>"; };
-		4131C017234B898C0028A615 /* crc32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crc32.h; path = rtc_base/crc32.h; sourceTree = "<group>"; };
-		4131C018234B898C0028A615 /* network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = network.h; path = rtc_base/network.h; sourceTree = "<group>"; };
-		4131C019234B898C0028A615 /* helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = helpers.h; path = rtc_base/helpers.h; sourceTree = "<group>"; };
-		4131C01A234B898C0028A615 /* async_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = async_socket.h; path = rtc_base/async_socket.h; sourceTree = "<group>"; };
-		4131C01B234B898C0028A615 /* nat_types.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = nat_types.cc; path = rtc_base/nat_types.cc; sourceTree = "<group>"; };
-		4131C01D234B898D0028A615 /* message_digest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = message_digest.h; path = rtc_base/message_digest.h; sourceTree = "<group>"; };
-		4131C08C234B89CF0028A615 /* weak_ptr.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = weak_ptr.cc; path = rtc_base/weak_ptr.cc; sourceTree = "<group>"; };
-		4131C08D234B89CF0028A615 /* openssl_stream_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openssl_stream_adapter.cc; path = rtc_base/openssl_stream_adapter.cc; sourceTree = "<group>"; };
-		4131C08E234B89CF0028A615 /* ssl_stream_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssl_stream_adapter.h; path = rtc_base/ssl_stream_adapter.h; sourceTree = "<group>"; };
-		4131C08F234B89CF0028A615 /* rate_statistics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rate_statistics.cc; path = rtc_base/rate_statistics.cc; sourceTree = "<group>"; };
-		4131C091234B89CF0028A615 /* ssl_fingerprint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssl_fingerprint.h; path = rtc_base/ssl_fingerprint.h; sourceTree = "<group>"; };
-		4131C092234B89D00028A615 /* stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stream.h; path = rtc_base/stream.h; sourceTree = "<group>"; };
-		4131C093234B89D00028A615 /* openssl_utility.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openssl_utility.cc; path = rtc_base/openssl_utility.cc; sourceTree = "<group>"; };
-		4131C094234B89D00028A615 /* ref_count.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ref_count.h; path = rtc_base/ref_count.h; sourceTree = "<group>"; };
-		4131C095234B89D00028A615 /* socket_address_pair.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = socket_address_pair.cc; path = rtc_base/socket_address_pair.cc; sourceTree = "<group>"; };
-		4131C096234B89D00028A615 /* sigslottester.h.pump */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = sigslottester.h.pump; path = rtc_base/sigslottester.h.pump; sourceTree = "<group>"; };
-		4131C097234B89D00028A615 /* string_encode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = string_encode.h; path = rtc_base/string_encode.h; sourceTree = "<group>"; };
-		4131C098234B89D00028A615 /* rate_tracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rate_tracker.h; path = rtc_base/rate_tracker.h; sourceTree = "<group>"; };
-		4131C099234B89D10028A615 /* string_to_number.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = string_to_number.h; path = rtc_base/string_to_number.h; sourceTree = "<group>"; };
-		4131C09A234B89D10028A615 /* proxy_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = proxy_server.cc; path = rtc_base/proxy_server.cc; sourceTree = "<group>"; };
-		4131C09B234B89D10028A615 /* swap_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = swap_queue.h; path = rtc_base/swap_queue.h; sourceTree = "<group>"; };
-		4131C09C234B89D10028A615 /* proxy_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = proxy_server.h; path = rtc_base/proxy_server.h; sourceTree = "<group>"; };
-		4131C09D234B89D10028A615 /* protobuf_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = protobuf_utils.h; path = rtc_base/protobuf_utils.h; sourceTree = "<group>"; };
-		4131C09E234B89D10028A615 /* server_socket_adapters.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = server_socket_adapters.cc; path = rtc_base/server_socket_adapters.cc; sourceTree = "<group>"; };
-		4131C09F234B89D20028A615 /* sigslot_tester.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sigslot_tester.h; path = rtc_base/sigslot_tester.h; sourceTree = "<group>"; };
-		4131C0A0234B89D20028A615 /* ssl_stream_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_stream_adapter.cc; path = rtc_base/ssl_stream_adapter.cc; sourceTree = "<group>"; };
-		4131C0A1234B89D20028A615 /* socket_address.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = socket_address.cc; path = rtc_base/socket_address.cc; sourceTree = "<group>"; };
-		4131C0A2234B89D20028A615 /* openssl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl.h; path = rtc_base/openssl.h; sourceTree = "<group>"; };
-		4131C0A3234B89D20028A615 /* rtc_certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_certificate.h; path = rtc_base/rtc_certificate.h; sourceTree = "<group>"; };
-		4131C0A4234B89D20028A615 /* proxy_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = proxy_info.h; path = rtc_base/proxy_info.h; sourceTree = "<group>"; };
-		4131C0A5234B89D20028A615 /* platform_thread_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = platform_thread_types.h; path = rtc_base/platform_thread_types.h; sourceTree = "<group>"; };
-		4131C0A6234B89D30028A615 /* rate_limiter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rate_limiter.h; path = rtc_base/rate_limiter.h; sourceTree = "<group>"; };
-		4131C0A7234B89D30028A615 /* rate_tracker.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rate_tracker.cc; path = rtc_base/rate_tracker.cc; sourceTree = "<group>"; };
-		4131C0A8234B89D30028A615 /* ssl_identity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssl_identity.h; path = rtc_base/ssl_identity.h; sourceTree = "<group>"; };
-		4131C0A9234B89D30028A615 /* socket_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = socket_stream.h; path = rtc_base/socket_stream.h; sourceTree = "<group>"; };
-		4131C0AA234B89D30028A615 /* platform_thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = platform_thread.h; path = rtc_base/platform_thread.h; sourceTree = "<group>"; };
-		4131C0AB234B89D30028A615 /* unique_id_generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = unique_id_generator.h; path = rtc_base/unique_id_generator.h; sourceTree = "<group>"; };
-		4131C0AC234B89D30028A615 /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = socket.h; path = rtc_base/socket.h; sourceTree = "<group>"; };
-		4131C0AD234B89D40028A615 /* time_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = time_utils.h; path = rtc_base/time_utils.h; sourceTree = "<group>"; };
-		4131C0AE234B89D40028A615 /* timestamp_aligner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = timestamp_aligner.h; path = rtc_base/timestamp_aligner.h; sourceTree = "<group>"; };
-		4131C0B0234B89D40028A615 /* openssl_certificate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openssl_certificate.cc; path = rtc_base/openssl_certificate.cc; sourceTree = "<group>"; };
-		4131C0B1234B89D40028A615 /* ssl_identity.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_identity.cc; path = rtc_base/ssl_identity.cc; sourceTree = "<group>"; };
-		4131C0B2234B89D40028A615 /* ssl_fingerprint.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_fingerprint.cc; path = rtc_base/ssl_fingerprint.cc; sourceTree = "<group>"; };
-		4131C0B3234B89D50028A615 /* socket_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = socket_factory.h; path = rtc_base/socket_factory.h; sourceTree = "<group>"; };
-		4131C0B4234B89D50028A615 /* thread.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = thread.cc; path = rtc_base/thread.cc; sourceTree = "<group>"; };
-		4131C0B5234B89D50028A615 /* rolling_accumulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rolling_accumulator.h; path = rtc_base/rolling_accumulator.h; sourceTree = "<group>"; };
-		4131C0B6234B89D50028A615 /* openssl_session_cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl_session_cache.h; path = rtc_base/openssl_session_cache.h; sourceTree = "<group>"; };
-		4131C0B7234B89D50028A615 /* openssl_identity.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openssl_identity.cc; path = rtc_base/openssl_identity.cc; sourceTree = "<group>"; };
-		4131C0B8234B89D50028A615 /* platform_thread.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = platform_thread.cc; path = rtc_base/platform_thread.cc; sourceTree = "<group>"; };
-		4131C0BA234B89D60028A615 /* ref_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ref_counter.h; path = rtc_base/ref_counter.h; sourceTree = "<group>"; };
-		4131C0BB234B89D60028A615 /* sanitizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sanitizer.h; path = rtc_base/sanitizer.h; sourceTree = "<group>"; };
-		4131C0BC234B89D60028A615 /* thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = thread.h; path = rtc_base/thread.h; sourceTree = "<group>"; };
-		4131C0BE234B89D60028A615 /* zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = zero_memory.h; path = rtc_base/zero_memory.h; sourceTree = "<group>"; };
-		4131C0BF234B89D60028A615 /* openssl_stream_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl_stream_adapter.h; path = rtc_base/openssl_stream_adapter.h; sourceTree = "<group>"; };
-		4131C0C0234B89D70028A615 /* rtc_certificate_generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_certificate_generator.h; path = rtc_base/rtc_certificate_generator.h; sourceTree = "<group>"; };
-		4131C0C2234B89D70028A615 /* race_checker.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = race_checker.cc; path = rtc_base/race_checker.cc; sourceTree = "<group>"; };
-		4131C0C3234B89D70028A615 /* ssl_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssl_adapter.h; path = rtc_base/ssl_adapter.h; sourceTree = "<group>"; };
-		4131C0C4234B89D70028A615 /* socket_address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = socket_address.h; path = rtc_base/socket_address.h; sourceTree = "<group>"; };
-		4131C0C5234B89D70028A615 /* socket_adapters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = socket_adapters.h; path = rtc_base/socket_adapters.h; sourceTree = "<group>"; };
-		4131C0C6234B89D80028A615 /* string_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = string_utils.h; path = rtc_base/string_utils.h; sourceTree = "<group>"; };
-		4131C0C7234B89D80028A615 /* timestamp_aligner.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = timestamp_aligner.cc; path = rtc_base/timestamp_aligner.cc; sourceTree = "<group>"; };
-		4131C0C9234B89D80028A615 /* type_traits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = type_traits.h; path = rtc_base/type_traits.h; sourceTree = "<group>"; };
-		4131C0CA234B89D80028A615 /* task_queue.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = task_queue.cc; path = rtc_base/task_queue.cc; sourceTree = "<group>"; };
-		4131C0CB234B89D80028A615 /* server_socket_adapters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = server_socket_adapters.h; path = rtc_base/server_socket_adapters.h; sourceTree = "<group>"; };
-		4131C0CC234B89D90028A615 /* rtc_certificate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_certificate.cc; path = rtc_base/rtc_certificate.cc; sourceTree = "<group>"; };
-		4131C0CD234B89D90028A615 /* openssl_identity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl_identity.h; path = rtc_base/openssl_identity.h; sourceTree = "<group>"; };
-		4131C0CE234B89D90028A615 /* physical_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = physical_socket_server.h; path = rtc_base/physical_socket_server.h; sourceTree = "<group>"; };
-		4131C0D0234B89D90028A615 /* socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = socket.cc; path = rtc_base/socket.cc; sourceTree = "<group>"; };
-		4131C0D1234B89DA0028A615 /* openssl_digest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openssl_digest.cc; path = rtc_base/openssl_digest.cc; sourceTree = "<group>"; };
-		4131C0D2234B89DA0028A615 /* trace_event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = trace_event.h; path = rtc_base/trace_event.h; sourceTree = "<group>"; };
-		4131C0D3234B89DA0028A615 /* physical_socket_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = physical_socket_server.cc; path = rtc_base/physical_socket_server.cc; sourceTree = "<group>"; };
-		4131C0D4234B89DA0028A615 /* random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = random.h; path = rtc_base/random.h; sourceTree = "<group>"; };
-		4131C0D5234B89DB0028A615 /* race_checker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = race_checker.h; path = rtc_base/race_checker.h; sourceTree = "<group>"; };
-		4131C0D6234B89DB0028A615 /* ssl_certificate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_certificate.cc; path = rtc_base/ssl_certificate.cc; sourceTree = "<group>"; };
-		4131C0D7234B89DB0028A615 /* task_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = task_queue.h; path = rtc_base/task_queue.h; sourceTree = "<group>"; };
-		4131C0D8234B89DB0028A615 /* unique_id_generator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = unique_id_generator.cc; path = rtc_base/unique_id_generator.cc; sourceTree = "<group>"; };
-		4131C0D9234B89DB0028A615 /* one_time_event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = one_time_event.h; path = rtc_base/one_time_event.h; sourceTree = "<group>"; };
-		4131C0DA234B89DC0028A615 /* openssl_certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl_certificate.h; path = rtc_base/openssl_certificate.h; sourceTree = "<group>"; };
-		4131C0DB234B89DC0028A615 /* socket_adapters.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = socket_adapters.cc; path = rtc_base/socket_adapters.cc; sourceTree = "<group>"; };
-		4131C0DC234B89DC0028A615 /* openssl_digest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl_digest.h; path = rtc_base/openssl_digest.h; sourceTree = "<group>"; };
-		4131C0DD234B89DC0028A615 /* ref_counted_object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ref_counted_object.h; path = rtc_base/ref_counted_object.h; sourceTree = "<group>"; };
-		4131C0DE234B89DC0028A615 /* time_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = time_utils.cc; path = rtc_base/time_utils.cc; sourceTree = "<group>"; };
-		4131C0DF234B89DC0028A615 /* openssl_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openssl_adapter.cc; path = rtc_base/openssl_adapter.cc; sourceTree = "<group>"; };
-		4131C0E0234B89DC0028A615 /* openssl_utility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl_utility.h; path = rtc_base/openssl_utility.h; sourceTree = "<group>"; };
-		4131C0E1234B89DD0028A615 /* socket_address_pair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = socket_address_pair.h; path = rtc_base/socket_address_pair.h; sourceTree = "<group>"; };
-		4131C0E2234B89DD0028A615 /* socket_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = socket_stream.cc; path = rtc_base/socket_stream.cc; sourceTree = "<group>"; };
-		4131C0E3234B89DD0028A615 /* ssl_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ssl_adapter.cc; path = rtc_base/ssl_adapter.cc; sourceTree = "<group>"; };
-		4131C0E4234B89DD0028A615 /* openssl_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl_adapter.h; path = rtc_base/openssl_adapter.h; sourceTree = "<group>"; };
-		4131C0E5234B89DD0028A615 /* zero_memory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = zero_memory.cc; path = rtc_base/zero_memory.cc; sourceTree = "<group>"; };
-		4131C0E6234B89DD0028A615 /* socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = socket_server.h; path = rtc_base/socket_server.h; sourceTree = "<group>"; };
-		4131C0E7234B89DE0028A615 /* OWNERS */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = OWNERS; path = rtc_base/OWNERS; sourceTree = "<group>"; };
-		4131C0E8234B89DE0028A615 /* ssl_roots.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssl_roots.h; path = rtc_base/ssl_roots.h; sourceTree = "<group>"; };
-		4131C0E9234B89DE0028A615 /* thread_annotations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = thread_annotations.h; path = rtc_base/thread_annotations.h; sourceTree = "<group>"; };
-		4131C0EB234B89DF0028A615 /* stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = stream.cc; path = rtc_base/stream.cc; sourceTree = "<group>"; };
-		4131C0EC234B89DF0028A615 /* rate_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rate_statistics.h; path = rtc_base/rate_statistics.h; sourceTree = "<group>"; };
-		4131C0ED234B89DF0028A615 /* rate_limiter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rate_limiter.cc; path = rtc_base/rate_limiter.cc; sourceTree = "<group>"; };
-		4131C0EE234B89DF0028A615 /* platform_thread_types.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = platform_thread_types.cc; path = rtc_base/platform_thread_types.cc; sourceTree = "<group>"; };
-		4131C0EF234B89DF0028A615 /* rtc_certificate_generator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_certificate_generator.cc; path = rtc_base/rtc_certificate_generator.cc; sourceTree = "<group>"; };
-		4131C0F0234B89E00028A615 /* string_encode.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = string_encode.cc; path = rtc_base/string_encode.cc; sourceTree = "<group>"; };
-		4131C0F2234B89E00028A615 /* openssl_session_cache.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openssl_session_cache.cc; path = rtc_base/openssl_session_cache.cc; sourceTree = "<group>"; };
-		4131C0F3234B89E10028A615 /* proxy_info.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = proxy_info.cc; path = rtc_base/proxy_info.cc; sourceTree = "<group>"; };
-		4131C0F4234B89E10028A615 /* random.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = random.cc; path = rtc_base/random.cc; sourceTree = "<group>"; };
-		4131C0F5234B89E10028A615 /* string_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = string_utils.cc; path = rtc_base/string_utils.cc; sourceTree = "<group>"; };
-		4131C0F6234B89E20028A615 /* ssl_certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ssl_certificate.h; path = rtc_base/ssl_certificate.h; sourceTree = "<group>"; };
-		4131C0F7234B89E20028A615 /* string_to_number.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = string_to_number.cc; path = rtc_base/string_to_number.cc; sourceTree = "<group>"; };
-		4131C0F8234B89E20028A615 /* weak_ptr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = weak_ptr.h; path = rtc_base/weak_ptr.h; sourceTree = "<group>"; };
+		4131BF66234B88A00028A615 /* media_engine.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = media_engine.cc; sourceTree = "<group>"; };
+		4131BF67234B88A00028A615 /* video_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_adapter.h; sourceTree = "<group>"; };
+		4131BF68234B88A00028A615 /* codec.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = codec.cc; sourceTree = "<group>"; };
+		4131BF69234B88A00028A615 /* turn_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = turn_utils.h; sourceTree = "<group>"; };
+		4131BF6A234B88A00028A615 /* media_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = media_constants.h; sourceTree = "<group>"; };
+		4131BF6B234B88A10028A615 /* adapted_video_track_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = adapted_video_track_source.cc; sourceTree = "<group>"; };
+		4131BF6C234B88A10028A615 /* video_source_base.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_source_base.cc; sourceTree = "<group>"; };
+		4131BF6D234B88A10028A615 /* rtp_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_utils.cc; sourceTree = "<group>"; };
+		4131BF6F234B88A10028A615 /* rid_description.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rid_description.h; sourceTree = "<group>"; };
+		4131BF70234B88A20028A615 /* rtp_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_utils.h; sourceTree = "<group>"; };
+		4131BF71234B88A20028A615 /* video_broadcaster.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_broadcaster.cc; sourceTree = "<group>"; };
+		4131BF72234B88A20028A615 /* video_source_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_source_base.h; sourceTree = "<group>"; };
+		4131BF74234B88A20028A615 /* stream_params.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = stream_params.cc; sourceTree = "<group>"; };
+		4131BF76234B88A30028A615 /* adapted_video_track_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adapted_video_track_source.h; sourceTree = "<group>"; };
+		4131BF78234B88A30028A615 /* codec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = codec.h; sourceTree = "<group>"; };
+		4131BF7A234B88A30028A615 /* media_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = media_engine.h; sourceTree = "<group>"; };
+		4131BF7B234B88A30028A615 /* video_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_adapter.cc; sourceTree = "<group>"; };
+		4131BF7C234B88A40028A615 /* rid_description.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rid_description.cc; sourceTree = "<group>"; };
+		4131BF7D234B88A40028A615 /* audio_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_source.h; sourceTree = "<group>"; };
+		4131BF7E234B88A40028A615 /* video_broadcaster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_broadcaster.h; sourceTree = "<group>"; };
+		4131BF7F234B88A40028A615 /* media_constants.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = media_constants.cc; sourceTree = "<group>"; };
+		4131BF80234B88A40028A615 /* stream_params.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stream_params.h; sourceTree = "<group>"; };
+		4131BF81234B88A40028A615 /* video_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_common.cc; sourceTree = "<group>"; };
+		4131BF82234B88A50028A615 /* delayable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delayable.h; sourceTree = "<group>"; };
+		4131BF83234B88A50028A615 /* media_channel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = media_channel.h; sourceTree = "<group>"; };
+		4131BF86234B88A50028A615 /* media_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = media_config.h; sourceTree = "<group>"; };
+		4131BF87234B88A50028A615 /* video_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_common.h; sourceTree = "<group>"; };
+		4131BF88234B88A60028A615 /* turn_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = turn_utils.cc; sourceTree = "<group>"; };
+		4131BFAE234B89770028A615 /* fake_ssl_identity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_ssl_identity.h; sourceTree = "<group>"; };
+		4131BFAF234B89770028A615 /* async_socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = async_socket.cc; sourceTree = "<group>"; };
+		4131BFB0234B89780028A615 /* log_sinks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = log_sinks.h; sourceTree = "<group>"; };
+		4131BFB2234B89780028A615 /* data_rate_limiter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = data_rate_limiter.cc; sourceTree = "<group>"; };
+		4131BFB3234B89780028A615 /* async_udp_socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = async_udp_socket.cc; sourceTree = "<group>"; };
+		4131BFB5234B89780028A615 /* network_monitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network_monitor.h; sourceTree = "<group>"; };
+		4131BFB6234B89780028A615 /* network_monitor.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network_monitor.cc; sourceTree = "<group>"; };
+		4131BFB7234B89790028A615 /* async_udp_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_udp_socket.h; sourceTree = "<group>"; };
+		4131BFB8234B89790028A615 /* checks.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checks.cc; sourceTree = "<group>"; };
+		4131BFB9234B89790028A615 /* memory_usage.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = memory_usage.cc; sourceTree = "<group>"; };
+		4131BFBA234B89790028A615 /* cpu_time.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cpu_time.cc; sourceTree = "<group>"; };
+		4131BFBB234B89790028A615 /* copy_on_write_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = copy_on_write_buffer.cc; sourceTree = "<group>"; };
+		4131BFBD234B897A0028A615 /* event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event.h; sourceTree = "<group>"; };
+		4131BFBE234B897A0028A615 /* async_packet_socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = async_packet_socket.cc; sourceTree = "<group>"; };
+		4131BFBF234B897A0028A615 /* nat_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nat_server.h; sourceTree = "<group>"; };
+		4131BFC0234B897A0028A615 /* net_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_helpers.h; sourceTree = "<group>"; };
+		4131BFC1234B897A0028A615 /* crypt_string.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = crypt_string.cc; sourceTree = "<group>"; };
+		4131BFC2234B897A0028A615 /* null_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = null_socket_server.h; sourceTree = "<group>"; };
+		4131BFC4234B897B0028A615 /* network_route.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network_route.h; sourceTree = "<group>"; };
+		4131BFC5234B897B0028A615 /* fake_network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_network.h; sourceTree = "<group>"; };
+		4131BFC7234B897B0028A615 /* event_tracer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = event_tracer.cc; sourceTree = "<group>"; };
+		4131BFC9234B897B0028A615 /* bit_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bit_buffer.cc; sourceTree = "<group>"; };
+		4131BFCA234B897C0028A615 /* async_tcp_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_tcp_socket.h; sourceTree = "<group>"; };
+		4131BFCB234B897C0028A615 /* nat_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = nat_server.cc; sourceTree = "<group>"; };
+		4131BFCC234B897C0028A615 /* dscp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dscp.h; sourceTree = "<group>"; };
+		4131BFCD234B897C0028A615 /* network.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network.cc; sourceTree = "<group>"; };
+		4131BFCE234B897C0028A615 /* crc32.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = crc32.cc; sourceTree = "<group>"; };
+		4131BFCF234B897C0028A615 /* byte_order.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = byte_order.h; sourceTree = "<group>"; };
+		4131BFD0234B897C0028A615 /* file_rotating_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = file_rotating_stream.cc; sourceTree = "<group>"; };
+		4131BFD1234B897D0028A615 /* buffer_queue.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = buffer_queue.cc; sourceTree = "<group>"; };
+		4131BFD2234B897D0028A615 /* bit_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_buffer.h; sourceTree = "<group>"; };
+		4131BFD3234B897D0028A615 /* byte_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = byte_buffer.cc; sourceTree = "<group>"; };
+		4131BFD5234B897D0028A615 /* null_socket_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = null_socket_server.cc; sourceTree = "<group>"; };
+		4131BFD6234B897D0028A615 /* ifaddrs_android.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ifaddrs_android.cc; sourceTree = "<group>"; };
+		4131BFD7234B897D0028A615 /* ip_address.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ip_address.cc; sourceTree = "<group>"; };
+		4131BFD9234B897E0028A615 /* DEPS */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = DEPS; sourceTree = "<group>"; };
+		4131BFDA234B897E0028A615 /* event.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = event.cc; sourceTree = "<group>"; };
+		4131BFDC234B897E0028A615 /* cpu_time.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cpu_time.h; sourceTree = "<group>"; };
+		4131BFDD234B897E0028A615 /* memory_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = memory_stream.cc; sourceTree = "<group>"; };
+		4131BFDE234B897E0028A615 /* crypt_string.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypt_string.h; sourceTree = "<group>"; };
+		4131BFE0234B897F0028A615 /* ifaddrs_android.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ifaddrs_android.h; sourceTree = "<group>"; };
+		4131BFE1234B897F0028A615 /* event_tracer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event_tracer.h; sourceTree = "<group>"; };
+		4131BFE2234B897F0028A615 /* arraysize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arraysize.h; sourceTree = "<group>"; };
+		4131BFE3234B897F0028A615 /* nat_socket_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nat_socket_factory.h; sourceTree = "<group>"; };
+		4131BFE4234B897F0028A615 /* nat_socket_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = nat_socket_factory.cc; sourceTree = "<group>"; };
+		4131BFE5234B897F0028A615 /* buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buffer.h; sourceTree = "<group>"; };
+		4131BFE6234B89800028A615 /* net_helper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = net_helper.cc; sourceTree = "<group>"; };
+		4131BFE7234B89800028A615 /* logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logging.h; sourceTree = "<group>"; };
+		4131BFE8234B89800028A615 /* async_resolver_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_resolver_interface.h; sourceTree = "<group>"; };
+		4131BFE9234B89800028A615 /* data_rate_limiter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = data_rate_limiter.h; sourceTree = "<group>"; };
+		4131BFEA234B89800028A615 /* async_tcp_socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = async_tcp_socket.cc; sourceTree = "<group>"; };
+		4131BFEC234B89800028A615 /* ifaddrs_converter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ifaddrs_converter.cc; sourceTree = "<group>"; };
+		4131BFED234B89810028A615 /* buffer_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buffer_queue.h; sourceTree = "<group>"; };
+		4131BFEE234B89810028A615 /* ifaddrs_converter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ifaddrs_converter.h; sourceTree = "<group>"; };
+		4131BFEF234B89810028A615 /* network_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network_constants.h; sourceTree = "<group>"; };
+		4131BFF0234B89810028A615 /* fake_clock.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_clock.cc; sourceTree = "<group>"; };
+		4131BFF1234B89810028A615 /* log_sinks.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = log_sinks.cc; sourceTree = "<group>"; };
+		4131BFF3234B89810028A615 /* ignore_wundef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ignore_wundef.h; sourceTree = "<group>"; };
+		4131BFF4234B89820028A615 /* checks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = checks.h; sourceTree = "<group>"; };
+		4131BFF6234B89820028A615 /* message_digest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = message_digest.cc; sourceTree = "<group>"; };
+		4131BFF7234B89820028A615 /* net_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net_helper.h; sourceTree = "<group>"; };
+		4131BFF8234B89820028A615 /* helpers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = helpers.cc; sourceTree = "<group>"; };
+		4131BFFB234B89830028A615 /* logging.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = logging.cc; sourceTree = "<group>"; };
+		4131BFFC234B89830028A615 /* nat_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nat_types.h; sourceTree = "<group>"; };
+		4131BFFD234B89830028A615 /* memory_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory_stream.h; sourceTree = "<group>"; };
+		4131BFFE234B89830028A615 /* memory_usage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory_usage.h; sourceTree = "<group>"; };
+		4131BFFF234B89830028A615 /* net_helpers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = net_helpers.cc; sourceTree = "<group>"; };
+		4131C001234B89880028A615 /* http_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = http_common.cc; sourceTree = "<group>"; };
+		4131C002234B89880028A615 /* compile_assert_c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compile_assert_c.h; sourceTree = "<group>"; };
+		4131C003234B89880028A615 /* copy_on_write_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = copy_on_write_buffer.h; sourceTree = "<group>"; };
+		4131C005234B89890028A615 /* byte_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = byte_buffer.h; sourceTree = "<group>"; };
+		4131C006234B89890028A615 /* mdns_responder_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mdns_responder_interface.h; sourceTree = "<group>"; };
+		4131C007234B89890028A615 /* fake_clock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_clock.h; sourceTree = "<group>"; };
+		4131C008234B89890028A615 /* async_resolver_interface.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = async_resolver_interface.cc; sourceTree = "<group>"; };
+		4131C009234B89890028A615 /* file_rotating_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file_rotating_stream.h; sourceTree = "<group>"; };
+		4131C00A234B89890028A615 /* BUILD.gn */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = BUILD.gn; sourceTree = "<group>"; };
+		4131C00E234B898A0028A615 /* ip_address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ip_address.h; sourceTree = "<group>"; };
+		4131C00F234B898A0028A615 /* fake_ssl_identity.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_ssl_identity.cc; sourceTree = "<group>"; };
+		4131C011234B898B0028A615 /* mac_ifaddrs_converter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mac_ifaddrs_converter.cc; sourceTree = "<group>"; };
+		4131C012234B898B0028A615 /* fake_mdns_responder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_mdns_responder.h; sourceTree = "<group>"; };
+		4131C013234B898B0028A615 /* http_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http_common.h; sourceTree = "<group>"; };
+		4131C014234B898B0028A615 /* firewall_socket_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = firewall_socket_server.cc; sourceTree = "<group>"; };
+		4131C015234B898B0028A615 /* firewall_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = firewall_socket_server.h; sourceTree = "<group>"; };
+		4131C016234B898B0028A615 /* async_packet_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_packet_socket.h; sourceTree = "<group>"; };
+		4131C017234B898C0028A615 /* crc32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crc32.h; sourceTree = "<group>"; };
+		4131C018234B898C0028A615 /* network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network.h; sourceTree = "<group>"; };
+		4131C019234B898C0028A615 /* helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = helpers.h; sourceTree = "<group>"; };
+		4131C01A234B898C0028A615 /* async_socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_socket.h; sourceTree = "<group>"; };
+		4131C01B234B898C0028A615 /* nat_types.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = nat_types.cc; sourceTree = "<group>"; };
+		4131C01D234B898D0028A615 /* message_digest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = message_digest.h; sourceTree = "<group>"; };
+		4131C08C234B89CF0028A615 /* weak_ptr.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = weak_ptr.cc; sourceTree = "<group>"; };
+		4131C08D234B89CF0028A615 /* openssl_stream_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openssl_stream_adapter.cc; sourceTree = "<group>"; };
+		4131C08E234B89CF0028A615 /* ssl_stream_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_stream_adapter.h; sourceTree = "<group>"; };
+		4131C08F234B89CF0028A615 /* rate_statistics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rate_statistics.cc; sourceTree = "<group>"; };
+		4131C091234B89CF0028A615 /* ssl_fingerprint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_fingerprint.h; sourceTree = "<group>"; };
+		4131C092234B89D00028A615 /* stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stream.h; sourceTree = "<group>"; };
+		4131C093234B89D00028A615 /* openssl_utility.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openssl_utility.cc; sourceTree = "<group>"; };
+		4131C094234B89D00028A615 /* ref_count.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ref_count.h; sourceTree = "<group>"; };
+		4131C095234B89D00028A615 /* socket_address_pair.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = socket_address_pair.cc; sourceTree = "<group>"; };
+		4131C096234B89D00028A615 /* sigslottester.h.pump */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = sigslottester.h.pump; sourceTree = "<group>"; };
+		4131C097234B89D00028A615 /* string_encode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_encode.h; sourceTree = "<group>"; };
+		4131C098234B89D00028A615 /* rate_tracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rate_tracker.h; sourceTree = "<group>"; };
+		4131C099234B89D10028A615 /* string_to_number.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_to_number.h; sourceTree = "<group>"; };
+		4131C09A234B89D10028A615 /* proxy_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = proxy_server.cc; sourceTree = "<group>"; };
+		4131C09B234B89D10028A615 /* swap_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = swap_queue.h; sourceTree = "<group>"; };
+		4131C09C234B89D10028A615 /* proxy_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = proxy_server.h; sourceTree = "<group>"; };
+		4131C09D234B89D10028A615 /* protobuf_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = protobuf_utils.h; sourceTree = "<group>"; };
+		4131C09E234B89D10028A615 /* server_socket_adapters.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = server_socket_adapters.cc; sourceTree = "<group>"; };
+		4131C09F234B89D20028A615 /* sigslot_tester.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sigslot_tester.h; sourceTree = "<group>"; };
+		4131C0A0234B89D20028A615 /* ssl_stream_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_stream_adapter.cc; sourceTree = "<group>"; };
+		4131C0A1234B89D20028A615 /* socket_address.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = socket_address.cc; sourceTree = "<group>"; };
+		4131C0A2234B89D20028A615 /* openssl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl.h; sourceTree = "<group>"; };
+		4131C0A3234B89D20028A615 /* rtc_certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_certificate.h; sourceTree = "<group>"; };
+		4131C0A4234B89D20028A615 /* proxy_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = proxy_info.h; sourceTree = "<group>"; };
+		4131C0A5234B89D20028A615 /* platform_thread_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platform_thread_types.h; sourceTree = "<group>"; };
+		4131C0A6234B89D30028A615 /* rate_limiter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rate_limiter.h; sourceTree = "<group>"; };
+		4131C0A7234B89D30028A615 /* rate_tracker.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rate_tracker.cc; sourceTree = "<group>"; };
+		4131C0A8234B89D30028A615 /* ssl_identity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_identity.h; sourceTree = "<group>"; };
+		4131C0A9234B89D30028A615 /* socket_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket_stream.h; sourceTree = "<group>"; };
+		4131C0AA234B89D30028A615 /* platform_thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platform_thread.h; sourceTree = "<group>"; };
+		4131C0AB234B89D30028A615 /* unique_id_generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unique_id_generator.h; sourceTree = "<group>"; };
+		4131C0AC234B89D30028A615 /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket.h; sourceTree = "<group>"; };
+		4131C0AD234B89D40028A615 /* time_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = time_utils.h; sourceTree = "<group>"; };
+		4131C0AE234B89D40028A615 /* timestamp_aligner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timestamp_aligner.h; sourceTree = "<group>"; };
+		4131C0B0234B89D40028A615 /* openssl_certificate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openssl_certificate.cc; sourceTree = "<group>"; };
+		4131C0B1234B89D40028A615 /* ssl_identity.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_identity.cc; sourceTree = "<group>"; };
+		4131C0B2234B89D40028A615 /* ssl_fingerprint.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_fingerprint.cc; sourceTree = "<group>"; };
+		4131C0B3234B89D50028A615 /* socket_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket_factory.h; sourceTree = "<group>"; };
+		4131C0B4234B89D50028A615 /* thread.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = thread.cc; sourceTree = "<group>"; };
+		4131C0B5234B89D50028A615 /* rolling_accumulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rolling_accumulator.h; sourceTree = "<group>"; };
+		4131C0B6234B89D50028A615 /* openssl_session_cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl_session_cache.h; sourceTree = "<group>"; };
+		4131C0B7234B89D50028A615 /* openssl_identity.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openssl_identity.cc; sourceTree = "<group>"; };
+		4131C0B8234B89D50028A615 /* platform_thread.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = platform_thread.cc; sourceTree = "<group>"; };
+		4131C0BA234B89D60028A615 /* ref_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ref_counter.h; sourceTree = "<group>"; };
+		4131C0BB234B89D60028A615 /* sanitizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sanitizer.h; sourceTree = "<group>"; };
+		4131C0BC234B89D60028A615 /* thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread.h; sourceTree = "<group>"; };
+		4131C0BE234B89D60028A615 /* zero_memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = zero_memory.h; sourceTree = "<group>"; };
+		4131C0BF234B89D60028A615 /* openssl_stream_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl_stream_adapter.h; sourceTree = "<group>"; };
+		4131C0C0234B89D70028A615 /* rtc_certificate_generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_certificate_generator.h; sourceTree = "<group>"; };
+		4131C0C2234B89D70028A615 /* race_checker.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = race_checker.cc; sourceTree = "<group>"; };
+		4131C0C3234B89D70028A615 /* ssl_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_adapter.h; sourceTree = "<group>"; };
+		4131C0C4234B89D70028A615 /* socket_address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket_address.h; sourceTree = "<group>"; };
+		4131C0C5234B89D70028A615 /* socket_adapters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket_adapters.h; sourceTree = "<group>"; };
+		4131C0C6234B89D80028A615 /* string_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_utils.h; sourceTree = "<group>"; };
+		4131C0C7234B89D80028A615 /* timestamp_aligner.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = timestamp_aligner.cc; sourceTree = "<group>"; };
+		4131C0C9234B89D80028A615 /* type_traits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type_traits.h; sourceTree = "<group>"; };
+		4131C0CA234B89D80028A615 /* task_queue.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = task_queue.cc; sourceTree = "<group>"; };
+		4131C0CB234B89D80028A615 /* server_socket_adapters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = server_socket_adapters.h; sourceTree = "<group>"; };
+		4131C0CC234B89D90028A615 /* rtc_certificate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_certificate.cc; sourceTree = "<group>"; };
+		4131C0CD234B89D90028A615 /* openssl_identity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl_identity.h; sourceTree = "<group>"; };
+		4131C0CE234B89D90028A615 /* physical_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = physical_socket_server.h; sourceTree = "<group>"; };
+		4131C0D0234B89D90028A615 /* socket.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = socket.cc; sourceTree = "<group>"; };
+		4131C0D1234B89DA0028A615 /* openssl_digest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openssl_digest.cc; sourceTree = "<group>"; };
+		4131C0D2234B89DA0028A615 /* trace_event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = trace_event.h; sourceTree = "<group>"; };
+		4131C0D3234B89DA0028A615 /* physical_socket_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = physical_socket_server.cc; sourceTree = "<group>"; };
+		4131C0D4234B89DA0028A615 /* random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = random.h; sourceTree = "<group>"; };
+		4131C0D5234B89DB0028A615 /* race_checker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = race_checker.h; sourceTree = "<group>"; };
+		4131C0D6234B89DB0028A615 /* ssl_certificate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_certificate.cc; sourceTree = "<group>"; };
+		4131C0D7234B89DB0028A615 /* task_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = task_queue.h; sourceTree = "<group>"; };
+		4131C0D8234B89DB0028A615 /* unique_id_generator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unique_id_generator.cc; sourceTree = "<group>"; };
+		4131C0D9234B89DB0028A615 /* one_time_event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = one_time_event.h; sourceTree = "<group>"; };
+		4131C0DA234B89DC0028A615 /* openssl_certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl_certificate.h; sourceTree = "<group>"; };
+		4131C0DB234B89DC0028A615 /* socket_adapters.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = socket_adapters.cc; sourceTree = "<group>"; };
+		4131C0DC234B89DC0028A615 /* openssl_digest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl_digest.h; sourceTree = "<group>"; };
+		4131C0DD234B89DC0028A615 /* ref_counted_object.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ref_counted_object.h; sourceTree = "<group>"; };
+		4131C0DE234B89DC0028A615 /* time_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = time_utils.cc; sourceTree = "<group>"; };
+		4131C0DF234B89DC0028A615 /* openssl_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openssl_adapter.cc; sourceTree = "<group>"; };
+		4131C0E0234B89DC0028A615 /* openssl_utility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl_utility.h; sourceTree = "<group>"; };
+		4131C0E1234B89DD0028A615 /* socket_address_pair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket_address_pair.h; sourceTree = "<group>"; };
+		4131C0E2234B89DD0028A615 /* socket_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = socket_stream.cc; sourceTree = "<group>"; };
+		4131C0E3234B89DD0028A615 /* ssl_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_adapter.cc; sourceTree = "<group>"; };
+		4131C0E4234B89DD0028A615 /* openssl_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl_adapter.h; sourceTree = "<group>"; };
+		4131C0E5234B89DD0028A615 /* zero_memory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = zero_memory.cc; sourceTree = "<group>"; };
+		4131C0E6234B89DD0028A615 /* socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket_server.h; sourceTree = "<group>"; };
+		4131C0E7234B89DE0028A615 /* OWNERS */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OWNERS; sourceTree = "<group>"; };
+		4131C0E8234B89DE0028A615 /* ssl_roots.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_roots.h; sourceTree = "<group>"; };
+		4131C0E9234B89DE0028A615 /* thread_annotations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_annotations.h; sourceTree = "<group>"; };
+		4131C0EB234B89DF0028A615 /* stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = stream.cc; sourceTree = "<group>"; };
+		4131C0EC234B89DF0028A615 /* rate_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rate_statistics.h; sourceTree = "<group>"; };
+		4131C0ED234B89DF0028A615 /* rate_limiter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rate_limiter.cc; sourceTree = "<group>"; };
+		4131C0EE234B89DF0028A615 /* platform_thread_types.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = platform_thread_types.cc; sourceTree = "<group>"; };
+		4131C0EF234B89DF0028A615 /* rtc_certificate_generator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_certificate_generator.cc; sourceTree = "<group>"; };
+		4131C0F0234B89E00028A615 /* string_encode.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_encode.cc; sourceTree = "<group>"; };
+		4131C0F2234B89E00028A615 /* openssl_session_cache.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openssl_session_cache.cc; sourceTree = "<group>"; };
+		4131C0F3234B89E10028A615 /* proxy_info.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = proxy_info.cc; sourceTree = "<group>"; };
+		4131C0F4234B89E10028A615 /* random.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cc; sourceTree = "<group>"; };
+		4131C0F5234B89E10028A615 /* string_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_utils.cc; sourceTree = "<group>"; };
+		4131C0F6234B89E20028A615 /* ssl_certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssl_certificate.h; sourceTree = "<group>"; };
+		4131C0F7234B89E20028A615 /* string_to_number.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_to_number.cc; sourceTree = "<group>"; };
+		4131C0F8234B89E20028A615 /* weak_ptr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = weak_ptr.h; sourceTree = "<group>"; };
 		4131C165234B8A400028A615 /* transport_description_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transport_description_factory.cc; sourceTree = "<group>"; };
 		4131C166234B8A400028A615 /* basic_packet_socket_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = basic_packet_socket_factory.h; sourceTree = "<group>"; };
 		4131C167234B8A400028A615 /* regathering_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = regathering_controller.cc; sourceTree = "<group>"; };
@@ -6613,27 +6613,27 @@
 		4131C220234B8BB00028A615 /* stable_target_rate_experiment.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stable_target_rate_experiment.cc; sourceTree = "<group>"; };
 		4131C222234B8BB10028A615 /* DEPS */ = {isa = PBXFileReference; lastKnownFileType = text; path = DEPS; sourceTree = "<group>"; };
 		4131C225234B8BB20028A615 /* stable_target_rate_experiment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = stable_target_rate_experiment.h; sourceTree = "<group>"; };
-		4131C245234B8CBB0028A615 /* webrtc_media_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = webrtc_media_engine.h; path = engine/webrtc_media_engine.h; sourceTree = "<group>"; };
-		4131C247234B8CBB0028A615 /* webrtc_media_engine_defaults.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = webrtc_media_engine_defaults.cc; path = engine/webrtc_media_engine_defaults.cc; sourceTree = "<group>"; };
-		4131C249234B8CBC0028A615 /* webrtc_media_engine.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = webrtc_media_engine.cc; path = engine/webrtc_media_engine.cc; sourceTree = "<group>"; };
-		4131C24B234B8CBC0028A615 /* payload_type_mapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = payload_type_mapper.h; path = engine/payload_type_mapper.h; sourceTree = "<group>"; };
-		4131C24C234B8CBC0028A615 /* multiplex_codec_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = multiplex_codec_factory.h; path = engine/multiplex_codec_factory.h; sourceTree = "<group>"; };
-		4131C24D234B8CBC0028A615 /* internal_encoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal_encoder_factory.h; path = engine/internal_encoder_factory.h; sourceTree = "<group>"; };
-		4131C251234B8CBD0028A615 /* internal_decoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal_decoder_factory.h; path = engine/internal_decoder_factory.h; sourceTree = "<group>"; };
-		4131C254234B8CBE0028A615 /* internal_encoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = internal_encoder_factory.cc; path = engine/internal_encoder_factory.cc; sourceTree = "<group>"; };
-		4131C255234B8CBE0028A615 /* null_webrtc_video_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = null_webrtc_video_engine.h; path = engine/null_webrtc_video_engine.h; sourceTree = "<group>"; };
-		4131C256234B8CBE0028A615 /* internal_decoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = internal_decoder_factory.cc; path = engine/internal_decoder_factory.cc; sourceTree = "<group>"; };
-		4131C258234B8CBE0028A615 /* payload_type_mapper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = payload_type_mapper.cc; path = engine/payload_type_mapper.cc; sourceTree = "<group>"; };
-		4131C25A234B8CBF0028A615 /* webrtc_video_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = webrtc_video_engine.h; path = engine/webrtc_video_engine.h; sourceTree = "<group>"; };
-		4131C25B234B8CBF0028A615 /* multiplex_codec_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = multiplex_codec_factory.cc; path = engine/multiplex_codec_factory.cc; sourceTree = "<group>"; };
-		4131C25E234B8CBF0028A615 /* webrtc_media_engine_defaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = webrtc_media_engine_defaults.h; path = engine/webrtc_media_engine_defaults.h; sourceTree = "<group>"; };
-		4131C263234B8CC00028A615 /* simulcast_encoder_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = simulcast_encoder_adapter.h; path = engine/simulcast_encoder_adapter.h; sourceTree = "<group>"; };
-		4131C265234B8CC10028A615 /* simulcast_encoder_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = simulcast_encoder_adapter.cc; path = engine/simulcast_encoder_adapter.cc; sourceTree = "<group>"; };
-		4131C267234B8CC10028A615 /* webrtc_video_engine.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = webrtc_video_engine.cc; path = engine/webrtc_video_engine.cc; sourceTree = "<group>"; };
-		4131C26A234B8CC20028A615 /* webrtc_voice_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = webrtc_voice_engine.h; path = engine/webrtc_voice_engine.h; sourceTree = "<group>"; };
-		4131C26C234B8CC20028A615 /* webrtc_voice_engine.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = webrtc_voice_engine.cc; path = engine/webrtc_voice_engine.cc; sourceTree = "<group>"; };
-		4131C26E234B8CC20028A615 /* adm_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = adm_helpers.h; path = engine/adm_helpers.h; sourceTree = "<group>"; };
-		4131C270234B8CC30028A615 /* adm_helpers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = adm_helpers.cc; path = engine/adm_helpers.cc; sourceTree = "<group>"; };
+		4131C245234B8CBB0028A615 /* webrtc_media_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_media_engine.h; sourceTree = "<group>"; };
+		4131C247234B8CBB0028A615 /* webrtc_media_engine_defaults.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = webrtc_media_engine_defaults.cc; sourceTree = "<group>"; };
+		4131C249234B8CBC0028A615 /* webrtc_media_engine.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = webrtc_media_engine.cc; sourceTree = "<group>"; };
+		4131C24B234B8CBC0028A615 /* payload_type_mapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = payload_type_mapper.h; sourceTree = "<group>"; };
+		4131C24C234B8CBC0028A615 /* multiplex_codec_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = multiplex_codec_factory.h; sourceTree = "<group>"; };
+		4131C24D234B8CBC0028A615 /* internal_encoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal_encoder_factory.h; sourceTree = "<group>"; };
+		4131C251234B8CBD0028A615 /* internal_decoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal_decoder_factory.h; sourceTree = "<group>"; };
+		4131C254234B8CBE0028A615 /* internal_encoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = internal_encoder_factory.cc; sourceTree = "<group>"; };
+		4131C255234B8CBE0028A615 /* null_webrtc_video_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = null_webrtc_video_engine.h; sourceTree = "<group>"; };
+		4131C256234B8CBE0028A615 /* internal_decoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = internal_decoder_factory.cc; sourceTree = "<group>"; };
+		4131C258234B8CBE0028A615 /* payload_type_mapper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = payload_type_mapper.cc; sourceTree = "<group>"; };
+		4131C25A234B8CBF0028A615 /* webrtc_video_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_video_engine.h; sourceTree = "<group>"; };
+		4131C25B234B8CBF0028A615 /* multiplex_codec_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = multiplex_codec_factory.cc; sourceTree = "<group>"; };
+		4131C25E234B8CBF0028A615 /* webrtc_media_engine_defaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_media_engine_defaults.h; sourceTree = "<group>"; };
+		4131C263234B8CC00028A615 /* simulcast_encoder_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simulcast_encoder_adapter.h; sourceTree = "<group>"; };
+		4131C265234B8CC10028A615 /* simulcast_encoder_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = simulcast_encoder_adapter.cc; sourceTree = "<group>"; };
+		4131C267234B8CC10028A615 /* webrtc_video_engine.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = webrtc_video_engine.cc; sourceTree = "<group>"; };
+		4131C26A234B8CC20028A615 /* webrtc_voice_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_voice_engine.h; sourceTree = "<group>"; };
+		4131C26C234B8CC20028A615 /* webrtc_voice_engine.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = webrtc_voice_engine.cc; sourceTree = "<group>"; };
+		4131C26E234B8CC20028A615 /* adm_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adm_helpers.h; sourceTree = "<group>"; };
+		4131C270234B8CC30028A615 /* adm_helpers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = adm_helpers.cc; sourceTree = "<group>"; };
 		4131C2B4234B8DB80028A615 /* create_peerconnection_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = create_peerconnection_factory.h; sourceTree = "<group>"; };
 		4131C2B6234B8DB80028A615 /* rtc_error.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_error.cc; sourceTree = "<group>"; };
 		4131C2B7234B8DB80028A615 /* create_peerconnection_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = create_peerconnection_factory.cc; sourceTree = "<group>"; };
@@ -6729,20 +6729,20 @@
 		4131C370234B957D0028A615 /* subband_erle_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = subband_erle_estimator.cc; sourceTree = "<group>"; };
 		4131C371234B957D0028A615 /* subtractor_output.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = subtractor_output.cc; sourceTree = "<group>"; };
 		4131C372234B957D0028A615 /* fullband_erle_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fullband_erle_estimator.cc; sourceTree = "<group>"; };
-		4131C39B234B96C10028A615 /* echo_canceller3_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = echo_canceller3_factory.cc; path = audio/echo_canceller3_factory.cc; sourceTree = "<group>"; };
-		4131C39C234B96C10028A615 /* audio_mixer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_mixer.h; path = audio/audio_mixer.h; sourceTree = "<group>"; };
-		4131C39D234B96C20028A615 /* audio_frame.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_frame.cc; path = audio/audio_frame.cc; sourceTree = "<group>"; };
-		4131C39E234B96C20028A615 /* audio_frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_frame.h; path = audio/audio_frame.h; sourceTree = "<group>"; };
-		4131C39F234B96C20028A615 /* echo_canceller3_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = echo_canceller3_config.cc; path = audio/echo_canceller3_config.cc; sourceTree = "<group>"; };
-		4131C3A0234B96C20028A615 /* echo_canceller3_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = echo_canceller3_factory.h; path = audio/echo_canceller3_factory.h; sourceTree = "<group>"; };
-		4131C3A1234B96C20028A615 /* channel_layout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = channel_layout.h; path = audio/channel_layout.h; sourceTree = "<group>"; };
-		4131C3A2234B96C20028A615 /* echo_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = echo_control.h; path = audio/echo_control.h; sourceTree = "<group>"; };
-		4131C3A3234B96C30028A615 /* echo_canceller3_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = echo_canceller3_config.h; path = audio/echo_canceller3_config.h; sourceTree = "<group>"; };
-		4131C3A4234B96C30028A615 /* channel_layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = channel_layout.cc; path = audio/channel_layout.cc; sourceTree = "<group>"; };
-		4131C3B0234B97110028A615 /* crypto_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crypto_options.h; path = crypto/crypto_options.h; sourceTree = "<group>"; };
-		4131C3B1234B97120028A615 /* frame_decryptor_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = frame_decryptor_interface.h; path = crypto/frame_decryptor_interface.h; sourceTree = "<group>"; };
-		4131C3B2234B97120028A615 /* crypto_options.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = crypto_options.cc; path = crypto/crypto_options.cc; sourceTree = "<group>"; };
-		4131C3B3234B97120028A615 /* frame_encryptor_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = frame_encryptor_interface.h; path = crypto/frame_encryptor_interface.h; sourceTree = "<group>"; };
+		4131C39B234B96C10028A615 /* echo_canceller3_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = echo_canceller3_factory.cc; sourceTree = "<group>"; };
+		4131C39C234B96C10028A615 /* audio_mixer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_mixer.h; sourceTree = "<group>"; };
+		4131C39D234B96C20028A615 /* audio_frame.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_frame.cc; sourceTree = "<group>"; };
+		4131C39E234B96C20028A615 /* audio_frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_frame.h; sourceTree = "<group>"; };
+		4131C39F234B96C20028A615 /* echo_canceller3_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = echo_canceller3_config.cc; sourceTree = "<group>"; };
+		4131C3A0234B96C20028A615 /* echo_canceller3_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_canceller3_factory.h; sourceTree = "<group>"; };
+		4131C3A1234B96C20028A615 /* channel_layout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_layout.h; sourceTree = "<group>"; };
+		4131C3A2234B96C20028A615 /* echo_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_control.h; sourceTree = "<group>"; };
+		4131C3A3234B96C30028A615 /* echo_canceller3_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = echo_canceller3_config.h; sourceTree = "<group>"; };
+		4131C3A4234B96C30028A615 /* channel_layout.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = channel_layout.cc; sourceTree = "<group>"; };
+		4131C3B0234B97110028A615 /* crypto_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_options.h; sourceTree = "<group>"; };
+		4131C3B1234B97120028A615 /* frame_decryptor_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_decryptor_interface.h; sourceTree = "<group>"; };
+		4131C3B2234B97120028A615 /* crypto_options.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = crypto_options.cc; sourceTree = "<group>"; };
+		4131C3B3234B97120028A615 /* frame_encryptor_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_encryptor_interface.h; sourceTree = "<group>"; };
 		4131C3B9234B97B30028A615 /* audio_coder_opus_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_coder_opus_common.cc; sourceTree = "<group>"; };
 		4131C3BA234B97B30028A615 /* audio_coder_opus_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_coder_opus_common.h; sourceTree = "<group>"; };
 		4131C3BB234B97B30028A615 /* audio_encoder_multi_channel_opus_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_multi_channel_opus_impl.h; sourceTree = "<group>"; };
@@ -6750,77 +6750,77 @@
 		4131C3BD234B97B40028A615 /* audio_decoder_multi_channel_opus_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_multi_channel_opus_impl.cc; sourceTree = "<group>"; };
 		4131C3BE234B97B40028A615 /* audio_encoder_multi_channel_opus_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_multi_channel_opus_impl.cc; sourceTree = "<group>"; };
 		4131C3C6234B97F30028A615 /* sctp_transport_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sctp_transport_internal.h; sourceTree = "<group>"; };
-		4131C3CC234B98420028A615 /* rtc_stats_report.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_stats_report.cc; path = stats/rtc_stats_report.cc; sourceTree = "<group>"; };
-		4131C3CD234B98420028A615 /* rtc_stats.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_stats.cc; path = stats/rtc_stats.cc; sourceTree = "<group>"; };
-		4131C3D0234C79CF0028A615 /* vp8_temporal_layers_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vp8_temporal_layers_factory.h; path = video_codecs/vp8_temporal_layers_factory.h; sourceTree = "<group>"; };
-		4131C3D1234C79D00028A615 /* vp8_temporal_layers_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = vp8_temporal_layers_factory.cc; path = video_codecs/vp8_temporal_layers_factory.cc; sourceTree = "<group>"; };
-		4131C3D2234C79D00028A615 /* vp8_frame_buffer_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vp8_frame_buffer_controller.h; path = video_codecs/vp8_frame_buffer_controller.h; sourceTree = "<group>"; };
-		4131C3D3234C79D00028A615 /* vp8_temporal_layers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = vp8_temporal_layers.cc; path = video_codecs/vp8_temporal_layers.cc; sourceTree = "<group>"; };
-		4131C3D4234C79D00028A615 /* vp8_frame_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = vp8_frame_config.cc; path = video_codecs/vp8_frame_config.cc; sourceTree = "<group>"; };
-		4131C3D5234C79D00028A615 /* vp8_frame_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vp8_frame_config.h; path = video_codecs/vp8_frame_config.h; sourceTree = "<group>"; };
-		4131C3DC234C7A070028A615 /* rtc_event_processor.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_event_processor.cc; path = rtc_event_log/rtc_event_processor.cc; sourceTree = "<group>"; };
-		4131C3DD234C7A070028A615 /* ice_logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ice_logger.h; path = rtc_event_log/ice_logger.h; sourceTree = "<group>"; };
-		4131C3DE234C7A070028A615 /* rtc_event_processor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event_processor.h; path = rtc_event_log/rtc_event_processor.h; sourceTree = "<group>"; };
-		4131C3E0234C7A080028A615 /* ice_logger.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ice_logger.cc; path = rtc_event_log/ice_logger.cc; sourceTree = "<group>"; };
-		4131C3E8234C7A490028A615 /* cascaded_biquad_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cascaded_biquad_filter.cc; path = utility/cascaded_biquad_filter.cc; sourceTree = "<group>"; };
-		4131C3E9234C7A490028A615 /* pffft_wrapper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pffft_wrapper.cc; path = utility/pffft_wrapper.cc; sourceTree = "<group>"; };
-		4131C3EA234C7A490028A615 /* cascaded_biquad_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = cascaded_biquad_filter.h; path = utility/cascaded_biquad_filter.h; sourceTree = "<group>"; };
-		4131C3EB234C7A490028A615 /* pffft_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pffft_wrapper.h; path = utility/pffft_wrapper.h; sourceTree = "<group>"; };
-		4131C3F0234C7B020028A615 /* audio_encoder_multi_channel_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_multi_channel_opus.h; path = audio_codecs/opus/audio_encoder_multi_channel_opus.h; sourceTree = "<group>"; };
-		4131C3F1234C7B020028A615 /* audio_encoder_multi_channel_opus_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_multi_channel_opus_config.h; path = audio_codecs/opus/audio_encoder_multi_channel_opus_config.h; sourceTree = "<group>"; };
-		4131C3F2234C7B020028A615 /* audio_decoder_multi_channel_opus.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder_multi_channel_opus.cc; path = audio_codecs/opus/audio_decoder_multi_channel_opus.cc; sourceTree = "<group>"; };
-		4131C3F3234C7B020028A615 /* audio_encoder_multi_channel_opus.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_multi_channel_opus.cc; path = audio_codecs/opus/audio_encoder_multi_channel_opus.cc; sourceTree = "<group>"; };
-		4131C3F4234C7B020028A615 /* audio_decoder_multi_channel_opus_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_multi_channel_opus_config.h; path = audio_codecs/opus/audio_decoder_multi_channel_opus_config.h; sourceTree = "<group>"; };
-		4131C3F5234C7B030028A615 /* audio_encoder_multi_channel_opus_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_multi_channel_opus_config.cc; path = audio_codecs/opus/audio_encoder_multi_channel_opus_config.cc; sourceTree = "<group>"; };
-		4131C3F6234C7B030028A615 /* audio_decoder_multi_channel_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_multi_channel_opus.h; path = audio_codecs/opus/audio_decoder_multi_channel_opus.h; sourceTree = "<group>"; };
+		4131C3CC234B98420028A615 /* rtc_stats_report.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_stats_report.cc; sourceTree = "<group>"; };
+		4131C3CD234B98420028A615 /* rtc_stats.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_stats.cc; sourceTree = "<group>"; };
+		4131C3D0234C79CF0028A615 /* vp8_temporal_layers_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8_temporal_layers_factory.h; sourceTree = "<group>"; };
+		4131C3D1234C79D00028A615 /* vp8_temporal_layers_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vp8_temporal_layers_factory.cc; sourceTree = "<group>"; };
+		4131C3D2234C79D00028A615 /* vp8_frame_buffer_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8_frame_buffer_controller.h; sourceTree = "<group>"; };
+		4131C3D3234C79D00028A615 /* vp8_temporal_layers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vp8_temporal_layers.cc; sourceTree = "<group>"; };
+		4131C3D4234C79D00028A615 /* vp8_frame_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vp8_frame_config.cc; sourceTree = "<group>"; };
+		4131C3D5234C79D00028A615 /* vp8_frame_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8_frame_config.h; sourceTree = "<group>"; };
+		4131C3DC234C7A070028A615 /* rtc_event_processor.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_processor.cc; sourceTree = "<group>"; };
+		4131C3DD234C7A070028A615 /* ice_logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ice_logger.h; sourceTree = "<group>"; };
+		4131C3DE234C7A070028A615 /* rtc_event_processor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_processor.h; sourceTree = "<group>"; };
+		4131C3E0234C7A080028A615 /* ice_logger.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ice_logger.cc; sourceTree = "<group>"; };
+		4131C3E8234C7A490028A615 /* cascaded_biquad_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cascaded_biquad_filter.cc; sourceTree = "<group>"; };
+		4131C3E9234C7A490028A615 /* pffft_wrapper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pffft_wrapper.cc; sourceTree = "<group>"; };
+		4131C3EA234C7A490028A615 /* cascaded_biquad_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cascaded_biquad_filter.h; sourceTree = "<group>"; };
+		4131C3EB234C7A490028A615 /* pffft_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pffft_wrapper.h; sourceTree = "<group>"; };
+		4131C3F0234C7B020028A615 /* audio_encoder_multi_channel_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_multi_channel_opus.h; sourceTree = "<group>"; };
+		4131C3F1234C7B020028A615 /* audio_encoder_multi_channel_opus_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_multi_channel_opus_config.h; sourceTree = "<group>"; };
+		4131C3F2234C7B020028A615 /* audio_decoder_multi_channel_opus.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_multi_channel_opus.cc; sourceTree = "<group>"; };
+		4131C3F3234C7B020028A615 /* audio_encoder_multi_channel_opus.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_multi_channel_opus.cc; sourceTree = "<group>"; };
+		4131C3F4234C7B020028A615 /* audio_decoder_multi_channel_opus_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_multi_channel_opus_config.h; sourceTree = "<group>"; };
+		4131C3F5234C7B030028A615 /* audio_encoder_multi_channel_opus_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_multi_channel_opus_config.cc; sourceTree = "<group>"; };
+		4131C3F6234C7B030028A615 /* audio_decoder_multi_channel_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_multi_channel_opus.h; sourceTree = "<group>"; };
 		4131C3FE234C7B350028A615 /* high_pass_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = high_pass_filter.h; sourceTree = "<group>"; };
 		4131C3FF234C7B350028A615 /* high_pass_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = high_pass_filter.cc; sourceTree = "<group>"; };
 		4131C402234C7B7E0028A615 /* auto_correlation.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = auto_correlation.cc; sourceTree = "<group>"; };
 		4131C403234C7B7E0028A615 /* auto_correlation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = auto_correlation.h; sourceTree = "<group>"; };
 		4131C404234C7B7E0028A615 /* rnn_vad_tool.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rnn_vad_tool.cc; sourceTree = "<group>"; };
 		4131C41C234C7C7C0028A615 /* video_bitrate_allocator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_bitrate_allocator.cc; sourceTree = "<group>"; };
-		4131C420234C7D240028A615 /* fifo_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fifo_buffer.h; path = rtc_base/memory/fifo_buffer.h; sourceTree = "<group>"; };
-		4131C421234C7D250028A615 /* fifo_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fifo_buffer.cc; path = rtc_base/memory/fifo_buffer.cc; sourceTree = "<group>"; };
-		4131C422234C7D250028A615 /* aligned_malloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = aligned_malloc.h; path = rtc_base/memory/aligned_malloc.h; sourceTree = "<group>"; };
-		4131C423234C7D250028A615 /* aligned_malloc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = aligned_malloc.cc; path = rtc_base/memory/aligned_malloc.cc; sourceTree = "<group>"; };
-		4131C42B234C7D8A0028A615 /* generic_frame_info.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = generic_frame_info.cc; path = generic_frame_descriptor/generic_frame_info.cc; sourceTree = "<group>"; };
-		4131C42C234C7D8A0028A615 /* generic_frame_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = generic_frame_info.h; path = generic_frame_descriptor/generic_frame_info.h; sourceTree = "<group>"; };
+		4131C420234C7D240028A615 /* fifo_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fifo_buffer.h; sourceTree = "<group>"; };
+		4131C421234C7D250028A615 /* fifo_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fifo_buffer.cc; sourceTree = "<group>"; };
+		4131C422234C7D250028A615 /* aligned_malloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aligned_malloc.h; sourceTree = "<group>"; };
+		4131C423234C7D250028A615 /* aligned_malloc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = aligned_malloc.cc; sourceTree = "<group>"; };
+		4131C42B234C7D8A0028A615 /* generic_frame_info.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = generic_frame_info.cc; sourceTree = "<group>"; };
+		4131C42C234C7D8A0028A615 /* generic_frame_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = generic_frame_info.h; sourceTree = "<group>"; };
 		4131C42F234C7D960028A615 /* frame_rate_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_rate_estimator.h; sourceTree = "<group>"; };
 		4131C430234C7D960028A615 /* frame_rate_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = frame_rate_estimator.cc; sourceTree = "<group>"; };
-		4131C437234C80070028A615 /* pffft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pffft.c; path = pffft/src/pffft.c; sourceTree = "<group>"; };
-		4131C438234C80070028A615 /* fftpack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fftpack.h; path = pffft/src/fftpack.h; sourceTree = "<group>"; };
-		4131C439234C80070028A615 /* pffft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pffft.h; path = pffft/src/pffft.h; sourceTree = "<group>"; };
-		4131C43A234C80070028A615 /* fftpack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fftpack.c; path = pffft/src/fftpack.c; sourceTree = "<group>"; };
+		4131C437234C80070028A615 /* pffft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pffft.c; sourceTree = "<group>"; };
+		4131C438234C80070028A615 /* fftpack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fftpack.h; sourceTree = "<group>"; };
+		4131C439234C80070028A615 /* pffft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pffft.h; sourceTree = "<group>"; };
+		4131C43A234C80070028A615 /* fftpack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fftpack.c; sourceTree = "<group>"; };
 		4131C43F234C80AA0028A615 /* decoded_frames_history.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = decoded_frames_history.cc; sourceTree = "<group>"; };
 		4131C441234C80AB0028A615 /* decoded_frames_history.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decoded_frames_history.h; sourceTree = "<group>"; };
-		4131C447234C80DB0028A615 /* channel_mixing_matrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = channel_mixing_matrix.h; path = utility/channel_mixing_matrix.h; sourceTree = "<group>"; };
-		4131C448234C80DB0028A615 /* channel_mixer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = channel_mixer.cc; path = utility/channel_mixer.cc; sourceTree = "<group>"; };
-		4131C449234C80DC0028A615 /* channel_mixer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = channel_mixer.h; path = utility/channel_mixer.h; sourceTree = "<group>"; };
-		4131C44A234C80DC0028A615 /* channel_mixing_matrix.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = channel_mixing_matrix.cc; path = utility/channel_mixing_matrix.cc; sourceTree = "<group>"; };
-		4131C450234C81180028A615 /* relay_port_factory_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = relay_port_factory_interface.h; path = client/relay_port_factory_interface.h; sourceTree = "<group>"; };
-		4131C451234C81180028A615 /* basic_port_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = basic_port_allocator.h; path = client/basic_port_allocator.h; sourceTree = "<group>"; };
-		4131C452234C81180028A615 /* turn_port_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = turn_port_factory.cc; path = client/turn_port_factory.cc; sourceTree = "<group>"; };
-		4131C453234C81180028A615 /* turn_port_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = turn_port_factory.h; path = client/turn_port_factory.h; sourceTree = "<group>"; };
-		4131C454234C81180028A615 /* basic_port_allocator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = basic_port_allocator.cc; path = client/basic_port_allocator.cc; sourceTree = "<group>"; };
-		4131C45B234C81710028A615 /* video_coding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_coding.h; path = include/video_coding.h; sourceTree = "<group>"; };
-		4131C45C234C81720028A615 /* video_error_codes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_error_codes.h; path = include/video_error_codes.h; sourceTree = "<group>"; };
-		4131C45D234C81720028A615 /* video_coding_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_coding_defines.h; path = include/video_coding_defines.h; sourceTree = "<group>"; };
-		4131C45E234C81720028A615 /* video_codec_initializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_codec_initializer.h; path = include/video_codec_initializer.h; sourceTree = "<group>"; };
-		4131C45F234C81720028A615 /* video_codec_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_codec_interface.h; path = include/video_codec_interface.h; sourceTree = "<group>"; };
-		4131C460234C81720028A615 /* video_codec_interface.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_codec_interface.cc; path = include/video_codec_interface.cc; sourceTree = "<group>"; };
-		4131C468234C81B40028A615 /* rtc_event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event.h; path = rtc_event_log/rtc_event.h; sourceTree = "<group>"; };
-		4131C469234C81B40028A615 /* rtc_event.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_event.cc; path = rtc_event_log/rtc_event.cc; sourceTree = "<group>"; };
-		4131C46A234C81B50028A615 /* rtc_event_log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event_log.h; path = rtc_event_log/rtc_event_log.h; sourceTree = "<group>"; };
-		4131C46B234C81B50028A615 /* rtc_event_log_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event_log_factory.h; path = rtc_event_log/rtc_event_log_factory.h; sourceTree = "<group>"; };
-		4131C46C234C81B50028A615 /* rtc_event_log_factory_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event_log_factory_interface.h; path = rtc_event_log/rtc_event_log_factory_interface.h; sourceTree = "<group>"; };
-		4131C46D234C81B50028A615 /* rtc_event_log_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_event_log_factory.cc; path = rtc_event_log/rtc_event_log_factory.cc; sourceTree = "<group>"; };
-		4131C46E234C81B60028A615 /* rtc_event_log.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_event_log.cc; path = rtc_event_log/rtc_event_log.cc; sourceTree = "<group>"; };
-		4131C476234C81EA0028A615 /* call_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = call_factory.h; path = call/call_factory.h; sourceTree = "<group>"; };
-		4131C477234C81EA0028A615 /* call_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = call_factory.cc; path = call/call_factory.cc; sourceTree = "<group>"; };
-		4131C47F234C82730028A615 /* task_queue_base.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = task_queue_base.cc; path = task_queue/task_queue_base.cc; sourceTree = "<group>"; };
-		4131C480234C82740028A615 /* default_task_queue_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = default_task_queue_factory.h; path = task_queue/default_task_queue_factory.h; sourceTree = "<group>"; };
-		4131C481234C82740028A615 /* task_queue_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = task_queue_base.h; path = task_queue/task_queue_base.h; sourceTree = "<group>"; };
-		4131C483234C82740028A615 /* task_queue_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = task_queue_factory.h; path = task_queue/task_queue_factory.h; sourceTree = "<group>"; };
+		4131C447234C80DB0028A615 /* channel_mixing_matrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_mixing_matrix.h; sourceTree = "<group>"; };
+		4131C448234C80DB0028A615 /* channel_mixer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = channel_mixer.cc; sourceTree = "<group>"; };
+		4131C449234C80DC0028A615 /* channel_mixer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_mixer.h; sourceTree = "<group>"; };
+		4131C44A234C80DC0028A615 /* channel_mixing_matrix.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = channel_mixing_matrix.cc; sourceTree = "<group>"; };
+		4131C450234C81180028A615 /* relay_port_factory_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = relay_port_factory_interface.h; sourceTree = "<group>"; };
+		4131C451234C81180028A615 /* basic_port_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = basic_port_allocator.h; sourceTree = "<group>"; };
+		4131C452234C81180028A615 /* turn_port_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = turn_port_factory.cc; sourceTree = "<group>"; };
+		4131C453234C81180028A615 /* turn_port_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = turn_port_factory.h; sourceTree = "<group>"; };
+		4131C454234C81180028A615 /* basic_port_allocator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = basic_port_allocator.cc; sourceTree = "<group>"; };
+		4131C45B234C81710028A615 /* video_coding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_coding.h; sourceTree = "<group>"; };
+		4131C45C234C81720028A615 /* video_error_codes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_error_codes.h; sourceTree = "<group>"; };
+		4131C45D234C81720028A615 /* video_coding_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_coding_defines.h; sourceTree = "<group>"; };
+		4131C45E234C81720028A615 /* video_codec_initializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_codec_initializer.h; sourceTree = "<group>"; };
+		4131C45F234C81720028A615 /* video_codec_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_codec_interface.h; sourceTree = "<group>"; };
+		4131C460234C81720028A615 /* video_codec_interface.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_codec_interface.cc; sourceTree = "<group>"; };
+		4131C468234C81B40028A615 /* rtc_event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event.h; sourceTree = "<group>"; };
+		4131C469234C81B40028A615 /* rtc_event.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event.cc; sourceTree = "<group>"; };
+		4131C46A234C81B50028A615 /* rtc_event_log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_log.h; sourceTree = "<group>"; };
+		4131C46B234C81B50028A615 /* rtc_event_log_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_log_factory.h; sourceTree = "<group>"; };
+		4131C46C234C81B50028A615 /* rtc_event_log_factory_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_log_factory_interface.h; sourceTree = "<group>"; };
+		4131C46D234C81B50028A615 /* rtc_event_log_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_log_factory.cc; sourceTree = "<group>"; };
+		4131C46E234C81B60028A615 /* rtc_event_log.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_log.cc; sourceTree = "<group>"; };
+		4131C476234C81EA0028A615 /* call_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = call_factory.h; sourceTree = "<group>"; };
+		4131C477234C81EA0028A615 /* call_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = call_factory.cc; sourceTree = "<group>"; };
+		4131C47F234C82730028A615 /* task_queue_base.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = task_queue_base.cc; sourceTree = "<group>"; };
+		4131C480234C82740028A615 /* default_task_queue_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = default_task_queue_factory.h; sourceTree = "<group>"; };
+		4131C481234C82740028A615 /* task_queue_base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = task_queue_base.h; sourceTree = "<group>"; };
+		4131C483234C82740028A615 /* task_queue_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = task_queue_factory.h; sourceTree = "<group>"; };
 		4131C48D234C82EE0028A615 /* field_trial_based_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = field_trial_based_config.cc; sourceTree = "<group>"; };
 		4131C48E234C82EE0028A615 /* field_trial_based_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = field_trial_based_config.h; sourceTree = "<group>"; };
 		4131C48F234C82EE0028A615 /* enums.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enums.h; sourceTree = "<group>"; };
@@ -6834,7 +6834,7 @@
 		4131C49A234C834E0028A615 /* buffered_frame_decryptor.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = buffered_frame_decryptor.cc; sourceTree = "<group>"; };
 		4131C49B234C834E0028A615 /* encoder_overshoot_detector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encoder_overshoot_detector.h; sourceTree = "<group>"; };
 		4131C49C234C834E0028A615 /* encoder_bitrate_adjuster.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = encoder_bitrate_adjuster.cc; sourceTree = "<group>"; };
-		4131C4B1234C838E0028A615 /* rtp_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_source.h; path = rtp/rtp_source.h; sourceTree = "<group>"; };
+		4131C4B1234C838E0028A615 /* rtp_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_source.h; sourceTree = "<group>"; };
 		4131C4B3234C83DC0028A615 /* remote_estimate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remote_estimate.h; sourceTree = "<group>"; };
 		4131C4B4234C83DD0028A615 /* remote_estimate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = remote_estimate.cc; sourceTree = "<group>"; };
 		4131C4B5234C83DD0028A615 /* loss_notification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loss_notification.h; sourceTree = "<group>"; };
@@ -6855,15 +6855,15 @@
 		4131C4D0234C84A20028A615 /* rtp_dependency_descriptor_writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_dependency_descriptor_writer.h; sourceTree = "<group>"; };
 		4131C4D1234C84A20028A615 /* rtp_sequence_number_map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_sequence_number_map.cc; sourceTree = "<group>"; };
 		4131C4D2234C84A30028A615 /* rtp_sequence_number_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_sequence_number_map.h; sourceTree = "<group>"; };
-		4131C4DF234C84DD0028A615 /* default_task_queue_factory_stdlib.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = default_task_queue_factory_stdlib.cc; path = task_queue/default_task_queue_factory_stdlib.cc; sourceTree = "<group>"; };
-		4131C4E2234C852E0028A615 /* repeating_task.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = repeating_task.h; path = Source/webrtc/rtc_base/task_utils/repeating_task.h; sourceTree = SOURCE_ROOT; };
-		4131C4E3234C852E0028A615 /* repeating_task.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = repeating_task.cc; path = Source/webrtc/rtc_base/task_utils/repeating_task.cc; sourceTree = SOURCE_ROOT; };
-		4131C4E8234C86110028A615 /* report_block_data.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = report_block_data.cc; path = rtp_rtcp/include/report_block_data.cc; sourceTree = "<group>"; };
-		4131C4E9234C86110028A615 /* report_block_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = report_block_data.h; path = rtp_rtcp/include/report_block_data.h; sourceTree = "<group>"; };
-		4131C4EA234C86110028A615 /* rtp_packet_sender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_packet_sender.h; path = rtp_rtcp/include/rtp_packet_sender.h; sourceTree = "<group>"; };
-		4131C4EB234C86110028A615 /* rtcp_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtcp_statistics.h; path = rtp_rtcp/include/rtcp_statistics.h; sourceTree = "<group>"; };
-		4131C4F0234C86380028A615 /* task_queue_stdlib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = task_queue_stdlib.h; path = rtc_base/task_queue_stdlib.h; sourceTree = "<group>"; };
-		4131C4F1234C86390028A615 /* task_queue_stdlib.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = task_queue_stdlib.cc; path = rtc_base/task_queue_stdlib.cc; sourceTree = "<group>"; };
+		4131C4DF234C84DD0028A615 /* default_task_queue_factory_stdlib.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = default_task_queue_factory_stdlib.cc; sourceTree = "<group>"; };
+		4131C4E2234C852E0028A615 /* repeating_task.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = repeating_task.h; sourceTree = "<group>"; };
+		4131C4E3234C852E0028A615 /* repeating_task.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = repeating_task.cc; sourceTree = "<group>"; };
+		4131C4E8234C86110028A615 /* report_block_data.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = report_block_data.cc; sourceTree = "<group>"; };
+		4131C4E9234C86110028A615 /* report_block_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = report_block_data.h; sourceTree = "<group>"; };
+		4131C4EA234C86110028A615 /* rtp_packet_sender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_packet_sender.h; sourceTree = "<group>"; };
+		4131C4EB234C86110028A615 /* rtcp_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtcp_statistics.h; sourceTree = "<group>"; };
+		4131C4F0234C86380028A615 /* task_queue_stdlib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = task_queue_stdlib.h; sourceTree = "<group>"; };
+		4131C4F1234C86390028A615 /* task_queue_stdlib.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = task_queue_stdlib.cc; sourceTree = "<group>"; };
 		4131C4F4234C867B0028A615 /* histogram.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = histogram.cc; sourceTree = "<group>"; };
 		4131C4F5234C867B0028A615 /* histogram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = histogram.h; sourceTree = "<group>"; };
 		4131C4F9234C86CA0028A615 /* yield_policy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yield_policy.h; sourceTree = "<group>"; };
@@ -6912,19 +6912,19 @@
 		4131C530234C8B180028A615 /* rtc_event_generic_packet_sent.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_generic_packet_sent.cc; sourceTree = "<group>"; };
 		4131C531234C8B180028A615 /* rtc_event_probe_result_failure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_probe_result_failure.h; sourceTree = "<group>"; };
 		4131C532234C8B190028A615 /* rtc_event_dtls_writable_state.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_dtls_writable_state.cc; sourceTree = "<group>"; };
-		4131C567234CBB480028A615 /* task_queue_libevent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = task_queue_libevent.h; path = rtc_base/task_queue_libevent.h; sourceTree = "<group>"; };
-		4131C568234CBB480028A615 /* task_queue_libevent.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = task_queue_libevent.cc; path = rtc_base/task_queue_libevent.cc; sourceTree = "<group>"; };
-		413239ED266524C700B38623 /* async_resolver.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = async_resolver.cc; path = rtc_base/async_resolver.cc; sourceTree = "<group>"; };
-		413239EE266524C700B38623 /* async_resolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = async_resolver.h; path = rtc_base/async_resolver.h; sourceTree = "<group>"; };
-		413239EF266524C700B38623 /* never_destroyed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = never_destroyed.h; path = rtc_base/never_destroyed.h; sourceTree = "<group>"; };
-		413239F3266524FD00B38623 /* openssl_key_pair.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openssl_key_pair.cc; path = rtc_base/openssl_key_pair.cc; sourceTree = "<group>"; };
-		413239F4266524FE00B38623 /* openssl_key_pair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openssl_key_pair.h; path = rtc_base/openssl_key_pair.h; sourceTree = "<group>"; };
-		413239F72665256400B38623 /* system_time.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = system_time.cc; path = rtc_base/system_time.cc; sourceTree = "<group>"; };
-		413239F82665256500B38623 /* system_time.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = system_time.h; path = rtc_base/system_time.h; sourceTree = "<group>"; };
-		413239FB266525C100B38623 /* boringssl_certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = boringssl_certificate.h; path = rtc_base/boringssl_certificate.h; sourceTree = "<group>"; };
-		413239FC266525C100B38623 /* boringssl_identity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = boringssl_identity.h; path = rtc_base/boringssl_identity.h; sourceTree = "<group>"; };
-		413239FD266525C100B38623 /* boringssl_certificate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = boringssl_certificate.cc; path = rtc_base/boringssl_certificate.cc; sourceTree = "<group>"; };
-		413239FE266525C200B38623 /* boringssl_identity.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = boringssl_identity.cc; path = rtc_base/boringssl_identity.cc; sourceTree = "<group>"; };
+		4131C567234CBB480028A615 /* task_queue_libevent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = task_queue_libevent.h; sourceTree = "<group>"; };
+		4131C568234CBB480028A615 /* task_queue_libevent.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = task_queue_libevent.cc; sourceTree = "<group>"; };
+		413239ED266524C700B38623 /* async_resolver.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = async_resolver.cc; sourceTree = "<group>"; };
+		413239EE266524C700B38623 /* async_resolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_resolver.h; sourceTree = "<group>"; };
+		413239EF266524C700B38623 /* never_destroyed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = never_destroyed.h; sourceTree = "<group>"; };
+		413239F3266524FD00B38623 /* openssl_key_pair.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = openssl_key_pair.cc; sourceTree = "<group>"; };
+		413239F4266524FE00B38623 /* openssl_key_pair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = openssl_key_pair.h; sourceTree = "<group>"; };
+		413239F72665256400B38623 /* system_time.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = system_time.cc; sourceTree = "<group>"; };
+		413239F82665256500B38623 /* system_time.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = system_time.h; sourceTree = "<group>"; };
+		413239FB266525C100B38623 /* boringssl_certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = boringssl_certificate.h; sourceTree = "<group>"; };
+		413239FC266525C100B38623 /* boringssl_identity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = boringssl_identity.h; sourceTree = "<group>"; };
+		413239FD266525C100B38623 /* boringssl_certificate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = boringssl_certificate.cc; sourceTree = "<group>"; };
+		413239FE266525C200B38623 /* boringssl_identity.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = boringssl_identity.cc; sourceTree = "<group>"; };
 		41323A042665261500B38623 /* default_socket_server.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = default_socket_server.cc; sourceTree = "<group>"; };
 		41323A052665261500B38623 /* default_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = default_socket_server.h; sourceTree = "<group>"; };
 		41323A082665265C00B38623 /* usage_pattern.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = usage_pattern.cc; sourceTree = "<group>"; };
@@ -6963,10 +6963,10 @@
 		41323A6126652AA200B38623 /* connection_context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = connection_context.h; sourceTree = "<group>"; };
 		41323A6426652AD500B38623 /* inter_arrival_delta.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inter_arrival_delta.cc; sourceTree = "<group>"; };
 		41323A6526652AD500B38623 /* inter_arrival_delta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inter_arrival_delta.h; sourceTree = "<group>"; };
-		41323A6826652B1500B38623 /* vp9_profile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vp9_profile.h; path = video_codecs/vp9_profile.h; sourceTree = "<group>"; };
-		41323A6926652B1500B38623 /* vp9_profile.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = vp9_profile.cc; path = video_codecs/vp9_profile.cc; sourceTree = "<group>"; };
-		41323A6C26652B5700B38623 /* callback_list.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = callback_list.cc; path = rtc_base/callback_list.cc; sourceTree = "<group>"; };
-		41323A6D26652B5800B38623 /* callback_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = callback_list.h; path = rtc_base/callback_list.h; sourceTree = "<group>"; };
+		41323A6826652B1500B38623 /* vp9_profile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp9_profile.h; sourceTree = "<group>"; };
+		41323A6926652B1500B38623 /* vp9_profile.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vp9_profile.cc; sourceTree = "<group>"; };
+		41323A6C26652B5700B38623 /* callback_list.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = callback_list.cc; sourceTree = "<group>"; };
+		41323A6D26652B5800B38623 /* callback_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = callback_list.h; sourceTree = "<group>"; };
 		41323A7126652BB000B38623 /* async_audio_processing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_audio_processing.h; sourceTree = "<group>"; };
 		41323A7226652BB000B38623 /* async_audio_processing.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = async_audio_processing.cc; sourceTree = "<group>"; };
 		41323A7526652BEF00B38623 /* packet_arrival_map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = packet_arrival_map.cc; sourceTree = "<group>"; };
@@ -6999,10 +6999,10 @@
 		41323AAB26652FEC00B38623 /* rnn_fc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rnn_fc.h; sourceTree = "<group>"; };
 		41323AAC26652FED00B38623 /* rnn_gru.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rnn_gru.h; sourceTree = "<group>"; };
 		41323AAD26652FED00B38623 /* rnn_fc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rnn_fc.cc; sourceTree = "<group>"; };
-		41323AB2266530C800B38623 /* version.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = version.cc; path = call/version.cc; sourceTree = "<group>"; };
-		41323AB3266530C900B38623 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = version.h; path = call/version.h; sourceTree = "<group>"; };
-		41323AB6266530F400B38623 /* sdp_video_format_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sdp_video_format_utils.cc; path = base/sdp_video_format_utils.cc; sourceTree = "<group>"; };
-		41323AB7266530F500B38623 /* sdp_video_format_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sdp_video_format_utils.h; path = base/sdp_video_format_utils.h; sourceTree = "<group>"; };
+		41323AB2266530C800B38623 /* version.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = version.cc; sourceTree = "<group>"; };
+		41323AB3266530C900B38623 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
+		41323AB6266530F400B38623 /* sdp_video_format_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sdp_video_format_utils.cc; sourceTree = "<group>"; };
+		41323AB7266530F500B38623 /* sdp_video_format_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sdp_video_format_utils.h; sourceTree = "<group>"; };
 		41323ABA2665359700B38623 /* qp_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qp_parser.cc; sourceTree = "<group>"; };
 		41323ABB2665359700B38623 /* qp_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qp_parser.h; sourceTree = "<group>"; };
 		41323ABE2665363300B38623 /* vector_math.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vector_math.h; sourceTree = "<group>"; };
@@ -7039,69 +7039,69 @@
 		41330A37212E2C3600280939 /* vpx_write_yuv_frame.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vpx_write_yuv_frame.c; sourceTree = "<group>"; };
 		41330A38212E2C3600280939 /* vpx_write_yuv_frame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vpx_write_yuv_frame.h; sourceTree = "<group>"; };
 		41330A39212E2C3600280939 /* vpx_thread.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vpx_thread.c; sourceTree = "<group>"; };
-		413A21381FE0F0EE00373E99 /* srtp_priv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = srtp_priv.h; path = include/srtp_priv.h; sourceTree = "<group>"; };
-		413A21391FE0F0EF00373E99 /* ekt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ekt.h; path = include/ekt.h; sourceTree = "<group>"; };
-		413A213A1FE0F0EF00373E99 /* srtp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = srtp.h; path = include/srtp.h; sourceTree = "<group>"; };
-		413A213B1FE0F0EF00373E99 /* ut_sim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ut_sim.h; path = include/ut_sim.h; sourceTree = "<group>"; };
-		413A213C1FE0F0EF00373E99 /* getopt_s.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = getopt_s.h; path = include/getopt_s.h; sourceTree = "<group>"; };
-		413A24021FE1990300373E99 /* RTCVideoViewShading.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoViewShading.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoViewShading.h; sourceTree = "<group>"; };
-		413A24031FE1990300373E99 /* RTCRtpReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCRtpReceiver.h; path = sdk/objc/Framework/Headers/WebRTC/RTCRtpReceiver.h; sourceTree = "<group>"; };
-		413A24041FE1990300373E99 /* RTCVideoCodecH264.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoCodecH264.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoCodecH264.h; sourceTree = "<group>"; };
-		413A24051FE1990300373E99 /* RTCVideoCapturer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoCapturer.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoCapturer.h; sourceTree = "<group>"; };
-		413A24061FE1990400373E99 /* RTCPeerConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCPeerConnection.h; path = sdk/objc/Framework/Headers/WebRTC/RTCPeerConnection.h; sourceTree = "<group>"; };
-		413A24081FE1990400373E99 /* RTCFieldTrials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCFieldTrials.h; path = sdk/objc/Framework/Headers/WebRTC/RTCFieldTrials.h; sourceTree = "<group>"; };
-		413A24091FE1990400373E99 /* RTCVideoFrameBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoFrameBuffer.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoFrameBuffer.h; sourceTree = "<group>"; };
-		413A240A1FE1990400373E99 /* RTCLegacyStatsReport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCLegacyStatsReport.h; path = sdk/objc/Framework/Headers/WebRTC/RTCLegacyStatsReport.h; sourceTree = "<group>"; };
-		413A240B1FE1990500373E99 /* RTCVideoCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoCodec.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoCodec.h; sourceTree = "<group>"; };
-		413A240C1FE1990500373E99 /* RTCConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCConfiguration.h; path = sdk/objc/Framework/Headers/WebRTC/RTCConfiguration.h; sourceTree = "<group>"; };
-		413A240D1FE1990500373E99 /* RTCRtpParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCRtpParameters.h; path = sdk/objc/Framework/Headers/WebRTC/RTCRtpParameters.h; sourceTree = "<group>"; };
-		413A240E1FE1990500373E99 /* RTCVideoEncoderVP9.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoEncoderVP9.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoEncoderVP9.h; sourceTree = "<group>"; };
-		413A240F1FE1990600373E99 /* RTCMediaStreamTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMediaStreamTrack.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMediaStreamTrack.h; sourceTree = "<group>"; };
-		413A24111FE1990600373E99 /* RTCMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMacros.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMacros.h; sourceTree = "<group>"; };
-		413A24121FE1990600373E99 /* RTCSessionDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCSessionDescription.h; path = sdk/objc/Framework/Headers/WebRTC/RTCSessionDescription.h; sourceTree = "<group>"; };
-		413A24131FE1990700373E99 /* RTCAudioSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCAudioSource.h; path = sdk/objc/Framework/Headers/WebRTC/RTCAudioSource.h; sourceTree = "<group>"; };
-		413A24141FE1990700373E99 /* RTCRtpEncodingParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCRtpEncodingParameters.h; path = sdk/objc/Framework/Headers/WebRTC/RTCRtpEncodingParameters.h; sourceTree = "<group>"; };
-		413A24151FE1990700373E99 /* RTCCameraVideoCapturer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCCameraVideoCapturer.h; path = sdk/objc/Framework/Headers/WebRTC/RTCCameraVideoCapturer.h; sourceTree = "<group>"; };
-		413A24161FE1990800373E99 /* RTCIceCandidate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCIceCandidate.h; path = sdk/objc/Framework/Headers/WebRTC/RTCIceCandidate.h; sourceTree = "<group>"; };
-		413A24171FE1990800373E99 /* RTCVideoFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoFrame.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoFrame.h; sourceTree = "<group>"; };
-		413A24181FE1990800373E99 /* RTCVideoTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoTrack.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoTrack.h; sourceTree = "<group>"; };
-		413A24191FE1990900373E99 /* RTCMediaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMediaSource.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMediaSource.h; sourceTree = "<group>"; };
-		413A241A1FE1990900373E99 /* RTCDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCDispatcher.h; path = sdk/objc/Framework/Headers/WebRTC/RTCDispatcher.h; sourceTree = "<group>"; };
-		413A241B1FE1990900373E99 /* RTCVideoCodecFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoCodecFactory.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoCodecFactory.h; sourceTree = "<group>"; };
-		413A241C1FE1990A00373E99 /* RTCMediaStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMediaStream.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMediaStream.h; sourceTree = "<group>"; };
-		413A241D1FE1990A00373E99 /* RTCDataChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCDataChannel.h; path = sdk/objc/Framework/Headers/WebRTC/RTCDataChannel.h; sourceTree = "<group>"; };
-		413A241E1FE1990A00373E99 /* RTCFileVideoCapturer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCFileVideoCapturer.h; path = sdk/objc/Framework/Headers/WebRTC/RTCFileVideoCapturer.h; sourceTree = "<group>"; };
-		413A241F1FE1990B00373E99 /* RTCAudioTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCAudioTrack.h; path = sdk/objc/Framework/Headers/WebRTC/RTCAudioTrack.h; sourceTree = "<group>"; };
-		413A24201FE1990C00373E99 /* RTCAudioSessionConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCAudioSessionConfiguration.h; path = sdk/objc/Framework/Headers/WebRTC/RTCAudioSessionConfiguration.h; sourceTree = "<group>"; };
-		413A24211FE1990C00373E99 /* RTCNSGLVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCNSGLVideoView.h; path = sdk/objc/Framework/Headers/WebRTC/RTCNSGLVideoView.h; sourceTree = "<group>"; };
-		413A24221FE1990D00373E99 /* RTCFileLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCFileLogger.h; path = sdk/objc/Framework/Headers/WebRTC/RTCFileLogger.h; sourceTree = "<group>"; };
-		413A24231FE1990E00373E99 /* RTCCameraPreviewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCCameraPreviewView.h; path = sdk/objc/Framework/Headers/WebRTC/RTCCameraPreviewView.h; sourceTree = "<group>"; };
-		413A24241FE1990F00373E99 /* RTCRtpSender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCRtpSender.h; path = sdk/objc/Framework/Headers/WebRTC/RTCRtpSender.h; sourceTree = "<group>"; };
-		413A24251FE1990F00373E99 /* RTCEAGLVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCEAGLVideoView.h; path = sdk/objc/Framework/Headers/WebRTC/RTCEAGLVideoView.h; sourceTree = "<group>"; };
-		413A24261FE1991000373E99 /* RTCIceServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCIceServer.h; path = sdk/objc/Framework/Headers/WebRTC/RTCIceServer.h; sourceTree = "<group>"; };
-		413A24271FE1991000373E99 /* RTCTracing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCTracing.h; path = sdk/objc/Framework/Headers/WebRTC/RTCTracing.h; sourceTree = "<group>"; };
-		413A24281FE1991100373E99 /* RTCVideoDecoderVP9.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoDecoderVP9.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoDecoderVP9.h; sourceTree = "<group>"; };
-		413A24291FE1991100373E99 /* RTCVideoSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoSource.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoSource.h; sourceTree = "<group>"; };
-		413A242A1FE1991200373E99 /* RTCAudioSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCAudioSession.h; path = sdk/objc/Framework/Headers/WebRTC/RTCAudioSession.h; sourceTree = "<group>"; };
-		413A242B1FE1991200373E99 /* RTCPeerConnectionFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCPeerConnectionFactory.h; path = sdk/objc/Framework/Headers/WebRTC/RTCPeerConnectionFactory.h; sourceTree = "<group>"; };
-		413A242C1FE1991300373E99 /* RTCMetrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMetrics.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMetrics.h; sourceTree = "<group>"; };
-		413A242D1FE1991300373E99 /* RTCVideoDecoderVP8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoDecoderVP8.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoDecoderVP8.h; sourceTree = "<group>"; };
-		413A242E1FE1991400373E99 /* RTCSSLAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCSSLAdapter.h; path = sdk/objc/Framework/Headers/WebRTC/RTCSSLAdapter.h; sourceTree = "<group>"; };
-		413A242F1FE1991500373E99 /* RTCMTLNSVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMTLNSVideoView.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMTLNSVideoView.h; sourceTree = "<group>"; };
-		413A24301FE1991500373E99 /* RTCMediaConstraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMediaConstraints.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMediaConstraints.h; sourceTree = "<group>"; };
-		413A24311FE1991500373E99 /* RTCLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCLogging.h; path = sdk/objc/Framework/Headers/WebRTC/RTCLogging.h; sourceTree = "<group>"; };
-		413A24321FE1991600373E99 /* RTCMetricsSampleInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMetricsSampleInfo.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMetricsSampleInfo.h; sourceTree = "<group>"; };
-		413A24331FE1991600373E99 /* UIDevice+RTCDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIDevice+RTCDevice.h"; path = "sdk/objc/Framework/Headers/WebRTC/UIDevice+RTCDevice.h"; sourceTree = "<group>"; };
-		413A24341FE1991700373E99 /* RTCRtpCodecParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCRtpCodecParameters.h; path = sdk/objc/Framework/Headers/WebRTC/RTCRtpCodecParameters.h; sourceTree = "<group>"; };
-		413A24361FE1991800373E99 /* RTCVideoEncoderVP8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoEncoderVP8.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoEncoderVP8.h; sourceTree = "<group>"; };
-		413A24371FE1991800373E99 /* RTCVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoRenderer.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoRenderer.h; sourceTree = "<group>"; };
-		413A24381FE1991900373E99 /* RTCDataChannelConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCDataChannelConfiguration.h; path = sdk/objc/Framework/Headers/WebRTC/RTCDataChannelConfiguration.h; sourceTree = "<group>"; };
-		413A24391FE1991900373E99 /* RTCMTLVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCMTLVideoView.h; path = sdk/objc/Framework/Headers/WebRTC/RTCMTLVideoView.h; sourceTree = "<group>"; };
-		413AD1A121265B0F003F7263 /* algorithm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = algorithm.h; path = "Source/third_party/abseil-cpp/absl/algorithm/algorithm.h"; sourceTree = SOURCE_ROOT; };
-		413AD1A221265B0F003F7263 /* container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = container.h; path = "Source/third_party/abseil-cpp/absl/algorithm/container.h"; sourceTree = SOURCE_ROOT; };
-		413AD1A721265B59003F7263 /* optimization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = optimization.h; path = "Source/third_party/abseil-cpp/absl/base/optimization.h"; sourceTree = SOURCE_ROOT; };
-		413AD1A921265B59003F7263 /* casts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = casts.h; path = "Source/third_party/abseil-cpp/absl/base/casts.h"; sourceTree = SOURCE_ROOT; };
-		413AD1AA21265B59003F7263 /* macros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = macros.h; path = "Source/third_party/abseil-cpp/absl/base/macros.h"; sourceTree = SOURCE_ROOT; };
+		413A21381FE0F0EE00373E99 /* srtp_priv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = srtp_priv.h; sourceTree = "<group>"; };
+		413A21391FE0F0EF00373E99 /* ekt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ekt.h; sourceTree = "<group>"; };
+		413A213A1FE0F0EF00373E99 /* srtp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = srtp.h; sourceTree = "<group>"; };
+		413A213B1FE0F0EF00373E99 /* ut_sim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ut_sim.h; sourceTree = "<group>"; };
+		413A213C1FE0F0EF00373E99 /* getopt_s.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = getopt_s.h; sourceTree = "<group>"; };
+		413A24021FE1990300373E99 /* RTCVideoViewShading.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoViewShading.h; sourceTree = "<group>"; };
+		413A24031FE1990300373E99 /* RTCRtpReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtpReceiver.h; sourceTree = "<group>"; };
+		413A24041FE1990300373E99 /* RTCVideoCodecH264.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoCodecH264.h; sourceTree = "<group>"; };
+		413A24051FE1990300373E99 /* RTCVideoCapturer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoCapturer.h; sourceTree = "<group>"; };
+		413A24061FE1990400373E99 /* RTCPeerConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCPeerConnection.h; sourceTree = "<group>"; };
+		413A24081FE1990400373E99 /* RTCFieldTrials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCFieldTrials.h; sourceTree = "<group>"; };
+		413A24091FE1990400373E99 /* RTCVideoFrameBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoFrameBuffer.h; sourceTree = "<group>"; };
+		413A240A1FE1990400373E99 /* RTCLegacyStatsReport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCLegacyStatsReport.h; sourceTree = "<group>"; };
+		413A240B1FE1990500373E99 /* RTCVideoCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoCodec.h; sourceTree = "<group>"; };
+		413A240C1FE1990500373E99 /* RTCConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCConfiguration.h; sourceTree = "<group>"; };
+		413A240D1FE1990500373E99 /* RTCRtpParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtpParameters.h; sourceTree = "<group>"; };
+		413A240E1FE1990500373E99 /* RTCVideoEncoderVP9.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoEncoderVP9.h; sourceTree = "<group>"; };
+		413A240F1FE1990600373E99 /* RTCMediaStreamTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMediaStreamTrack.h; sourceTree = "<group>"; };
+		413A24111FE1990600373E99 /* RTCMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMacros.h; sourceTree = "<group>"; };
+		413A24121FE1990600373E99 /* RTCSessionDescription.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCSessionDescription.h; sourceTree = "<group>"; };
+		413A24131FE1990700373E99 /* RTCAudioSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCAudioSource.h; sourceTree = "<group>"; };
+		413A24141FE1990700373E99 /* RTCRtpEncodingParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtpEncodingParameters.h; sourceTree = "<group>"; };
+		413A24151FE1990700373E99 /* RTCCameraVideoCapturer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCCameraVideoCapturer.h; sourceTree = "<group>"; };
+		413A24161FE1990800373E99 /* RTCIceCandidate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCIceCandidate.h; sourceTree = "<group>"; };
+		413A24171FE1990800373E99 /* RTCVideoFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoFrame.h; sourceTree = "<group>"; };
+		413A24181FE1990800373E99 /* RTCVideoTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoTrack.h; sourceTree = "<group>"; };
+		413A24191FE1990900373E99 /* RTCMediaSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMediaSource.h; sourceTree = "<group>"; };
+		413A241A1FE1990900373E99 /* RTCDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCDispatcher.h; sourceTree = "<group>"; };
+		413A241B1FE1990900373E99 /* RTCVideoCodecFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoCodecFactory.h; sourceTree = "<group>"; };
+		413A241C1FE1990A00373E99 /* RTCMediaStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMediaStream.h; sourceTree = "<group>"; };
+		413A241D1FE1990A00373E99 /* RTCDataChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCDataChannel.h; sourceTree = "<group>"; };
+		413A241E1FE1990A00373E99 /* RTCFileVideoCapturer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCFileVideoCapturer.h; sourceTree = "<group>"; };
+		413A241F1FE1990B00373E99 /* RTCAudioTrack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCAudioTrack.h; sourceTree = "<group>"; };
+		413A24201FE1990C00373E99 /* RTCAudioSessionConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCAudioSessionConfiguration.h; sourceTree = "<group>"; };
+		413A24211FE1990C00373E99 /* RTCNSGLVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCNSGLVideoView.h; sourceTree = "<group>"; };
+		413A24221FE1990D00373E99 /* RTCFileLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCFileLogger.h; sourceTree = "<group>"; };
+		413A24231FE1990E00373E99 /* RTCCameraPreviewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCCameraPreviewView.h; sourceTree = "<group>"; };
+		413A24241FE1990F00373E99 /* RTCRtpSender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtpSender.h; sourceTree = "<group>"; };
+		413A24251FE1990F00373E99 /* RTCEAGLVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCEAGLVideoView.h; sourceTree = "<group>"; };
+		413A24261FE1991000373E99 /* RTCIceServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCIceServer.h; sourceTree = "<group>"; };
+		413A24271FE1991000373E99 /* RTCTracing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCTracing.h; sourceTree = "<group>"; };
+		413A24281FE1991100373E99 /* RTCVideoDecoderVP9.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoDecoderVP9.h; sourceTree = "<group>"; };
+		413A24291FE1991100373E99 /* RTCVideoSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoSource.h; sourceTree = "<group>"; };
+		413A242A1FE1991200373E99 /* RTCAudioSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCAudioSession.h; sourceTree = "<group>"; };
+		413A242B1FE1991200373E99 /* RTCPeerConnectionFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCPeerConnectionFactory.h; sourceTree = "<group>"; };
+		413A242C1FE1991300373E99 /* RTCMetrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMetrics.h; sourceTree = "<group>"; };
+		413A242D1FE1991300373E99 /* RTCVideoDecoderVP8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoDecoderVP8.h; sourceTree = "<group>"; };
+		413A242E1FE1991400373E99 /* RTCSSLAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCSSLAdapter.h; sourceTree = "<group>"; };
+		413A242F1FE1991500373E99 /* RTCMTLNSVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMTLNSVideoView.h; sourceTree = "<group>"; };
+		413A24301FE1991500373E99 /* RTCMediaConstraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMediaConstraints.h; sourceTree = "<group>"; };
+		413A24311FE1991500373E99 /* RTCLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCLogging.h; sourceTree = "<group>"; };
+		413A24321FE1991600373E99 /* RTCMetricsSampleInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMetricsSampleInfo.h; sourceTree = "<group>"; };
+		413A24331FE1991600373E99 /* UIDevice+RTCDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIDevice+RTCDevice.h"; sourceTree = "<group>"; };
+		413A24341FE1991700373E99 /* RTCRtpCodecParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtpCodecParameters.h; sourceTree = "<group>"; };
+		413A24361FE1991800373E99 /* RTCVideoEncoderVP8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoEncoderVP8.h; sourceTree = "<group>"; };
+		413A24371FE1991800373E99 /* RTCVideoRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoRenderer.h; sourceTree = "<group>"; };
+		413A24381FE1991900373E99 /* RTCDataChannelConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCDataChannelConfiguration.h; sourceTree = "<group>"; };
+		413A24391FE1991900373E99 /* RTCMTLVideoView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMTLVideoView.h; sourceTree = "<group>"; };
+		413AD1A121265B0F003F7263 /* algorithm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "algorithm.h"; sourceTree = "<group>"; };
+		413AD1A221265B0F003F7263 /* container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "container.h"; sourceTree = "<group>"; };
+		413AD1A721265B59003F7263 /* optimization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "optimization.h"; sourceTree = "<group>"; };
+		413AD1A921265B59003F7263 /* casts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "casts.h"; sourceTree = "<group>"; };
+		413AD1AA21265B59003F7263 /* macros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "macros.h"; sourceTree = "<group>"; };
 		413E67642169854500EF37ED /* RTCVideoEncoderVP8.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCVideoEncoderVP8.mm; sourceTree = "<group>"; };
 		413E676E2169863A00EF37ED /* temporal_layers_checker.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = temporal_layers_checker.cc; sourceTree = "<group>"; };
 		413E677B216986AD00EF37ED /* rtp_header_extension_size.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_header_extension_size.cc; sourceTree = "<group>"; };
@@ -7323,21 +7323,21 @@
 		4140377F24AA32DB00BCE9B2 /* vp9_quantize_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp9_quantize_sse2.c; sourceTree = "<group>"; };
 		4140378024AA32DC00BCE9B2 /* vp9_dct_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = vp9_dct_sse2.asm; sourceTree = "<group>"; };
 		4140378124AA32DC00BCE9B2 /* vp9_diamond_search_sad_avx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp9_diamond_search_sad_avx.c; sourceTree = "<group>"; };
-		4140379024AB2FB200BCE9B2 /* ethreading.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ethreading.h; path = encoder/ethreading.h; sourceTree = "<group>"; };
-		4140379124AB2FB200BCE9B2 /* quantize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = quantize.h; path = encoder/quantize.h; sourceTree = "<group>"; };
-		4140379224AB2FB200BCE9B2 /* segmentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = segmentation.h; path = encoder/segmentation.h; sourceTree = "<group>"; };
-		4140379324AB2FB300BCE9B2 /* ratectrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ratectrl.h; path = encoder/ratectrl.h; sourceTree = "<group>"; };
-		4140379424AB2FB300BCE9B2 /* dct_value_cost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dct_value_cost.h; path = encoder/dct_value_cost.h; sourceTree = "<group>"; };
-		4140379524AB2FB300BCE9B2 /* boolhuff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = boolhuff.h; path = encoder/boolhuff.h; sourceTree = "<group>"; };
-		4140379624AB2FB300BCE9B2 /* pickinter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pickinter.h; path = encoder/pickinter.h; sourceTree = "<group>"; };
-		4140379724AB2FB300BCE9B2 /* encodemb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = encodemb.h; path = encoder/encodemb.h; sourceTree = "<group>"; };
-		4140379824AB2FB400BCE9B2 /* rdopt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rdopt.h; path = encoder/rdopt.h; sourceTree = "<group>"; };
-		4140379924AB2FB400BCE9B2 /* lookahead.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lookahead.h; path = encoder/lookahead.h; sourceTree = "<group>"; };
-		4140379A24AB2FB400BCE9B2 /* temporal_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = temporal_filter.h; path = encoder/temporal_filter.h; sourceTree = "<group>"; };
-		4140379B24AB2FB400BCE9B2 /* copy_c.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = copy_c.c; path = encoder/copy_c.c; sourceTree = "<group>"; };
-		4140379C24AB2FB500BCE9B2 /* modecosts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = modecosts.h; path = encoder/modecosts.h; sourceTree = "<group>"; };
-		4140379D24AB2FB500BCE9B2 /* treewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = treewriter.h; path = encoder/treewriter.h; sourceTree = "<group>"; };
-		4140379E24AB2FB500BCE9B2 /* mr_dissim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mr_dissim.h; path = encoder/mr_dissim.h; sourceTree = "<group>"; };
+		4140379024AB2FB200BCE9B2 /* ethreading.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ethreading.h; sourceTree = "<group>"; };
+		4140379124AB2FB200BCE9B2 /* quantize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quantize.h; sourceTree = "<group>"; };
+		4140379224AB2FB200BCE9B2 /* segmentation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = segmentation.h; sourceTree = "<group>"; };
+		4140379324AB2FB300BCE9B2 /* ratectrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ratectrl.h; sourceTree = "<group>"; };
+		4140379424AB2FB300BCE9B2 /* dct_value_cost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dct_value_cost.h; sourceTree = "<group>"; };
+		4140379524AB2FB300BCE9B2 /* boolhuff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = boolhuff.h; sourceTree = "<group>"; };
+		4140379624AB2FB300BCE9B2 /* pickinter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pickinter.h; sourceTree = "<group>"; };
+		4140379724AB2FB300BCE9B2 /* encodemb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encodemb.h; sourceTree = "<group>"; };
+		4140379824AB2FB400BCE9B2 /* rdopt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rdopt.h; sourceTree = "<group>"; };
+		4140379924AB2FB400BCE9B2 /* lookahead.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lookahead.h; sourceTree = "<group>"; };
+		4140379A24AB2FB400BCE9B2 /* temporal_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = temporal_filter.h; sourceTree = "<group>"; };
+		4140379B24AB2FB400BCE9B2 /* copy_c.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = copy_c.c; sourceTree = "<group>"; };
+		4140379C24AB2FB500BCE9B2 /* modecosts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = modecosts.h; sourceTree = "<group>"; };
+		4140379D24AB2FB500BCE9B2 /* treewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = treewriter.h; sourceTree = "<group>"; };
+		4140379E24AB2FB500BCE9B2 /* mr_dissim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mr_dissim.h; sourceTree = "<group>"; };
 		414037AF24AB359600BCE9B2 /* vp9_denoiser_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp9_denoiser_neon.c; sourceTree = "<group>"; };
 		414037B024AB359600BCE9B2 /* vp9_error_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp9_error_neon.c; sourceTree = "<group>"; };
 		414037B124AB359700BCE9B2 /* vp9_frame_scale_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp9_frame_scale_neon.c; sourceTree = "<group>"; };
@@ -7345,18 +7345,18 @@
 		414037B724AB35E100BCE9B2 /* sum_squares_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sum_squares_neon.c; sourceTree = "<group>"; };
 		414037B924AC76E900BCE9B2 /* WebKitVP9Decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitVP9Decoder.h; sourceTree = "<group>"; };
 		414037BA24AC76E900BCE9B2 /* WebKitVP9Decoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebKitVP9Decoder.cpp; sourceTree = "<group>"; };
-		4140B8181E4E3383007409E6 /* audio_encoder_pcm.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_pcm.cc; path = g711/audio_encoder_pcm.cc; sourceTree = "<group>"; };
-		4140B8191E4E3383007409E6 /* audio_encoder_pcm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_pcm.h; path = g711/audio_encoder_pcm.h; sourceTree = "<group>"; };
-		4140B81A1E4E3383007409E6 /* audio_decoder_pcm.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder_pcm.cc; path = g711/audio_decoder_pcm.cc; sourceTree = "<group>"; };
-		4140B81B1E4E3383007409E6 /* audio_decoder_pcm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_pcm.h; path = g711/audio_decoder_pcm.h; sourceTree = "<group>"; };
-		4140B81C1E4E3383007409E6 /* g711_interface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = g711_interface.c; path = g711/g711_interface.c; sourceTree = "<group>"; };
-		4140B81D1E4E3383007409E6 /* g711_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = g711_interface.h; path = g711/g711_interface.h; sourceTree = "<group>"; };
-		4140B8281E4E3396007409E6 /* audio_decoder_g722.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder_g722.cc; path = g722/audio_decoder_g722.cc; sourceTree = "<group>"; };
-		4140B8291E4E3396007409E6 /* audio_decoder_g722.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_g722.h; path = g722/audio_decoder_g722.h; sourceTree = "<group>"; };
-		4140B82A1E4E3396007409E6 /* audio_encoder_g722.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_g722.cc; path = g722/audio_encoder_g722.cc; sourceTree = "<group>"; };
-		4140B82B1E4E3396007409E6 /* audio_encoder_g722.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_g722.h; path = g722/audio_encoder_g722.h; sourceTree = "<group>"; };
-		4140B82F1E4E3396007409E6 /* g722_interface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = g722_interface.c; path = g722/g722_interface.c; sourceTree = "<group>"; };
-		4140B8301E4E3396007409E6 /* g722_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = g722_interface.h; path = g722/g722_interface.h; sourceTree = "<group>"; };
+		4140B8181E4E3383007409E6 /* audio_encoder_pcm.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_pcm.cc; sourceTree = "<group>"; };
+		4140B8191E4E3383007409E6 /* audio_encoder_pcm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_pcm.h; sourceTree = "<group>"; };
+		4140B81A1E4E3383007409E6 /* audio_decoder_pcm.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_pcm.cc; sourceTree = "<group>"; };
+		4140B81B1E4E3383007409E6 /* audio_decoder_pcm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_pcm.h; sourceTree = "<group>"; };
+		4140B81C1E4E3383007409E6 /* g711_interface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = g711_interface.c; sourceTree = "<group>"; };
+		4140B81D1E4E3383007409E6 /* g711_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = g711_interface.h; sourceTree = "<group>"; };
+		4140B8281E4E3396007409E6 /* audio_decoder_g722.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_g722.cc; sourceTree = "<group>"; };
+		4140B8291E4E3396007409E6 /* audio_decoder_g722.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_g722.h; sourceTree = "<group>"; };
+		4140B82A1E4E3396007409E6 /* audio_encoder_g722.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_g722.cc; sourceTree = "<group>"; };
+		4140B82B1E4E3396007409E6 /* audio_encoder_g722.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_g722.h; sourceTree = "<group>"; };
+		4140B82F1E4E3396007409E6 /* g722_interface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = g722_interface.c; sourceTree = "<group>"; };
+		4140B8301E4E3396007409E6 /* g722_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = g722_interface.h; sourceTree = "<group>"; };
 		41433D2C1F79B39200387B4D /* libwebrtc.exp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.exports; path = libwebrtc.exp; sourceTree = "<group>"; };
 		4144B3D021698966004363AC /* RTCNativeMutableI420Buffer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCNativeMutableI420Buffer.mm; sourceTree = "<group>"; };
 		4144B3D92169A06F004363AC /* RTCVideoDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoDecoder.h; sourceTree = "<group>"; };
@@ -7381,39 +7381,39 @@
 		414502122152E16F0033B4D3 /* vp9_rtcd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vp9_rtcd.h; sourceTree = "<group>"; };
 		414502132152E16F0033B4D3 /* vpx_config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vpx_config.h; sourceTree = "<group>"; };
 		414502142152E16F0033B4D3 /* vpx_scale_rtcd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vpx_scale_rtcd.h; sourceTree = "<group>"; };
-		4145E48B1EF88B9600FCF6E6 /* video_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_decoder.h; path = Source/webrtc/api/video_codecs/video_decoder.h; sourceTree = SOURCE_ROOT; };
-		4145E48C1EF88B9D00FCF6E6 /* video_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_encoder.h; path = Source/webrtc/api/video_codecs/video_encoder.h; sourceTree = SOURCE_ROOT; };
-		4145E4901EF88EF500FCF6E6 /* webrtc_libyuv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = webrtc_libyuv.h; path = libyuv/include/webrtc_libyuv.h; sourceTree = "<group>"; };
-		4145E4AF1EF8943D00FCF6E6 /* nalu_rewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = nalu_rewriter.h; path = Source/webrtc/sdk/objc/Framework/Classes/VideoToolbox/nalu_rewriter.h; sourceTree = SOURCE_ROOT; };
-		4145E4C31EF896D200FCF6E6 /* rtcstats_objects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtcstats_objects.h; path = stats/rtcstats_objects.h; sourceTree = "<group>"; };
+		4145E48B1EF88B9600FCF6E6 /* video_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_decoder.h; sourceTree = "<group>"; };
+		4145E48C1EF88B9D00FCF6E6 /* video_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_encoder.h; sourceTree = "<group>"; };
+		4145E4901EF88EF500FCF6E6 /* webrtc_libyuv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_libyuv.h; sourceTree = "<group>"; };
+		4145E4AF1EF8943D00FCF6E6 /* nalu_rewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nalu_rewriter.h; sourceTree = "<group>"; };
+		4145E4C31EF896D200FCF6E6 /* rtcstats_objects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtcstats_objects.h; sourceTree = "<group>"; };
 		4145E4D31EF8CC7600FCF6E6 /* downsampled_render_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = downsampled_render_buffer.h; sourceTree = "<group>"; };
 		4145E4D41EF8CC7600FCF6E6 /* downsampled_render_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = downsampled_render_buffer.cc; sourceTree = "<group>"; };
 		4145E4D71EF8CC9A00FCF6E6 /* render_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = render_buffer.cc; sourceTree = "<group>"; };
 		4145E4D81EF8CC9A00FCF6E6 /* render_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = render_buffer.h; sourceTree = "<group>"; };
 		4145E4DB1EF8CCEE00FCF6E6 /* rtp_header_extension_map.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_header_extension_map.cc; sourceTree = "<group>"; };
-		4145E4DD1EF8CD3400FCF6E6 /* audio_encoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder.cc; path = audio_codecs/audio_encoder.cc; sourceTree = "<group>"; };
-		4145E4DE1EF8CD3900FCF6E6 /* audio_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder.h; path = audio_codecs/audio_encoder.h; sourceTree = "<group>"; };
-		4145F60F1FE1E16F00EB9CAF /* audio_device_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_device_defines.h; path = include/audio_device_defines.h; sourceTree = "<group>"; };
-		4145F6101FE1E16F00EB9CAF /* audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_device.h; path = include/audio_device.h; sourceTree = "<group>"; };
-		4145F6111FE1E16F00EB9CAF /* audio_device_data_observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_device_data_observer.h; path = include/audio_device_data_observer.h; sourceTree = "<group>"; };
+		4145E4DD1EF8CD3400FCF6E6 /* audio_encoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder.cc; sourceTree = "<group>"; };
+		4145E4DE1EF8CD3900FCF6E6 /* audio_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder.h; sourceTree = "<group>"; };
+		4145F60F1FE1E16F00EB9CAF /* audio_device_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_device_defines.h; sourceTree = "<group>"; };
+		4145F6101FE1E16F00EB9CAF /* audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_device.h; sourceTree = "<group>"; };
+		4145F6111FE1E16F00EB9CAF /* audio_device_data_observer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_device_data_observer.h; sourceTree = "<group>"; };
 		4145F6161FE1EFC900EB9CAF /* vp8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8.h; sourceTree = "<group>"; };
-		4145F6191FE1F38B00EB9CAF /* sdp_video_format.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sdp_video_format.h; path = video_codecs/sdp_video_format.h; sourceTree = "<group>"; };
-		4145F61A1FE1F38C00EB9CAF /* video_decoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_decoder_factory.h; path = video_codecs/video_decoder_factory.h; sourceTree = "<group>"; };
-		4145F61B1FE1F38D00EB9CAF /* video_encoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_encoder_factory.h; path = video_codecs/video_encoder_factory.h; sourceTree = "<group>"; };
-		4145F61C1FE1F38D00EB9CAF /* video_encoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_encoder.cc; path = video_codecs/video_encoder.cc; sourceTree = "<group>"; };
+		4145F6191FE1F38B00EB9CAF /* sdp_video_format.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sdp_video_format.h; sourceTree = "<group>"; };
+		4145F61A1FE1F38C00EB9CAF /* video_decoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_decoder_factory.h; sourceTree = "<group>"; };
+		4145F61B1FE1F38D00EB9CAF /* video_encoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_encoder_factory.h; sourceTree = "<group>"; };
+		4145F61C1FE1F38D00EB9CAF /* video_encoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_encoder.cc; sourceTree = "<group>"; };
 		414FB869216BB767001F5492 /* RTCRtpEncodingParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCRtpEncodingParameters.h; sourceTree = "<group>"; };
 		414FB86A216BB768001F5492 /* RTCRtpEncodingParameters.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCRtpEncodingParameters.mm; sourceTree = "<group>"; };
-		4154499F21CAC330001C0A55 /* ecdh.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ecdh.c; path = ecdh/ecdh.c; sourceTree = "<group>"; };
-		415449A121CAC34D001C0A55 /* unicode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = unicode.c; path = bytestring/unicode.c; sourceTree = "<group>"; };
-		415449A321CAC371001C0A55 /* v3_ocsp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_ocsp.c; path = x509v3/v3_ocsp.c; sourceTree = "<group>"; };
+		4154499F21CAC330001C0A55 /* ecdh.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecdh.c; sourceTree = "<group>"; };
+		415449A121CAC34D001C0A55 /* unicode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = unicode.c; sourceTree = "<group>"; };
+		415449A321CAC371001C0A55 /* v3_ocsp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_ocsp.c; sourceTree = "<group>"; };
 		415449A521CAC399001C0A55 /* div_extra.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = div_extra.c; sourceTree = "<group>"; };
 		415449A621CAC399001C0A55 /* gcd_extra.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gcd_extra.c; sourceTree = "<group>"; };
-		415449AA21CAC3CF001C0A55 /* kdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = kdf.c; path = tls/kdf.c; sourceTree = "<group>"; };
+		415449AA21CAC3CF001C0A55 /* kdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kdf.c; sourceTree = "<group>"; };
 		415449AC21CAC3F4001C0A55 /* felem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = felem.c; sourceTree = "<group>"; };
 		415449AD21CAC3F5001C0A55 /* simple_mul.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = simple_mul.c; sourceTree = "<group>"; };
 		415449AE21CAC3F5001C0A55 /* scalar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scalar.c; sourceTree = "<group>"; };
 		415449B521CAC4CE001C0A55 /* util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = util.c; sourceTree = "<group>"; };
-		415449BA21CAC5B3001C0A55 /* ecdh_extra.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ecdh_extra.c; path = ecdh_extra/ecdh_extra.c; sourceTree = "<group>"; };
+		415449BA21CAC5B3001C0A55 /* ecdh_extra.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecdh_extra.c; sourceTree = "<group>"; };
 		41566796215BE7730032296A /* compat-queue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "compat-queue.h"; sourceTree = "<group>"; };
 		41566797215BE7730032296A /* floatnum.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = floatnum.h; sourceTree = "<group>"; };
 		41566798215BE7730032296A /* bitvect.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bitvect.c; sourceTree = "<group>"; };
@@ -7430,19 +7430,19 @@
 		415667A3215BE7760032296A /* symrec.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = symrec.c; sourceTree = "<group>"; };
 		4158649623BE05E800A0A61E /* WebKitEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitEncoder.h; sourceTree = "<group>"; };
 		4158649723BE05E900A0A61E /* WebKitEncoder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKitEncoder.mm; sourceTree = "<group>"; };
-		415F1FC52127308E00064CBF /* audio_state.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_state.cc; path = call/audio_state.cc; sourceTree = "<group>"; };
-		415F1FD02127313D00064CBF /* receive_time_calculator.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = receive_time_calculator.cc; path = call/receive_time_calculator.cc; sourceTree = "<group>"; };
-		415F1FD12127313E00064CBF /* rtp_payload_params.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rtp_payload_params.h; path = call/rtp_payload_params.h; sourceTree = "<group>"; };
-		415F1FD22127313E00064CBF /* degraded_call.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = degraded_call.h; path = call/degraded_call.h; sourceTree = "<group>"; };
-		415F1FD32127313E00064CBF /* rtp_video_sender.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_video_sender.cc; path = call/rtp_video_sender.cc; sourceTree = "<group>"; };
-		415F1FD42127313E00064CBF /* rtp_video_sender.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rtp_video_sender.h; path = call/rtp_video_sender.h; sourceTree = "<group>"; };
-		415F1FD52127313E00064CBF /* receive_time_calculator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = receive_time_calculator.h; path = call/receive_time_calculator.h; sourceTree = "<group>"; };
-		415F1FD62127313E00064CBF /* rtp_video_sender_interface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rtp_video_sender_interface.h; path = call/rtp_video_sender_interface.h; sourceTree = "<group>"; };
-		415F1FD72127313F00064CBF /* call_config.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = call_config.cc; path = call/call_config.cc; sourceTree = "<group>"; };
-		415F1FD92127313F00064CBF /* rtp_bitrate_configurator.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_bitrate_configurator.cc; path = call/rtp_bitrate_configurator.cc; sourceTree = "<group>"; };
-		415F1FDA2127313F00064CBF /* call_config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = call_config.h; path = call/call_config.h; sourceTree = "<group>"; };
-		415F886D27394FF50047AD64 /* bitstream_reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitstream_reader.h; path = rtc_base/bitstream_reader.h; sourceTree = "<group>"; };
-		415F886E27394FF50047AD64 /* bitstream_reader.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = bitstream_reader.cc; path = rtc_base/bitstream_reader.cc; sourceTree = "<group>"; };
+		415F1FC52127308E00064CBF /* audio_state.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_state.cc; sourceTree = "<group>"; };
+		415F1FD02127313D00064CBF /* receive_time_calculator.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = receive_time_calculator.cc; sourceTree = "<group>"; };
+		415F1FD12127313E00064CBF /* rtp_payload_params.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rtp_payload_params.h; sourceTree = "<group>"; };
+		415F1FD22127313E00064CBF /* degraded_call.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = degraded_call.h; sourceTree = "<group>"; };
+		415F1FD32127313E00064CBF /* rtp_video_sender.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_video_sender.cc; sourceTree = "<group>"; };
+		415F1FD42127313E00064CBF /* rtp_video_sender.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rtp_video_sender.h; sourceTree = "<group>"; };
+		415F1FD52127313E00064CBF /* receive_time_calculator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = receive_time_calculator.h; sourceTree = "<group>"; };
+		415F1FD62127313E00064CBF /* rtp_video_sender_interface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rtp_video_sender_interface.h; sourceTree = "<group>"; };
+		415F1FD72127313F00064CBF /* call_config.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = call_config.cc; sourceTree = "<group>"; };
+		415F1FD92127313F00064CBF /* rtp_bitrate_configurator.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_bitrate_configurator.cc; sourceTree = "<group>"; };
+		415F1FDA2127313F00064CBF /* call_config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = call_config.h; sourceTree = "<group>"; };
+		415F886D27394FF50047AD64 /* bitstream_reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitstream_reader.h; sourceTree = "<group>"; };
+		415F886E27394FF50047AD64 /* bitstream_reader.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bitstream_reader.cc; sourceTree = "<group>"; };
 		415F887127395F230047AD64 /* rtp_util.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_util.cc; sourceTree = "<group>"; };
 		415F887227395F240047AD64 /* rtp_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_util.h; sourceTree = "<group>"; };
 		415F8876273960000047AD64 /* jsep_transport_collection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jsep_transport_collection.h; sourceTree = "<group>"; };
@@ -7453,7 +7453,7 @@
 		415F887F2739608B0047AD64 /* loss_based_bwe_v2.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loss_based_bwe_v2.cc; sourceTree = "<group>"; };
 		415F8882273960B90047AD64 /* framerate_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = framerate_controller.cc; sourceTree = "<group>"; };
 		415F8883273960B90047AD64 /* framerate_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = framerate_controller.h; sourceTree = "<group>"; };
-		415F8886273961260047AD64 /* denormal_disabler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = denormal_disabler.cc; path = source/denormal_disabler.cc; sourceTree = "<group>"; };
+		415F8886273961260047AD64 /* denormal_disabler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = denormal_disabler.cc; sourceTree = "<group>"; };
 		415F8888273961700047AD64 /* capture_clock_offset_updater.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = capture_clock_offset_updater.h; sourceTree = "<group>"; };
 		415F8889273961700047AD64 /* absolute_capture_time_interpolator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = absolute_capture_time_interpolator.h; sourceTree = "<group>"; };
 		415F888A273961700047AD64 /* absolute_capture_time_interpolator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = absolute_capture_time_interpolator.cc; sourceTree = "<group>"; };
@@ -7470,7 +7470,7 @@
 		415F88A7273962810047AD64 /* bandwidth_quality_scaler_settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bandwidth_quality_scaler_settings.h; sourceTree = "<group>"; };
 		415F88AA273962BE0047AD64 /* bandwidth_quality_scaler_resource.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bandwidth_quality_scaler_resource.cc; sourceTree = "<group>"; };
 		415F88AB273962BE0047AD64 /* bandwidth_quality_scaler_resource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bandwidth_quality_scaler_resource.h; sourceTree = "<group>"; };
-		415F88B0273963240047AD64 /* gain_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gain_control.h; path = agc/gain_control.h; sourceTree = "<group>"; };
+		415F88B0273963240047AD64 /* gain_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gain_control.h; sourceTree = "<group>"; };
 		415F88BC2739636B0047AD64 /* vector_math_avx2.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vector_math_avx2.cc; sourceTree = "<group>"; };
 		415F88BE273964100047AD64 /* wrapping_async_dns_resolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wrapping_async_dns_resolver.h; sourceTree = "<group>"; };
 		415F88BF273964110047AD64 /* wrapping_async_dns_resolver.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = wrapping_async_dns_resolver.cc; sourceTree = "<group>"; };
@@ -7507,20 +7507,20 @@
 		416225F5216981F400A91C9B /* helpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = helpers.h; sourceTree = "<group>"; };
 		416225F6216981F400A91C9B /* RTCVideoEncoderH264.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCVideoEncoderH264.mm; sourceTree = "<group>"; };
 		416225F7216981F400A91C9B /* RTCDefaultVideoEncoderFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCDefaultVideoEncoderFactory.h; sourceTree = "<group>"; };
-		416731A5212E0425001280EB /* rdopt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = rdopt.c; path = encoder/rdopt.c; sourceTree = "<group>"; };
-		416731A6212E0425001280EB /* boolhuff.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = boolhuff.c; path = encoder/boolhuff.c; sourceTree = "<group>"; };
-		416731A7212E0425001280EB /* ratectrl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = ratectrl.c; path = encoder/ratectrl.c; sourceTree = "<group>"; };
-		416731A8212E0426001280EB /* onyx_if.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = onyx_if.c; path = encoder/onyx_if.c; sourceTree = "<group>"; };
-		416731A9212E0426001280EB /* segmentation.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = segmentation.c; path = encoder/segmentation.c; sourceTree = "<group>"; };
-		416731AA212E0426001280EB /* mr_dissim.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = mr_dissim.c; path = encoder/mr_dissim.c; sourceTree = "<group>"; };
-		416731AB212E0427001280EB /* modecosts.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = modecosts.c; path = encoder/modecosts.c; sourceTree = "<group>"; };
-		416731AC212E0427001280EB /* lookahead.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = lookahead.c; path = encoder/lookahead.c; sourceTree = "<group>"; };
-		416731AD212E0427001280EB /* picklpf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = picklpf.c; path = encoder/picklpf.c; sourceTree = "<group>"; };
-		416731AE212E0428001280EB /* mcomp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = mcomp.c; path = encoder/mcomp.c; sourceTree = "<group>"; };
-		416731AF212E0428001280EB /* denoising.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = denoising.c; path = encoder/denoising.c; sourceTree = "<group>"; };
-		416731B0212E0428001280EB /* ethreading.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = ethreading.c; path = encoder/ethreading.c; sourceTree = "<group>"; };
-		416731B1212E0429001280EB /* tokenize.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tokenize.c; path = encoder/tokenize.c; sourceTree = "<group>"; };
-		416731B2212E0429001280EB /* treewriter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = treewriter.c; path = encoder/treewriter.c; sourceTree = "<group>"; };
+		416731A5212E0425001280EB /* rdopt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rdopt.c; sourceTree = "<group>"; };
+		416731A6212E0425001280EB /* boolhuff.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = boolhuff.c; sourceTree = "<group>"; };
+		416731A7212E0425001280EB /* ratectrl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ratectrl.c; sourceTree = "<group>"; };
+		416731A8212E0426001280EB /* onyx_if.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = onyx_if.c; sourceTree = "<group>"; };
+		416731A9212E0426001280EB /* segmentation.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = segmentation.c; sourceTree = "<group>"; };
+		416731AA212E0426001280EB /* mr_dissim.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mr_dissim.c; sourceTree = "<group>"; };
+		416731AB212E0427001280EB /* modecosts.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = modecosts.c; sourceTree = "<group>"; };
+		416731AC212E0427001280EB /* lookahead.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lookahead.c; sourceTree = "<group>"; };
+		416731AD212E0427001280EB /* picklpf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = picklpf.c; sourceTree = "<group>"; };
+		416731AE212E0428001280EB /* mcomp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = mcomp.c; sourceTree = "<group>"; };
+		416731AF212E0428001280EB /* denoising.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = denoising.c; sourceTree = "<group>"; };
+		416731B0212E0428001280EB /* ethreading.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ethreading.c; sourceTree = "<group>"; };
+		416731B1212E0429001280EB /* tokenize.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = tokenize.c; sourceTree = "<group>"; };
+		416731B2212E0429001280EB /* treewriter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = treewriter.c; sourceTree = "<group>"; };
 		416731DA212E045D001280EB /* quantize_sse4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quantize_sse4.c; sourceTree = "<group>"; };
 		416731DB212E045D001280EB /* vp8_quantize_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp8_quantize_sse2.c; sourceTree = "<group>"; };
 		416731DC212E045D001280EB /* dct_sse2.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = dct_sse2.asm; sourceTree = "<group>"; };
@@ -7558,10 +7558,10 @@
 		41673206212E0491001280EB /* idct_blk.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = idct_blk.c; sourceTree = "<group>"; };
 		416B09CE2A3C7CE60017367B /* libaom_av1_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libaom_av1_decoder.h; sourceTree = "<group>"; };
 		416B09CF2A3C7CE60017367B /* libaom_av1_decoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libaom_av1_decoder.cc; sourceTree = "<group>"; };
-		416B09D22A3C7D440017367B /* fake_media_engine.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fake_media_engine.cc; path = base/fake_media_engine.cc; sourceTree = "<group>"; };
-		416B09D32A3C7D440017367B /* media_channel_impl.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = media_channel_impl.cc; path = base/media_channel_impl.cc; sourceTree = "<group>"; };
-		416B09D42A3C7D450017367B /* fake_frame_source.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fake_frame_source.cc; path = base/fake_frame_source.cc; sourceTree = "<group>"; };
-		416B09D52A3C7D450017367B /* fake_video_renderer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fake_video_renderer.cc; path = base/fake_video_renderer.cc; sourceTree = "<group>"; };
+		416B09D22A3C7D440017367B /* fake_media_engine.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fake_media_engine.cc; sourceTree = "<group>"; };
+		416B09D32A3C7D440017367B /* media_channel_impl.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = media_channel_impl.cc; sourceTree = "<group>"; };
+		416B09D42A3C7D450017367B /* fake_frame_source.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fake_frame_source.cc; sourceTree = "<group>"; };
+		416B09D52A3C7D450017367B /* fake_video_renderer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = fake_video_renderer.cc; sourceTree = "<group>"; };
 		416B09D72A3C7DA20017367B /* field_trials_registry.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = field_trials_registry.cc; sourceTree = "<group>"; };
 		416B09D82A3C7DA20017367B /* field_trials.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = field_trials.cc; sourceTree = "<group>"; };
 		416B09D92A3C7DA20017367B /* legacy_stats_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = legacy_stats_types.h; sourceTree = "<group>"; };
@@ -7637,7 +7637,7 @@
 		416B0A6D2A3C829F0017367B /* clipping_predictor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clipping_predictor.h; sourceTree = "<group>"; };
 		416B0A6E2A3C82A00017367B /* clipping_predictor_level_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = clipping_predictor_level_buffer.h; sourceTree = "<group>"; };
 		416B0A732A3C87090017367B /* resolution.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resolution.h; sourceTree = "<group>"; };
-		416B0A752A3C87BE0017367B /* media_channel_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = media_channel_impl.h; path = base/media_channel_impl.h; sourceTree = "<group>"; };
+		416B0A752A3C87BE0017367B /* media_channel_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = media_channel_impl.h; sourceTree = "<group>"; };
 		416D2F101FA8CC0400097345 /* VideoProcessing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoProcessing.framework; path = System/Library/PrivateFrameworks/VideoProcessing.framework; sourceTree = SDKROOT; };
 		417953AC2169823D0028266B /* nalu_rewriter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = nalu_rewriter.cc; sourceTree = "<group>"; };
 		417953AD2169823E0028266B /* RTCDefaultVideoDecoderFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RTCDefaultVideoDecoderFactory.m; sourceTree = "<group>"; };
@@ -7651,8 +7651,8 @@
 		417953CE2169834E0028266B /* channel_send.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_send.h; sourceTree = "<group>"; };
 		417953D02169834F0028266B /* channel_receive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_receive.h; sourceTree = "<group>"; };
 		417953D22169834F0028266B /* channel_receive.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = channel_receive.cc; sourceTree = "<group>"; };
-		417953D9216983900028266B /* metrics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = metrics.cc; path = source/metrics.cc; sourceTree = "<group>"; };
-		417953DA216983900028266B /* field_trial.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = field_trial.cc; path = source/field_trial.cc; sourceTree = "<group>"; };
+		417953D9216983900028266B /* metrics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = metrics.cc; sourceTree = "<group>"; };
+		417953DA216983900028266B /* field_trial.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = field_trial.cc; sourceTree = "<group>"; };
 		417953DE216983C90028266B /* module_fec_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module_fec_types.h; sourceTree = "<group>"; };
 		417953E0216983C90028266B /* module_common_types_public.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module_common_types_public.h; sourceTree = "<group>"; };
 		417953E2216983CA0028266B /* module_common_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module_common_types.h; sourceTree = "<group>"; };
@@ -7668,14 +7668,14 @@
 		41795402216985200028266B /* RTCVideoDecoderVP8.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCVideoDecoderVP8.mm; sourceTree = "<group>"; };
 		41795403216985200028266B /* RTCWrappedNativeVideoDecoder.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RTCWrappedNativeVideoDecoder.mm; sourceTree = "<group>"; };
 		41795404216985200028266B /* RTCWrappedNativeVideoEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RTCWrappedNativeVideoEncoder.h; sourceTree = "<group>"; };
-		417B013927FDA4CB00C74DE3 /* task_queue_gcd.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = task_queue_gcd.cc; path = rtc_base/task_queue_gcd.cc; sourceTree = "<group>"; };
+		417B013927FDA4CB00C74DE3 /* task_queue_gcd.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = task_queue_gcd.cc; sourceTree = "<group>"; };
 		417B013B27FDA7DF00C74DE3 /* gcd_helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = gcd_helpers.m; sourceTree = "<group>"; };
 		417C037223B210C400DE5D8B /* main_noop.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main_noop.c; sourceTree = "<group>"; };
 		41889D74216BB7B6004614DD /* RTCRtpEncodingParameters+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RTCRtpEncodingParameters+Private.h"; sourceTree = "<group>"; };
-		418938BA242A3D37007FDC41 /* VQ_WMat_EC_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = VQ_WMat_EC_sse4_1.c; path = silk/x86/VQ_WMat_EC_sse4_1.c; sourceTree = "<group>"; };
-		418938BB242A3D38007FDC41 /* VAD_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = VAD_sse4_1.c; path = silk/x86/VAD_sse4_1.c; sourceTree = "<group>"; };
-		418938BC242A3D38007FDC41 /* NSQ_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NSQ_sse4_1.c; path = silk/x86/NSQ_sse4_1.c; sourceTree = "<group>"; };
-		418938BD242A3D38007FDC41 /* NSQ_del_dec_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NSQ_del_dec_sse4_1.c; path = silk/x86/NSQ_del_dec_sse4_1.c; sourceTree = "<group>"; };
+		418938BA242A3D37007FDC41 /* VQ_WMat_EC_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = VQ_WMat_EC_sse4_1.c; sourceTree = "<group>"; };
+		418938BB242A3D38007FDC41 /* VAD_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = VAD_sse4_1.c; sourceTree = "<group>"; };
+		418938BC242A3D38007FDC41 /* NSQ_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NSQ_sse4_1.c; sourceTree = "<group>"; };
+		418938BD242A3D38007FDC41 /* NSQ_del_dec_sse4_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NSQ_del_dec_sse4_1.c; sourceTree = "<group>"; };
 		418938CC242A69CA007FDC41 /* encode_usage_resource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encode_usage_resource.h; sourceTree = "<group>"; };
 		418938CD242A69CA007FDC41 /* quality_scaler_resource.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = quality_scaler_resource.cc; sourceTree = "<group>"; };
 		418938CE242A69CA007FDC41 /* quality_scaler_resource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quality_scaler_resource.h; sourceTree = "<group>"; };
@@ -7816,21 +7816,21 @@
 		41893A2E242A7678007FDC41 /* tick_timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tick_timer.h; sourceTree = "<group>"; };
 		41893A2F242A7678007FDC41 /* neteq_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_factory.h; sourceTree = "<group>"; };
 		41893A30242A7678007FDC41 /* neteq.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = neteq.cc; sourceTree = "<group>"; };
-		41893A3F242A76F2007FDC41 /* operations_chain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = operations_chain.h; path = rtc_base/operations_chain.h; sourceTree = "<group>"; };
-		41893A40242A76F2007FDC41 /* operations_chain.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = operations_chain.cc; path = rtc_base/operations_chain.cc; sourceTree = "<group>"; };
+		41893A3F242A76F2007FDC41 /* operations_chain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operations_chain.h; sourceTree = "<group>"; };
+		41893A40242A76F2007FDC41 /* operations_chain.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = operations_chain.cc; sourceTree = "<group>"; };
 		41893A43242A774F007FDC41 /* acm_remixing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = acm_remixing.h; sourceTree = "<group>"; };
 		41893A44242A774F007FDC41 /* acm_remixing.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = acm_remixing.cc; sourceTree = "<group>"; };
-		41893A47242A7789007FDC41 /* divide_round.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = divide_round.h; path = rtc_base/numerics/divide_round.h; sourceTree = "<group>"; };
-		41893A48242A7789007FDC41 /* event_based_exponential_moving_average.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = event_based_exponential_moving_average.cc; path = rtc_base/numerics/event_based_exponential_moving_average.cc; sourceTree = "<group>"; };
-		41893A4C242A77B4007FDC41 /* running_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = running_statistics.h; path = rtc_base/numerics/running_statistics.h; sourceTree = "<group>"; };
-		41893A4D242A77B4007FDC41 /* math_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = math_utils.h; path = rtc_base/numerics/math_utils.h; sourceTree = "<group>"; };
-		41893A4F242A77B5007FDC41 /* safe_conversions_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = safe_conversions_impl.h; path = rtc_base/numerics/safe_conversions_impl.h; sourceTree = "<group>"; };
-		41893A50242A77B5007FDC41 /* event_rate_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_rate_counter.h; path = rtc_base/numerics/event_rate_counter.h; sourceTree = "<group>"; };
-		41893A51242A77B5007FDC41 /* event_based_exponential_moving_average.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_based_exponential_moving_average.h; path = rtc_base/numerics/event_based_exponential_moving_average.h; sourceTree = "<group>"; };
-		41893A52242A77B7007FDC41 /* sample_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sample_stats.h; path = rtc_base/numerics/sample_stats.h; sourceTree = "<group>"; };
-		41893A53242A77B7007FDC41 /* event_rate_counter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = event_rate_counter.cc; path = rtc_base/numerics/event_rate_counter.cc; sourceTree = "<group>"; };
-		41893A54242A77B8007FDC41 /* sequence_number_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sequence_number_util.h; path = rtc_base/numerics/sequence_number_util.h; sourceTree = "<group>"; };
-		41893A55242A77B8007FDC41 /* sample_stats.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sample_stats.cc; path = rtc_base/numerics/sample_stats.cc; sourceTree = "<group>"; };
+		41893A47242A7789007FDC41 /* divide_round.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = divide_round.h; sourceTree = "<group>"; };
+		41893A48242A7789007FDC41 /* event_based_exponential_moving_average.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = event_based_exponential_moving_average.cc; sourceTree = "<group>"; };
+		41893A4C242A77B4007FDC41 /* running_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = running_statistics.h; sourceTree = "<group>"; };
+		41893A4D242A77B4007FDC41 /* math_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = math_utils.h; sourceTree = "<group>"; };
+		41893A4F242A77B5007FDC41 /* safe_conversions_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = safe_conversions_impl.h; sourceTree = "<group>"; };
+		41893A50242A77B5007FDC41 /* event_rate_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event_rate_counter.h; sourceTree = "<group>"; };
+		41893A51242A77B5007FDC41 /* event_based_exponential_moving_average.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event_based_exponential_moving_average.h; sourceTree = "<group>"; };
+		41893A52242A77B7007FDC41 /* sample_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sample_stats.h; sourceTree = "<group>"; };
+		41893A53242A77B7007FDC41 /* event_rate_counter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = event_rate_counter.cc; sourceTree = "<group>"; };
+		41893A54242A77B8007FDC41 /* sequence_number_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sequence_number_util.h; sourceTree = "<group>"; };
+		41893A55242A77B8007FDC41 /* sample_stats.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sample_stats.cc; sourceTree = "<group>"; };
 		41893A61242A77DA007FDC41 /* default_neteq_controller_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = default_neteq_controller_factory.cc; sourceTree = "<group>"; };
 		41893A67242A7825007FDC41 /* rtp_packet_pacer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_packet_pacer.h; sourceTree = "<group>"; };
 		41893A68242A7825007FDC41 /* task_queue_paced_sender.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = task_queue_paced_sender.cc; sourceTree = "<group>"; };
@@ -7882,16 +7882,16 @@
 		419241382127372400634FCF /* pitch_search.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pitch_search.cc; sourceTree = "<group>"; };
 		41924173212738C200634FCF /* transport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transport.h; sourceTree = "<group>"; };
 		41924174212738C200634FCF /* transport.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transport.cc; sourceTree = "<group>"; };
-		41924178212738FB00634FCF /* rtc_event_log_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_event_log_impl.cc; path = rtc_event_log/rtc_event_log_impl.cc; sourceTree = "<group>"; };
-		4192417F2127497100634FCF /* bad_variant_access.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = bad_variant_access.cc; path = types/bad_variant_access.cc; sourceTree = "<group>"; };
-		419241802127497100634FCF /* bad_variant_access.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bad_variant_access.h; path = types/bad_variant_access.h; sourceTree = "<group>"; };
+		41924178212738FB00634FCF /* rtc_event_log_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_log_impl.cc; sourceTree = "<group>"; };
+		4192417F2127497100634FCF /* bad_variant_access.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bad_variant_access.cc; sourceTree = "<group>"; };
+		419241802127497100634FCF /* bad_variant_access.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bad_variant_access.h; sourceTree = "<group>"; };
 		4192418A212749C800634FCF /* transport_feedback_adapter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transport_feedback_adapter.cc; sourceTree = "<group>"; };
 		4192418F2127581000634FCF /* fec_private_tables_bursty.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fec_private_tables_bursty.cc; sourceTree = "<group>"; };
-		419241932127586400634FCF /* rnn_vad_weights.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rnn_vad_weights.h; path = src/rnn_vad_weights.h; sourceTree = "<group>"; };
-		419241942127586400634FCF /* rnn_vad_weights.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rnn_vad_weights.cc; path = src/rnn_vad_weights.cc; sourceTree = "<group>"; };
-		419241972127586500634FCF /* rnn_activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rnn_activations.h; path = src/rnn_activations.h; sourceTree = "<group>"; };
-		4192419D2127588200634FCF /* audio_codec_pair_id.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_codec_pair_id.h; path = audio_codecs/audio_codec_pair_id.h; sourceTree = "<group>"; };
-		4192419E2127588200634FCF /* audio_codec_pair_id.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_codec_pair_id.cc; path = audio_codecs/audio_codec_pair_id.cc; sourceTree = "<group>"; };
+		419241932127586400634FCF /* rnn_vad_weights.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rnn_vad_weights.h; sourceTree = "<group>"; };
+		419241942127586400634FCF /* rnn_vad_weights.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rnn_vad_weights.cc; sourceTree = "<group>"; };
+		419241972127586500634FCF /* rnn_activations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rnn_activations.h; sourceTree = "<group>"; };
+		4192419D2127588200634FCF /* audio_codec_pair_id.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_codec_pair_id.h; sourceTree = "<group>"; };
+		4192419E2127588200634FCF /* audio_codec_pair_id.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_codec_pair_id.cc; sourceTree = "<group>"; };
 		419241A1212758D200634FCF /* spectral_features_internal.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spectral_features_internal.cc; sourceTree = "<group>"; };
 		419241A2212758D200634FCF /* symmetric_matrix_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = symmetric_matrix_buffer.h; sourceTree = "<group>"; };
 		419241A3212758D200634FCF /* rnn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rnn.h; sourceTree = "<group>"; };
@@ -7900,8 +7900,8 @@
 		419241A6212758D200634FCF /* spectral_features.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spectral_features.cc; sourceTree = "<group>"; };
 		419241A7212758D300634FCF /* ring_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ring_buffer.h; sourceTree = "<group>"; };
 		419241AF2127590200634FCF /* rtp_generic_frame_descriptor_extension.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_generic_frame_descriptor_extension.cc; sourceTree = "<group>"; };
-		419241CE2127597C00634FCF /* simulated_network.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = simulated_network.cc; path = call/simulated_network.cc; sourceTree = "<group>"; };
-		419241CF2127597C00634FCF /* simulated_network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = simulated_network.h; path = call/simulated_network.h; sourceTree = "<group>"; };
+		419241CE2127597C00634FCF /* simulated_network.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = simulated_network.cc; sourceTree = "<group>"; };
+		419241CF2127597C00634FCF /* simulated_network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simulated_network.h; sourceTree = "<group>"; };
 		419241D2212759A100634FCF /* fec_private_tables_random.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fec_private_tables_random.cc; sourceTree = "<group>"; };
 		419241D521275A2F00634FCF /* time_delta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = time_delta.h; sourceTree = "<group>"; };
 		419241D621275A2F00634FCF /* data_rate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = data_rate.h; sourceTree = "<group>"; };
@@ -7964,26 +7964,26 @@
 		41953C082152ED6400136625 /* highbd_vpx_convolve_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_vpx_convolve_neon.c; sourceTree = "<group>"; };
 		41953C092152ED6400136625 /* quantize_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = quantize_neon.c; sourceTree = "<group>"; };
 		419C82991FE20CA10040C30F /* interval_budget.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = interval_budget.cc; sourceTree = "<group>"; };
-		419C829B1FE20D1B0040C30F /* audio_processing_statistics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_processing_statistics.cc; path = include/audio_processing_statistics.cc; sourceTree = "<group>"; };
-		419C829C1FE20D1C0040C30F /* audio_processing_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_processing_statistics.h; path = include/audio_processing_statistics.h; sourceTree = "<group>"; };
-		419C82A01FE20DC60040C30F /* video_send_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_send_stream.cc; path = call/video_send_stream.cc; sourceTree = "<group>"; };
-		419C82A11FE20DC70040C30F /* rtp_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_config.cc; path = call/rtp_config.cc; sourceTree = "<group>"; };
-		419C82A31FE20DC70040C30F /* rtp_packet_sink_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_packet_sink_interface.h; path = call/rtp_packet_sink_interface.h; sourceTree = "<group>"; };
-		419C82A41FE20DC80040C30F /* rtx_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtx_receive_stream.cc; path = call/rtx_receive_stream.cc; sourceTree = "<group>"; };
-		419C82A51FE20DC80040C30F /* rtp_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_config.h; path = call/rtp_config.h; sourceTree = "<group>"; };
-		419C82A71FE20DC90040C30F /* video_send_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_send_stream.h; path = call/video_send_stream.h; sourceTree = "<group>"; };
-		419C82A91FE20DCA0040C30F /* rtp_stream_receiver_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_stream_receiver_controller.cc; path = call/rtp_stream_receiver_controller.cc; sourceTree = "<group>"; };
-		419C82AB1FE20DCB0040C30F /* video_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_receive_stream.cc; path = call/video_receive_stream.cc; sourceTree = "<group>"; };
-		419C82AD1FE20DCB0040C30F /* rtp_stream_receiver_controller_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_stream_receiver_controller_interface.h; path = call/rtp_stream_receiver_controller_interface.h; sourceTree = "<group>"; };
-		419C82AE1FE20DCC0040C30F /* rtp_stream_receiver_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_stream_receiver_controller.h; path = call/rtp_stream_receiver_controller.h; sourceTree = "<group>"; };
-		419C82AF1FE20DCC0040C30F /* rtx_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtx_receive_stream.h; path = call/rtx_receive_stream.h; sourceTree = "<group>"; };
-		419C82B11FE20DCD0040C30F /* video_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_receive_stream.h; path = call/video_receive_stream.h; sourceTree = "<group>"; };
-		419C82EA1FE20EB40040C30F /* audio_encoder_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_opus.h; path = audio_codecs/opus/audio_encoder_opus.h; sourceTree = "<group>"; };
-		419C82EB1FE20EB40040C30F /* audio_encoder_opus_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_opus_config.h; path = audio_codecs/opus/audio_encoder_opus_config.h; sourceTree = "<group>"; };
-		419C82EC1FE20EB40040C30F /* audio_decoder_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_opus.h; path = audio_codecs/opus/audio_decoder_opus.h; sourceTree = "<group>"; };
-		419C82ED1FE20EB40040C30F /* audio_encoder_opus_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_opus_config.cc; path = audio_codecs/opus/audio_encoder_opus_config.cc; sourceTree = "<group>"; };
-		419C82EE1FE20EB40040C30F /* audio_decoder_opus.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder_opus.cc; path = audio_codecs/opus/audio_decoder_opus.cc; sourceTree = "<group>"; };
-		419C82EF1FE20EB50040C30F /* audio_encoder_opus.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_opus.cc; path = audio_codecs/opus/audio_encoder_opus.cc; sourceTree = "<group>"; };
+		419C829B1FE20D1B0040C30F /* audio_processing_statistics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_processing_statistics.cc; sourceTree = "<group>"; };
+		419C829C1FE20D1C0040C30F /* audio_processing_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_processing_statistics.h; sourceTree = "<group>"; };
+		419C82A01FE20DC60040C30F /* video_send_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_send_stream.cc; sourceTree = "<group>"; };
+		419C82A11FE20DC70040C30F /* rtp_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_config.cc; sourceTree = "<group>"; };
+		419C82A31FE20DC70040C30F /* rtp_packet_sink_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_packet_sink_interface.h; sourceTree = "<group>"; };
+		419C82A41FE20DC80040C30F /* rtx_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtx_receive_stream.cc; sourceTree = "<group>"; };
+		419C82A51FE20DC80040C30F /* rtp_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_config.h; sourceTree = "<group>"; };
+		419C82A71FE20DC90040C30F /* video_send_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_send_stream.h; sourceTree = "<group>"; };
+		419C82A91FE20DCA0040C30F /* rtp_stream_receiver_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_stream_receiver_controller.cc; sourceTree = "<group>"; };
+		419C82AB1FE20DCB0040C30F /* video_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_receive_stream.cc; sourceTree = "<group>"; };
+		419C82AD1FE20DCB0040C30F /* rtp_stream_receiver_controller_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_stream_receiver_controller_interface.h; sourceTree = "<group>"; };
+		419C82AE1FE20DCC0040C30F /* rtp_stream_receiver_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_stream_receiver_controller.h; sourceTree = "<group>"; };
+		419C82AF1FE20DCC0040C30F /* rtx_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtx_receive_stream.h; sourceTree = "<group>"; };
+		419C82B11FE20DCD0040C30F /* video_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_receive_stream.h; sourceTree = "<group>"; };
+		419C82EA1FE20EB40040C30F /* audio_encoder_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_opus.h; sourceTree = "<group>"; };
+		419C82EB1FE20EB40040C30F /* audio_encoder_opus_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_opus_config.h; sourceTree = "<group>"; };
+		419C82EC1FE20EB40040C30F /* audio_decoder_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_opus.h; sourceTree = "<group>"; };
+		419C82ED1FE20EB40040C30F /* audio_encoder_opus_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_opus_config.cc; sourceTree = "<group>"; };
+		419C82EE1FE20EB40040C30F /* audio_decoder_opus.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_opus.cc; sourceTree = "<group>"; };
+		419C82EF1FE20EB50040C30F /* audio_encoder_opus.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_opus.cc; sourceTree = "<group>"; };
 		419C82F61FE20EFB0040C30F /* rtcp_transceiver.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtcp_transceiver.cc; sourceTree = "<group>"; };
 		419C82F71FE20EFC0040C30F /* rtcp_transceiver_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtcp_transceiver_impl.cc; sourceTree = "<group>"; };
 		419C82F81FE20EFC0040C30F /* rtcp_transceiver_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtcp_transceiver_config.h; sourceTree = "<group>"; };
@@ -7991,56 +7991,56 @@
 		419C82FA1FE20EFD0040C30F /* rtcp_transceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtcp_transceiver.h; sourceTree = "<group>"; };
 		419C82FC1FE20EFE0040C30F /* rtcp_transceiver_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtcp_transceiver_impl.h; sourceTree = "<group>"; };
 		419C82FE1FE20F010040C30F /* rtp_packet_received.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_packet_received.cc; sourceTree = "<group>"; };
-		419C830A1FE20F3B0040C30F /* audio_network_adaptor_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_network_adaptor_config.cc; path = audio_network_adaptor/audio_network_adaptor_config.cc; sourceTree = "<group>"; };
+		419C830A1FE20F3B0040C30F /* audio_network_adaptor_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_network_adaptor_config.cc; sourceTree = "<group>"; };
 		419C83161FE242B10040C30F /* fir_filter_c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fir_filter_c.h; sourceTree = "<group>"; };
 		419C83171FE242B20040C30F /* fir_filter_c.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fir_filter_c.cc; sourceTree = "<group>"; };
 		419C83181FE242B20040C30F /* fir_filter_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fir_filter_factory.h; sourceTree = "<group>"; };
 		419C83191FE242B20040C30F /* fir_filter_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fir_filter_factory.cc; sourceTree = "<group>"; };
 		419C831E1FE242E50040C30F /* video_stream_encoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_stream_encoder.cc; sourceTree = "<group>"; };
 		419C832B1FE245CC0040C30F /* interval_budget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interval_budget.h; sourceTree = "<group>"; };
-		419C83371FE246220040C30F /* audio_encoder_g722_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_g722_config.h; path = audio_codecs/g722/audio_encoder_g722_config.h; sourceTree = "<group>"; };
-		419C83381FE246220040C30F /* audio_decoder_g722.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_g722.h; path = audio_codecs/g722/audio_decoder_g722.h; sourceTree = "<group>"; };
-		419C83391FE246220040C30F /* audio_encoder_g722.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_g722.cc; path = audio_codecs/g722/audio_encoder_g722.cc; sourceTree = "<group>"; };
-		419C833A1FE246220040C30F /* audio_decoder_g722.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder_g722.cc; path = audio_codecs/g722/audio_decoder_g722.cc; sourceTree = "<group>"; };
-		419C833B1FE246230040C30F /* audio_encoder_g722.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_g722.h; path = audio_codecs/g722/audio_encoder_g722.h; sourceTree = "<group>"; };
-		419C83421FE246620040C30F /* percentile_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = percentile_filter.h; path = rtc_base/numerics/percentile_filter.h; sourceTree = "<group>"; };
-		419C83431FE246620040C30F /* exp_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = exp_filter.cc; path = rtc_base/numerics/exp_filter.cc; sourceTree = "<group>"; };
-		419C83441FE246630040C30F /* exp_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = exp_filter.h; path = rtc_base/numerics/exp_filter.h; sourceTree = "<group>"; };
-		419C83451FE246630040C30F /* histogram_percentile_counter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = histogram_percentile_counter.cc; path = rtc_base/numerics/histogram_percentile_counter.cc; sourceTree = "<group>"; };
-		419C83471FE246630040C30F /* safe_conversions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = safe_conversions.h; path = rtc_base/numerics/safe_conversions.h; sourceTree = "<group>"; };
-		419C83481FE246630040C30F /* safe_minmax.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = safe_minmax.h; path = rtc_base/numerics/safe_minmax.h; sourceTree = "<group>"; };
-		419C83491FE246640040C30F /* moving_max_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = moving_max_counter.h; path = rtc_base/numerics/moving_max_counter.h; sourceTree = "<group>"; };
-		419C834A1FE246640040C30F /* mod_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mod_ops.h; path = rtc_base/numerics/mod_ops.h; sourceTree = "<group>"; };
-		419C834B1FE246640040C30F /* safe_compare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = safe_compare.h; path = rtc_base/numerics/safe_compare.h; sourceTree = "<group>"; };
-		419C834C1FE246640040C30F /* histogram_percentile_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = histogram_percentile_counter.h; path = rtc_base/numerics/histogram_percentile_counter.h; sourceTree = "<group>"; };
-		419C83B61FE247B10040C30F /* rtp_rtcp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_rtcp.h; path = rtp_rtcp/include/rtp_rtcp.h; sourceTree = "<group>"; };
-		419C83B71FE247B20040C30F /* rtp_header_extension_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_header_extension_map.h; path = rtp_rtcp/include/rtp_header_extension_map.h; sourceTree = "<group>"; };
-		419C83B81FE247B20040C30F /* remote_ntp_time_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = remote_ntp_time_estimator.h; path = rtp_rtcp/include/remote_ntp_time_estimator.h; sourceTree = "<group>"; };
-		419C83BB1FE247B30040C30F /* rtp_rtcp_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_rtcp_defines.h; path = rtp_rtcp/include/rtp_rtcp_defines.h; sourceTree = "<group>"; };
-		419C83BC1FE247B30040C30F /* rtp_cvo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_cvo.h; path = rtp_rtcp/include/rtp_cvo.h; sourceTree = "<group>"; };
-		419C83BD1FE247B30040C30F /* receive_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = receive_statistics.h; path = rtp_rtcp/include/receive_statistics.h; sourceTree = "<group>"; };
-		419C83BE1FE247B30040C30F /* flexfec_receiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = flexfec_receiver.h; path = rtp_rtcp/include/flexfec_receiver.h; sourceTree = "<group>"; };
-		419C83C01FE247B40040C30F /* rtp_rtcp_defines.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_rtcp_defines.cc; path = rtp_rtcp/include/rtp_rtcp_defines.cc; sourceTree = "<group>"; };
-		419C83C11FE247B40040C30F /* flexfec_sender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = flexfec_sender.h; path = rtp_rtcp/include/flexfec_sender.h; sourceTree = "<group>"; };
-		419C83E31FE248340040C30F /* audio_encoder_g711.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_g711.cc; path = audio_codecs/g711/audio_encoder_g711.cc; sourceTree = "<group>"; };
-		419C83E41FE248350040C30F /* audio_decoder_g711.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_g711.h; path = audio_codecs/g711/audio_decoder_g711.h; sourceTree = "<group>"; };
-		419C83E51FE248350040C30F /* audio_decoder_g711.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder_g711.cc; path = audio_codecs/g711/audio_decoder_g711.cc; sourceTree = "<group>"; };
-		419C83E61FE248350040C30F /* audio_encoder_g711.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_g711.h; path = audio_codecs/g711/audio_encoder_g711.h; sourceTree = "<group>"; };
-		419C83EC1FE2488C0040C30F /* audio_decoder_L16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_L16.h; path = audio_codecs/L16/audio_decoder_L16.h; sourceTree = "<group>"; };
-		419C83ED1FE2488C0040C30F /* audio_encoder_L16.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_L16.cc; path = audio_codecs/L16/audio_encoder_L16.cc; sourceTree = "<group>"; };
-		419C83EE1FE2488C0040C30F /* audio_decoder_L16.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder_L16.cc; path = audio_codecs/L16/audio_decoder_L16.cc; sourceTree = "<group>"; };
-		419C83EF1FE2488C0040C30F /* audio_encoder_L16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_L16.h; path = audio_codecs/L16/audio_encoder_L16.h; sourceTree = "<group>"; };
+		419C83371FE246220040C30F /* audio_encoder_g722_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_g722_config.h; sourceTree = "<group>"; };
+		419C83381FE246220040C30F /* audio_decoder_g722.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_g722.h; sourceTree = "<group>"; };
+		419C83391FE246220040C30F /* audio_encoder_g722.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_g722.cc; sourceTree = "<group>"; };
+		419C833A1FE246220040C30F /* audio_decoder_g722.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_g722.cc; sourceTree = "<group>"; };
+		419C833B1FE246230040C30F /* audio_encoder_g722.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_g722.h; sourceTree = "<group>"; };
+		419C83421FE246620040C30F /* percentile_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = percentile_filter.h; sourceTree = "<group>"; };
+		419C83431FE246620040C30F /* exp_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = exp_filter.cc; sourceTree = "<group>"; };
+		419C83441FE246630040C30F /* exp_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = exp_filter.h; sourceTree = "<group>"; };
+		419C83451FE246630040C30F /* histogram_percentile_counter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = histogram_percentile_counter.cc; sourceTree = "<group>"; };
+		419C83471FE246630040C30F /* safe_conversions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = safe_conversions.h; sourceTree = "<group>"; };
+		419C83481FE246630040C30F /* safe_minmax.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = safe_minmax.h; sourceTree = "<group>"; };
+		419C83491FE246640040C30F /* moving_max_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = moving_max_counter.h; sourceTree = "<group>"; };
+		419C834A1FE246640040C30F /* mod_ops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mod_ops.h; sourceTree = "<group>"; };
+		419C834B1FE246640040C30F /* safe_compare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = safe_compare.h; sourceTree = "<group>"; };
+		419C834C1FE246640040C30F /* histogram_percentile_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = histogram_percentile_counter.h; sourceTree = "<group>"; };
+		419C83B61FE247B10040C30F /* rtp_rtcp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_rtcp.h; sourceTree = "<group>"; };
+		419C83B71FE247B20040C30F /* rtp_header_extension_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_header_extension_map.h; sourceTree = "<group>"; };
+		419C83B81FE247B20040C30F /* remote_ntp_time_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remote_ntp_time_estimator.h; sourceTree = "<group>"; };
+		419C83BB1FE247B30040C30F /* rtp_rtcp_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_rtcp_defines.h; sourceTree = "<group>"; };
+		419C83BC1FE247B30040C30F /* rtp_cvo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_cvo.h; sourceTree = "<group>"; };
+		419C83BD1FE247B30040C30F /* receive_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = receive_statistics.h; sourceTree = "<group>"; };
+		419C83BE1FE247B30040C30F /* flexfec_receiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flexfec_receiver.h; sourceTree = "<group>"; };
+		419C83C01FE247B40040C30F /* rtp_rtcp_defines.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_rtcp_defines.cc; sourceTree = "<group>"; };
+		419C83C11FE247B40040C30F /* flexfec_sender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flexfec_sender.h; sourceTree = "<group>"; };
+		419C83E31FE248340040C30F /* audio_encoder_g711.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_g711.cc; sourceTree = "<group>"; };
+		419C83E41FE248350040C30F /* audio_decoder_g711.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_g711.h; sourceTree = "<group>"; };
+		419C83E51FE248350040C30F /* audio_decoder_g711.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_g711.cc; sourceTree = "<group>"; };
+		419C83E61FE248350040C30F /* audio_encoder_g711.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_g711.h; sourceTree = "<group>"; };
+		419C83EC1FE2488C0040C30F /* audio_decoder_L16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_L16.h; sourceTree = "<group>"; };
+		419C83ED1FE2488C0040C30F /* audio_encoder_L16.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_L16.cc; sourceTree = "<group>"; };
+		419C83EE1FE2488C0040C30F /* audio_decoder_L16.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_L16.cc; sourceTree = "<group>"; };
+		419C83EF1FE2488C0040C30F /* audio_encoder_L16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_L16.h; sourceTree = "<group>"; };
 		419C83F61FE248F00040C30F /* decimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decimator.h; sourceTree = "<group>"; };
 		419C83F71FE248F00040C30F /* decimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = decimator.cc; sourceTree = "<group>"; };
 		419C840C1FE249A90040C30F /* video_timing.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_timing.cc; sourceTree = "<group>"; };
 		419C840D1FE249AA0040C30F /* video_content_type.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_content_type.cc; sourceTree = "<group>"; };
 		419C840E1FE249AA0040C30F /* video_timing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_timing.h; sourceTree = "<group>"; };
 		419C840F1FE249AB0040C30F /* video_content_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_content_type.h; sourceTree = "<group>"; };
-		419C84181FE24AED0040C30F /* rtc_event_log_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_event_log_parser.cc; path = rtc_event_log/rtc_event_log_parser.cc; sourceTree = "<group>"; };
-		419C84191FE24AEE0040C30F /* rtc_stream_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtc_stream_config.cc; path = rtc_event_log/rtc_stream_config.cc; sourceTree = "<group>"; };
-		419C841A1FE24AEE0040C30F /* rtc_stream_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_stream_config.h; path = rtc_event_log/rtc_stream_config.h; sourceTree = "<group>"; };
-		419C841B1FE24AEE0040C30F /* rtc_event_log_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event_log_parser.h; path = rtc_event_log/rtc_event_log_parser.h; sourceTree = "<group>"; };
-		419C84211FE24BA50040C30F /* rtc_event_log_output_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event_log_output_file.h; path = rtc_event_log/output/rtc_event_log_output_file.h; sourceTree = "<group>"; };
+		419C84181FE24AED0040C30F /* rtc_event_log_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_log_parser.cc; sourceTree = "<group>"; };
+		419C84191FE24AEE0040C30F /* rtc_stream_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_stream_config.cc; sourceTree = "<group>"; };
+		419C841A1FE24AEE0040C30F /* rtc_stream_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_stream_config.h; sourceTree = "<group>"; };
+		419C841B1FE24AEE0040C30F /* rtc_event_log_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_log_parser.h; sourceTree = "<group>"; };
+		419C84211FE24BA50040C30F /* rtc_event_log_output_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_log_output_file.h; sourceTree = "<group>"; };
 		419C842B1FE24E7E0040C30F /* default_temporal_layers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = default_temporal_layers.cc; sourceTree = "<group>"; };
 		419C842C1FE24E7F0040C30F /* screenshare_layers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = screenshare_layers.h; sourceTree = "<group>"; };
 		419C84301FE24E7F0040C30F /* screenshare_layers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = screenshare_layers.cc; sourceTree = "<group>"; };
@@ -8099,13 +8099,13 @@
 		419EA20D215C51B60082BFD2 /* dwarf2-dbgfmt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "dwarf2-dbgfmt.h"; sourceTree = "<group>"; };
 		419EA20E215C51B60082BFD2 /* dwarf2-dbgfmt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "dwarf2-dbgfmt.c"; sourceTree = "<group>"; };
 		419EA20F215C51B60082BFD2 /* dwarf2-aranges.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "dwarf2-aranges.c"; sourceTree = "<group>"; };
-		41A08BB721268A7D001D5D7B /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = memory.h; path = memory/memory.h; sourceTree = "<group>"; };
+		41A08BB721268A7D001D5D7B /* memory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		41A08BB921269552001D5D7B /* rtc_event_ice_candidate_pair_config.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_ice_candidate_pair_config.cc; sourceTree = "<group>"; };
 		41A08BBA21269552001D5D7B /* rtc_event_ice_candidate_pair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_ice_candidate_pair.h; sourceTree = "<group>"; };
 		41A08BBB21269552001D5D7B /* rtc_event_ice_candidate_pair_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_ice_candidate_pair_config.h; sourceTree = "<group>"; };
 		41A08BBC21269553001D5D7B /* rtc_event_ice_candidate_pair.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtc_event_ice_candidate_pair.cc; sourceTree = "<group>"; };
-		41A08BC5212695DE001D5D7B /* bad_optional_access.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bad_optional_access.h; path = types/bad_optional_access.h; sourceTree = "<group>"; };
-		41A08BC6212695DE001D5D7B /* bad_optional_access.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = bad_optional_access.cc; path = types/bad_optional_access.cc; sourceTree = "<group>"; };
+		41A08BC5212695DE001D5D7B /* bad_optional_access.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bad_optional_access.h; sourceTree = "<group>"; };
+		41A08BC6212695DE001D5D7B /* bad_optional_access.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bad_optional_access.cc; sourceTree = "<group>"; };
 		41A08BC92126961F001D5D7B /* raw_logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = raw_logging.h; sourceTree = "<group>"; };
 		41A08BCA2126961F001D5D7B /* raw_logging.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = raw_logging.cc; sourceTree = "<group>"; };
 		41A08BCD21272EE1001D5D7B /* gain_controller2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gain_controller2.h; sourceTree = "<group>"; };
@@ -8173,10 +8173,10 @@
 		41A391A61EFC454F00C4516A /* tls_cbc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tls_cbc.c; sourceTree = "<group>"; };
 		41A391B81EFC45CD00C4516A /* bn_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bn_asn1.c; sourceTree = "<group>"; };
 		41A391BA1EFC45CD00C4516A /* convert.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = convert.c; sourceTree = "<group>"; };
-		41A391BD1EFC460C00C4516A /* pkcs8_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pkcs8_x509.c; path = pkcs8/pkcs8_x509.c; sourceTree = "<group>"; };
+		41A391BD1EFC460C00C4516A /* pkcs8_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs8_x509.c; sourceTree = "<group>"; };
 		41A391C31EFC465600C4516A /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
 		41A391C41EFC465600C4516A /* pool.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pool.c; sourceTree = "<group>"; };
-		41A391CB1EFC46DE00C4516A /* x_all.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_all.c; path = x509/x_all.c; sourceTree = "<group>"; };
+		41A391CB1EFC46DE00C4516A /* x_all.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_all.c; sourceTree = "<group>"; };
 		41A391D11EFC484C00C4516A /* rsa_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_asn1.c; sourceTree = "<group>"; };
 		41A391D71EFC488400C4516A /* ec_asn1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ec_asn1.c; sourceTree = "<group>"; };
 		41A391DA1EFC489900C4516A /* digest_extra.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = digest_extra.c; sourceTree = "<group>"; };
@@ -8191,8 +8191,8 @@
 		41A391FA1EFC493000C4516A /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
 		41A391FB1EFC493000C4516A /* key_wrap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = key_wrap.c; sourceTree = "<group>"; };
 		41A391FC1EFC493000C4516A /* mode_wrappers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mode_wrappers.c; sourceTree = "<group>"; };
-		41A392051EFC4A6300C4516A /* p_ed25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_ed25519.c; path = evp/p_ed25519.c; sourceTree = "<group>"; };
-		41A392071EFC4A7100C4516A /* p_ed25519_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_ed25519_asn1.c; path = evp/p_ed25519_asn1.c; sourceTree = "<group>"; };
+		41A392051EFC4A6300C4516A /* p_ed25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_ed25519.c; sourceTree = "<group>"; };
+		41A392071EFC4A7100C4516A /* p_ed25519_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_ed25519_asn1.c; sourceTree = "<group>"; };
 		41A3920B1EFC4AFE00C4516A /* deterministic.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = deterministic.c; sourceTree = "<group>"; };
 		41A3920C1EFC4AFE00C4516A /* forkunsafe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = forkunsafe.c; sourceTree = "<group>"; };
 		41A3920D1EFC4AFE00C4516A /* fuchsia.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fuchsia.c; sourceTree = "<group>"; };
@@ -8222,8 +8222,8 @@
 		41B8D78D28C8888000E5FA37 /* legacy_stats_collector.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = legacy_stats_collector.cc; sourceTree = "<group>"; };
 		41B8D78E28C8888000E5FA37 /* legacy_stats_collector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = legacy_stats_collector.h; sourceTree = "<group>"; };
 		41B8D78F28C8888000E5FA37 /* legacy_stats_collector_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = legacy_stats_collector_interface.h; sourceTree = "<group>"; };
-		41B8D79328C888A900E5FA37 /* pending_task_safety_flag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pending_task_safety_flag.h; path = task_queue/pending_task_safety_flag.h; sourceTree = "<group>"; };
-		41B8D79428C888AA00E5FA37 /* pending_task_safety_flag.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pending_task_safety_flag.cc; path = task_queue/pending_task_safety_flag.cc; sourceTree = "<group>"; };
+		41B8D79328C888A900E5FA37 /* pending_task_safety_flag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pending_task_safety_flag.h; sourceTree = "<group>"; };
+		41B8D79428C888AA00E5FA37 /* pending_task_safety_flag.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pending_task_safety_flag.cc; sourceTree = "<group>"; };
 		41B8D79728C888F500E5FA37 /* packet_arrival_history.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = packet_arrival_history.cc; sourceTree = "<group>"; };
 		41B8D79828C888F500E5FA37 /* packet_arrival_history.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = packet_arrival_history.h; sourceTree = "<group>"; };
 		41B8D79B28C8893400E5FA37 /* ice_switch_reason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ice_switch_reason.h; sourceTree = "<group>"; };
@@ -8277,28 +8277,28 @@
 		41B8D80428C88C7600E5FA37 /* vp8_scalability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8_scalability.h; sourceTree = "<group>"; };
 		41B8D80728C88D5B00E5FA37 /* frame_helpers.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = frame_helpers.cc; sourceTree = "<group>"; };
 		41B8D80828C88D5D00E5FA37 /* frame_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_helpers.h; sourceTree = "<group>"; };
-		41B8D80F28C88DC800E5FA37 /* video_decoder_factory_template_libvpx_vp9_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_decoder_factory_template_libvpx_vp9_adapter.h; path = video_codecs/video_decoder_factory_template_libvpx_vp9_adapter.h; sourceTree = "<group>"; };
-		41B8D81028C88DC800E5FA37 /* video_encoder_factory_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_encoder_factory_template.h; path = video_codecs/video_encoder_factory_template.h; sourceTree = "<group>"; };
-		41B8D81128C88DC800E5FA37 /* video_decoder_factory_template_dav1d_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_decoder_factory_template_dav1d_adapter.h; path = video_codecs/video_decoder_factory_template_dav1d_adapter.h; sourceTree = "<group>"; };
-		41B8D81228C88DC900E5FA37 /* simulcast_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = simulcast_stream.cc; path = video_codecs/simulcast_stream.cc; sourceTree = "<group>"; };
-		41B8D81328C88DC900E5FA37 /* scalability_mode.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scalability_mode.cc; path = video_codecs/scalability_mode.cc; sourceTree = "<group>"; };
-		41B8D81428C88DC900E5FA37 /* video_encoder_factory_template_libaom_av1_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_encoder_factory_template_libaom_av1_adapter.h; path = video_codecs/video_encoder_factory_template_libaom_av1_adapter.h; sourceTree = "<group>"; };
-		41B8D81528C88DC900E5FA37 /* video_decoder_factory_template_open_h264_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_decoder_factory_template_open_h264_adapter.h; path = video_codecs/video_decoder_factory_template_open_h264_adapter.h; sourceTree = "<group>"; };
-		41B8D81628C88DCA00E5FA37 /* video_encoder_factory_template_open_h264_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_encoder_factory_template_open_h264_adapter.h; path = video_codecs/video_encoder_factory_template_open_h264_adapter.h; sourceTree = "<group>"; };
-		41B8D81728C88DCC00E5FA37 /* video_decoder_factory_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_decoder_factory_template.h; path = video_codecs/video_decoder_factory_template.h; sourceTree = "<group>"; };
-		41B8D81828C88DCD00E5FA37 /* video_decoder_factory_template_libvpx_vp8_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_decoder_factory_template_libvpx_vp8_adapter.h; path = video_codecs/video_decoder_factory_template_libvpx_vp8_adapter.h; sourceTree = "<group>"; };
-		41B8D81928C88DCE00E5FA37 /* video_encoder_factory_template_libvpx_vp8_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_encoder_factory_template_libvpx_vp8_adapter.h; path = video_codecs/video_encoder_factory_template_libvpx_vp8_adapter.h; sourceTree = "<group>"; };
-		41B8D81A28C88DCE00E5FA37 /* simulcast_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = simulcast_stream.h; path = video_codecs/simulcast_stream.h; sourceTree = "<group>"; };
-		41B8D81B28C88DCE00E5FA37 /* scalability_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scalability_mode.h; path = video_codecs/scalability_mode.h; sourceTree = "<group>"; };
-		41B8D81C28C88DCE00E5FA37 /* video_encoder_factory_template_libvpx_vp9_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_encoder_factory_template_libvpx_vp9_adapter.h; path = video_codecs/video_encoder_factory_template_libvpx_vp9_adapter.h; sourceTree = "<group>"; };
+		41B8D80F28C88DC800E5FA37 /* video_decoder_factory_template_libvpx_vp9_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_decoder_factory_template_libvpx_vp9_adapter.h; sourceTree = "<group>"; };
+		41B8D81028C88DC800E5FA37 /* video_encoder_factory_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_encoder_factory_template.h; sourceTree = "<group>"; };
+		41B8D81128C88DC800E5FA37 /* video_decoder_factory_template_dav1d_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_decoder_factory_template_dav1d_adapter.h; sourceTree = "<group>"; };
+		41B8D81228C88DC900E5FA37 /* simulcast_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = simulcast_stream.cc; sourceTree = "<group>"; };
+		41B8D81328C88DC900E5FA37 /* scalability_mode.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scalability_mode.cc; sourceTree = "<group>"; };
+		41B8D81428C88DC900E5FA37 /* video_encoder_factory_template_libaom_av1_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_encoder_factory_template_libaom_av1_adapter.h; sourceTree = "<group>"; };
+		41B8D81528C88DC900E5FA37 /* video_decoder_factory_template_open_h264_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_decoder_factory_template_open_h264_adapter.h; sourceTree = "<group>"; };
+		41B8D81628C88DCA00E5FA37 /* video_encoder_factory_template_open_h264_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_encoder_factory_template_open_h264_adapter.h; sourceTree = "<group>"; };
+		41B8D81728C88DCC00E5FA37 /* video_decoder_factory_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_decoder_factory_template.h; sourceTree = "<group>"; };
+		41B8D81828C88DCD00E5FA37 /* video_decoder_factory_template_libvpx_vp8_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_decoder_factory_template_libvpx_vp8_adapter.h; sourceTree = "<group>"; };
+		41B8D81928C88DCE00E5FA37 /* video_encoder_factory_template_libvpx_vp8_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_encoder_factory_template_libvpx_vp8_adapter.h; sourceTree = "<group>"; };
+		41B8D81A28C88DCE00E5FA37 /* simulcast_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simulcast_stream.h; sourceTree = "<group>"; };
+		41B8D81B28C88DCE00E5FA37 /* scalability_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scalability_mode.h; sourceTree = "<group>"; };
+		41B8D81C28C88DCE00E5FA37 /* video_encoder_factory_template_libvpx_vp9_adapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_encoder_factory_template_libvpx_vp9_adapter.h; sourceTree = "<group>"; };
 		41B8D82B28C88E0700E5FA37 /* prioritized_packet_queue.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = prioritized_packet_queue.cc; sourceTree = "<group>"; };
 		41B8D82C28C88E0900E5FA37 /* prioritized_packet_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = prioritized_packet_queue.h; sourceTree = "<group>"; };
 		41B8D82F28C88E4600E5FA37 /* ulpfec_receiver.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ulpfec_receiver.cc; sourceTree = "<group>"; };
 		41B8D83028C88E4600E5FA37 /* ulpfec_receiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ulpfec_receiver.h; sourceTree = "<group>"; };
 		41B8D83328C88E6100E5FA37 /* config_selector.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = config_selector.cc; sourceTree = "<group>"; };
 		41B8D83428C88E6200E5FA37 /* config_selector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config_selector.h; sourceTree = "<group>"; };
-		41B8D83728C88EC700E5FA37 /* av1_profile.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = av1_profile.cc; path = video_codecs/av1_profile.cc; sourceTree = "<group>"; };
-		41B8D83828C88EC800E5FA37 /* av1_profile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = av1_profile.h; path = video_codecs/av1_profile.h; sourceTree = "<group>"; };
+		41B8D83728C88EC700E5FA37 /* av1_profile.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = av1_profile.cc; sourceTree = "<group>"; };
+		41B8D83828C88EC800E5FA37 /* av1_profile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = av1_profile.h; sourceTree = "<group>"; };
 		41B8D83B28C896A800E5FA37 /* make_ref_counted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = make_ref_counted.h; sourceTree = "<group>"; };
 		41B8D83E28C899B300E5FA37 /* function_ref.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function_ref.h; sourceTree = "<group>"; };
 		41B8D83F28C899B300E5FA37 /* any_invocable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = any_invocable.h; sourceTree = "<group>"; };
@@ -8308,7 +8308,7 @@
 		41B8D84D28C89AC200E5FA37 /* field_trials_view.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = field_trials_view.h; sourceTree = "<group>"; };
 		41B8D84F28C89B0B00E5FA37 /* video_track_source_constraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_track_source_constraints.h; sourceTree = "<group>"; };
 		41B8D85228C89B6800E5FA37 /* metronome.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = metronome.h; sourceTree = "<group>"; };
-		41B8D85428C89C7700E5FA37 /* always_valid_pointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = always_valid_pointer.h; path = rtc_base/memory/always_valid_pointer.h; sourceTree = "<group>"; };
+		41B8D85428C89C7700E5FA37 /* always_valid_pointer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = always_valid_pointer.h; sourceTree = "<group>"; };
 		41B8D86628CB84D200E5FA37 /* internal_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal_types.h; sourceTree = "<group>"; };
 		41B8D86728CB84D300E5FA37 /* sequence_numbers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sequence_numbers.h; sourceTree = "<group>"; };
 		41B8D86828CB84D300E5FA37 /* str_join.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = str_join.h; sourceTree = "<group>"; };
@@ -8524,9 +8524,9 @@
 		41BE71A2215C463700A7B196 /* phash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = phash.h; sourceTree = "<group>"; };
 		41BE71DF215C470B00A7B196 /* libyasm-stdint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "libyasm-stdint.h"; sourceTree = "<group>"; };
 		41BE71E0215C470B00A7B196 /* license.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = license.c; sourceTree = "<group>"; };
-		41C01FC2242B5C0A00E08018 /* rtc_stats_collector_callback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_stats_collector_callback.h; path = stats/rtc_stats_collector_callback.h; sourceTree = "<group>"; };
-		41C01FC3242B5C0A00E08018 /* rtc_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_stats.h; path = stats/rtc_stats.h; sourceTree = "<group>"; };
-		41C01FC4242B5C0A00E08018 /* rtc_stats_report.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_stats_report.h; path = stats/rtc_stats_report.h; sourceTree = "<group>"; };
+		41C01FC2242B5C0A00E08018 /* rtc_stats_collector_callback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_stats_collector_callback.h; sourceTree = "<group>"; };
+		41C01FC3242B5C0A00E08018 /* rtc_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_stats.h; sourceTree = "<group>"; };
+		41C01FC4242B5C0A00E08018 /* rtc_stats_report.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_stats_report.h; sourceTree = "<group>"; };
 		41C01FC8242B652A00E08018 /* rtc_export_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_export_template.h; sourceTree = "<group>"; };
 		41C01FC9242B652B00E08018 /* rtc_export.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_export.h; sourceTree = "<group>"; };
 		41C6290E212E2DE2002313D4 /* highbd_idct32x32_add_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = highbd_idct32x32_add_sse2.c; sourceTree = "<group>"; };
@@ -8600,15 +8600,15 @@
 		41CB0A26215C8DAA0097B8AA /* highbd_inv_txfm_sse2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = highbd_inv_txfm_sse2.h; sourceTree = "<group>"; };
 		41CB0A27215C8DAB0097B8AA /* bitdepth_conversion_avx2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitdepth_conversion_avx2.h; sourceTree = "<group>"; };
 		41CB0A58215C90500097B8AA /* subpixel_ssse3.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = subpixel_ssse3.asm; sourceTree = "<group>"; };
-		41CBAF90212E037E00DE1E1D /* decodemv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decodemv.c; path = decoder/decodemv.c; sourceTree = "<group>"; };
-		41CBAF91212E037F00DE1E1D /* error_concealment.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = error_concealment.c; path = decoder/error_concealment.c; sourceTree = "<group>"; };
-		41CBAFA4212E03AC00DE1E1D /* denoising.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = denoising.h; path = encoder/denoising.h; sourceTree = "<group>"; };
-		41CBAFA5212E03AC00DE1E1D /* mcomp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = mcomp.h; path = encoder/mcomp.h; sourceTree = "<group>"; };
-		41CBAFA6212E03AD00DE1E1D /* bitstream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = bitstream.h; path = encoder/bitstream.h; sourceTree = "<group>"; };
-		41CBAFA7212E03AD00DE1E1D /* bitstream.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = bitstream.c; path = encoder/bitstream.c; sourceTree = "<group>"; };
-		41CBAFA8212E03AD00DE1E1D /* vp8_quantize.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = vp8_quantize.c; path = encoder/vp8_quantize.c; sourceTree = "<group>"; };
-		41CBAFA9212E03AD00DE1E1D /* firstpass.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = firstpass.c; path = encoder/firstpass.c; sourceTree = "<group>"; };
-		41CBAFAA212E03AD00DE1E1D /* pickinter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pickinter.c; path = encoder/pickinter.c; sourceTree = "<group>"; };
+		41CBAF90212E037E00DE1E1D /* decodemv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decodemv.c; sourceTree = "<group>"; };
+		41CBAF91212E037F00DE1E1D /* error_concealment.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = error_concealment.c; sourceTree = "<group>"; };
+		41CBAFA4212E03AC00DE1E1D /* denoising.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = denoising.h; sourceTree = "<group>"; };
+		41CBAFA5212E03AC00DE1E1D /* mcomp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mcomp.h; sourceTree = "<group>"; };
+		41CBAFA6212E03AD00DE1E1D /* bitstream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bitstream.h; sourceTree = "<group>"; };
+		41CBAFA7212E03AD00DE1E1D /* bitstream.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bitstream.c; sourceTree = "<group>"; };
+		41CBAFA8212E03AD00DE1E1D /* vp8_quantize.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vp8_quantize.c; sourceTree = "<group>"; };
+		41CBAFA9212E03AD00DE1E1D /* firstpass.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = firstpass.c; sourceTree = "<group>"; };
+		41CBAFAA212E03AD00DE1E1D /* pickinter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = pickinter.c; sourceTree = "<group>"; };
 		41D1240E215C51CE0036B057 /* dwarf2-info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "dwarf2-info.c"; sourceTree = "<group>"; };
 		41D1241A215C520F0036B057 /* cpp-preproc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "cpp-preproc.c"; sourceTree = "<group>"; };
 		41D1241D215C52230036B057 /* gas-eval.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "gas-eval.c"; sourceTree = "<group>"; };
@@ -8640,14 +8640,14 @@
 		41D729072665091A00651A0B /* cipher_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cipher_types.h; sourceTree = "<group>"; };
 		41D7291326650CC300651A0B /* vp9_ext_ratectrl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp9_ext_ratectrl.h; sourceTree = "<group>"; };
 		41D7291426650CC400651A0B /* vp9_ext_ratectrl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp9_ext_ratectrl.c; sourceTree = "<group>"; };
-		41D7291726650F1100651A0B /* scale_uv.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scale_uv.cc; path = source/scale_uv.cc; sourceTree = "<group>"; };
-		41D7291A26651D6A00651A0B /* h264_profile_level_id.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = h264_profile_level_id.h; path = video_codecs/h264_profile_level_id.h; sourceTree = "<group>"; };
-		41D7291B26651D6A00651A0B /* h264_profile_level_id.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = h264_profile_level_id.cc; path = video_codecs/h264_profile_level_id.cc; sourceTree = "<group>"; };
+		41D7291726650F1100651A0B /* scale_uv.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_uv.cc; sourceTree = "<group>"; };
+		41D7291A26651D6A00651A0B /* h264_profile_level_id.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = h264_profile_level_id.h; sourceTree = "<group>"; };
+		41D7291B26651D6A00651A0B /* h264_profile_level_id.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h264_profile_level_id.cc; sourceTree = "<group>"; };
 		41D7291F26651F7200651A0B /* libvpx_vp9_encoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libvpx_vp9_encoder.cc; sourceTree = "<group>"; };
 		41D7292026651F7200651A0B /* libvpx_vp9_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libvpx_vp9_encoder.h; sourceTree = "<group>"; };
 		41D7292126651F7300651A0B /* libvpx_vp9_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libvpx_vp9_decoder.h; sourceTree = "<group>"; };
 		41D7292226651F7300651A0B /* libvpx_vp9_decoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libvpx_vp9_decoder.cc; sourceTree = "<group>"; };
-		41DB1A9324321614005AB8EA /* rtcstats_objects.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtcstats_objects.cc; path = stats/rtcstats_objects.cc; sourceTree = "<group>"; };
+		41DB1A9324321614005AB8EA /* rtcstats_objects.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtcstats_objects.cc; sourceTree = "<group>"; };
 		41DC18942922758600DAEB3C /* crc32c_arm64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crc32c_arm64.h; sourceTree = "<group>"; };
 		41DC18952922758600DAEB3C /* crc32c_arm64_check.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crc32c_arm64_check.h; sourceTree = "<group>"; };
 		41DC18962922758600DAEB3C /* crc32c_sse42_check.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crc32c_sse42_check.h; sourceTree = "<group>"; };
@@ -8661,24 +8661,24 @@
 		41DC25872922788300DAEB3C /* crc32c_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crc32c_config.h; sourceTree = "<group>"; };
 		41DC258A292278A800DAEB3C /* crc32c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crc32c.h; sourceTree = "<group>"; };
 		41DC258D2922797000DAEB3C /* crc32c_prefetch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crc32c_prefetch.h; sourceTree = "<group>"; };
-		41DDB24B21265BD700296D47 /* fixed_array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fixed_array.h; path = container/fixed_array.h; sourceTree = "<group>"; };
-		41DDB24C21265BD700296D47 /* inlined_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = inlined_vector.h; path = container/inlined_vector.h; sourceTree = "<group>"; };
-		41DDB24F21265BE900296D47 /* optional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = optional.h; path = types/optional.h; sourceTree = "<group>"; };
+		41DDB24B21265BD700296D47 /* fixed_array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fixed_array.h; sourceTree = "<group>"; };
+		41DDB24C21265BD700296D47 /* inlined_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inlined_vector.h; sourceTree = "<group>"; };
+		41DDB24F21265BE900296D47 /* optional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = optional.h; sourceTree = "<group>"; };
 		41DDB268212679D100296D47 /* string_builder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_builder.h; sourceTree = "<group>"; };
 		41DDB269212679D100296D47 /* audio_format_to_string.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_format_to_string.h; sourceTree = "<group>"; };
 		41DDB26A212679D200296D47 /* string_builder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_builder.cc; sourceTree = "<group>"; };
 		41DDB26B212679D200296D47 /* audio_format_to_string.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_format_to_string.cc; sourceTree = "<group>"; };
-		41DDB27021267AC000296D47 /* video_codec.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = video_codec.cc; path = video_codecs/video_codec.cc; sourceTree = "<group>"; };
-		41DDB27121267AC000296D47 /* video_codec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = video_codec.h; path = video_codecs/video_codec.h; sourceTree = "<group>"; };
-		41DDB27221267AC000296D47 /* video_decoder.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = video_decoder.cc; path = video_codecs/video_decoder.cc; sourceTree = "<group>"; };
-		41DDB27321267AC000296D47 /* builtin_video_decoder_factory.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = builtin_video_decoder_factory.cc; path = video_codecs/builtin_video_decoder_factory.cc; sourceTree = "<group>"; };
-		41DDB27421267AC100296D47 /* video_decoder_software_fallback_wrapper.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = video_decoder_software_fallback_wrapper.cc; path = video_codecs/video_decoder_software_fallback_wrapper.cc; sourceTree = "<group>"; };
-		41DDB27521267AC100296D47 /* video_encoder_software_fallback_wrapper.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = video_encoder_software_fallback_wrapper.cc; path = video_codecs/video_encoder_software_fallback_wrapper.cc; sourceTree = "<group>"; };
-		41DDB27621267AC100296D47 /* builtin_video_decoder_factory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = builtin_video_decoder_factory.h; path = video_codecs/builtin_video_decoder_factory.h; sourceTree = "<group>"; };
-		41DDB27721267AC100296D47 /* builtin_video_encoder_factory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = builtin_video_encoder_factory.h; path = video_codecs/builtin_video_encoder_factory.h; sourceTree = "<group>"; };
-		41DDB27821267AC100296D47 /* video_decoder_software_fallback_wrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = video_decoder_software_fallback_wrapper.h; path = video_codecs/video_decoder_software_fallback_wrapper.h; sourceTree = "<group>"; };
-		41DDB27921267AC200296D47 /* video_encoder_software_fallback_wrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = video_encoder_software_fallback_wrapper.h; path = video_codecs/video_encoder_software_fallback_wrapper.h; sourceTree = "<group>"; };
-		41DDB27A21267AC200296D47 /* sdp_video_format.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = sdp_video_format.cc; path = video_codecs/sdp_video_format.cc; sourceTree = "<group>"; wrapsLines = 0; };
+		41DDB27021267AC000296D47 /* video_codec.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = video_codec.cc; sourceTree = "<group>"; };
+		41DDB27121267AC000296D47 /* video_codec.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = video_codec.h; sourceTree = "<group>"; };
+		41DDB27221267AC000296D47 /* video_decoder.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = video_decoder.cc; sourceTree = "<group>"; };
+		41DDB27321267AC000296D47 /* builtin_video_decoder_factory.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = builtin_video_decoder_factory.cc; sourceTree = "<group>"; };
+		41DDB27421267AC100296D47 /* video_decoder_software_fallback_wrapper.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = video_decoder_software_fallback_wrapper.cc; sourceTree = "<group>"; };
+		41DDB27521267AC100296D47 /* video_encoder_software_fallback_wrapper.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = video_encoder_software_fallback_wrapper.cc; sourceTree = "<group>"; };
+		41DDB27621267AC100296D47 /* builtin_video_decoder_factory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = builtin_video_decoder_factory.h; sourceTree = "<group>"; };
+		41DDB27721267AC100296D47 /* builtin_video_encoder_factory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = builtin_video_encoder_factory.h; sourceTree = "<group>"; };
+		41DDB27821267AC100296D47 /* video_decoder_software_fallback_wrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = video_decoder_software_fallback_wrapper.h; sourceTree = "<group>"; };
+		41DDB27921267AC200296D47 /* video_encoder_software_fallback_wrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = video_encoder_software_fallback_wrapper.h; sourceTree = "<group>"; };
+		41DDB27A21267AC200296D47 /* sdp_video_format.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = sdp_video_format.cc; sourceTree = "<group>"; wrapsLines = 0; };
 		41E02C7F212734B800C27CD6 /* decoder_database.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decoder_database.h; sourceTree = "<group>"; };
 		41E02C82212734B800C27CD6 /* fec_controller_default.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fec_controller_default.cc; sourceTree = "<group>"; };
 		41E02C83212734B800C27CD6 /* decoder_database.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = decoder_database.cc; sourceTree = "<group>"; };
@@ -8702,14 +8702,14 @@
 		41E02CA12127352C00C27CD6 /* alr_detector.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = alr_detector.cc; sourceTree = "<group>"; };
 		41E02CA22127352C00C27CD6 /* goog_cc_network_control.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = goog_cc_network_control.cc; sourceTree = "<group>"; };
 		41E02CA32127352D00C27CD6 /* delay_increase_detector_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_increase_detector_interface.h; sourceTree = "<group>"; };
-		41E02CC22127358700C27CD6 /* builtin_video_encoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = builtin_video_encoder_factory.cc; path = video_codecs/builtin_video_encoder_factory.cc; sourceTree = "<group>"; };
+		41E02CC22127358700C27CD6 /* builtin_video_encoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = builtin_video_encoder_factory.cc; sourceTree = "<group>"; };
 		41E02CC7212735B600C27CD6 /* bitrate_settings.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bitrate_settings.cc; sourceTree = "<group>"; };
 		41E02CC8212735B700C27CD6 /* network_types.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network_types.cc; sourceTree = "<group>"; };
 		41E02CC9212735B700C27CD6 /* network_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network_types.h; sourceTree = "<group>"; };
 		41E02CCA212735B700C27CD6 /* network_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network_control.h; sourceTree = "<group>"; };
 		41E02CCB212735B700C27CD6 /* bitrate_settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitrate_settings.h; sourceTree = "<group>"; };
-		41E02CD12127360600C27CD6 /* sample_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sample_counter.h; path = rtc_base/numerics/sample_counter.h; sourceTree = "<group>"; };
-		41E02CD22127360700C27CD6 /* sample_counter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sample_counter.cc; path = rtc_base/numerics/sample_counter.cc; sourceTree = "<group>"; };
+		41E02CD12127360600C27CD6 /* sample_counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sample_counter.h; sourceTree = "<group>"; };
+		41E02CD22127360700C27CD6 /* sample_counter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sample_counter.cc; sourceTree = "<group>"; };
 		41E02CD72127363C00C27CD6 /* transport_feedback_adapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = transport_feedback_adapter.h; sourceTree = "<group>"; };
 		41E59E9323ACB6520095A94B /* system_state.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = system_state.h; sourceTree = "<group>"; };
 		41E59E9423ACC1230095A94B /* vp8_rtcd_no_acceleration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vp8_rtcd_no_acceleration.h; sourceTree = "<group>"; };
@@ -8772,10 +8772,10 @@
 		41EAF1CB212E2B69009F73EC /* bitreader_buffer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bitreader_buffer.c; sourceTree = "<group>"; };
 		41EAF1CC212E2B69009F73EC /* fwd_txfm.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fwd_txfm.h; sourceTree = "<group>"; };
 		41EAF1CD212E2B6A009F73EC /* bitwriter_buffer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bitwriter_buffer.c; sourceTree = "<group>"; };
-		41ECEAB320630107009D5141 /* RTCVideoCodec+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RTCVideoCodec+Private.h"; path = "PeerConnection/RTCVideoCodec+Private.h"; sourceTree = "<group>"; };
+		41ECEAB320630107009D5141 /* RTCVideoCodec+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RTCVideoCodec+Private.h"; sourceTree = "<group>"; };
 		41ECEABB206403C1009D5141 /* WebKitUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitUtilities.h; sourceTree = "<group>"; };
 		41ECEABD20640498009D5141 /* WebKitUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKitUtilities.mm; sourceTree = "<group>"; };
-		41ECEABF20640F27009D5141 /* NSString+StdString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSString+StdString.h"; path = "Common/NSString+StdString.h"; sourceTree = "<group>"; };
+		41ECEABF20640F27009D5141 /* NSString+StdString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+StdString.h"; sourceTree = "<group>"; };
 		41ECEAFB20646664009D5141 /* VideoProcessingSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoProcessingSoftLink.h; sourceTree = "<group>"; };
 		41EED7782152ED83000F2A16 /* save_reg_neon.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = save_reg_neon.asm; sourceTree = "<group>"; };
 		41EED7792152ED83000F2A16 /* loopfilter_16_neon.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = loopfilter_16_neon.asm; sourceTree = "<group>"; };
@@ -8783,22 +8783,22 @@
 		41EED77B2152ED84000F2A16 /* vpx_convolve_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vpx_convolve_neon.c; sourceTree = "<group>"; };
 		41EED7BB2152EEC8000F2A16 /* arm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arm.h; sourceTree = "<group>"; };
 		41EED7BC2152EEC8000F2A16 /* arm_cpudetect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = arm_cpudetect.c; sourceTree = "<group>"; };
-		41EEFD9E212E03EB00E54E93 /* encodemv.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = encodemv.c; path = encoder/encodemv.c; sourceTree = "<group>"; };
-		41EEFD9F212E03EB00E54E93 /* picklpf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = picklpf.h; path = encoder/picklpf.h; sourceTree = "<group>"; };
-		41EEFDA0212E03EC00E54E93 /* block.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = block.h; path = encoder/block.h; sourceTree = "<group>"; };
-		41EEFDA1212E03ED00E54E93 /* encodemb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = encodemb.c; path = encoder/encodemb.c; sourceTree = "<group>"; };
-		41EEFDA2212E03ED00E54E93 /* tokenize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = tokenize.h; path = encoder/tokenize.h; sourceTree = "<group>"; };
-		41EEFDA3212E03EE00E54E93 /* encodeframe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = encodeframe.h; path = encoder/encodeframe.h; sourceTree = "<group>"; };
-		41EEFDA4212E03EE00E54E93 /* firstpass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = firstpass.h; path = encoder/firstpass.h; sourceTree = "<group>"; };
-		41EEFDA5212E03EE00E54E93 /* dct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = dct.c; path = encoder/dct.c; sourceTree = "<group>"; };
-		41EEFDA6212E03EF00E54E93 /* encodeintra.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = encodeintra.c; path = encoder/encodeintra.c; sourceTree = "<group>"; };
-		41EEFDA7212E03EF00E54E93 /* onyx_int.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = onyx_int.h; path = encoder/onyx_int.h; sourceTree = "<group>"; };
-		41EEFDA8212E03EF00E54E93 /* encodeframe.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = encodeframe.c; path = encoder/encodeframe.c; sourceTree = "<group>"; };
-		41EEFDA9212E03F000E54E93 /* encodeintra.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = encodeintra.h; path = encoder/encodeintra.h; sourceTree = "<group>"; };
-		41EEFDAA212E03F000E54E93 /* dct_value_tokens.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dct_value_tokens.h; path = encoder/dct_value_tokens.h; sourceTree = "<group>"; };
-		41EEFDAB212E03F000E54E93 /* temporal_filter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = temporal_filter.c; path = encoder/temporal_filter.c; sourceTree = "<group>"; };
-		41EEFDAC212E03F000E54E93 /* defaultcoefcounts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = defaultcoefcounts.h; path = encoder/defaultcoefcounts.h; sourceTree = "<group>"; };
-		41EEFDAD212E03F100E54E93 /* encodemv.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = encodemv.h; path = encoder/encodemv.h; sourceTree = "<group>"; };
+		41EEFD9E212E03EB00E54E93 /* encodemv.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encodemv.c; sourceTree = "<group>"; };
+		41EEFD9F212E03EB00E54E93 /* picklpf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = picklpf.h; sourceTree = "<group>"; };
+		41EEFDA0212E03EC00E54E93 /* block.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = block.h; sourceTree = "<group>"; };
+		41EEFDA1212E03ED00E54E93 /* encodemb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encodemb.c; sourceTree = "<group>"; };
+		41EEFDA2212E03ED00E54E93 /* tokenize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = tokenize.h; sourceTree = "<group>"; };
+		41EEFDA3212E03EE00E54E93 /* encodeframe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = encodeframe.h; sourceTree = "<group>"; };
+		41EEFDA4212E03EE00E54E93 /* firstpass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = firstpass.h; sourceTree = "<group>"; };
+		41EEFDA5212E03EE00E54E93 /* dct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dct.c; sourceTree = "<group>"; };
+		41EEFDA6212E03EF00E54E93 /* encodeintra.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encodeintra.c; sourceTree = "<group>"; };
+		41EEFDA7212E03EF00E54E93 /* onyx_int.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = onyx_int.h; sourceTree = "<group>"; };
+		41EEFDA8212E03EF00E54E93 /* encodeframe.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encodeframe.c; sourceTree = "<group>"; };
+		41EEFDA9212E03F000E54E93 /* encodeintra.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = encodeintra.h; sourceTree = "<group>"; };
+		41EEFDAA212E03F000E54E93 /* dct_value_tokens.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dct_value_tokens.h; sourceTree = "<group>"; };
+		41EEFDAB212E03F000E54E93 /* temporal_filter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = temporal_filter.c; sourceTree = "<group>"; };
+		41EEFDAC212E03F000E54E93 /* defaultcoefcounts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = defaultcoefcounts.h; sourceTree = "<group>"; };
+		41EEFDAD212E03F100E54E93 /* encodemv.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = encodemv.h; sourceTree = "<group>"; };
 		41F2637021267B4A00274F59 /* spl_sqrt_floor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spl_sqrt_floor.h; sourceTree = "<group>"; };
 		41F2637121267B4A00274F59 /* spl_sqrt_floor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_sqrt_floor.c; sourceTree = "<group>"; };
 		41F2638721267F4000274F59 /* fft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fft.h; sourceTree = "<group>"; };
@@ -8830,7 +8830,7 @@
 		41F263C42126818900274F59 /* video_bitrate_allocation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = video_bitrate_allocation.h; sourceTree = "<group>"; };
 		41F263C62126818A00274F59 /* video_source_interface.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = video_source_interface.cc; sourceTree = "<group>"; };
 		41F263C72126818A00274F59 /* encoded_frame.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = encoded_frame.cc; sourceTree = "<group>"; };
-		41F411AC1EF8D91E00343C26 /* null_aec_dump_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = null_aec_dump_factory.cc; path = Source/webrtc/modules/audio_processing/aec_dump/null_aec_dump_factory.cc; sourceTree = SOURCE_ROOT; };
+		41F411AC1EF8D91E00343C26 /* null_aec_dump_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = null_aec_dump_factory.cc; sourceTree = "<group>"; };
 		41F77D16215BE45E00E72967 /* yasm */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = yasm; sourceTree = BUILT_PRODUCTS_DIR; };
 		41F77D1E215BE4AD00E72967 /* yasm.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = yasm.xcconfig; sourceTree = "<group>"; };
 		41F77D30215BE72A00E72967 /* yasm-options.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "yasm-options.c"; sourceTree = "<group>"; };
@@ -8852,18 +8852,18 @@
 		41F77D43215BE74A00E72967 /* bc-data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "bc-data.c"; sourceTree = "<group>"; };
 		41F77D44215BE74B00E72967 /* xstrdup.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = xstrdup.c; sourceTree = "<group>"; };
 		41F77D45215BE74B00E72967 /* insn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = insn.h; sourceTree = "<group>"; };
-		41F9BF932051C82000ABF0B9 /* audio_encoder_factory_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_factory_template.h; path = audio_codecs/audio_encoder_factory_template.h; sourceTree = "<group>"; };
-		41F9BF942051C82000ABF0B9 /* audio_encoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_factory.h; path = audio_codecs/audio_encoder_factory.h; sourceTree = "<group>"; };
-		41F9BF952051C82100ABF0B9 /* audio_decoder_factory_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_factory_template.h; path = audio_codecs/audio_decoder_factory_template.h; sourceTree = "<group>"; };
+		41F9BF932051C82000ABF0B9 /* audio_encoder_factory_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_factory_template.h; sourceTree = "<group>"; };
+		41F9BF942051C82000ABF0B9 /* audio_encoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_factory.h; sourceTree = "<group>"; };
+		41F9BF952051C82100ABF0B9 /* audio_decoder_factory_template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_factory_template.h; sourceTree = "<group>"; };
 		41F9BF992051C84B00ABF0B9 /* audio_transport_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_transport_impl.cc; sourceTree = "<group>"; };
 		41F9BF9A2051C84B00ABF0B9 /* audio_transport_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_transport_impl.h; sourceTree = "<group>"; };
 		41F9BF9F2051C88500ABF0B9 /* audio_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_util.h; sourceTree = "<group>"; };
-		41F9BFC42051CAE400ABF0B9 /* signal_processing_library.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = signal_processing_library.h; path = signal_processing/include/signal_processing_library.h; sourceTree = "<group>"; };
+		41F9BFC42051CAE400ABF0B9 /* signal_processing_library.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = signal_processing_library.h; sourceTree = "<group>"; };
 		41F9BFC62051DCE800ABF0B9 /* webrtc_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_vad.h; sourceTree = "<group>"; };
 		41F9BFCD2051DDE400ABF0B9 /* fft_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fft_buffer.h; sourceTree = "<group>"; };
 		41F9BFD12051DDE400ABF0B9 /* fft_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fft_buffer.cc; sourceTree = "<group>"; };
-		41FCBB1321B1F7AA00A5DF27 /* moving_average.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = moving_average.cc; path = rtc_base/numerics/moving_average.cc; sourceTree = "<group>"; };
-		41FCBB1421B1F7AA00A5DF27 /* moving_average.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = moving_average.h; path = rtc_base/numerics/moving_average.h; sourceTree = "<group>"; };
+		41FCBB1321B1F7AA00A5DF27 /* moving_average.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = moving_average.cc; sourceTree = "<group>"; };
+		41FCBB1421B1F7AA00A5DF27 /* moving_average.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = moving_average.h; sourceTree = "<group>"; };
 		41FCBB1721B1F7CC00A5DF27 /* builtin_video_bitrate_allocator_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = builtin_video_bitrate_allocator_factory.cc; sourceTree = "<group>"; };
 		41FCBB1821B1F7CC00A5DF27 /* encoded_image.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encoded_image.h; sourceTree = "<group>"; };
 		41FCBB1921B1F7CC00A5DF27 /* encoded_image.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = encoded_image.cc; sourceTree = "<group>"; };
@@ -8882,7 +8882,7 @@
 		41FCBB5821B1FE6E00A5DF27 /* frame_dumping_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_dumping_decoder.h; sourceTree = "<group>"; };
 		41FCBB5D21B1FEC400A5DF27 /* goog_cc_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = goog_cc_factory.h; sourceTree = "<group>"; };
 		41FCBB5E21B1FEC400A5DF27 /* goog_cc_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = goog_cc_factory.cc; sourceTree = "<group>"; };
-		41FCBB6221B1FEF500A5DF27 /* vp8_temporal_layers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vp8_temporal_layers.h; path = video_codecs/vp8_temporal_layers.h; sourceTree = "<group>"; };
+		41FCBB6221B1FEF500A5DF27 /* vp8_temporal_layers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8_temporal_layers.h; sourceTree = "<group>"; };
 		41FCBB6F21B1FF7400A5DF27 /* hdr_metadata.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hdr_metadata.cc; sourceTree = "<group>"; };
 		41FCBB7021B1FF7400A5DF27 /* hdr_metadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hdr_metadata.h; sourceTree = "<group>"; };
 		41FCBB7321B1FFA400A5DF27 /* cocoa_threading.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = cocoa_threading.mm; sourceTree = "<group>"; };
@@ -8899,9 +8899,9 @@
 		41FE8647215C526000B62C07 /* nasm-preproc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nasm-preproc.c"; sourceTree = "<group>"; };
 		41FE8648215C526000B62C07 /* nasm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nasm.h; sourceTree = "<group>"; };
 		41FE8650215C530600B62C07 /* nasm-listfmt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nasm-listfmt.c"; sourceTree = "<group>"; };
-		41FE8657215C534E00B62C07 /* nasm-parse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "nasm-parse.c"; path = "Source/third_party/yasm/modules/parsers/nasm/nasm-parse.c"; sourceTree = SOURCE_ROOT; };
-		41FE8658215C534E00B62C07 /* nasm-parser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "nasm-parser.c"; path = "Source/third_party/yasm/modules/parsers/nasm/nasm-parser.c"; sourceTree = SOURCE_ROOT; };
-		41FE8659215C534E00B62C07 /* nasm-parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "nasm-parser.h"; path = "Source/third_party/yasm/modules/parsers/nasm/nasm-parser.h"; sourceTree = SOURCE_ROOT; };
+		41FE8657215C534E00B62C07 /* nasm-parse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nasm-parse.c"; sourceTree = "<group>"; };
+		41FE8658215C534E00B62C07 /* nasm-parser.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nasm-parser.c"; sourceTree = "<group>"; };
+		41FE8659215C534E00B62C07 /* nasm-parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nasm-parser.h"; sourceTree = "<group>"; };
 		41FE865C215C538900B62C07 /* nasm-token.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nasm-token.c"; sourceTree = "<group>"; };
 		41FE8660215C53AE00B62C07 /* gas-parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "gas-parser.h"; sourceTree = "<group>"; };
 		41FE8661215C53AE00B62C07 /* gas-parse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "gas-parse.c"; sourceTree = "<group>"; };
@@ -8923,8 +8923,8 @@
 		442459362ACB928400E105A1 /* ghash-neon-armv8.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "ghash-neon-armv8.pl"; sourceTree = "<group>"; };
 		442459372ACB928500E105A1 /* aesv8-gcm-armv8.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "aesv8-gcm-armv8.pl"; sourceTree = "<group>"; };
 		442459382ACB928500E105A1 /* ghash-ssse3-x86_64.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = "ghash-ssse3-x86_64.pl"; sourceTree = "<group>"; };
-		442459392ACB933B00E105A1 /* celt_lpc_sse4_1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = celt_lpc_sse4_1.c; path = x86/celt_lpc_sse4_1.c; sourceTree = "<group>"; };
-		4424593A2ACB93B000E105A1 /* jnt_sad_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jnt_sad_sse2.c; path = x86/jnt_sad_sse2.c; sourceTree = "<group>"; };
+		442459392ACB933B00E105A1 /* celt_lpc_sse4_1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = celt_lpc_sse4_1.c; sourceTree = "<group>"; };
+		4424593A2ACB93B000E105A1 /* jnt_sad_sse2.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = jnt_sad_sse2.c; sourceTree = "<group>"; };
 		448D48342AB0BDB00065014C /* fuzz-libvpx-vp8 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "fuzz-libvpx-vp8"; sourceTree = BUILT_PRODUCTS_DIR; };
 		448D48412AB0BEBA0065014C /* vpx_dec_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vpx_dec_fuzzer.cc; sourceTree = "<group>"; };
 		449187232AB3800D007266F2 /* Base-libvpx.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Base-libvpx.xcconfig"; sourceTree = "<group>"; };
@@ -8972,16 +8972,16 @@
 		5C119FF81E457400004F0987 /* fine_audio_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fine_audio_buffer.cc; sourceTree = "<group>"; };
 		5C119FF91E457400004F0987 /* fine_audio_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fine_audio_buffer.h; sourceTree = "<group>"; };
 		5C119FFA1E457400004F0987 /* mock_audio_device_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_audio_device_buffer.h; sourceTree = "<group>"; };
-		5C11A0071E457448004F0987 /* audio_device_mac.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_device_mac.cc; path = mac/audio_device_mac.cc; sourceTree = "<group>"; };
-		5C11A0081E457448004F0987 /* audio_device_mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_device_mac.h; path = mac/audio_device_mac.h; sourceTree = "<group>"; };
-		5C11A0091E457448004F0987 /* audio_mixer_manager_mac.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_mixer_manager_mac.cc; path = mac/audio_mixer_manager_mac.cc; sourceTree = "<group>"; };
-		5C11A00A1E457448004F0987 /* audio_mixer_manager_mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_mixer_manager_mac.h; path = mac/audio_mixer_manager_mac.h; sourceTree = "<group>"; };
-		5C11A0171E457578004F0987 /* audio_device_dummy.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_device_dummy.cc; path = dummy/audio_device_dummy.cc; sourceTree = "<group>"; };
-		5C11A0181E457578004F0987 /* audio_device_dummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_device_dummy.h; path = dummy/audio_device_dummy.h; sourceTree = "<group>"; };
-		5C11A0191E457578004F0987 /* file_audio_device_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = file_audio_device_factory.cc; path = dummy/file_audio_device_factory.cc; sourceTree = "<group>"; };
-		5C11A01A1E457578004F0987 /* file_audio_device_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = file_audio_device_factory.h; path = dummy/file_audio_device_factory.h; sourceTree = "<group>"; };
-		5C11A01B1E457578004F0987 /* file_audio_device.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = file_audio_device.cc; path = dummy/file_audio_device.cc; sourceTree = "<group>"; };
-		5C11A01C1E457578004F0987 /* file_audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = file_audio_device.h; path = dummy/file_audio_device.h; sourceTree = "<group>"; };
+		5C11A0071E457448004F0987 /* audio_device_mac.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_device_mac.cc; sourceTree = "<group>"; };
+		5C11A0081E457448004F0987 /* audio_device_mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_device_mac.h; sourceTree = "<group>"; };
+		5C11A0091E457448004F0987 /* audio_mixer_manager_mac.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_mixer_manager_mac.cc; sourceTree = "<group>"; };
+		5C11A00A1E457448004F0987 /* audio_mixer_manager_mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_mixer_manager_mac.h; sourceTree = "<group>"; };
+		5C11A0171E457578004F0987 /* audio_device_dummy.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_device_dummy.cc; sourceTree = "<group>"; };
+		5C11A0181E457578004F0987 /* audio_device_dummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_device_dummy.h; sourceTree = "<group>"; };
+		5C11A0191E457578004F0987 /* file_audio_device_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = file_audio_device_factory.cc; sourceTree = "<group>"; };
+		5C11A01A1E457578004F0987 /* file_audio_device_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file_audio_device_factory.h; sourceTree = "<group>"; };
+		5C11A01B1E457578004F0987 /* file_audio_device.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = file_audio_device.cc; sourceTree = "<group>"; };
+		5C11A01C1E457578004F0987 /* file_audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file_audio_device.h; sourceTree = "<group>"; };
 		5C316D881E66323F008BE64D /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		5C316D8A1E66333C008BE64D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		5C4B43B01E42877A002651C8 /* boringssl.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = boringssl.xcconfig; sourceTree = "<group>"; };
@@ -9010,90 +9010,90 @@
 		5C4B43CF1E42A49E002651C8 /* tasn_new.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tasn_new.c; sourceTree = "<group>"; };
 		5C4B43D01E42A49E002651C8 /* tasn_typ.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tasn_typ.c; sourceTree = "<group>"; };
 		5C4B43D11E42A49E002651C8 /* tasn_utl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tasn_utl.c; sourceTree = "<group>"; };
-		5C4B43F71E42A4CC002651C8 /* base64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = base64.c; path = base64/base64.c; sourceTree = "<group>"; };
-		5C4B43FA1E42A4F1002651C8 /* bio_mem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bio_mem.c; path = bio/bio_mem.c; sourceTree = "<group>"; };
-		5C4B43FB1E42A4F1002651C8 /* bio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bio.c; path = bio/bio.c; sourceTree = "<group>"; };
-		5C4B43FD1E42A4F1002651C8 /* connect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = connect.c; path = bio/connect.c; sourceTree = "<group>"; };
-		5C4B43FE1E42A4F1002651C8 /* fd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fd.c; path = bio/fd.c; sourceTree = "<group>"; };
-		5C4B43FF1E42A4F1002651C8 /* file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = file.c; path = bio/file.c; sourceTree = "<group>"; };
-		5C4B44001E42A4F1002651C8 /* hexdump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = hexdump.c; path = bio/hexdump.c; sourceTree = "<group>"; };
-		5C4B44011E42A4F1002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal.h; path = bio/internal.h; sourceTree = "<group>"; };
-		5C4B44021E42A4F1002651C8 /* pair.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pair.c; path = bio/pair.c; sourceTree = "<group>"; };
-		5C4B44031E42A4F1002651C8 /* printf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = printf.c; path = bio/printf.c; sourceTree = "<group>"; };
-		5C4B44041E42A4F1002651C8 /* socket_helper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = socket_helper.c; path = bio/socket_helper.c; sourceTree = "<group>"; };
-		5C4B44051E42A4F1002651C8 /* socket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = socket.c; path = bio/socket.c; sourceTree = "<group>"; };
-		5C4B443F1E42A549002651C8 /* buf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = buf.c; path = buf/buf.c; sourceTree = "<group>"; };
-		5C4B44641E42A6E2002651C8 /* ext_dat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ext_dat.h; path = x509v3/ext_dat.h; sourceTree = "<group>"; };
-		5C4B446D1E42A6E2002651C8 /* v3_akey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_akey.c; path = x509v3/v3_akey.c; sourceTree = "<group>"; };
-		5C4B446E1E42A6E2002651C8 /* v3_akeya.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_akeya.c; path = x509v3/v3_akeya.c; sourceTree = "<group>"; };
-		5C4B446F1E42A6E2002651C8 /* v3_alt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_alt.c; path = x509v3/v3_alt.c; sourceTree = "<group>"; };
-		5C4B44701E42A6E2002651C8 /* v3_bcons.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_bcons.c; path = x509v3/v3_bcons.c; sourceTree = "<group>"; };
-		5C4B44711E42A6E2002651C8 /* v3_bitst.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_bitst.c; path = x509v3/v3_bitst.c; sourceTree = "<group>"; };
-		5C4B44721E42A6E2002651C8 /* v3_conf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_conf.c; path = x509v3/v3_conf.c; sourceTree = "<group>"; };
-		5C4B44731E42A6E2002651C8 /* v3_cpols.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_cpols.c; path = x509v3/v3_cpols.c; sourceTree = "<group>"; };
-		5C4B44741E42A6E2002651C8 /* v3_crld.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_crld.c; path = x509v3/v3_crld.c; sourceTree = "<group>"; };
-		5C4B44751E42A6E2002651C8 /* v3_enum.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_enum.c; path = x509v3/v3_enum.c; sourceTree = "<group>"; };
-		5C4B44761E42A6E2002651C8 /* v3_extku.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_extku.c; path = x509v3/v3_extku.c; sourceTree = "<group>"; };
-		5C4B44771E42A6E2002651C8 /* v3_genn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_genn.c; path = x509v3/v3_genn.c; sourceTree = "<group>"; };
-		5C4B44781E42A6E2002651C8 /* v3_ia5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_ia5.c; path = x509v3/v3_ia5.c; sourceTree = "<group>"; };
-		5C4B44791E42A6E2002651C8 /* v3_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_info.c; path = x509v3/v3_info.c; sourceTree = "<group>"; };
-		5C4B447A1E42A6E2002651C8 /* v3_int.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_int.c; path = x509v3/v3_int.c; sourceTree = "<group>"; };
-		5C4B447B1E42A6E2002651C8 /* v3_lib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_lib.c; path = x509v3/v3_lib.c; sourceTree = "<group>"; };
-		5C4B447C1E42A6E2002651C8 /* v3_ncons.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_ncons.c; path = x509v3/v3_ncons.c; sourceTree = "<group>"; };
-		5C4B447F1E42A6E2002651C8 /* v3_pcons.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_pcons.c; path = x509v3/v3_pcons.c; sourceTree = "<group>"; };
-		5C4B44811E42A6E2002651C8 /* v3_pmaps.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_pmaps.c; path = x509v3/v3_pmaps.c; sourceTree = "<group>"; };
-		5C4B44821E42A6E2002651C8 /* v3_prn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_prn.c; path = x509v3/v3_prn.c; sourceTree = "<group>"; };
-		5C4B44831E42A6E2002651C8 /* v3_purp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_purp.c; path = x509v3/v3_purp.c; sourceTree = "<group>"; };
-		5C4B44841E42A6E2002651C8 /* v3_skey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_skey.c; path = x509v3/v3_skey.c; sourceTree = "<group>"; };
-		5C4B44861E42A6E2002651C8 /* v3_utl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = v3_utl.c; path = x509v3/v3_utl.c; sourceTree = "<group>"; };
-		5C4B44AC1E42A6F7002651C8 /* a_digest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = a_digest.c; path = x509/a_digest.c; sourceTree = "<group>"; };
-		5C4B44AD1E42A6F7002651C8 /* a_sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = a_sign.c; path = x509/a_sign.c; sourceTree = "<group>"; };
-		5C4B44AF1E42A6F7002651C8 /* a_verify.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = a_verify.c; path = x509/a_verify.c; sourceTree = "<group>"; };
-		5C4B44B01E42A6F7002651C8 /* algorithm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = algorithm.c; path = x509/algorithm.c; sourceTree = "<group>"; };
-		5C4B44B11E42A6F7002651C8 /* asn1_gen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = asn1_gen.c; path = x509/asn1_gen.c; sourceTree = "<group>"; };
-		5C4B44B21E42A6F7002651C8 /* by_dir.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = by_dir.c; path = x509/by_dir.c; sourceTree = "<group>"; };
-		5C4B44B31E42A6F7002651C8 /* by_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = by_file.c; path = x509/by_file.c; sourceTree = "<group>"; };
-		5C4B44B51E42A6F7002651C8 /* i2d_pr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = i2d_pr.c; path = x509/i2d_pr.c; sourceTree = "<group>"; };
-		5C4B44B61E42A6F7002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal.h; path = x509/internal.h; sourceTree = "<group>"; };
-		5C4B44B91E42A6F7002651C8 /* rsa_pss.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rsa_pss.c; path = x509/rsa_pss.c; sourceTree = "<group>"; };
-		5C4B44BA1E42A6F7002651C8 /* t_crl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = t_crl.c; path = x509/t_crl.c; sourceTree = "<group>"; };
-		5C4B44BB1E42A6F7002651C8 /* t_req.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = t_req.c; path = x509/t_req.c; sourceTree = "<group>"; };
-		5C4B44BC1E42A6F7002651C8 /* t_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = t_x509.c; path = x509/t_x509.c; sourceTree = "<group>"; };
-		5C4B44BD1E42A6F7002651C8 /* t_x509a.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = t_x509a.c; path = x509/t_x509a.c; sourceTree = "<group>"; };
-		5C4B44BF1E42A6F7002651C8 /* x_algor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_algor.c; path = x509/x_algor.c; sourceTree = "<group>"; };
-		5C4B44C01E42A6F7002651C8 /* x_all.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_all.c; path = x509/x_all.c; sourceTree = "<group>"; };
-		5C4B44C11E42A6F7002651C8 /* x_attrib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_attrib.c; path = x509/x_attrib.c; sourceTree = "<group>"; };
-		5C4B44C21E42A6F7002651C8 /* x_crl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_crl.c; path = x509/x_crl.c; sourceTree = "<group>"; };
-		5C4B44C31E42A6F7002651C8 /* x_exten.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_exten.c; path = x509/x_exten.c; sourceTree = "<group>"; };
-		5C4B44C41E42A6F7002651C8 /* x_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_info.c; path = x509/x_info.c; sourceTree = "<group>"; };
-		5C4B44C51E42A6F7002651C8 /* x_name.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_name.c; path = x509/x_name.c; sourceTree = "<group>"; };
-		5C4B44C61E42A6F7002651C8 /* x_pkey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_pkey.c; path = x509/x_pkey.c; sourceTree = "<group>"; };
-		5C4B44C71E42A6F7002651C8 /* x_pubkey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_pubkey.c; path = x509/x_pubkey.c; sourceTree = "<group>"; };
-		5C4B44C81E42A6F7002651C8 /* x_req.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_req.c; path = x509/x_req.c; sourceTree = "<group>"; };
-		5C4B44C91E42A6F7002651C8 /* x_sig.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_sig.c; path = x509/x_sig.c; sourceTree = "<group>"; };
-		5C4B44CA1E42A6F7002651C8 /* x_spki.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_spki.c; path = x509/x_spki.c; sourceTree = "<group>"; };
-		5C4B44CB1E42A6F7002651C8 /* x_val.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_val.c; path = x509/x_val.c; sourceTree = "<group>"; };
-		5C4B44CC1E42A6F7002651C8 /* x_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_x509.c; path = x509/x_x509.c; sourceTree = "<group>"; };
-		5C4B44CD1E42A6F7002651C8 /* x_x509a.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x_x509a.c; path = x509/x_x509a.c; sourceTree = "<group>"; };
-		5C4B44CE1E42A6F7002651C8 /* x509_att.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_att.c; path = x509/x509_att.c; sourceTree = "<group>"; };
-		5C4B44CF1E42A6F7002651C8 /* x509_cmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_cmp.c; path = x509/x509_cmp.c; sourceTree = "<group>"; };
-		5C4B44D01E42A6F7002651C8 /* x509_d2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_d2.c; path = x509/x509_d2.c; sourceTree = "<group>"; };
-		5C4B44D11E42A6F7002651C8 /* x509_def.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_def.c; path = x509/x509_def.c; sourceTree = "<group>"; };
-		5C4B44D21E42A6F7002651C8 /* x509_ext.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_ext.c; path = x509/x509_ext.c; sourceTree = "<group>"; };
-		5C4B44D31E42A6F7002651C8 /* x509_lu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_lu.c; path = x509/x509_lu.c; sourceTree = "<group>"; };
-		5C4B44D41E42A6F7002651C8 /* x509_obj.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_obj.c; path = x509/x509_obj.c; sourceTree = "<group>"; };
-		5C4B44D61E42A6F7002651C8 /* x509_req.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_req.c; path = x509/x509_req.c; sourceTree = "<group>"; };
-		5C4B44D71E42A6F7002651C8 /* x509_set.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_set.c; path = x509/x509_set.c; sourceTree = "<group>"; };
-		5C4B44D91E42A6F7002651C8 /* x509_trs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_trs.c; path = x509/x509_trs.c; sourceTree = "<group>"; };
-		5C4B44DA1E42A6F7002651C8 /* x509_txt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_txt.c; path = x509/x509_txt.c; sourceTree = "<group>"; };
-		5C4B44DB1E42A6F7002651C8 /* x509_v3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_v3.c; path = x509/x509_v3.c; sourceTree = "<group>"; };
-		5C4B44DC1E42A6F7002651C8 /* x509_vfy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_vfy.c; path = x509/x509_vfy.c; sourceTree = "<group>"; };
-		5C4B44DD1E42A6F7002651C8 /* x509_vpm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509_vpm.c; path = x509/x509_vpm.c; sourceTree = "<group>"; };
-		5C4B44DE1E42A6F7002651C8 /* x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509.c; path = x509/x509.c; sourceTree = "<group>"; };
-		5C4B44DF1E42A6F7002651C8 /* x509cset.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509cset.c; path = x509/x509cset.c; sourceTree = "<group>"; };
-		5C4B44E01E42A6F7002651C8 /* x509name.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509name.c; path = x509/x509name.c; sourceTree = "<group>"; };
-		5C4B44E11E42A6F7002651C8 /* x509rset.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509rset.c; path = x509/x509rset.c; sourceTree = "<group>"; };
-		5C4B44E21E42A6F7002651C8 /* x509spki.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x509spki.c; path = x509/x509spki.c; sourceTree = "<group>"; };
+		5C4B43F71E42A4CC002651C8 /* base64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base64.c; sourceTree = "<group>"; };
+		5C4B43FA1E42A4F1002651C8 /* bio_mem.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bio_mem.c; sourceTree = "<group>"; };
+		5C4B43FB1E42A4F1002651C8 /* bio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bio.c; sourceTree = "<group>"; };
+		5C4B43FD1E42A4F1002651C8 /* connect.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = connect.c; sourceTree = "<group>"; };
+		5C4B43FE1E42A4F1002651C8 /* fd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fd.c; sourceTree = "<group>"; };
+		5C4B43FF1E42A4F1002651C8 /* file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = file.c; sourceTree = "<group>"; };
+		5C4B44001E42A4F1002651C8 /* hexdump.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hexdump.c; sourceTree = "<group>"; };
+		5C4B44011E42A4F1002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+		5C4B44021E42A4F1002651C8 /* pair.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pair.c; sourceTree = "<group>"; };
+		5C4B44031E42A4F1002651C8 /* printf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = printf.c; sourceTree = "<group>"; };
+		5C4B44041E42A4F1002651C8 /* socket_helper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = socket_helper.c; sourceTree = "<group>"; };
+		5C4B44051E42A4F1002651C8 /* socket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = socket.c; sourceTree = "<group>"; };
+		5C4B443F1E42A549002651C8 /* buf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = buf.c; sourceTree = "<group>"; };
+		5C4B44641E42A6E2002651C8 /* ext_dat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ext_dat.h; sourceTree = "<group>"; };
+		5C4B446D1E42A6E2002651C8 /* v3_akey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_akey.c; sourceTree = "<group>"; };
+		5C4B446E1E42A6E2002651C8 /* v3_akeya.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_akeya.c; sourceTree = "<group>"; };
+		5C4B446F1E42A6E2002651C8 /* v3_alt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_alt.c; sourceTree = "<group>"; };
+		5C4B44701E42A6E2002651C8 /* v3_bcons.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_bcons.c; sourceTree = "<group>"; };
+		5C4B44711E42A6E2002651C8 /* v3_bitst.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_bitst.c; sourceTree = "<group>"; };
+		5C4B44721E42A6E2002651C8 /* v3_conf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_conf.c; sourceTree = "<group>"; };
+		5C4B44731E42A6E2002651C8 /* v3_cpols.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_cpols.c; sourceTree = "<group>"; };
+		5C4B44741E42A6E2002651C8 /* v3_crld.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_crld.c; sourceTree = "<group>"; };
+		5C4B44751E42A6E2002651C8 /* v3_enum.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_enum.c; sourceTree = "<group>"; };
+		5C4B44761E42A6E2002651C8 /* v3_extku.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_extku.c; sourceTree = "<group>"; };
+		5C4B44771E42A6E2002651C8 /* v3_genn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_genn.c; sourceTree = "<group>"; };
+		5C4B44781E42A6E2002651C8 /* v3_ia5.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_ia5.c; sourceTree = "<group>"; };
+		5C4B44791E42A6E2002651C8 /* v3_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_info.c; sourceTree = "<group>"; };
+		5C4B447A1E42A6E2002651C8 /* v3_int.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_int.c; sourceTree = "<group>"; };
+		5C4B447B1E42A6E2002651C8 /* v3_lib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_lib.c; sourceTree = "<group>"; };
+		5C4B447C1E42A6E2002651C8 /* v3_ncons.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_ncons.c; sourceTree = "<group>"; };
+		5C4B447F1E42A6E2002651C8 /* v3_pcons.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_pcons.c; sourceTree = "<group>"; };
+		5C4B44811E42A6E2002651C8 /* v3_pmaps.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_pmaps.c; sourceTree = "<group>"; };
+		5C4B44821E42A6E2002651C8 /* v3_prn.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_prn.c; sourceTree = "<group>"; };
+		5C4B44831E42A6E2002651C8 /* v3_purp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_purp.c; sourceTree = "<group>"; };
+		5C4B44841E42A6E2002651C8 /* v3_skey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_skey.c; sourceTree = "<group>"; };
+		5C4B44861E42A6E2002651C8 /* v3_utl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = v3_utl.c; sourceTree = "<group>"; };
+		5C4B44AC1E42A6F7002651C8 /* a_digest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = a_digest.c; sourceTree = "<group>"; };
+		5C4B44AD1E42A6F7002651C8 /* a_sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = a_sign.c; sourceTree = "<group>"; };
+		5C4B44AF1E42A6F7002651C8 /* a_verify.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = a_verify.c; sourceTree = "<group>"; };
+		5C4B44B01E42A6F7002651C8 /* algorithm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = algorithm.c; sourceTree = "<group>"; };
+		5C4B44B11E42A6F7002651C8 /* asn1_gen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = asn1_gen.c; sourceTree = "<group>"; };
+		5C4B44B21E42A6F7002651C8 /* by_dir.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = by_dir.c; sourceTree = "<group>"; };
+		5C4B44B31E42A6F7002651C8 /* by_file.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = by_file.c; sourceTree = "<group>"; };
+		5C4B44B51E42A6F7002651C8 /* i2d_pr.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = i2d_pr.c; sourceTree = "<group>"; };
+		5C4B44B61E42A6F7002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+		5C4B44B91E42A6F7002651C8 /* rsa_pss.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rsa_pss.c; sourceTree = "<group>"; };
+		5C4B44BA1E42A6F7002651C8 /* t_crl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_crl.c; sourceTree = "<group>"; };
+		5C4B44BB1E42A6F7002651C8 /* t_req.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_req.c; sourceTree = "<group>"; };
+		5C4B44BC1E42A6F7002651C8 /* t_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_x509.c; sourceTree = "<group>"; };
+		5C4B44BD1E42A6F7002651C8 /* t_x509a.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = t_x509a.c; sourceTree = "<group>"; };
+		5C4B44BF1E42A6F7002651C8 /* x_algor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_algor.c; sourceTree = "<group>"; };
+		5C4B44C01E42A6F7002651C8 /* x_all.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_all.c; sourceTree = "<group>"; };
+		5C4B44C11E42A6F7002651C8 /* x_attrib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_attrib.c; sourceTree = "<group>"; };
+		5C4B44C21E42A6F7002651C8 /* x_crl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_crl.c; sourceTree = "<group>"; };
+		5C4B44C31E42A6F7002651C8 /* x_exten.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_exten.c; sourceTree = "<group>"; };
+		5C4B44C41E42A6F7002651C8 /* x_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_info.c; sourceTree = "<group>"; };
+		5C4B44C51E42A6F7002651C8 /* x_name.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_name.c; sourceTree = "<group>"; };
+		5C4B44C61E42A6F7002651C8 /* x_pkey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_pkey.c; sourceTree = "<group>"; };
+		5C4B44C71E42A6F7002651C8 /* x_pubkey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_pubkey.c; sourceTree = "<group>"; };
+		5C4B44C81E42A6F7002651C8 /* x_req.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_req.c; sourceTree = "<group>"; };
+		5C4B44C91E42A6F7002651C8 /* x_sig.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_sig.c; sourceTree = "<group>"; };
+		5C4B44CA1E42A6F7002651C8 /* x_spki.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_spki.c; sourceTree = "<group>"; };
+		5C4B44CB1E42A6F7002651C8 /* x_val.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_val.c; sourceTree = "<group>"; };
+		5C4B44CC1E42A6F7002651C8 /* x_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_x509.c; sourceTree = "<group>"; };
+		5C4B44CD1E42A6F7002651C8 /* x_x509a.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x_x509a.c; sourceTree = "<group>"; };
+		5C4B44CE1E42A6F7002651C8 /* x509_att.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_att.c; sourceTree = "<group>"; };
+		5C4B44CF1E42A6F7002651C8 /* x509_cmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_cmp.c; sourceTree = "<group>"; };
+		5C4B44D01E42A6F7002651C8 /* x509_d2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_d2.c; sourceTree = "<group>"; };
+		5C4B44D11E42A6F7002651C8 /* x509_def.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_def.c; sourceTree = "<group>"; };
+		5C4B44D21E42A6F7002651C8 /* x509_ext.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_ext.c; sourceTree = "<group>"; };
+		5C4B44D31E42A6F7002651C8 /* x509_lu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_lu.c; sourceTree = "<group>"; };
+		5C4B44D41E42A6F7002651C8 /* x509_obj.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_obj.c; sourceTree = "<group>"; };
+		5C4B44D61E42A6F7002651C8 /* x509_req.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_req.c; sourceTree = "<group>"; };
+		5C4B44D71E42A6F7002651C8 /* x509_set.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_set.c; sourceTree = "<group>"; };
+		5C4B44D91E42A6F7002651C8 /* x509_trs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_trs.c; sourceTree = "<group>"; };
+		5C4B44DA1E42A6F7002651C8 /* x509_txt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_txt.c; sourceTree = "<group>"; };
+		5C4B44DB1E42A6F7002651C8 /* x509_v3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_v3.c; sourceTree = "<group>"; };
+		5C4B44DC1E42A6F7002651C8 /* x509_vfy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_vfy.c; sourceTree = "<group>"; };
+		5C4B44DD1E42A6F7002651C8 /* x509_vpm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509_vpm.c; sourceTree = "<group>"; };
+		5C4B44DE1E42A6F7002651C8 /* x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509.c; sourceTree = "<group>"; };
+		5C4B44DF1E42A6F7002651C8 /* x509cset.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509cset.c; sourceTree = "<group>"; };
+		5C4B44E01E42A6F7002651C8 /* x509name.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509name.c; sourceTree = "<group>"; };
+		5C4B44E11E42A6F7002651C8 /* x509rset.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509rset.c; sourceTree = "<group>"; };
+		5C4B44E21E42A6F7002651C8 /* x509spki.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x509spki.c; sourceTree = "<group>"; };
 		5C4B451E1E42A71B002651C8 /* crypto.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypto.c; sourceTree = "<group>"; };
 		5C4B451F1E42A71B002651C8 /* ex_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ex_data.c; sourceTree = "<group>"; };
 		5C4B45201E42A71B002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
@@ -9104,70 +9104,70 @@
 		5C4B45261E42A71B002651C8 /* thread_pthread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread_pthread.c; sourceTree = "<group>"; };
 		5C4B45281E42A71B002651C8 /* thread_win.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread_win.c; sourceTree = "<group>"; };
 		5C4B45291E42A71B002651C8 /* thread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread.c; sourceTree = "<group>"; };
-		5C4B453A1E42A72C002651C8 /* stack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stack.c; path = stack/stack.c; sourceTree = "<group>"; };
-		5C4B45501E42A753002651C8 /* rc4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rc4.c; path = rc4/rc4.c; sourceTree = "<group>"; };
-		5C4B45601E42A784002651C8 /* poly1305_vec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = poly1305_vec.c; path = poly1305/poly1305_vec.c; sourceTree = "<group>"; };
-		5C4B45611E42A784002651C8 /* poly1305.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = poly1305.c; path = poly1305/poly1305.c; sourceTree = "<group>"; };
-		5C4B45641E42A792002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal.h; path = pkcs8/internal.h; sourceTree = "<group>"; };
-		5C4B45661E42A792002651C8 /* p5_pbev2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p5_pbev2.c; path = pkcs8/p5_pbev2.c; sourceTree = "<group>"; };
-		5C4B45691E42A792002651C8 /* pkcs8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pkcs8.c; path = pkcs8/pkcs8.c; sourceTree = "<group>"; };
-		5C4B45721E42A7D4002651C8 /* pem_all.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pem_all.c; path = pem/pem_all.c; sourceTree = "<group>"; };
-		5C4B45731E42A7D4002651C8 /* pem_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pem_info.c; path = pem/pem_info.c; sourceTree = "<group>"; };
-		5C4B45741E42A7D4002651C8 /* pem_lib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pem_lib.c; path = pem/pem_lib.c; sourceTree = "<group>"; };
-		5C4B45751E42A7D4002651C8 /* pem_oth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pem_oth.c; path = pem/pem_oth.c; sourceTree = "<group>"; };
-		5C4B45761E42A7D4002651C8 /* pem_pk8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pem_pk8.c; path = pem/pem_pk8.c; sourceTree = "<group>"; };
-		5C4B45771E42A7D4002651C8 /* pem_pkey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pem_pkey.c; path = pem/pem_pkey.c; sourceTree = "<group>"; };
-		5C4B45781E42A7D4002651C8 /* pem_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pem_x509.c; path = pem/pem_x509.c; sourceTree = "<group>"; };
-		5C4B45791E42A7D4002651C8 /* pem_xaux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pem_xaux.c; path = pem/pem_xaux.c; sourceTree = "<group>"; };
-		5C4B45821E42A7F1002651C8 /* obj_dat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = obj_dat.h; path = obj/obj_dat.h; sourceTree = "<group>"; };
-		5C4B45841E42A7F1002651C8 /* obj_xref.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = obj_xref.c; path = obj/obj_xref.c; sourceTree = "<group>"; };
-		5C4B45861E42A7F1002651C8 /* obj.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = obj.c; path = obj/obj.c; sourceTree = "<group>"; };
-		5C4B45AD1E42A83F002651C8 /* lhash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lhash.c; path = lhash/lhash.c; sourceTree = "<group>"; };
-		5C4B45B91E42A87E002651C8 /* evp_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = evp_asn1.c; path = evp/evp_asn1.c; sourceTree = "<group>"; };
-		5C4B45BA1E42A87E002651C8 /* evp_ctx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = evp_ctx.c; path = evp/evp_ctx.c; sourceTree = "<group>"; };
-		5C4B45BB1E42A87E002651C8 /* evp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = evp.c; path = evp/evp.c; sourceTree = "<group>"; };
-		5C4B45BC1E42A87E002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal.h; path = evp/internal.h; sourceTree = "<group>"; };
-		5C4B45BD1E42A87E002651C8 /* p_dsa_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_dsa_asn1.c; path = evp/p_dsa_asn1.c; sourceTree = "<group>"; };
-		5C4B45BE1E42A87E002651C8 /* p_ec_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_ec_asn1.c; path = evp/p_ec_asn1.c; sourceTree = "<group>"; };
-		5C4B45BF1E42A87E002651C8 /* p_ec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_ec.c; path = evp/p_ec.c; sourceTree = "<group>"; };
-		5C4B45C01E42A87E002651C8 /* p_rsa_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_rsa_asn1.c; path = evp/p_rsa_asn1.c; sourceTree = "<group>"; };
-		5C4B45C11E42A87E002651C8 /* p_rsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = p_rsa.c; path = evp/p_rsa.c; sourceTree = "<group>"; };
-		5C4B45C31E42A87E002651C8 /* pbkdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pbkdf.c; path = evp/pbkdf.c; sourceTree = "<group>"; };
-		5C4B45C41E42A87E002651C8 /* print.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = print.c; path = evp/print.c; sourceTree = "<group>"; };
-		5C4B45C51E42A87E002651C8 /* sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sign.c; path = evp/sign.c; sourceTree = "<group>"; };
-		5C4B45D51E42A893002651C8 /* err.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = err.c; path = err/err.c; sourceTree = "<group>"; };
-		5C4B45D81E42A8A4002651C8 /* engine.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = engine.c; path = engine/engine.c; sourceTree = "<group>"; };
-		5C4B45FC1E42A943002651C8 /* dsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dsa.c; path = dsa/dsa.c; sourceTree = "<group>"; };
-		5C4B462E1E42A989002651C8 /* chacha.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = chacha.c; path = chacha/chacha.c; sourceTree = "<group>"; };
-		5C4B46301E42A994002651C8 /* asn1_compat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = asn1_compat.c; path = bytestring/asn1_compat.c; sourceTree = "<group>"; };
-		5C4B46311E42A994002651C8 /* ber.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ber.c; path = bytestring/ber.c; sourceTree = "<group>"; };
-		5C4B46321E42A994002651C8 /* cbb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cbb.c; path = bytestring/cbb.c; sourceTree = "<group>"; };
-		5C4B46331E42A994002651C8 /* cbs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cbs.c; path = bytestring/cbs.c; sourceTree = "<group>"; };
-		5C4B46341E42A994002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal.h; path = bytestring/internal.h; sourceTree = "<group>"; };
-		5C4B47D51E42C01C002651C8 /* conf_def.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = conf_def.h; path = conf/conf_def.h; sourceTree = "<group>"; };
-		5C4B47D61E42C01C002651C8 /* conf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = conf.c; path = conf/conf.c; sourceTree = "<group>"; };
-		5C4B47D71E42C01C002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = internal.h; path = conf/internal.h; sourceTree = "<group>"; };
+		5C4B453A1E42A72C002651C8 /* stack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stack.c; sourceTree = "<group>"; };
+		5C4B45501E42A753002651C8 /* rc4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rc4.c; sourceTree = "<group>"; };
+		5C4B45601E42A784002651C8 /* poly1305_vec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = poly1305_vec.c; sourceTree = "<group>"; };
+		5C4B45611E42A784002651C8 /* poly1305.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = poly1305.c; sourceTree = "<group>"; };
+		5C4B45641E42A792002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+		5C4B45661E42A792002651C8 /* p5_pbev2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p5_pbev2.c; sourceTree = "<group>"; };
+		5C4B45691E42A792002651C8 /* pkcs8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs8.c; sourceTree = "<group>"; };
+		5C4B45721E42A7D4002651C8 /* pem_all.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem_all.c; sourceTree = "<group>"; };
+		5C4B45731E42A7D4002651C8 /* pem_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem_info.c; sourceTree = "<group>"; };
+		5C4B45741E42A7D4002651C8 /* pem_lib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem_lib.c; sourceTree = "<group>"; };
+		5C4B45751E42A7D4002651C8 /* pem_oth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem_oth.c; sourceTree = "<group>"; };
+		5C4B45761E42A7D4002651C8 /* pem_pk8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem_pk8.c; sourceTree = "<group>"; };
+		5C4B45771E42A7D4002651C8 /* pem_pkey.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem_pkey.c; sourceTree = "<group>"; };
+		5C4B45781E42A7D4002651C8 /* pem_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem_x509.c; sourceTree = "<group>"; };
+		5C4B45791E42A7D4002651C8 /* pem_xaux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pem_xaux.c; sourceTree = "<group>"; };
+		5C4B45821E42A7F1002651C8 /* obj_dat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = obj_dat.h; sourceTree = "<group>"; };
+		5C4B45841E42A7F1002651C8 /* obj_xref.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = obj_xref.c; sourceTree = "<group>"; };
+		5C4B45861E42A7F1002651C8 /* obj.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = obj.c; sourceTree = "<group>"; };
+		5C4B45AD1E42A83F002651C8 /* lhash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lhash.c; sourceTree = "<group>"; };
+		5C4B45B91E42A87E002651C8 /* evp_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = evp_asn1.c; sourceTree = "<group>"; };
+		5C4B45BA1E42A87E002651C8 /* evp_ctx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = evp_ctx.c; sourceTree = "<group>"; };
+		5C4B45BB1E42A87E002651C8 /* evp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = evp.c; sourceTree = "<group>"; };
+		5C4B45BC1E42A87E002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+		5C4B45BD1E42A87E002651C8 /* p_dsa_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_dsa_asn1.c; sourceTree = "<group>"; };
+		5C4B45BE1E42A87E002651C8 /* p_ec_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_ec_asn1.c; sourceTree = "<group>"; };
+		5C4B45BF1E42A87E002651C8 /* p_ec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_ec.c; sourceTree = "<group>"; };
+		5C4B45C01E42A87E002651C8 /* p_rsa_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_rsa_asn1.c; sourceTree = "<group>"; };
+		5C4B45C11E42A87E002651C8 /* p_rsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = p_rsa.c; sourceTree = "<group>"; };
+		5C4B45C31E42A87E002651C8 /* pbkdf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pbkdf.c; sourceTree = "<group>"; };
+		5C4B45C41E42A87E002651C8 /* print.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = print.c; sourceTree = "<group>"; };
+		5C4B45C51E42A87E002651C8 /* sign.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sign.c; sourceTree = "<group>"; };
+		5C4B45D51E42A893002651C8 /* err.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = err.c; sourceTree = "<group>"; };
+		5C4B45D81E42A8A4002651C8 /* engine.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = engine.c; sourceTree = "<group>"; };
+		5C4B45FC1E42A943002651C8 /* dsa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa.c; sourceTree = "<group>"; };
+		5C4B462E1E42A989002651C8 /* chacha.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = chacha.c; sourceTree = "<group>"; };
+		5C4B46301E42A994002651C8 /* asn1_compat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = asn1_compat.c; sourceTree = "<group>"; };
+		5C4B46311E42A994002651C8 /* ber.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ber.c; sourceTree = "<group>"; };
+		5C4B46321E42A994002651C8 /* cbb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cbb.c; sourceTree = "<group>"; };
+		5C4B46331E42A994002651C8 /* cbs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cbs.c; sourceTree = "<group>"; };
+		5C4B46341E42A994002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+		5C4B47D51E42C01C002651C8 /* conf_def.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = conf_def.h; sourceTree = "<group>"; };
+		5C4B47D61E42C01C002651C8 /* conf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = conf.c; sourceTree = "<group>"; };
+		5C4B47D71E42C01C002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
 		5C4B47E81E42C066002651C8 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
-		5C4B48451E42C0F4002651C8 /* dsa_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dsa_asn1.c; path = dsa/dsa_asn1.c; sourceTree = "<group>"; };
+		5C4B48451E42C0F4002651C8 /* dsa_asn1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dsa_asn1.c; sourceTree = "<group>"; };
 		5C4B4A8E1E42C336002651C8 /* libopus.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libopus.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C4B4A8F1E42C431002651C8 /* opus.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = opus.xcconfig; sourceTree = "<group>"; };
-		5C4B4A931E42C52D002651C8 /* analysis.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = analysis.c; path = src/analysis.c; sourceTree = "<group>"; };
-		5C4B4A941E42C52D002651C8 /* analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = analysis.h; path = src/analysis.h; sourceTree = "<group>"; };
-		5C4B4A951E42C52D002651C8 /* mlp_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mlp_data.c; path = src/mlp_data.c; sourceTree = "<group>"; };
-		5C4B4A961E42C52D002651C8 /* mlp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = mlp.c; path = src/mlp.c; sourceTree = "<group>"; };
-		5C4B4A971E42C52D002651C8 /* mlp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mlp.h; path = src/mlp.h; sourceTree = "<group>"; };
-		5C4B4A981E42C52D002651C8 /* opus_compare.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = opus_compare.c; path = src/opus_compare.c; sourceTree = "<group>"; };
-		5C4B4A991E42C52D002651C8 /* opus_decoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = opus_decoder.c; path = src/opus_decoder.c; sourceTree = "<group>"; };
-		5C4B4A9A1E42C52D002651C8 /* opus_demo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = opus_demo.c; path = src/opus_demo.c; sourceTree = "<group>"; };
-		5C4B4A9B1E42C52D002651C8 /* opus_encoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = opus_encoder.c; path = src/opus_encoder.c; sourceTree = "<group>"; };
-		5C4B4A9C1E42C52D002651C8 /* opus_multistream_decoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = opus_multistream_decoder.c; path = src/opus_multistream_decoder.c; sourceTree = "<group>"; };
-		5C4B4A9D1E42C52D002651C8 /* opus_multistream_encoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = opus_multistream_encoder.c; path = src/opus_multistream_encoder.c; sourceTree = "<group>"; };
-		5C4B4A9E1E42C52D002651C8 /* opus_multistream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = opus_multistream.c; path = src/opus_multistream.c; sourceTree = "<group>"; };
-		5C4B4A9F1E42C52D002651C8 /* opus_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = opus_private.h; path = src/opus_private.h; sourceTree = "<group>"; };
-		5C4B4AA01E42C52D002651C8 /* opus.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = opus.c; path = src/opus.c; sourceTree = "<group>"; };
-		5C4B4AA11E42C52D002651C8 /* repacketizer_demo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = repacketizer_demo.c; path = src/repacketizer_demo.c; sourceTree = "<group>"; };
-		5C4B4AA21E42C52D002651C8 /* repacketizer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = repacketizer.c; path = src/repacketizer.c; sourceTree = "<group>"; };
-		5C4B4AA31E42C52D002651C8 /* tansig_table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = tansig_table.h; path = src/tansig_table.h; sourceTree = "<group>"; };
+		5C4B4A931E42C52D002651C8 /* analysis.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = analysis.c; sourceTree = "<group>"; };
+		5C4B4A941E42C52D002651C8 /* analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = analysis.h; sourceTree = "<group>"; };
+		5C4B4A951E42C52D002651C8 /* mlp_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mlp_data.c; sourceTree = "<group>"; };
+		5C4B4A961E42C52D002651C8 /* mlp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mlp.c; sourceTree = "<group>"; };
+		5C4B4A971E42C52D002651C8 /* mlp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mlp.h; sourceTree = "<group>"; };
+		5C4B4A981E42C52D002651C8 /* opus_compare.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = opus_compare.c; sourceTree = "<group>"; };
+		5C4B4A991E42C52D002651C8 /* opus_decoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = opus_decoder.c; sourceTree = "<group>"; };
+		5C4B4A9A1E42C52D002651C8 /* opus_demo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = opus_demo.c; sourceTree = "<group>"; };
+		5C4B4A9B1E42C52D002651C8 /* opus_encoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = opus_encoder.c; sourceTree = "<group>"; };
+		5C4B4A9C1E42C52D002651C8 /* opus_multistream_decoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = opus_multistream_decoder.c; sourceTree = "<group>"; };
+		5C4B4A9D1E42C52D002651C8 /* opus_multistream_encoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = opus_multistream_encoder.c; sourceTree = "<group>"; };
+		5C4B4A9E1E42C52D002651C8 /* opus_multistream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = opus_multistream.c; sourceTree = "<group>"; };
+		5C4B4A9F1E42C52D002651C8 /* opus_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = opus_private.h; sourceTree = "<group>"; };
+		5C4B4AA01E42C52D002651C8 /* opus.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = opus.c; sourceTree = "<group>"; };
+		5C4B4AA11E42C52D002651C8 /* repacketizer_demo.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = repacketizer_demo.c; sourceTree = "<group>"; };
+		5C4B4AA21E42C52D002651C8 /* repacketizer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = repacketizer.c; sourceTree = "<group>"; };
+		5C4B4AA31E42C52D002651C8 /* tansig_table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tansig_table.h; sourceTree = "<group>"; };
 		5C4B4C101E431F75002651C8 /* bitrate_adjuster.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bitrate_adjuster.cc; sourceTree = "<group>"; };
 		5C4B4C151E431F75002651C8 /* video_frame_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_frame_buffer.cc; sourceTree = "<group>"; };
 		5C4B4C241E431F9C002651C8 /* audio_converter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_converter.cc; sourceTree = "<group>"; };
@@ -9190,36 +9190,36 @@
 		5C4B4C541E431F9C002651C8 /* wav_header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wav_header.h; sourceTree = "<group>"; };
 		5C4B4C561E431F9C002651C8 /* window_generator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = window_generator.cc; sourceTree = "<group>"; };
 		5C4B4C571E431F9C002651C8 /* window_generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = window_generator.h; sourceTree = "<group>"; };
-		5C4B4C941E4320A9002651C8 /* clock.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = clock.cc; path = source/clock.cc; sourceTree = "<group>"; };
-		5C4B4C981E4320A9002651C8 /* cpu_features.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cpu_features.cc; path = source/cpu_features.cc; sourceTree = "<group>"; };
-		5C4B4C991E4320A9002651C8 /* cpu_info.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cpu_info.cc; path = source/cpu_info.cc; sourceTree = "<group>"; };
-		5C4B4CB41E4320A9002651C8 /* sleep.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sleep.cc; path = source/sleep.cc; sourceTree = "<group>"; };
-		5C4B4CF61E432168002651C8 /* spake25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = spake25519.c; path = curve25519/spake25519.c; sourceTree = "<group>"; };
-		5C4B4D2F1E4323D4002651C8 /* compare_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = compare_common.cc; path = source/compare_common.cc; sourceTree = "<group>"; };
-		5C4B4D341E4323D4002651C8 /* compare.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = compare.cc; path = source/compare.cc; sourceTree = "<group>"; };
-		5C4B4D351E4323D4002651C8 /* convert_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convert_argb.cc; path = source/convert_argb.cc; sourceTree = "<group>"; };
-		5C4B4D361E4323D4002651C8 /* convert_from_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convert_from_argb.cc; path = source/convert_from_argb.cc; sourceTree = "<group>"; };
-		5C4B4D371E4323D4002651C8 /* convert_from.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convert_from.cc; path = source/convert_from.cc; sourceTree = "<group>"; };
-		5C4B4D381E4323D4002651C8 /* convert_jpeg.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convert_jpeg.cc; path = source/convert_jpeg.cc; sourceTree = "<group>"; };
-		5C4B4D391E4323D4002651C8 /* convert_to_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convert_to_argb.cc; path = source/convert_to_argb.cc; sourceTree = "<group>"; };
-		5C4B4D3A1E4323D4002651C8 /* convert_to_i420.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convert_to_i420.cc; path = source/convert_to_i420.cc; sourceTree = "<group>"; };
-		5C4B4D3B1E4323D4002651C8 /* convert.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convert.cc; path = source/convert.cc; sourceTree = "<group>"; };
-		5C4B4D3C1E4323D4002651C8 /* cpu_id.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cpu_id.cc; path = source/cpu_id.cc; sourceTree = "<group>"; };
-		5C4B4D3D1E4323D4002651C8 /* mjpeg_decoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mjpeg_decoder.cc; path = source/mjpeg_decoder.cc; sourceTree = "<group>"; };
-		5C4B4D3E1E4323D4002651C8 /* mjpeg_validate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mjpeg_validate.cc; path = source/mjpeg_validate.cc; sourceTree = "<group>"; };
-		5C4B4D3F1E4323D4002651C8 /* planar_functions.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = planar_functions.cc; path = source/planar_functions.cc; sourceTree = "<group>"; };
-		5C4B4D401E4323D4002651C8 /* rotate_any.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rotate_any.cc; path = source/rotate_any.cc; sourceTree = "<group>"; };
-		5C4B4D411E4323D4002651C8 /* rotate_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rotate_argb.cc; path = source/rotate_argb.cc; sourceTree = "<group>"; };
-		5C4B4D421E4323D4002651C8 /* rotate_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rotate_common.cc; path = source/rotate_common.cc; sourceTree = "<group>"; };
-		5C4B4D481E4323D4002651C8 /* rotate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rotate.cc; path = source/rotate.cc; sourceTree = "<group>"; };
-		5C4B4D491E4323D4002651C8 /* row_any.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = row_any.cc; path = source/row_any.cc; sourceTree = "<group>"; };
-		5C4B4D4A1E4323D4002651C8 /* row_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = row_common.cc; path = source/row_common.cc; sourceTree = "<group>"; };
-		5C4B4D511E4323D4002651C8 /* scale_any.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scale_any.cc; path = source/scale_any.cc; sourceTree = "<group>"; };
-		5C4B4D521E4323D4002651C8 /* scale_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scale_argb.cc; path = source/scale_argb.cc; sourceTree = "<group>"; };
-		5C4B4D531E4323D4002651C8 /* scale_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scale_common.cc; path = source/scale_common.cc; sourceTree = "<group>"; };
-		5C4B4D591E4323D4002651C8 /* scale.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scale.cc; path = source/scale.cc; sourceTree = "<group>"; };
-		5C4B4D5A1E4323D4002651C8 /* video_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = video_common.cc; path = source/video_common.cc; sourceTree = "<group>"; };
-		5C5F408F1E978FD200D94279 /* SigProc_FIX_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SigProc_FIX_sse.h; path = silk/x86/SigProc_FIX_sse.h; sourceTree = "<group>"; };
+		5C4B4C941E4320A9002651C8 /* clock.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = clock.cc; sourceTree = "<group>"; };
+		5C4B4C981E4320A9002651C8 /* cpu_features.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cpu_features.cc; sourceTree = "<group>"; };
+		5C4B4C991E4320A9002651C8 /* cpu_info.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cpu_info.cc; sourceTree = "<group>"; };
+		5C4B4CB41E4320A9002651C8 /* sleep.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sleep.cc; sourceTree = "<group>"; };
+		5C4B4CF61E432168002651C8 /* spake25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spake25519.c; sourceTree = "<group>"; };
+		5C4B4D2F1E4323D4002651C8 /* compare_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = compare_common.cc; sourceTree = "<group>"; };
+		5C4B4D341E4323D4002651C8 /* compare.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = compare.cc; sourceTree = "<group>"; };
+		5C4B4D351E4323D4002651C8 /* convert_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convert_argb.cc; sourceTree = "<group>"; };
+		5C4B4D361E4323D4002651C8 /* convert_from_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convert_from_argb.cc; sourceTree = "<group>"; };
+		5C4B4D371E4323D4002651C8 /* convert_from.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convert_from.cc; sourceTree = "<group>"; };
+		5C4B4D381E4323D4002651C8 /* convert_jpeg.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convert_jpeg.cc; sourceTree = "<group>"; };
+		5C4B4D391E4323D4002651C8 /* convert_to_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convert_to_argb.cc; sourceTree = "<group>"; };
+		5C4B4D3A1E4323D4002651C8 /* convert_to_i420.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convert_to_i420.cc; sourceTree = "<group>"; };
+		5C4B4D3B1E4323D4002651C8 /* convert.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = convert.cc; sourceTree = "<group>"; };
+		5C4B4D3C1E4323D4002651C8 /* cpu_id.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cpu_id.cc; sourceTree = "<group>"; };
+		5C4B4D3D1E4323D4002651C8 /* mjpeg_decoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mjpeg_decoder.cc; sourceTree = "<group>"; };
+		5C4B4D3E1E4323D4002651C8 /* mjpeg_validate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mjpeg_validate.cc; sourceTree = "<group>"; };
+		5C4B4D3F1E4323D4002651C8 /* planar_functions.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = planar_functions.cc; sourceTree = "<group>"; };
+		5C4B4D401E4323D4002651C8 /* rotate_any.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotate_any.cc; sourceTree = "<group>"; };
+		5C4B4D411E4323D4002651C8 /* rotate_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotate_argb.cc; sourceTree = "<group>"; };
+		5C4B4D421E4323D4002651C8 /* rotate_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotate_common.cc; sourceTree = "<group>"; };
+		5C4B4D481E4323D4002651C8 /* rotate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotate.cc; sourceTree = "<group>"; };
+		5C4B4D491E4323D4002651C8 /* row_any.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = row_any.cc; sourceTree = "<group>"; };
+		5C4B4D4A1E4323D4002651C8 /* row_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = row_common.cc; sourceTree = "<group>"; };
+		5C4B4D511E4323D4002651C8 /* scale_any.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_any.cc; sourceTree = "<group>"; };
+		5C4B4D521E4323D4002651C8 /* scale_argb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_argb.cc; sourceTree = "<group>"; };
+		5C4B4D531E4323D4002651C8 /* scale_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_common.cc; sourceTree = "<group>"; };
+		5C4B4D591E4323D4002651C8 /* scale.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale.cc; sourceTree = "<group>"; };
+		5C4B4D5A1E4323D4002651C8 /* video_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_common.cc; sourceTree = "<group>"; };
+		5C5F408F1E978FD200D94279 /* SigProc_FIX_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SigProc_FIX_sse.h; sourceTree = "<group>"; };
 		5C63FC601E418411002CA531 /* libboringssl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboringssl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C85C4CA1E5780DD00D097B1 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		5CD284611E6A57F40094FDC8 /* i420_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = i420_buffer.cc; sourceTree = "<group>"; };
@@ -9237,25 +9237,25 @@
 		5CD2848D1E6A5F410094FDC8 /* frame_combiner.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = frame_combiner.cc; sourceTree = "<group>"; };
 		5CD2848E1E6A5F410094FDC8 /* frame_combiner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_combiner.h; sourceTree = "<group>"; };
 		5CD2848F1E6A5F410094FDC8 /* output_rate_calculator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = output_rate_calculator.h; sourceTree = "<group>"; };
-		5CD2849D1E6A5F9F0094FDC8 /* audio_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_receive_stream.h; path = call/audio_receive_stream.h; sourceTree = "<group>"; };
-		5CD2849E1E6A5F9F0094FDC8 /* audio_send_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_send_stream.cc; path = call/audio_send_stream.cc; sourceTree = "<group>"; };
-		5CD2849F1E6A5F9F0094FDC8 /* audio_send_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_send_stream.h; path = call/audio_send_stream.h; sourceTree = "<group>"; };
-		5CD284A01E6A5F9F0094FDC8 /* audio_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_state.h; path = call/audio_state.h; sourceTree = "<group>"; };
-		5CD284A61E6A5F9F0094FDC8 /* call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = call.h; path = call/call.h; sourceTree = "<group>"; };
-		5CD284A81E6A5F9F0094FDC8 /* flexfec_receive_stream_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = flexfec_receive_stream_impl.cc; path = call/flexfec_receive_stream_impl.cc; sourceTree = "<group>"; };
-		5CD284A91E6A5F9F0094FDC8 /* flexfec_receive_stream_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = flexfec_receive_stream_impl.h; path = call/flexfec_receive_stream_impl.h; sourceTree = "<group>"; };
-		5CD284AE1E6A5F9F0094FDC8 /* syncable.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = syncable.cc; path = call/syncable.cc; sourceTree = "<group>"; };
-		5CD284AF1E6A5F9F0094FDC8 /* syncable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = syncable.h; path = call/syncable.h; sourceTree = "<group>"; };
+		5CD2849D1E6A5F9F0094FDC8 /* audio_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_receive_stream.h; sourceTree = "<group>"; };
+		5CD2849E1E6A5F9F0094FDC8 /* audio_send_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_send_stream.cc; sourceTree = "<group>"; };
+		5CD2849F1E6A5F9F0094FDC8 /* audio_send_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_send_stream.h; sourceTree = "<group>"; };
+		5CD284A01E6A5F9F0094FDC8 /* audio_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_state.h; sourceTree = "<group>"; };
+		5CD284A61E6A5F9F0094FDC8 /* call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = call.h; sourceTree = "<group>"; };
+		5CD284A81E6A5F9F0094FDC8 /* flexfec_receive_stream_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = flexfec_receive_stream_impl.cc; sourceTree = "<group>"; };
+		5CD284A91E6A5F9F0094FDC8 /* flexfec_receive_stream_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flexfec_receive_stream_impl.h; sourceTree = "<group>"; };
+		5CD284AE1E6A5F9F0094FDC8 /* syncable.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = syncable.cc; sourceTree = "<group>"; };
+		5CD284AF1E6A5F9F0094FDC8 /* syncable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = syncable.h; sourceTree = "<group>"; };
 		5CD285341E6A61590094FDC8 /* video_codec_initializer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = video_codec_initializer.cc; sourceTree = "<group>"; };
-		5CD2853C1E6A61D20094FDC8 /* audio_decoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_factory.h; path = audio_codecs/audio_decoder_factory.h; sourceTree = "<group>"; };
-		5CD2853D1E6A61D20094FDC8 /* audio_decoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder.cc; path = audio_codecs/audio_decoder.cc; sourceTree = "<group>"; };
-		5CD2853E1E6A61D20094FDC8 /* audio_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder.h; path = audio_codecs/audio_decoder.h; sourceTree = "<group>"; };
-		5CD2853F1E6A61D20094FDC8 /* audio_format.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_format.cc; path = audio_codecs/audio_format.cc; sourceTree = "<group>"; };
-		5CD285401E6A61D20094FDC8 /* audio_format.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_format.h; path = audio_codecs/audio_format.h; sourceTree = "<group>"; };
-		5CD285411E6A61D20094FDC8 /* builtin_audio_decoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = builtin_audio_decoder_factory.cc; path = audio_codecs/builtin_audio_decoder_factory.cc; sourceTree = "<group>"; };
-		5CD285421E6A61D20094FDC8 /* builtin_audio_decoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = builtin_audio_decoder_factory.h; path = audio_codecs/builtin_audio_decoder_factory.h; sourceTree = "<group>"; };
-		5CD2854B1E6A62130094FDC8 /* audio_frame_operations.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_frame_operations.cc; path = utility/audio_frame_operations.cc; sourceTree = "<group>"; };
-		5CD2854C1E6A62130094FDC8 /* audio_frame_operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_frame_operations.h; path = utility/audio_frame_operations.h; sourceTree = "<group>"; };
+		5CD2853C1E6A61D20094FDC8 /* audio_decoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_factory.h; sourceTree = "<group>"; };
+		5CD2853D1E6A61D20094FDC8 /* audio_decoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder.cc; sourceTree = "<group>"; };
+		5CD2853E1E6A61D20094FDC8 /* audio_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder.h; sourceTree = "<group>"; };
+		5CD2853F1E6A61D20094FDC8 /* audio_format.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_format.cc; sourceTree = "<group>"; };
+		5CD285401E6A61D20094FDC8 /* audio_format.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_format.h; sourceTree = "<group>"; };
+		5CD285411E6A61D20094FDC8 /* builtin_audio_decoder_factory.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = builtin_audio_decoder_factory.cc; sourceTree = "<group>"; };
+		5CD285421E6A61D20094FDC8 /* builtin_audio_decoder_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = builtin_audio_decoder_factory.h; sourceTree = "<group>"; };
+		5CD2854B1E6A62130094FDC8 /* audio_frame_operations.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_frame_operations.cc; sourceTree = "<group>"; };
+		5CD2854C1E6A62130094FDC8 /* audio_frame_operations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_frame_operations.h; sourceTree = "<group>"; };
 		5CD285601E6A63430094FDC8 /* adaptive_fir_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = adaptive_fir_filter.cc; sourceTree = "<group>"; };
 		5CD285611E6A63430094FDC8 /* adaptive_fir_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adaptive_fir_filter.h; sourceTree = "<group>"; };
 		5CD285621E6A63430094FDC8 /* aec_state.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = aec_state.cc; sourceTree = "<group>"; };
@@ -9316,24 +9316,24 @@
 		5CD285F31E6A63F60094FDC8 /* smoothing_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = smoothing_filter.h; sourceTree = "<group>"; };
 		5CD285F81E6A64520094FDC8 /* rtcp_nack_stats.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtcp_nack_stats.cc; sourceTree = "<group>"; };
 		5CD285F91E6A64520094FDC8 /* rtcp_nack_stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtcp_nack_stats.h; sourceTree = "<group>"; };
-		5CD2860E1E6A64C90094FDC8 /* moving_max.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = moving_max.cc; path = echo_detector/moving_max.cc; sourceTree = "<group>"; };
-		5CD2860F1E6A64C90094FDC8 /* moving_max.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = moving_max.h; path = echo_detector/moving_max.h; sourceTree = "<group>"; };
-		5CD286121E6A66130094FDC8 /* event_log_writer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = event_log_writer.cc; path = audio_network_adaptor/event_log_writer.cc; sourceTree = "<group>"; };
-		5CD286131E6A66130094FDC8 /* event_log_writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event_log_writer.h; path = audio_network_adaptor/event_log_writer.h; sourceTree = "<group>"; };
-		5CD286261E6A669D0094FDC8 /* rtp_to_ntp_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_to_ntp_estimator.cc; path = source/rtp_to_ntp_estimator.cc; sourceTree = "<group>"; };
+		5CD2860E1E6A64C90094FDC8 /* moving_max.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = moving_max.cc; sourceTree = "<group>"; };
+		5CD2860F1E6A64C90094FDC8 /* moving_max.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = moving_max.h; sourceTree = "<group>"; };
+		5CD286121E6A66130094FDC8 /* event_log_writer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = event_log_writer.cc; sourceTree = "<group>"; };
+		5CD286131E6A66130094FDC8 /* event_log_writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event_log_writer.h; sourceTree = "<group>"; };
+		5CD286261E6A669D0094FDC8 /* rtp_to_ntp_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_to_ntp_estimator.cc; sourceTree = "<group>"; };
 		5CD286281E6A66C80094FDC8 /* quality_threshold.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = quality_threshold.cc; sourceTree = "<group>"; };
 		5CD286291E6A66C80094FDC8 /* quality_threshold.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quality_threshold.h; sourceTree = "<group>"; };
-		5CDD83431E43257200621E92 /* h264_bitstream_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = h264_bitstream_parser.cc; path = h264/h264_bitstream_parser.cc; sourceTree = "<group>"; };
-		5CDD83441E43257200621E92 /* h264_bitstream_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = h264_bitstream_parser.h; path = h264/h264_bitstream_parser.h; sourceTree = "<group>"; };
-		5CDD83451E43257200621E92 /* h264_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = h264_common.cc; path = h264/h264_common.cc; sourceTree = "<group>"; };
-		5CDD83461E43257200621E92 /* h264_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = h264_common.h; path = h264/h264_common.h; sourceTree = "<group>"; };
-		5CDD83481E43257200621E92 /* pps_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pps_parser.cc; path = h264/pps_parser.cc; sourceTree = "<group>"; };
-		5CDD83491E43257200621E92 /* pps_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pps_parser.h; path = h264/pps_parser.h; sourceTree = "<group>"; };
-		5CDD834E1E43257200621E92 /* sps_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sps_parser.cc; path = h264/sps_parser.cc; sourceTree = "<group>"; };
-		5CDD834F1E43257200621E92 /* sps_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sps_parser.h; path = h264/sps_parser.h; sourceTree = "<group>"; };
-		5CDD83511E43257200621E92 /* sps_vui_rewriter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sps_vui_rewriter.cc; path = h264/sps_vui_rewriter.cc; sourceTree = "<group>"; };
-		5CDD83521E43257200621E92 /* sps_vui_rewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sps_vui_rewriter.h; path = h264/sps_vui_rewriter.h; sourceTree = "<group>"; };
-		5CDD83661E4325D500621E92 /* webrtc_libyuv.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = webrtc_libyuv.cc; path = libyuv/webrtc_libyuv.cc; sourceTree = "<group>"; };
+		5CDD83431E43257200621E92 /* h264_bitstream_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h264_bitstream_parser.cc; sourceTree = "<group>"; };
+		5CDD83441E43257200621E92 /* h264_bitstream_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = h264_bitstream_parser.h; sourceTree = "<group>"; };
+		5CDD83451E43257200621E92 /* h264_common.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h264_common.cc; sourceTree = "<group>"; };
+		5CDD83461E43257200621E92 /* h264_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = h264_common.h; sourceTree = "<group>"; };
+		5CDD83481E43257200621E92 /* pps_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pps_parser.cc; sourceTree = "<group>"; };
+		5CDD83491E43257200621E92 /* pps_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pps_parser.h; sourceTree = "<group>"; };
+		5CDD834E1E43257200621E92 /* sps_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sps_parser.cc; sourceTree = "<group>"; };
+		5CDD834F1E43257200621E92 /* sps_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sps_parser.h; sourceTree = "<group>"; };
+		5CDD83511E43257200621E92 /* sps_vui_rewriter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sps_vui_rewriter.cc; sourceTree = "<group>"; };
+		5CDD83521E43257200621E92 /* sps_vui_rewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sps_vui_rewriter.h; sourceTree = "<group>"; };
+		5CDD83661E4325D500621E92 /* webrtc_libyuv.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = webrtc_libyuv.cc; sourceTree = "<group>"; };
 		5CDD836B1E439A3500621E92 /* frame_dropper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = frame_dropper.cc; sourceTree = "<group>"; };
 		5CDD836C1E439A3500621E92 /* frame_dropper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_dropper.h; sourceTree = "<group>"; };
 		5CDD836D1E439A3500621E92 /* ivf_file_writer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ivf_file_writer.cc; sourceTree = "<group>"; };
@@ -9364,10 +9364,10 @@
 		5CDD840B1E439B2900621E92 /* audio_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder.h; sourceTree = "<group>"; };
 		5CDD84121E439B2900621E92 /* legacy_encoded_audio_frame.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = legacy_encoded_audio_frame.cc; sourceTree = "<group>"; };
 		5CDD84131E439B2900621E92 /* legacy_encoded_audio_frame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = legacy_encoded_audio_frame.h; sourceTree = "<group>"; };
-		5CDD84211E439BCB00621E92 /* compare_gcc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = compare_gcc.cc; path = source/compare_gcc.cc; sourceTree = "<group>"; };
-		5CDD84221E439BCB00621E92 /* rotate_gcc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rotate_gcc.cc; path = source/rotate_gcc.cc; sourceTree = "<group>"; };
-		5CDD84231E439BCB00621E92 /* row_gcc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = row_gcc.cc; path = source/row_gcc.cc; sourceTree = "<group>"; };
-		5CDD84241E439BCB00621E92 /* scale_gcc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scale_gcc.cc; path = source/scale_gcc.cc; sourceTree = "<group>"; };
+		5CDD84211E439BCB00621E92 /* compare_gcc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = compare_gcc.cc; sourceTree = "<group>"; };
+		5CDD84221E439BCB00621E92 /* rotate_gcc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotate_gcc.cc; sourceTree = "<group>"; };
+		5CDD84231E439BCB00621E92 /* row_gcc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = row_gcc.cc; sourceTree = "<group>"; };
+		5CDD84241E439BCB00621E92 /* scale_gcc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_gcc.cc; sourceTree = "<group>"; };
 		5CDD84891E43AF1300621E92 /* audio_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_buffer.cc; sourceTree = "<group>"; };
 		5CDD848A1E43AF1300621E92 /* audio_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_buffer.h; sourceTree = "<group>"; };
 		5CDD848B1E43AF1300621E92 /* audio_processing_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_processing_impl.cc; sourceTree = "<group>"; };
@@ -9392,10 +9392,10 @@
 		5CDD84F91E43B1EA00621E92 /* audio_coding_module.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_coding_module.cc; sourceTree = "<group>"; };
 		5CDD84FB1E43B1EA00621E92 /* call_statistics.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = call_statistics.cc; sourceTree = "<group>"; };
 		5CDD84FC1E43B1EA00621E92 /* call_statistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = call_statistics.h; sourceTree = "<group>"; };
-		5CDD851C1E43B39C00621E92 /* bitrate_allocator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = bitrate_allocator.cc; path = call/bitrate_allocator.cc; sourceTree = "<group>"; };
-		5CDD851D1E43B39C00621E92 /* bitrate_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitrate_allocator.h; path = call/bitrate_allocator.h; sourceTree = "<group>"; };
-		5CDD85221E43B39C00621E92 /* call.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = call.cc; path = call/call.cc; sourceTree = "<group>"; };
-		5CDD85261E43B39C00621E92 /* flexfec_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = flexfec_receive_stream.h; path = call/flexfec_receive_stream.h; sourceTree = "<group>"; };
+		5CDD851C1E43B39C00621E92 /* bitrate_allocator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bitrate_allocator.cc; sourceTree = "<group>"; };
+		5CDD851D1E43B39C00621E92 /* bitrate_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitrate_allocator.h; sourceTree = "<group>"; };
+		5CDD85221E43B39C00621E92 /* call.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = call.cc; sourceTree = "<group>"; };
+		5CDD85261E43B39C00621E92 /* flexfec_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flexfec_receive_stream.h; sourceTree = "<group>"; };
 		5CDD854B1E43B42B00621E92 /* h264.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h264.cc; sourceTree = "<group>"; };
 		5CDD85601E43B5C000621E92 /* encoder_rtcp_feedback.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = encoder_rtcp_feedback.cc; sourceTree = "<group>"; };
 		5CDD85611E43B5C000621E92 /* encoder_rtcp_feedback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encoder_rtcp_feedback.h; sourceTree = "<group>"; };
@@ -9419,51 +9419,51 @@
 		5CDD85E11E43B81000621E92 /* aecm_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = aecm_defines.h; path = Source/webrtc/modules/audio_processing/aecm/aecm_defines.h; sourceTree = SOURCE_ROOT; };
 		5CDD85E21E43B81000621E92 /* echo_control_mobile.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = echo_control_mobile.cc; path = Source/webrtc/modules/audio_processing/aecm/echo_control_mobile.cc; sourceTree = SOURCE_ROOT; };
 		5CDD85E31E43B81000621E92 /* echo_control_mobile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = echo_control_mobile.h; path = Source/webrtc/modules/audio_processing/aecm/echo_control_mobile.h; sourceTree = SOURCE_ROOT; };
-		5CDD860A1E43B8B400621E92 /* auto_corr_to_refl_coef.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = auto_corr_to_refl_coef.c; path = signal_processing/auto_corr_to_refl_coef.c; sourceTree = "<group>"; };
-		5CDD860B1E43B8B400621E92 /* auto_correlation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = auto_correlation.c; path = signal_processing/auto_correlation.c; sourceTree = "<group>"; };
-		5CDD860E1E43B8B400621E92 /* complex_bit_reverse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = complex_bit_reverse.c; path = signal_processing/complex_bit_reverse.c; sourceTree = "<group>"; };
-		5CDD86101E43B8B400621E92 /* complex_fft_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = complex_fft_tables.h; path = signal_processing/complex_fft_tables.h; sourceTree = "<group>"; };
-		5CDD86111E43B8B400621E92 /* complex_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = complex_fft.c; path = signal_processing/complex_fft.c; sourceTree = "<group>"; };
-		5CDD86121E43B8B400621E92 /* copy_set_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = copy_set_operations.c; path = signal_processing/copy_set_operations.c; sourceTree = "<group>"; };
-		5CDD86151E43B8B400621E92 /* cross_correlation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cross_correlation.c; path = signal_processing/cross_correlation.c; sourceTree = "<group>"; };
-		5CDD86161E43B8B400621E92 /* division_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = division_operations.c; path = signal_processing/division_operations.c; sourceTree = "<group>"; };
-		5CDD861A1E43B8B400621E92 /* downsample_fast.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = downsample_fast.c; path = signal_processing/downsample_fast.c; sourceTree = "<group>"; };
-		5CDD861B1E43B8B400621E92 /* energy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = energy.c; path = signal_processing/energy.c; sourceTree = "<group>"; };
-		5CDD861E1E43B8B400621E92 /* filter_ar_fast_q12.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filter_ar_fast_q12.c; path = signal_processing/filter_ar_fast_q12.c; sourceTree = "<group>"; };
-		5CDD861F1E43B8B400621E92 /* filter_ar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filter_ar.c; path = signal_processing/filter_ar.c; sourceTree = "<group>"; };
-		5CDD86201E43B8B400621E92 /* filter_ma_fast_q12.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filter_ma_fast_q12.c; path = signal_processing/filter_ma_fast_q12.c; sourceTree = "<group>"; };
-		5CDD86211E43B8B400621E92 /* get_hanning_window.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = get_hanning_window.c; path = signal_processing/get_hanning_window.c; sourceTree = "<group>"; };
-		5CDD86221E43B8B400621E92 /* get_scaling_square.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = get_scaling_square.c; path = signal_processing/get_scaling_square.c; sourceTree = "<group>"; };
-		5CDD86231E43B8B400621E92 /* ilbc_specific_functions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ilbc_specific_functions.c; path = signal_processing/ilbc_specific_functions.c; sourceTree = "<group>"; };
-		5CDD86251E43B8B400621E92 /* levinson_durbin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = levinson_durbin.c; path = signal_processing/levinson_durbin.c; sourceTree = "<group>"; };
-		5CDD86261E43B8B400621E92 /* lpc_to_refl_coef.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lpc_to_refl_coef.c; path = signal_processing/lpc_to_refl_coef.c; sourceTree = "<group>"; };
-		5CDD86291E43B8B400621E92 /* min_max_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = min_max_operations.c; path = signal_processing/min_max_operations.c; sourceTree = "<group>"; };
-		5CDD862A1E43B8B400621E92 /* randomization_functions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = randomization_functions.c; path = signal_processing/randomization_functions.c; sourceTree = "<group>"; };
-		5CDD862C1E43B8B400621E92 /* real_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = real_fft.c; path = signal_processing/real_fft.c; sourceTree = "<group>"; };
-		5CDD862D1E43B8B400621E92 /* refl_coef_to_lpc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = refl_coef_to_lpc.c; path = signal_processing/refl_coef_to_lpc.c; sourceTree = "<group>"; };
-		5CDD862E1E43B8B400621E92 /* resample_48khz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample_48khz.c; path = signal_processing/resample_48khz.c; sourceTree = "<group>"; };
-		5CDD862F1E43B8B400621E92 /* resample_by_2_internal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample_by_2_internal.c; path = signal_processing/resample_by_2_internal.c; sourceTree = "<group>"; };
-		5CDD86301E43B8B500621E92 /* resample_by_2_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = resample_by_2_internal.h; path = signal_processing/resample_by_2_internal.h; sourceTree = "<group>"; };
-		5CDD86321E43B8B500621E92 /* resample_by_2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample_by_2.c; path = signal_processing/resample_by_2.c; sourceTree = "<group>"; };
-		5CDD86331E43B8B500621E92 /* resample_fractional.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample_fractional.c; path = signal_processing/resample_fractional.c; sourceTree = "<group>"; };
-		5CDD86341E43B8B500621E92 /* resample.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resample.c; path = signal_processing/resample.c; sourceTree = "<group>"; };
-		5CDD86361E43B8B500621E92 /* spl_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = spl_init.c; path = signal_processing/spl_init.c; sourceTree = "<group>"; };
-		5CDD86371E43B8B500621E92 /* spl_inl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = spl_inl.c; path = signal_processing/spl_inl.c; sourceTree = "<group>"; };
-		5CDD863B1E43B8B500621E92 /* spl_sqrt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = spl_sqrt.c; path = signal_processing/spl_sqrt.c; sourceTree = "<group>"; };
-		5CDD863C1E43B8B500621E92 /* splitting_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = splitting_filter.c; path = signal_processing/splitting_filter.c; sourceTree = "<group>"; };
-		5CDD863D1E43B8B500621E92 /* sqrt_of_one_minus_x_squared.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sqrt_of_one_minus_x_squared.c; path = signal_processing/sqrt_of_one_minus_x_squared.c; sourceTree = "<group>"; };
-		5CDD863F1E43B8B500621E92 /* vector_scaling_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vector_scaling_operations.c; path = signal_processing/vector_scaling_operations.c; sourceTree = "<group>"; };
-		5CDD86791E43B93800621E92 /* delay_estimator_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = delay_estimator_internal.h; path = utility/delay_estimator_internal.h; sourceTree = "<group>"; };
-		5CDD867B1E43B93800621E92 /* delay_estimator_wrapper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = delay_estimator_wrapper.cc; path = utility/delay_estimator_wrapper.cc; sourceTree = "<group>"; };
-		5CDD867C1E43B93800621E92 /* delay_estimator_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = delay_estimator_wrapper.h; path = utility/delay_estimator_wrapper.h; sourceTree = "<group>"; };
-		5CDD867D1E43B93800621E92 /* delay_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = delay_estimator.cc; path = utility/delay_estimator.cc; sourceTree = "<group>"; };
-		5CDD867E1E43B93800621E92 /* delay_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = delay_estimator.h; path = utility/delay_estimator.h; sourceTree = "<group>"; };
-		5CDD86981E43B99400621E92 /* circular_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = circular_buffer.cc; path = echo_detector/circular_buffer.cc; sourceTree = "<group>"; };
-		5CDD86991E43B99400621E92 /* circular_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = circular_buffer.h; path = echo_detector/circular_buffer.h; sourceTree = "<group>"; };
-		5CDD869B1E43B99400621E92 /* mean_variance_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mean_variance_estimator.cc; path = echo_detector/mean_variance_estimator.cc; sourceTree = "<group>"; };
-		5CDD869C1E43B99400621E92 /* mean_variance_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mean_variance_estimator.h; path = echo_detector/mean_variance_estimator.h; sourceTree = "<group>"; };
-		5CDD869E1E43B99400621E92 /* normalized_covariance_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = normalized_covariance_estimator.cc; path = echo_detector/normalized_covariance_estimator.cc; sourceTree = "<group>"; };
-		5CDD869F1E43B99400621E92 /* normalized_covariance_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = normalized_covariance_estimator.h; path = echo_detector/normalized_covariance_estimator.h; sourceTree = "<group>"; };
+		5CDD860A1E43B8B400621E92 /* auto_corr_to_refl_coef.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = auto_corr_to_refl_coef.c; sourceTree = "<group>"; };
+		5CDD860B1E43B8B400621E92 /* auto_correlation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = auto_correlation.c; sourceTree = "<group>"; };
+		5CDD860E1E43B8B400621E92 /* complex_bit_reverse.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = complex_bit_reverse.c; sourceTree = "<group>"; };
+		5CDD86101E43B8B400621E92 /* complex_fft_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = complex_fft_tables.h; sourceTree = "<group>"; };
+		5CDD86111E43B8B400621E92 /* complex_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = complex_fft.c; sourceTree = "<group>"; };
+		5CDD86121E43B8B400621E92 /* copy_set_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = copy_set_operations.c; sourceTree = "<group>"; };
+		5CDD86151E43B8B400621E92 /* cross_correlation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cross_correlation.c; sourceTree = "<group>"; };
+		5CDD86161E43B8B400621E92 /* division_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = division_operations.c; sourceTree = "<group>"; };
+		5CDD861A1E43B8B400621E92 /* downsample_fast.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = downsample_fast.c; sourceTree = "<group>"; };
+		5CDD861B1E43B8B400621E92 /* energy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = energy.c; sourceTree = "<group>"; };
+		5CDD861E1E43B8B400621E92 /* filter_ar_fast_q12.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_ar_fast_q12.c; sourceTree = "<group>"; };
+		5CDD861F1E43B8B400621E92 /* filter_ar.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_ar.c; sourceTree = "<group>"; };
+		5CDD86201E43B8B400621E92 /* filter_ma_fast_q12.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_ma_fast_q12.c; sourceTree = "<group>"; };
+		5CDD86211E43B8B400621E92 /* get_hanning_window.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = get_hanning_window.c; sourceTree = "<group>"; };
+		5CDD86221E43B8B400621E92 /* get_scaling_square.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = get_scaling_square.c; sourceTree = "<group>"; };
+		5CDD86231E43B8B400621E92 /* ilbc_specific_functions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ilbc_specific_functions.c; sourceTree = "<group>"; };
+		5CDD86251E43B8B400621E92 /* levinson_durbin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = levinson_durbin.c; sourceTree = "<group>"; };
+		5CDD86261E43B8B400621E92 /* lpc_to_refl_coef.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lpc_to_refl_coef.c; sourceTree = "<group>"; };
+		5CDD86291E43B8B400621E92 /* min_max_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = min_max_operations.c; sourceTree = "<group>"; };
+		5CDD862A1E43B8B400621E92 /* randomization_functions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = randomization_functions.c; sourceTree = "<group>"; };
+		5CDD862C1E43B8B400621E92 /* real_fft.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = real_fft.c; sourceTree = "<group>"; };
+		5CDD862D1E43B8B400621E92 /* refl_coef_to_lpc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = refl_coef_to_lpc.c; sourceTree = "<group>"; };
+		5CDD862E1E43B8B400621E92 /* resample_48khz.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_48khz.c; sourceTree = "<group>"; };
+		5CDD862F1E43B8B400621E92 /* resample_by_2_internal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_by_2_internal.c; sourceTree = "<group>"; };
+		5CDD86301E43B8B500621E92 /* resample_by_2_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resample_by_2_internal.h; sourceTree = "<group>"; };
+		5CDD86321E43B8B500621E92 /* resample_by_2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_by_2.c; sourceTree = "<group>"; };
+		5CDD86331E43B8B500621E92 /* resample_fractional.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample_fractional.c; sourceTree = "<group>"; };
+		5CDD86341E43B8B500621E92 /* resample.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resample.c; sourceTree = "<group>"; };
+		5CDD86361E43B8B500621E92 /* spl_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_init.c; sourceTree = "<group>"; };
+		5CDD86371E43B8B500621E92 /* spl_inl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_inl.c; sourceTree = "<group>"; };
+		5CDD863B1E43B8B500621E92 /* spl_sqrt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = spl_sqrt.c; sourceTree = "<group>"; };
+		5CDD863C1E43B8B500621E92 /* splitting_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = splitting_filter.c; sourceTree = "<group>"; };
+		5CDD863D1E43B8B500621E92 /* sqrt_of_one_minus_x_squared.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sqrt_of_one_minus_x_squared.c; sourceTree = "<group>"; };
+		5CDD863F1E43B8B500621E92 /* vector_scaling_operations.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vector_scaling_operations.c; sourceTree = "<group>"; };
+		5CDD86791E43B93800621E92 /* delay_estimator_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator_internal.h; sourceTree = "<group>"; };
+		5CDD867B1E43B93800621E92 /* delay_estimator_wrapper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = delay_estimator_wrapper.cc; sourceTree = "<group>"; };
+		5CDD867C1E43B93800621E92 /* delay_estimator_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator_wrapper.h; sourceTree = "<group>"; };
+		5CDD867D1E43B93800621E92 /* delay_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = delay_estimator.cc; sourceTree = "<group>"; };
+		5CDD867E1E43B93800621E92 /* delay_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = delay_estimator.h; sourceTree = "<group>"; };
+		5CDD86981E43B99400621E92 /* circular_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = circular_buffer.cc; sourceTree = "<group>"; };
+		5CDD86991E43B99400621E92 /* circular_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = circular_buffer.h; sourceTree = "<group>"; };
+		5CDD869B1E43B99400621E92 /* mean_variance_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mean_variance_estimator.cc; sourceTree = "<group>"; };
+		5CDD869C1E43B99400621E92 /* mean_variance_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mean_variance_estimator.h; sourceTree = "<group>"; };
+		5CDD869E1E43B99400621E92 /* normalized_covariance_estimator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = normalized_covariance_estimator.cc; sourceTree = "<group>"; };
+		5CDD869F1E43B99400621E92 /* normalized_covariance_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = normalized_covariance_estimator.h; sourceTree = "<group>"; };
 		5CDD86C61E43BA2700621E92 /* vad_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_core.c; sourceTree = "<group>"; };
 		5CDD86C71E43BA2700621E92 /* vad_core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_core.h; sourceTree = "<group>"; };
 		5CDD86C91E43BA2700621E92 /* vad_filterbank.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vad_filterbank.c; sourceTree = "<group>"; };
@@ -9474,56 +9474,56 @@
 		5CDD86D01E43BA2700621E92 /* vad_sp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_sp.h; sourceTree = "<group>"; };
 		5CDD86D31E43BA2800621E92 /* vad.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vad.cc; sourceTree = "<group>"; };
 		5CDD86D41E43BA2800621E92 /* webrtc_vad.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = webrtc_vad.c; sourceTree = "<group>"; };
-		5CDD86E81E43BA6D00621E92 /* analog_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = analog_agc.h; path = agc/legacy/analog_agc.h; sourceTree = "<group>"; };
-		5CDD86EA1E43BA6D00621E92 /* digital_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = digital_agc.h; path = agc/legacy/digital_agc.h; sourceTree = "<group>"; };
-		5CDD86EB1E43BA6D00621E92 /* gain_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gain_control.h; path = agc/legacy/gain_control.h; sourceTree = "<group>"; };
-		5CDD86F21E43BA7500621E92 /* agc_manager_direct.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = agc_manager_direct.cc; path = agc/agc_manager_direct.cc; sourceTree = "<group>"; };
-		5CDD86F31E43BA7500621E92 /* agc_manager_direct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = agc_manager_direct.h; path = agc/agc_manager_direct.h; sourceTree = "<group>"; };
-		5CDD86F41E43BA7500621E92 /* agc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = agc.cc; path = agc/agc.cc; sourceTree = "<group>"; };
-		5CDD86F51E43BA7500621E92 /* agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = agc.h; path = agc/agc.h; sourceTree = "<group>"; };
-		5CDD86F91E43BA7500621E92 /* loudness_histogram.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = loudness_histogram.cc; path = agc/loudness_histogram.cc; sourceTree = "<group>"; };
-		5CDD86FA1E43BA7500621E92 /* loudness_histogram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = loudness_histogram.h; path = agc/loudness_histogram.h; sourceTree = "<group>"; };
-		5CDD86FB1E43BA7500621E92 /* mock_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mock_agc.h; path = agc/mock_agc.h; sourceTree = "<group>"; };
-		5CDD86FC1E43BA7500621E92 /* utility.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = utility.cc; path = agc/utility.cc; sourceTree = "<group>"; };
-		5CDD86FD1E43BA7500621E92 /* utility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = utility.h; path = agc/utility.h; sourceTree = "<group>"; };
-		5CDD870B1E43BABE00621E92 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = common.h; path = vad/common.h; sourceTree = "<group>"; };
-		5CDD870D1E43BABE00621E92 /* gmm.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = gmm.cc; path = vad/gmm.cc; sourceTree = "<group>"; };
-		5CDD870E1E43BABE00621E92 /* gmm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gmm.h; path = vad/gmm.h; sourceTree = "<group>"; };
-		5CDD870F1E43BABE00621E92 /* noise_gmm_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = noise_gmm_tables.h; path = vad/noise_gmm_tables.h; sourceTree = "<group>"; };
-		5CDD87111E43BABE00621E92 /* pitch_based_vad.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pitch_based_vad.cc; path = vad/pitch_based_vad.cc; sourceTree = "<group>"; };
-		5CDD87121E43BABE00621E92 /* pitch_based_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pitch_based_vad.h; path = vad/pitch_based_vad.h; sourceTree = "<group>"; };
-		5CDD87141E43BABE00621E92 /* pitch_internal.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pitch_internal.cc; path = vad/pitch_internal.cc; sourceTree = "<group>"; };
-		5CDD87151E43BABE00621E92 /* pitch_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pitch_internal.h; path = vad/pitch_internal.h; sourceTree = "<group>"; };
-		5CDD87171E43BABE00621E92 /* pole_zero_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pole_zero_filter.cc; path = vad/pole_zero_filter.cc; sourceTree = "<group>"; };
-		5CDD87181E43BABE00621E92 /* pole_zero_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pole_zero_filter.h; path = vad/pole_zero_filter.h; sourceTree = "<group>"; };
-		5CDD871A1E43BABE00621E92 /* standalone_vad.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = standalone_vad.cc; path = vad/standalone_vad.cc; sourceTree = "<group>"; };
-		5CDD871B1E43BABE00621E92 /* standalone_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = standalone_vad.h; path = vad/standalone_vad.h; sourceTree = "<group>"; };
-		5CDD871C1E43BABE00621E92 /* vad_audio_proc_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vad_audio_proc_internal.h; path = vad/vad_audio_proc_internal.h; sourceTree = "<group>"; };
-		5CDD871E1E43BABE00621E92 /* vad_audio_proc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = vad_audio_proc.cc; path = vad/vad_audio_proc.cc; sourceTree = "<group>"; };
-		5CDD871F1E43BABE00621E92 /* vad_audio_proc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vad_audio_proc.h; path = vad/vad_audio_proc.h; sourceTree = "<group>"; };
-		5CDD87211E43BABE00621E92 /* vad_circular_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = vad_circular_buffer.cc; path = vad/vad_circular_buffer.cc; sourceTree = "<group>"; };
-		5CDD87221E43BABE00621E92 /* vad_circular_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vad_circular_buffer.h; path = vad/vad_circular_buffer.h; sourceTree = "<group>"; };
-		5CDD87241E43BABE00621E92 /* voice_activity_detector.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = voice_activity_detector.cc; path = vad/voice_activity_detector.cc; sourceTree = "<group>"; };
-		5CDD87251E43BABE00621E92 /* voice_activity_detector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = voice_activity_detector.h; path = vad/voice_activity_detector.h; sourceTree = "<group>"; };
-		5CDD87261E43BABE00621E92 /* voice_gmm_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = voice_gmm_tables.h; path = vad/voice_gmm_tables.h; sourceTree = "<group>"; };
-		5CDD87451E43BAF500621E92 /* push_resampler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = push_resampler.cc; path = resampler/push_resampler.cc; sourceTree = "<group>"; };
-		5CDD87471E43BAF500621E92 /* push_sinc_resampler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = push_sinc_resampler.cc; path = resampler/push_sinc_resampler.cc; sourceTree = "<group>"; };
-		5CDD87481E43BAF500621E92 /* push_sinc_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = push_sinc_resampler.h; path = resampler/push_sinc_resampler.h; sourceTree = "<group>"; };
-		5CDD874A1E43BAF500621E92 /* resampler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = resampler.cc; path = resampler/resampler.cc; sourceTree = "<group>"; };
-		5CDD874E1E43BAF500621E92 /* sinc_resampler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sinc_resampler.cc; path = resampler/sinc_resampler.cc; sourceTree = "<group>"; };
-		5CDD874F1E43BAF500621E92 /* sinc_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sinc_resampler.h; path = resampler/sinc_resampler.h; sourceTree = "<group>"; };
-		5CDD87501E43BAF500621E92 /* sinusoidal_linear_chirp_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sinusoidal_linear_chirp_source.cc; path = resampler/sinusoidal_linear_chirp_source.cc; sourceTree = "<group>"; };
-		5CDD87511E43BAF500621E92 /* sinusoidal_linear_chirp_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sinusoidal_linear_chirp_source.h; path = resampler/sinusoidal_linear_chirp_source.h; sourceTree = "<group>"; };
-		5CDD87861E43BC0500621E92 /* filter_functions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filter_functions.c; path = source/filter_functions.c; sourceTree = "<group>"; };
-		5CDD87991E43BC0500621E92 /* os_specific_inline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = os_specific_inline.h; path = source/os_specific_inline.h; sourceTree = "<group>"; };
-		5CDD879B1E43BC0500621E92 /* pitch_estimator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pitch_estimator.c; path = source/pitch_estimator.c; sourceTree = "<group>"; };
-		5CDD879C1E43BC0500621E92 /* pitch_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pitch_estimator.h; path = source/pitch_estimator.h; sourceTree = "<group>"; };
-		5CDD879D1E43BC0500621E92 /* pitch_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pitch_filter.c; path = source/pitch_filter.c; sourceTree = "<group>"; };
-		5CDD87A21E43BC0500621E92 /* settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = settings.h; path = source/settings.h; sourceTree = "<group>"; };
-		5CDD87A51E43BC0500621E92 /* structs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = structs.h; path = source/structs.h; sourceTree = "<group>"; };
-		5CDD87E01E43BD7000621E92 /* sinc_resampler_sse.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sinc_resampler_sse.cc; path = resampler/sinc_resampler_sse.cc; sourceTree = "<group>"; };
-		5CDD87E31E43BDA100621E92 /* apm_data_dumper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = apm_data_dumper.cc; path = logging/apm_data_dumper.cc; sourceTree = "<group>"; };
-		5CDD87E41E43BDA100621E92 /* apm_data_dumper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = apm_data_dumper.h; path = logging/apm_data_dumper.h; sourceTree = "<group>"; };
+		5CDD86E81E43BA6D00621E92 /* analog_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = analog_agc.h; sourceTree = "<group>"; };
+		5CDD86EA1E43BA6D00621E92 /* digital_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = digital_agc.h; sourceTree = "<group>"; };
+		5CDD86EB1E43BA6D00621E92 /* gain_control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gain_control.h; sourceTree = "<group>"; };
+		5CDD86F21E43BA7500621E92 /* agc_manager_direct.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = agc_manager_direct.cc; sourceTree = "<group>"; };
+		5CDD86F31E43BA7500621E92 /* agc_manager_direct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agc_manager_direct.h; sourceTree = "<group>"; };
+		5CDD86F41E43BA7500621E92 /* agc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = agc.cc; sourceTree = "<group>"; };
+		5CDD86F51E43BA7500621E92 /* agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agc.h; sourceTree = "<group>"; };
+		5CDD86F91E43BA7500621E92 /* loudness_histogram.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loudness_histogram.cc; sourceTree = "<group>"; };
+		5CDD86FA1E43BA7500621E92 /* loudness_histogram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loudness_histogram.h; sourceTree = "<group>"; };
+		5CDD86FB1E43BA7500621E92 /* mock_agc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_agc.h; sourceTree = "<group>"; };
+		5CDD86FC1E43BA7500621E92 /* utility.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = utility.cc; sourceTree = "<group>"; };
+		5CDD86FD1E43BA7500621E92 /* utility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utility.h; sourceTree = "<group>"; };
+		5CDD870B1E43BABE00621E92 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		5CDD870D1E43BABE00621E92 /* gmm.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gmm.cc; sourceTree = "<group>"; };
+		5CDD870E1E43BABE00621E92 /* gmm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gmm.h; sourceTree = "<group>"; };
+		5CDD870F1E43BABE00621E92 /* noise_gmm_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = noise_gmm_tables.h; sourceTree = "<group>"; };
+		5CDD87111E43BABE00621E92 /* pitch_based_vad.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pitch_based_vad.cc; sourceTree = "<group>"; };
+		5CDD87121E43BABE00621E92 /* pitch_based_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pitch_based_vad.h; sourceTree = "<group>"; };
+		5CDD87141E43BABE00621E92 /* pitch_internal.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pitch_internal.cc; sourceTree = "<group>"; };
+		5CDD87151E43BABE00621E92 /* pitch_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pitch_internal.h; sourceTree = "<group>"; };
+		5CDD87171E43BABE00621E92 /* pole_zero_filter.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pole_zero_filter.cc; sourceTree = "<group>"; };
+		5CDD87181E43BABE00621E92 /* pole_zero_filter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pole_zero_filter.h; sourceTree = "<group>"; };
+		5CDD871A1E43BABE00621E92 /* standalone_vad.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = standalone_vad.cc; sourceTree = "<group>"; };
+		5CDD871B1E43BABE00621E92 /* standalone_vad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = standalone_vad.h; sourceTree = "<group>"; };
+		5CDD871C1E43BABE00621E92 /* vad_audio_proc_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_audio_proc_internal.h; sourceTree = "<group>"; };
+		5CDD871E1E43BABE00621E92 /* vad_audio_proc.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vad_audio_proc.cc; sourceTree = "<group>"; };
+		5CDD871F1E43BABE00621E92 /* vad_audio_proc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_audio_proc.h; sourceTree = "<group>"; };
+		5CDD87211E43BABE00621E92 /* vad_circular_buffer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vad_circular_buffer.cc; sourceTree = "<group>"; };
+		5CDD87221E43BABE00621E92 /* vad_circular_buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vad_circular_buffer.h; sourceTree = "<group>"; };
+		5CDD87241E43BABE00621E92 /* voice_activity_detector.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = voice_activity_detector.cc; sourceTree = "<group>"; };
+		5CDD87251E43BABE00621E92 /* voice_activity_detector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = voice_activity_detector.h; sourceTree = "<group>"; };
+		5CDD87261E43BABE00621E92 /* voice_gmm_tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = voice_gmm_tables.h; sourceTree = "<group>"; };
+		5CDD87451E43BAF500621E92 /* push_resampler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = push_resampler.cc; sourceTree = "<group>"; };
+		5CDD87471E43BAF500621E92 /* push_sinc_resampler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = push_sinc_resampler.cc; sourceTree = "<group>"; };
+		5CDD87481E43BAF500621E92 /* push_sinc_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = push_sinc_resampler.h; sourceTree = "<group>"; };
+		5CDD874A1E43BAF500621E92 /* resampler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = resampler.cc; sourceTree = "<group>"; };
+		5CDD874E1E43BAF500621E92 /* sinc_resampler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sinc_resampler.cc; sourceTree = "<group>"; };
+		5CDD874F1E43BAF500621E92 /* sinc_resampler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sinc_resampler.h; sourceTree = "<group>"; };
+		5CDD87501E43BAF500621E92 /* sinusoidal_linear_chirp_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sinusoidal_linear_chirp_source.cc; sourceTree = "<group>"; };
+		5CDD87511E43BAF500621E92 /* sinusoidal_linear_chirp_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sinusoidal_linear_chirp_source.h; sourceTree = "<group>"; };
+		5CDD87861E43BC0500621E92 /* filter_functions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filter_functions.c; sourceTree = "<group>"; };
+		5CDD87991E43BC0500621E92 /* os_specific_inline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = os_specific_inline.h; sourceTree = "<group>"; };
+		5CDD879B1E43BC0500621E92 /* pitch_estimator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pitch_estimator.c; sourceTree = "<group>"; };
+		5CDD879C1E43BC0500621E92 /* pitch_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pitch_estimator.h; sourceTree = "<group>"; };
+		5CDD879D1E43BC0500621E92 /* pitch_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pitch_filter.c; sourceTree = "<group>"; };
+		5CDD87A21E43BC0500621E92 /* settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = settings.h; sourceTree = "<group>"; };
+		5CDD87A51E43BC0500621E92 /* structs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = structs.h; sourceTree = "<group>"; };
+		5CDD87E01E43BD7000621E92 /* sinc_resampler_sse.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sinc_resampler_sse.cc; sourceTree = "<group>"; };
+		5CDD87E31E43BDA100621E92 /* apm_data_dumper.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = apm_data_dumper.cc; sourceTree = "<group>"; };
+		5CDD87E41E43BDA100621E92 /* apm_data_dumper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = apm_data_dumper.h; sourceTree = "<group>"; };
 		5CDD87FC1E43BE3C00621E92 /* byte_io.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = byte_io.h; sourceTree = "<group>"; };
 		5CDD87FE1E43BE3C00621E92 /* dtmf_queue.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dtmf_queue.cc; sourceTree = "<group>"; };
 		5CDD87FF1E43BE3C00621E92 /* dtmf_queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dtmf_queue.h; sourceTree = "<group>"; };
@@ -9687,35 +9687,35 @@
 		5CDD89F31E43BFB300621E92 /* time_stretch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = time_stretch.h; sourceTree = "<group>"; };
 		5CDD89F51E43BFB300621E92 /* timestamp_scaler.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = timestamp_scaler.cc; sourceTree = "<group>"; };
 		5CDD89F61E43BFB300621E92 /* timestamp_scaler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timestamp_scaler.h; sourceTree = "<group>"; };
-		5CDD8A601E43C00F00621E92 /* audio_checksum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_checksum.h; path = tools/audio_checksum.h; sourceTree = "<group>"; };
-		5CDD8A611E43C00F00621E92 /* audio_loop.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_loop.cc; path = tools/audio_loop.cc; sourceTree = "<group>"; };
-		5CDD8A621E43C00F00621E92 /* audio_loop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_loop.h; path = tools/audio_loop.h; sourceTree = "<group>"; };
-		5CDD8A631E43C00F00621E92 /* audio_sink.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_sink.cc; path = tools/audio_sink.cc; sourceTree = "<group>"; };
-		5CDD8A641E43C00F00621E92 /* audio_sink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_sink.h; path = tools/audio_sink.h; sourceTree = "<group>"; };
-		5CDD8A651E43C00F00621E92 /* constant_pcm_packet_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = constant_pcm_packet_source.cc; path = tools/constant_pcm_packet_source.cc; sourceTree = "<group>"; };
-		5CDD8A661E43C00F00621E92 /* constant_pcm_packet_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = constant_pcm_packet_source.h; path = tools/constant_pcm_packet_source.h; sourceTree = "<group>"; };
-		5CDD8A681E43C00F00621E92 /* encode_neteq_input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = encode_neteq_input.cc; path = tools/encode_neteq_input.cc; sourceTree = "<group>"; };
-		5CDD8A691E43C00F00621E92 /* encode_neteq_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = encode_neteq_input.h; path = tools/encode_neteq_input.h; sourceTree = "<group>"; };
-		5CDD8A6A1E43C00F00621E92 /* fake_decode_from_file.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = fake_decode_from_file.cc; path = tools/fake_decode_from_file.cc; sourceTree = "<group>"; };
-		5CDD8A6B1E43C00F00621E92 /* fake_decode_from_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_decode_from_file.h; path = tools/fake_decode_from_file.h; sourceTree = "<group>"; };
-		5CDD8A6D1E43C00F00621E92 /* input_audio_file.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = input_audio_file.cc; path = tools/input_audio_file.cc; sourceTree = "<group>"; };
-		5CDD8A6E1E43C00F00621E92 /* input_audio_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = input_audio_file.h; path = tools/input_audio_file.h; sourceTree = "<group>"; };
-		5CDD8A711E43C00F00621E92 /* neteq_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_input.h; path = tools/neteq_input.h; sourceTree = "<group>"; };
-		5CDD8A781E43C00F00621E92 /* neteq_replacement_input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = neteq_replacement_input.cc; path = tools/neteq_replacement_input.cc; sourceTree = "<group>"; };
-		5CDD8A791E43C00F00621E92 /* neteq_replacement_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_replacement_input.h; path = tools/neteq_replacement_input.h; sourceTree = "<group>"; };
-		5CDD8A7D1E43C00F00621E92 /* output_audio_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = output_audio_file.h; path = tools/output_audio_file.h; sourceTree = "<group>"; };
-		5CDD8A7E1E43C00F00621E92 /* output_wav_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = output_wav_file.h; path = tools/output_wav_file.h; sourceTree = "<group>"; };
-		5CDD8A7F1E43C00F00621E92 /* packet_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = packet_source.cc; path = tools/packet_source.cc; sourceTree = "<group>"; };
-		5CDD8A801E43C00F00621E92 /* packet_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = packet_source.h; path = tools/packet_source.h; sourceTree = "<group>"; };
-		5CDD8A821E43C00F00621E92 /* packet.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = packet.cc; path = tools/packet.cc; sourceTree = "<group>"; };
-		5CDD8A831E43C00F00621E92 /* packet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = packet.h; path = tools/packet.h; sourceTree = "<group>"; };
-		5CDD8A841E43C00F00621E92 /* resample_input_audio_file.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = resample_input_audio_file.cc; path = tools/resample_input_audio_file.cc; sourceTree = "<group>"; };
-		5CDD8A851E43C00F00621E92 /* resample_input_audio_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = resample_input_audio_file.h; path = tools/resample_input_audio_file.h; sourceTree = "<group>"; };
-		5CDD8A891E43C00F00621E92 /* rtp_file_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_file_source.cc; path = tools/rtp_file_source.cc; sourceTree = "<group>"; };
-		5CDD8A8A1E43C00F00621E92 /* rtp_file_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_file_source.h; path = tools/rtp_file_source.h; sourceTree = "<group>"; };
-		5CDD8A8B1E43C00F00621E92 /* rtp_generator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtp_generator.cc; path = tools/rtp_generator.cc; sourceTree = "<group>"; };
-		5CDD8A8C1E43C00F00621E92 /* rtp_generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_generator.h; path = tools/rtp_generator.h; sourceTree = "<group>"; };
-		5CDD8A8D1E43C00F00621E92 /* rtpcat.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rtpcat.cc; path = tools/rtpcat.cc; sourceTree = "<group>"; };
+		5CDD8A601E43C00F00621E92 /* audio_checksum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_checksum.h; sourceTree = "<group>"; };
+		5CDD8A611E43C00F00621E92 /* audio_loop.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_loop.cc; sourceTree = "<group>"; };
+		5CDD8A621E43C00F00621E92 /* audio_loop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_loop.h; sourceTree = "<group>"; };
+		5CDD8A631E43C00F00621E92 /* audio_sink.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_sink.cc; sourceTree = "<group>"; };
+		5CDD8A641E43C00F00621E92 /* audio_sink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_sink.h; sourceTree = "<group>"; };
+		5CDD8A651E43C00F00621E92 /* constant_pcm_packet_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = constant_pcm_packet_source.cc; sourceTree = "<group>"; };
+		5CDD8A661E43C00F00621E92 /* constant_pcm_packet_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constant_pcm_packet_source.h; sourceTree = "<group>"; };
+		5CDD8A681E43C00F00621E92 /* encode_neteq_input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = encode_neteq_input.cc; sourceTree = "<group>"; };
+		5CDD8A691E43C00F00621E92 /* encode_neteq_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encode_neteq_input.h; sourceTree = "<group>"; };
+		5CDD8A6A1E43C00F00621E92 /* fake_decode_from_file.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_decode_from_file.cc; sourceTree = "<group>"; };
+		5CDD8A6B1E43C00F00621E92 /* fake_decode_from_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_decode_from_file.h; sourceTree = "<group>"; };
+		5CDD8A6D1E43C00F00621E92 /* input_audio_file.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = input_audio_file.cc; sourceTree = "<group>"; };
+		5CDD8A6E1E43C00F00621E92 /* input_audio_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = input_audio_file.h; sourceTree = "<group>"; };
+		5CDD8A711E43C00F00621E92 /* neteq_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_input.h; sourceTree = "<group>"; };
+		5CDD8A781E43C00F00621E92 /* neteq_replacement_input.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = neteq_replacement_input.cc; sourceTree = "<group>"; };
+		5CDD8A791E43C00F00621E92 /* neteq_replacement_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_replacement_input.h; sourceTree = "<group>"; };
+		5CDD8A7D1E43C00F00621E92 /* output_audio_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = output_audio_file.h; sourceTree = "<group>"; };
+		5CDD8A7E1E43C00F00621E92 /* output_wav_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = output_wav_file.h; sourceTree = "<group>"; };
+		5CDD8A7F1E43C00F00621E92 /* packet_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = packet_source.cc; sourceTree = "<group>"; };
+		5CDD8A801E43C00F00621E92 /* packet_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = packet_source.h; sourceTree = "<group>"; };
+		5CDD8A821E43C00F00621E92 /* packet.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = packet.cc; sourceTree = "<group>"; };
+		5CDD8A831E43C00F00621E92 /* packet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = packet.h; sourceTree = "<group>"; };
+		5CDD8A841E43C00F00621E92 /* resample_input_audio_file.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = resample_input_audio_file.cc; sourceTree = "<group>"; };
+		5CDD8A851E43C00F00621E92 /* resample_input_audio_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resample_input_audio_file.h; sourceTree = "<group>"; };
+		5CDD8A891E43C00F00621E92 /* rtp_file_source.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_file_source.cc; sourceTree = "<group>"; };
+		5CDD8A8A1E43C00F00621E92 /* rtp_file_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_file_source.h; sourceTree = "<group>"; };
+		5CDD8A8B1E43C00F00621E92 /* rtp_generator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtp_generator.cc; sourceTree = "<group>"; };
+		5CDD8A8C1E43C00F00621E92 /* rtp_generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_generator.h; sourceTree = "<group>"; };
+		5CDD8A8D1E43C00F00621E92 /* rtpcat.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rtpcat.cc; sourceTree = "<group>"; };
 		5CDD8ABD1E43C23900621E92 /* audio_receive_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_receive_stream.cc; sourceTree = "<group>"; };
 		5CDD8ABE1E43C23900621E92 /* audio_receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_receive_stream.h; sourceTree = "<group>"; };
 		5CDD8AC01E43C23900621E92 /* audio_send_stream.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_send_stream.cc; sourceTree = "<group>"; };
@@ -9731,25 +9731,25 @@
 		5CDD8C571E43C60900621E92 /* audio_encoder_opus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_opus.h; sourceTree = "<group>"; };
 		5CDD8C591E43C60900621E92 /* opus_inst.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = opus_inst.h; sourceTree = "<group>"; };
 		5CDD8C5B1E43C60900621E92 /* opus_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = opus_interface.h; sourceTree = "<group>"; };
-		5CDD8C6C1E43C66000621E92 /* click_annotate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = click_annotate.cc; path = transient/click_annotate.cc; sourceTree = "<group>"; };
-		5CDD8C6D1E43C66000621E92 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = common.h; path = transient/common.h; sourceTree = "<group>"; };
-		5CDD8C6E1E43C66000621E92 /* daubechies_8_wavelet_coeffs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = daubechies_8_wavelet_coeffs.h; path = transient/daubechies_8_wavelet_coeffs.h; sourceTree = "<group>"; };
-		5CDD8C701E43C66000621E92 /* dyadic_decimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dyadic_decimator.h; path = transient/dyadic_decimator.h; sourceTree = "<group>"; };
-		5CDD8C721E43C66000621E92 /* file_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = file_utils.cc; path = transient/file_utils.cc; sourceTree = "<group>"; };
-		5CDD8C731E43C66000621E92 /* file_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = file_utils.h; path = transient/file_utils.h; sourceTree = "<group>"; };
-		5CDD8C751E43C66000621E92 /* moving_moments.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = moving_moments.cc; path = transient/moving_moments.cc; sourceTree = "<group>"; };
-		5CDD8C761E43C66000621E92 /* moving_moments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = moving_moments.h; path = transient/moving_moments.h; sourceTree = "<group>"; };
-		5CDD8C791E43C66000621E92 /* transient_detector.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = transient_detector.cc; path = transient/transient_detector.cc; sourceTree = "<group>"; };
-		5CDD8C7A1E43C66000621E92 /* transient_detector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = transient_detector.h; path = transient/transient_detector.h; sourceTree = "<group>"; };
-		5CDD8C7E1E43C66000621E92 /* transient_suppressor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = transient_suppressor.h; path = transient/transient_suppressor.h; sourceTree = "<group>"; };
-		5CDD8C801E43C66000621E92 /* wpd_node.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wpd_node.cc; path = transient/wpd_node.cc; sourceTree = "<group>"; };
-		5CDD8C811E43C66000621E92 /* wpd_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wpd_node.h; path = transient/wpd_node.h; sourceTree = "<group>"; };
-		5CDD8C831E43C66000621E92 /* wpd_tree.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wpd_tree.cc; path = transient/wpd_tree.cc; sourceTree = "<group>"; };
-		5CDD8C841E43C66000621E92 /* wpd_tree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = wpd_tree.h; path = transient/wpd_tree.h; sourceTree = "<group>"; };
-		5CDD8C9F1E43C6F700621E92 /* audio_encoder_cng.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_cng.cc; path = cng/audio_encoder_cng.cc; sourceTree = "<group>"; };
-		5CDD8CA01E43C6F700621E92 /* audio_encoder_cng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_cng.h; path = cng/audio_encoder_cng.h; sourceTree = "<group>"; };
-		5CDD8CA41E43C6F700621E92 /* webrtc_cng.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = webrtc_cng.cc; path = cng/webrtc_cng.cc; sourceTree = "<group>"; };
-		5CDD8CA51E43C6F700621E92 /* webrtc_cng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = webrtc_cng.h; path = cng/webrtc_cng.h; sourceTree = "<group>"; };
+		5CDD8C6C1E43C66000621E92 /* click_annotate.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = click_annotate.cc; sourceTree = "<group>"; };
+		5CDD8C6D1E43C66000621E92 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		5CDD8C6E1E43C66000621E92 /* daubechies_8_wavelet_coeffs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = daubechies_8_wavelet_coeffs.h; sourceTree = "<group>"; };
+		5CDD8C701E43C66000621E92 /* dyadic_decimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dyadic_decimator.h; sourceTree = "<group>"; };
+		5CDD8C721E43C66000621E92 /* file_utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = file_utils.cc; sourceTree = "<group>"; };
+		5CDD8C731E43C66000621E92 /* file_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = file_utils.h; sourceTree = "<group>"; };
+		5CDD8C751E43C66000621E92 /* moving_moments.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = moving_moments.cc; sourceTree = "<group>"; };
+		5CDD8C761E43C66000621E92 /* moving_moments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = moving_moments.h; sourceTree = "<group>"; };
+		5CDD8C791E43C66000621E92 /* transient_detector.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transient_detector.cc; sourceTree = "<group>"; };
+		5CDD8C7A1E43C66000621E92 /* transient_detector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transient_detector.h; sourceTree = "<group>"; };
+		5CDD8C7E1E43C66000621E92 /* transient_suppressor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = transient_suppressor.h; sourceTree = "<group>"; };
+		5CDD8C801E43C66000621E92 /* wpd_node.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = wpd_node.cc; sourceTree = "<group>"; };
+		5CDD8C811E43C66000621E92 /* wpd_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wpd_node.h; sourceTree = "<group>"; };
+		5CDD8C831E43C66000621E92 /* wpd_tree.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = wpd_tree.cc; sourceTree = "<group>"; };
+		5CDD8C841E43C66000621E92 /* wpd_tree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wpd_tree.h; sourceTree = "<group>"; };
+		5CDD8C9F1E43C6F700621E92 /* audio_encoder_cng.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_cng.cc; sourceTree = "<group>"; };
+		5CDD8CA01E43C6F700621E92 /* audio_encoder_cng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_cng.h; sourceTree = "<group>"; };
+		5CDD8CA41E43C6F700621E92 /* webrtc_cng.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = webrtc_cng.cc; sourceTree = "<group>"; };
+		5CDD8CA51E43C6F700621E92 /* webrtc_cng.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webrtc_cng.h; sourceTree = "<group>"; };
 		5CDD8CAD1E43C75200621E92 /* _kiss_fft_guts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _kiss_fft_guts.h; sourceTree = "<group>"; };
 		5CDD8CAE1E43C75200621E92 /* arch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arch.h; sourceTree = "<group>"; };
 		5CDD8CB01E43C75200621E92 /* bands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bands.c; sourceTree = "<group>"; };
@@ -9796,180 +9796,180 @@
 		5CDD8CDD1E43C75200621E92 /* static_modes_float.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = static_modes_float.h; sourceTree = "<group>"; };
 		5CDD8CDF1E43C75200621E92 /* vq.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vq.c; sourceTree = "<group>"; };
 		5CDD8CE01E43C75200621E92 /* vq.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vq.h; sourceTree = "<group>"; };
-		5CDD8D1A1E43C76400621E92 /* x86_celt_map.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x86_celt_map.c; path = x86/x86_celt_map.c; sourceTree = "<group>"; };
-		5CDD8D1B1E43C76400621E92 /* x86cpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x86cpu.c; path = x86/x86cpu.c; sourceTree = "<group>"; };
-		5CDD8D1C1E43C76400621E92 /* x86cpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = x86cpu.h; path = x86/x86cpu.h; sourceTree = "<group>"; };
-		5CDD8D5E1E43C7D900621E92 /* A2NLSF.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = A2NLSF.c; path = silk/A2NLSF.c; sourceTree = "<group>"; };
-		5CDD8D5F1E43C7D900621E92 /* ana_filt_bank_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ana_filt_bank_1.c; path = silk/ana_filt_bank_1.c; sourceTree = "<group>"; };
-		5CDD8D601E43C7D900621E92 /* API.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = API.h; path = silk/API.h; sourceTree = "<group>"; };
-		5CDD8D621E43C7D900621E92 /* biquad_alt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = biquad_alt.c; path = silk/biquad_alt.c; sourceTree = "<group>"; };
-		5CDD8D631E43C7D900621E92 /* bwexpander_32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bwexpander_32.c; path = silk/bwexpander_32.c; sourceTree = "<group>"; };
-		5CDD8D641E43C7D900621E92 /* bwexpander.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bwexpander.c; path = silk/bwexpander.c; sourceTree = "<group>"; };
-		5CDD8D651E43C7D900621E92 /* check_control_input.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = check_control_input.c; path = silk/check_control_input.c; sourceTree = "<group>"; };
-		5CDD8D661E43C7D900621E92 /* CNG.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = CNG.c; path = silk/CNG.c; sourceTree = "<group>"; };
-		5CDD8D671E43C7D900621E92 /* code_signs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = code_signs.c; path = silk/code_signs.c; sourceTree = "<group>"; };
-		5CDD8D681E43C7D900621E92 /* control_audio_bandwidth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = control_audio_bandwidth.c; path = silk/control_audio_bandwidth.c; sourceTree = "<group>"; };
-		5CDD8D691E43C7D900621E92 /* control_codec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = control_codec.c; path = silk/control_codec.c; sourceTree = "<group>"; };
-		5CDD8D6A1E43C7D900621E92 /* control_SNR.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = control_SNR.c; path = silk/control_SNR.c; sourceTree = "<group>"; };
-		5CDD8D6B1E43C7D900621E92 /* control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = control.h; path = silk/control.h; sourceTree = "<group>"; };
-		5CDD8D6C1E43C7D900621E92 /* debug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = debug.c; path = silk/debug.c; sourceTree = "<group>"; };
-		5CDD8D6D1E43C7D900621E92 /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = debug.h; path = silk/debug.h; sourceTree = "<group>"; };
-		5CDD8D6E1E43C7D900621E92 /* dec_API.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = dec_API.c; path = silk/dec_API.c; sourceTree = "<group>"; };
-		5CDD8D6F1E43C7D900621E92 /* decode_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decode_core.c; path = silk/decode_core.c; sourceTree = "<group>"; };
-		5CDD8D701E43C7D900621E92 /* decode_frame.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decode_frame.c; path = silk/decode_frame.c; sourceTree = "<group>"; };
-		5CDD8D711E43C7D900621E92 /* decode_indices.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decode_indices.c; path = silk/decode_indices.c; sourceTree = "<group>"; };
-		5CDD8D721E43C7D900621E92 /* decode_parameters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decode_parameters.c; path = silk/decode_parameters.c; sourceTree = "<group>"; };
-		5CDD8D731E43C7D900621E92 /* decode_pitch.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decode_pitch.c; path = silk/decode_pitch.c; sourceTree = "<group>"; };
-		5CDD8D741E43C7D900621E92 /* decode_pulses.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decode_pulses.c; path = silk/decode_pulses.c; sourceTree = "<group>"; };
-		5CDD8D751E43C7D900621E92 /* decoder_set_fs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = decoder_set_fs.c; path = silk/decoder_set_fs.c; sourceTree = "<group>"; };
-		5CDD8D761E43C7D900621E92 /* define.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = define.h; path = silk/define.h; sourceTree = "<group>"; };
-		5CDD8D771E43C7D900621E92 /* enc_API.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = enc_API.c; path = silk/enc_API.c; sourceTree = "<group>"; };
-		5CDD8D781E43C7D900621E92 /* encode_indices.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = encode_indices.c; path = silk/encode_indices.c; sourceTree = "<group>"; };
-		5CDD8D791E43C7D900621E92 /* encode_pulses.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = encode_pulses.c; path = silk/encode_pulses.c; sourceTree = "<group>"; };
-		5CDD8D7A1E43C7D900621E92 /* errors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = errors.h; path = silk/errors.h; sourceTree = "<group>"; };
-		5CDD8D7D1E43C7D900621E92 /* gain_quant.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = gain_quant.c; path = silk/gain_quant.c; sourceTree = "<group>"; };
-		5CDD8D7E1E43C7D900621E92 /* HP_variable_cutoff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = HP_variable_cutoff.c; path = silk/HP_variable_cutoff.c; sourceTree = "<group>"; };
-		5CDD8D7F1E43C7D900621E92 /* init_decoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = init_decoder.c; path = silk/init_decoder.c; sourceTree = "<group>"; };
-		5CDD8D801E43C7D900621E92 /* init_encoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = init_encoder.c; path = silk/init_encoder.c; sourceTree = "<group>"; };
-		5CDD8D811E43C7D900621E92 /* Inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Inlines.h; path = silk/Inlines.h; sourceTree = "<group>"; };
-		5CDD8D821E43C7D900621E92 /* inner_prod_aligned.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = inner_prod_aligned.c; path = silk/inner_prod_aligned.c; sourceTree = "<group>"; };
-		5CDD8D831E43C7D900621E92 /* interpolate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = interpolate.c; path = silk/interpolate.c; sourceTree = "<group>"; };
-		5CDD8D841E43C7D900621E92 /* lin2log.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = lin2log.c; path = silk/lin2log.c; sourceTree = "<group>"; };
-		5CDD8D851E43C7D900621E92 /* log2lin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = log2lin.c; path = silk/log2lin.c; sourceTree = "<group>"; };
-		5CDD8D861E43C7D900621E92 /* LP_variable_cutoff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LP_variable_cutoff.c; path = silk/LP_variable_cutoff.c; sourceTree = "<group>"; };
-		5CDD8D871E43C7D900621E92 /* LPC_analysis_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LPC_analysis_filter.c; path = silk/LPC_analysis_filter.c; sourceTree = "<group>"; };
-		5CDD8D881E43C7D900621E92 /* LPC_inv_pred_gain.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LPC_inv_pred_gain.c; path = silk/LPC_inv_pred_gain.c; sourceTree = "<group>"; };
-		5CDD8D891E43C7D900621E92 /* MacroCount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MacroCount.h; path = silk/MacroCount.h; sourceTree = "<group>"; };
-		5CDD8D8A1E43C7D900621E92 /* MacroDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MacroDebug.h; path = silk/MacroDebug.h; sourceTree = "<group>"; };
-		5CDD8D8B1E43C7D900621E92 /* macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = macros.h; path = silk/macros.h; sourceTree = "<group>"; };
-		5CDD8D8C1E43C7D900621E92 /* main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = main.h; path = silk/main.h; sourceTree = "<group>"; };
-		5CDD8D8E1E43C7D900621E92 /* NLSF_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NLSF_decode.c; path = silk/NLSF_decode.c; sourceTree = "<group>"; };
-		5CDD8D8F1E43C7D900621E92 /* NLSF_del_dec_quant.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NLSF_del_dec_quant.c; path = silk/NLSF_del_dec_quant.c; sourceTree = "<group>"; };
-		5CDD8D901E43C7D900621E92 /* NLSF_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NLSF_encode.c; path = silk/NLSF_encode.c; sourceTree = "<group>"; };
-		5CDD8D911E43C7D900621E92 /* NLSF_stabilize.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NLSF_stabilize.c; path = silk/NLSF_stabilize.c; sourceTree = "<group>"; };
-		5CDD8D921E43C7D900621E92 /* NLSF_unpack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NLSF_unpack.c; path = silk/NLSF_unpack.c; sourceTree = "<group>"; };
-		5CDD8D931E43C7D900621E92 /* NLSF_VQ_weights_laroia.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NLSF_VQ_weights_laroia.c; path = silk/NLSF_VQ_weights_laroia.c; sourceTree = "<group>"; };
-		5CDD8D941E43C7D900621E92 /* NLSF_VQ.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NLSF_VQ.c; path = silk/NLSF_VQ.c; sourceTree = "<group>"; };
-		5CDD8D951E43C7D900621E92 /* NLSF2A.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NLSF2A.c; path = silk/NLSF2A.c; sourceTree = "<group>"; };
-		5CDD8D961E43C7D900621E92 /* NSQ_del_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NSQ_del_dec.c; path = silk/NSQ_del_dec.c; sourceTree = "<group>"; };
-		5CDD8D971E43C7D900621E92 /* NSQ.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NSQ.c; path = silk/NSQ.c; sourceTree = "<group>"; };
-		5CDD8D981E43C7D900621E92 /* NSQ.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NSQ.h; path = silk/NSQ.h; sourceTree = "<group>"; };
-		5CDD8D991E43C7D900621E92 /* pitch_est_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pitch_est_defines.h; path = silk/pitch_est_defines.h; sourceTree = "<group>"; };
-		5CDD8D9A1E43C7D900621E92 /* pitch_est_tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pitch_est_tables.c; path = silk/pitch_est_tables.c; sourceTree = "<group>"; };
-		5CDD8D9B1E43C7D900621E92 /* PLC.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = PLC.c; path = silk/PLC.c; sourceTree = "<group>"; };
-		5CDD8D9C1E43C7D900621E92 /* PLC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PLC.h; path = silk/PLC.h; sourceTree = "<group>"; };
-		5CDD8D9D1E43C7D900621E92 /* process_NLSFs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = process_NLSFs.c; path = silk/process_NLSFs.c; sourceTree = "<group>"; };
-		5CDD8D9E1E43C7D900621E92 /* quant_LTP_gains.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = quant_LTP_gains.c; path = silk/quant_LTP_gains.c; sourceTree = "<group>"; };
-		5CDD8D9F1E43C7D900621E92 /* resampler_down2_3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resampler_down2_3.c; path = silk/resampler_down2_3.c; sourceTree = "<group>"; };
-		5CDD8DA01E43C7D900621E92 /* resampler_down2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resampler_down2.c; path = silk/resampler_down2.c; sourceTree = "<group>"; };
-		5CDD8DA11E43C7D900621E92 /* resampler_private_AR2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resampler_private_AR2.c; path = silk/resampler_private_AR2.c; sourceTree = "<group>"; };
-		5CDD8DA21E43C7D900621E92 /* resampler_private_down_FIR.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resampler_private_down_FIR.c; path = silk/resampler_private_down_FIR.c; sourceTree = "<group>"; };
-		5CDD8DA31E43C7D900621E92 /* resampler_private_IIR_FIR.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resampler_private_IIR_FIR.c; path = silk/resampler_private_IIR_FIR.c; sourceTree = "<group>"; };
-		5CDD8DA41E43C7D900621E92 /* resampler_private_up2_HQ.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resampler_private_up2_HQ.c; path = silk/resampler_private_up2_HQ.c; sourceTree = "<group>"; };
-		5CDD8DA51E43C7D900621E92 /* resampler_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = resampler_private.h; path = silk/resampler_private.h; sourceTree = "<group>"; };
-		5CDD8DA61E43C7D900621E92 /* resampler_rom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resampler_rom.c; path = silk/resampler_rom.c; sourceTree = "<group>"; };
-		5CDD8DA71E43C7D900621E92 /* resampler_rom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = resampler_rom.h; path = silk/resampler_rom.h; sourceTree = "<group>"; };
-		5CDD8DA81E43C7D900621E92 /* resampler_structs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = resampler_structs.h; path = silk/resampler_structs.h; sourceTree = "<group>"; };
-		5CDD8DA91E43C7D900621E92 /* resampler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = resampler.c; path = silk/resampler.c; sourceTree = "<group>"; };
-		5CDD8DAA1E43C7D900621E92 /* shell_coder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = shell_coder.c; path = silk/shell_coder.c; sourceTree = "<group>"; };
-		5CDD8DAB1E43C7D900621E92 /* sigm_Q15.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sigm_Q15.c; path = silk/sigm_Q15.c; sourceTree = "<group>"; };
-		5CDD8DAC1E43C7D900621E92 /* SigProc_FIX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SigProc_FIX.h; path = silk/SigProc_FIX.h; sourceTree = "<group>"; };
-		5CDD8DAD1E43C7D900621E92 /* sort.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sort.c; path = silk/sort.c; sourceTree = "<group>"; };
-		5CDD8DAE1E43C7D900621E92 /* stereo_decode_pred.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stereo_decode_pred.c; path = silk/stereo_decode_pred.c; sourceTree = "<group>"; };
-		5CDD8DAF1E43C7D900621E92 /* stereo_encode_pred.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stereo_encode_pred.c; path = silk/stereo_encode_pred.c; sourceTree = "<group>"; };
-		5CDD8DB01E43C7D900621E92 /* stereo_find_predictor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stereo_find_predictor.c; path = silk/stereo_find_predictor.c; sourceTree = "<group>"; };
-		5CDD8DB11E43C7D900621E92 /* stereo_LR_to_MS.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stereo_LR_to_MS.c; path = silk/stereo_LR_to_MS.c; sourceTree = "<group>"; };
-		5CDD8DB21E43C7D900621E92 /* stereo_MS_to_LR.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stereo_MS_to_LR.c; path = silk/stereo_MS_to_LR.c; sourceTree = "<group>"; };
-		5CDD8DB31E43C7D900621E92 /* stereo_quant_pred.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stereo_quant_pred.c; path = silk/stereo_quant_pred.c; sourceTree = "<group>"; };
-		5CDD8DB41E43C7D900621E92 /* structs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = structs.h; path = silk/structs.h; sourceTree = "<group>"; };
-		5CDD8DB51E43C7D900621E92 /* sum_sqr_shift.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sum_sqr_shift.c; path = silk/sum_sqr_shift.c; sourceTree = "<group>"; };
-		5CDD8DB61E43C7D900621E92 /* table_LSF_cos.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = table_LSF_cos.c; path = silk/table_LSF_cos.c; sourceTree = "<group>"; };
-		5CDD8DB71E43C7D900621E92 /* tables_gain.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tables_gain.c; path = silk/tables_gain.c; sourceTree = "<group>"; };
-		5CDD8DB81E43C7D900621E92 /* tables_LTP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tables_LTP.c; path = silk/tables_LTP.c; sourceTree = "<group>"; };
-		5CDD8DB91E43C7D900621E92 /* tables_NLSF_CB_NB_MB.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tables_NLSF_CB_NB_MB.c; path = silk/tables_NLSF_CB_NB_MB.c; sourceTree = "<group>"; };
-		5CDD8DBA1E43C7D900621E92 /* tables_NLSF_CB_WB.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tables_NLSF_CB_WB.c; path = silk/tables_NLSF_CB_WB.c; sourceTree = "<group>"; };
-		5CDD8DBB1E43C7D900621E92 /* tables_other.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tables_other.c; path = silk/tables_other.c; sourceTree = "<group>"; };
-		5CDD8DBC1E43C7D900621E92 /* tables_pitch_lag.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tables_pitch_lag.c; path = silk/tables_pitch_lag.c; sourceTree = "<group>"; };
-		5CDD8DBD1E43C7D900621E92 /* tables_pulses_per_block.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tables_pulses_per_block.c; path = silk/tables_pulses_per_block.c; sourceTree = "<group>"; };
-		5CDD8DBE1E43C7D900621E92 /* tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = tables.h; path = silk/tables.h; sourceTree = "<group>"; };
-		5CDD8DBF1E43C7D900621E92 /* tuning_parameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = tuning_parameters.h; path = silk/tuning_parameters.h; sourceTree = "<group>"; };
-		5CDD8DC01E43C7D900621E92 /* typedef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = typedef.h; path = silk/typedef.h; sourceTree = "<group>"; };
-		5CDD8DC11E43C7D900621E92 /* VAD.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = VAD.c; path = silk/VAD.c; sourceTree = "<group>"; };
-		5CDD8DC21E43C7D900621E92 /* VQ_WMat_EC.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = VQ_WMat_EC.c; path = silk/VQ_WMat_EC.c; sourceTree = "<group>"; };
-		5CDD8E251E43C7EC00621E92 /* main_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = main_sse.h; path = silk/x86/main_sse.h; sourceTree = "<group>"; };
-		5CDD8E2B1E43C7EC00621E92 /* x86_silk_map.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = x86_silk_map.c; path = silk/x86/x86_silk_map.c; sourceTree = "<group>"; };
-		5CDD8E9C1E43C9C100621E92 /* apply_sine_window_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = apply_sine_window_FLP.c; path = silk/float/apply_sine_window_FLP.c; sourceTree = "<group>"; };
-		5CDD8E9D1E43C9C100621E92 /* autocorrelation_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = autocorrelation_FLP.c; path = silk/float/autocorrelation_FLP.c; sourceTree = "<group>"; };
-		5CDD8E9E1E43C9C100621E92 /* burg_modified_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = burg_modified_FLP.c; path = silk/float/burg_modified_FLP.c; sourceTree = "<group>"; };
-		5CDD8E9F1E43C9C100621E92 /* bwexpander_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bwexpander_FLP.c; path = silk/float/bwexpander_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA01E43C9C100621E92 /* corrMatrix_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = corrMatrix_FLP.c; path = silk/float/corrMatrix_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA11E43C9C100621E92 /* encode_frame_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = encode_frame_FLP.c; path = silk/float/encode_frame_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA21E43C9C100621E92 /* energy_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = energy_FLP.c; path = silk/float/energy_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA31E43C9C100621E92 /* find_LPC_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = find_LPC_FLP.c; path = silk/float/find_LPC_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA41E43C9C100621E92 /* find_LTP_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = find_LTP_FLP.c; path = silk/float/find_LTP_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA51E43C9C100621E92 /* find_pitch_lags_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = find_pitch_lags_FLP.c; path = silk/float/find_pitch_lags_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA61E43C9C100621E92 /* find_pred_coefs_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = find_pred_coefs_FLP.c; path = silk/float/find_pred_coefs_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA71E43C9C100621E92 /* inner_product_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = inner_product_FLP.c; path = silk/float/inner_product_FLP.c; sourceTree = "<group>"; };
-		5CDD8EA81E43C9C100621E92 /* k2a_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = k2a_FLP.c; path = silk/float/k2a_FLP.c; sourceTree = "<group>"; };
-		5CDD8EAA1E43C9C100621E92 /* LPC_analysis_filter_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LPC_analysis_filter_FLP.c; path = silk/float/LPC_analysis_filter_FLP.c; sourceTree = "<group>"; };
-		5CDD8EAB1E43C9C100621E92 /* LPC_inv_pred_gain_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LPC_inv_pred_gain_FLP.c; path = silk/float/LPC_inv_pred_gain_FLP.c; sourceTree = "<group>"; };
-		5CDD8EAC1E43C9C100621E92 /* LTP_analysis_filter_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LTP_analysis_filter_FLP.c; path = silk/float/LTP_analysis_filter_FLP.c; sourceTree = "<group>"; };
-		5CDD8EAD1E43C9C100621E92 /* LTP_scale_ctrl_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LTP_scale_ctrl_FLP.c; path = silk/float/LTP_scale_ctrl_FLP.c; sourceTree = "<group>"; };
-		5CDD8EAE1E43C9C100621E92 /* main_FLP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = main_FLP.h; path = silk/float/main_FLP.h; sourceTree = "<group>"; };
-		5CDD8EAF1E43C9C100621E92 /* noise_shape_analysis_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = noise_shape_analysis_FLP.c; path = silk/float/noise_shape_analysis_FLP.c; sourceTree = "<group>"; };
-		5CDD8EB01E43C9C100621E92 /* pitch_analysis_core_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pitch_analysis_core_FLP.c; path = silk/float/pitch_analysis_core_FLP.c; sourceTree = "<group>"; };
-		5CDD8EB21E43C9C100621E92 /* process_gains_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = process_gains_FLP.c; path = silk/float/process_gains_FLP.c; sourceTree = "<group>"; };
-		5CDD8EB31E43C9C100621E92 /* regularize_correlations_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = regularize_correlations_FLP.c; path = silk/float/regularize_correlations_FLP.c; sourceTree = "<group>"; };
-		5CDD8EB41E43C9C100621E92 /* residual_energy_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = residual_energy_FLP.c; path = silk/float/residual_energy_FLP.c; sourceTree = "<group>"; };
-		5CDD8EB51E43C9C100621E92 /* scale_copy_vector_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = scale_copy_vector_FLP.c; path = silk/float/scale_copy_vector_FLP.c; sourceTree = "<group>"; };
-		5CDD8EB61E43C9C100621E92 /* scale_vector_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = scale_vector_FLP.c; path = silk/float/scale_vector_FLP.c; sourceTree = "<group>"; };
-		5CDD8EB71E43C9C100621E92 /* schur_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = schur_FLP.c; path = silk/float/schur_FLP.c; sourceTree = "<group>"; };
-		5CDD8EB81E43C9C100621E92 /* SigProc_FLP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SigProc_FLP.h; path = silk/float/SigProc_FLP.h; sourceTree = "<group>"; };
-		5CDD8EBA1E43C9C100621E92 /* sort_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sort_FLP.c; path = silk/float/sort_FLP.c; sourceTree = "<group>"; };
-		5CDD8EBB1E43C9C100621E92 /* structs_FLP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = structs_FLP.h; path = silk/float/structs_FLP.h; sourceTree = "<group>"; };
-		5CDD8EBC1E43C9C100621E92 /* warped_autocorrelation_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = warped_autocorrelation_FLP.c; path = silk/float/warped_autocorrelation_FLP.c; sourceTree = "<group>"; };
-		5CDD8EBD1E43C9C100621E92 /* wrappers_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = wrappers_FLP.c; path = silk/float/wrappers_FLP.c; sourceTree = "<group>"; };
-		5CDD8F031E43CAF800621E92 /* apply_sine_window_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = apply_sine_window_FIX.c; path = silk/fixed/apply_sine_window_FIX.c; sourceTree = "<group>"; };
-		5CDD8F041E43CAF900621E92 /* autocorr_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = autocorr_FIX.c; path = silk/fixed/autocorr_FIX.c; sourceTree = "<group>"; };
-		5CDD8F051E43CAF900621E92 /* burg_modified_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = burg_modified_FIX.c; path = silk/fixed/burg_modified_FIX.c; sourceTree = "<group>"; };
-		5CDD8F061E43CAF900621E92 /* corrMatrix_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = corrMatrix_FIX.c; path = silk/fixed/corrMatrix_FIX.c; sourceTree = "<group>"; };
-		5CDD8F071E43CAF900621E92 /* encode_frame_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = encode_frame_FIX.c; path = silk/fixed/encode_frame_FIX.c; sourceTree = "<group>"; };
-		5CDD8F081E43CAF900621E92 /* find_LPC_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = find_LPC_FIX.c; path = silk/fixed/find_LPC_FIX.c; sourceTree = "<group>"; };
-		5CDD8F091E43CAF900621E92 /* find_LTP_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = find_LTP_FIX.c; path = silk/fixed/find_LTP_FIX.c; sourceTree = "<group>"; };
-		5CDD8F0A1E43CAF900621E92 /* find_pitch_lags_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = find_pitch_lags_FIX.c; path = silk/fixed/find_pitch_lags_FIX.c; sourceTree = "<group>"; };
-		5CDD8F0B1E43CAF900621E92 /* find_pred_coefs_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = find_pred_coefs_FIX.c; path = silk/fixed/find_pred_coefs_FIX.c; sourceTree = "<group>"; };
-		5CDD8F0C1E43CAF900621E92 /* k2a_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = k2a_FIX.c; path = silk/fixed/k2a_FIX.c; sourceTree = "<group>"; };
-		5CDD8F0D1E43CAF900621E92 /* k2a_Q16_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = k2a_Q16_FIX.c; path = silk/fixed/k2a_Q16_FIX.c; sourceTree = "<group>"; };
-		5CDD8F0E1E43CAF900621E92 /* LTP_analysis_filter_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LTP_analysis_filter_FIX.c; path = silk/fixed/LTP_analysis_filter_FIX.c; sourceTree = "<group>"; };
-		5CDD8F0F1E43CAF900621E92 /* LTP_scale_ctrl_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = LTP_scale_ctrl_FIX.c; path = silk/fixed/LTP_scale_ctrl_FIX.c; sourceTree = "<group>"; };
-		5CDD8F101E43CAF900621E92 /* main_FIX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = main_FIX.h; path = silk/fixed/main_FIX.h; sourceTree = "<group>"; };
-		5CDD8F121E43CAF900621E92 /* noise_shape_analysis_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = noise_shape_analysis_FIX.c; path = silk/fixed/noise_shape_analysis_FIX.c; sourceTree = "<group>"; };
-		5CDD8F131E43CAF900621E92 /* pitch_analysis_core_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pitch_analysis_core_FIX.c; path = silk/fixed/pitch_analysis_core_FIX.c; sourceTree = "<group>"; };
-		5CDD8F151E43CAF900621E92 /* process_gains_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = process_gains_FIX.c; path = silk/fixed/process_gains_FIX.c; sourceTree = "<group>"; };
-		5CDD8F161E43CAF900621E92 /* regularize_correlations_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = regularize_correlations_FIX.c; path = silk/fixed/regularize_correlations_FIX.c; sourceTree = "<group>"; };
-		5CDD8F171E43CAF900621E92 /* residual_energy_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = residual_energy_FIX.c; path = silk/fixed/residual_energy_FIX.c; sourceTree = "<group>"; };
-		5CDD8F181E43CAF900621E92 /* residual_energy16_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = residual_energy16_FIX.c; path = silk/fixed/residual_energy16_FIX.c; sourceTree = "<group>"; };
-		5CDD8F191E43CAF900621E92 /* schur_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = schur_FIX.c; path = silk/fixed/schur_FIX.c; sourceTree = "<group>"; };
-		5CDD8F1A1E43CAF900621E92 /* schur64_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = schur64_FIX.c; path = silk/fixed/schur64_FIX.c; sourceTree = "<group>"; };
-		5CDD8F1C1E43CAF900621E92 /* structs_FIX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = structs_FIX.h; path = silk/fixed/structs_FIX.h; sourceTree = "<group>"; };
-		5CDD8F1D1E43CAF900621E92 /* vector_ops_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vector_ops_FIX.c; path = silk/fixed/vector_ops_FIX.c; sourceTree = "<group>"; };
-		5CDD8F1E1E43CAF900621E92 /* warped_autocorrelation_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = warped_autocorrelation_FIX.c; path = silk/fixed/warped_autocorrelation_FIX.c; sourceTree = "<group>"; };
-		5CDD8F571E43CBDF00621E92 /* audio_network_adaptor_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_network_adaptor_impl.cc; path = audio_network_adaptor/audio_network_adaptor_impl.cc; sourceTree = "<group>"; };
-		5CDD8F581E43CBDF00621E92 /* audio_network_adaptor_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_network_adaptor_impl.h; path = audio_network_adaptor/audio_network_adaptor_impl.h; sourceTree = "<group>"; };
-		5CDD8F5C1E43CBDF00621E92 /* bitrate_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = bitrate_controller.cc; path = audio_network_adaptor/bitrate_controller.cc; sourceTree = "<group>"; };
-		5CDD8F5D1E43CBDF00621E92 /* bitrate_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitrate_controller.h; path = audio_network_adaptor/bitrate_controller.h; sourceTree = "<group>"; };
-		5CDD8F5F1E43CBDF00621E92 /* channel_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = channel_controller.cc; path = audio_network_adaptor/channel_controller.cc; sourceTree = "<group>"; };
-		5CDD8F601E43CBDF00621E92 /* channel_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = channel_controller.h; path = audio_network_adaptor/channel_controller.h; sourceTree = "<group>"; };
-		5CDD8F631E43CBDF00621E92 /* controller_manager.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = controller_manager.cc; path = audio_network_adaptor/controller_manager.cc; sourceTree = "<group>"; };
-		5CDD8F641E43CBDF00621E92 /* controller_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = controller_manager.h; path = audio_network_adaptor/controller_manager.h; sourceTree = "<group>"; };
-		5CDD8F651E43CBDF00621E92 /* controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = controller.cc; path = audio_network_adaptor/controller.cc; sourceTree = "<group>"; };
-		5CDD8F661E43CBDF00621E92 /* controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = controller.h; path = audio_network_adaptor/controller.h; sourceTree = "<group>"; };
-		5CDD8F671E43CBDF00621E92 /* debug_dump_writer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = debug_dump_writer.cc; path = audio_network_adaptor/debug_dump_writer.cc; sourceTree = "<group>"; };
-		5CDD8F681E43CBDF00621E92 /* debug_dump_writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = debug_dump_writer.h; path = audio_network_adaptor/debug_dump_writer.h; sourceTree = "<group>"; };
-		5CDD8F6B1E43CBE000621E92 /* dtx_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = dtx_controller.cc; path = audio_network_adaptor/dtx_controller.cc; sourceTree = "<group>"; };
-		5CDD8F6C1E43CBE000621E92 /* dtx_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dtx_controller.h; path = audio_network_adaptor/dtx_controller.h; sourceTree = "<group>"; };
-		5CDD8F711E43CBE000621E92 /* frame_length_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = frame_length_controller.cc; path = audio_network_adaptor/frame_length_controller.cc; sourceTree = "<group>"; };
-		5CDD8F721E43CBE000621E92 /* frame_length_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = frame_length_controller.h; path = audio_network_adaptor/frame_length_controller.h; sourceTree = "<group>"; };
+		5CDD8D1A1E43C76400621E92 /* x86_celt_map.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x86_celt_map.c; sourceTree = "<group>"; };
+		5CDD8D1B1E43C76400621E92 /* x86cpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x86cpu.c; sourceTree = "<group>"; };
+		5CDD8D1C1E43C76400621E92 /* x86cpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x86cpu.h; sourceTree = "<group>"; };
+		5CDD8D5E1E43C7D900621E92 /* A2NLSF.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = A2NLSF.c; sourceTree = "<group>"; };
+		5CDD8D5F1E43C7D900621E92 /* ana_filt_bank_1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ana_filt_bank_1.c; sourceTree = "<group>"; };
+		5CDD8D601E43C7D900621E92 /* API.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = API.h; sourceTree = "<group>"; };
+		5CDD8D621E43C7D900621E92 /* biquad_alt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = biquad_alt.c; sourceTree = "<group>"; };
+		5CDD8D631E43C7D900621E92 /* bwexpander_32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bwexpander_32.c; sourceTree = "<group>"; };
+		5CDD8D641E43C7D900621E92 /* bwexpander.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bwexpander.c; sourceTree = "<group>"; };
+		5CDD8D651E43C7D900621E92 /* check_control_input.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = check_control_input.c; sourceTree = "<group>"; };
+		5CDD8D661E43C7D900621E92 /* CNG.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = CNG.c; sourceTree = "<group>"; };
+		5CDD8D671E43C7D900621E92 /* code_signs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = code_signs.c; sourceTree = "<group>"; };
+		5CDD8D681E43C7D900621E92 /* control_audio_bandwidth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = control_audio_bandwidth.c; sourceTree = "<group>"; };
+		5CDD8D691E43C7D900621E92 /* control_codec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = control_codec.c; sourceTree = "<group>"; };
+		5CDD8D6A1E43C7D900621E92 /* control_SNR.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = control_SNR.c; sourceTree = "<group>"; };
+		5CDD8D6B1E43C7D900621E92 /* control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = control.h; sourceTree = "<group>"; };
+		5CDD8D6C1E43C7D900621E92 /* debug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = debug.c; sourceTree = "<group>"; };
+		5CDD8D6D1E43C7D900621E92 /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
+		5CDD8D6E1E43C7D900621E92 /* dec_API.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_API.c; sourceTree = "<group>"; };
+		5CDD8D6F1E43C7D900621E92 /* decode_core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decode_core.c; sourceTree = "<group>"; };
+		5CDD8D701E43C7D900621E92 /* decode_frame.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decode_frame.c; sourceTree = "<group>"; };
+		5CDD8D711E43C7D900621E92 /* decode_indices.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decode_indices.c; sourceTree = "<group>"; };
+		5CDD8D721E43C7D900621E92 /* decode_parameters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decode_parameters.c; sourceTree = "<group>"; };
+		5CDD8D731E43C7D900621E92 /* decode_pitch.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decode_pitch.c; sourceTree = "<group>"; };
+		5CDD8D741E43C7D900621E92 /* decode_pulses.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decode_pulses.c; sourceTree = "<group>"; };
+		5CDD8D751E43C7D900621E92 /* decoder_set_fs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = decoder_set_fs.c; sourceTree = "<group>"; };
+		5CDD8D761E43C7D900621E92 /* define.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = define.h; sourceTree = "<group>"; };
+		5CDD8D771E43C7D900621E92 /* enc_API.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_API.c; sourceTree = "<group>"; };
+		5CDD8D781E43C7D900621E92 /* encode_indices.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = encode_indices.c; sourceTree = "<group>"; };
+		5CDD8D791E43C7D900621E92 /* encode_pulses.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = encode_pulses.c; sourceTree = "<group>"; };
+		5CDD8D7A1E43C7D900621E92 /* errors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = errors.h; sourceTree = "<group>"; };
+		5CDD8D7D1E43C7D900621E92 /* gain_quant.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = gain_quant.c; sourceTree = "<group>"; };
+		5CDD8D7E1E43C7D900621E92 /* HP_variable_cutoff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = HP_variable_cutoff.c; sourceTree = "<group>"; };
+		5CDD8D7F1E43C7D900621E92 /* init_decoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = init_decoder.c; sourceTree = "<group>"; };
+		5CDD8D801E43C7D900621E92 /* init_encoder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = init_encoder.c; sourceTree = "<group>"; };
+		5CDD8D811E43C7D900621E92 /* Inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Inlines.h; sourceTree = "<group>"; };
+		5CDD8D821E43C7D900621E92 /* inner_prod_aligned.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = inner_prod_aligned.c; sourceTree = "<group>"; };
+		5CDD8D831E43C7D900621E92 /* interpolate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = interpolate.c; sourceTree = "<group>"; };
+		5CDD8D841E43C7D900621E92 /* lin2log.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lin2log.c; sourceTree = "<group>"; };
+		5CDD8D851E43C7D900621E92 /* log2lin.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = log2lin.c; sourceTree = "<group>"; };
+		5CDD8D861E43C7D900621E92 /* LP_variable_cutoff.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LP_variable_cutoff.c; sourceTree = "<group>"; };
+		5CDD8D871E43C7D900621E92 /* LPC_analysis_filter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LPC_analysis_filter.c; sourceTree = "<group>"; };
+		5CDD8D881E43C7D900621E92 /* LPC_inv_pred_gain.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LPC_inv_pred_gain.c; sourceTree = "<group>"; };
+		5CDD8D891E43C7D900621E92 /* MacroCount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MacroCount.h; sourceTree = "<group>"; };
+		5CDD8D8A1E43C7D900621E92 /* MacroDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MacroDebug.h; sourceTree = "<group>"; };
+		5CDD8D8B1E43C7D900621E92 /* macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macros.h; sourceTree = "<group>"; };
+		5CDD8D8C1E43C7D900621E92 /* main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main.h; sourceTree = "<group>"; };
+		5CDD8D8E1E43C7D900621E92 /* NLSF_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NLSF_decode.c; sourceTree = "<group>"; };
+		5CDD8D8F1E43C7D900621E92 /* NLSF_del_dec_quant.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NLSF_del_dec_quant.c; sourceTree = "<group>"; };
+		5CDD8D901E43C7D900621E92 /* NLSF_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NLSF_encode.c; sourceTree = "<group>"; };
+		5CDD8D911E43C7D900621E92 /* NLSF_stabilize.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NLSF_stabilize.c; sourceTree = "<group>"; };
+		5CDD8D921E43C7D900621E92 /* NLSF_unpack.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NLSF_unpack.c; sourceTree = "<group>"; };
+		5CDD8D931E43C7D900621E92 /* NLSF_VQ_weights_laroia.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NLSF_VQ_weights_laroia.c; sourceTree = "<group>"; };
+		5CDD8D941E43C7D900621E92 /* NLSF_VQ.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NLSF_VQ.c; sourceTree = "<group>"; };
+		5CDD8D951E43C7D900621E92 /* NLSF2A.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NLSF2A.c; sourceTree = "<group>"; };
+		5CDD8D961E43C7D900621E92 /* NSQ_del_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NSQ_del_dec.c; sourceTree = "<group>"; };
+		5CDD8D971E43C7D900621E92 /* NSQ.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = NSQ.c; sourceTree = "<group>"; };
+		5CDD8D981E43C7D900621E92 /* NSQ.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSQ.h; sourceTree = "<group>"; };
+		5CDD8D991E43C7D900621E92 /* pitch_est_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pitch_est_defines.h; sourceTree = "<group>"; };
+		5CDD8D9A1E43C7D900621E92 /* pitch_est_tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pitch_est_tables.c; sourceTree = "<group>"; };
+		5CDD8D9B1E43C7D900621E92 /* PLC.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = PLC.c; sourceTree = "<group>"; };
+		5CDD8D9C1E43C7D900621E92 /* PLC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PLC.h; sourceTree = "<group>"; };
+		5CDD8D9D1E43C7D900621E92 /* process_NLSFs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = process_NLSFs.c; sourceTree = "<group>"; };
+		5CDD8D9E1E43C7D900621E92 /* quant_LTP_gains.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant_LTP_gains.c; sourceTree = "<group>"; };
+		5CDD8D9F1E43C7D900621E92 /* resampler_down2_3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resampler_down2_3.c; sourceTree = "<group>"; };
+		5CDD8DA01E43C7D900621E92 /* resampler_down2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resampler_down2.c; sourceTree = "<group>"; };
+		5CDD8DA11E43C7D900621E92 /* resampler_private_AR2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resampler_private_AR2.c; sourceTree = "<group>"; };
+		5CDD8DA21E43C7D900621E92 /* resampler_private_down_FIR.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resampler_private_down_FIR.c; sourceTree = "<group>"; };
+		5CDD8DA31E43C7D900621E92 /* resampler_private_IIR_FIR.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resampler_private_IIR_FIR.c; sourceTree = "<group>"; };
+		5CDD8DA41E43C7D900621E92 /* resampler_private_up2_HQ.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resampler_private_up2_HQ.c; sourceTree = "<group>"; };
+		5CDD8DA51E43C7D900621E92 /* resampler_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resampler_private.h; sourceTree = "<group>"; };
+		5CDD8DA61E43C7D900621E92 /* resampler_rom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resampler_rom.c; sourceTree = "<group>"; };
+		5CDD8DA71E43C7D900621E92 /* resampler_rom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resampler_rom.h; sourceTree = "<group>"; };
+		5CDD8DA81E43C7D900621E92 /* resampler_structs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resampler_structs.h; sourceTree = "<group>"; };
+		5CDD8DA91E43C7D900621E92 /* resampler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = resampler.c; sourceTree = "<group>"; };
+		5CDD8DAA1E43C7D900621E92 /* shell_coder.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = shell_coder.c; sourceTree = "<group>"; };
+		5CDD8DAB1E43C7D900621E92 /* sigm_Q15.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sigm_Q15.c; sourceTree = "<group>"; };
+		5CDD8DAC1E43C7D900621E92 /* SigProc_FIX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SigProc_FIX.h; sourceTree = "<group>"; };
+		5CDD8DAD1E43C7D900621E92 /* sort.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sort.c; sourceTree = "<group>"; };
+		5CDD8DAE1E43C7D900621E92 /* stereo_decode_pred.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stereo_decode_pred.c; sourceTree = "<group>"; };
+		5CDD8DAF1E43C7D900621E92 /* stereo_encode_pred.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stereo_encode_pred.c; sourceTree = "<group>"; };
+		5CDD8DB01E43C7D900621E92 /* stereo_find_predictor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stereo_find_predictor.c; sourceTree = "<group>"; };
+		5CDD8DB11E43C7D900621E92 /* stereo_LR_to_MS.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stereo_LR_to_MS.c; sourceTree = "<group>"; };
+		5CDD8DB21E43C7D900621E92 /* stereo_MS_to_LR.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stereo_MS_to_LR.c; sourceTree = "<group>"; };
+		5CDD8DB31E43C7D900621E92 /* stereo_quant_pred.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stereo_quant_pred.c; sourceTree = "<group>"; };
+		5CDD8DB41E43C7D900621E92 /* structs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = structs.h; sourceTree = "<group>"; };
+		5CDD8DB51E43C7D900621E92 /* sum_sqr_shift.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sum_sqr_shift.c; sourceTree = "<group>"; };
+		5CDD8DB61E43C7D900621E92 /* table_LSF_cos.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = table_LSF_cos.c; sourceTree = "<group>"; };
+		5CDD8DB71E43C7D900621E92 /* tables_gain.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tables_gain.c; sourceTree = "<group>"; };
+		5CDD8DB81E43C7D900621E92 /* tables_LTP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tables_LTP.c; sourceTree = "<group>"; };
+		5CDD8DB91E43C7D900621E92 /* tables_NLSF_CB_NB_MB.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tables_NLSF_CB_NB_MB.c; sourceTree = "<group>"; };
+		5CDD8DBA1E43C7D900621E92 /* tables_NLSF_CB_WB.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tables_NLSF_CB_WB.c; sourceTree = "<group>"; };
+		5CDD8DBB1E43C7D900621E92 /* tables_other.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tables_other.c; sourceTree = "<group>"; };
+		5CDD8DBC1E43C7D900621E92 /* tables_pitch_lag.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tables_pitch_lag.c; sourceTree = "<group>"; };
+		5CDD8DBD1E43C7D900621E92 /* tables_pulses_per_block.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tables_pulses_per_block.c; sourceTree = "<group>"; };
+		5CDD8DBE1E43C7D900621E92 /* tables.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tables.h; sourceTree = "<group>"; };
+		5CDD8DBF1E43C7D900621E92 /* tuning_parameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tuning_parameters.h; sourceTree = "<group>"; };
+		5CDD8DC01E43C7D900621E92 /* typedef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = typedef.h; sourceTree = "<group>"; };
+		5CDD8DC11E43C7D900621E92 /* VAD.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = VAD.c; sourceTree = "<group>"; };
+		5CDD8DC21E43C7D900621E92 /* VQ_WMat_EC.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = VQ_WMat_EC.c; sourceTree = "<group>"; };
+		5CDD8E251E43C7EC00621E92 /* main_sse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main_sse.h; sourceTree = "<group>"; };
+		5CDD8E2B1E43C7EC00621E92 /* x86_silk_map.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x86_silk_map.c; sourceTree = "<group>"; };
+		5CDD8E9C1E43C9C100621E92 /* apply_sine_window_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = apply_sine_window_FLP.c; sourceTree = "<group>"; };
+		5CDD8E9D1E43C9C100621E92 /* autocorrelation_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = autocorrelation_FLP.c; sourceTree = "<group>"; };
+		5CDD8E9E1E43C9C100621E92 /* burg_modified_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = burg_modified_FLP.c; sourceTree = "<group>"; };
+		5CDD8E9F1E43C9C100621E92 /* bwexpander_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bwexpander_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA01E43C9C100621E92 /* corrMatrix_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = corrMatrix_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA11E43C9C100621E92 /* encode_frame_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = encode_frame_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA21E43C9C100621E92 /* energy_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = energy_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA31E43C9C100621E92 /* find_LPC_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = find_LPC_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA41E43C9C100621E92 /* find_LTP_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = find_LTP_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA51E43C9C100621E92 /* find_pitch_lags_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = find_pitch_lags_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA61E43C9C100621E92 /* find_pred_coefs_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = find_pred_coefs_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA71E43C9C100621E92 /* inner_product_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = inner_product_FLP.c; sourceTree = "<group>"; };
+		5CDD8EA81E43C9C100621E92 /* k2a_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = k2a_FLP.c; sourceTree = "<group>"; };
+		5CDD8EAA1E43C9C100621E92 /* LPC_analysis_filter_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LPC_analysis_filter_FLP.c; sourceTree = "<group>"; };
+		5CDD8EAB1E43C9C100621E92 /* LPC_inv_pred_gain_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LPC_inv_pred_gain_FLP.c; sourceTree = "<group>"; };
+		5CDD8EAC1E43C9C100621E92 /* LTP_analysis_filter_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LTP_analysis_filter_FLP.c; sourceTree = "<group>"; };
+		5CDD8EAD1E43C9C100621E92 /* LTP_scale_ctrl_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LTP_scale_ctrl_FLP.c; sourceTree = "<group>"; };
+		5CDD8EAE1E43C9C100621E92 /* main_FLP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main_FLP.h; sourceTree = "<group>"; };
+		5CDD8EAF1E43C9C100621E92 /* noise_shape_analysis_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = noise_shape_analysis_FLP.c; sourceTree = "<group>"; };
+		5CDD8EB01E43C9C100621E92 /* pitch_analysis_core_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pitch_analysis_core_FLP.c; sourceTree = "<group>"; };
+		5CDD8EB21E43C9C100621E92 /* process_gains_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = process_gains_FLP.c; sourceTree = "<group>"; };
+		5CDD8EB31E43C9C100621E92 /* regularize_correlations_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = regularize_correlations_FLP.c; sourceTree = "<group>"; };
+		5CDD8EB41E43C9C100621E92 /* residual_energy_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = residual_energy_FLP.c; sourceTree = "<group>"; };
+		5CDD8EB51E43C9C100621E92 /* scale_copy_vector_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scale_copy_vector_FLP.c; sourceTree = "<group>"; };
+		5CDD8EB61E43C9C100621E92 /* scale_vector_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = scale_vector_FLP.c; sourceTree = "<group>"; };
+		5CDD8EB71E43C9C100621E92 /* schur_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = schur_FLP.c; sourceTree = "<group>"; };
+		5CDD8EB81E43C9C100621E92 /* SigProc_FLP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SigProc_FLP.h; sourceTree = "<group>"; };
+		5CDD8EBA1E43C9C100621E92 /* sort_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sort_FLP.c; sourceTree = "<group>"; };
+		5CDD8EBB1E43C9C100621E92 /* structs_FLP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = structs_FLP.h; sourceTree = "<group>"; };
+		5CDD8EBC1E43C9C100621E92 /* warped_autocorrelation_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = warped_autocorrelation_FLP.c; sourceTree = "<group>"; };
+		5CDD8EBD1E43C9C100621E92 /* wrappers_FLP.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = wrappers_FLP.c; sourceTree = "<group>"; };
+		5CDD8F031E43CAF800621E92 /* apply_sine_window_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = apply_sine_window_FIX.c; sourceTree = "<group>"; };
+		5CDD8F041E43CAF900621E92 /* autocorr_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = autocorr_FIX.c; sourceTree = "<group>"; };
+		5CDD8F051E43CAF900621E92 /* burg_modified_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = burg_modified_FIX.c; sourceTree = "<group>"; };
+		5CDD8F061E43CAF900621E92 /* corrMatrix_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = corrMatrix_FIX.c; sourceTree = "<group>"; };
+		5CDD8F071E43CAF900621E92 /* encode_frame_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = encode_frame_FIX.c; sourceTree = "<group>"; };
+		5CDD8F081E43CAF900621E92 /* find_LPC_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = find_LPC_FIX.c; sourceTree = "<group>"; };
+		5CDD8F091E43CAF900621E92 /* find_LTP_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = find_LTP_FIX.c; sourceTree = "<group>"; };
+		5CDD8F0A1E43CAF900621E92 /* find_pitch_lags_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = find_pitch_lags_FIX.c; sourceTree = "<group>"; };
+		5CDD8F0B1E43CAF900621E92 /* find_pred_coefs_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = find_pred_coefs_FIX.c; sourceTree = "<group>"; };
+		5CDD8F0C1E43CAF900621E92 /* k2a_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = k2a_FIX.c; sourceTree = "<group>"; };
+		5CDD8F0D1E43CAF900621E92 /* k2a_Q16_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = k2a_Q16_FIX.c; sourceTree = "<group>"; };
+		5CDD8F0E1E43CAF900621E92 /* LTP_analysis_filter_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LTP_analysis_filter_FIX.c; sourceTree = "<group>"; };
+		5CDD8F0F1E43CAF900621E92 /* LTP_scale_ctrl_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = LTP_scale_ctrl_FIX.c; sourceTree = "<group>"; };
+		5CDD8F101E43CAF900621E92 /* main_FIX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = main_FIX.h; sourceTree = "<group>"; };
+		5CDD8F121E43CAF900621E92 /* noise_shape_analysis_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = noise_shape_analysis_FIX.c; sourceTree = "<group>"; };
+		5CDD8F131E43CAF900621E92 /* pitch_analysis_core_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pitch_analysis_core_FIX.c; sourceTree = "<group>"; };
+		5CDD8F151E43CAF900621E92 /* process_gains_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = process_gains_FIX.c; sourceTree = "<group>"; };
+		5CDD8F161E43CAF900621E92 /* regularize_correlations_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = regularize_correlations_FIX.c; sourceTree = "<group>"; };
+		5CDD8F171E43CAF900621E92 /* residual_energy_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = residual_energy_FIX.c; sourceTree = "<group>"; };
+		5CDD8F181E43CAF900621E92 /* residual_energy16_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = residual_energy16_FIX.c; sourceTree = "<group>"; };
+		5CDD8F191E43CAF900621E92 /* schur_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = schur_FIX.c; sourceTree = "<group>"; };
+		5CDD8F1A1E43CAF900621E92 /* schur64_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = schur64_FIX.c; sourceTree = "<group>"; };
+		5CDD8F1C1E43CAF900621E92 /* structs_FIX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = structs_FIX.h; sourceTree = "<group>"; };
+		5CDD8F1D1E43CAF900621E92 /* vector_ops_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vector_ops_FIX.c; sourceTree = "<group>"; };
+		5CDD8F1E1E43CAF900621E92 /* warped_autocorrelation_FIX.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = warped_autocorrelation_FIX.c; sourceTree = "<group>"; };
+		5CDD8F571E43CBDF00621E92 /* audio_network_adaptor_impl.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_network_adaptor_impl.cc; sourceTree = "<group>"; };
+		5CDD8F581E43CBDF00621E92 /* audio_network_adaptor_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_network_adaptor_impl.h; sourceTree = "<group>"; };
+		5CDD8F5C1E43CBDF00621E92 /* bitrate_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bitrate_controller.cc; sourceTree = "<group>"; };
+		5CDD8F5D1E43CBDF00621E92 /* bitrate_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitrate_controller.h; sourceTree = "<group>"; };
+		5CDD8F5F1E43CBDF00621E92 /* channel_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = channel_controller.cc; sourceTree = "<group>"; };
+		5CDD8F601E43CBDF00621E92 /* channel_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channel_controller.h; sourceTree = "<group>"; };
+		5CDD8F631E43CBDF00621E92 /* controller_manager.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = controller_manager.cc; sourceTree = "<group>"; };
+		5CDD8F641E43CBDF00621E92 /* controller_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = controller_manager.h; sourceTree = "<group>"; };
+		5CDD8F651E43CBDF00621E92 /* controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = controller.cc; sourceTree = "<group>"; };
+		5CDD8F661E43CBDF00621E92 /* controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = controller.h; sourceTree = "<group>"; };
+		5CDD8F671E43CBDF00621E92 /* debug_dump_writer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = debug_dump_writer.cc; sourceTree = "<group>"; };
+		5CDD8F681E43CBDF00621E92 /* debug_dump_writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debug_dump_writer.h; sourceTree = "<group>"; };
+		5CDD8F6B1E43CBE000621E92 /* dtx_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dtx_controller.cc; sourceTree = "<group>"; };
+		5CDD8F6C1E43CBE000621E92 /* dtx_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dtx_controller.h; sourceTree = "<group>"; };
+		5CDD8F711E43CBE000621E92 /* frame_length_controller.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = frame_length_controller.cc; sourceTree = "<group>"; };
+		5CDD8F721E43CBE000621E92 /* frame_length_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_length_controller.h; sourceTree = "<group>"; };
 		5CDD8F981E43CCBE00621E92 /* bitrate_prober.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bitrate_prober.cc; sourceTree = "<group>"; };
 		5CDD8F991E43CCBE00621E92 /* bitrate_prober.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitrate_prober.h; sourceTree = "<group>"; };
 		5CDD8F9C1E43CCBE00621E92 /* packet_router.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = packet_router.cc; sourceTree = "<group>"; };
@@ -9989,45 +9989,45 @@
 		5CDD8FCB1E43CD6600621E92 /* remote_bitrate_estimator_single_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remote_bitrate_estimator_single_stream.h; sourceTree = "<group>"; };
 		5CDD8FCE1E43CD6600621E92 /* remote_estimator_proxy.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = remote_estimator_proxy.cc; sourceTree = "<group>"; };
 		5CDD8FCF1E43CD6600621E92 /* remote_estimator_proxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remote_estimator_proxy.h; sourceTree = "<group>"; };
-		5CDD8FE41E43CDCA00621E92 /* audio_processing.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_processing.cc; path = include/audio_processing.cc; sourceTree = "<group>"; };
-		5CDD8FE51E43CDCA00621E92 /* audio_processing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_processing.h; path = include/audio_processing.h; sourceTree = "<group>"; };
-		5CDD8FE81E43CDCA00621E92 /* mock_audio_processing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mock_audio_processing.h; path = include/mock_audio_processing.h; sourceTree = "<group>"; };
+		5CDD8FE41E43CDCA00621E92 /* audio_processing.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_processing.cc; sourceTree = "<group>"; };
+		5CDD8FE51E43CDCA00621E92 /* audio_processing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_processing.h; sourceTree = "<group>"; };
+		5CDD8FE81E43CDCA00621E92 /* mock_audio_processing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_audio_processing.h; sourceTree = "<group>"; };
 		5CDD8FF01E43CDF400621E92 /* audio_encoder_copy_red.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_copy_red.cc; sourceTree = "<group>"; };
 		5CDD8FF11E43CDF400621E92 /* audio_encoder_copy_red.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_copy_red.h; sourceTree = "<group>"; };
-		5CDD8FF61E43CE3A00621E92 /* audio_decoder_pcm16b.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_decoder_pcm16b.cc; path = pcm16b/audio_decoder_pcm16b.cc; sourceTree = "<group>"; };
-		5CDD8FF71E43CE3A00621E92 /* audio_decoder_pcm16b.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_decoder_pcm16b.h; path = pcm16b/audio_decoder_pcm16b.h; sourceTree = "<group>"; };
-		5CDD8FF81E43CE3A00621E92 /* audio_encoder_pcm16b.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = audio_encoder_pcm16b.cc; path = pcm16b/audio_encoder_pcm16b.cc; sourceTree = "<group>"; };
-		5CDD8FF91E43CE3A00621E92 /* audio_encoder_pcm16b.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_encoder_pcm16b.h; path = pcm16b/audio_encoder_pcm16b.h; sourceTree = "<group>"; };
-		5CDD8FFA1E43CE3A00621E92 /* pcm16b.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcm16b.c; path = pcm16b/pcm16b.c; sourceTree = "<group>"; };
-		5CDD8FFB1E43CE3A00621E92 /* pcm16b.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pcm16b.h; path = pcm16b/pcm16b.h; sourceTree = "<group>"; };
-		5CDD90871E43D33800621E92 /* ekt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ekt.c; path = srtp/ekt.c; sourceTree = "<group>"; };
-		5CDD90881E43D33800621E92 /* srtp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = srtp.c; path = srtp/srtp.c; sourceTree = "<group>"; };
-		5CDD908D1E43D4CC00621E92 /* rdb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rdb.c; path = replay/rdb.c; sourceTree = "<group>"; };
-		5CDD908E1E43D4CC00621E92 /* rdbx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rdbx.c; path = replay/rdbx.c; sourceTree = "<group>"; };
-		5CDD908F1E43D4CC00621E92 /* ut_sim.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ut_sim.c; path = replay/ut_sim.c; sourceTree = "<group>"; };
-		5CDD90981E43D50900621E92 /* datatypes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = datatypes.c; path = math/datatypes.c; sourceTree = "<group>"; };
-		5CDD90991E43D50900621E92 /* stat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = stat.c; path = math/stat.c; sourceTree = "<group>"; };
-		5CDD909C1E43D51100621E92 /* alloc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = alloc.c; path = kernel/alloc.c; sourceTree = "<group>"; };
-		5CDD909D1E43D51100621E92 /* crypto_kernel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = crypto_kernel.c; path = kernel/crypto_kernel.c; sourceTree = "<group>"; };
-		5CDD909E1E43D51100621E92 /* err.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = err.c; path = kernel/err.c; sourceTree = "<group>"; };
-		5CDD909F1E43D51100621E92 /* key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = key.c; path = kernel/key.c; sourceTree = "<group>"; };
-		5CDD90A41E43D51B00621E92 /* auth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = auth.c; path = hash/auth.c; sourceTree = "<group>"; };
-		5CDD90A51E43D51B00621E92 /* hmac_ossl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = hmac_ossl.c; path = hash/hmac_ossl.c; sourceTree = "<group>"; };
-		5CDD90A61E43D51B00621E92 /* null_auth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = null_auth.c; path = hash/null_auth.c; sourceTree = "<group>"; };
-		5CDD90AA1E43D52900621E92 /* aes_gcm_ossl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = aes_gcm_ossl.c; path = cipher/aes_gcm_ossl.c; sourceTree = "<group>"; };
-		5CDD90AB1E43D52900621E92 /* aes_icm_ossl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = aes_icm_ossl.c; path = cipher/aes_icm_ossl.c; sourceTree = "<group>"; };
-		5CDD90AC1E43D52900621E92 /* cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cipher.c; path = cipher/cipher.c; sourceTree = "<group>"; };
-		5CDD90AD1E43D52900621E92 /* null_cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = null_cipher.c; path = cipher/null_cipher.c; sourceTree = "<group>"; };
-		5CFACF5A226E9A1A0056C7D0 /* pkcs7_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pkcs7_x509.c; path = pkcs7/pkcs7_x509.c; sourceTree = "<group>"; };
-		5CFACF5B226E9A1A0056C7D0 /* pkcs7.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pkcs7.c; path = pkcs7/pkcs7.c; sourceTree = "<group>"; };
-		5CFD53851E4BD3A300482908 /* compare_neon.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = compare_neon.cc; path = source/compare_neon.cc; sourceTree = "<group>"; };
-		5CFD53861E4BD3A300482908 /* compare_neon64.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = compare_neon64.cc; path = source/compare_neon64.cc; sourceTree = "<group>"; };
-		5CFD53871E4BD3A300482908 /* rotate_neon.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rotate_neon.cc; path = source/rotate_neon.cc; sourceTree = "<group>"; };
-		5CFD53881E4BD3A300482908 /* rotate_neon64.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rotate_neon64.cc; path = source/rotate_neon64.cc; sourceTree = "<group>"; };
-		5CFD53891E4BD3A300482908 /* row_neon.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = row_neon.cc; path = source/row_neon.cc; sourceTree = "<group>"; };
-		5CFD538A1E4BD3A300482908 /* row_neon64.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = row_neon64.cc; path = source/row_neon64.cc; sourceTree = "<group>"; };
-		5CFD538B1E4BD3A300482908 /* scale_neon.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scale_neon.cc; path = source/scale_neon.cc; sourceTree = "<group>"; };
-		5CFD538C1E4BD3A300482908 /* scale_neon64.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scale_neon64.cc; path = source/scale_neon64.cc; sourceTree = "<group>"; };
+		5CDD8FF61E43CE3A00621E92 /* audio_decoder_pcm16b.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_decoder_pcm16b.cc; sourceTree = "<group>"; };
+		5CDD8FF71E43CE3A00621E92 /* audio_decoder_pcm16b.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_decoder_pcm16b.h; sourceTree = "<group>"; };
+		5CDD8FF81E43CE3A00621E92 /* audio_encoder_pcm16b.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = audio_encoder_pcm16b.cc; sourceTree = "<group>"; };
+		5CDD8FF91E43CE3A00621E92 /* audio_encoder_pcm16b.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_encoder_pcm16b.h; sourceTree = "<group>"; };
+		5CDD8FFA1E43CE3A00621E92 /* pcm16b.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pcm16b.c; sourceTree = "<group>"; };
+		5CDD8FFB1E43CE3A00621E92 /* pcm16b.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pcm16b.h; sourceTree = "<group>"; };
+		5CDD90871E43D33800621E92 /* ekt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ekt.c; sourceTree = "<group>"; };
+		5CDD90881E43D33800621E92 /* srtp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = srtp.c; sourceTree = "<group>"; };
+		5CDD908D1E43D4CC00621E92 /* rdb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rdb.c; sourceTree = "<group>"; };
+		5CDD908E1E43D4CC00621E92 /* rdbx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rdbx.c; sourceTree = "<group>"; };
+		5CDD908F1E43D4CC00621E92 /* ut_sim.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ut_sim.c; sourceTree = "<group>"; };
+		5CDD90981E43D50900621E92 /* datatypes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = datatypes.c; sourceTree = "<group>"; };
+		5CDD90991E43D50900621E92 /* stat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stat.c; sourceTree = "<group>"; };
+		5CDD909C1E43D51100621E92 /* alloc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alloc.c; sourceTree = "<group>"; };
+		5CDD909D1E43D51100621E92 /* crypto_kernel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypto_kernel.c; sourceTree = "<group>"; };
+		5CDD909E1E43D51100621E92 /* err.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = err.c; sourceTree = "<group>"; };
+		5CDD909F1E43D51100621E92 /* key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = key.c; sourceTree = "<group>"; };
+		5CDD90A41E43D51B00621E92 /* auth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = auth.c; sourceTree = "<group>"; };
+		5CDD90A51E43D51B00621E92 /* hmac_ossl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hmac_ossl.c; sourceTree = "<group>"; };
+		5CDD90A61E43D51B00621E92 /* null_auth.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = null_auth.c; sourceTree = "<group>"; };
+		5CDD90AA1E43D52900621E92 /* aes_gcm_ossl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aes_gcm_ossl.c; sourceTree = "<group>"; };
+		5CDD90AB1E43D52900621E92 /* aes_icm_ossl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aes_icm_ossl.c; sourceTree = "<group>"; };
+		5CDD90AC1E43D52900621E92 /* cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cipher.c; sourceTree = "<group>"; };
+		5CDD90AD1E43D52900621E92 /* null_cipher.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = null_cipher.c; sourceTree = "<group>"; };
+		5CFACF5A226E9A1A0056C7D0 /* pkcs7_x509.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs7_x509.c; sourceTree = "<group>"; };
+		5CFACF5B226E9A1A0056C7D0 /* pkcs7.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pkcs7.c; sourceTree = "<group>"; };
+		5CFD53851E4BD3A300482908 /* compare_neon.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = compare_neon.cc; sourceTree = "<group>"; };
+		5CFD53861E4BD3A300482908 /* compare_neon64.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = compare_neon64.cc; sourceTree = "<group>"; };
+		5CFD53871E4BD3A300482908 /* rotate_neon.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotate_neon.cc; sourceTree = "<group>"; };
+		5CFD53881E4BD3A300482908 /* rotate_neon64.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rotate_neon64.cc; sourceTree = "<group>"; };
+		5CFD53891E4BD3A300482908 /* row_neon.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = row_neon.cc; sourceTree = "<group>"; };
+		5CFD538A1E4BD3A300482908 /* row_neon64.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = row_neon64.cc; sourceTree = "<group>"; };
+		5CFD538B1E4BD3A300482908 /* scale_neon.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_neon.cc; sourceTree = "<group>"; };
+		5CFD538C1E4BD3A300482908 /* scale_neon64.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scale_neon64.cc; sourceTree = "<group>"; };
 		5D7C59C51208C68B001C873E /* libwebrtc.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = libwebrtc.xcconfig; sourceTree = "<group>"; };
 		5D7C59C61208C68B001C873E /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		5D7C59C71208C68B001C873E /* DebugRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = DebugRelease.xcconfig; sourceTree = "<group>"; };
@@ -10235,16 +10235,16 @@
 		DD77E1FF27FB766800DC90C0 /* variant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = variant.h; sourceTree = "<group>"; };
 		DDEBB11924C0187400ADBD44 /* libaom.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libaom.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDEBB11E24C0189600ADBD44 /* libaom.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = libaom.xcconfig; sourceTree = "<group>"; };
-		DDF308E327C56D15006A526F /* options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = options.h; path = base/options.h; sourceTree = "<group>"; };
-		DDF308E427C56D15006A526F /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = config.h; path = base/config.h; sourceTree = "<group>"; };
-		DDF308E527C56D15006A526F /* const_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = const_init.h; path = base/const_init.h; sourceTree = "<group>"; };
-		DDF308E627C56D15006A526F /* policy_checks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = policy_checks.h; path = base/policy_checks.h; sourceTree = "<group>"; };
-		DDF308E727C56D15006A526F /* dynamic_annotations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dynamic_annotations.h; path = base/dynamic_annotations.h; sourceTree = "<group>"; };
-		DDF308E827C56D16006A526F /* thread_annotations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = thread_annotations.h; path = base/thread_annotations.h; sourceTree = "<group>"; };
-		DDF308E927C56D16006A526F /* call_once.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = call_once.h; path = base/call_once.h; sourceTree = "<group>"; };
-		DDF308EA27C56D16006A526F /* port.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = port.h; path = base/port.h; sourceTree = "<group>"; };
-		DDF308EB27C56D16006A526F /* attributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = attributes.h; path = base/attributes.h; sourceTree = "<group>"; };
-		DDF308EC27C56D16006A526F /* log_severity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = log_severity.h; path = base/log_severity.h; sourceTree = "<group>"; };
+		DDF308E327C56D15006A526F /* options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = options.h; sourceTree = "<group>"; };
+		DDF308E427C56D15006A526F /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		DDF308E527C56D15006A526F /* const_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = const_init.h; sourceTree = "<group>"; };
+		DDF308E627C56D15006A526F /* policy_checks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = policy_checks.h; sourceTree = "<group>"; };
+		DDF308E727C56D15006A526F /* dynamic_annotations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dynamic_annotations.h; sourceTree = "<group>"; };
+		DDF308E827C56D16006A526F /* thread_annotations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_annotations.h; sourceTree = "<group>"; };
+		DDF308E927C56D16006A526F /* call_once.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = call_once.h; sourceTree = "<group>"; };
+		DDF308EA27C56D16006A526F /* port.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = port.h; sourceTree = "<group>"; };
+		DDF308EB27C56D16006A526F /* attributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = attributes.h; sourceTree = "<group>"; };
+		DDF308EC27C56D16006A526F /* log_severity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = log_severity.h; sourceTree = "<group>"; };
 		DDF308F827C56D24006A526F /* invoke.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = invoke.h; sourceTree = "<group>"; };
 		DDF308F927C56D24006A526F /* inline_variable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_variable.h; sourceTree = "<group>"; };
 		DDF308FA27C56D24006A526F /* spinlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spinlock.h; sourceTree = "<group>"; };
@@ -10273,13 +10273,13 @@
 		DDF3091127C56D27006A526F /* unscaledcycleclock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unscaledcycleclock.h; sourceTree = "<group>"; };
 		DDF3091227C56D27006A526F /* endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = endian.h; sourceTree = "<group>"; };
 		DDF3091427C56D28006A526F /* inline_variable_testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_variable_testing.h; sourceTree = "<group>"; };
-		DDF3093327C59390006A526F /* btree_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = btree_map.h; path = container/btree_map.h; sourceTree = "<group>"; };
-		DDF3093427C59390006A526F /* flat_hash_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = flat_hash_set.h; path = container/flat_hash_set.h; sourceTree = "<group>"; };
-		DDF3093527C59390006A526F /* btree_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = btree_set.h; path = container/btree_set.h; sourceTree = "<group>"; };
-		DDF3093627C59390006A526F /* flat_hash_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = flat_hash_map.h; path = container/flat_hash_map.h; sourceTree = "<group>"; };
-		DDF3093727C59391006A526F /* btree_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = btree_test.h; path = container/btree_test.h; sourceTree = "<group>"; };
-		DDF3093827C59391006A526F /* node_hash_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = node_hash_map.h; path = container/node_hash_map.h; sourceTree = "<group>"; };
-		DDF3093927C59391006A526F /* node_hash_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = node_hash_set.h; path = container/node_hash_set.h; sourceTree = "<group>"; };
+		DDF3093327C59390006A526F /* btree_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = btree_map.h; sourceTree = "<group>"; };
+		DDF3093427C59390006A526F /* flat_hash_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flat_hash_set.h; sourceTree = "<group>"; };
+		DDF3093527C59390006A526F /* btree_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = btree_set.h; sourceTree = "<group>"; };
+		DDF3093627C59390006A526F /* flat_hash_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flat_hash_map.h; sourceTree = "<group>"; };
+		DDF3093727C59391006A526F /* btree_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = btree_test.h; sourceTree = "<group>"; };
+		DDF3093827C59391006A526F /* node_hash_map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = node_hash_map.h; sourceTree = "<group>"; };
+		DDF3093927C59391006A526F /* node_hash_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = node_hash_set.h; sourceTree = "<group>"; };
 		DDF3094127C593AF006A526F /* cordz_handle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cordz_handle.h; sourceTree = "<group>"; };
 		DDF3094227C593AF006A526F /* cordz_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cordz_functions.h; sourceTree = "<group>"; };
 		DDF3094327C593AF006A526F /* str_join_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = str_join_internal.h; sourceTree = "<group>"; };
@@ -10318,11 +10318,11 @@
 		DDF3097D27C593CC006A526F /* strip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strip.h; sourceTree = "<group>"; };
 		DDF3097E27C593CC006A526F /* str_join.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = str_join.h; sourceTree = "<group>"; };
 		DDF3097F27C593CD006A526F /* substitute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = substitute.h; sourceTree = "<group>"; };
-		DDF3098D27C593DB006A526F /* compare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = compare.h; path = types/compare.h; sourceTree = "<group>"; };
-		DDF3098E27C593DB006A526F /* any.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = any.h; path = types/any.h; sourceTree = "<group>"; };
-		DDF3098F27C593DB006A526F /* bad_any_cast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bad_any_cast.h; path = types/bad_any_cast.h; sourceTree = "<group>"; };
-		DDF3099027C593DC006A526F /* variant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = variant.h; path = types/variant.h; sourceTree = "<group>"; };
-		DDF3099127C593DC006A526F /* span.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = span.h; path = types/span.h; sourceTree = "<group>"; };
+		DDF3098D27C593DB006A526F /* compare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compare.h; sourceTree = "<group>"; };
+		DDF3098E27C593DB006A526F /* any.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = any.h; sourceTree = "<group>"; };
+		DDF3098F27C593DB006A526F /* bad_any_cast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bad_any_cast.h; sourceTree = "<group>"; };
+		DDF3099027C593DC006A526F /* variant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = variant.h; sourceTree = "<group>"; };
+		DDF3099127C593DC006A526F /* span.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = span.h; sourceTree = "<group>"; };
 		DDF3099727C59450006A526F /* async_dns_resolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_dns_resolver.h; sourceTree = "<group>"; };
 		DDF3099827C59450006A526F /* video_track_source_proxy_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_track_source_proxy_factory.h; sourceTree = "<group>"; };
 		DDF3099927C59450006A526F /* priority.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = priority.h; sourceTree = "<group>"; };
@@ -10334,31 +10334,31 @@
 		DDF3099F27C59451006A526F /* packet_socket_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = packet_socket_factory.h; sourceTree = "<group>"; };
 		DDF309A927C59819006A526F /* bitrate_allocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitrate_allocation.h; sourceTree = "<group>"; };
 		DDF309AA27C59819006A526F /* call_factory_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = call_factory_interface.h; sourceTree = "<group>"; };
-		DDF309AD27C59854006A526F /* task_queue_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = task_queue_test.h; path = task_queue/task_queue_test.h; sourceTree = "<group>"; };
+		DDF309AD27C59854006A526F /* task_queue_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = task_queue_test.h; sourceTree = "<group>"; };
 		DDF309B027C5987D006A526F /* sctp_transport_factory_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sctp_transport_factory_interface.h; sourceTree = "<group>"; };
 		DDF309B327C59896006A526F /* video_layers_allocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_layers_allocation.h; sourceTree = "<group>"; };
 		DDF309B427C59896006A526F /* render_resolution.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = render_resolution.h; sourceTree = "<group>"; };
 		DDF309B527C59896006A526F /* rtp_video_frame_assembler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_video_frame_assembler.h; sourceTree = "<group>"; };
-		DDF309B927C598A1006A526F /* bitstream_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bitstream_parser.h; path = video_codecs/bitstream_parser.h; sourceTree = "<group>"; };
-		DDF309BA27C598A1006A526F /* spatial_layer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = spatial_layer.h; path = video_codecs/spatial_layer.h; sourceTree = "<group>"; };
+		DDF309B927C598A1006A526F /* bitstream_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitstream_parser.h; sourceTree = "<group>"; };
+		DDF309BA27C598A1006A526F /* spatial_layer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spatial_layer.h; sourceTree = "<group>"; };
 		DDF309BD27C598C2006A526F /* mock_voe_channel_proxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_voe_channel_proxy.h; sourceTree = "<group>"; };
-		DDF309BF27C598DA006A526F /* rtp_transport_controller_send_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_transport_controller_send_factory.h; path = call/rtp_transport_controller_send_factory.h; sourceTree = "<group>"; };
-		DDF309C027C598DA006A526F /* rtp_bitrate_configurator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_bitrate_configurator.h; path = call/rtp_bitrate_configurator.h; sourceTree = "<group>"; };
-		DDF309C127C598DA006A526F /* rampup_tests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rampup_tests.h; path = call/rampup_tests.h; sourceTree = "<group>"; };
-		DDF309C227C598DA006A526F /* simulated_packet_receiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = simulated_packet_receiver.h; path = call/simulated_packet_receiver.h; sourceTree = "<group>"; };
-		DDF309C327C598DB006A526F /* audio_sender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_sender.h; path = call/audio_sender.h; sourceTree = "<group>"; };
-		DDF309C427C598DB006A526F /* receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = receive_stream.h; path = call/receive_stream.h; sourceTree = "<group>"; };
-		DDF309C527C598DB006A526F /* rtp_transport_controller_send_factory_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_transport_controller_send_factory_interface.h; path = call/rtp_transport_controller_send_factory_interface.h; sourceTree = "<group>"; };
-		DDF309C627C598DB006A526F /* rtp_transport_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtp_transport_config.h; path = call/rtp_transport_config.h; sourceTree = "<group>"; };
-		DDF309CF27C598FF006A526F /* spl_inl_mips.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = spl_inl_mips.h; path = signal_processing/include/spl_inl_mips.h; sourceTree = "<group>"; };
-		DDF309D027C598FF006A526F /* spl_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = spl_inl.h; path = signal_processing/include/spl_inl.h; sourceTree = "<group>"; };
-		DDF309D127C598FF006A526F /* spl_inl_armv7.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = spl_inl_armv7.h; path = signal_processing/include/spl_inl_armv7.h; sourceTree = "<group>"; };
-		DDF309D527C59908006A526F /* real_fft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = real_fft.h; path = signal_processing/include/real_fft.h; sourceTree = "<group>"; };
+		DDF309BF27C598DA006A526F /* rtp_transport_controller_send_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_transport_controller_send_factory.h; sourceTree = "<group>"; };
+		DDF309C027C598DA006A526F /* rtp_bitrate_configurator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_bitrate_configurator.h; sourceTree = "<group>"; };
+		DDF309C127C598DA006A526F /* rampup_tests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rampup_tests.h; sourceTree = "<group>"; };
+		DDF309C227C598DA006A526F /* simulated_packet_receiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simulated_packet_receiver.h; sourceTree = "<group>"; };
+		DDF309C327C598DB006A526F /* audio_sender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_sender.h; sourceTree = "<group>"; };
+		DDF309C427C598DB006A526F /* receive_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = receive_stream.h; sourceTree = "<group>"; };
+		DDF309C527C598DB006A526F /* rtp_transport_controller_send_factory_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_transport_controller_send_factory_interface.h; sourceTree = "<group>"; };
+		DDF309C627C598DB006A526F /* rtp_transport_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtp_transport_config.h; sourceTree = "<group>"; };
+		DDF309CF27C598FF006A526F /* spl_inl_mips.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spl_inl_mips.h; sourceTree = "<group>"; };
+		DDF309D027C598FF006A526F /* spl_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spl_inl.h; sourceTree = "<group>"; };
+		DDF309D127C598FF006A526F /* spl_inl_armv7.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spl_inl_armv7.h; sourceTree = "<group>"; };
+		DDF309D527C59908006A526F /* real_fft.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = real_fft.h; sourceTree = "<group>"; };
 		DDF309D727C59930006A526F /* ooura_fft_tables_neon_sse2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ooura_fft_tables_neon_sse2.h; sourceTree = "<group>"; };
 		DDF309D927C5997A006A526F /* fir_filter_neon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fir_filter_neon.h; sourceTree = "<group>"; };
 		DDF309DA27C5997A006A526F /* fir_filter_avx2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fir_filter_avx2.h; sourceTree = "<group>"; };
-		DDF309DD27C59997006A526F /* video_frame_buffer_pool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = video_frame_buffer_pool.h; path = include/video_frame_buffer_pool.h; sourceTree = "<group>"; };
-		DDF309DE27C59997006A526F /* quality_limitation_reason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = quality_limitation_reason.h; path = include/quality_limitation_reason.h; sourceTree = "<group>"; };
+		DDF309DD27C59997006A526F /* video_frame_buffer_pool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_frame_buffer_pool.h; sourceTree = "<group>"; };
+		DDF309DE27C59997006A526F /* quality_limitation_reason.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quality_limitation_reason.h; sourceTree = "<group>"; };
 		DDF309E127C599B0006A526F /* frame_counts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_counts.h; sourceTree = "<group>"; };
 		DDF309E327C599C0006A526F /* rtc_event_field_encoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_field_encoding.h; sourceTree = "<group>"; };
 		DDF309E427C599C0006A526F /* rtc_event_field_encoding_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_field_encoding_parser.h; sourceTree = "<group>"; };
@@ -10366,43 +10366,43 @@
 		DDF309E627C599C0006A526F /* rtc_event_field_extraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_field_extraction.h; sourceTree = "<group>"; };
 		DDF309E727C599C0006A526F /* rtc_event_frame_decoded.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_frame_decoded.h; sourceTree = "<group>"; };
 		DDF309E827C599C0006A526F /* rtc_event_remote_estimate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_remote_estimate.h; sourceTree = "<group>"; };
-		DDF309EF27C599D9006A526F /* fake_rtc_event_log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_rtc_event_log.h; path = rtc_event_log/fake_rtc_event_log.h; sourceTree = "<group>"; };
-		DDF309F027C599D9006A526F /* fake_rtc_event_log_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_rtc_event_log_factory.h; path = rtc_event_log/fake_rtc_event_log_factory.h; sourceTree = "<group>"; };
-		DDF309F127C599D9006A526F /* rtc_event_log_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event_log_impl.h; path = rtc_event_log/rtc_event_log_impl.h; sourceTree = "<group>"; };
-		DDF309F227C599DA006A526F /* rtc_event_log_unittest_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rtc_event_log_unittest_helper.h; path = rtc_event_log/rtc_event_log_unittest_helper.h; sourceTree = "<group>"; };
-		DDF309F727C599E9006A526F /* fake_video_renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_video_renderer.h; path = base/fake_video_renderer.h; sourceTree = "<group>"; };
-		DDF309F827C599E9006A526F /* test_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = test_utils.h; path = base/test_utils.h; sourceTree = "<group>"; };
-		DDF309F927C599EA006A526F /* fake_frame_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_frame_source.h; path = base/fake_frame_source.h; sourceTree = "<group>"; };
-		DDF309FA27C599EA006A526F /* fake_rtp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_rtp.h; path = base/fake_rtp.h; sourceTree = "<group>"; };
-		DDF309FB27C599EA006A526F /* fake_network_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_network_interface.h; path = base/fake_network_interface.h; sourceTree = "<group>"; };
-		DDF309FC27C599EA006A526F /* fake_media_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_media_engine.h; path = base/fake_media_engine.h; sourceTree = "<group>"; };
-		DDF30A0327C599F6006A526F /* fake_video_codec_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_video_codec_factory.h; path = engine/fake_video_codec_factory.h; sourceTree = "<group>"; };
-		DDF30A0427C599F6006A526F /* fake_webrtc_video_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_webrtc_video_engine.h; path = engine/fake_webrtc_video_engine.h; sourceTree = "<group>"; };
-		DDF30A0527C599F6006A526F /* fake_webrtc_call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_webrtc_call.h; path = engine/fake_webrtc_call.h; sourceTree = "<group>"; };
-		DDF30A0927C59A6E006A526F /* fec_controller_plr_based.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fec_controller_plr_based.h; path = audio_network_adaptor/fec_controller_plr_based.h; sourceTree = "<group>"; };
-		DDF30A0A27C59A6E006A526F /* frame_length_controller_v2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = frame_length_controller_v2.h; path = audio_network_adaptor/frame_length_controller_v2.h; sourceTree = "<group>"; };
-		DDF30A1B27C59B1C006A526F /* neteq_stats_getter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_stats_getter.h; path = tools/neteq_stats_getter.h; sourceTree = "<group>"; };
-		DDF30A1C27C59B1C006A526F /* neteq_event_log_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_event_log_input.h; path = tools/neteq_event_log_input.h; sourceTree = "<group>"; };
-		DDF30A1D27C59B1C006A526F /* neteq_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_test.h; path = tools/neteq_test.h; sourceTree = "<group>"; };
-		DDF30A2027C59B1D006A526F /* neteq_performance_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_performance_test.h; path = tools/neteq_performance_test.h; sourceTree = "<group>"; };
-		DDF30A2127C59B1D006A526F /* neteq_quality_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_quality_test.h; path = tools/neteq_quality_test.h; sourceTree = "<group>"; };
-		DDF30A2227C59B1D006A526F /* neteq_delay_analyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_delay_analyzer.h; path = tools/neteq_delay_analyzer.h; sourceTree = "<group>"; };
-		DDF30A2327C59B1D006A526F /* neteq_stats_plotter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_stats_plotter.h; path = tools/neteq_stats_plotter.h; sourceTree = "<group>"; };
-		DDF30A2427C59B1D006A526F /* initial_packet_inserter_neteq_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = initial_packet_inserter_neteq_input.h; path = tools/initial_packet_inserter_neteq_input.h; sourceTree = "<group>"; };
-		DDF30A2527C59B1E006A526F /* neteq_test_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = neteq_test_factory.h; path = tools/neteq_test_factory.h; sourceTree = "<group>"; };
+		DDF309EF27C599D9006A526F /* fake_rtc_event_log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_rtc_event_log.h; sourceTree = "<group>"; };
+		DDF309F027C599D9006A526F /* fake_rtc_event_log_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_rtc_event_log_factory.h; sourceTree = "<group>"; };
+		DDF309F127C599D9006A526F /* rtc_event_log_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_log_impl.h; sourceTree = "<group>"; };
+		DDF309F227C599DA006A526F /* rtc_event_log_unittest_helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtc_event_log_unittest_helper.h; sourceTree = "<group>"; };
+		DDF309F727C599E9006A526F /* fake_video_renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_video_renderer.h; sourceTree = "<group>"; };
+		DDF309F827C599E9006A526F /* test_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_utils.h; sourceTree = "<group>"; };
+		DDF309F927C599EA006A526F /* fake_frame_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_frame_source.h; sourceTree = "<group>"; };
+		DDF309FA27C599EA006A526F /* fake_rtp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_rtp.h; sourceTree = "<group>"; };
+		DDF309FB27C599EA006A526F /* fake_network_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_network_interface.h; sourceTree = "<group>"; };
+		DDF309FC27C599EA006A526F /* fake_media_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_media_engine.h; sourceTree = "<group>"; };
+		DDF30A0327C599F6006A526F /* fake_video_codec_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_video_codec_factory.h; sourceTree = "<group>"; };
+		DDF30A0427C599F6006A526F /* fake_webrtc_video_engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_webrtc_video_engine.h; sourceTree = "<group>"; };
+		DDF30A0527C599F6006A526F /* fake_webrtc_call.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_webrtc_call.h; sourceTree = "<group>"; };
+		DDF30A0927C59A6E006A526F /* fec_controller_plr_based.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fec_controller_plr_based.h; sourceTree = "<group>"; };
+		DDF30A0A27C59A6E006A526F /* frame_length_controller_v2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = frame_length_controller_v2.h; sourceTree = "<group>"; };
+		DDF30A1B27C59B1C006A526F /* neteq_stats_getter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_stats_getter.h; sourceTree = "<group>"; };
+		DDF30A1C27C59B1C006A526F /* neteq_event_log_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_event_log_input.h; sourceTree = "<group>"; };
+		DDF30A1D27C59B1C006A526F /* neteq_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_test.h; sourceTree = "<group>"; };
+		DDF30A2027C59B1D006A526F /* neteq_performance_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_performance_test.h; sourceTree = "<group>"; };
+		DDF30A2127C59B1D006A526F /* neteq_quality_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_quality_test.h; sourceTree = "<group>"; };
+		DDF30A2227C59B1D006A526F /* neteq_delay_analyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_delay_analyzer.h; sourceTree = "<group>"; };
+		DDF30A2327C59B1D006A526F /* neteq_stats_plotter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_stats_plotter.h; sourceTree = "<group>"; };
+		DDF30A2427C59B1D006A526F /* initial_packet_inserter_neteq_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = initial_packet_inserter_neteq_input.h; sourceTree = "<group>"; };
+		DDF30A2527C59B1E006A526F /* neteq_test_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neteq_test_factory.h; sourceTree = "<group>"; };
 		DDF30A3227C59B3C006A526F /* audio_coding_module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_coding_module.h; sourceTree = "<group>"; };
 		DDF30A3327C59B3C006A526F /* audio_coding_module_typedefs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_coding_module_typedefs.h; sourceTree = "<group>"; };
-		DDF30A4F27C59B72006A526F /* fake_audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fake_audio_device.h; path = include/fake_audio_device.h; sourceTree = "<group>"; };
-		DDF30A5027C59B72006A526F /* mock_audio_transport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mock_audio_transport.h; path = include/mock_audio_transport.h; sourceTree = "<group>"; };
-		DDF30A5127C59B72006A526F /* test_audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = test_audio_device.h; path = include/test_audio_device.h; sourceTree = "<group>"; };
-		DDF30A5227C59B72006A526F /* audio_device_default.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_device_default.h; path = include/audio_device_default.h; sourceTree = "<group>"; };
-		DDF30A5327C59B72006A526F /* mock_audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mock_audio_device.h; path = include/mock_audio_device.h; sourceTree = "<group>"; };
-		DDF30A5427C59B72006A526F /* audio_device_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_device_factory.h; path = include/audio_device_factory.h; sourceTree = "<group>"; };
+		DDF30A4F27C59B72006A526F /* fake_audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_audio_device.h; sourceTree = "<group>"; };
+		DDF30A5027C59B72006A526F /* mock_audio_transport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_audio_transport.h; sourceTree = "<group>"; };
+		DDF30A5127C59B72006A526F /* test_audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_audio_device.h; sourceTree = "<group>"; };
+		DDF30A5227C59B72006A526F /* audio_device_default.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_device_default.h; sourceTree = "<group>"; };
+		DDF30A5327C59B72006A526F /* mock_audio_device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_audio_device.h; sourceTree = "<group>"; };
+		DDF30A5427C59B72006A526F /* audio_device_factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_device_factory.h; sourceTree = "<group>"; };
 		DDF30A5B27C59B80006A526F /* audio_device_name.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_device_name.h; sourceTree = "<group>"; };
 		DDF30A5D27C59B8E006A526F /* gain_change_calculator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gain_change_calculator.h; sourceTree = "<group>"; };
 		DDF30A5E27C59B8E006A526F /* sine_wave_generator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sine_wave_generator.h; sourceTree = "<group>"; };
-		DDF30A6227C59BA3006A526F /* capture_stream_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = capture_stream_info.h; path = aec_dump/capture_stream_info.h; sourceTree = "<group>"; };
-		DDF30A6327C59BA3006A526F /* mock_aec_dump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mock_aec_dump.h; path = aec_dump/mock_aec_dump.h; sourceTree = "<group>"; };
+		DDF30A6227C59BA3006A526F /* capture_stream_info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = capture_stream_info.h; sourceTree = "<group>"; };
+		DDF30A6327C59BA3006A526F /* mock_aec_dump.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mock_aec_dump.h; sourceTree = "<group>"; };
 		DDF30A6727C59BBE006A526F /* test_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_utils.h; sourceTree = "<group>"; };
 		DDF30A6927C59BC7006A526F /* agc2_testing_common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = agc2_testing_common.h; sourceTree = "<group>"; };
 		DDF30A6A27C59BC7006A526F /* interpolated_gain_curve.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = interpolated_gain_curve.h; sourceTree = "<group>"; };
@@ -10442,25 +10442,25 @@
 		DDF30AC627C5A364006A526F /* warn_current_thread_is_deadlocked.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = warn_current_thread_is_deadlocked.h; sourceTree = "<group>"; };
 		DDF30AC727C5A364006A526F /* gcd_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gcd_helpers.h; sourceTree = "<group>"; };
 		DDF30AC827C5A364006A526F /* assume.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = assume.h; sourceTree = "<group>"; };
-		DDF30ACD27C5A3A2006A526F /* test_base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = test_base64.h; path = rtc_base/test_base64.h; sourceTree = "<group>"; };
-		DDF30ACF27C5A3A2006A526F /* test_client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = test_client.h; path = rtc_base/test_client.h; sourceTree = "<group>"; };
-		DDF30AD027C5A3A3006A526F /* win32_socket_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = win32_socket_init.h; path = rtc_base/win32_socket_init.h; sourceTree = "<group>"; };
-		DDF30AD127C5A3A3006A526F /* task_queue_gcd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = task_queue_gcd.h; path = rtc_base/task_queue_gcd.h; sourceTree = "<group>"; };
-		DDF30AD227C5A3A3006A526F /* socket_unittest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = socket_unittest.h; path = rtc_base/socket_unittest.h; sourceTree = "<group>"; };
-		DDF30AD327C5A3A3006A526F /* task_queue_for_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = task_queue_for_test.h; path = rtc_base/task_queue_for_test.h; sourceTree = "<group>"; };
-		DDF30AD427C5A3A3006A526F /* untyped_function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = untyped_function.h; path = rtc_base/untyped_function.h; sourceTree = "<group>"; };
-		DDF30AD527C5A3A3006A526F /* test_echo_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = test_echo_server.h; path = rtc_base/test_echo_server.h; sourceTree = "<group>"; };
-		DDF30AD627C5A3A3006A526F /* task_queue_win.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = task_queue_win.h; path = rtc_base/task_queue_win.h; sourceTree = "<group>"; };
-		DDF30AD727C5A3A4006A526F /* test_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = test_utils.h; path = rtc_base/test_utils.h; sourceTree = "<group>"; };
-		DDF30AD827C5A3A4006A526F /* win32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = win32.h; path = rtc_base/win32.h; sourceTree = "<group>"; };
-		DDF30AD927C5A3A4006A526F /* win32_window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = win32_window.h; path = rtc_base/win32_window.h; sourceTree = "<group>"; };
-		DDF30ADB27C5A3A4006A526F /* gtest_prod_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gtest_prod_util.h; path = rtc_base/gtest_prod_util.h; sourceTree = "<group>"; };
-		DDF30ADC27C5A3A4006A526F /* bounded_inline_vector_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bounded_inline_vector_impl.h; path = rtc_base/bounded_inline_vector_impl.h; sourceTree = "<group>"; };
-		DDF30ADD27C5A3A4006A526F /* strong_alias.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = strong_alias.h; path = rtc_base/strong_alias.h; sourceTree = "<group>"; };
-		DDF30ADE27C5A3A5006A526F /* bounded_inline_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bounded_inline_vector.h; path = rtc_base/bounded_inline_vector.h; sourceTree = "<group>"; };
-		DDF30ADF27C5A3A5006A526F /* gunit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = gunit.h; path = rtc_base/gunit.h; sourceTree = "<group>"; };
-		DDF30AE027C5A3A5006A526F /* test_certificate_verifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = test_certificate_verifier.h; path = rtc_base/test_certificate_verifier.h; sourceTree = "<group>"; };
-		DDF30AE127C5A3A5006A526F /* virtual_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = virtual_socket_server.h; path = rtc_base/virtual_socket_server.h; sourceTree = "<group>"; };
+		DDF30ACD27C5A3A2006A526F /* test_base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_base64.h; sourceTree = "<group>"; };
+		DDF30ACF27C5A3A2006A526F /* test_client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_client.h; sourceTree = "<group>"; };
+		DDF30AD027C5A3A3006A526F /* win32_socket_init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = win32_socket_init.h; sourceTree = "<group>"; };
+		DDF30AD127C5A3A3006A526F /* task_queue_gcd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = task_queue_gcd.h; sourceTree = "<group>"; };
+		DDF30AD227C5A3A3006A526F /* socket_unittest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket_unittest.h; sourceTree = "<group>"; };
+		DDF30AD327C5A3A3006A526F /* task_queue_for_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = task_queue_for_test.h; sourceTree = "<group>"; };
+		DDF30AD427C5A3A3006A526F /* untyped_function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = untyped_function.h; sourceTree = "<group>"; };
+		DDF30AD527C5A3A3006A526F /* test_echo_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_echo_server.h; sourceTree = "<group>"; };
+		DDF30AD627C5A3A3006A526F /* task_queue_win.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = task_queue_win.h; sourceTree = "<group>"; };
+		DDF30AD727C5A3A4006A526F /* test_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_utils.h; sourceTree = "<group>"; };
+		DDF30AD827C5A3A4006A526F /* win32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = win32.h; sourceTree = "<group>"; };
+		DDF30AD927C5A3A4006A526F /* win32_window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = win32_window.h; sourceTree = "<group>"; };
+		DDF30ADB27C5A3A4006A526F /* gtest_prod_util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gtest_prod_util.h; sourceTree = "<group>"; };
+		DDF30ADC27C5A3A4006A526F /* bounded_inline_vector_impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bounded_inline_vector_impl.h; sourceTree = "<group>"; };
+		DDF30ADD27C5A3A4006A526F /* strong_alias.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strong_alias.h; sourceTree = "<group>"; };
+		DDF30ADE27C5A3A5006A526F /* bounded_inline_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bounded_inline_vector.h; sourceTree = "<group>"; };
+		DDF30ADF27C5A3A5006A526F /* gunit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gunit.h; sourceTree = "<group>"; };
+		DDF30AE027C5A3A5006A526F /* test_certificate_verifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = test_certificate_verifier.h; sourceTree = "<group>"; };
+		DDF30AE127C5A3A5006A526F /* virtual_socket_server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = virtual_socket_server.h; sourceTree = "<group>"; };
 		DDF30AF727C5A3BA006A526F /* RTCStatisticsReport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCStatisticsReport.h; sourceTree = "<group>"; };
 		DDF30AF827C5A3BA006A526F /* RTCDataChannelConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RTCDataChannelConfiguration+Private.h"; sourceTree = "<group>"; };
 		DDF30AF927C5A3BA006A526F /* RTCRtcpParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtcpParameters.h; sourceTree = "<group>"; };
@@ -10540,23 +10540,23 @@
 		DDF30B8B27C5A3F1006A526F /* RTCMutableYUVPlanarBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCMutableYUVPlanarBuffer.h; sourceTree = "<group>"; };
 		DDF30B8C27C5A3F1006A526F /* RTCLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCLogging.h; sourceTree = "<group>"; };
 		DDF30B8D27C5A3F1006A526F /* RTCYUVPlanarBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCYUVPlanarBuffer.h; sourceTree = "<group>"; };
-		DDF30B9527C5A421006A526F /* scoped_cftyperef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = scoped_cftyperef.h; path = Common/scoped_cftyperef.h; sourceTree = "<group>"; };
-		DDF30B9727C5A429006A526F /* RTCPeerConnectionFactory+Native.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RTCPeerConnectionFactory+Native.h"; path = "PeerConnection/RTCPeerConnectionFactory+Native.h"; sourceTree = "<group>"; };
-		DDF30B9827C5A429006A526F /* RTCConfiguration+Native.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RTCConfiguration+Native.h"; path = "PeerConnection/RTCConfiguration+Native.h"; sourceTree = "<group>"; };
-		DDF30B9B27C5A434006A526F /* RTCDefaultShader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCDefaultShader.h; path = Video/RTCDefaultShader.h; sourceTree = "<group>"; };
-		DDF30B9C27C5A434006A526F /* RTCNV12TextureCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCNV12TextureCache.h; path = Video/RTCNV12TextureCache.h; sourceTree = "<group>"; };
-		DDF30B9F27C5A45C006A526F /* RTCCertificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCCertificate.h; path = sdk/objc/Framework/Headers/WebRTC/RTCCertificate.h; sourceTree = "<group>"; };
-		DDF30BA027C5A45C006A526F /* RTCDefaultVideoEncoderFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCDefaultVideoEncoderFactory.h; path = sdk/objc/Framework/Headers/WebRTC/RTCDefaultVideoEncoderFactory.h; sourceTree = "<group>"; };
-		DDF30BA127C5A45C006A526F /* RTCDtmfSender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCDtmfSender.h; path = sdk/objc/Framework/Headers/WebRTC/RTCDtmfSender.h; sourceTree = "<group>"; };
-		DDF30BA227C5A45C006A526F /* RTCH264ProfileLevelId.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCH264ProfileLevelId.h; path = sdk/objc/Framework/Headers/WebRTC/RTCH264ProfileLevelId.h; sourceTree = "<group>"; };
-		DDF30BA327C5A45C006A526F /* RTCRtpHeaderExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCRtpHeaderExtension.h; path = sdk/objc/Framework/Headers/WebRTC/RTCRtpHeaderExtension.h; sourceTree = "<group>"; };
-		DDF30BA427C5A45C006A526F /* RTCPeerConnectionFactoryOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCPeerConnectionFactoryOptions.h; path = sdk/objc/Framework/Headers/WebRTC/RTCPeerConnectionFactoryOptions.h; sourceTree = "<group>"; };
-		DDF30BA527C5A45C006A526F /* RTCRtcpParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCRtcpParameters.h; path = sdk/objc/Framework/Headers/WebRTC/RTCRtcpParameters.h; sourceTree = "<group>"; };
-		DDF30BA627C5A45D006A526F /* RTCRtpTransceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCRtpTransceiver.h; path = sdk/objc/Framework/Headers/WebRTC/RTCRtpTransceiver.h; sourceTree = "<group>"; };
-		DDF30BA727C5A45D006A526F /* RTCCVPixelBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCCVPixelBuffer.h; path = sdk/objc/Framework/Headers/WebRTC/RTCCVPixelBuffer.h; sourceTree = "<group>"; };
-		DDF30BA827C5A45D006A526F /* RTCCallbackLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCCallbackLogger.h; path = sdk/objc/Framework/Headers/WebRTC/RTCCallbackLogger.h; sourceTree = "<group>"; };
-		DDF30BA927C5A45D006A526F /* RTCDefaultVideoDecoderFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCDefaultVideoDecoderFactory.h; path = sdk/objc/Framework/Headers/WebRTC/RTCDefaultVideoDecoderFactory.h; sourceTree = "<group>"; };
-		DDF30BAA27C5A45D006A526F /* RTCVideoCodecInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RTCVideoCodecInfo.h; path = sdk/objc/Framework/Headers/WebRTC/RTCVideoCodecInfo.h; sourceTree = "<group>"; };
+		DDF30B9527C5A421006A526F /* scoped_cftyperef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scoped_cftyperef.h; sourceTree = "<group>"; };
+		DDF30B9727C5A429006A526F /* RTCPeerConnectionFactory+Native.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RTCPeerConnectionFactory+Native.h"; sourceTree = "<group>"; };
+		DDF30B9827C5A429006A526F /* RTCConfiguration+Native.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RTCConfiguration+Native.h"; sourceTree = "<group>"; };
+		DDF30B9B27C5A434006A526F /* RTCDefaultShader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCDefaultShader.h; sourceTree = "<group>"; };
+		DDF30B9C27C5A434006A526F /* RTCNV12TextureCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCNV12TextureCache.h; sourceTree = "<group>"; };
+		DDF30B9F27C5A45C006A526F /* RTCCertificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCCertificate.h; sourceTree = "<group>"; };
+		DDF30BA027C5A45C006A526F /* RTCDefaultVideoEncoderFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCDefaultVideoEncoderFactory.h; sourceTree = "<group>"; };
+		DDF30BA127C5A45C006A526F /* RTCDtmfSender.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCDtmfSender.h; sourceTree = "<group>"; };
+		DDF30BA227C5A45C006A526F /* RTCH264ProfileLevelId.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCH264ProfileLevelId.h; sourceTree = "<group>"; };
+		DDF30BA327C5A45C006A526F /* RTCRtpHeaderExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtpHeaderExtension.h; sourceTree = "<group>"; };
+		DDF30BA427C5A45C006A526F /* RTCPeerConnectionFactoryOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCPeerConnectionFactoryOptions.h; sourceTree = "<group>"; };
+		DDF30BA527C5A45C006A526F /* RTCRtcpParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtcpParameters.h; sourceTree = "<group>"; };
+		DDF30BA627C5A45D006A526F /* RTCRtpTransceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCRtpTransceiver.h; sourceTree = "<group>"; };
+		DDF30BA727C5A45D006A526F /* RTCCVPixelBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCCVPixelBuffer.h; sourceTree = "<group>"; };
+		DDF30BA827C5A45D006A526F /* RTCCallbackLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCCallbackLogger.h; sourceTree = "<group>"; };
+		DDF30BA927C5A45D006A526F /* RTCDefaultVideoDecoderFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCDefaultVideoDecoderFactory.h; sourceTree = "<group>"; };
+		DDF30BAA27C5A45D006A526F /* RTCVideoCodecInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCVideoCodecInfo.h; sourceTree = "<group>"; };
 		DDF30BB727C5A487006A526F /* scoped_cftyperef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scoped_cftyperef.h; sourceTree = "<group>"; };
 		DDF30BB827C5A488006A526F /* RTCCameraPreviewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCCameraPreviewView.h; sourceTree = "<group>"; };
 		DDF30BB927C5A488006A526F /* RTCDispatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCDispatcher.h; sourceTree = "<group>"; };
@@ -10584,10 +10584,10 @@
 		DDF30BE727C5A4D9006A526F /* video_quality_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = video_quality_test.h; sourceTree = "<group>"; };
 		DDF30D0627C5C003006A526F /* libabsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libabsl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF30D0B27C5C01A006A526F /* libabsl.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = libabsl.xcconfig; sourceTree = "<group>"; };
-		DDF30D8127C5C454006A526F /* audio_frame_processor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = audio_frame_processor.h; path = audio/audio_frame_processor.h; sourceTree = "<group>"; };
+		DDF30D8127C5C454006A526F /* audio_frame_processor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_frame_processor.h; sourceTree = "<group>"; };
 		DDF30D8427C5C6BC006A526F /* audio_network_adaptor_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_network_adaptor_config.h; sourceTree = "<group>"; };
 		DDF30D8527C5C6BC006A526F /* audio_network_adaptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audio_network_adaptor.h; sourceTree = "<group>"; };
-		DDF30D8D27C5C6F9006A526F /* filter_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = filter_functions.h; path = source/filter_functions.h; sourceTree = "<group>"; };
+		DDF30D8D27C5C6F9006A526F /* filter_functions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filter_functions.h; sourceTree = "<group>"; };
 		DDF30D9027C5C725006A526F /* receive_side_congestion_controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = receive_side_congestion_controller.h; sourceTree = "<group>"; };
 		DDF30D9327C5C756006A526F /* bwe_defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bwe_defines.h; sourceTree = "<group>"; };
 		DDF30D9427C5C756006A526F /* remote_bitrate_estimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remote_bitrate_estimator.h; sourceTree = "<group>"; };
@@ -11012,7 +11012,7 @@
 				4140379D24AB2FB500BCE9B2 /* treewriter.h */,
 				41CBAFA8212E03AD00DE1E1D /* vp8_quantize.c */,
 			);
-			name = encoder;
+			path = encoder;
 			sourceTree = "<group>";
 		};
 		4105EBB0212E0348008C0C20 /* decoder */ = {
@@ -11028,7 +11028,7 @@
 				4105EBB3212E035C008C0C20 /* threading.c */,
 				4105EBB6212E035D008C0C20 /* treereader.h */,
 			);
-			name = decoder;
+			path = decoder;
 			sourceTree = "<group>";
 		};
 		4106D56B216C2B91001E3C40 /* strings */ = {
@@ -11131,7 +11131,7 @@
 				410B35A1292B6E740003E515 /* transpose_neon.h */,
 				410B3598292B6E6E0003E515 /* variance_neon.c */,
 			);
-			name = arm;
+			path = arm;
 			sourceTree = "<group>";
 		};
 		410B358F292B6E4F0003E515 /* x86 */ = {
@@ -11224,7 +11224,7 @@
 				410B35C4292B6EA00003E515 /* obmc_variance_avx2.c */,
 				410B35C6292B6EA10003E515 /* obmc_variance_sse4.c */,
 			);
-			name = x86;
+			path = x86;
 			sourceTree = "<group>";
 		};
 		410B35B9292B6E990003E515 /* include */ = {
@@ -11708,7 +11708,7 @@
 				41109AA71E5FA19200C0955A /* video_frame_buffer.h */,
 				DDF309DD27C59997006A526F /* video_frame_buffer_pool.h */,
 			);
-			name = include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		4119275F2A375B15007C09F6 /* digestsign */ = {
@@ -11838,7 +11838,7 @@
 				41323A6926652B1500B38623 /* vp9_profile.cc */,
 				41323A6826652B1500B38623 /* vp9_profile.h */,
 			);
-			name = video_codecs;
+			path = video_codecs;
 			sourceTree = "<group>";
 		};
 		41299B98212736B200B3414B /* rnn_vad */ = {
@@ -11882,8 +11882,7 @@
 				412FF9DB254B3FC7001DF036 /* recursive_critical_section.cc */,
 				412FF9DD254B3FC8001DF036 /* recursive_critical_section.h */,
 			);
-			name = deprecated;
-			path = rtc_base/deprecated;
+			path = deprecated;
 			sourceTree = "<group>";
 		};
 		412FFA38254B42DC001DF036 /* adaptation */ = {
@@ -11935,7 +11934,7 @@
 				DDF30A6327C59BA3006A526F /* mock_aec_dump.h */,
 				41F411AC1EF8D91E00343C26 /* null_aec_dump_factory.cc */,
 			);
-			name = aec_dump;
+			path = aec_dump;
 			sourceTree = "<group>";
 		};
 		4131BE73234B85380028A615 /* hrss */ = {
@@ -11943,7 +11942,7 @@
 			children = (
 				4131BE74234B85590028A615 /* hrss.c */,
 			);
-			name = hrss;
+			path = hrss;
 			sourceTree = "<group>";
 		};
 		4131C39A234B96840028A615 /* audio */ = {
@@ -11964,7 +11963,7 @@
 				412FF94F254B3341001DF036 /* echo_detector_creator.cc */,
 				412FF950254B3341001DF036 /* echo_detector_creator.h */,
 			);
-			name = audio;
+			path = audio;
 			sourceTree = "<group>";
 		};
 		4131C3AF234B96F90028A615 /* crypto */ = {
@@ -11975,7 +11974,7 @@
 				4131C3B1234B97120028A615 /* frame_decryptor_interface.h */,
 				4131C3B3234B97120028A615 /* frame_encryptor_interface.h */,
 			);
-			name = crypto;
+			path = crypto;
 			sourceTree = "<group>";
 		};
 		4131C3CB234B982A0028A615 /* stats */ = {
@@ -11985,7 +11984,7 @@
 				4131C3CC234B98420028A615 /* rtc_stats_report.cc */,
 				41DB1A9324321614005AB8EA /* rtcstats_objects.cc */,
 			);
-			name = stats;
+			path = stats;
 			sourceTree = "<group>";
 		};
 		4131C41F234C7D070028A615 /* memory */ = {
@@ -11997,7 +11996,7 @@
 				4131C421234C7D250028A615 /* fifo_buffer.cc */,
 				4131C420234C7D240028A615 /* fifo_buffer.h */,
 			);
-			name = memory;
+			path = memory;
 			sourceTree = "<group>";
 		};
 		4131C42A234C7D700028A615 /* generic_frame_descriptor */ = {
@@ -12006,7 +12005,7 @@
 				4131C42B234C7D8A0028A615 /* generic_frame_info.cc */,
 				4131C42C234C7D8A0028A615 /* generic_frame_info.h */,
 			);
-			name = generic_frame_descriptor;
+			path = generic_frame_descriptor;
 			sourceTree = "<group>";
 		};
 		4131C433234C7E040028A615 /* pffft */ = {
@@ -12014,7 +12013,7 @@
 			children = (
 				4131C434234C7E100028A615 /* src */,
 			);
-			name = pffft;
+			path = pffft;
 			sourceTree = "<group>";
 		};
 		4131C434234C7E100028A615 /* src */ = {
@@ -12025,7 +12024,7 @@
 				4131C437234C80070028A615 /* pffft.c */,
 				4131C439234C80070028A615 /* pffft.h */,
 			);
-			name = src;
+			path = src;
 			sourceTree = "<group>";
 		};
 		4131C44F234C81040028A615 /* client */ = {
@@ -12037,7 +12036,7 @@
 				4131C452234C81180028A615 /* turn_port_factory.cc */,
 				4131C453234C81180028A615 /* turn_port_factory.h */,
 			);
-			name = client;
+			path = client;
 			sourceTree = "<group>";
 		};
 		4131C45A234C81510028A615 /* include */ = {
@@ -12050,7 +12049,7 @@
 				4131C45D234C81720028A615 /* video_coding_defines.h */,
 				4131C45C234C81720028A615 /* video_error_codes.h */,
 			);
-			name = include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		4131C467234C81970028A615 /* rtc_event_log */ = {
@@ -12064,7 +12063,7 @@
 				4131C46B234C81B50028A615 /* rtc_event_log_factory.h */,
 				4131C46C234C81B50028A615 /* rtc_event_log_factory_interface.h */,
 			);
-			name = rtc_event_log;
+			path = rtc_event_log;
 			sourceTree = "<group>";
 		};
 		4131C47E234C824D0028A615 /* task_queue */ = {
@@ -12079,7 +12078,7 @@
 				4131C483234C82740028A615 /* task_queue_factory.h */,
 				DDF309AD27C59854006A526F /* task_queue_test.h */,
 			);
-			name = task_queue;
+			path = task_queue;
 			sourceTree = "<group>";
 		};
 		4131C4A7234C83660028A615 /* media */ = {
@@ -12096,7 +12095,7 @@
 				412FFA18254B4112001DF036 /* dependency_descriptor.h */,
 				4131C4B1234C838E0028A615 /* rtp_source.h */,
 			);
-			name = rtp;
+			path = rtp;
 			sourceTree = "<group>";
 		};
 		4131C4E1234C85040028A615 /* task_utils */ = {
@@ -12105,8 +12104,7 @@
 				4131C4E3234C852E0028A615 /* repeating_task.cc */,
 				4131C4E2234C852E0028A615 /* repeating_task.h */,
 			);
-			name = task_utils;
-			path = rtc_base/task_utils;
+			path = task_utils;
 			sourceTree = "<group>";
 		};
 		41323A03266525F700B38623 /* internal */ = {
@@ -12115,8 +12113,7 @@
 				41323A042665261500B38623 /* default_socket_server.cc */,
 				41323A052665261500B38623 /* default_socket_server.h */,
 			);
-			name = internal;
-			path = rtc_base/internal;
+			path = internal;
 			sourceTree = "<group>";
 		};
 		41323A142665282000B38623 /* interface */ = {
@@ -12184,7 +12181,7 @@
 				413A21381FE0F0EE00373E99 /* srtp_priv.h */,
 				413A213B1FE0F0EF00373E99 /* ut_sim.h */,
 			);
-			name = include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		413A21431FE18D0100373E99 /* rtc_base */ = {
@@ -12439,7 +12436,7 @@
 				4131C0E5234B89DD0028A615 /* zero_memory.cc */,
 				4131C0BE234B89D60028A615 /* zero_memory.h */,
 			);
-			name = rtc_base;
+			path = rtc_base;
 			sourceTree = "<group>";
 		};
 		413A24001FE198BE00373E99 /* Headers */ = {
@@ -12447,7 +12444,7 @@
 			children = (
 				413A24011FE198EB00373E99 /* WebRTC */,
 			);
-			name = Headers;
+			path = Headers;
 			sourceTree = "<group>";
 		};
 		413A24011FE198EB00373E99 /* WebRTC */ = {
@@ -12519,7 +12516,7 @@
 				413A24021FE1990300373E99 /* RTCVideoViewShading.h */,
 				413A24331FE1991600373E99 /* UIDevice+RTCDevice.h */,
 			);
-			name = WebRTC;
+			path = WebRTC;
 			sourceTree = "<group>";
 		};
 		413AD19E21265ACB003F7263 /* abseil-cpp */ = {
@@ -12527,7 +12524,7 @@
 			children = (
 				413AD19F21265ADF003F7263 /* absl */,
 			);
-			name = "abseil-cpp";
+			path = "abseil-cpp";
 			sourceTree = "<group>";
 		};
 		413AD19F21265ADF003F7263 /* absl */ = {
@@ -12552,8 +12549,7 @@
 				41DDB24A21265BA800296D47 /* types */,
 				DD77DAE027F66AC700DC90C0 /* utility */,
 			);
-			name = absl;
-			path = "abseil-cpp/absl";
+			path = absl;
 			sourceTree = "<group>";
 		};
 		413AD1A021265AFA003F7263 /* algorithm */ = {
@@ -12562,7 +12558,7 @@
 				413AD1A121265B0F003F7263 /* algorithm.h */,
 				413AD1A221265B0F003F7263 /* container.h */,
 			);
-			name = algorithm;
+			path = algorithm;
 			sourceTree = "<group>";
 		};
 		413AD1A621265B35003F7263 /* base */ = {
@@ -12583,7 +12579,7 @@
 				DDF308EA27C56D16006A526F /* port.h */,
 				DDF308E827C56D16006A526F /* thread_annotations.h */,
 			);
-			name = base;
+			path = base;
 			sourceTree = "<group>";
 		};
 		413E6787216987A500EF37ED /* video_frame_buffer */ = {
@@ -12864,7 +12860,7 @@
 				4140B81C1E4E3383007409E6 /* g711_interface.c */,
 				4140B81D1E4E3383007409E6 /* g711_interface.h */,
 			);
-			name = g711;
+			path = g711;
 			sourceTree = "<group>";
 		};
 		4140B8171E4E3365007409E6 /* g722 */ = {
@@ -12877,7 +12873,7 @@
 				4140B82F1E4E3396007409E6 /* g722_interface.c */,
 				4140B8301E4E3396007409E6 /* g722_interface.h */,
 			);
-			name = g722;
+			path = g722;
 			sourceTree = "<group>";
 		};
 		4144B3E32169C5BD004363AC /* peerconnection */ = {
@@ -12978,8 +12974,7 @@
 				DDF30BB727C5A487006A526F /* scoped_cftyperef.h */,
 				DDF30BBB27C5A488006A526F /* UIDevice+RTCDevice.h */,
 			);
-			name = helpers;
-			path = sdk/objc/helpers;
+			path = helpers;
 			sourceTree = "<group>";
 		};
 		4145E48F1EF88EF500FCF6E6 /* include */ = {
@@ -12987,7 +12982,7 @@
 			children = (
 				4145E4901EF88EF500FCF6E6 /* webrtc_libyuv.h */,
 			);
-			name = include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		4145E4931EF890E500FCF6E6 /* Video */ = {
@@ -12996,7 +12991,7 @@
 				DDF30B9B27C5A434006A526F /* RTCDefaultShader.h */,
 				DDF30B9C27C5A434006A526F /* RTCNV12TextureCache.h */,
 			);
-			name = Video;
+			path = Video;
 			sourceTree = "<group>";
 		};
 		4145E4971EF8918600FCF6E6 /* VideoToolbox */ = {
@@ -13015,7 +13010,7 @@
 				41C01FC4242B5C0A00E08018 /* rtc_stats_report.h */,
 				4145E4C31EF896D200FCF6E6 /* rtcstats_objects.h */,
 			);
-			name = stats;
+			path = stats;
 			sourceTree = "<group>";
 		};
 		4145F60E1FE1E15400EB9CAF /* include */ = {
@@ -13031,7 +13026,7 @@
 				DDF30A5027C59B72006A526F /* mock_audio_transport.h */,
 				DDF30A5127C59B72006A526F /* test_audio_device.h */,
 			);
-			name = include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		4145F6151FE1EF5C00EB9CAF /* include */ = {
@@ -13049,7 +13044,7 @@
 			children = (
 				4154499F21CAC330001C0A55 /* ecdh.c */,
 			);
-			name = ecdh;
+			path = ecdh;
 			sourceTree = "<group>";
 		};
 		415449A921CAC3BC001C0A55 /* tls */ = {
@@ -13057,7 +13052,7 @@
 			children = (
 				415449AA21CAC3CF001C0A55 /* kdf.c */,
 			);
-			name = tls;
+			path = tls;
 			sourceTree = "<group>";
 		};
 		415449B421CAC43F001C0A55 /* ecdh_extra */ = {
@@ -13065,7 +13060,7 @@
 			children = (
 				415449BA21CAC5B3001C0A55 /* ecdh_extra.c */,
 			);
-			name = ecdh_extra;
+			path = ecdh_extra;
 			sourceTree = "<group>";
 		};
 		416225C72169814100A91C9B /* native */ = {
@@ -13074,8 +13069,7 @@
 				416225C82169815900A91C9B /* api */,
 				416225C92169816600A91C9B /* src */,
 			);
-			name = native;
-			path = sdk/objc/native;
+			path = native;
 			sourceTree = "<group>";
 		};
 		416225C82169815900A91C9B /* api */ = {
@@ -13122,8 +13116,7 @@
 				416225EB216981CE00A91C9B /* video_codec */,
 				413E6787216987A500EF37ED /* video_frame_buffer */,
 			);
-			name = components;
-			path = sdk/objc/components;
+			path = components;
 			sourceTree = "<group>";
 		};
 		416225EB216981CE00A91C9B /* video_codec */ = {
@@ -13182,8 +13175,7 @@
 				416731DB212E045D001280EB /* vp8_quantize_sse2.c */,
 				416731DF212E045E001280EB /* vp8_quantize_ssse3.c */,
 			);
-			name = x86;
-			path = encoder/x86;
+			path = x86;
 			sourceTree = "<group>";
 		};
 		416B09F42A3C7F640017367B /* deprecated */ = {
@@ -13274,8 +13266,7 @@
 				DDF30B8727C5A3F1006A526F /* RTCVideoRenderer.h */,
 				DDF30B8D27C5A3F1006A526F /* RTCYUVPlanarBuffer.h */,
 			);
-			name = base;
-			path = sdk/objc/base;
+			path = base;
 			sourceTree = "<group>";
 		};
 		417953FB216984DC0028266B /* api */ = {
@@ -13285,8 +13276,7 @@
 				417953FC216984F40028266B /* video_codec */,
 				413E67A62169893600EF37ED /* video_frame_buffer */,
 			);
-			name = api;
-			path = sdk/objc/api;
+			path = api;
 			sourceTree = "<group>";
 		};
 		417953FC216984F40028266B /* video_codec */ = {
@@ -13320,7 +13310,7 @@
 				41ECEABF20640F27009D5141 /* NSString+StdString.h */,
 				DDF30B9527C5A421006A526F /* scoped_cftyperef.h */,
 			);
-			name = Common;
+			path = Common;
 			sourceTree = "<group>";
 		};
 		418938CA242A69AE007FDC41 /* adaptation */ = {
@@ -13374,8 +13364,7 @@
 				412FF955254B3BF2001DF036 /* video_stream_input_state_provider.cc */,
 				412FF958254B3BF3001DF036 /* video_stream_input_state_provider.h */,
 			);
-			name = adaptation;
-			path = call/adaptation;
+			path = adaptation;
 			sourceTree = "<group>";
 		};
 		41893961242A721B007FDC41 /* ns */ = {
@@ -13454,8 +13443,7 @@
 			children = (
 				419100A72152EC6600A6F17B /* neon */,
 			);
-			name = arm;
-			path = encoder/arm;
+			path = arm;
 			sourceTree = "<group>";
 		};
 		419100A72152EC6600A6F17B /* neon */ = {
@@ -13581,8 +13569,7 @@
 				4131C4FB234C86CA0028A615 /* yield_policy.cc */,
 				4131C4F9234C86CA0028A615 /* yield_policy.h */,
 			);
-			name = synchronization;
-			path = rtc_base/synchronization;
+			path = synchronization;
 			sourceTree = "<group>";
 		};
 		419241652127387900634FCF /* experiments */ = {
@@ -13628,8 +13615,7 @@
 				4131C201234B8BA70028A615 /* struct_parameters_parser.cc */,
 				4131C1F8234B8BA50028A615 /* struct_parameters_parser.h */,
 			);
-			name = experiments;
-			path = rtc_base/experiments;
+			path = experiments;
 			sourceTree = "<group>";
 		};
 		419241912127583900634FCF /* rnnnoise */ = {
@@ -13648,7 +13634,7 @@
 				419241942127586400634FCF /* rnn_vad_weights.cc */,
 				419241932127586400634FCF /* rnn_vad_weights.h */,
 			);
-			name = src;
+			path = src;
 			sourceTree = "<group>";
 		};
 		419241D421275A1800634FCF /* units */ = {
@@ -13674,8 +13660,7 @@
 				419241F82127660E00634FCF /* api */,
 				419241FA2127661700634FCF /* src */,
 			);
-			name = Native;
-			path = sdk/objc/Framework/Native;
+			path = Native;
 			sourceTree = "<group>";
 		};
 		419241F82127660E00634FCF /* api */ = {
@@ -13715,7 +13700,7 @@
 				419C82ED1FE20EB40040C30F /* audio_encoder_opus_config.cc */,
 				419C82EB1FE20EB40040C30F /* audio_encoder_opus_config.h */,
 			);
-			name = opus;
+			path = opus;
 			sourceTree = "<group>";
 		};
 		419C83211FE244FE0040C30F /* events */ = {
@@ -13790,8 +13775,7 @@
 				4131C527234C8B160028A615 /* rtc_event_video_send_stream_config.cc */,
 				4131C526234C8B160028A615 /* rtc_event_video_send_stream_config.h */,
 			);
-			name = events;
-			path = rtc_event_log/events;
+			path = events;
 			sourceTree = "<group>";
 		};
 		419C83361FE246090040C30F /* g722 */ = {
@@ -13803,7 +13787,7 @@
 				419C833B1FE246230040C30F /* audio_encoder_g722.h */,
 				419C83371FE246220040C30F /* audio_encoder_g722_config.h */,
 			);
-			name = g722;
+			path = g722;
 			sourceTree = "<group>";
 		};
 		419C83411FE246380040C30F /* numerics */ = {
@@ -13835,7 +13819,7 @@
 				41893A52242A77B7007FDC41 /* sample_stats.h */,
 				41893A54242A77B8007FDC41 /* sequence_number_util.h */,
 			);
-			name = numerics;
+			path = numerics;
 			sourceTree = "<group>";
 		};
 		419C835A1FE246770040C30F /* isac */ = {
@@ -13862,7 +13846,7 @@
 				419C83C01FE247B40040C30F /* rtp_rtcp_defines.cc */,
 				419C83BB1FE247B30040C30F /* rtp_rtcp_defines.h */,
 			);
-			name = include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		419C83E21FE248210040C30F /* g711 */ = {
@@ -13873,7 +13857,7 @@
 				419C83E31FE248340040C30F /* audio_encoder_g711.cc */,
 				419C83E61FE248350040C30F /* audio_encoder_g711.h */,
 			);
-			name = g711;
+			path = g711;
 			sourceTree = "<group>";
 		};
 		419C83EB1FE248770040C30F /* L16 */ = {
@@ -13884,7 +13868,7 @@
 				419C83ED1FE2488C0040C30F /* audio_encoder_L16.cc */,
 				419C83EF1FE2488C0040C30F /* audio_encoder_L16.h */,
 			);
-			name = L16;
+			path = L16;
 			sourceTree = "<group>";
 		};
 		419C84201FE24B960040C30F /* output */ = {
@@ -13892,7 +13876,7 @@
 			children = (
 				419C84211FE24BA50040C30F /* rtc_event_log_output_file.h */,
 			);
-			name = output;
+			path = output;
 			sourceTree = "<group>";
 		};
 		419C847A1FE256940040C30F /* third_party */ = {
@@ -13929,8 +13913,7 @@
 				414037BA24AC76E900BCE9B2 /* WebKitVP9Decoder.cpp */,
 				414037B924AC76E900BCE9B2 /* WebKitVP9Decoder.h */,
 			);
-			name = WebKit;
-			path = sdk/WebKit;
+			path = WebKit;
 			sourceTree = "<group>";
 		};
 		419C84A71FE303CA0040C30F /* include */ = {
@@ -13996,8 +13979,7 @@
 				41FE8658215C534E00B62C07 /* nasm-parser.c */,
 				41FE8659215C534E00B62C07 /* nasm-parser.h */,
 			);
-			name = nasm;
-			path = gas;
+			path = nasm;
 			sourceTree = "<group>";
 		};
 		419EA20A215C50E10082BFD2 /* dbgfmts */ = {
@@ -14028,7 +14010,7 @@
 			children = (
 				41A08BB721268A7D001D5D7B /* memory.h */,
 			);
-			name = memory;
+			path = memory;
 			sourceTree = "<group>";
 		};
 		41A08BD921272F3E001D5D7B /* agc2 */ = {
@@ -14090,9 +14072,8 @@
 				41A391511EFC446E00C4516A /* sha256.c */,
 				41A391521EFC446E00C4516A /* sha512.c */,
 			);
-			name = sha;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/sha;
-			sourceTree = SOURCE_ROOT;
+			path = sha;
+			sourceTree = "<group>";
 		};
 		41A391441EFC446E00C4516A /* asm */ = {
 			isa = PBXGroup;
@@ -14124,9 +14105,8 @@
 				41A391621EFC447400C4516A /* ofb.c */,
 				41A391631EFC447400C4516A /* polyval.c */,
 			);
-			name = modes;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/modes;
-			sourceTree = SOURCE_ROOT;
+			path = modes;
+			sourceTree = "<group>";
 		};
 		41A391541EFC447400C4516A /* asm */ = {
 			isa = PBXGroup;
@@ -14155,9 +14135,8 @@
 				41A3916B1EFC447900C4516A /* rand.c */,
 				41A3916C1EFC447900C4516A /* urandom.c */,
 			);
-			name = rand;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/rand;
-			sourceTree = SOURCE_ROOT;
+			path = rand;
+			sourceTree = "<group>";
 		};
 		41A391651EFC447900C4516A /* asm */ = {
 			isa = PBXGroup;
@@ -14176,9 +14155,8 @@
 				41A391711EFC447C00C4516A /* rsa.c */,
 				41A391721EFC447C00C4516A /* rsa_impl.c */,
 			);
-			name = rsa;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/rsa;
-			sourceTree = SOURCE_ROOT;
+			path = rsa;
+			sourceTree = "<group>";
 		};
 		41A391891EFC44EA00C4516A /* cipher */ = {
 			isa = PBXGroup;
@@ -14188,9 +14166,8 @@
 				41A3918C1EFC44EA00C4516A /* e_aes.c */,
 				41A3918E1EFC44EA00C4516A /* internal.h */,
 			);
-			name = cipher;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/cipher;
-			sourceTree = SOURCE_ROOT;
+			path = cipher;
+			sourceTree = "<group>";
 		};
 		41A391941EFC454F00C4516A /* cipher_extra */ = {
 			isa = PBXGroup;
@@ -14317,8 +14294,7 @@
 			children = (
 				41A392181EFC5AB800C4516A /* x25519-asm-arm.S */,
 			);
-			name = asm;
-			path = curve25519/asm;
+			path = asm;
 			sourceTree = "<group>";
 		};
 		41B8D77A28C8880B00E5FA37 /* timing */ = {
@@ -14363,8 +14339,7 @@
 				41B8D7C828C88AF300E5FA37 /* var_int.cc */,
 				41B8D7CD28C88AF600E5FA37 /* var_int.h */,
 			);
-			name = encoder;
-			path = rtc_event_log/encoder;
+			path = encoder;
 			sourceTree = "<group>";
 		};
 		41B8D83D28C8998600E5FA37 /* internal */ = {
@@ -15062,7 +15037,7 @@
 				DDF3093827C59391006A526F /* node_hash_map.h */,
 				DDF3093927C59391006A526F /* node_hash_set.h */,
 			);
-			name = container;
+			path = container;
 			sourceTree = "<group>";
 		};
 		41DDB24A21265BA800296D47 /* types */ = {
@@ -15080,7 +15055,7 @@
 				DDF3099127C593DC006A526F /* span.h */,
 				DDF3099027C593DC006A526F /* variant.h */,
 			);
-			name = types;
+			path = types;
 			sourceTree = "<group>";
 		};
 		41DDB267212679AE00296D47 /* strings */ = {
@@ -15094,8 +15069,7 @@
 				412FFA1E254B41BA001DF036 /* string_format.cc */,
 				412FFA1F254B41BB001DF036 /* string_format.h */,
 			);
-			name = strings;
-			path = rtc_base/strings;
+			path = strings;
 			sourceTree = "<group>";
 		};
 		41E02C8F212734E800C27CD6 /* goog_cc */ = {
@@ -15205,9 +15179,8 @@
 			children = (
 				41EA53A41EFC2BFD002FF04C /* hmac.c */,
 			);
-			name = hmac;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/hmac;
-			sourceTree = SOURCE_ROOT;
+			path = hmac;
+			sourceTree = "<group>";
 		};
 		41EA53A61EFC2C4D002FF04C /* digest */ = {
 			isa = PBXGroup;
@@ -15217,9 +15190,8 @@
 				41EA53A91EFC2C4D002FF04C /* internal.h */,
 				41EA53AA1EFC2C4D002FF04C /* md32_common.h */,
 			);
-			name = digest;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/digest;
-			sourceTree = SOURCE_ROOT;
+			path = digest;
+			sourceTree = "<group>";
 		};
 		41EA53AF1EFC2C8B002FF04C /* ec */ = {
 			isa = PBXGroup;
@@ -15239,9 +15211,8 @@
 				415449B521CAC4CE001C0A55 /* util.c */,
 				41EA53C21EFC2C8B002FF04C /* wnaf.c */,
 			);
-			name = ec;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/ec;
-			sourceTree = SOURCE_ROOT;
+			path = ec;
+			sourceTree = "<group>";
 		};
 		41EA53B01EFC2C8B002FF04C /* asm */ = {
 			isa = PBXGroup;
@@ -15256,9 +15227,8 @@
 			children = (
 				41EA53D41EFC2CDC002FF04C /* ecdsa.c */,
 			);
-			name = ecdsa;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/ecdsa;
-			sourceTree = SOURCE_ROOT;
+			path = ecdsa;
+			sourceTree = "<group>";
 		};
 		41EA53DA1EFC2D1A002FF04C /* bn */ = {
 			isa = PBXGroup;
@@ -15287,9 +15257,8 @@
 				41EA53FA1EFC2D1B002FF04C /* shift.c */,
 				41EA53FB1EFC2D1B002FF04C /* sqrt.c */,
 			);
-			name = bn;
-			path = Source/third_party/boringssl/src/crypto/fipsmodule/bn;
-			sourceTree = SOURCE_ROOT;
+			path = bn;
+			sourceTree = "<group>";
 		};
 		41EA53DC1EFC2D1A002FF04C /* asm */ = {
 			isa = PBXGroup;
@@ -15351,7 +15320,7 @@
 				DDF30B9727C5A429006A526F /* RTCPeerConnectionFactory+Native.h */,
 				41ECEAB320630107009D5141 /* RTCVideoCodec+Private.h */,
 			);
-			name = PeerConnection;
+			path = PeerConnection;
 			sourceTree = "<group>";
 		};
 		41F2636B21267B2300274F59 /* third_party */ = {
@@ -15395,8 +15364,7 @@
 				41F263A7212680A700274F59 /* unused.h */,
 				DDF30AC627C5A364006A526F /* warn_current_thread_is_deadlocked.h */,
 			);
-			name = system;
-			path = rtc_base/system;
+			path = system;
 			sourceTree = "<group>";
 		};
 		41F263B4212680E800274F59 /* third_party */ = {
@@ -15405,8 +15373,7 @@
 				4424593B2ACB949400E105A1 /* base64 */,
 				4424593C2ACB94FB00E105A1 /* sigslot */,
 			);
-			name = third_party;
-			path = rtc_base/third_party;
+			path = third_party;
 			sourceTree = "<group>";
 		};
 		41F411BD1EF8DB8200343C26 /* vp8 */ = {
@@ -15543,7 +15510,7 @@
 				DDF309D127C598FF006A526F /* spl_inl_armv7.h */,
 				DDF309CF27C598FF006A526F /* spl_inl_mips.h */,
 			);
-			name = include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		41FCBB1F21B1F81400A5DF27 /* internal */ = {
@@ -15582,8 +15549,7 @@
 				DDF308FD27C56D25006A526F /* unaligned_access.h */,
 				DDF3091127C56D27006A526F /* unscaledcycleclock.h */,
 			);
-			name = internal;
-			path = base/internal;
+			path = internal;
 			sourceTree = "<group>";
 		};
 		41FCBB2421B1F85D00A5DF27 /* network */ = {
@@ -15592,8 +15558,7 @@
 				41FCBB2521B1F87E00A5DF27 /* sent_packet.cc */,
 				41FCBB2621B1F87E00A5DF27 /* sent_packet.h */,
 			);
-			name = network;
-			path = rtc_base/network;
+			path = network;
 			sourceTree = "<group>";
 		};
 		41FCBB8121B2005A00A5DF27 /* internal */ = {
@@ -15923,7 +15888,7 @@
 				5C11A0091E457448004F0987 /* audio_mixer_manager_mac.cc */,
 				5C11A00A1E457448004F0987 /* audio_mixer_manager_mac.h */,
 			);
-			name = mac;
+			path = mac;
 			sourceTree = "<group>";
 		};
 		5C11A0161E45756C004F0987 /* dummy */ = {
@@ -15936,7 +15901,7 @@
 				5C11A0191E457578004F0987 /* file_audio_device_factory.cc */,
 				5C11A01A1E457578004F0987 /* file_audio_device_factory.h */,
 			);
-			name = dummy;
+			path = dummy;
 			sourceTree = "<group>";
 		};
 		5C42CEBF1E4130A000D08A35 /* webrtc */ = {
@@ -16001,7 +15966,7 @@
 			children = (
 				5C4B43F71E42A4CC002651C8 /* base64.c */,
 			);
-			name = base64;
+			path = base64;
 			sourceTree = "<group>";
 		};
 		5C4B43F91E42A4D7002651C8 /* bio */ = {
@@ -16019,7 +15984,7 @@
 				5C4B44051E42A4F1002651C8 /* socket.c */,
 				5C4B44041E42A4F1002651C8 /* socket_helper.c */,
 			);
-			name = bio;
+			path = bio;
 			sourceTree = "<group>";
 		};
 		5C4B44411E42A553002651C8 /* buf */ = {
@@ -16027,7 +15992,7 @@
 			children = (
 				5C4B443F1E42A549002651C8 /* buf.c */,
 			);
-			name = buf;
+			path = buf;
 			sourceTree = "<group>";
 		};
 		5C4B44421E42A588002651C8 /* bytestring */ = {
@@ -16040,7 +16005,7 @@
 				5C4B46341E42A994002651C8 /* internal.h */,
 				415449A121CAC34D001C0A55 /* unicode.c */,
 			);
-			name = bytestring;
+			path = bytestring;
 			sourceTree = "<group>";
 		};
 		5C4B44431E42A597002651C8 /* chacha */ = {
@@ -16048,7 +16013,7 @@
 			children = (
 				5C4B462E1E42A989002651C8 /* chacha.c */,
 			);
-			name = chacha;
+			path = chacha;
 			sourceTree = "<group>";
 		};
 		5C4B44491E42A5DB002651C8 /* dsa */ = {
@@ -16057,7 +16022,7 @@
 				5C4B45FC1E42A943002651C8 /* dsa.c */,
 				5C4B48451E42C0F4002651C8 /* dsa_asn1.c */,
 			);
-			name = dsa;
+			path = dsa;
 			sourceTree = "<group>";
 		};
 		5C4B444D1E42A5FA002651C8 /* engine */ = {
@@ -16065,7 +16030,7 @@
 			children = (
 				5C4B45D81E42A8A4002651C8 /* engine.c */,
 			);
-			name = engine;
+			path = engine;
 			sourceTree = "<group>";
 		};
 		5C4B444E1E42A600002651C8 /* err */ = {
@@ -16073,7 +16038,7 @@
 			children = (
 				5C4B45D51E42A893002651C8 /* err.c */,
 			);
-			name = err;
+			path = err;
 			sourceTree = "<group>";
 		};
 		5C4B444F1E42A609002651C8 /* evp */ = {
@@ -16097,7 +16062,7 @@
 				5C4B45C41E42A87E002651C8 /* print.c */,
 				5C4B45C51E42A87E002651C8 /* sign.c */,
 			);
-			name = evp;
+			path = evp;
 			sourceTree = "<group>";
 		};
 		5C4B44521E42A61A002651C8 /* lhash */ = {
@@ -16105,7 +16070,7 @@
 			children = (
 				5C4B45AD1E42A83F002651C8 /* lhash.c */,
 			);
-			name = lhash;
+			path = lhash;
 			sourceTree = "<group>";
 		};
 		5C4B44571E42A645002651C8 /* obj */ = {
@@ -16115,7 +16080,7 @@
 				5C4B45821E42A7F1002651C8 /* obj_dat.h */,
 				5C4B45841E42A7F1002651C8 /* obj_xref.c */,
 			);
-			name = obj;
+			path = obj;
 			sourceTree = "<group>";
 		};
 		5C4B44581E42A64B002651C8 /* pem */ = {
@@ -16130,7 +16095,7 @@
 				5C4B45781E42A7D4002651C8 /* pem_x509.c */,
 				5C4B45791E42A7D4002651C8 /* pem_xaux.c */,
 			);
-			name = pem;
+			path = pem;
 			sourceTree = "<group>";
 		};
 		5C4B445A1E42A65A002651C8 /* pkcs8 */ = {
@@ -16141,7 +16106,7 @@
 				5C4B45691E42A792002651C8 /* pkcs8.c */,
 				41A391BD1EFC460C00C4516A /* pkcs8_x509.c */,
 			);
-			name = pkcs8;
+			path = pkcs8;
 			sourceTree = "<group>";
 		};
 		5C4B445B1E42A664002651C8 /* poly1305 */ = {
@@ -16150,7 +16115,7 @@
 				5C4B45611E42A784002651C8 /* poly1305.c */,
 				5C4B45601E42A784002651C8 /* poly1305_vec.c */,
 			);
-			name = poly1305;
+			path = poly1305;
 			sourceTree = "<group>";
 		};
 		5C4B445E1E42A676002651C8 /* rc4 */ = {
@@ -16158,7 +16123,7 @@
 			children = (
 				5C4B45501E42A753002651C8 /* rc4.c */,
 			);
-			name = rc4;
+			path = rc4;
 			sourceTree = "<group>";
 		};
 		5C4B44611E42A690002651C8 /* stack */ = {
@@ -16166,7 +16131,7 @@
 			children = (
 				5C4B453A1E42A72C002651C8 /* stack.c */,
 			);
-			name = stack;
+			path = stack;
 			sourceTree = "<group>";
 		};
 		5C4B44621E42A698002651C8 /* x509 */ = {
@@ -16224,7 +16189,7 @@
 				5C4B44CC1E42A6F7002651C8 /* x_x509.c */,
 				5C4B44CD1E42A6F7002651C8 /* x_x509a.c */,
 			);
-			name = x509;
+			path = x509;
 			sourceTree = "<group>";
 		};
 		5C4B44631E42A6A7002651C8 /* x509v3 */ = {
@@ -16255,7 +16220,7 @@
 				5C4B44841E42A6E2002651C8 /* v3_skey.c */,
 				5C4B44861E42A6E2002651C8 /* v3_utl.c */,
 			);
-			name = x509v3;
+			path = x509v3;
 			sourceTree = "<group>";
 		};
 		5C4B47D41E42C00F002651C8 /* conf */ = {
@@ -16265,7 +16230,7 @@
 				5C4B47D51E42C01C002651C8 /* conf_def.h */,
 				5C4B47D71E42C01C002651C8 /* internal.h */,
 			);
-			name = conf;
+			path = conf;
 			sourceTree = "<group>";
 		};
 		5C4B47DE1E42C04D002651C8 /* ssl */ = {
@@ -16370,7 +16335,7 @@
 				4131BF6C234B88A10028A615 /* video_source_base.cc */,
 				4131BF72234B88A20028A615 /* video_source_base.h */,
 			);
-			name = base;
+			path = base;
 			sourceTree = "<group>";
 		};
 		5C4B484B1E42C199002651C8 /* engine */ = {
@@ -16401,7 +16366,7 @@
 				4131C26C234B8CC20028A615 /* webrtc_voice_engine.cc */,
 				4131C26A234B8CC20028A615 /* webrtc_voice_engine.h */,
 			);
-			name = engine;
+			path = engine;
 			sourceTree = "<group>";
 		};
 		5C4B4A901E42C4C8002651C8 /* opus */ = {
@@ -16409,7 +16374,7 @@
 			children = (
 				5C4B4A911E42C4E3002651C8 /* src */,
 			);
-			name = opus;
+			path = opus;
 			sourceTree = "<group>";
 		};
 		5C4B4A911E42C4E3002651C8 /* src */ = {
@@ -16420,8 +16385,7 @@
 				5CDD8D5D1E43C7C700621E92 /* silk */,
 				5C4B4A921E42C522002651C8 /* src */,
 			);
-			name = src;
-			path = opus/src;
+			path = src;
 			sourceTree = "<group>";
 		};
 		5C4B4A921E42C522002651C8 /* src */ = {
@@ -16445,7 +16409,7 @@
 				5C4B4AA11E42C52D002651C8 /* repacketizer_demo.c */,
 				5C4B4AA31E42C52D002651C8 /* tansig_table.h */,
 			);
-			name = src;
+			path = src;
 			sourceTree = "<group>";
 		};
 		5C4B4B571E431C20002651C8 /* sdk */ = {
@@ -16454,7 +16418,7 @@
 				5C4B4B581E431C49002651C8 /* objc */,
 				419C84961FE2FE9C0040C30F /* WebKit */,
 			);
-			name = sdk;
+			path = sdk;
 			sourceTree = "<group>";
 		};
 		5C4B4B581E431C49002651C8 /* objc */ = {
@@ -16467,7 +16431,7 @@
 				4144B3EC2169C61C004363AC /* helpers */,
 				416225C72169814100A91C9B /* native */,
 			);
-			name = objc;
+			path = objc;
 			sourceTree = "<group>";
 		};
 		5C4B4B591E431C55002651C8 /* Framework */ = {
@@ -16477,7 +16441,7 @@
 				413A24001FE198BE00373E99 /* Headers */,
 				419241F7212765EE00634FCF /* Native */,
 			);
-			name = Framework;
+			path = Framework;
 			sourceTree = "<group>";
 		};
 		5C4B4B5A1E431C63002651C8 /* Classes */ = {
@@ -16488,8 +16452,7 @@
 				4145E4931EF890E500FCF6E6 /* Video */,
 				4145E4971EF8918600FCF6E6 /* VideoToolbox */,
 			);
-			name = Classes;
-			path = sdk/objc/Framework/Classes;
+			path = Classes;
 			sourceTree = "<group>";
 		};
 		5C4B4C0F1E431F49002651C8 /* common_video */ = {
@@ -16573,7 +16536,7 @@
 				5CD286261E6A669D0094FDC8 /* rtp_to_ntp_estimator.cc */,
 				5C4B4CB41E4320A9002651C8 /* sleep.cc */,
 			);
-			name = source;
+			path = source;
 			sourceTree = "<group>";
 		};
 		5C4B4CF01E432156002651C8 /* curve25519 */ = {
@@ -16585,7 +16548,7 @@
 				412FF943254B10A5001DF036 /* internal.h */,
 				5C4B4CF61E432168002651C8 /* spake25519.c */,
 			);
-			name = curve25519;
+			path = curve25519;
 			sourceTree = "<group>";
 		};
 		5C4B4D2D1E4323AA002651C8 /* libyuv */ = {
@@ -16638,7 +16601,7 @@
 				41D7291726650F1100651A0B /* scale_uv.cc */,
 				5C4B4D5A1E4323D4002651C8 /* video_common.cc */,
 			);
-			name = source;
+			path = source;
 			sourceTree = "<group>";
 		};
 		5C63F8CB1E416CC3002CA531 /* third_party */ = {
@@ -17203,7 +17166,7 @@
 				413091F91EF8CFF300757C55 /* builtin_audio_encoder_factory.cc */,
 				413091FA1EF8CFF800757C55 /* builtin_audio_encoder_factory.h */,
 			);
-			name = audio_codecs;
+			path = audio_codecs;
 			sourceTree = "<group>";
 		};
 		5CD2854A1E6A62090094FDC8 /* utility */ = {
@@ -17216,7 +17179,7 @@
 				4131C44A234C80DC0028A615 /* channel_mixing_matrix.cc */,
 				4131C447234C80DB0028A615 /* channel_mixing_matrix.h */,
 			);
-			name = utility;
+			path = utility;
 			sourceTree = "<group>";
 		};
 		5CD2855F1E6A63050094FDC8 /* aec3 */ = {
@@ -17373,7 +17336,7 @@
 				5CDD83511E43257200621E92 /* sps_vui_rewriter.cc */,
 				5CDD83521E43257200621E92 /* sps_vui_rewriter.h */,
 			);
-			name = h264;
+			path = h264;
 			sourceTree = "<group>";
 		};
 		5CDD83651E4325C200621E92 /* libyuv */ = {
@@ -17382,7 +17345,7 @@
 				4145E48F1EF88EF500FCF6E6 /* include */,
 				5CDD83661E4325D500621E92 /* webrtc_libyuv.cc */,
 			);
-			name = libyuv;
+			path = libyuv;
 			sourceTree = "<group>";
 		};
 		5CDD83681E4399E400621E92 /* modules */ = {
@@ -17590,7 +17553,7 @@
 				419C829C1FE20D1C0040C30F /* audio_processing_statistics.h */,
 				5CDD8FE81E43CDCA00621E92 /* mock_audio_processing.h */,
 			);
-			name = include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		5CDD84CA1E43B02D00621E92 /* utility */ = {
@@ -17692,7 +17655,7 @@
 				419C82A01FE20DC60040C30F /* video_send_stream.cc */,
 				419C82A71FE20DC90040C30F /* video_send_stream.h */,
 			);
-			name = call;
+			path = call;
 			sourceTree = "<group>";
 		};
 		5CDD853D1E43B3F800621E92 /* codecs */ = {
@@ -17855,7 +17818,7 @@
 				5CDD863D1E43B8B500621E92 /* sqrt_of_one_minus_x_squared.c */,
 				5CDD863F1E43B8B500621E92 /* vector_scaling_operations.c */,
 			);
-			name = signal_processing;
+			path = signal_processing;
 			sourceTree = "<group>";
 		};
 		5CDD86751E43B92900621E92 /* utility */ = {
@@ -17871,7 +17834,7 @@
 				4131C3E9234C7A490028A615 /* pffft_wrapper.cc */,
 				4131C3EB234C7A490028A615 /* pffft_wrapper.h */,
 			);
-			name = utility;
+			path = utility;
 			sourceTree = "<group>";
 		};
 		5CDD86961E43B98200621E92 /* echo_detector */ = {
@@ -17886,7 +17849,7 @@
 				5CDD869E1E43B99400621E92 /* normalized_covariance_estimator.cc */,
 				5CDD869F1E43B99400621E92 /* normalized_covariance_estimator.h */,
 			);
-			name = echo_detector;
+			path = echo_detector;
 			sourceTree = "<group>";
 		};
 		5CDD86C41E43BA1800621E92 /* vad */ = {
@@ -17922,7 +17885,7 @@
 				5CDD86FC1E43BA7500621E92 /* utility.cc */,
 				5CDD86FD1E43BA7500621E92 /* utility.h */,
 			);
-			name = agc;
+			path = agc;
 			sourceTree = "<group>";
 		};
 		5CDD86E61E43BA6100621E92 /* legacy */ = {
@@ -17934,7 +17897,7 @@
 				5CDD86EA1E43BA6D00621E92 /* digital_agc.h */,
 				5CDD86EB1E43BA6D00621E92 /* gain_control.h */,
 			);
-			name = legacy;
+			path = legacy;
 			sourceTree = "<group>";
 		};
 		5CDD870A1E43BAB100621E92 /* vad */ = {
@@ -17961,7 +17924,7 @@
 				5CDD87251E43BABE00621E92 /* voice_activity_detector.h */,
 				5CDD87261E43BABE00621E92 /* voice_gmm_tables.h */,
 			);
-			name = vad;
+			path = vad;
 			sourceTree = "<group>";
 		};
 		5CDD87431E43BAE900621E92 /* resampler */ = {
@@ -17977,7 +17940,7 @@
 				5CDD87501E43BAF500621E92 /* sinusoidal_linear_chirp_source.cc */,
 				5CDD87511E43BAF500621E92 /* sinusoidal_linear_chirp_source.h */,
 			);
-			name = resampler;
+			path = resampler;
 			sourceTree = "<group>";
 		};
 		5CDD876D1E43BB7E00621E92 /* isac */ = {
@@ -18012,7 +17975,7 @@
 				5CDD87A21E43BC0500621E92 /* settings.h */,
 				5CDD87A51E43BC0500621E92 /* structs.h */,
 			);
-			name = source;
+			path = source;
 			sourceTree = "<group>";
 		};
 		5CDD87E21E43BD9100621E92 /* logging */ = {
@@ -18021,7 +17984,7 @@
 				5CDD87E31E43BDA100621E92 /* apm_data_dumper.cc */,
 				5CDD87E41E43BDA100621E92 /* apm_data_dumper.h */,
 			);
-			name = logging;
+			path = logging;
 			sourceTree = "<group>";
 		};
 		5CDD87F91E43BE1C00621E92 /* rtp_rtcp */ = {
@@ -18030,7 +17993,7 @@
 				419C83B51FE2475A0040C30F /* include */,
 				5CDD87FA1E43BE2600621E92 /* source */,
 			);
-			name = rtp_rtcp;
+			path = rtp_rtcp;
 			sourceTree = "<group>";
 		};
 		5CDD87FA1E43BE2600621E92 /* source */ = {
@@ -18185,8 +18148,7 @@
 				414035F024AA0F5300BCE9B2 /* video_rtp_depacketizer_vp9.cc */,
 				414035F124AA0F5300BCE9B2 /* video_rtp_depacketizer_vp9.h */,
 			);
-			name = source;
-			path = rtp_rtcp/source;
+			path = source;
 			sourceTree = "<group>";
 		};
 		5CDD88EB1E43BF2500621E92 /* rtcp_packet */ = {
@@ -18365,7 +18327,7 @@
 				5CDD8A8C1E43C00F00621E92 /* rtp_generator.h */,
 				5CDD8A8D1E43C00F00621E92 /* rtpcat.cc */,
 			);
-			name = tools;
+			path = tools;
 			sourceTree = "<group>";
 		};
 		5CDD8ABB1E43C22200621E92 /* audio */ = {
@@ -18468,7 +18430,7 @@
 				5CDD8C831E43C66000621E92 /* wpd_tree.cc */,
 				5CDD8C841E43C66000621E92 /* wpd_tree.h */,
 			);
-			name = transient;
+			path = transient;
 			sourceTree = "<group>";
 		};
 		5CDD8C9D1E43C6EB00621E92 /* cng */ = {
@@ -18479,7 +18441,7 @@
 				5CDD8CA41E43C6F700621E92 /* webrtc_cng.cc */,
 				5CDD8CA51E43C6F700621E92 /* webrtc_cng.h */,
 			);
-			name = cng;
+			path = cng;
 			sourceTree = "<group>";
 		};
 		5CDD8CAC1E43C72300621E92 /* celt */ = {
@@ -18551,7 +18513,7 @@
 				5CDD8D1B1E43C76400621E92 /* x86cpu.c */,
 				5CDD8D1C1E43C76400621E92 /* x86cpu.h */,
 			);
-			name = x86;
+			path = x86;
 			sourceTree = "<group>";
 		};
 		5CDD8D5D1E43C7C700621E92 /* silk */ = {
@@ -18659,7 +18621,7 @@
 				5CDD8DC11E43C7D900621E92 /* VAD.c */,
 				5CDD8DC21E43C7D900621E92 /* VQ_WMat_EC.c */,
 			);
-			name = silk;
+			path = silk;
 			sourceTree = "<group>";
 		};
 		5CDD8E241E43C7DC00621E92 /* x86 */ = {
@@ -18673,7 +18635,7 @@
 				418938BA242A3D37007FDC41 /* VQ_WMat_EC_sse4_1.c */,
 				5CDD8E2B1E43C7EC00621E92 /* x86_silk_map.c */,
 			);
-			name = x86;
+			path = x86;
 			sourceTree = "<group>";
 		};
 		5CDD8E9B1E43C9A400621E92 /* float */ = {
@@ -18711,7 +18673,7 @@
 				5CDD8EBC1E43C9C100621E92 /* warped_autocorrelation_FLP.c */,
 				5CDD8EBD1E43C9C100621E92 /* wrappers_FLP.c */,
 			);
-			name = float;
+			path = float;
 			sourceTree = "<group>";
 		};
 		5CDD8F021E43CA1300621E92 /* fixed */ = {
@@ -18743,7 +18705,7 @@
 				5CDD8F1D1E43CAF900621E92 /* vector_ops_FIX.c */,
 				5CDD8F1E1E43CAF900621E92 /* warped_autocorrelation_FIX.c */,
 			);
-			name = fixed;
+			path = fixed;
 			sourceTree = "<group>";
 		};
 		5CDD8F551E43CBCA00621E92 /* audio_network_adaptor */ = {
@@ -18772,7 +18734,7 @@
 				5CDD8F721E43CBE000621E92 /* frame_length_controller.h */,
 				DDF30A0A27C59A6E006A526F /* frame_length_controller_v2.h */,
 			);
-			name = audio_network_adaptor;
+			path = audio_network_adaptor;
 			sourceTree = "<group>";
 		};
 		5CDD8F951E43CCA200621E92 /* pacing */ = {
@@ -18855,7 +18817,7 @@
 				413111CA2552A36B001B9D95 /* pcm16b_common.cc */,
 				413111CB2552A36C001B9D95 /* pcm16b_common.h */,
 			);
-			name = pcm16b;
+			path = pcm16b;
 			sourceTree = "<group>";
 		};
 		5CDD90331E43CF2700621E92 /* logging */ = {
@@ -18886,7 +18848,7 @@
 				419C84191FE24AEE0040C30F /* rtc_stream_config.cc */,
 				419C841A1FE24AEE0040C30F /* rtc_stream_config.h */,
 			);
-			name = rtc_event_log;
+			path = rtc_event_log;
 			sourceTree = "<group>";
 		};
 		5CDD90841E43D30300621E92 /* libsrtp */ = {
@@ -18905,7 +18867,7 @@
 				5CDD90871E43D33800621E92 /* ekt.c */,
 				5CDD90881E43D33800621E92 /* srtp.c */,
 			);
-			name = srtp;
+			path = srtp;
 			sourceTree = "<group>";
 		};
 		5CDD908B1E43D4A700621E92 /* crypto */ = {
@@ -18928,7 +18890,7 @@
 				5CDD908E1E43D4CC00621E92 /* rdbx.c */,
 				5CDD908F1E43D4CC00621E92 /* ut_sim.c */,
 			);
-			name = replay;
+			path = replay;
 			sourceTree = "<group>";
 		};
 		5CDD90931E43D4E400621E92 /* cipher */ = {
@@ -18939,7 +18901,7 @@
 				5CDD90AC1E43D52900621E92 /* cipher.c */,
 				5CDD90AD1E43D52900621E92 /* null_cipher.c */,
 			);
-			name = cipher;
+			path = cipher;
 			sourceTree = "<group>";
 		};
 		5CDD90941E43D4ED00621E92 /* hash */ = {
@@ -18949,7 +18911,7 @@
 				5CDD90A51E43D51B00621E92 /* hmac_ossl.c */,
 				5CDD90A61E43D51B00621E92 /* null_auth.c */,
 			);
-			name = hash;
+			path = hash;
 			sourceTree = "<group>";
 		};
 		5CDD90951E43D4F000621E92 /* kernel */ = {
@@ -18960,7 +18922,7 @@
 				5CDD909E1E43D51100621E92 /* err.c */,
 				5CDD909F1E43D51100621E92 /* key.c */,
 			);
-			name = kernel;
+			path = kernel;
 			sourceTree = "<group>";
 		};
 		5CDD90961E43D4F600621E92 /* math */ = {
@@ -18969,7 +18931,7 @@
 				5CDD90981E43D50900621E92 /* datatypes.c */,
 				5CDD90991E43D50900621E92 /* stat.c */,
 			);
-			name = math;
+			path = math;
 			sourceTree = "<group>";
 		};
 		5CFACF59226E99F20056C7D0 /* pkcs7 */ = {
@@ -18978,7 +18940,7 @@
 				5CFACF5B226E9A1A0056C7D0 /* pkcs7.c */,
 				5CFACF5A226E9A1A0056C7D0 /* pkcs7_x509.c */,
 			);
-			name = pkcs7;
+			path = pkcs7;
 			sourceTree = "<group>";
 		};
 		5D7C59C41208C68B001C873E /* Configurations */ = {
@@ -19296,8 +19258,7 @@
 			children = (
 				DD77E13327F6813700DC90C0 /* unit_base.h */,
 			);
-			name = units;
-			path = rtc_base/units;
+			path = units;
 			sourceTree = "<group>";
 		};
 		DD77E13927F75D8E00DC90C0 /* internal */ = {
@@ -19331,8 +19292,7 @@
 				DD77E13E27F75D8F00DC90C0 /* unordered_set_members_test.h */,
 				DD77E15727F75D8F00DC90C0 /* unordered_set_modifiers_test.h */,
 			);
-			name = internal;
-			path = container/internal;
+			path = internal;
 			sourceTree = "<group>";
 		};
 		DD77E1D427F7E55500DC90C0 /* h265 */ = {
@@ -19361,8 +19321,7 @@
 				DD77E1DF27F7E64200DC90C0 /* invoke.h */,
 				DD77E1DA27F7E64200DC90C0 /* move_only_int.h */,
 			);
-			name = containers;
-			path = rtc_base/containers;
+			path = containers;
 			sourceTree = "<group>";
 		};
 		DD77E1F427FB766800DC90C0 /* internal */ = {
@@ -19379,8 +19338,7 @@
 				DD77E1F527FB766800DC90C0 /* transform_args.h */,
 				DD77E1FF27FB766800DC90C0 /* variant.h */,
 			);
-			name = internal;
-			path = types/internal;
+			path = internal;
 			sourceTree = "<group>";
 		};
 		DDEBB11F24C0191800ADBD44 /* libaom */ = {
@@ -19440,8 +19398,7 @@
 				DDF30D8527C5C6BC006A526F /* audio_network_adaptor.h */,
 				DDF30D8427C5C6BC006A526F /* audio_network_adaptor_config.h */,
 			);
-			name = include;
-			path = audio_network_adaptor/include;
+			path = include;
 			sourceTree = "<group>";
 		};
 		DDF30D8F27C5C725006A526F /* include */ = {


### PR DESCRIPTION
#### 36c3a8590f2b585a915209dff2c583b1ad6dc597
<pre>
Follow-up: Clean up libwebrtc Xcode project
<a href="https://bugs.webkit.org/show_bug.cgi?id=262527">https://bugs.webkit.org/show_bug.cgi?id=262527</a>
&lt;rdar://116386161&gt;

Unreviewed Xcode project clean-up.

* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
- Run `tidy-Xcode-project-file --map-folders` on the Xcode project.
  (See Bug 188754.)

Canonical link: <a href="https://commits.webkit.org/268773@main">https://commits.webkit.org/268773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12cf1ed20c4f656ce7e8e42f8538f73d58ffcb0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21265 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20888 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/20713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/17965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23416 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/18771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/18958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/18948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19539 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23096 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2550 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->