### PR TITLE
Fix most of test-webkitpy on Python 3.12

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -83,10 +83,7 @@ else:
 
 AutoInstall.register(Package('pyparsing', Version(2, 4, 7)))
 
-if sys.version_info >= (3, 12):
-    AutoInstall.register(Package('requests', Version(2, 31, 0)))
-else:
-    AutoInstall.register(Package('requests', Version(2, 24)))
+AutoInstall.register(Package('requests', Version(2, 26, 0)))
 
 if sys.version_info >= (3, 0):
     AutoInstall.register(Package('tomli', Version(2, 0, 1), wheel=True))
@@ -94,13 +91,10 @@ if sys.version_info >= (3, 0):
 else:
     AutoInstall.register(Package('setuptools_scm', Version(5, 0, 2), pypi_name='setuptools-scm'))
 AutoInstall.register(Package('socks', Version(1, 7, 1), pypi_name='PySocks'))
-AutoInstall.register(Package('six', Version(1, 15, 0)))
+AutoInstall.register(Package('six', Version(1, 16, 0)))
 AutoInstall.register(Package('tblib', Version(1, 7, 0)))
 
-if sys.version_info >= (3, 12):
-    AutoInstall.register(Package('urllib3', Version(2, 0, 4)))
-else:
-    AutoInstall.register(Package('urllib3', Version(1, 25, 10)))
+AutoInstall.register(Package('urllib3', Version(1, 26, 17)))
 
 AutoInstall.register(Package('wheel', Version(0, 35, 1)))
 AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -35,7 +35,7 @@ from webkitcorepy import AutoInstall, Package, Version
 AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
 
 if sys.version_info >= (3, 7):
-    AutoInstall.register(Package('pylint', Version(2, 6, 0)))
+    AutoInstall.register(Package('pylint', Version(2, 13, 9)))
     AutoInstall.register(
         Package("pytest", Version(7, 2, 0),
                 implicit_deps=["attr", "pluggy", "iniconfig"]
@@ -73,7 +73,6 @@ AutoInstall.register(Package('configparser', Version(4, 0, 2), implicit_deps=['p
 AutoInstall.register(Package('contextlib2', Version(0, 6, 0)))
 AutoInstall.register(Package('coverage', Version(5, 2, 1)))
 AutoInstall.register(Package('funcsigs', Version(1, 0, 2)))
-AutoInstall.register(Package('genshi', Version(0, 7, 3), pypi_name='Genshi'))
 AutoInstall.register(Package('html5lib', Version(1, 1)))
 AutoInstall.register(Package('iniconfig', Version(1, 1, 1)))
 AutoInstall.register(Package('mechanize', Version(0, 4, 5)))
@@ -84,13 +83,24 @@ AutoInstall.register(Package('mozterm', Version(1, 0, 0)))
 AutoInstall.register(Package('pluggy', Version(0, 13, 1)))
 AutoInstall.register(Package('py', Version(1, 11, 0)))
 AutoInstall.register(Package('pycodestyle', Version(2, 5, 0)))
-AutoInstall.register(Package('pyfakefs', Version(3, 7, 2)))
+
+if sys.version_info >= (3, 7):
+    AutoInstall.register(Package('pyfakefs', Version(5, 2, 4)))
+else:
+    AutoInstall.register(Package('pyfakefs', Version(3, 7, 2)))
+
 AutoInstall.register(Package('scandir', Version(1, 10, 0)))
-AutoInstall.register(Package('soupsieve', Version(1, 9, 6)))
+
+if sys.version_info >= (3, 6):
+    AutoInstall.register(Package('soupsieve', Version(2, 2, 1)))
+else:
+    AutoInstall.register(Package('soupsieve', Version(1, 9, 6)))
+
 if sys.version_info < (3, 8):
     AutoInstall.register(Package('selenium', Version(3, 141, 0)))
 else:
     AutoInstall.register(Package('selenium', Version(4, 12, 0)))
+
 AutoInstall.register(Package('toml', Version(0, 10, 1), implicit_deps=['pyparsing']))
 AutoInstall.register(Package('wcwidth', Version(0, 2, 5)))
 AutoInstall.register(Package('webencodings', Version(0, 5, 1)))

--- a/Tools/Scripts/webkitpy/conftest.py
+++ b/Tools/Scripts/webkitpy/conftest.py
@@ -26,6 +26,8 @@ import sys
 
 import pytest
 
+from webkitcorepy import AutoInstall
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "serial: tests that must be run in serial")
@@ -104,3 +106,7 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
+
+
+def pytest_collection_finish(session):
+    AutoInstall.install_everything()


### PR DESCRIPTION
#### 46e33611bc5cbc47e8baa50a2cad8b2c2225f1bd
<pre>
Fix most of test-webkitpy on Python 3.12
<a href="https://bugs.webkit.org/show_bug.cgi?id=260877">https://bugs.webkit.org/show_bug.cgi?id=260877</a>

Reviewed by Jonathan Bedard.

This bumps many dependencies to versions which support Python 3.12,
largely either because of meta hooks changes (six, also vendored via
urllib3), because of removals (pylint, soupsieve), or because of use of
non-public API (pyfakefs).

This downgrades the version of urllib3 we are declaring on Python 3.12
as we are unable to install &gt;=2 due to the lack of support of PEP 517
(see <a href="https://bugs.webkit.org/show_bug.cgi?id=261082).">https://bugs.webkit.org/show_bug.cgi?id=261082).</a> This also has the
advantage of using the same version on all configurations.

Additionally, change both versions of requests (again, to a singular
version) to be compatible with the version of urllib3 we&apos;re specifying.

Also, remove Genshi, because as noted in
<a href="https://bugs.webkit.org/show_bug.cgi?id=261103">https://bugs.webkit.org/show_bug.cgi?id=261103</a> it is in fact
unused. This avoids having to deal with its incompatibilities.

Finally, when running via pytest, install everything via the
AutoInstaller prior to the start of test execution

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/webkitpy/__init__.py:
* Tools/Scripts/webkitpy/conftest.py:
(pytest_collection_modifyitems):
(pytest_collection_finish):

Canonical link: <a href="https://commits.webkit.org/268856@main">https://commits.webkit.org/268856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70c1d682b22c8f6e86f94acf88f9bef5d84e69d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19384 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20691 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23531 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/20974 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18869 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25175 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23076 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16679 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/20691 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18867 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5007 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->