### PR TITLE
Legends could be valid non-spanner siblings of RenderMultiColumnSet

### DIFF
--- a/LayoutTests/fast/multicol/crash-when-legend-is-present-expected.txt
+++ b/LayoutTests/fast/multicol/crash-when-legend-is-present-expected.txt
@@ -1,0 +1,1 @@
+or assert

--- a/LayoutTests/fast/multicol/crash-when-legend-is-present.html
+++ b/LayoutTests/fast/multicol/crash-when-legend-is-present.html
@@ -1,0 +1,16 @@
+<style>
+html {
+  outline-style: auto;
+}
+fieldset {
+  overflow-y: -webkit-paged-y;
+}
+</style>
+<fieldset id=container><legend></legend><label id=child></label></fieldset><script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+document.body.offsetHeight;
+child.innerText = "pass if no crash";
+document.body.offsetHeight;
+container.innerText = "or assert";
+</script>

--- a/LayoutTests/http/wpt/webcodecs/I420ToNV12-convert-heap-buffer-overflow-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/I420ToNV12-convert-heap-buffer-overflow-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VideoFrame constructor should throw type error with bad data
+

--- a/LayoutTests/http/wpt/webcodecs/I420ToNV12-convert-heap-buffer-overflow.html
+++ b/LayoutTests/http/wpt/webcodecs/I420ToNV12-convert-heap-buffer-overflow.html
@@ -1,0 +1,19 @@
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  function createVideoFrame () {
+    new VideoFrame(new ArrayBuffer(2), {
+      format: 'I420',
+      codedWidth: 2,
+      codedHeight: 2,
+      timestamp: 0,
+      visibleRect: {
+        width: 1,
+        height: 2
+      },
+    });
+  }
+  test(() => {
+      assert_throws_js(TypeError, () => createVideoFrame());
+  }, "VideoFrame constructor should throw type error with bad data");
+</script>

--- a/LayoutTests/http/wpt/webcodecs/createNV12-heap-buffer-overflow-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/createNV12-heap-buffer-overflow-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VideoFrame constructor should throw type error with bad data
+

--- a/LayoutTests/http/wpt/webcodecs/createNV12-heap-buffer-overflow.html
+++ b/LayoutTests/http/wpt/webcodecs/createNV12-heap-buffer-overflow.html
@@ -1,0 +1,19 @@
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+function createVideoFrame() {
+    new VideoFrame(new Uint8Array(4), {
+      format: 'NV12',
+      codedWidth: 2,
+      codedHeight: 2,
+      timestamp: 0,
+      layout: [
+        {offset: 0, stride: 2},
+        {offset: 0, stride: 2},
+      ],
+    });
+  }
+test(() => {
+  assert_throws_js(TypeError, () => createVideoFrame());
+}, "VideoFrame constructor should throw type error with bad data");
+</script>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
@@ -212,7 +212,8 @@ ExceptionOr<CombinedPlaneLayout> computeLayoutAndAllocationSize(const DOMRectIni
         computedLayout.sourceHeight = parsedRect.height / sampleHeight;
         computedLayout.sourceLeftBytes = pixelSampleCount * parsedRect.x / sampleWidthBytes;
         computedLayout.sourceWidthBytes = pixelSampleCount * parsedRect.width / sampleWidthBytes;
-
+        if (!computedLayout.sourceWidthBytes)
+            return Exception { TypeError, "layout width bytes is zero"_s };
         if (layout) {
             if (layout.value()[i].stride < computedLayout.sourceWidthBytes)
                 return Exception { TypeError, "layout stride is invalid"_s };

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
@@ -235,7 +235,7 @@ ExceptionOr<CombinedPlaneLayout> computeLayoutAndAllocationSize(const DOMRectIni
         endOffsets.uncheckedAppend(planeEnd);
         minAllocationSize = std::max(minAllocationSize, planeEnd);
 
-        for (size_t j = 1; j < i; ++j) {
+        for (size_t j = 0; j < i; ++j) {
             if (planeEnd > computedLayouts[j].destinationOffset && endOffsets[j] > computedLayout.destinationOffset)
                 return Exception { TypeError, "planes are overlapping"_s };
         }

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -91,11 +91,18 @@ RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t 
     auto scope = makeScopeExit([&rawPixelBuffer] {
         CVPixelBufferUnlockBaseAddress(rawPixelBuffer, 0);
     });
+    ASSERT(span.size() >= height * planeY.sourceWidthBytes);
+    if (span.size() < height * planeY.sourceWidthBytes)
+        return nullptr;
 
     auto* data = span.data();
     data = copyToCVPixelBufferPlane(rawPixelBuffer, 0, data, height, planeY.sourceWidthBytes);
     if (CVPixelBufferGetPlaneCount(rawPixelBuffer) == 2) {
-        if (CVPixelBufferGetWidthOfPlane(rawPixelBuffer, 1) != (width / 2) || CVPixelBufferGetHeightOfPlane(rawPixelBuffer, 1) != (height / 2))
+        const auto heightUV = height / 2;
+        ASSERT(span.data() + span.size() >= data + (heightUV * planeUV.sourceWidthBytes));
+        if (CVPixelBufferGetWidthOfPlane(rawPixelBuffer, 1) != (width / 2)
+            || CVPixelBufferGetHeightOfPlane(rawPixelBuffer, 1) != heightUV
+            || (data + (heightUV * planeUV.sourceWidthBytes) > span.data() + span.size()))
             return nullptr;
         copyToCVPixelBufferPlane(rawPixelBuffer, 1, data, height / 2, planeUV.sourceWidthBytes);
     }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -373,7 +373,10 @@ RenderObject* RenderTreeBuilder::MultiColumn::processPossibleSpannerDescendant(R
             // column set at the end of the multicol container. We don't really check here if the
             // child inserted precedes any spanner or not (as that's an expensive operation). Just
             // make sure we have a column set at the end. It's no big deal if it remains unused.
-            if (!lastSet->nextSibling())
+
+            // Legends are siblings of RenderMultiColumnSets not because they are spanners, but because they don't participate in multi-column context.
+            auto hasMultiColumnSet = !lastSet->nextSibling() || lastSet->nextSibling()->isLegend();
+            if (hasMultiColumnSet)
                 return nextDescendant;
         }
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7859,6 +7859,7 @@ void WebPageProxy::backForwardAddItem(BackForwardListItemState&& itemState)
 void WebPageProxy::backForwardAddItemShared(Ref<WebProcessProxy>&& process, BackForwardListItemState&& itemState)
 {
     URL itemURL { itemState.pageState.mainFrameState.urlString };
+    URL itemOriginalURL { itemState.pageState.mainFrameState.originalURLString };
 #if PLATFORM(COCOA)
     if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::PushStateFilePathRestriction)
 #if PLATFORM(MAC)
@@ -7868,6 +7869,7 @@ void WebPageProxy::backForwardAddItemShared(Ref<WebProcessProxy>&& process, Back
 #endif // PLATFORM(COCOA)
         ASSERT(!itemURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemURL));
         MESSAGE_CHECK(process, !itemURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemURL));
+        MESSAGE_CHECK(process, !itemOriginalURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemOriginalURL));
 #if PLATFORM(COCOA)
     }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5599,6 +5599,9 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
     if (frame->isMainFrame() && navigationID)
         navigation = navigationState().navigation(navigationID);
 
+    if (navigation && frame->isMainFrame() && navigation->currentRequest().url().isValid())
+        MESSAGE_CHECK(process, navigation->currentRequest().url() == url);
+
     LOG(Loading, "WebPageProxy %" PRIu64 " in process pid %i didStartProvisionalLoadForFrame to frameID %" PRIu64 ", navigationID %" PRIu64 ", url %s", internals().identifier.toUInt64(), process->processID(), frameID.object().toUInt64(), navigationID, url.string().utf8().data());
     WEBPAGEPROXY_RELEASE_LOG(Loading, "didStartProvisionalLoadForFrame: frameID=%" PRIu64 ", isMainFrame=%d", frameID.object().toUInt64(), frame->isMainFrame());
 


### PR DESCRIPTION
#### 089727e3a24abd707bc0ccc4d033c6a5c3b9e8b5
<pre>
Legends could be valid non-spanner siblings of RenderMultiColumnSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=258675">https://bugs.webkit.org/show_bug.cgi?id=258675</a>
&lt;rdar://111221306&gt;

Reviewed by Antti Koivisto.

We usually construct one RenderMultiColumnSet renderer for a multi-column context.

e.g:
&lt;div style=&quot;column-count: 2&quot;&gt;
  &lt;div&gt;&lt;/div&gt;
  &lt;div&gt;&lt;/div&gt;
  &lt;div&gt;&lt;/div&gt;
&lt;/div&gt;

generates the following render tree structure:

DIV RenderBlockFlow
  RenderMultiColumnFlowThread
    DIV RenderBlockFlow
    DIV RenderBlockFlow
    DIV RenderBlockFlow
  RenderMultiColumnSet

We also construct RenderMultiColumnSets for column spanners
e.g.
&lt;div style=&quot;column-count: 2&quot;&gt;
  &lt;div style=&quot;column-span: all&quot;&gt;&lt;/div&gt;
  &lt;div&gt;&lt;/div&gt;
  &lt;div&gt;&lt;/div&gt;
&lt;/div&gt;

where the spanner is moved out of the column context indicating it spans all the columns

DIV RenderBlockFlow
  RenderMultiColumnFlowThread
    RenderMultiColumnSpannerPlaceholder (this is the &lt;div&gt;&apos;s original insertion point)
    DIV RenderBlockFlow
    DIV RenderBlockFlow
  RenderMultiColumnSet
  DIV RenderBlockFlow (moved out column spanner)
  RenderMultiColumnSet

However since &lt;legend&gt; does not participate in multi-column, it does _not_ get moved under RenderMultiColumnFlowThread when constructing the multi-column context
and ends up being a sibling of the RenderMultiColumnSet.

e.g.

FIELDSET RenderFieldSet
  RenderMultiColumnFlowThread
    RenderBlock
  RenderMultiColumnSet
  LEGEND RenderBlock

and later it gets mistaken for a column spanner and as the result we construct a redundant RenderMultiColumnSet.

This patch handles this case by checking against legend siblings.

* LayoutTests/fast/multicol/crash-when-legend-is-present-expected.txt: Added.
* LayoutTests/fast/multicol/crash-when-legend-is-present.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
(WebCore::RenderTreeBuilder::MultiColumn::processPossibleSpannerDescendant):

Originally-landed-as: 265870.61@safari-7616-branch (9ff2ba06a74f). rdar://116424838
Canonical link: <a href="https://commits.webkit.org/269104@main">https://commits.webkit.org/269104@main</a>
</pre>
----------------------------------------------------------------------
#### 176844ce6b7081d18c274f3c391b5c3a81f84f2c
<pre>
Heap-buffer-overflow in WebCore::VideoFrame::createNV12.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257550.">https://bugs.webkit.org/show_bug.cgi?id=257550.</a>
rdar://110003963 (jsc_fuz/wktr: heap-buffer-overflow in WebCore::VideoFrame::createNV12()).

Reviewed by Youenn Fablet.

This change add a check to see if the given data buffer is longer than width*height inorder to avoid the out of bounds access of the data buffer..

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/createNV12-heap-buffer-overflow-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/createNV12-heap-buffer-overflow.html: Added.
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::createNV12):

Originally-landed-as: 265870.60@safari-7616-branch (6a266ad796ff). rdar://116424723
Canonical link: <a href="https://commits.webkit.org/269103@main">https://commits.webkit.org/269103@main</a>
</pre>
----------------------------------------------------------------------
#### c031542a9d50bb2a0c103818d0a88838b54ff794
<pre>
Heap-buffer-overflow in I420ToNV12 when the length of the given data buffer is higher than allocation size but lower than the product of width and height of the videoframe.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257548.">https://bugs.webkit.org/show_bug.cgi?id=257548.</a>
rdar://109886863.

Reviewed by Youenn Fablet.

This change add a check to see if the given data buffer is longer than width*height inorder to avoid the out of bounds access of the buffer.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/I420ToNV12-heap-buffer-overflow-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/I420ToNV12-heap-buffer-overflow.html: Added.
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitUtilities.mm:
    (webrtc::pixelBufferFromI420Buffer):

Originally-landed-as: 265870.56@safari-7616-branch (430e9edcf1f4). rdar://116424551
Canonical link: <a href="https://commits.webkit.org/269102@main">https://commits.webkit.org/269102@main</a>
</pre>
----------------------------------------------------------------------
#### d120c8413d8434b8547cc82ca6856679f2563752
<pre>
MESSAGE_CHECK() originalURLString in WebPageProxy::backForwardAddItemShared()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259111">https://bugs.webkit.org/show_bug.cgi?id=259111</a>
rdar://112058151

Reviewed by Brent Fulgham.

MESSAGE_CHECK() originalURLString in WebPageProxy::backForwardAddItemShared()
as hardening, the same way we already do for urlString.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardAddItemShared):

Originally-landed-as: 265870.12@safari-7616-branch (3f548e40249b). rdar://116424474
Canonical link: <a href="https://commits.webkit.org/269101@main">https://commits.webkit.org/269101@main</a>
</pre>
----------------------------------------------------------------------
#### 57974637773d4ac594a1775866b9cb3a3656037c
<pre>
Data Isolation/PSON bypass due to UI-side PageLoadState state-machine relying on data which is distinct from that used to make Policy/Network Load decisions
<a href="https://bugs.webkit.org/show_bug.cgi?id=257732">https://bugs.webkit.org/show_bug.cgi?id=257732</a>
rdar://107186055

Reviewed by Chris Dumez.

When `didStartProvisionalLoadForFrame` is called, pageLoadState is updated to store the provisional URL
with a value passed from the web process. This URL is later consulted in `processForNavigationInternal`
when determining if the navigation is same-site. Since this URL is coming from the web process, we
should verify that the URL has not been changed from when it was set on the navigation object in
`decidePolicyForNavigationAction`.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):

Originally-landed-as: 265870.10@safari-7616-branch (b5aa6d4342b7). rdar://116424252
Canonical link: <a href="https://commits.webkit.org/269100@main">https://commits.webkit.org/269100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/812c862a8e4cc4c3b1974f809fb51a75bae641e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22654 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20677 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23507 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25163 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19025 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23061 "2 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16667 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18845 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5154 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->