### PR TITLE
Remove Path::polygonPathFromPoints()

### DIFF
--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -237,7 +237,7 @@ Path DictationCaretAnimator::makeDictationTailConePath(const FloatRect& rect) co
     const auto verticalOffsetLTR = isLTR ? verticalOffset : 0.f;
     const auto verticalOffsetRTL = isLTR ? 0.f : verticalOffset;
 
-    return Path::polygonPathFromPoints({
+    return Path(Vector<FloatPoint> {
         { rect.x(), rect.y() + verticalOffsetLTR },
         { rect.x(), rect.maxY() - verticalOffsetLTR },
         { rect.maxX(), rect.maxY() - verticalOffsetRTL },

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -141,11 +141,6 @@ const PathImpl* Path::asImpl() const
     return nullptr;
 }
 
-Path Path::polygonPathFromPoints(const Vector<FloatPoint>& points)
-{
-    return Path(points);
-}
-
 void Path::moveTo(const FloatPoint& point)
 {
     if (isEmpty())

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -57,9 +57,6 @@ public:
 
     WEBCORE_EXPORT bool operator==(const Path&) const;
 
-    // FIXME: Remove this method when the call of it from WebKitAdditions in is removed.
-    static Path polygonPathFromPoints(const Vector<FloatPoint>&);
-
     WEBCORE_EXPORT void moveTo(const FloatPoint&);
 
     WEBCORE_EXPORT void addLineTo(const FloatPoint&);


### PR DESCRIPTION
#### 526ba602e6bb7c944366954db3bb75bf986a8e0d
<pre>
Remove Path::polygonPathFromPoints()
<a href="https://bugs.webkit.org/show_bug.cgi?id=262563">https://bugs.webkit.org/show_bug.cgi?id=262563</a>
rdar://116414788

Reviewed by Simon Fraser.

It is only used once and it can be replaced by a public constructor.

* Source/WebCore/platform/DictationCaretAnimator.cpp:
(WebCore::DictationCaretAnimator::makeDictationTailConePath const):
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::polygonPathFromPoints): Deleted.
* Source/WebCore/platform/graphics/Path.h:

Canonical link: <a href="https://commits.webkit.org/268809@main">https://commits.webkit.org/268809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc098fa9ef90da9e0afc34014de351320cd81dfa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19336 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21316 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23467 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17920 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18815 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25079 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23026 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16641 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18808 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4976 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->