### PR TITLE
Remove a bogus assert in restoreScrollPositionAndViewState

### DIFF
--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -122,17 +122,7 @@ void FrameLoader::HistoryController::clearScrollPositionAndViewState()
 */
 void FrameLoader::HistoryController::restoreScrollPositionAndViewState()
 {
-    if (!m_frame.loader().stateMachine().committedFirstRealDocumentLoad())
-        return;
-
-    ASSERT(m_currentItem);
-    
-    // FIXME: As the ASSERT attests, it seems we should always have a currentItem here.
-    // One counterexample is <rdar://problem/4917290>
-    // For now, to cover this issue in release builds, there is no technical harm to returning
-    // early and from a user standpoint - as in the above radar - the previous page load failed 
-    // so there *is* no scroll or view state to restore!
-    if (!m_currentItem)
+    if (!m_currentItem || !m_frame.loader().stateMachine().committedFirstRealDocumentLoad())
         return;
 
     RefPtr view = m_frame.view();


### PR DESCRIPTION
#### 8a2524e6b2d8d3e1eb1111013eed5b6dae1e0d22
<pre>
Remove a bogus assert in restoreScrollPositionAndViewState

<a href="https://bugs.webkit.org/show_bug.cgi?id=252944">https://bugs.webkit.org/show_bug.cgi?id=252944</a>
rdar://problem/106232374

Reviewed by Chris Dumez.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/dea55cb041d519f2f42a85449e3071b3c9813f30">https://chromium.googlesource.com/chromium/blink/+/dea55cb041d519f2f42a85449e3071b3c9813f30</a>

iframes initially populated by javascript urls can cause us to call
restoreDocumentState() without a current history item.

* Source/WebCore/loader/HistoryController.cpp:
(FrameLoader::HistoryController::restoreScrollPositionAndViewState):

Canonical link: <a href="https://commits.webkit.org/268803@main">https://commits.webkit.org/268803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8446f29691a8548b4264f105506ecc5b14aba7c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22575 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20635 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23431 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25059 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23005 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16614 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18773 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4974 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->