### PR TITLE
GraphicsLayer::removeAllChildren shouldn't be n^2

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -322,12 +322,15 @@ bool GraphicsLayer::replaceChild(GraphicsLayer* oldChild, Ref<GraphicsLayer>&& n
 
 void GraphicsLayer::removeAllChildren()
 {
-    while (m_children.size()) {
-        GraphicsLayer* curLayer = m_children[0].ptr();
-        ASSERT(curLayer->parent());
-        curLayer->removeFromParent();
-        // curLayer may be destroyed here.
-    }
+    if (m_children.isEmpty())
+        return;
+
+    willModifyChildren();
+
+    for (auto& child : m_children)
+        child->setParent(nullptr);
+
+    m_children.clear();
 }
 
 void GraphicsLayer::removeFromParentInternal()
@@ -401,6 +404,9 @@ void GraphicsLayer::setOpacity(float opacity)
 
 void GraphicsLayer::removeFromParent()
 {
+    if (m_parent)
+        m_parent->willModifyChildren();
+
     // removeFromParentInternal is nonvirtual, for use in willBeDestroyed,
     // which is called from destructors.
     removeFromParentInternal();

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -330,7 +330,7 @@ public:
     WEBCORE_EXPORT virtual bool replaceChild(GraphicsLayer* oldChild, Ref<GraphicsLayer>&& newChild);
 
     WEBCORE_EXPORT void removeAllChildren();
-    WEBCORE_EXPORT virtual void removeFromParent();
+    WEBCORE_EXPORT void removeFromParent();
 
     // The parent() of a maskLayer is set to the layer being masked.
     GraphicsLayer* maskLayer() const { return m_maskLayer.get(); }
@@ -696,6 +696,8 @@ protected:
     // Should be called from derived class destructors. Should call willBeDestroyed() on super.
     WEBCORE_EXPORT void willBeDestroyed();
     bool beingDestroyed() const { return m_beingDestroyed; }
+
+    virtual void willModifyChildren() { }
 
     // This method is used by platform GraphicsLayer classes to clear the filters
     // when compositing is not done in hardware. It is not virtual, so the caller

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -532,11 +532,9 @@ bool GraphicsLayerCA::replaceChild(GraphicsLayer* oldChild, Ref<GraphicsLayer>&&
     return false;
 }
 
-void GraphicsLayerCA::removeFromParent()
+void GraphicsLayerCA::willModifyChildren()
 {
-    if (m_parent)
-        downcast<GraphicsLayerCA>(*m_parent).noteSublayersChanged();
-    GraphicsLayer::removeFromParent();
+    noteSublayersChanged();
 }
 
 void GraphicsLayerCA::setMaskLayer(RefPtr<GraphicsLayer>&& layer)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -72,7 +72,7 @@ public:
     WEBCORE_EXPORT void addChildBelow(Ref<GraphicsLayer>&&, GraphicsLayer* sibling) override;
     WEBCORE_EXPORT bool replaceChild(GraphicsLayer* oldChild, Ref<GraphicsLayer>&& newChild) override;
 
-    WEBCORE_EXPORT void removeFromParent() override;
+    WEBCORE_EXPORT void willModifyChildren() override;
 
     WEBCORE_EXPORT void setMaskLayer(RefPtr<GraphicsLayer>&&) override;
     WEBCORE_EXPORT void setReplicatedLayer(GraphicsLayer*) override;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -241,11 +241,9 @@ bool CoordinatedGraphicsLayer::replaceChild(GraphicsLayer* oldChild, Ref<Graphic
     return true;
 }
 
-void CoordinatedGraphicsLayer::removeFromParent()
+void CoordinatedGraphicsLayer::willModifyChildren()
 {
-    if (CoordinatedGraphicsLayer* parentLayer = downcast<CoordinatedGraphicsLayer>(parent()))
-        parentLayer->didChangeChildren();
-    GraphicsLayer::removeFromParent();
+    didChangeChildren();
 }
 
 void CoordinatedGraphicsLayer::setEventRegion(EventRegion&& eventRegion)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -72,7 +72,7 @@ public:
     void addChildAbove(Ref<GraphicsLayer>&&, GraphicsLayer*) override;
     void addChildBelow(Ref<GraphicsLayer>&&, GraphicsLayer*) override;
     bool replaceChild(GraphicsLayer*, Ref<GraphicsLayer>&&) override;
-    void removeFromParent() override;
+    void willModifyChildren() override;
     void setEventRegion(EventRegion&&) override;
 #if ENABLE(SCROLLING_THREAD)
     void setScrollingNodeID(ScrollingNodeID) override;

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -222,11 +222,9 @@ bool GraphicsLayerWC::replaceChild(GraphicsLayer* oldChild, Ref<GraphicsLayer>&&
     return false;
 }
 
-void GraphicsLayerWC::removeFromParent()
+void GraphicsLayerWC::willModifyChildren()
 {
-    if (m_parent)
-        static_cast<GraphicsLayerWC*>(m_parent)->noteLayerPropertyChanged(WCLayerChange::Children);
-    GraphicsLayer::removeFromParent();
+    noteLayerPropertyChanged(WCLayerChange::Children);
 }
 
 void GraphicsLayerWC::setMaskLayer(RefPtr<GraphicsLayer>&& layer)

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
@@ -63,7 +63,7 @@ public:
     void addChildAbove(Ref<GraphicsLayer>&&, GraphicsLayer* sibling) override;
     void addChildBelow(Ref<GraphicsLayer>&&, GraphicsLayer* sibling) override;
     bool replaceChild(GraphicsLayer* oldChild, Ref<GraphicsLayer>&& newChild) override;
-    void removeFromParent() override;
+    void willModifyChildren() override;
     void setMaskLayer(RefPtr<GraphicsLayer>&&) override;
     void setReplicatedLayer(GraphicsLayer*) override;
     void setReplicatedByLayer(RefPtr<GraphicsLayer>&&) override;


### PR DESCRIPTION
#### 106c4aae5f4384ffb3c573f86ae4f5aa9ad0dc07
<pre>
GraphicsLayer::removeAllChildren shouldn&apos;t be n^2
<a href="https://bugs.webkit.org/show_bug.cgi?id=250654">https://bugs.webkit.org/show_bug.cgi?id=250654</a>
rdar://104534645

Reviewed by Simon Fraser.

`GraphicsLayer::removeAllChildren()` used to select the first sublayer in the
`m_children` vector and call `removeFromParent()` on it. This would null out
`m_parent` on that sublayer and then remove the layer from m_children. This
would end up being expensive because removing items from the beginning of a
vector is expensive and involves moving following items to fill the empty
position.

To avoid the issue, I made the following changes:
1. Have GraphicsLayer::removeAllChildren() null out all parents on sub-layers
   then clear m_children all at once. No more Vector::removeFirstMatching()
   for each sub-layer.
2. GraphicsLayer::removeFromParent() used to be virtual, to notify the parent
   layer that the children changed. However, removeFromParent() is no longer
   called in removeAllChildren() after my change. To address the issue, I am
   marking GraphicsLayer::removeFromParent() as non-virtual and introducing
   a new GraphicsLayer::willModifyChildren() virtual function. This new
   virtual gets called at the beginning of removeFromParent(), before removing
   the layer from its parent, to match pre-existing behavior in child classes.
   willModifyChildren() also gets called once in GraphicsLayer::removeAllChildren()
   before removing all sub-layers, instead of one virtual function call per
   sub-layer.

This is inspired by the following Blink change but I chose a different approach
that I believe is more optimal:
- <a href="https://chromium.googlesource.com/chromium/blink/+/ea1156d6f005f978e4da707ef4e2060c2fc7151f">https://chromium.googlesource.com/chromium/blink/+/ea1156d6f005f978e4da707ef4e2060c2fc7151f</a>

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::removeAllChildren):
(WebCore::GraphicsLayer::removeFromParent):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::willModifyChildren):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::willModifyChildren):
(WebCore::GraphicsLayerCA::removeFromParent): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::willModifyChildren):
(WebCore::CoordinatedGraphicsLayer::removeFromParent): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
(WebKit::GraphicsLayerWC::willModifyChildren):
(WebKit::GraphicsLayerWC::removeFromParent): Deleted.
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h:

Canonical link: <a href="https://commits.webkit.org/268814@main">https://commits.webkit.org/268814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e24a38bec46b5b6080c651abb02b5327180a3fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22632 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19349 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21337 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23486 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18832 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23045 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16654 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18828 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4979 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->