### PR TITLE
[WGSL] Rewrite pointer variables

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -63,8 +63,9 @@ protected:
         : Node(span)
     { }
 
-private:
     const Type* m_inferredType { nullptr };
+
+private:
     std::optional<ConstantValue> m_constantValue { std::nullopt };
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTIdentityExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentityExpression.h
@@ -44,7 +44,9 @@ private:
     IdentityExpression(SourceSpan span, Expression::Ref&& expression)
         : Expression(span)
         , m_expression(WTFMove(expression))
-    { }
+    {
+        m_inferredType = m_expression.get().inferredType();
+    }
 
     Expression::Ref m_expression;
 };

--- a/Source/WebGPU/WGSL/AST/ASTParameter.h
+++ b/Source/WebGPU/WGSL/AST/ASTParameter.h
@@ -45,10 +45,15 @@ public:
     using List = ReferenceWrapperVector<Parameter>;
 
     NodeKind kind() const override;
+    ParameterRole role() const { return m_role; }
+
     Identifier& name() { return m_name; }
     Expression& typeName() { return m_typeName.get(); }
     Attribute::List& attributes() { return m_attributes; }
-    ParameterRole role() { return m_role; }
+
+    const Identifier& name() const { return m_name; }
+    const Expression& typeName() const { return m_typeName.get(); }
+    const Attribute::List& attributes() const { return m_attributes; }
 
 private:
     Parameter(SourceSpan span, Identifier&& name, Expression::Ref&& typeName, Attribute::List&& attributes, ParameterRole role)

--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -56,6 +56,7 @@ public:
     VariableFlavor flavor() const { return m_flavor; };
     VariableFlavor& flavor() { return m_flavor; };
     Identifier& name() { return m_name; }
+    Identifier& originalName() { return m_originalName; }
     Attribute::List& attributes() { return m_attributes; }
     VariableQualifier* maybeQualifier() { return m_qualifier; }
     Expression* maybeTypeName() { return m_type; }
@@ -76,6 +77,7 @@ private:
     Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr qualifier, Expression::Ptr type, Expression::Ptr initializer, Attribute::List&& attributes)
         : Declaration(span)
         , m_name(WTFMove(name))
+        , m_originalName(m_name)
         , m_attributes(WTFMove(attributes))
         , m_qualifier(qualifier)
         , m_type(type)
@@ -86,6 +88,7 @@ private:
     }
 
     Identifier m_name;
+    Identifier m_originalName;
     Attribute::List m_attributes;
     // Each of the following may be null
     // But at least one of type and initializer must be non-null

--- a/Source/WebGPU/WGSL/CallGraph.h
+++ b/Source/WebGPU/WGSL/CallGraph.h
@@ -35,6 +35,11 @@ namespace WGSL {
 
 class ShaderModule;
 struct PipelineLayout;
+struct PrepareResult;
+
+namespace Reflection {
+struct EntryPointInformation;
+}
 
 class CallGraph {
     friend class CallGraphBuilder;
@@ -48,6 +53,7 @@ public:
     struct EntryPoint {
         AST::Function& function;
         AST::StageAttribute::Stage stage;
+        Reflection::EntryPointInformation& information;
     };
 
     ShaderModule& ast() const { return m_ast; }
@@ -63,6 +69,6 @@ private:
     HashMap<AST::Function*, Vector<Callee>> m_calleeMap;
 };
 
-CallGraph buildCallGraph(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts);
+CallGraph buildCallGraph(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts, PrepareResult&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/EntryPointRewriter.h
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.h
@@ -30,6 +30,6 @@ namespace WGSL {
 class CallGraph;
 struct PrepareResult;
 
-void rewriteEntryPoints(CallGraph&, PrepareResult&);
+void rewriteEntryPoints(CallGraph&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/PointerRewriter.cpp
+++ b/Source/WebGPU/WGSL/PointerRewriter.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PointerRewriter.h"
+
+#include "AST.h"
+#include "ASTVisitor.h"
+#include "CallGraph.h"
+#include "ContextProviderInlines.h"
+#include "WGSL.h"
+#include "WGSLShaderModule.h"
+#include <wtf/SetForScope.h>
+
+namespace WGSL {
+
+class PointerRewriter : public AST::Visitor, public ContextProvider<AST::Expression*> {
+public:
+    PointerRewriter(CallGraph& callGraph)
+        : AST::Visitor()
+        , m_callGraph(callGraph)
+    {
+    }
+
+    void run();
+
+    void visit(AST::CompoundStatement&) override;
+    void visit(AST::ForStatement&) override;
+    void visit(AST::VariableStatement&) override;
+    void visit(AST::PhonyAssignmentStatement&) override;
+    void visit(AST::IdentifierExpression&) override;
+    void visit(AST::UnaryExpression&) override;
+
+private:
+    CallGraph& m_callGraph;
+    unsigned m_currentStatementIndex { 0 };
+    Vector<unsigned> m_indicesToDelete;
+};
+
+void PointerRewriter::run()
+{
+    AST::Visitor::visit(m_callGraph.ast());
+}
+
+void PointerRewriter::visit(AST::CompoundStatement& statement)
+{
+    auto indexScope = SetForScope(m_currentStatementIndex, 0);
+    auto insertionScope = SetForScope(m_indicesToDelete, Vector<unsigned>());
+    ContextScope blockScope(this);
+
+    for (auto& statement : statement.statements()) {
+        AST::Visitor::visit(statement);
+        ++m_currentStatementIndex;
+    }
+
+    for (int i = m_indicesToDelete.size() - 1; i >= 0; --i)
+        m_callGraph.ast().remove(statement.statements(), m_indicesToDelete[i]);
+}
+
+void PointerRewriter::visit(AST::ForStatement& statement)
+{
+    ContextScope forScope(this);
+    AST::Visitor::visit(statement);
+}
+
+void PointerRewriter::visit(AST::VariableStatement& statement)
+{
+    AST::Visitor::visit(statement);
+
+    auto& variable = statement.variable();
+    auto* initializer = variable.maybeInitializer();
+    if (!initializer) {
+        introduceVariable(variable.name(), nullptr);
+        return;
+    }
+
+    auto* pointerType = std::get_if<Types::Pointer>(initializer->inferredType());
+    if (!pointerType) {
+        introduceVariable(variable.name(), nullptr);
+        return;
+    }
+
+    introduceVariable(variable.name(), initializer);
+    m_indicesToDelete.append(m_currentStatementIndex);
+}
+
+void PointerRewriter::visit(AST::PhonyAssignmentStatement& statement)
+{
+    auto* pointerType = std::get_if<Types::Pointer>(statement.rhs().inferredType());
+    if (!pointerType)
+        return;
+    m_indicesToDelete.append(m_currentStatementIndex);
+}
+
+void PointerRewriter::visit(AST::IdentifierExpression& identifier)
+{
+    auto* variable = readVariable(identifier.identifier());
+    if (!variable || !*variable)
+        return;
+
+    m_callGraph.ast().replace(identifier, **variable);
+}
+
+void PointerRewriter::visit(AST::UnaryExpression& unary)
+{
+    AST::Visitor::visit(unary);
+
+    if (unary.operation() != AST::UnaryOperation::Dereference)
+        return;
+
+    AST::Expression* nested = &unary.expression();
+    while (is<AST::IdentityExpression>(*nested))
+        nested = &downcast<AST::IdentityExpression>(*nested).expression();
+    if (!is<AST::UnaryExpression>(*nested))
+        return;
+
+    auto& nestedUnary = downcast<AST::UnaryExpression>(*nested);
+    if (nestedUnary.operation() != AST::UnaryOperation::AddressOf)
+        return;
+
+    m_callGraph.ast().replace(unary, nestedUnary.expression());
+}
+
+void rewritePointers(CallGraph& callGraph)
+{
+    PointerRewriter(callGraph).run();
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/PointerRewriter.h
+++ b/Source/WebGPU/WGSL/PointerRewriter.h
@@ -25,13 +25,10 @@
 
 #pragma once
 
-#include <wtf/text/WTFString.h>
-
 namespace WGSL {
 
 class CallGraph;
-struct PipelineLayout;
 
-void rewriteGlobalVariables(CallGraph&, const HashMap<String, std::optional<PipelineLayout>>&);
+void rewritePointers(CallGraph&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -35,6 +35,7 @@
 #include "Metal/MetalCodeGenerator.h"
 #include "Parser.h"
 #include "PhaseTimer.h"
+#include "PointerRewriter.h"
 #include "TypeCheck.h"
 #include "WGSLShaderModule.h"
 
@@ -97,10 +98,11 @@ inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, std::o
     {
         PhaseTimer phaseTimer("prepare total", phaseTimes);
 
-        RUN_PASS_WITH_RESULT(callGraph, buildCallGraph, ast, pipelineLayouts);
-        RUN_PASS(rewriteEntryPoints, callGraph, result);
-        RUN_PASS(rewriteGlobalVariables, callGraph, pipelineLayouts, result);
+        RUN_PASS_WITH_RESULT(callGraph, buildCallGraph, ast, pipelineLayouts, result);
         RUN_PASS(mangleNames, callGraph, result);
+        RUN_PASS(rewritePointers, callGraph);
+        RUN_PASS(rewriteEntryPoints, callGraph);
+        RUN_PASS(rewriteGlobalVariables, callGraph, pipelineLayouts);
 
         dumpASTAtEndIfNeeded(ast);
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -96,7 +96,7 @@ public:
     }
 
     template<typename CurrentType, typename ReplacementType>
-    std::enable_if_t<sizeof(CurrentType) < sizeof(ReplacementType), void> replace(CurrentType& current, ReplacementType& replacement)
+    std::enable_if_t<sizeof(CurrentType) < sizeof(ReplacementType) || std::is_same_v<ReplacementType, AST::Expression>, void> replace(CurrentType& current, ReplacementType& replacement)
     {
         m_replacements.append([&current, currentCopy = current]() mutable {
             bitwise_cast<AST::IdentityExpression*>(&current)->~IdentityExpression();
@@ -108,7 +108,7 @@ public:
     }
 
     template<typename CurrentType, typename ReplacementType>
-    std::enable_if_t<sizeof(CurrentType) >= sizeof(ReplacementType), void> replace(CurrentType& current, ReplacementType& replacement)
+    std::enable_if_t<sizeof(CurrentType) >= sizeof(ReplacementType) && !std::is_same_v<ReplacementType, AST::Expression>, void> replace(CurrentType& current, ReplacementType& replacement)
     {
         m_replacements.append([&current, currentCopy = current]() mutable {
             bitwise_cast<ReplacementType*>(&current)->~ReplacementType();
@@ -148,6 +148,37 @@ public:
         m_replacements.append([&vector, position]() {
             vector.remove(position);
         });
+    }
+
+    template<typename T, size_t size, typename T2, size_t size2>
+    void insertVector(const Vector<T, size>& constVector, size_t position, const Vector<T2, size2>& value)
+    {
+        auto& vector = const_cast<Vector<T, size>&>(constVector);
+        vector.insertVector(position, value);
+        m_replacements.append([&vector, position, length = value.size()]() {
+            vector.remove(position, length);
+        });
+    }
+
+    template<typename T, size_t size>
+    void remove(const Vector<T, size>& constVector, size_t position)
+    {
+        auto& vector = const_cast<Vector<T, size>&>(constVector);
+        auto entry = vector[position];
+        m_replacements.append([&vector, position, entry]() mutable {
+            vector.insert(position, entry);
+        });
+        vector.remove(position);
+    }
+
+    template<typename T, size_t size>
+    void clear(const Vector<T, size>& constVector)
+    {
+        auto& vector = const_cast<Vector<T, size>&>(constVector);
+        m_replacements.append([&vector, contents = WTFMove(vector)]() mutable {
+            vector = contents;
+        });
+        vector.clear();
     }
 
     void revertReplacements()

--- a/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
@@ -4,10 +4,10 @@
 var<private> x: i32;
 var<private> y: i32;
 
-// CHECK: int function\d\(int parameter\d\)
+// CHECK: int function\d\(int global\d\)
 fn f() -> i32
 {
-    //CHECK: parameter\d
+    //CHECK: global\d
     _ = y;
     return 0;
 }
@@ -19,25 +19,25 @@ fn g() -> i32
     return 0;
 }
 
-// CHECK: int function\d\(int parameter\d\)
+// CHECK: int function\d\(int global\d\)
 fn h() -> i32
 {
     _ = y;
     return 0;
 }
 
-// CHECK: int function\d\(int parameter\d\)
+// CHECK: int function\d\(int global\d\)
 fn i() -> i32
 {
-    // CHECK: function\d\(parameter\d\)
+    // CHECK: function\d\(global\d\)
     _ = f();
     return 0;
 }
 
-// CHECK: float function\d\(float parameter\d, int parameter\d\)
+// CHECK: float function\d\(float parameter\d, int global\d\)
 fn j(x: f32) -> f32
 {
-    // CHECK: function\d\(parameter\d\)
+    // CHECK: function\d\(global\d\)
     _ = f();
     return x;
 }
@@ -45,22 +45,22 @@ fn j(x: f32) -> f32
 @compute @workgroup_size(1)
 fn main()
 {
-    // CHECK: int local\d
-    // CHECK: int local\d
+    // CHECK: int global\d
+    // CHECK: int global\d
     _ = x;
 
-    // CHECK: function\d\(local\d\)
+    // CHECK: function\d\(global\d\)
     _ = f();
 
     // CHECK: function\d\(\)
     _ = g();
 
-    // CHECK: function\d\(local\d\)
+    // CHECK: function\d\(global\d\)
     _ = h();
 
-    // CHECK: function\d\(local\d\)
+    // CHECK: function\d\(global\d\)
     _ = i();
 
-    // CHECK: function\d\(function\d\(42., local\d\), local\d\)
+    // CHECK: function\d\(function\d\(42., global\d\), global\d\)
     _ = j(j(42));
 }

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -38,19 +38,19 @@ fn testUnpacked() -> i32
 fn testAssignment() -> i32
 {
     // packed struct
-    // CHECK: local\d+ = __unpack\(parameter\d+\);
+    // CHECK: local\d+ = __unpack\(global\d+\);
     var t = t1;
-    // CHECK-NEXT: parameter\d+ = parameter\d+;
+    // CHECK-NEXT: global\d+ = global\d+;
     t1 = t2;
-    // CHECK-NEXT: parameter\d+ = __pack\(local\d+\);
+    // CHECK-NEXT: global\d+ = __pack\(local\d+\);
     t2 = t;
 
     // array of packed structs
-    // CHECK-NEXT: local\d+ = __unpack_array\(parameter\d+\);
+    // CHECK-NEXT: local\d+ = __unpack_array\(global\d+\);
     var at = at1;
-    // CHECK-NEXT: parameter\d+ = parameter\d+;
+    // CHECK-NEXT: global\d+ = global\d+;
     at1 = at2;
-    // CHECK-NEXT: parameter\d+ = __pack_array\(local\d+\);
+    // CHECK-NEXT: global\d+ = __pack_array\(local\d+\);
     at2 = at;
 
     return 0;
@@ -58,20 +58,20 @@ fn testAssignment() -> i32
 
 fn testFieldAccess() -> i32
 {
-    // CHECK: parameter\d+\.v2f\.x = parameter\d+\.v2f\.x;
-    // CHECK-NEXT: parameter\d+\.v3f\.x = parameter\d+\.v3f\.x;
-    // CHECK-NEXT: parameter\d+\.v4f\.x = parameter\d+\.v4f\.x;
-    // CHECK-NEXT: parameter\d+\.v2u\.x = parameter\d+\.v2u\.x;
-    // CHECK-NEXT: parameter\d+\.v3u\.x = parameter\d+\.v3u\.x;
-    // CHECK-NEXT: parameter\d+\.v4u\.x = parameter\d+\.v4u\.x;
-    // CHECK-NEXT: parameter\d+\.v2f = parameter\d+\.v2f;
-    // CHECK-NEXT: parameter\d+\.v3f = float3\(parameter\d+\.v3f\);
-    // CHECK-NEXT: parameter\d+\.v4f = parameter\d+\.v4f;
-    // CHECK-NEXT: parameter\d+\.v2u = parameter\d+\.v2u;
-    // CHECK-NEXT: parameter\d+\.v3u = uint3\(parameter\d+\.v3u\);
-    // CHECK-NEXT: parameter\d+\.v4u = parameter\d+\.v4u;
-    // CHECK-NEXT: parameter\d+\.f = parameter\d+\.f;
-    // CHECK-NEXT: parameter\d+\.u = parameter\d+\.u;
+    // CHECK: global\d+\.v2f\.x = global\d+\.v2f\.x;
+    // CHECK-NEXT: global\d+\.v3f\.x = global\d+\.v3f\.x;
+    // CHECK-NEXT: global\d+\.v4f\.x = global\d+\.v4f\.x;
+    // CHECK-NEXT: global\d+\.v2u\.x = global\d+\.v2u\.x;
+    // CHECK-NEXT: global\d+\.v3u\.x = global\d+\.v3u\.x;
+    // CHECK-NEXT: global\d+\.v4u\.x = global\d+\.v4u\.x;
+    // CHECK-NEXT: global\d+\.v2f = global\d+\.v2f;
+    // CHECK-NEXT: global\d+\.v3f = float3\(global\d+\.v3f\);
+    // CHECK-NEXT: global\d+\.v4f = global\d+\.v4f;
+    // CHECK-NEXT: global\d+\.v2u = global\d+\.v2u;
+    // CHECK-NEXT: global\d+\.v3u = uint3\(global\d+\.v3u\);
+    // CHECK-NEXT: global\d+\.v4u = global\d+\.v4u;
+    // CHECK-NEXT: global\d+\.f = global\d+\.f;
+    // CHECK-NEXT: global\d+\.u = global\d+\.u;
     t.v2f.x = t1.v2f.x;
     t.v3f.x = t1.v3f.x;
     t.v4f.x = t1.v4f.x;
@@ -87,20 +87,20 @@ fn testFieldAccess() -> i32
     t.f     = t1.f;
     t.u     = t1.u;
 
-    // CHECK-NEXT: parameter\d+\.v2f\.x = parameter\d+\.v2f\.x;
-    // CHECK-NEXT: parameter\d+\.v3f\.x = parameter\d+\.v3f\.x;
-    // CHECK-NEXT: parameter\d+\.v4f\.x = parameter\d+\.v4f\.x;
-    // CHECK-NEXT: parameter\d+\.v2u\.x = parameter\d+\.v2u\.x;
-    // CHECK-NEXT: parameter\d+\.v3u\.x = parameter\d+\.v3u\.x;
-    // CHECK-NEXT: parameter\d+\.v4u\.x = parameter\d+\.v4u\.x;
-    // CHECK-NEXT: parameter\d+\.v2f = parameter\d+\.v2f;
-    // CHECK-NEXT: parameter\d+\.v3f = parameter\d+\.v3f;
-    // CHECK-NEXT: parameter\d+\.v4f = parameter\d+\.v4f;
-    // CHECK-NEXT: parameter\d+\.v2u = parameter\d+\.v2u;
-    // CHECK-NEXT: parameter\d+\.v3u = parameter\d+\.v3u;
-    // CHECK-NEXT: parameter\d+\.v4u = parameter\d+\.v4u;
-    // CHECK-NEXT: parameter\d+\.f = parameter\d+\.f;
-    // CHECK-NEXT: parameter\d+\.u = parameter\d+\.u;
+    // CHECK-NEXT: global\d+\.v2f\.x = global\d+\.v2f\.x;
+    // CHECK-NEXT: global\d+\.v3f\.x = global\d+\.v3f\.x;
+    // CHECK-NEXT: global\d+\.v4f\.x = global\d+\.v4f\.x;
+    // CHECK-NEXT: global\d+\.v2u\.x = global\d+\.v2u\.x;
+    // CHECK-NEXT: global\d+\.v3u\.x = global\d+\.v3u\.x;
+    // CHECK-NEXT: global\d+\.v4u\.x = global\d+\.v4u\.x;
+    // CHECK-NEXT: global\d+\.v2f = global\d+\.v2f;
+    // CHECK-NEXT: global\d+\.v3f = global\d+\.v3f;
+    // CHECK-NEXT: global\d+\.v4f = global\d+\.v4f;
+    // CHECK-NEXT: global\d+\.v2u = global\d+\.v2u;
+    // CHECK-NEXT: global\d+\.v3u = global\d+\.v3u;
+    // CHECK-NEXT: global\d+\.v4u = global\d+\.v4u;
+    // CHECK-NEXT: global\d+\.f = global\d+\.f;
+    // CHECK-NEXT: global\d+\.u = global\d+\.u;
     t1.v2f.x = t2.v2f.x;
     t1.v3f.x = t2.v3f.x;
     t1.v4f.x = t2.v4f.x;
@@ -116,20 +116,20 @@ fn testFieldAccess() -> i32
     t1.f     = t2.f;
     t1.u     = t2.u;
 
-    // CHECK-NEXT: parameter\d+\.v2f\.x = parameter\d+\.v2f\.x;
-    // CHECK-NEXT: parameter\d+\.v3f\.x = parameter\d+\.v3f\.x;
-    // CHECK-NEXT: parameter\d+\.v4f\.x = parameter\d+\.v4f\.x;
-    // CHECK-NEXT: parameter\d+\.v2u\.x = parameter\d+\.v2u\.x;
-    // CHECK-NEXT: parameter\d+\.v3u\.x = parameter\d+\.v3u\.x;
-    // CHECK-NEXT: parameter\d+\.v4u\.x = parameter\d+\.v4u\.x;
-    // CHECK-NEXT: parameter\d+\.v2f = parameter\d+\.v2f;
-    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(parameter\d+\.v3f\);
-    // CHECK-NEXT: parameter\d+\.v4f = parameter\d+\.v4f;
-    // CHECK-NEXT: parameter\d+\.v2u = parameter\d+\.v2u;
-    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(parameter\d+\.v3u\);
-    // CHECK-NEXT: parameter\d+\.v4u = parameter\d+\.v4u;
-    // CHECK-NEXT: parameter\d+\.f = parameter\d+\.f;
-    // CHECK-NEXT: parameter\d+\.u = parameter\d+\.u;
+    // CHECK-NEXT: global\d+\.v2f\.x = global\d+\.v2f\.x;
+    // CHECK-NEXT: global\d+\.v3f\.x = global\d+\.v3f\.x;
+    // CHECK-NEXT: global\d+\.v4f\.x = global\d+\.v4f\.x;
+    // CHECK-NEXT: global\d+\.v2u\.x = global\d+\.v2u\.x;
+    // CHECK-NEXT: global\d+\.v3u\.x = global\d+\.v3u\.x;
+    // CHECK-NEXT: global\d+\.v4u\.x = global\d+\.v4u\.x;
+    // CHECK-NEXT: global\d+\.v2f = global\d+\.v2f;
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(global\d+\.v3f\);
+    // CHECK-NEXT: global\d+\.v4f = global\d+\.v4f;
+    // CHECK-NEXT: global\d+\.v2u = global\d+\.v2u;
+    // CHECK-NEXT: global\d+\.v3u = packed_uint3\(global\d+\.v3u\);
+    // CHECK-NEXT: global\d+\.v4u = global\d+\.v4u;
+    // CHECK-NEXT: global\d+\.f = global\d+\.f;
+    // CHECK-NEXT: global\d+\.u = global\d+\.u;
     t2.v2f.x = t.v2f.x;
     t2.v3f.x = t.v3f.x;
     t2.v4f.x = t.v4f.x;
@@ -150,10 +150,10 @@ fn testFieldAccess() -> i32
 
 fn testIndexAccess() -> i32
 {
-    // CHECK: local\d+ = __unpack_array\(parameter\d+\);
-    // CHECK-NEXT: local\d+\[0\] = __unpack\(parameter\d+\[0\]\);
-    // CHECK-NEXT: parameter\d+\[0\] = parameter\d+\[0\];
-    // CHECK-NEXT: parameter\d+\[0\] = __pack\(local\d+\[0\]\);
+    // CHECK: local\d+ = __unpack_array\(global\d+\);
+    // CHECK-NEXT: local\d+\[0\] = __unpack\(global\d+\[0\]\);
+    // CHECK-NEXT: global\d+\[0\] = global\d+\[0\];
+    // CHECK-NEXT: global\d+\[0\] = __pack\(local\d+\[0\]\);
     var at = at1;
     at[0] = at1[0];
     at1[0] = at2[0];
@@ -164,20 +164,20 @@ fn testIndexAccess() -> i32
 
 fn testBinaryOperations() -> i32
 {
-    // CHECK: parameter\d+\.v2f\.x = \(2. \* parameter\d+\.v2f\.x\);
-    // CHECK-NEXT: parameter\d+\.v3f\.x = \(2. \* parameter\d+\.v3f\.x\);
-    // CHECK-NEXT: parameter\d+\.v4f\.x = \(2. \* parameter\d+\.v4f\.x\);
-    // CHECK-NEXT: parameter\d+\.v2u\.x = \(2u \* parameter\d+\.v2u\.x\);
-    // CHECK-NEXT: parameter\d+\.v3u\.x = \(2u \* parameter\d+\.v3u\.x\);
-    // CHECK-NEXT: parameter\d+\.v4u\.x = \(2u \* parameter\d+\.v4u\.x\);
-    // CHECK-NEXT: parameter\d+\.v2f = \(2. \* parameter\d+\.v2f\);
-    // CHECK-NEXT: parameter\d+\.v3f = \(2. \* float3\(parameter\d+\.v3f\)\);
-    // CHECK-NEXT: parameter\d+\.v4f = \(2. \* parameter\d+\.v4f\);
-    // CHECK-NEXT: parameter\d+\.v2u = \(2u \* parameter\d+\.v2u\);
-    // CHECK-NEXT: parameter\d+\.v3u = \(2u \* uint3\(parameter\d+\.v3u\)\);
-    // CHECK-NEXT: parameter\d+\.v4u = \(2u \* parameter\d+\.v4u\);
-    // CHECK-NEXT: parameter\d+\.f = \(2. \* parameter\d+\.f\);
-    // CHECK-NEXT: parameter\d+\.u = \(2u \* parameter\d+\.u\);
+    // CHECK: global\d+\.v2f\.x = \(2. \* global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = \(2. \* global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = \(2. \* global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2u\.x = \(2u \* global\d+\.v2u\.x\);
+    // CHECK-NEXT: global\d+\.v3u\.x = \(2u \* global\d+\.v3u\.x\);
+    // CHECK-NEXT: global\d+\.v4u\.x = \(2u \* global\d+\.v4u\.x\);
+    // CHECK-NEXT: global\d+\.v2f = \(2. \* global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = \(2. \* float3\(global\d+\.v3f\)\);
+    // CHECK-NEXT: global\d+\.v4f = \(2. \* global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.v2u = \(2u \* global\d+\.v2u\);
+    // CHECK-NEXT: global\d+\.v3u = \(2u \* uint3\(global\d+\.v3u\)\);
+    // CHECK-NEXT: global\d+\.v4u = \(2u \* global\d+\.v4u\);
+    // CHECK-NEXT: global\d+\.f = \(2. \* global\d+\.f\);
+    // CHECK-NEXT: global\d+\.u = \(2u \* global\d+\.u\);
     t.v2f.x = 2 * t1.v2f.x;
     t.v3f.x = 2 * t1.v3f.x;
     t.v4f.x = 2 * t1.v4f.x;
@@ -193,20 +193,20 @@ fn testBinaryOperations() -> i32
     t.f     = 2 * t1.f;
     t.u     = 2 * t1.u;
 
-    // CHECK-NEXT: parameter\d+\.v2f\.x = \(2. \* parameter\d+\.v2f\.x\);
-    // CHECK-NEXT: parameter\d+\.v3f\.x = \(2. \* parameter\d+\.v3f\.x\);
-    // CHECK-NEXT: parameter\d+\.v4f\.x = \(2. \* parameter\d+\.v4f\.x\);
-    // CHECK-NEXT: parameter\d+\.v2u\.x = \(2u \* parameter\d+\.v2u\.x\);
-    // CHECK-NEXT: parameter\d+\.v3u\.x = \(2u \* parameter\d+\.v3u\.x\);
-    // CHECK-NEXT: parameter\d+\.v4u\.x = \(2u \* parameter\d+\.v4u\.x\);
-    // CHECK-NEXT: parameter\d+\.v2f = \(2. \* parameter\d+\.v2f\);
-    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(\(2. \* float3\(parameter\d+\.v3f\)\)\);
-    // CHECK-NEXT: parameter\d+\.v4f = \(2. \* parameter\d+\.v4f\);
-    // CHECK-NEXT: parameter\d+\.v2u = \(2u \* parameter\d+\.v2u\);
-    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(\(2u \* uint3\(parameter\d+\.v3u\)\)\);
-    // CHECK-NEXT: parameter\d+\.v4u = \(2u \* parameter\d+\.v4u\);
-    // CHECK-NEXT: parameter\d+\.f = \(2. \* parameter\d+\.f\);
-    // CHECK-NEXT: parameter\d+\.u = \(2u \* parameter\d+\.u\);
+    // CHECK-NEXT: global\d+\.v2f\.x = \(2. \* global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = \(2. \* global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = \(2. \* global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2u\.x = \(2u \* global\d+\.v2u\.x\);
+    // CHECK-NEXT: global\d+\.v3u\.x = \(2u \* global\d+\.v3u\.x\);
+    // CHECK-NEXT: global\d+\.v4u\.x = \(2u \* global\d+\.v4u\.x\);
+    // CHECK-NEXT: global\d+\.v2f = \(2. \* global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(\(2. \* float3\(global\d+\.v3f\)\)\);
+    // CHECK-NEXT: global\d+\.v4f = \(2. \* global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.v2u = \(2u \* global\d+\.v2u\);
+    // CHECK-NEXT: global\d+\.v3u = packed_uint3\(\(2u \* uint3\(global\d+\.v3u\)\)\);
+    // CHECK-NEXT: global\d+\.v4u = \(2u \* global\d+\.v4u\);
+    // CHECK-NEXT: global\d+\.f = \(2. \* global\d+\.f\);
+    // CHECK-NEXT: global\d+\.u = \(2u \* global\d+\.u\);
     t1.v2f.x = 2 * t2.v2f.x;
     t1.v3f.x = 2 * t2.v3f.x;
     t1.v4f.x = 2 * t2.v4f.x;
@@ -222,20 +222,20 @@ fn testBinaryOperations() -> i32
     t1.f     = 2 * t2.f;
     t1.u     = 2 * t2.u;
 
-    // CHECK-NEXT: parameter\d+\.v2f\.x = \(2. \* parameter\d+\.v2f\.x\);
-    // CHECK-NEXT: parameter\d+\.v3f\.x = \(2. \* parameter\d+\.v3f\.x\);
-    // CHECK-NEXT: parameter\d+\.v4f\.x = \(2. \* parameter\d+\.v4f\.x\);
-    // CHECK-NEXT: parameter\d+\.v2u\.x = \(2u \* parameter\d+\.v2u\.x\);
-    // CHECK-NEXT: parameter\d+\.v3u\.x = \(2u \* parameter\d+\.v3u\.x\);
-    // CHECK-NEXT: parameter\d+\.v4u\.x = \(2u \* parameter\d+\.v4u\.x\);
-    // CHECK-NEXT: parameter\d+\.v2f = \(2. \* parameter\d+\.v2f\);
-    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(\(2. \* parameter\d+\.v3f\)\);
-    // CHECK-NEXT: parameter\d+\.v4f = \(2. \* parameter\d+\.v4f\);
-    // CHECK-NEXT: parameter\d+\.v2u = \(2u \* parameter\d+\.v2u\);
-    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(\(2u \* parameter\d+\.v3u\)\);
-    // CHECK-NEXT: parameter\d+\.v4u = \(2u \* parameter\d+\.v4u\);
-    // CHECK-NEXT: parameter\d+\.f = \(2. \* parameter\d+\.f\);
-    // CHECK-NEXT: parameter\d+\.u = \(2u \* parameter\d+\.u\);
+    // CHECK-NEXT: global\d+\.v2f\.x = \(2. \* global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = \(2. \* global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = \(2. \* global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2u\.x = \(2u \* global\d+\.v2u\.x\);
+    // CHECK-NEXT: global\d+\.v3u\.x = \(2u \* global\d+\.v3u\.x\);
+    // CHECK-NEXT: global\d+\.v4u\.x = \(2u \* global\d+\.v4u\.x\);
+    // CHECK-NEXT: global\d+\.v2f = \(2. \* global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(\(2. \* global\d+\.v3f\)\);
+    // CHECK-NEXT: global\d+\.v4f = \(2. \* global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.v2u = \(2u \* global\d+\.v2u\);
+    // CHECK-NEXT: global\d+\.v3u = packed_uint3\(\(2u \* global\d+\.v3u\)\);
+    // CHECK-NEXT: global\d+\.v4u = \(2u \* global\d+\.v4u\);
+    // CHECK-NEXT: global\d+\.f = \(2. \* global\d+\.f\);
+    // CHECK-NEXT: global\d+\.u = \(2u \* global\d+\.u\);
     t2.v2f.x = 2 * t.v2f.x;
     t2.v3f.x = 2 * t.v3f.x;
     t2.v4f.x = 2 * t.v4f.x;
@@ -256,13 +256,13 @@ fn testBinaryOperations() -> i32
 
 fn testUnaryOperations() -> i32
 {
-    // CHECK: parameter\d+\.v2f\.x = -parameter\d+\.v2f\.x;
-    // CHECK-NEXT: parameter\d+\.v3f\.x = -parameter\d+\.v3f\.x;
-    // CHECK-NEXT: parameter\d+\.v4f\.x = -parameter\d+\.v4f\.x;
-    // CHECK-NEXT: parameter\d+\.v2f = -parameter\d+\.v2f;
-    // CHECK-NEXT: parameter\d+\.v3f = -float3\(parameter\d+\.v3f\);
-    // CHECK-NEXT: parameter\d+\.v4f = -parameter\d+\.v4f;
-    // CHECK-NEXT: parameter\d+\.f = -parameter\d+\.f;
+    // CHECK: global\d+\.v2f\.x = -global\d+\.v2f\.x;
+    // CHECK-NEXT: global\d+\.v3f\.x = -global\d+\.v3f\.x;
+    // CHECK-NEXT: global\d+\.v4f\.x = -global\d+\.v4f\.x;
+    // CHECK-NEXT: global\d+\.v2f = -global\d+\.v2f;
+    // CHECK-NEXT: global\d+\.v3f = -float3\(global\d+\.v3f\);
+    // CHECK-NEXT: global\d+\.v4f = -global\d+\.v4f;
+    // CHECK-NEXT: global\d+\.f = -global\d+\.f;
     t.v2f.x = -t1.v2f.x;
     t.v3f.x = -t1.v3f.x;
     t.v4f.x = -t1.v4f.x;
@@ -271,13 +271,13 @@ fn testUnaryOperations() -> i32
     t.v4f   = -t1.v4f;
     t.f     = -t1.f;
 
-    // CHECK-NEXT: parameter\d+\.v2f\.x = -parameter\d+\.v2f\.x;
-    // CHECK-NEXT: parameter\d+\.v3f\.x = -parameter\d+\.v3f\.x;
-    // CHECK-NEXT: parameter\d+\.v4f\.x = -parameter\d+\.v4f\.x;
-    // CHECK-NEXT: parameter\d+\.v2f = -parameter\d+\.v2f;
-    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(-float3\(parameter\d+\.v3f\)\);
-    // CHECK-NEXT: parameter\d+\.v4f = -parameter\d+\.v4f;
-    // CHECK-NEXT: parameter\d+\.f = -parameter\d+\.f;
+    // CHECK-NEXT: global\d+\.v2f\.x = -global\d+\.v2f\.x;
+    // CHECK-NEXT: global\d+\.v3f\.x = -global\d+\.v3f\.x;
+    // CHECK-NEXT: global\d+\.v4f\.x = -global\d+\.v4f\.x;
+    // CHECK-NEXT: global\d+\.v2f = -global\d+\.v2f;
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(-float3\(global\d+\.v3f\)\);
+    // CHECK-NEXT: global\d+\.v4f = -global\d+\.v4f;
+    // CHECK-NEXT: global\d+\.f = -global\d+\.f;
     t1.v2f.x = -t2.v2f.x;
     t1.v3f.x = -t2.v3f.x;
     t1.v4f.x = -t2.v4f.x;
@@ -286,13 +286,13 @@ fn testUnaryOperations() -> i32
     t1.v4f   = -t2.v4f;
     t1.f     = -t2.f;
 
-    // CHECK-NEXT: parameter\d+\.v2f\.x = -parameter\d+\.v2f\.x;
-    // CHECK-NEXT: parameter\d+\.v3f\.x = -parameter\d+\.v3f\.x;
-    // CHECK-NEXT: parameter\d+\.v4f\.x = -parameter\d+\.v4f\.x;
-    // CHECK-NEXT: parameter\d+\.v2f = -parameter\d+\.v2f;
-    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(-parameter\d+\.v3f\);
-    // CHECK-NEXT: parameter\d+\.v4f = -parameter\d+\.v4f;
-    // CHECK-NEXT: parameter\d+\.f = -parameter\d+\.f;
+    // CHECK-NEXT: global\d+\.v2f\.x = -global\d+\.v2f\.x;
+    // CHECK-NEXT: global\d+\.v3f\.x = -global\d+\.v3f\.x;
+    // CHECK-NEXT: global\d+\.v4f\.x = -global\d+\.v4f\.x;
+    // CHECK-NEXT: global\d+\.v2f = -global\d+\.v2f;
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(-global\d+\.v3f\);
+    // CHECK-NEXT: global\d+\.v4f = -global\d+\.v4f;
+    // CHECK-NEXT: global\d+\.f = -global\d+\.f;
     t2.v2f.x = -t.v2f.x;
     t2.v3f.x = -t.v3f.x;
     t2.v4f.x = -t.v4f.x;
@@ -306,20 +306,20 @@ fn testUnaryOperations() -> i32
 
 fn testCall() -> i32
 {
-    // CHECK: parameter\d+\.v2f\.x = abs\(parameter\d+\.v2f\.x\);
-    // CHECK-NEXT: parameter\d+\.v3f\.x = abs\(parameter\d+\.v3f\.x\);
-    // CHECK-NEXT: parameter\d+\.v4f\.x = abs\(parameter\d+\.v4f\.x\);
-    // CHECK-NEXT: parameter\d+\.v2u\.x = abs\(parameter\d+\.v2u\.x\);
-    // CHECK-NEXT: parameter\d+\.v3u\.x = abs\(parameter\d+\.v3u\.x\);
-    // CHECK-NEXT: parameter\d+\.v4u\.x = abs\(parameter\d+\.v4u\.x\);
-    // CHECK-NEXT: parameter\d+\.v2f = abs\(parameter\d+\.v2f\);
-    // CHECK-NEXT: parameter\d+\.v3f = abs\(float3\(parameter\d+\.v3f\)\);
-    // CHECK-NEXT: parameter\d+\.v4f = abs\(parameter\d+\.v4f\);
-    // CHECK-NEXT: parameter\d+\.v2u = abs\(parameter\d+\.v2u\);
-    // CHECK-NEXT: parameter\d+\.v3u = abs\(uint3\(parameter\d+\.v3u\)\);
-    // CHECK-NEXT: parameter\d+\.v4u = abs\(parameter\d+\.v4u\);
-    // CHECK-NEXT: parameter\d+\.f = abs\(parameter\d+\.f\);
-    // CHECK-NEXT: parameter\d+\.u = abs\(parameter\d+\.u\);
+    // CHECK: global\d+\.v2f\.x = abs\(global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = abs\(global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = abs\(global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2u\.x = abs\(global\d+\.v2u\.x\);
+    // CHECK-NEXT: global\d+\.v3u\.x = abs\(global\d+\.v3u\.x\);
+    // CHECK-NEXT: global\d+\.v4u\.x = abs\(global\d+\.v4u\.x\);
+    // CHECK-NEXT: global\d+\.v2f = abs\(global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = abs\(float3\(global\d+\.v3f\)\);
+    // CHECK-NEXT: global\d+\.v4f = abs\(global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.v2u = abs\(global\d+\.v2u\);
+    // CHECK-NEXT: global\d+\.v3u = abs\(uint3\(global\d+\.v3u\)\);
+    // CHECK-NEXT: global\d+\.v4u = abs\(global\d+\.v4u\);
+    // CHECK-NEXT: global\d+\.f = abs\(global\d+\.f\);
+    // CHECK-NEXT: global\d+\.u = abs\(global\d+\.u\);
     t.v2f.x = abs(t1.v2f.x);
     t.v3f.x = abs(t1.v3f.x);
     t.v4f.x = abs(t1.v4f.x);
@@ -335,20 +335,20 @@ fn testCall() -> i32
     t.f     = abs(t1.f);
     t.u     = abs(t1.u);
 
-    // CHECK-NEXT: parameter\d+\.v2f\.x = abs\(parameter\d+\.v2f\.x\);
-    // CHECK-NEXT: parameter\d+\.v3f\.x = abs\(parameter\d+\.v3f\.x\);
-    // CHECK-NEXT: parameter\d+\.v4f\.x = abs\(parameter\d+\.v4f\.x\);
-    // CHECK-NEXT: parameter\d+\.v2u\.x = abs\(parameter\d+\.v2u\.x\);
-    // CHECK-NEXT: parameter\d+\.v3u\.x = abs\(parameter\d+\.v3u\.x\);
-    // CHECK-NEXT: parameter\d+\.v4u\.x = abs\(parameter\d+\.v4u\.x\);
-    // CHECK-NEXT: parameter\d+\.v2f = abs\(parameter\d+\.v2f\);
-    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(abs\(float3\(parameter\d+\.v3f\)\)\);
-    // CHECK-NEXT: parameter\d+\.v4f = abs\(parameter\d+\.v4f\);
-    // CHECK-NEXT: parameter\d+\.v2u = abs\(parameter\d+\.v2u\);
-    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(abs\(uint3\(parameter\d+\.v3u\)\)\);
-    // CHECK-NEXT: parameter\d+\.v4u = abs\(parameter\d+\.v4u\);
-    // CHECK-NEXT: parameter\d+\.f = abs\(parameter\d+\.f\);
-    // CHECK-NEXT: parameter\d+\.u = abs\(parameter\d+\.u\);
+    // CHECK-NEXT: global\d+\.v2f\.x = abs\(global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = abs\(global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = abs\(global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2u\.x = abs\(global\d+\.v2u\.x\);
+    // CHECK-NEXT: global\d+\.v3u\.x = abs\(global\d+\.v3u\.x\);
+    // CHECK-NEXT: global\d+\.v4u\.x = abs\(global\d+\.v4u\.x\);
+    // CHECK-NEXT: global\d+\.v2f = abs\(global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(abs\(float3\(global\d+\.v3f\)\)\);
+    // CHECK-NEXT: global\d+\.v4f = abs\(global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.v2u = abs\(global\d+\.v2u\);
+    // CHECK-NEXT: global\d+\.v3u = packed_uint3\(abs\(uint3\(global\d+\.v3u\)\)\);
+    // CHECK-NEXT: global\d+\.v4u = abs\(global\d+\.v4u\);
+    // CHECK-NEXT: global\d+\.f = abs\(global\d+\.f\);
+    // CHECK-NEXT: global\d+\.u = abs\(global\d+\.u\);
     t1.v2f.x = abs(t2.v2f.x);
     t1.v3f.x = abs(t2.v3f.x);
     t1.v4f.x = abs(t2.v4f.x);
@@ -364,20 +364,20 @@ fn testCall() -> i32
     t1.f     = abs(t2.f);
     t1.u     = abs(t2.u);
 
-    // CHECK-NEXT: parameter\d+\.v2f\.x = abs\(parameter\d+\.v2f\.x\);
-    // CHECK-NEXT: parameter\d+\.v3f\.x = abs\(parameter\d+\.v3f\.x\);
-    // CHECK-NEXT: parameter\d+\.v4f\.x = abs\(parameter\d+\.v4f\.x\);
-    // CHECK-NEXT: parameter\d+\.v2u\.x = abs\(parameter\d+\.v2u\.x\);
-    // CHECK-NEXT: parameter\d+\.v3u\.x = abs\(parameter\d+\.v3u\.x\);
-    // CHECK-NEXT: parameter\d+\.v4u\.x = abs\(parameter\d+\.v4u\.x\);
-    // CHECK-NEXT: parameter\d+\.v2f = abs\(parameter\d+\.v2f\);
-    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(abs\(parameter\d+\.v3f\)\);
-    // CHECK-NEXT: parameter\d+\.v4f = abs\(parameter\d+\.v4f\);
-    // CHECK-NEXT: parameter\d+\.v2u = abs\(parameter\d+\.v2u\);
-    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(abs\(parameter\d+\.v3u\)\);
-    // CHECK-NEXT: parameter\d+\.v4u = abs\(parameter\d+\.v4u\);
-    // CHECK-NEXT: parameter\d+\.f = abs\(parameter\d+\.f\);
-    // CHECK-NEXT: parameter\d+\.u = abs\(parameter\d+\.u\);
+    // CHECK-NEXT: global\d+\.v2f\.x = abs\(global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = abs\(global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = abs\(global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2u\.x = abs\(global\d+\.v2u\.x\);
+    // CHECK-NEXT: global\d+\.v3u\.x = abs\(global\d+\.v3u\.x\);
+    // CHECK-NEXT: global\d+\.v4u\.x = abs\(global\d+\.v4u\.x\);
+    // CHECK-NEXT: global\d+\.v2f = abs\(global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(abs\(global\d+\.v3f\)\);
+    // CHECK-NEXT: global\d+\.v4f = abs\(global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.v2u = abs\(global\d+\.v2u\);
+    // CHECK-NEXT: global\d+\.v3u = packed_uint3\(abs\(global\d+\.v3u\)\);
+    // CHECK-NEXT: global\d+\.v4u = abs\(global\d+\.v4u\);
+    // CHECK-NEXT: global\d+\.f = abs\(global\d+\.f\);
+    // CHECK-NEXT: global\d+\.u = abs\(global\d+\.u\);
     t2.v2f.x = abs(t.v2f.x);
     t2.v3f.x = abs(t.v3f.x);
     t2.v4f.x = abs(t.v4f.x);

--- a/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
@@ -10,13 +10,65 @@ fn f2(x: ptr<private, i32>) -> i32
     return *x;
 }
 
+fn f3(x: vec3<f32>) { }
+
 var<private> global: i32;
+
+struct S { x: vec3<f32> }
+@group(0) @binding(0) var<storage, read_write> global2 : S;
+
+fn testSimplePointerRewriting()
+{
+    let x = &global2;
+    f3((*x).x);
+}
+
+fn testIndirectPointerRewriting()
+{
+    let x = &global2;
+    let y = x;
+    let z = y;
+    f3((*z).x);
+}
+
+fn testPhonyPointerElimination()
+{
+    _ = &global2;
+}
+
+fn testShadowedGlobalRewriting()
+{
+    let x = &global2;
+    let global2 = 0;
+    f3((*x).x);
+}
+
+fn testShadowedLocalRewriting()
+{
+    var x: S;
+    let y = &x;
+    {
+        let x = 0;
+        f3((*y).x);
+    }
+}
 
 @compute @workgroup_size(1)
 fn main()
 {
     var local: i32;
 
+    _ = &global2;
+
+    let x = &global2;
+    let y = x;
+
     f1(&local);
     f2(&global);
+
+    testSimplePointerRewriting();
+    testIndirectPointerRewriting();
+    testPhonyPointerElimination();
+    testShadowedGlobalRewriting();
+    testShadowedLocalRewriting();
 }

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		97099AC32AA60D58003B41F8 /* ASTArrayTypeExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 97099AC02AA60D58003B41F8 /* ASTArrayTypeExpression.h */; };
 		97099AC62AC49AAB003B41F8 /* WGSLEnums.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97099AC42AC49AAB003B41F8 /* WGSLEnums.cpp */; };
 		97099AC72AC49AAB003B41F8 /* WGSLEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = 97099AC52AC49AAB003B41F8 /* WGSLEnums.h */; };
+		97099ACA2ACB2213003B41F8 /* PointerRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97099AC82ACB2213003B41F8 /* PointerRewriter.h */; };
+		97099ACB2ACB2213003B41F8 /* PointerRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97099AC92ACB2213003B41F8 /* PointerRewriter.cpp */; };
 		97296766299C09BC001C8BD4 /* TypeDeclarations.rb in Sources */ = {isa = PBXBuildFile; fileRef = 97296765299C09B0001C8BD4 /* TypeDeclarations.rb */; };
 		973F784729C8A78200166C66 /* Pipeline.h in Headers */ = {isa = PBXBuildFile; fileRef = 973F784529C8A78200166C66 /* Pipeline.h */; };
 		973F784829C8A78200166C66 /* Pipeline.mm in Sources */ = {isa = PBXBuildFile; fileRef = 973F784629C8A78200166C66 /* Pipeline.mm */; };
@@ -402,6 +404,8 @@
 		97099AC02AA60D58003B41F8 /* ASTArrayTypeExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTArrayTypeExpression.h; sourceTree = "<group>"; };
 		97099AC42AC49AAB003B41F8 /* WGSLEnums.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WGSLEnums.cpp; sourceTree = "<group>"; };
 		97099AC52AC49AAB003B41F8 /* WGSLEnums.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLEnums.h; sourceTree = "<group>"; };
+		97099AC82ACB2213003B41F8 /* PointerRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PointerRewriter.h; sourceTree = "<group>"; };
+		97099AC92ACB2213003B41F8 /* PointerRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PointerRewriter.cpp; sourceTree = "<group>"; };
 		97296764299BFB72001C8BD4 /* main.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = main.rb; sourceTree = "<group>"; };
 		97296765299C09B0001C8BD4 /* TypeDeclarations.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = TypeDeclarations.rb; sourceTree = "<group>"; };
 		973F784529C8A78200166C66 /* Pipeline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Pipeline.h; sourceTree = "<group>"; };
@@ -616,6 +620,8 @@
 				339B7B1727D7FFA40072BF9A /* Parser.h */,
 				66DC575428627E0B0014CABD /* ParserPrivate.h */,
 				979240BC29753B2A0050EA2C /* PhaseTimer.h */,
+				97099AC92ACB2213003B41F8 /* PointerRewriter.cpp */,
+				97099AC82ACB2213003B41F8 /* PointerRewriter.h */,
 				338BB2D127B6B63F00E066AB /* SourceSpan.h */,
 				338BB2CF27B6B61B00E066AB /* Token.cpp */,
 				338BB2CD27B6B60200E066AB /* Token.h */,
@@ -862,6 +868,7 @@
 				339B7B1827D7FFA40072BF9A /* Parser.h in Headers */,
 				66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */,
 				979240C029753B2A0050EA2C /* PhaseTimer.h in Headers */,
+				97099ACA2ACB2213003B41F8 /* PointerRewriter.h in Headers */,
 				338BB2D227B6B63F00E066AB /* SourceSpan.h in Headers */,
 				338BB2CE27B6B60200E066AB /* Token.h in Headers */,
 				978A912F298AD3DA00B37E5E /* TypeCheck.h in Headers */,
@@ -1092,6 +1099,7 @@
 				979240B9297018290050EA2C /* MetalFunctionWriter.cpp in Sources */,
 				9776BE732992A236002D6D93 /* Overload.cpp in Sources */,
 				339B7B1B27D800090072BF9A /* Parser.cpp in Sources */,
+				97099ACB2ACB2213003B41F8 /* PointerRewriter.cpp in Sources */,
 				338BB2D027B6B61B00E066AB /* Token.cpp in Sources */,
 				978A9130298AD3DA00B37E5E /* TypeCheck.cpp in Sources */,
 				97296766299C09BC001C8BD4 /* TypeDeclarations.rb in Sources */,

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -129,6 +129,7 @@ Ref<ShaderModule> Device::createShaderModule(const WGPUShaderModuleDescriptor& d
         for (const auto& error : failedCheck.errors) {
             message.print("\n"_s, error);
         }
+        dataLogLn(message.toString());
         generateAValidationError(message.toString());
         return ShaderModule::createInvalid(*this);
     }

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -80,10 +80,10 @@ fn main(@builtin(position) position : vec4<f32>,
 
 using namespace metal;
 
-[[fragment]] void function0(unsigned parameter0 [[sample_mask]], unsigned parameter1 [[sample_id]], vec<float, 4> parameter2 [[position]])
+[[fragment]] void function0(vec<float, 4> parameter0 [[position]], unsigned parameter1 [[sample_id]], unsigned parameter2 [[sample_mask]])
 {
-    vec<float, 4> local0 = parameter2;
-    unsigned local1 = (parameter1 + parameter0);
+    vec<float, 4> local0 = parameter0;
+    unsigned local1 = (parameter1 + parameter2);
 }
 
 )"_s);


### PR DESCRIPTION
#### f8937a35f02f3c64eb02529b413b65c33d65e565
<pre>
[WGSL] Rewrite pointer variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=262541">https://bugs.webkit.org/show_bug.cgi?id=262541</a>
rdar://116402059

Reviewed by Mike Wyrzykowski.

Taking the address of resource variables, which have to be packed, generates
invalid code such as `&amp;unpack(...)`, where we try to take the address of an
rvalue. In order to fix this, we eliminate all pointer variables and replace
all references to it with the variable&apos;s right-hand side.
This patch also moves the name mangling pass from being the last pass to run
to being the first. This resolves issues shadowing where the right-hand side
of the eliminated variable would be copied into a place where one of the
variables it references has been shadowed. This is fixed since all variables
are given unique names during mangling. It also has the side-effect of generate
more meaningful names in the final program, while still replacing all original
names.

* Source/WebGPU/WGSL/AST/ASTExpression.h:
* Source/WebGPU/WGSL/AST/ASTIdentityExpression.h:
* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/CallGraph.cpp:
(WGSL::CallGraphBuilder::CallGraphBuilder):
(WGSL::CallGraphBuilder::initializeMappings):
(WGSL::buildCallGraph):
* Source/WebGPU/WGSL/CallGraph.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::EntryPointRewriter):
(WGSL::rewriteEntryPoints):
(WGSL::EntryPointRewriter::takeEntryPointInformation): Deleted.
* Source/WebGPU/WGSL/EntryPointRewriter.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::RewriteGlobalVariables):
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::usesOverride):
(WGSL::rewriteGlobalVariables):
* Source/WebGPU/WGSL/GlobalVariableRewriter.h:
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::MangledName::toString const):
(WGSL::NameManglerVisitor::visit):
(WGSL::NameManglerVisitor::visitVariableDeclaration):
* Source/WebGPU/WGSL/PointerRewriter.cpp: Added.
(WGSL::PointerRewriter::PointerRewriter):
(WGSL::PointerRewriter::run):
(WGSL::PointerRewriter::visit):
(WGSL::rewritePointers):
* Source/WebGPU/WGSL/PointerRewriter.h: Copied from Source/WebGPU/WGSL/EntryPointRewriter.h.
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::replace):
(WGSL::ShaderModule::std::enable_if_t&lt;sizeof):
(WGSL::ShaderModule::remove):
* Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl:
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:
* Source/WebGPU/WGSL/tests/valid/pointers.wgsl:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::Device::createShaderModule):

Canonical link: <a href="https://commits.webkit.org/268846@main">https://commits.webkit.org/268846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dcd37115e1379c5e683db150c2d9c2b40d3aa33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20847 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21431 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23591 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25212 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23121 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16712 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18920 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4999 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23249 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->