### PR TITLE
[WebAuthn] Pass correct origin as parent and display as RegistrableDomain

### DIFF
--- a/JSTests/stress/typed-array-extends.js
+++ b/JSTests/stress/typed-array-extends.js
@@ -1,0 +1,13 @@
+// Crash on Debug builds
+var array = [];
+for (var i = 0; i < 1e4; ++i)
+    array.push(i);
+Reflect.defineProperty(array, Symbol.iterator, {
+    get() {
+        array.length = 0;
+        Reflect.deleteProperty(array, Symbol.iterator);
+        return undefined;
+    },
+    configurable: true
+});
+new Uint8Array(array);

--- a/LayoutTests/http/tests/security/resources/xslt-external-entity.svg
+++ b/LayoutTests/http/tests/security/resources/xslt-external-entity.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="#"?>
+
+<xsl:stylesheet id="color-change" version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+ <xsl:template match="/">
+	<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1000 1000">
+		<foreignObject id="myObj" width="1000" height="1000">
+		    <div style="font-size:xxx-large" xmlns="http://www.w3.org/1999/xhtml">
+			document() <xsl:copy-of  select="document('xslt2.py')"/>
+		    </div>
+		</foreignObject>
+	</svg>
+ </xsl:template>
+</xsl:stylesheet>

--- a/LayoutTests/http/tests/security/resources/xslt2.py
+++ b/LayoutTests/http/tests/security/resources/xslt2.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import base64
+import os
+import sys
+
+sys.stdout.write('Access-Control-Allow-Origin: *\r\n')
+sys.stdout.write('\r\n')
+sys.stdout.write('<!DOCTYPE p [')
+sys.stdout.write('<!ENTITY passwd SYSTEM "file:///etc/passwd">')
+sys.stdout.write('<!ENTITY hosts SYSTEM "file:///etc/hosts">')
+sys.stdout.write('<!ENTITY group SYSTEM "file://localhost/etc/group">')
+sys.stdout.write(']>')
+sys.stdout.write('<p>')
+sys.stdout.write('  <p style="border-style: dotted;" id="pw">/etc/passwd:')
+sys.stdout.write('&passwd;')
+sys.stdout.write('  </p>')
+sys.stdout.write(' <p style="border-style: dotted;">/etc/hosts:')
+sys.stdout.write('&hosts;')
+sys.stdout.write('  </p>')
+sys.stdout.write(' <p style="border-style: dotted;">/etc/group:')
+sys.stdout.write('&group;')
+sys.stdout.write('  </p>')
+sys.stdout.write('</p>')
+sys.stdout.write('')
+sys.exit(0)

--- a/LayoutTests/http/tests/security/xslt-external-entity-expected.txt
+++ b/LayoutTests/http/tests/security/xslt-external-entity-expected.txt
@@ -1,0 +1,2 @@
+ALERT: document() /etc/passwd: /etc/hosts: /etc/group:
+

--- a/LayoutTests/http/tests/security/xslt-external-entity.html
+++ b/LayoutTests/http/tests/security/xslt-external-entity.html
@@ -1,0 +1,12 @@
+<script>
+if (window.testRunner) { testRunner.dumpAsText() }
+function go() {
+    const i = document.getElementById('i');
+    const doc = i.contentWindow.document;
+    const div = doc.getElementsByTagName("div")[0];
+    const text = div.innerText;
+    alert(text);
+}
+</script>
+
+<iframe id=i src="resources/xslt-external-entity.svg" width=500 height=500 onload=go()></iframe>

--- a/LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/navigating-iframe-sandbox-expected.txt
+++ b/LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/navigating-iframe-sandbox-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Refused to display 'http://127.0.0.1:8800/WebKit/html/browsers/browsing-the-web/navigating-across-documents/resources/only-same-origin-allowed.py' in a frame because it set 'X-Frame-Options' to 'SAMEORIGIN'.
+CONSOLE MESSAGE: Not allowed to redirect to data:text/html,FAIL due to its scheme
+
+PASS Ensure document gets replaced with an error document in case of blocked navigation
+PASS Ensure document gets replaced with an error document in case of blocked redirection
+

--- a/LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/navigating-iframe-sandbox.html
+++ b/LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/navigating-iframe-sandbox.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<title>iframe sandboxing when navigation fails</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<iframe id="myframe1"></iframe>
+<iframe id="myframe2"></iframe>
+<script>
+promise_test(async t => {
+    const promise = new Promise(resolve => window.onmessage = e => resolve(e.data));
+    myframe1.src = "resources/frame-posting-messages.html";
+    assert_equals(await promise, "hello");
+
+    myframe1.contentWindow.location = "http://127.0.0.1:8800/WebKit/html/browsers/browsing-the-web/navigating-across-documents/resources/only-same-origin-allowed.py";
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // Navigation is blocked, previous document should be replaced with an error document
+    let counter = 0;
+    let isOk = false;
+    while (++counter < 10 && !isOk) {
+        isOk = await new Promise(resolve => {
+            window.onmessage = () => resolve(false);
+            setTimeout(() => resolve(true), 200);
+        });
+    }
+    assert_true(isOk);
+}, "Ensure document gets replaced with an error document in case of blocked navigation");
+
+promise_test(async t => {
+    const promise = new Promise(resolve => window.onmessage = e => resolve(e.data));
+    myframe2.src = "resources/frame-posting-messages.html";
+    assert_equals(await promise, "hello");
+
+    myframe2.contentWindow.location = "http://localhost:8800/html/browsers/browsing-the-web/navigating-across-documents/resources/redirect.py?location=data:text/html,FAIL";
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // Redirection is blocked, previous document should be replaced with an error document
+    let counter = 0;
+    let isOk = false;
+    while (++counter < 10 && !isOk) {
+        isOk = await new Promise(resolve => {
+            window.onmessage = () => resolve(false);
+            setTimeout(() => resolve(true), 200);
+        });
+    }
+    assert_true(isOk);
+}, "Ensure document gets replaced with an error document in case of blocked redirection");
+</script>

--- a/LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/resources/frame-posting-messages.html
+++ b/LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/resources/frame-posting-messages.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<script>
+setInterval(() => {
+    parent.postMessage("hello", "*");
+}, 50);
+</script>

--- a/LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/resources/only-same-origin-allowed.py
+++ b/LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/resources/only-same-origin-allowed.py
@@ -1,0 +1,9 @@
+import random
+
+
+def main(request, response):
+    headers = [
+        (b"Content-type", b"text/html"),
+        (b"X-Frame-Options", b"SAMEORIGIN")
+    ]
+    return headers, "log('" + str(random.random()) + "');"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https-expected.txt
@@ -1,19 +1,19 @@
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 
 PASS navigation allowed for []
 PASS navigation allowed for [""]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-blank.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-blank.https-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 
 
 PASS Wait for the DOM to be built.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-srcdoc.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-srcdoc.https-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Refused to display 'https://localhost:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://localhost:9443" from accessing a frame at "https://localhost:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 
 
 PASS Wait for the DOM to be built.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https-expected.txt
@@ -1,21 +1,21 @@
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 
 PASS navigation allowed for []
 PASS navigation allowed for [""]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-blank.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-blank.https-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 
 
 PASS Wait for the DOM to be built.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-srcdoc.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-srcdoc.https-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Refused to display 'https://web-platform.test:9443/common/blank.html' in a frame because of Cross-Origin-Embedder-Policy.
-CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "null".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
+CONSOLE MESSAGE: Sandbox access violation: Blocked a frame at "https://web-platform.test:9443" from accessing a frame at "https://web-platform.test:9443".  The frame being accessed is sandboxed and lacks the "allow-same-origin" flag.
 
 
 PASS Wait for the DOM to be built.

--- a/LayoutTests/platform/mac-monterey-wk1/http/tests/security/xss-DENIED-xsl-external-entity-no-logging-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk1/http/tests/security/xss-DENIED-xsl-external-entity-no-logging-expected.txt
@@ -1,0 +1,2 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600

--- a/LayoutTests/platform/mac-monterey/http/tests/security/xslt-external-entity-expected.txt
+++ b/LayoutTests/platform/mac-monterey/http/tests/security/xslt-external-entity-expected.txt
@@ -1,0 +1,14 @@
+CONSOLE MESSAGE: Failure to process entity passwd
+
+CONSOLE MESSAGE: Entity 'passwd' not defined
+
+CONSOLE MESSAGE: Failure to process entity hosts
+
+CONSOLE MESSAGE: Entity 'hosts' not defined
+
+CONSOLE MESSAGE: Failure to process entity group
+
+CONSOLE MESSAGE: Entity 'group' not defined
+
+ALERT: document()
+

--- a/LayoutTests/platform/mac-monterey/http/tests/security/xss-DENIED-xsl-external-entity-expected.txt
+++ b/LayoutTests/platform/mac-monterey/http/tests/security/xss-DENIED-xsl-external-entity-expected.txt
@@ -1,6 +1,8 @@
 CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/resources/target.xml from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
 
-CONSOLE MESSAGE: Unsafe attempt to load URL http://localhost:8000/security/resources/target.xml from origin http://127.0.0.1:8000. Domains, protocols and ports must match.
+CONSOLE MESSAGE: Failure to process entity ent
 
-This test includes a cross-origin external entity. It passes if the load fails and thus there is no text below this line.
+CONSOLE MESSAGE: Entity 'ent' not defined
 
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600

--- a/LayoutTests/workers/empty-post-message-service-workers-crash-expected.txt
+++ b/LayoutTests/workers/empty-post-message-service-workers-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/workers/empty-post-message-service-workers-crash.html
+++ b/LayoutTests/workers/empty-post-message-service-workers-crash.html
@@ -1,0 +1,26 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+  onload = () => {
+    document.createElement('audio').src = 'data:application/vnd.apple.mpegURL;base64,xx';
+    for (let i = 0; i <= 50; i++) {
+      if (50 == i) {
+        if (window.testRunner)
+          testRunner.notifyDone();
+      }
+      let w = new Worker('empty-post-message-service-workers-crash.js');
+      w.onmessage = () => {
+        w.postMessage(undefined);
+      };
+      w.postMessage(undefined);
+    }
+  };
+</script>
+<html>
+  <body>
+    <p>PASS if no crash</p>
+  </body>
+</html>

--- a/LayoutTests/workers/empty-post-message-service-workers-crash.js
+++ b/LayoutTests/workers/empty-post-message-service-workers-crash.js
@@ -1,0 +1,4 @@
+onmessage = () => {
+  postMessage(undefined)
+}
+new Worker('empty-post-message-service-workers-crash.js');

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -413,7 +413,7 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
 
     if constexpr (TypedArrayStorageType != TypeBigInt64 || TypedArrayStorageType != TypeBigUint64) {
         if (JSArray* array = jsDynamicCast<JSArray*>(object); LIKELY(array && isJSArray(array))) {
-            if (safeLength == length && (safeLength + objectOffset) >= array->length() && array->isIteratorProtocolFastAndNonObservable()) {
+            if (safeLength == length && (safeLength + objectOffset) <= array->length() && array->isIteratorProtocolFastAndNonObservable()) {
                 IndexingType indexingType = array->indexingType() & IndexingShapeMask;
                 if (indexingType == Int32Shape) {
                     copyFromInt32ShapeArray(offset, array, objectOffset, safeLength);

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -59,7 +59,7 @@ ScopeAndCrossOriginParent CredentialsContainer::scopeAndCrossOriginParent() cons
         if (!origin.isSameOriginDomain(document->securityOrigin()) && !areRegistrableDomainsEqual(url, document->url()))
             isSameSite = false;
         if (!crossOriginParent && !origin.isSameOriginAs(document->securityOrigin()))
-            crossOriginParent = origin.data();
+            crossOriginParent = document->securityOrigin().data();
     }
 
     if (!crossOriginParent)

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -547,6 +547,7 @@ private:
     void dataReceived(const SharedBuffer&);
 
     bool maybeLoadEmpty();
+    void loadErrorDocument();
 
     bool isMultipartReplacingLoad() const;
     bool isPostOrRedirectAfterPost(const ResourceRequest&, const ResourceResponse&);

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -134,7 +134,7 @@ private:
     std::unique_ptr<ResourceRequest> createResourceRequest(const String& initiatorIdentifier);
     void notifyFinished();
 
-    WorkerScriptLoaderClient* m_client { nullptr };
+    WeakPtr<WorkerScriptLoaderClient> m_client;
     RefPtr<ThreadableLoader> m_threadableLoader;
     RefPtr<TextResourceDecoder> m_decoder;
     ScriptBuffer m_script;

--- a/Source/WebCore/workers/WorkerScriptLoaderClient.h
+++ b/Source/WebCore/workers/WorkerScriptLoaderClient.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class ResourceResponse;
 
-class WorkerScriptLoaderClient {
+class WorkerScriptLoaderClient : public CanMakeWeakPtr<WorkerScriptLoaderClient> {
 public:
     virtual void didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse&) = 0;
     virtual void notifyFinished() = 0;

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -448,6 +448,8 @@ static bool shouldAllowExternalLoad(const URL& url)
     // retrieved content.  If we had more context, we could potentially allow
     // the parser to load a DTD.  As things stand, we take the conservative
     // route and allow same-origin requests only.
+    if (!XMLDocumentParserScope::currentCachedResourceLoader || !XMLDocumentParserScope::currentCachedResourceLoader->document())
+        return false;
     if (!XMLDocumentParserScope::currentCachedResourceLoader->document()->securityOrigin().canRequest(url, OriginAccessPatternsForWebProcess::singleton())) {
         XMLDocumentParserScope::currentCachedResourceLoader->printAccessDeniedMessage(url);
         return false;
@@ -535,6 +537,15 @@ static void errorFunc(void*, const char*, ...)
 }
 #endif
 
+static xmlExternalEntityLoader defaultEntityLoader { nullptr };
+
+static xmlParserInputPtr entityLoader(const char* url, const char* id, xmlParserCtxtPtr context)
+{
+    if (!shouldAllowExternalLoad(URL(String::fromUTF8(url))))
+        return nullptr;
+    return defaultEntityLoader(url, id, context);
+}
+
 static void initializeXMLParser()
 {
     static std::once_flag flag;
@@ -542,6 +553,8 @@ static void initializeXMLParser()
         xmlInitParser();
         xmlRegisterInputCallbacks(matchFunc, openFunc, readFunc, closeFunc);
         xmlRegisterOutputCallbacks(matchFunc, openFunc, writeFunc, closeFunc);
+        defaultEntityLoader = xmlGetExternalEntityLoader();
+        xmlSetExternalEntityLoader(entityLoader);
         libxmlLoaderThread = &Thread::current();
     });
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -40,6 +40,7 @@
 #import <WebCore/BufferSource.h>
 #import <WebCore/ExceptionData.h>
 #import <WebCore/PublicKeyCredentialCreationOptions.h>
+#import <WebCore/RegistrableDomain.h>
 #import <WebCore/SecurityOrigin.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/CompletionHandler.h>
@@ -310,7 +311,7 @@ static inline RetainPtr<ASCPublicKeyCredentialAssertionOptions> configureAsserti
             [assertionOptions setExtensions:toASCExtensions(*options.extensions).get()];
     }
     if (parentOrigin && [assertionOptions respondsToSelector:@selector(setDestinationSiteForCrossSiteAssertion:)])
-        assertionOptions.get().destinationSiteForCrossSiteAssertion = parentOrigin->toString();
+        assertionOptions.get().destinationSiteForCrossSiteAssertion = RegistrableDomain { *parentOrigin }.string();
     else if (parentOrigin && ![assertionOptions respondsToSelector:@selector(setDestinationSiteForCrossSiteAssertion:)])
         return nil;
     if (options.timeout && [assertionOptions respondsToSelector:@selector(setTimeout:)])


### PR DESCRIPTION
#### 29f66ed8b60d011f66c423fa9bee7882381dab7c
<pre>
[WebAuthn] Pass correct origin as parent and display as RegistrableDomain
<a href="https://bugs.webkit.org/show_bug.cgi?id=258165">https://bugs.webkit.org/show_bug.cgi?id=258165</a>
rdar://110863705

Reviewed by Chris Dumez.

We passed the wrong domain as the parent origin here. This patch fixes it and also changes
the format to just the registrable domain to match how the other domain is shown.

* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::scopeAndCrossOriginParent const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::configureAssertionOptions):

Originally-landed-as: 265870.134@safari-7616-branch (54fe9f25d668). rdar://116425892
Canonical link: <a href="https://commits.webkit.org/269109@main">https://commits.webkit.org/269109@main</a>
</pre>
----------------------------------------------------------------------
#### 65f6eb50727a9f91a15f35f0971e26ba5b858391
<pre>
Check if external entity loads from libxslt are allowed before loading them
<a href="https://bugs.webkit.org/show_bug.cgi?id=259235">https://bugs.webkit.org/show_bug.cgi?id=259235</a>
rdar://111457167

Reviewed by David Kilzer.

Otherwise tricky use of libxslt can make arbitrary file loads to files allowed by the
web content process&apos;s sandbox.  We should limit it to what the current security origin
can request.

Monterey has an older version of libxml2 which fails differently in this case.
Tests exist that verify that allowed external entities are still allowed.
The important thing is that the contents of the files are not in the Monterey test expectations.

* LayoutTests/http/tests/security/resources/xslt-external-entity.svg: Added.
* LayoutTests/http/tests/security/resources/xslt2.py: Added.
* LayoutTests/http/tests/security/xslt-external-entity-expected.txt: Added.
* LayoutTests/http/tests/security/xslt-external-entity.html: Added.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::shouldAllowExternalLoad):
(WebCore::entityLoader):
(WebCore::initializeXMLParser):

Originally-landed-as: 265870.131@safari-7616-branch (d2e39548861d). rdar://116425810
Canonical link: <a href="https://commits.webkit.org/269108@main">https://commits.webkit.org/269108@main</a>
</pre>
----------------------------------------------------------------------
#### 19642719bec427c59771fdb0c90bc9980129406a
<pre>
Fix UAF in WorkerScriptLoader::didReceiveResponse
<a href="https://bugs.webkit.org/show_bug.cgi?id=259278">https://bugs.webkit.org/show_bug.cgi?id=259278</a>
rdar://109722407

Reviewed by Chris Dumez and David Kilzer.

This change adopts WeakPtrs for WorkerScriptLoaderClient, thereby fixing
the UAF which happens when m_client goes away when the callback passed
to swConnection.matchRegistration is invoked.

* LayoutTests/workers/empty-post-message-service-workers-crash-expected.txt: Added.
* LayoutTests/workers/empty-post-message-service-workers-crash.html: Added.
* LayoutTests/workers/empty-post-message-service-workers-crash.js: Added.
(onmessage):
* Source/WebCore/workers/WorkerScriptLoader.h:
* Source/WebCore/workers/WorkerScriptLoaderClient.h:

Originally-landed-as: 265870.130@safari-7616-branch (6b1737e3545c). rdar://116425737
Canonical link: <a href="https://commits.webkit.org/269107@main">https://commits.webkit.org/269107@main</a>
</pre>
----------------------------------------------------------------------
#### a5dec2a6471d8212558d030e733681803ea0b3fe
<pre>
[JSC] TypedArray setFromArrayLike condition is wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=259268">https://bugs.webkit.org/show_bug.cgi?id=259268</a>
rdar://112387533

Reviewed by Mark Lam.

The condition is opposite. This patch fixes it with the test.

* JSTests/stress/typed-array-extends.js: Added.
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::setFromArrayLike):

Originally-landed-as: 265870.128@safari-7616-branch (e4cc04578783). rdar://116425595
Canonical link: <a href="https://commits.webkit.org/269106@main">https://commits.webkit.org/269106@main</a>
</pre>
----------------------------------------------------------------------
#### 1294929f7ff20abdc681ae2e5555273e4639004a
<pre>
WebKit applies dynamic sandbox flags on failed navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=259099">https://bugs.webkit.org/show_bug.cgi?id=259099</a>
rdar://112044768

Reviewed by Alex Christensen.

In case of stopped navigation or failed navigation, we were sandboxing the current document.
The current document was thus running but in a different configuration.
Other browsers create a new document in that case, Firefox with the request URL and Chrome with a special error scheme URL.
To limit the scope of changes, we are now creating a new error document, which is empty, and are sandboxing this new document.
This gets us closer to Firefox and Safari.
We are still calling the fail delegate in case the application wants to do additional handling on this document.

* LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/navigating-iframe-sandbox-expected.txt: Added.
* LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/navigating-iframe-sandbox.html: Added.
* LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/resources/frame-posting-messages.html: Added.
* LayoutTests/http/wpt/html/browsers/browsing-the-web/navigating-across-documents/resources/only-same-origin-allowed.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-blank.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-srcdoc.https-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/header-parsing.https-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-blank.https-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/require-corp-about-srcdoc.https-expected.txt:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
(WebCore::DocumentLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied):
(WebCore::DocumentLoader::loadErrorDocument):
* Source/WebCore/loader/DocumentLoader.h:

Originally-landed-as: 265870.62@safari-7616-branch (4fc1843e1263). rdar://116425228
Canonical link: <a href="https://commits.webkit.org/269105@main">https://commits.webkit.org/269105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e55d5a71a696582ca0602d97ee969c82d84302c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20684 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23508 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25174 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18087 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23075 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20188 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19616 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17237 "1 flakes") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24172 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18687 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5746 "Found 4 jsc stress test failures: stress/sampling-profiler-microtasks.js.bytecode-cache, stress/sampling-profiler-microtasks.js.dfg-eager, stress/sampling-profiler-microtasks.js.dfg-eager-no-cjit-validate, stress/sampling-profiler-microtasks.js.eager-jettison-no-cjit") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23178 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25434 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2675 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19434 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5570 "Passed tests") | 
<!--EWS-Status-Bubble-End-->