### PR TITLE
[WGSL] Add support for constant multiplication

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -93,6 +93,22 @@ static ConstantValue constantMinus(const Type*, const FixedVector<ConstantValue>
     return binaryMinus();
 }
 
+static ConstantValue constantMultiply(const Type*, const FixedVector<ConstantValue>& arguments)
+{
+    ASSERT(arguments.size() == 2);
+
+    auto& lhs = arguments[0];
+    auto& rhs = arguments[1];
+
+    // FIXME: handle constant matrices
+
+    return scalarOrVector([&](const auto& left, auto& right) -> ConstantValue {
+        if (left.isInt() && right.isInt())
+            return left.toInt() * right.toInt();
+        return left.toDouble() * right.toDouble();
+    }, lhs, rhs);
+}
+
 static ConstantValue zeroValue(const Type* type)
 {
     return WTF::switchOn(*type,

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -311,6 +311,7 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
 
     m_constantFunctions.add("pow"_s, constantPow);
     m_constantFunctions.add("-"_s, constantMinus);
+    m_constantFunctions.add("*"_s, constantMultiply);
     m_constantFunctions.add("vec2"_s, constantVector2);
     m_constantFunctions.add("vec2f"_s, constantVector2);
     m_constantFunctions.add("vec2i"_s, constantVector2);

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -38,6 +38,16 @@ fn testArrayConstants() -> i32
     return 0;
 }
 
+fn testConstantMultiplication()
+{
+  const x1 = 2 * 2;
+  const x2 = 2 * 2.0;
+  const x3 = 2.0 * 2.0;
+  const x4 = 2.0 * vec2(2.0);
+  const x5 = vec2(2.0) * vec2(2.0);
+  const x6 = vec2(2.0) * 2.0;
+}
+
 @compute @workgroup_size(1)
 fn testVectorConstants() -> i32
 {


### PR DESCRIPTION
#### d765150c66dc7be4de1bcfcc44e12c711e5f81ca
<pre>
[WGSL] Add support for constant multiplication
<a href="https://bugs.webkit.org/show_bug.cgi?id=262561">https://bugs.webkit.org/show_bug.cgi?id=262561</a>
rdar://116413844

Reviewed by Mike Wyrzykowski.

Implement the constant function for multiplication. The function is mostly complete,
it can handle all overloads for scalars and vectors, but since we don&apos;t yet support
constant matrices I couldn&apos;t support the overloads that operate on them.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::constantMultiply):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
* Source/WebGPU/WGSL/tests/valid/constants.wgsl:

Canonical link: <a href="https://commits.webkit.org/268834@main">https://commits.webkit.org/268834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a93b383c1f93da23fd2580241305f2c2a37f5c90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19331 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20651 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23461 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17914 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25086 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23030 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16635 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18802 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4990 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23138 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->