### PR TITLE
[WGSL] Sort globals by binding

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -850,11 +850,15 @@ void RewriteGlobalVariables::insertStructs(const UsedResources& usedResources)
         if (usedResource == usedResources.end())
             continue;
 
-        const auto& bindingGlobalMap = groupBinding.value;
+        auto& bindingGlobalMap = groupBinding.value;
         const IndexMap<Global*>& usedBindings = usedResource->value;
 
         AST::Identifier structName = argumentBufferStructName(group);
         AST::StructureMember::List structMembers;
+
+        std::sort(bindingGlobalMap.begin(), bindingGlobalMap.end(), [&](auto& a, auto& b) {
+            return a.first < b.first;
+        });
 
         for (auto [binding, globalName] : bindingGlobalMap) {
             if (!usedBindings.contains(binding))

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -621,8 +621,11 @@ void TypeChecker::visit(AST::PhonyAssignmentStatement& statement)
 
 void TypeChecker::visit(AST::ReturnStatement& statement)
 {
-    // FIXME: handle functions that return void
-    auto* type = infer(*statement.maybeExpression());
+    const Type* type;
+    if (auto* expression = statement.maybeExpression())
+        type = infer(*expression);
+    else
+        type = m_types.bottomType();
 
     // FIXME: unify type with the curent function's return type
     UNUSED_PARAM(type);

--- a/Source/WebGPU/WGSL/tests/valid/global-ordering.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-ordering.wgsl
@@ -1,0 +1,11 @@
+// RUN: %metal-compile main
+
+@group(0) @binding(1) var<storage> y: i32;
+@group(0) @binding(0) var<storage> x: i32;
+
+@compute @workgroup_size(1)
+fn main()
+{
+    _ = y;
+    _ = x;
+}


### PR DESCRIPTION
#### 5c3faf8a43239e12db67045ff3b0f8872aa4de7c
<pre>
[WGSL] Sort globals by binding
<a href="https://bugs.webkit.org/show_bug.cgi?id=262547">https://bugs.webkit.org/show_bug.cgi?id=262547</a>
rdar://116403111

Reviewed by Mike Wyrzykowski.

For now, we directly translate `@binding(x)` into `[[id(x)]]` for global variables,
but based on order of usage and declaration, we can end up with the variables out
of order in the argument buffer struct. In order to temporarily fix that, we simply
sort the globals by their binding value.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/valid/global-ordering.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/268835@main">https://commits.webkit.org/268835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e880aff3532adbe97895f24b19262739b09e247

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19299 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23426 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17887 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25048 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22994 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16609 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18769 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4988 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->