### PR TITLE
Save iframe resources to disk

### DIFF
--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -35,6 +35,7 @@ namespace WebCore {
 class Attribute;
 class DocumentType;
 class Element;
+class LocalFrame;
 class Node;
 class Range;
 
@@ -106,6 +107,9 @@ private:
     bool inXMLFragmentSerialization() const { return m_serializationSyntax == SerializationSyntax::XML; }
     void generateUniquePrefix(QualifiedName&, const Namespaces&);
     QualifiedName xmlAttributeSerialization(const Attribute&, Namespaces*);
+    LocalFrame* frameForAttributeReplacement(const Element&);
+    Attribute replaceAttributeIfNecessary(const Element&, const Attribute&);
+    void appendURLAttributeIfNecessary(StringBuilder&, const Element&, Namespaces*);
 
     StringBuilder m_markup;
     const ResolveURLs m_resolveURLs;

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -44,7 +44,7 @@ public:
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(FragmentedSharedBuffer&);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const URL&, FragmentedSharedBuffer&);
     WEBCORE_EXPORT static Ref<LegacyWebArchive> create(Ref<ArchiveResource>&& mainResource, Vector<Ref<ArchiveResource>>&& subresources, Vector<Ref<LegacyWebArchive>>&& subframeArchives);
-    WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(Node&, Function<bool(LocalFrame&)>&& frameFilter = { }, const String& mainResourceFileName = { });
+    WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(Node&, Function<bool(LocalFrame&)>&& frameFilter = { }, const String& mainFrameFileName = { });
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(LocalFrame&);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> createFromSelection(LocalFrame*);
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const SimpleRange&);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm
@@ -211,6 +211,106 @@ TEST(WebArchive, SaveResourcesBasic)
     Util::run(&saved);
 }
 
+static const char* htmlDataBytes = R"TESTRESOURCE(
+<script>
+count = 0;
+function onFrameLoaded() {
+    if (++count == 3) {
+        frame = document.getElementById("iframe1_id");
+        if (frame && !frame.contentDocument.body.innerHTML)
+            frame.contentDocument.body.innerHTML = "<p>iframe1</p><img src='image.png'>";
+        window.webkit.messageHandlers.testHandler.postMessage("done");
+    }
+}
+</script>
+<iframe onload="onFrameLoaded();" id="iframe1_id"></iframe>
+<iframe onload="onFrameLoaded();" src="iframe.html"></iframe>
+<iframe onload="onFrameLoaded();" srcdoc="<p>iframe3</p><img src='image.png'>"></iframe>
+)TESTRESOURCE";
+static const char* iframeHTMLDataBytes = R"TESTRESOURCE(<p>iframe2</p><img src='image.png'>)TESTRESOURCE";
+
+TEST(WebArchive, SaveResourcesSubframe)
+{
+    RetainPtr<NSURL> directoryURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"SaveResourcesTest"] isDirectory:YES];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    [fileManager removeItemAtURL:directoryURL.get() error:nil];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webarchivetest"];
+    NSData *htmlData = [NSData dataWithBytes:htmlDataBytes length:strlen(htmlDataBytes)];
+    NSData *iframeHTMLData = [NSData dataWithBytes:iframeHTMLDataBytes length:strlen(iframeHTMLDataBytes)];
+    NSData *imageData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"400x400-green" withExtension:@"png" subdirectory:@"TestWebKitAPI.resources"]];
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        NSData *data = nil;
+        NSString *mimeType = nil;
+        if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/main.html"]) {
+            mimeType = @"text/html";
+            data = htmlData;
+        } else if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/iframe.html"]) {
+            mimeType = @"text/html";
+            data = iframeHTMLData;
+        } else if ([task.request.URL.absoluteString isEqualToString:@"webarchivetest://host/image.png"]) {
+            mimeType = @"image/png";
+            data = imageData;
+        } else
+            FAIL();
+
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:data];
+        [task didFinish];
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    static bool messageReceived = false;
+    [webView performAfterReceivingMessage:@"done" action:[&] {
+        messageReceived = true;
+    }];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"webarchivetest://host/main.html"]]];
+    Util::run(&messageReceived);
+
+    static bool saved = false;
+    [webView _saveResources:directoryURL.get() suggestedFileName:@"host" completionHandler:^(NSError *error) {
+        EXPECT_NULL(error);
+        NSString *mainResourcePath = [directoryURL URLByAppendingPathComponent:@"host.html"].path;
+        EXPECT_TRUE([fileManager fileExistsAtPath:mainResourcePath]);
+        NSString *savedMainResourceString = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:mainResourcePath] encoding:NSUTF8StringEncoding];
+
+        NSString *resourceDirectoryName = @"host_files";
+        NSString *resourceDirectoryPath = [directoryURL URLByAppendingPathComponent:resourceDirectoryName].path;
+        NSArray *resourceFileNames = [fileManager contentsOfDirectoryAtPath:resourceDirectoryPath error:0];
+        EXPECT_EQ(4llu, resourceFileNames.count);
+        unsigned frameFileCount = 0;
+        unsigned imageFileCount = 0;
+        NSMutableSet *frameResourceContentsToFind = [NSMutableSet set];
+        [frameResourceContentsToFind addObjectsFromArray:[NSArray arrayWithObjects:@"iframe1", @"iframe2", @"iframe3", nil]];
+        for (NSString *fileName in resourceFileNames) {
+            NSString *replacementPath = [resourceDirectoryName stringByAppendingPathComponent:fileName];
+            if ([fileName containsString:@"frame_"]) {
+                NSString *resourceFilePath = [resourceDirectoryPath stringByAppendingPathComponent:fileName];
+                NSString* savedSubframeResourceString = [[NSString alloc] initWithData:[NSData dataWithContentsOfFile:resourceFilePath] encoding:NSUTF8StringEncoding];
+                [savedSubframeResourceString containsString:replacementPath];
+                NSRange range = [savedSubframeResourceString rangeOfString:@"iframe"];
+                EXPECT_NE(NSNotFound, (long)range.location);
+                NSString *iframeContent = [savedSubframeResourceString substringWithRange:NSMakeRange(range.location, range.length + 1)];
+                [frameResourceContentsToFind removeObject:iframeContent];
+                ++frameFileCount;
+            }
+            if ([fileName isEqualToString:@"image.png"])
+                ++imageFileCount;
+
+            // Ensure urls are replaced with file path.
+            [savedMainResourceString containsString:replacementPath];
+        }
+        EXPECT_EQ(3u, frameFileCount);
+        EXPECT_EQ(1u, imageFileCount);
+        EXPECT_EQ(0u, frameResourceContentsToFind.count);
+        saved = true;
+    }];
+    Util::run(&saved);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(MAC) || PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 53dd791f052cd7ee77e99c492a0b480166fb12b0
<pre>
Save iframe resources to disk
<a href="https://bugs.webkit.org/show_bug.cgi?id=262567">https://bugs.webkit.org/show_bug.cgi?id=262567</a>
rdar://116420990

Reviewed by Ryosuke Niwa.

This patch adds support for saving iframe resource to disk. To achive that:
1. each iframe main resource is saved as a single file, where file name is decided based on frame ID.
2. iframe main resources and subresources are stored in [main_resources_file_name]_files directory as other subresources
of main frame.
3. subresource urls in iframe main resources are changed to relative file paths.
4. iframe urls in main frame resource are changed to relative file paths.

Test: WebArchive.SaveResourcesSubframe

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::appendStartTag):
(WebCore::MarkupAccumulator::frameForAttributeReplacement):
(WebCore::MarkupAccumulator::replaceAttributeIfNecessary): replace srcdoc attribute with src attribute whose value is
relative file path.
(WebCore::MarkupAccumulator::appendURLAttributeIfNecessary): if src or srcdoc attribute does not exist, create a new
src attribute with url set to relative file path.
* Source/WebCore/editing/MarkupAccumulator.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/268858@main">https://commits.webkit.org/268858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98bfaab7624f73f39c005c36f503c5052b84b724

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20739 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20664 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23485 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25144 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23039 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16652 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18827 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5011 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->