### PR TITLE
[WGSL] Always initialize serialized variables

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -477,10 +477,15 @@ void FunctionDefinitionWriter::serializeVariable(AST::Variable& variable)
 
     visit(type);
     m_stringBuilder.append(" ", variable.name());
-    if (variable.maybeInitializer() && variable.flavor() != AST::VariableFlavor::Override) {
+
+    if (variable.flavor() == AST::VariableFlavor::Override)
+        return;
+
+    if (auto* initializer = variable.maybeInitializer()) {
         m_stringBuilder.append(" = ");
-        visit(type, *variable.maybeInitializer());
-    }
+        visit(type, *initializer);
+    } else
+        m_stringBuilder.append(" { }");
 }
 
 void FunctionDefinitionWriter::visit(AST::Attribute& attribute)

--- a/Source/WebGPU/WGSL/tests/lit.cfg
+++ b/Source/WebGPU/WGSL/tests/lit.cfg
@@ -22,7 +22,6 @@ config.environment['DYLD_FRAMEWORK_PATH'] = port._build_path()
 
 # FIXME: fix these so this list is empty
 ignored_warnings = [
-    '-Wno-uninitialized',
     '-Wno-unused-variable',
     '-Wno-missing-braces',
 ]

--- a/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
@@ -45,8 +45,8 @@ fn j(x: f32) -> f32
 @compute @workgroup_size(1)
 fn main()
 {
-    // CHECK: int local\d;
-    // CHECK: int local\d;
+    // CHECK: int local\d
+    // CHECK: int local\d
     _ = x;
 
     // CHECK: function\d\(local\d\)


### PR DESCRIPTION
#### e8715062927169f213d7af04dfb19af987e9cf57
<pre>
[WGSL] Always initialize serialized variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=262545">https://bugs.webkit.org/show_bug.cgi?id=262545</a>
rdar://116402632

Reviewed by Mike Wyrzykowski.

When a variable declaration had no user-defined initialization, we just emitted
an unitialized variable, but that is not correct since WGSL has default initial
values[1]. For now, we just emit curly braces with the C++ default initialization,
which seems to match the zero values in WGSL.

[1]: <a href="https://www.w3.org/TR/WGSL/#default-initial-value">https://www.w3.org/TR/WGSL/#default-initial-value</a>

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::serializeVariable):
* Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl:

Canonical link: <a href="https://commits.webkit.org/268836@main">https://commits.webkit.org/268836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/553825e177c8baede2332e3ab3da6bdec9570b53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22567 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19296 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20628 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23423 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17886 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25046 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22992 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16608 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18766 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4987 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->