### PR TITLE
ScrollView::convertChildToSelf / convertSelfToChild fail to take top content inset into account

### DIFF
--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -1114,6 +1114,30 @@ Scrollbar* ScrollView::scrollbarAtPoint(const IntPoint& windowPoint)
     return 0;
 }
 
+IntPoint ScrollView::convertChildToSelf(const Widget* child, IntPoint point) const
+{
+    if (!isScrollViewScrollbar(child))
+        point -= toIntSize(documentScrollPositionRelativeToViewOrigin());
+    point.moveBy(child->location());
+    return point;
+}
+
+FloatPoint ScrollView::convertChildToSelf(const Widget* child, FloatPoint point) const
+{
+    if (!isScrollViewScrollbar(child))
+        point -= toFloatSize(documentScrollPositionRelativeToViewOrigin());
+    point.moveBy(child->location());
+    return point;
+}
+
+IntPoint ScrollView::convertSelfToChild(const Widget* child, IntPoint point) const
+{
+    if (!isScrollViewScrollbar(child))
+        point += toIntSize(documentScrollPositionRelativeToViewOrigin());
+    point.moveBy(-child->location());
+    return point;
+}
+
 void ScrollView::setScrollbarOverlayStyle(ScrollbarOverlayStyle overlayStyle)
 {
     ScrollableArea::setScrollbarOverlayStyle(overlayStyle);

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -354,32 +354,9 @@ public:
     // For platforms that need to hit test scrollbars from within the engine's event handlers (like Win32).
     Scrollbar* scrollbarAtPoint(const IntPoint& windowPoint);
 
-    IntPoint convertChildToSelf(const Widget* child, const IntPoint& point) const
-    {
-        IntPoint newPoint = point;
-        if (!isScrollViewScrollbar(child))
-            newPoint = point - toIntSize(scrollPosition());
-        newPoint.moveBy(child->location());
-        return newPoint;
-    }
-
-    FloatPoint convertChildToSelf(const Widget* child, const FloatPoint& point) const
-    {
-        FloatPoint newPoint = point;
-        if (!isScrollViewScrollbar(child))
-            newPoint -= toFloatSize(scrollPosition());
-        newPoint.moveBy(child->location());
-        return newPoint;
-    }
-
-    IntPoint convertSelfToChild(const Widget* child, const IntPoint& point) const
-    {
-        IntPoint newPoint = point;
-        if (!isScrollViewScrollbar(child))
-            newPoint = point + toIntSize(scrollPosition());
-        newPoint.moveBy(-child->location());
-        return newPoint;
-    }
+    IntPoint convertChildToSelf(const Widget*, IntPoint) const;
+    FloatPoint convertChildToSelf(const Widget*, FloatPoint) const;
+    IntPoint convertSelfToChild(const Widget*, IntPoint) const;
 
     // Widget override. Handles painting of the contents of the view as well as the scrollbars.
     WEBCORE_EXPORT void paint(GraphicsContext&, const IntRect&, Widget::SecurityOriginPaintPolicy = SecurityOriginPaintPolicy::AnyOrigin, RegionContext* = nullptr) final;

--- a/Source/WebCore/platform/Widget.cpp
+++ b/Source/WebCore/platform/Widget.cpp
@@ -226,8 +226,8 @@ IntRect Widget::convertToContainingView(const IntRect& localRect) const
 
 IntRect Widget::convertFromContainingView(const IntRect& parentRect) const
 {
-    if (const ScrollView* parentScrollView = parent()) {
-        IntRect localRect = parentRect;
+    if (const auto* parentScrollView = parent()) {
+        auto localRect = parentRect;
         localRect.setLocation(parentScrollView->convertSelfToChild(this, localRect.location()));
         return localRect;
     }
@@ -247,7 +247,7 @@ FloatRect Widget::convertFromContainingView(const FloatRect& parentRect) const
 
 IntPoint Widget::convertToContainingView(const IntPoint& localPoint) const
 {
-    if (const ScrollView* parentScrollView = parent())
+    if (const auto* parentScrollView = parent())
         return parentScrollView->convertChildToSelf(this, localPoint);
 
     return localPoint;
@@ -255,7 +255,7 @@ IntPoint Widget::convertToContainingView(const IntPoint& localPoint) const
 
 IntPoint Widget::convertFromContainingView(const IntPoint& parentPoint) const
 {
-    if (const ScrollView* parentScrollView = parent())
+    if (const auto* parentScrollView = parent())
         return parentScrollView->convertSelfToChild(this, parentPoint);
 
     return parentPoint;


### PR DESCRIPTION
#### 7b193c245074e736d83051b75490e4e6dfe0baa1
<pre>
ScrollView::convertChildToSelf / convertSelfToChild fail to take top content inset into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=262585">https://bugs.webkit.org/show_bug.cgi?id=262585</a>
rdar://116430905

Reviewed by Tim Horton.

ScrollView::convertChildToSelf() and convertSelfToChild() offset the point by the scroll position, but this
fails to take top content inset, and left-side scrollbars into account.

This code path isn&apos;t hit in general browsing, but future PDF plugin code needs it to work.

Move the implementations to the .cpp file, and use documentScrollPositionRelativeToViewOrigin()
instead of scrollPosition(). Pass the points by value.

* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::convertChildToSelf const):
(WebCore::ScrollView::convertSelfToChild const):
* Source/WebCore/platform/ScrollView.h:
(WebCore::ScrollView::convertChildToSelf const): Deleted.
(WebCore::ScrollView::convertSelfToChild const): Deleted.
* Source/WebCore/platform/Widget.cpp:
(WebCore::Widget::convertFromContainingView const): auto
(WebCore::Widget::convertToContainingView const): auto

Canonical link: <a href="https://commits.webkit.org/268942@main">https://commits.webkit.org/268942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57aa52850c109b0facd0e2470c978be57d7ce06f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19374 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20682 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23517 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25169 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23070 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16673 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18854 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5056 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->