### PR TITLE
[iOS] Stop overriding -[UIScrollView _rubberBandOffsetForOffset:maxOffset:minOffset:range:outside:]

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1136,7 +1136,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @end
 
 @interface UIScrollView (IPI)
-- (CGFloat)_rubberBandOffsetForOffset:(CGFloat)newOffset maxOffset:(CGFloat)maxOffset minOffset:(CGFloat)minOffset range:(CGFloat)range outside:(BOOL *)outside;
 - (void)_adjustForAutomaticKeyboardInfo:(NSDictionary *)info animated:(BOOL)animated lastAdjustment:(CGFloat*)lastAdjustment;
 - (BOOL)_isScrollingToTop;
 - (BOOL)_canScrollWithoutBouncingX;

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -295,49 +295,6 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
     return CGFAbs(a - b) < 1;
 }
 
-- (CGFloat)_rubberBandOffsetForOffset:(CGFloat)newOffset maxOffset:(CGFloat)maxOffset minOffset:(CGFloat)minOffset range:(CGFloat)range outside:(BOOL *)outside
-{
-    UIEdgeInsets contentInsets = self.contentInset;
-    CGSize contentSize = self.contentSize;
-    CGRect bounds = self.bounds;
-
-    CGFloat minimalHorizontalRange = bounds.size.width - contentInsets.left - contentInsets.right;
-    CGFloat contentWidthAtMinimumScale = contentSize.width * (self.minimumZoomScale / self.zoomScale);
-    if (contentWidthAtMinimumScale < minimalHorizontalRange) {
-        CGFloat unobscuredEmptyHorizontalMarginAtMinimumScale = minimalHorizontalRange - contentWidthAtMinimumScale;
-        minimalHorizontalRange -= unobscuredEmptyHorizontalMarginAtMinimumScale;
-    }
-    if (contentSize.width < minimalHorizontalRange) {
-        if (valuesAreWithinOnePixel(minOffset, -contentInsets.left)
-            && valuesAreWithinOnePixel(maxOffset, contentSize.width + contentInsets.right - bounds.size.width)
-            && valuesAreWithinOnePixel(range, bounds.size.width)) {
-
-            CGFloat emptyHorizontalMargin = (minimalHorizontalRange - contentSize.width) / 2;
-            minOffset -= emptyHorizontalMargin;
-            maxOffset = minOffset;
-        }
-    }
-
-    CGFloat minimalVerticalRange = bounds.size.height - contentInsets.top - contentInsets.bottom;
-    CGFloat contentHeightAtMinimumScale = contentSize.height * (self.minimumZoomScale / self.zoomScale);
-    if (contentHeightAtMinimumScale < minimalVerticalRange) {
-        CGFloat unobscuredEmptyVerticalMarginAtMinimumScale = minimalVerticalRange - contentHeightAtMinimumScale;
-        minimalVerticalRange -= unobscuredEmptyVerticalMarginAtMinimumScale;
-    }
-    if (contentSize.height < minimalVerticalRange) {
-        if (valuesAreWithinOnePixel(minOffset, -contentInsets.top)
-            && valuesAreWithinOnePixel(maxOffset, contentSize.height + contentInsets.bottom - bounds.size.height)
-            && valuesAreWithinOnePixel(range, bounds.size.height)) {
-
-            CGFloat emptyVerticalMargin = (minimalVerticalRange - contentSize.height) / 2;
-            minOffset -= emptyVerticalMargin;
-            maxOffset = minOffset;
-        }
-    }
-
-    return [super _rubberBandOffsetForOffset:newOffset maxOffset:maxOffset minOffset:minOffset range:range outside:outside];
-}
-
 - (void)setContentInset:(UIEdgeInsets)contentInset
 {
     [super setContentInset:contentInset];


### PR DESCRIPTION
#### 998883d0ff3f1cf70ed35a175892b5afb66ae0d9
<pre>
[iOS] Stop overriding -[UIScrollView _rubberBandOffsetForOffset:maxOffset:minOffset:range:outside:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=262564">https://bugs.webkit.org/show_bug.cgi?id=262564</a>
rdar://114330182

Reviewed by Tim Horton.

Stop overriding this internal `UIScrollView` method; UIKit will (hopefully) address this in the
future for all scroll views that support pinch-zoom, in rdar://116415439.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _rubberBandOffsetForOffset:maxOffset:minOffset:range:outside:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/268808@main">https://commits.webkit.org/268808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60d95414e49a1240f391a22f15b24eb95f20b5f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21320 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23470 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17924 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23028 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19588 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18811 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4975 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->