### PR TITLE
[WGSL] constantMinus cannot assume both operands have the same type

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -81,10 +81,8 @@ static ConstantValue constantMinus(const Type*, const FixedVector<ConstantValue>
 
     const auto& binaryMinus = [&]() -> ConstantValue {
         return scalarOrVector([&](const auto& left, auto& right) -> ConstantValue {
-            if (left.isInt()) {
-                ASSERT(right.isInt());
+            if (left.isInt() && right.isInt())
                 return left.toInt() - right.toInt();
-            }
             return left.toDouble() - right.toDouble();
         }, arguments[0], arguments[1]);
     };

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -53,6 +53,12 @@ fn testAbstractIntPromotion()
     const f = pow(vec2(0), vec2(0));
 }
 
+fn testMixedConstantValue()
+{
+    const x = 1 - 0.5;
+    _ = x;
+}
+
 // Attribute constants
 const group = 0;
 const binding = 1;


### PR DESCRIPTION
#### f69491a2d8dfca4faea2b491a116747ceca72ecd
<pre>
[WGSL] constantMinus cannot assume both operands have the same type
<a href="https://bugs.webkit.org/show_bug.cgi?id=262549">https://bugs.webkit.org/show_bug.cgi?id=262549</a>
rdar://116403317

Reviewed by Mike Wyrzykowski.

It is valid to have a constant of the form `const x = 1 - 0.5`, where both
sides will be inferred to have type AbstractFloat, but the ConstantValues
will be int and float, so the constant function has to convert both operands
to float if either of them is a float.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::constantMinus):
* Source/WebGPU/WGSL/tests/valid/constants.wgsl:

Canonical link: <a href="https://commits.webkit.org/268831@main">https://commits.webkit.org/268831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60e21fd5495cc2d7cef4dff3a994513f44a588bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19323 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20647 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23452 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17911 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25066 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16630 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18793 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4989 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23130 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->