### PR TITLE
[content-visibility] Fix forced layout on absolutely positioned elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-092-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-092-expected.txt
@@ -1,0 +1,3 @@
+
+PASS getComputedStyle works in hidden c-v subtree and an absolutely positioned element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-092.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-092.html
@@ -1,0 +1,24 @@
+<!doctype HTML>
+<meta charset="utf8">
+<title>CSS Content Visibility: getComputedStyle works in hidden c-v subtree and an absolutely positioned element</title>
+<link rel="author" title="Rob Buis" href="mailto:rbuis@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-contain/#content-visibility">
+<meta name="assert" content="getComputedStyle works in hidden c-v subtree and an absolutely positioned element">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#container { content-visibility: hidden }
+</style>
+
+<div id=container style="width:200px">
+<div id=target style="width:50%;position: absolute"></div>
+</div>
+
+<script>
+test(() => {
+  const computedStyle = getComputedStyle(target);
+  assert_equals(computedStyle.width, "100px");
+}, "getComputedStyle works in hidden c-v subtree and an absolutely positioned element");
+</script>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -951,7 +951,7 @@ LayoutUnit RenderBlock::marginIntrinsicLogicalWidthForChild(RenderBox& child) co
 
 void RenderBlock::layoutPositionedObject(RenderBox& r, bool relayoutChildren, bool fixedPositionObjectsOnly)
 {
-    if (isSkippedContentRoot()) {
+    if (isSkippedContentRootForLayout()) {
         r.clearNeedsLayoutForDescendants();
         r.clearNeedsLayout();
         return;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2285,6 +2285,11 @@ bool RenderElement::isSkippedContentRoot() const
     return WebCore::isSkippedContentRoot(style(), element());
 }
 
+bool RenderElement::isSkippedContentRootForLayout() const
+{
+    return WebCore::isSkippedContentRoot(style(), element()) && !view().frameView().layoutContext().needsSkippedContentLayout();
+}
+
 bool RenderElement::hasEligibleContainmentForSizeQuery() const
 {
     if (!shouldApplyLayoutContainment())

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -294,6 +294,7 @@ public:
     bool createsNewFormattingContext() const;
 
     bool isSkippedContentRoot() const;
+    bool isSkippedContentRootForLayout() const;
 
     void clearNeedsLayoutForDescendants();
 


### PR DESCRIPTION
#### 804d915b91f346edca2aafc405d45b743d548dd8
<pre>
[content-visibility] Fix forced layout on absolutely positioned elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=262558">https://bugs.webkit.org/show_bug.cgi?id=262558</a>

Reviewed by Tim Nguyen.

Correct RenderBlock::layoutPositionedObject to take forced layout into account, content-visibility-092.html verifies this.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-092-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-092.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::layoutPositionedObject):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::isSkippedContentRootForLayout const):
* Source/WebCore/rendering/RenderElement.h:

Canonical link: <a href="https://commits.webkit.org/268840@main">https://commits.webkit.org/268840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3bb3d4cdd2fd590c8eeae13d5dc8068161d0b83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21422 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23582 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18910 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23118 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16708 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18746 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4993 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19486 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->