### PR TITLE
Crash in Vector::expandCapacity; WebCore::ISOFairPlayStreamingKeyContextBox::parse()

### DIFF
--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
@@ -132,7 +132,7 @@ ExceptionOr<void> ApplePayAMSUIPaymentHandler::show(Document& document)
 {
     ASSERT(m_applePayAMSUIRequest);
 
-    if (!page().startApplePayAMSUISession(document, *this, *m_applePayAMSUIRequest))
+    if (!page().startApplePayAMSUISession(document.topDocument().url(), *this, *m_applePayAMSUIRequest))
         return Exception { AbortError };
 
     return { };

--- a/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
@@ -109,7 +109,7 @@ void ApplePaySetup::begin(Document& document, Vector<RefPtr<ApplePaySetupFeature
     m_beginPromise = WTFMove(promise);
     m_pendingActivity = makePendingActivity(*this);
 
-    page->paymentCoordinator().beginApplePaySetup(m_configuration, document.url(), WTFMove(features), [this](bool result) {
+    page->paymentCoordinator().beginApplePaySetup(m_configuration, document.topDocument().url(), WTFMove(features), [this](bool result) {
         if (m_beginPromise)
             std::exchange(m_beginPromise, std::nullopt)->resolve(result);
     });

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -102,7 +102,7 @@ bool PaymentCoordinator::beginPaymentSession(Document& document, PaymentSession&
     auto linkIconURLs = LinkIconCollector { document }.iconsOfTypes({ LinkIconType::TouchIcon, LinkIconType::TouchPrecomposedIcon }).map([](auto& icon) {
         return icon.url;
     });
-    auto showPaymentUI = m_client->showPaymentUI(document.url(), WTFMove(linkIconURLs), paymentRequest);
+    auto showPaymentUI = m_client->showPaymentUI(document.topDocument().url(), WTFMove(linkIconURLs), paymentRequest);
     PAYMENT_COORDINATOR_RELEASE_LOG("beginPaymentSession() -> %d", showPaymentUI);
     if (!showPaymentUI)
         return false;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4007,14 +4007,14 @@ void Page::setPaymentCoordinator(std::unique_ptr<PaymentCoordinator>&& paymentCo
 
 #if ENABLE(APPLE_PAY_AMS_UI)
 
-bool Page::startApplePayAMSUISession(Document& document, ApplePayAMSUIPaymentHandler& paymentHandler, const ApplePayAMSUIRequest& request)
+bool Page::startApplePayAMSUISession(const URL& originatingURL, ApplePayAMSUIPaymentHandler& paymentHandler, const ApplePayAMSUIRequest& request)
 {
     if (hasActiveApplePayAMSUISession())
         return false;
 
     m_activeApplePayAMSUIPaymentHandler = &paymentHandler;
 
-    chrome().client().startApplePayAMSUISession(document.url(), request, [weakThis = WeakPtr { *this }, paymentHandlerPtr = &paymentHandler] (std::optional<bool>&& result) {
+    chrome().client().startApplePayAMSUISession(originatingURL, request, [weakThis = WeakPtr { *this }, paymentHandlerPtr = &paymentHandler] (std::optional<bool>&& result) {
         auto strongThis = weakThis.get();
         if (!strongThis)
             return;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -612,7 +612,7 @@ public:
 
 #if ENABLE(APPLE_PAY_AMS_UI)
     bool hasActiveApplePayAMSUISession() const { return m_activeApplePayAMSUIPaymentHandler; }
-    bool startApplePayAMSUISession(Document&, ApplePayAMSUIPaymentHandler&, const ApplePayAMSUIRequest&);
+    bool startApplePayAMSUISession(const URL&, ApplePayAMSUIPaymentHandler&, const ApplePayAMSUIRequest&);
     void abortApplePayAMSUISession(ApplePayAMSUIPaymentHandler&);
 #endif
 


### PR DESCRIPTION
#### 5ecbe3c213f7f81d9d8a3110b370ae1a79b2d9d3
<pre>
Crash in Vector::expandCapacity; WebCore::ISOFairPlayStreamingKeyContextBox::parse()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258712">https://bugs.webkit.org/show_bug.cgi?id=258712</a>
rdar://111171940

Reviewed by Youenn Fablet.

In a number of cases, malformed or malicious boxes claim to have a size much larger
than the memory passed to the parser. Cap the m_size parameter to the remaining size
of the memory buffer to avoid situations where we attempt to create a vector big
enough to hold MAX_INT entries.

* Source/WebCore/platform/graphics/iso/ISOBox.cpp:
(WebCore::ISOBox::peekBox):
(WebCore::ISOBox::parse):

Originally-landed-as: 265870.2@safari-7616-branch (dfdca2cf04a5). rdar://116423096
</pre>
----------------------------------------------------------------------
#### effcb1be99d959681be436de48a525f9cbec9405
<pre>
Ensure -[PKPaymentRequest originatingURL] is always set to the top-level document URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=259667">https://bugs.webkit.org/show_bug.cgi?id=259667</a>
rdar://113143083

Reviewed by Andy Estes.

We support Apple Pay on cross-origin iframes following 262616@main, but
since we are plumbing the iframe domain rather than that of the parent
document embedding said iframe, we lose some Apple Pay domain validation
and abuse detection mitigations.

In this patch, we preserve our existing security mitigations by passing
the top-level domain to `-[PKPaymentRequest setOriginatingURL:]`.
This change also aligns ourselves to the existing shipping model for
payment session domain reporting in iOS 16.

Note that this patch necessitates that a website provide the top level
domain in its merchant session, i.e. &quot;you can iFrame in Apple Pay, but
your merchant session must use the top-level domain&quot;. This is a
pre-existing invariant in PassKit, and this commit aligns WebKit in the
same direction.

* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp:
(WebCore::ApplePayAMSUIPaymentHandler::show):
* Source/WebCore/Modules/applepay/ApplePaySetup.cpp:
(WebCore::ApplePaySetup::begin):
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::beginPaymentSession):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::startApplePayAMSUISession):
* Source/WebCore/page/Page.h:

Originally-landed-as: 265870.231@eng/105809792_safari-7616-branch (bb9c7e0fd205). rdar://116422876
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ecbe3c213f7f81d9d8a3110b370ae1a79b2d9d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21351 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20674 "14 flakes 179 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23503 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17945 "6 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18845 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25157 "121 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23062 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16666 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18842 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23174 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2692 "Failed to checkout and rebase branch from PR 18584") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->