### PR TITLE
clobberize needs to be more precise with the *ByOffset nodes

### DIFF
--- a/JSTests/stress/getbyoffset-cse-consistency.js
+++ b/JSTests/stress/getbyoffset-cse-consistency.js
@@ -1,0 +1,25 @@
+let a = {};
+a.foo = 1;
+a.bar = 1.1;
+
+let b = {};
+b.baz = 3.3;
+b.foo = 1;
+
+function func(flag) {
+    let tmp = flag ? a : b;
+
+    let x;
+    for (let i = 0; i < 10; ++i) {
+        if (flag)
+            x = tmp.foo;
+        else
+            x = tmp.foo;
+    }
+    return x;
+}
+
+for (let i = 0; i < 1e5; ++i) {
+    if (func(i % 2) !== 1)
+        throw new Error();
+}

--- a/JSTests/stress/multigetbyoffset-cse-consistency.js
+++ b/JSTests/stress/multigetbyoffset-cse-consistency.js
@@ -1,0 +1,38 @@
+let a = {};
+a.foo = 1;
+a.bar = 1.1;
+a.other = 4.4;
+
+let b = {};
+b.baz = 3.3;
+b.foo = 1;
+b.other = 5.4;
+
+let c = {};
+c.other = 3.4;
+c.other2 = 9.1;
+c.foo = 1;
+
+function func(flag1, flag2) {
+    let tmp = a;
+    if (flag1) {
+        tmp = b;
+        if (flag2)
+            tmp = c;
+    }
+
+
+    let x;
+    for (let i = 0; i < 10; ++i) {
+        if (flag1)
+            x = tmp.foo;
+        else
+            x = tmp.foo;
+    }
+    return x;
+}
+
+for (let i = 0; i < 1e5; ++i) {
+    if (func(i % 2, i % 3) !== 1)
+        throw new Error();
+}

--- a/LayoutTests/compositing/reflections/video-mask-reflection-crash-expected.txt
+++ b/LayoutTests/compositing/reflections/video-mask-reflection-crash-expected.txt
@@ -1,0 +1,3 @@
+This test should not crash.
+
+

--- a/LayoutTests/compositing/reflections/video-mask-reflection-crash.html
+++ b/LayoutTests/compositing/reflections/video-mask-reflection-crash.html
@@ -1,0 +1,19 @@
+<style>
+    video {
+        mask-image: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7);
+        -webkit-box-reflect: below 10px;
+    }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    function runTest()
+    {
+        document.getElementsByTagName('video')[0].src = "x";
+    }
+</script>
+<body onload=runTest()>
+    <p>This test should not crash.</p>
+    <video controls="controls">
+</body>

--- a/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCSEPhase.cpp
@@ -677,6 +677,12 @@ public:
     
     bool run()
     {
+
+        if (DFGCSEPhaseInternal::verbose) {
+            dataLog("Graph before Global CSE:\n");
+            m_graph.dump();
+        }
+
         ASSERT(m_graph.m_fixpointState == FixpointNotConverged);
         ASSERT(m_graph.m_form == SSA);
         

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1476,7 +1476,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         unsigned identifierNumber = node->storageAccessData().identifierNumber;
         AbstractHeap heap(NamedProperties, identifierNumber);
         read(heap);
-        def(HeapLocation(NamedPropertyLoc, heap, node->child2()), LazyNode(node));
+        def(HeapLocation(NamedPropertyLoc, heap, node->child2(), &node->storageAccessData()), LazyNode(node));
         return;
     }
 
@@ -1485,7 +1485,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         read(JSObject_butterfly);
         AbstractHeap heap(NamedProperties, node->multiGetByOffsetData().identifierNumber);
         read(heap);
-        def(HeapLocation(NamedPropertyLoc, heap, node->child1()), LazyNode(node));
+        def(HeapLocation(NamedPropertyLoc, heap, node->child1(), &node->multiGetByOffsetData()), LazyNode(node));
         return;
     }
         
@@ -1498,7 +1498,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             write(JSCell_structureID);
         if (node->multiPutByOffsetData().reallocatesStorage())
             write(JSObject_butterfly);
-        def(HeapLocation(NamedPropertyLoc, heap, node->child1()), LazyNode(node->child2().node()));
+        def(HeapLocation(NamedPropertyLoc, heap, node->child1(), &node->multiPutByOffsetData()), LazyNode(node->child2().node()));
         return;
     }
 
@@ -1520,7 +1520,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         unsigned identifierNumber = node->storageAccessData().identifierNumber;
         AbstractHeap heap(NamedProperties, identifierNumber);
         write(heap);
-        def(HeapLocation(NamedPropertyLoc, heap, node->child2()), LazyNode(node->child3().node()));
+        def(HeapLocation(NamedPropertyLoc, heap, node->child2(), &node->storageAccessData()), LazyNode(node->child3().node()));
         return;
     }
         

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -89,16 +89,20 @@ public:
     HeapLocation(
         LocationKind kind = InvalidLocationKind,
         AbstractHeap heap = AbstractHeap(),
-        Node* base = nullptr, LazyNode index = LazyNode(), Node* descriptor = nullptr)
+        Node* base = nullptr,
+        LazyNode index = LazyNode(),
+        Node* descriptor = nullptr,
+        void* extraState = nullptr)
         : m_kind(kind)
         , m_heap(heap)
         , m_base(base)
         , m_index(index)
         , m_descriptor(descriptor)
+        , m_extraState(extraState)
     {
         ASSERT((kind == InvalidLocationKind) == !heap);
         ASSERT(!!m_heap || !m_base);
-        ASSERT(m_base || (!m_index && !m_descriptor));
+        ASSERT(m_base || (!m_index && !m_descriptor && !m_extraState));
     }
 
     HeapLocation(LocationKind kind, AbstractHeap heap, Node* base, Node* index, Node* descriptor = nullptr)
@@ -108,6 +112,11 @@ public:
     
     HeapLocation(LocationKind kind, AbstractHeap heap, Edge base, Edge index = Edge(), Edge descriptor = Edge())
         : HeapLocation(kind, heap, base.node(), index.node(), descriptor.node())
+    {
+    }
+
+    HeapLocation(LocationKind kind, AbstractHeap heap, Edge base, void* extraState)
+        : HeapLocation(kind, heap, base.node(), nullptr, nullptr, extraState)
     {
     }
     
@@ -126,10 +135,16 @@ public:
     AbstractHeap heap() const { return m_heap; }
     Node* base() const { return m_base; }
     LazyNode index() const { return m_index; }
+    void* extraState() const { return m_extraState; }
     
     unsigned hash() const
     {
-        return m_kind + m_heap.hash() + m_index.hash() + static_cast<unsigned>(bitwise_cast<uintptr_t>(m_base)) + static_cast<unsigned>(bitwise_cast<uintptr_t>(m_descriptor));
+        return m_kind
+            + m_heap.hash()
+            + m_index.hash()
+            + static_cast<unsigned>(bitwise_cast<uintptr_t>(m_base))
+            + static_cast<unsigned>(bitwise_cast<uintptr_t>(m_descriptor))
+            + static_cast<unsigned>(bitwise_cast<uintptr_t>(m_extraState));
     }
     
     friend bool operator==(const HeapLocation&, const HeapLocation&) = default;
@@ -147,6 +162,7 @@ private:
     Node* m_base;
     LazyNode m_index;
     Node* m_descriptor;
+    void* m_extraState { nullptr };
 };
 
 struct HeapLocationHash {

--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
@@ -132,7 +132,7 @@ ExceptionOr<void> ApplePayAMSUIPaymentHandler::show(Document& document)
 {
     ASSERT(m_applePayAMSUIRequest);
 
-    if (!page().startApplePayAMSUISession(document, *this, *m_applePayAMSUIRequest))
+    if (!page().startApplePayAMSUISession(document.topDocument().url(), *this, *m_applePayAMSUIRequest))
         return Exception { AbortError };
 
     return { };

--- a/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
@@ -109,7 +109,7 @@ void ApplePaySetup::begin(Document& document, Vector<RefPtr<ApplePaySetupFeature
     m_beginPromise = WTFMove(promise);
     m_pendingActivity = makePendingActivity(*this);
 
-    page->paymentCoordinator().beginApplePaySetup(m_configuration, document.url(), WTFMove(features), [this](bool result) {
+    page->paymentCoordinator().beginApplePaySetup(m_configuration, document.topDocument().url(), WTFMove(features), [this](bool result) {
         if (m_beginPromise)
             std::exchange(m_beginPromise, std::nullopt)->resolve(result);
     });

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -102,7 +102,7 @@ bool PaymentCoordinator::beginPaymentSession(Document& document, PaymentSession&
     auto linkIconURLs = LinkIconCollector { document }.iconsOfTypes({ LinkIconType::TouchIcon, LinkIconType::TouchPrecomposedIcon }).map([](auto& icon) {
         return icon.url;
     });
-    auto showPaymentUI = m_client->showPaymentUI(document.url(), WTFMove(linkIconURLs), paymentRequest);
+    auto showPaymentUI = m_client->showPaymentUI(document.topDocument().url(), WTFMove(linkIconURLs), paymentRequest);
     PAYMENT_COORDINATOR_RELEASE_LOG("beginPaymentSession() -> %d", showPaymentUI);
     if (!showPaymentUI)
         return false;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4005,14 +4005,14 @@ void Page::setPaymentCoordinator(std::unique_ptr<PaymentCoordinator>&& paymentCo
 
 #if ENABLE(APPLE_PAY_AMS_UI)
 
-bool Page::startApplePayAMSUISession(Document& document, ApplePayAMSUIPaymentHandler& paymentHandler, const ApplePayAMSUIRequest& request)
+bool Page::startApplePayAMSUISession(const URL& originatingURL, ApplePayAMSUIPaymentHandler& paymentHandler, const ApplePayAMSUIRequest& request)
 {
     if (hasActiveApplePayAMSUISession())
         return false;
 
     m_activeApplePayAMSUIPaymentHandler = &paymentHandler;
 
-    chrome().client().startApplePayAMSUISession(document.url(), request, [weakThis = WeakPtr { *this }, paymentHandlerPtr = &paymentHandler] (std::optional<bool>&& result) {
+    chrome().client().startApplePayAMSUISession(originatingURL, request, [weakThis = WeakPtr { *this }, paymentHandlerPtr = &paymentHandler] (std::optional<bool>&& result) {
         auto strongThis = weakThis.get();
         if (!strongThis)
             return;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -612,7 +612,7 @@ public:
 
 #if ENABLE(APPLE_PAY_AMS_UI)
     bool hasActiveApplePayAMSUISession() const { return m_activeApplePayAMSUIPaymentHandler; }
-    bool startApplePayAMSUISession(Document&, ApplePayAMSUIPaymentHandler&, const ApplePayAMSUIRequest&);
+    bool startApplePayAMSUISession(const URL&, ApplePayAMSUIPaymentHandler&, const ApplePayAMSUIRequest&);
     void abortApplePayAMSUISession(ApplePayAMSUIPaymentHandler&);
 #endif
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -557,7 +557,7 @@ void GraphicsLayerCA::setReplicatedLayer(GraphicsLayer* layer)
         return;
 
     GraphicsLayer::setReplicatedLayer(layer);
-    noteLayerPropertyChanged(ReplicatedLayerChanged);
+    noteLayerPropertyChanged(ReplicatedLayerChanged | ChildrenChanged);
 }
 
 void GraphicsLayerCA::setReplicatedByLayer(RefPtr<GraphicsLayer>&& layer)


### PR DESCRIPTION
#### 08d5d17c766ffc7ca6a7c833c5720eb71b427784
<pre>
clobberize needs to be more precise with the *ByOffset nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261544">https://bugs.webkit.org/show_bug.cgi?id=261544</a>
rdar://115399657

Reviewed by Yusuke Suzuki and Mark Lam.

CSE phase uses clobberize to figure out if it&apos;s safe to merge two operations that
def the same HeapLocation. Since HeapLocation does not currently have a way to
track the offset used by the various *ByOffset nodes it can get confused and
think that two ByOffset instructions produce the same value even if they don&apos;t
use the same offset. This patch solves this by adding a new field to HeapLocation,
which takes the metadata associated with the corresponding *ByOffset node. If two
*ByOffset operations don&apos;t share the same metadata then they cannot be CSEed.

* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:
(JSC::DFG::HeapLocation::HeapLocation):
(JSC::DFG::HeapLocation::extraState const):
(JSC::DFG::HeapLocation::hash const):

Originally-landed-as: 265870.558@safari-7616-branch (47e039ffd689). rdar://116426362
Canonical link: <a href="https://commits.webkit.org/269099@main">https://commits.webkit.org/269099@main</a>
</pre>
----------------------------------------------------------------------
#### 538c84a313edd834976fd519fc3aea603aa5a167
<pre>
Ensure -[PKPaymentRequest originatingURL] is always set to the top-level document URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=259667">https://bugs.webkit.org/show_bug.cgi?id=259667</a>
rdar://113143083

Reviewed by Andy Estes.

We support Apple Pay on cross-origin iframes following 262616@main, but
since we are plumbing the iframe domain rather than that of the parent
document embedding said iframe, we lose some Apple Pay domain validation
and abuse detection mitigations.

In this patch, we preserve our existing security mitigations by passing
the top-level domain to `-[PKPaymentRequest setOriginatingURL:]`.
This change also aligns ourselves to the existing shipping model for
payment session domain reporting in iOS 16.

Note that this patch necessitates that a website provide the top level
domain in its merchant session, i.e. &quot;you can iFrame in Apple Pay, but
your merchant session must use the top-level domain&quot;. This is a
pre-existing invariant in PassKit, and this commit aligns WebKit in the
same direction.

* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp:
(WebCore::ApplePayAMSUIPaymentHandler::show):
* Source/WebCore/Modules/applepay/ApplePaySetup.cpp:
(WebCore::ApplePaySetup::begin):
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::beginPaymentSession):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::startApplePayAMSUISession):
* Source/WebCore/page/Page.h:

Originally-landed-as: 265870.231@eng/105809792_safari-7616-branch (bb9c7e0fd205). rdar://116426149
Canonical link: <a href="https://commits.webkit.org/269098@main">https://commits.webkit.org/269098@main</a>
</pre>
----------------------------------------------------------------------
#### 75cec00a439631f768dea754cf68c753c63ce185
<pre>
Crash under PlatformCALayerRemote::recursiveBuildTransaction()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259607">https://bugs.webkit.org/show_bug.cgi?id=259607</a>
rdar://32076163

Reviewed by Tim Horton.

In some scenarios, we can end up with a PlatformCALayerRemote which remains in a sublayer list after
being deleted.

The testcase has a &lt;video&gt; which toggles from composited to non-composited and back. This video has
a mask, and a reflection. The reflection RendeLayer (the RenderReplica&apos;s layer) remains composited.
When this happens, the masks layer&apos;s clone remains in the sublayer list of the &quot;replica flattening&quot;
layer, but it&apos;s owning reference, in the LayerClones struct owned by the video layer, went away when
the video stopped being composited temporarily. The real issue is that we failed to rebuild the
sublayer list of the &quot;replica flattening&quot; layer in this case, so make sure we trigger that.

* LayoutTests/compositing/reflections/video-mask-reflection-crash-expected.txt: Added.
* LayoutTests/compositing/reflections/video-mask-reflection-crash.html: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setReplicatedLayer):

Originally-landed-as: 265870.224@safari-7616-branch (73eb68ead0fc). rdar://116426044
Canonical link: <a href="https://commits.webkit.org/269097@main">https://commits.webkit.org/269097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c3d7bd0158ed6a0a86d0836d124807082387939

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20766 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20680 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23511 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25164 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18090 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23063 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20192 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16671 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24175 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18849 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18689 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5155 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23181 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25437 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19437 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5572 "Passed tests") | 
<!--EWS-Status-Bubble-End-->