### PR TITLE
[scroll-anchoring] Handle writing-mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL Horizontal LTR. assert_equals: expected 150 but got 120
-FAIL Horizontal RTL. assert_equals: expected 130 but got 150
-FAIL Vertical-LR LTR. assert_equals: expected 120 but got 150
-FAIL Vertical-LR RTL. assert_equals: expected 120 but got 150
-FAIL Vertical-RL LTR. assert_equals: expected -120 but got -150
+PASS Horizontal LTR.
+PASS Horizontal RTL.
+PASS Vertical-LR LTR.
+PASS Vertical-LR RTL.
+FAIL Vertical-RL LTR. assert_equals: expected -120 but got -200
 FAIL Vertical-RL RTL. assert_equals: expected -120 but got -150
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -60,6 +60,7 @@ private:
     CandidateExaminationResult examineAnchorCandidate(Element&);
     bool didFindPriorityCandidate(Document&);
     FloatPoint computeOffsetFromOwningScroller(RenderObject& candidate);
+    FloatSize computeAdjustment(RenderElement& renderer);
     LocalFrameView& frameView();
 
     ScrollableArea& m_owningScrollableArea;


### PR DESCRIPTION
#### 6c4d6d124bfc8df424e5a4add6b56872f9d31295
<pre>
[scroll-anchoring] Handle writing-mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=262574">https://bugs.webkit.org/show_bug.cgi?id=262574</a>
<a href="https://rdar.apple.com/116427084">rdar://116427084</a>

Reviewed by NOBODY (OOPS!).

Handle all values of writing-mode and direction for scroll anchoring
adjustments.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::computeOffset):
(WebCore::ScrollAnchoringController::notifyChildHadSuppressingStyleChange):
(WebCore::scrollAnchoringControllerForElement):
(WebCore::ScrollAnchoringController::notifyParentScrollAnchoringControllerHadSuppressingStyleChange):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c4d6d124bfc8df424e5a4add6b56872f9d31295

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/31294 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/28383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/32061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/12307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/7216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/28029 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31630 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/8394 "Found 1 new test failure: fast/scrolling/programmatic-horizontal-bt-document-scroll.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/7213 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/7382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/35137 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/28460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/28304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/33516 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/7441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5482 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/31354 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/9116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/8140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->