### PR TITLE
[WGSL] Initial plumbing for evaluating override expressions from the API

### DIFF
--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -82,21 +82,13 @@ EntryPointRewriter::EntryPointRewriter(ShaderModule& shaderModule, const AST::Fu
 {
     switch (m_stage) {
     case AST::StageAttribute::Stage::Compute: {
-        unsigned x = 0;
-        unsigned y = 1;
-        unsigned z = 1;
         for (auto& attribute : function.attributes()) {
             if (!is<AST::WorkgroupSizeAttribute>(attribute))
                 continue;
             auto& workgroupSize = downcast<AST::WorkgroupSizeAttribute>(attribute);
-            x = workgroupSize.x().constantValue()->toInt();
-            if (auto* maybeY = workgroupSize.maybeY())
-                y = maybeY->constantValue()->toInt();
-            if (auto* maybeZ = workgroupSize.maybeZ())
-                z = maybeZ->constantValue()->toInt();
+            m_information.typedEntryPoint = Reflection::Compute { &workgroupSize.x(), workgroupSize.maybeY(), workgroupSize.maybeZ() };
+            break;
         }
-        ASSERT(x);
-        m_information.typedEntryPoint = Reflection::Compute { x, y, z };
         break;
     }
     case AST::StageAttribute::Stage::Vertex:

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WGSL.h"
 
+#include "ASTIdentifierExpression.h"
 #include "CallGraph.h"
 #include "EntryPointRewriter.h"
 #include "GlobalSorting.h"
@@ -124,6 +125,14 @@ PrepareResult prepare(ShaderModule& ast, const String& entryPointName, const std
     HashMap<String, std::optional<PipelineLayout>> pipelineLayouts;
     pipelineLayouts.add(entryPointName, pipelineLayout);
     return prepareImpl(ast, pipelineLayouts);
+}
+
+ConstantValue evaluate(const AST::Expression& expression, const HashMap<String, ConstantValue>& constants)
+{
+    if (auto constantValue = expression.constantValue())
+        return *constantValue;
+    ASSERT(is<const AST::IdentifierExpression>(expression));
+    return constants.get(downcast<const AST::IdentifierExpression>(expression).identifier());
 }
 
 }

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CompilationMessage.h"
+#include "ConstantValue.h"
 #include <cinttypes>
 #include <cstdint>
 #include <memory>
@@ -43,6 +44,10 @@ namespace WGSL {
 //
 
 class ShaderModule;
+
+namespace AST {
+class Expression;
+}
 
 struct SuccessfulCheck {
     SuccessfulCheck() = delete;
@@ -172,9 +177,9 @@ struct Fragment {
 };
 
 struct WorkgroupSize {
-    unsigned width;
-    unsigned height;
-    unsigned depth;
+    const AST::Expression* width;
+    const AST::Expression* height;
+    const AST::Expression* depth;
 };
 
 struct Compute {
@@ -213,5 +218,7 @@ struct PrepareResult {
 // All failures must have already been caught in check().
 PrepareResult prepare(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&);
 PrepareResult prepare(ShaderModule&, const String& entryPointName, const std::optional<PipelineLayout>&);
+
+ConstantValue evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WebGPU/Pipeline.h
+++ b/Source/WebGPU/WebGPU/Pipeline.h
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "ConstantValue.h"
 #import "ShaderModule.h"
 
 namespace WebGPU {
@@ -34,8 +35,8 @@ struct LibraryCreationResult {
 
 std::optional<LibraryCreationResult> createLibrary(id<MTLDevice>, const ShaderModule&, const PipelineLayout*, const String& entryPointName, NSString *label);
 
-MTLFunctionConstantValues *createConstantValues(uint32_t constantCount, const WGPUConstantEntry* constants, const WGSL::Reflection::EntryPointInformation&);
+std::tuple<MTLFunctionConstantValues *, HashMap<String, WGSL::ConstantValue>> createConstantValues(uint32_t constantCount, const WGPUConstantEntry* constants, const WGSL::Reflection::EntryPointInformation&);
 
-id<MTLFunction> createFunction(id<MTLLibrary>, const WGSL::Reflection::EntryPointInformation&, unsigned constantCount, const WGPUConstantEntry*, NSString *label);
+id<MTLFunction> createFunction(id<MTLLibrary>, const WGSL::Reflection::EntryPointInformation&, MTLFunctionConstantValues *, NSString *label);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -60,51 +60,56 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
     return { { library, entryPointInformation } };
 }
 
-MTLFunctionConstantValues *createConstantValues(uint32_t constantCount, const WGPUConstantEntry* constants, const WGSL::Reflection::EntryPointInformation& entryPointInformation)
+std::tuple<MTLFunctionConstantValues *, HashMap<String, WGSL::ConstantValue>> createConstantValues(uint32_t constantCount, const WGPUConstantEntry* constants, const WGSL::Reflection::EntryPointInformation& entryPointInformation)
 {
+    HashMap<String, WGSL::ConstantValue> wgslConstantValues;
+
+    if (!constantCount)
+        return { };
+
     auto constantValues = [MTLFunctionConstantValues new];
     for (uint32_t i = 0; i < constantCount; ++i) {
         const auto& entry = constants[i];
         auto indexIterator = entryPointInformation.specializationConstants.find(fromAPI(entry.key));
         if (indexIterator == entryPointInformation.specializationConstants.end())
-            return nullptr;
+            return { };
         const auto& specializationConstant = indexIterator->value;
         switch (specializationConstant.type) {
         case WGSL::Reflection::SpecializationConstantType::Boolean: {
             bool value = entry.value;
+            wgslConstantValues.add(fromAPI(entry.key), value);
             [constantValues setConstantValue:&value type:MTLDataTypeBool withName:specializationConstant.mangledName];
             break;
         }
         case WGSL::Reflection::SpecializationConstantType::Float: {
             float value = entry.value;
+            wgslConstantValues.add(fromAPI(entry.key), value);
             [constantValues setConstantValue:&value type:MTLDataTypeFloat withName:specializationConstant.mangledName];
             break;
         }
         case WGSL::Reflection::SpecializationConstantType::Int: {
             int value = entry.value;
+            wgslConstantValues.add(fromAPI(entry.key), value);
             [constantValues setConstantValue:&value type:MTLDataTypeInt withName:specializationConstant.mangledName];
             break;
         }
         case WGSL::Reflection::SpecializationConstantType::Unsigned: {
             unsigned value = entry.value;
+            wgslConstantValues.add(fromAPI(entry.key), value);
             [constantValues setConstantValue:&value type:MTLDataTypeUInt withName:specializationConstant.mangledName];
             break;
         }
         }
     }
-    return constantValues;
+    return { constantValues, WTFMove(wgslConstantValues) };
 }
 
-id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflection::EntryPointInformation& entryPointInformation, unsigned constantCount, const WGPUConstantEntry* constants, NSString *label)
+id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflection::EntryPointInformation& entryPointInformation, MTLFunctionConstantValues *constantValues, NSString *label)
 {
     auto functionDescriptor = [MTLFunctionDescriptor new];
     functionDescriptor.name = entryPointInformation.mangledName;
-    if (constantCount) {
-        auto constantValues = createConstantValues(constantCount, constants, entryPointInformation);
-        if (!constantValues)
-            return nullptr;
+    if (constantValues)
         functionDescriptor.constantValues = constantValues;
-    }
     NSError *error = nil;
     id<MTLFunction> function = [library newFunctionWithDescriptor:functionDescriptor error:&error];
     if (error)

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -572,7 +572,8 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
         if (!pipelineLayout)
             addPipelineLayouts(bindGroupEntries, entryPointInformation.defaultLayout);
-        auto vertexFunction = createFunction(libraryCreationResult->library, entryPointInformation, descriptor.vertex.constantCount, descriptor.vertex.constants, label);
+        auto [constantValues, _] = createConstantValues(descriptor.vertex.constantCount, descriptor.vertex.constants, entryPointInformation);
+        auto vertexFunction = createFunction(libraryCreationResult->library, entryPointInformation, constantValues, label);
         if (!vertexFunction)
             return RenderPipeline::createInvalid(*this);
         mtlRenderPipelineDescriptor.vertexFunction = vertexFunction;
@@ -599,7 +600,8 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
         if (!pipelineLayout)
             addPipelineLayouts(bindGroupEntries, entryPointInformation.defaultLayout);
 
-        auto fragmentFunction = createFunction(libraryCreationResult->library, entryPointInformation, fragmentDescriptor.constantCount, fragmentDescriptor.constants, label);
+        auto [constantValues, _] = createConstantValues(fragmentDescriptor.constantCount, fragmentDescriptor.constants, entryPointInformation);
+        auto fragmentFunction = createFunction(libraryCreationResult->library, entryPointInformation, constantValues, label);
         if (!fragmentFunction)
             return RenderPipeline::createInvalid(*this);
         mtlRenderPipelineDescriptor.fragmentFunction = fragmentFunction;


### PR DESCRIPTION
#### fa9c962a0aee56992300252665f4be6ef4535620
<pre>
[WGSL] Initial plumbing for evaluating override expressions from the API
<a href="https://bugs.webkit.org/show_bug.cgi?id=262562">https://bugs.webkit.org/show_bug.cgi?id=262562</a>
rdar://116414218

Reviewed by Mike Wyrzykowski.

The API needs to be able to evaluate override expressions for e.g. attributes and
override variable initializer expressions. This is first step in that direction,
which exposes a (currently very limited) function to evaluate expressions from the
API. This initial implementation, although very basic, should unblock some of the
samples that require resolving override variables in the workgroup_size attribute.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::EntryPointRewriter):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::evaluate):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::createComputePipelineState):
(WebGPU::metalSize):
(WebGPU::Device::createComputePipeline):
* Source/WebGPU/WebGPU/Pipeline.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createConstantValues):
(WebGPU::createFunction):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):

Canonical link: <a href="https://commits.webkit.org/268833@main">https://commits.webkit.org/268833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26249c152a5fd9381125515023d9ae940abbebb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19333 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20653 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23464 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17917 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25077 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23024 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16638 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18805 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4992 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23141 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->