### PR TITLE
webkitbot fails to run due to Autoinstall issues

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -26,8 +26,9 @@
 import {stat} from "fs";
 import path from "path";
 import util from "util";
+import which from "which";
 import {execFile, spawn} from "child_process";
-import HttpsProxyAgent from "https-proxy-agent";
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import LogLevel from "@slack/rtm-api";
 import SlackRTMAPI from "@slack/rtm-api";
 import AsyncTaskQueue from "./AsyncTaskQueue.mjs";
@@ -471,7 +472,9 @@ Type \`help COMMAND\` for help on my individual commands.`,
         let results;
         try {
             const webkitPatchPath = path.resolve("BotWebKit", "Tools", "Scripts", "webkit-patch");
-            results = await execFileAsync(webkitPatchPath, [
+            var pythonPath = which.sync('python3')
+            results = await execFileAsync(pythonPath, [
+                webkitPatchPath,
                 "create-revert",
                 "--force-clean",
                 // In principle, we should pass --non-interactive here, but it
@@ -488,6 +491,8 @@ Type \`help COMMAND\` for help on my individual commands.`,
                     CHANGE_LOG_EMAIL_ADDRESS: "commit-queue@webkit.org",
                     WEBKIT_BUGZILLA_USERNAME: process.env.webkitBugzillaUsername,
                     WEBKIT_BUGZILLA_PASSWORD: process.env.webkitBugzillaPassword,
+                    http_proxy: process.env.http_proxy,
+                    https_proxy: process.env.http_proxy,
                 },
                 timeout: defaultTimeoutForRevert,
                 maxBuffer: 1024 * 1024 * 50,

--- a/Tools/WebKitBot/src/index.mjs
+++ b/Tools/WebKitBot/src/index.mjs
@@ -26,7 +26,7 @@
 import dotenv from "dotenv";
 import storage from "node-persist";
 import WebKitBot from "./WebKitBot.mjs";
-import HttpsProxyAgent from "https-proxy-agent";
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import LogLevel from "@slack/web-api";
 import SlackWebAPI from "@slack/web-api";
 


### PR DESCRIPTION
#### c0c7953c13f3ba6d0b9e4a365ffd55c6cb4e125f
<pre>
webkitbot fails to run due to Autoinstall issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=262560">https://bugs.webkit.org/show_bug.cgi?id=262560</a>
rdar://116135662 (webkitbot intermittently failing due to networking issues(?))

Reviewed by Alexey Proskuryakov.

Populate PROXY environment variables to webkit-patch to allow download of
PIP packages by Autoinstall, and launch webkit-patch by explicitly calling
python3 so sys.executable get populated in Autoinstall.
Updated HttpsProxyAgent statement to fix &quot;httpsProxyAgent is not a constructor&quot; error.

* Tools/WebKitBot/src/WebKitBot.mjs:

Canonical link: <a href="https://commits.webkit.org/268855@main">https://commits.webkit.org/268855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baf1f18e7954d82b6c48677f6b1ab068b8979d86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20712 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20830 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23579 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25205 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23114 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18909 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5008 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->