### PR TITLE
Expand site isolation postMessage testing

### DIFF
--- a/LayoutTests/http/tests/site-isolation/post-message-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/post-message-expected.txt
@@ -1,5 +1,8 @@
+PASS posting a message to about:blank threw an exception: SyntaxError: The string did not match the expected pattern.
+PASS posting a non-serializable message threw an exception: DataCloneError: The object can not be cloned.
 PASS successfullyParsed is true
 
 TEST COMPLETE
 PASS received 'iframe received hello'
+PASS received 'iframe received world'
 

--- a/LayoutTests/http/tests/site-isolation/post-message.html
+++ b/LayoutTests/http/tests/site-isolation/post-message.html
@@ -6,12 +6,30 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
 }
 
+let messageCount = 0;
 addEventListener("message", (event) => {
     testPassed("received '" + event.data + "'");
-    testRunner.notifyDone();
+    messageCount = messageCount + 1;
+    if (messageCount == 2) { testRunner.notifyDone() }
 });
 
-onload = ()=>{ frame.contentWindow.postMessage("hello", "*") }
+onload = ()=>{
+    frame.contentWindow.postMessage("hello", "*")
+    frame.contentWindow.postMessage("should not be received", "http://webkit.org")
+    frame.contentWindow.postMessage("world", "http://localhost:8000")
+
+    try {
+        frame.contentWindow.postMessage("should throw", "about:blank")
+    } catch (e) {
+        testPassed("posting a message to about:blank threw an exception: " + e)
+    }
+
+    try {
+        frame.contentWindow.postMessage(window.performance, "/")
+    } catch (e) {
+        testPassed("posting a non-serializable message threw an exception: " + e)
+    }
+}
 
 </script>
 <iframe src="http://localhost:8000/site-isolation/resources/post-message-to-parent.html" id="frame"></iframe>


### PR DESCRIPTION
#### c18f49f61402054d48923e7331187fbcf9535008
<pre>
Expand site isolation postMessage testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=262590">https://bugs.webkit.org/show_bug.cgi?id=262590</a>
rdar://116436305

Reviewed by Pascoe.

RemoteDOMWindow::postMessage has some branches that weren&apos;t tested.

* LayoutTests/http/tests/site-isolation/post-message-expected.txt:
* LayoutTests/http/tests/site-isolation/post-message.html:

Canonical link: <a href="https://commits.webkit.org/268827@main">https://commits.webkit.org/268827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/458c03e78b020299829eccbf27807365e9059d43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19388 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21379 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23537 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25176 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23077 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19638 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18706 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23202 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2565 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->