### PR TITLE
Mixed content checker should not hang in site isolated iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/https-load-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/https-load-expected.txt
@@ -1,0 +1,2 @@
+ALERT: received 'fetched https successfully'
+

--- a/LayoutTests/http/tests/site-isolation/https-load.html
+++ b/LayoutTests/http/tests/site-isolation/https-load.html
@@ -1,0 +1,12 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+addEventListener("message", (event) => {
+    alert("received '" + event.data + "'");
+    testRunner.notifyDone();
+});
+</script>
+<iframe src="https://localhost:8443/site-isolation/resources/fetch-https.html" id="frame"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/fetch-https.html
+++ b/LayoutTests/http/tests/site-isolation/resources/fetch-https.html
@@ -1,0 +1,5 @@
+<script>
+fetch("/site-isolation/resources/fetch-https.html").then(()=>{
+    window.parent.postMessage("fetched https successfully", "*")
+})
+</script>

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -66,6 +66,10 @@ static bool foundMixedContentInFrameTree(const LocalFrame& frame, const URL& url
         RELEASE_ASSERT_WITH_MESSAGE(abstractParentFrame, "Should never have a parentless non main frame");
         if (auto* parentFrame = dynamicDowncast<LocalFrame>(abstractParentFrame))
             document = parentFrame->document();
+        else {
+            // FIXME: <rdar://116259764> Make mixed content checks work correctly with site isolated iframes.
+            document = nullptr;
+        }
     }
 
     return false;


### PR DESCRIPTION
#### 9b95468b01eb6f0f63974e17218b539338e5a83b
<pre>
Mixed content checker should not hang in site isolated iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=262581">https://bugs.webkit.org/show_bug.cgi?id=262581</a>
rdar://116430288

Reviewed by Pascoe.

When loading any https resource in a site-isolated https iframe, we would hang the process
because foundMixedContentInFrameTree doesn&apos;t update its document pointer in the loop.
This makes the load succeed so we can investigate other things with site isolation, with
future work to be done to make the mixed content checks actually correct.

* LayoutTests/http/tests/site-isolation/https-load-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/https-load.html: Added.
* LayoutTests/http/tests/site-isolation/resources/fetch-https.html: Added.
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::foundMixedContentInFrameTree):

Canonical link: <a href="https://commits.webkit.org/268816@main">https://commits.webkit.org/268816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b59eeb1f06b88c196f8dd9c6e96aef1a2929bab3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22656 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21356 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23509 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/17947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18849 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23058 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18685 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23179 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2562 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/19435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->