### PR TITLE
[WGSL] Support for atomic functions

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1180,6 +1180,65 @@ static void emitWorkgroupUniformLoad(FunctionDefinitionWriter* writer, AST::Call
     writer->stringBuilder().append(")");
 }
 
+static void atomicFunction(const char* name, FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->stringBuilder().append(name, "(");
+    bool first = true;
+    for (auto& argument : call.arguments()) {
+        if (!first)
+            writer->stringBuilder().append(", ");
+        first = false;
+        writer->visit(argument);
+    }
+    writer->stringBuilder().append(", memory_order_relaxed)");
+}
+
+static void emitAtomicLoad(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_load_explicit", writer, call);
+}
+
+static void emitAtomicStore(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_store_explicit", writer, call);
+}
+
+static void emitAtomicAdd(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_fetch_add_explicit", writer, call);
+}
+
+static void emitAtomicSub(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_fetch_sub_explicit", writer, call);
+}
+
+static void emitAtomicMax(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_fetch_max_explicit", writer, call);
+}
+
+static void emitAtomicMin(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_fetch_min_explicit", writer, call);
+}
+
+static void emitAtomicOr(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_fetch_or_explicit", writer, call);
+}
+
+static void emitAtomicXor(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_fetch_xor_explicit", writer, call);
+}
+
+static void emitAtomicExchange(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    atomicFunction("atomic_exchange_explicit", writer, call);
+}
+
+
 void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call)
 {
     auto isArray = is<AST::ArrayTypeExpression>(call.target());
@@ -1211,6 +1270,15 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
 
     if (is<AST::IdentifierExpression>(call.target())) {
         static constexpr std::pair<ComparableASCIILiteral, void(*)(FunctionDefinitionWriter*, AST::CallExpression&)> builtinMappings[] {
+            { "atomicAdd", emitAtomicAdd },
+            { "atomicExchange", emitAtomicExchange },
+            { "atomicLoad", emitAtomicLoad },
+            { "atomicMax", emitAtomicMax },
+            { "atomicMin", emitAtomicMin },
+            { "atomicOr", emitAtomicOr },
+            { "atomicStore", emitAtomicStore },
+            { "atomicSub", emitAtomicSub },
+            { "atomicXor", emitAtomicXor },
             { "storageBarrier", emitStorageBarrier },
             { "textureDimensions", emitTextureDimensions },
             { "textureLoad", emitTextureLoad },

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -48,6 +48,7 @@ struct AbstractChannelFormat;
 struct AbstractReference;
 struct AbstractPointer;
 struct AbstractArray;
+struct AbstractAtomic;
 
 using AbstractTypeImpl = std::variant<
     AbstractVector,
@@ -58,6 +59,7 @@ using AbstractTypeImpl = std::variant<
     AbstractReference,
     AbstractPointer,
     AbstractArray,
+    AbstractAtomic,
     TypeVariable,
     const Type*
 >;
@@ -105,6 +107,10 @@ struct AbstractPointer {
 };
 
 struct AbstractArray {
+    AbstractType element;
+};
+
+struct AbstractAtomic {
     AbstractType element;
 };
 

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -968,6 +968,40 @@ operator :textureStore, {
     [F, T < ConcreteInteger].(texture_storage_3d[F, write], vec3[T], vec4[ChannelFormat[F]]) => void,
 }
 
+# 16.8. Atomic Built-in Functions (https://www.w3.org/TR/WGSL/#atomic-builtin-functions)
+
+# 16.8.1
+operator :atomicLoad, {
+    # fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
+    [AS, T].(ptr[AS, atomic[T], read_write]) => T,
+}
+
+
+# 16.8.2
+operator :atomicStore, {
+    # fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
+    [AS, T].(ptr[AS, atomic[T], read_write], T) => void,
+}
+
+# 16.8.3. Atomic Read-modify-write (this spec entry contains several functions)
+[
+    :atomicAdd,
+    :atomicSub,
+    :atomicMax,
+    :atomicMin,
+    :atomicOr,
+    :atomicXor,
+    :atomicExchange,
+].each do |op|
+    operator op, {
+        # fn #{op}(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+        [AS, T].(ptr[AS, atomic[T], read_write], T) => T,
+    }
+end
+
+# FIXME: Implement atomicCompareExchangeWeak (which depends on the result struct that is not currently supported)
+# fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+
 # 16.11. Synchronization Built-in Functions (https://www.w3.org/TR/WGSL/#sync-builtin-functions)
 
 # 16.11.1.

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -350,6 +350,7 @@ module DSL
         array = AbstractType.new(:Array)
         ptr = AbstractType.new(:Pointer)
         ref = AbstractType.new(:Reference)
+        atomic = AbstractType.new(:Atomic)
 
         # texture kinds
         Texture1d = Variable.new(:"Types::Texture::Kind::Texture1d", nil)

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2614,6 +2614,47 @@ fn testTextureStore()
     textureStore(ts3d, vec3(0), vec4f(0));
 }
 
+// 16.8. Atomic Built-in Functions (https://www.w3.org/TR/WGSL/#atomic-builtin-functions)
+var<workgroup> x: atomic<i32>;
+
+// RUN: %metal-compile testAtomicFunctions
+@compute @workgroup_size(1)
+fn testAtomicFunctions()
+{
+    testAtomicLoad();
+    testAtomicStore();
+    testAtomicReadWriteModify();
+}
+
+// 16.8.1
+fn testAtomicLoad()
+{
+    // [AS, T].(ptr[AS, atomic[T], read_write]) => T,
+    _ = atomicLoad(&x);
+}
+
+// 16.8.2
+fn testAtomicStore()
+{
+    /*[AS, T].(ptr[AS, atomic[T], read_write], T) => void,*/
+    atomicStore(&x, 42);
+}
+
+// 16.8.3. Atomic Read-modify-write (this spec entry contains several functions)
+fn testAtomicReadWriteModify()
+{
+    // [AS, T].(ptr[AS, atomic[T], read_write], T) => T,
+    _ = atomicAdd(&x, 42);
+    _ = atomicSub(&x, 42);
+    _ = atomicMax(&x, 42);
+    _ = atomicMin(&x, 42);
+    _ = atomicOr(&x, 42);
+    _ = atomicXor(&x, 42);
+    _ = atomicExchange(&x, 42);
+}
+
+// FIXME: Implement atomicCompareExchangeWeak (which depends on the result struct that is not currently supported)
+
 // 16.11. Synchronization Built-in Functions (https://www.w3.org/TR/WGSL/#sync-builtin-functions)
 
 // 16.11.1.


### PR DESCRIPTION
#### ac4a3aa79eaa96d8f5e94c5e8bf59f2e2ed7d026
<pre>
[WGSL] Support for atomic functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=262350">https://bugs.webkit.org/show_bug.cgi?id=262350</a>
rdar://116211761

Reviewed by Mike Wyrzykowski.

Add support for all atomic functions from the spec[1], except for `atomicCompareExchangeWeak`
since we don&apos;t yet support the custom return structs.

[1]: <a href="https://www.w3.org/TR/WGSL/#atomic-builtin-functions">https://www.w3.org/TR/WGSL/#atomic-builtin-functions</a>

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::atomicFunction):
(WGSL::Metal::emitAtomicLoad):
(WGSL::Metal::emitAtomicStore):
(WGSL::Metal::emitAtomicAdd):
(WGSL::Metal::emitAtomicSub):
(WGSL::Metal::emitAtomicMax):
(WGSL::Metal::emitAtomicMin):
(WGSL::Metal::emitAtomicOr):
(WGSL::Metal::emitAtomicXor):
(WGSL::Metal::emitAtomicExchange):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WTF::printInternal):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/268832@main">https://commits.webkit.org/268832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60f78f7eb0300b6dcab77bb0b54885c43af88959

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22606 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19332 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20650 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23462 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17915 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25074 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23021 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16637 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18803 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4991 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->