### PR TITLE
Provide raw JSON and whether a scope is default in application manifest

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -57,12 +57,15 @@ struct ApplicationManifest {
         OptionSet<Purpose> purposes;
     };
 
+    String rawJSON;
     String name;
     String shortName;
     String description;
     URL scope;
+    bool isDefaultScope { false };
     Display display;
     std::optional<ScreenOrientationLockType> orientation;
+    URL manifestURL;
     URL startURL;
     URL id;
     Color backgroundColor;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -51,7 +51,7 @@ private:
     String parseName(const JSON::Object&);
     String parseDescription(const JSON::Object&);
     String parseShortName(const JSON::Object&);
-    URL parseScope(const JSON::Object&, const URL&, const URL&);
+    std::optional<URL> parseScope(const JSON::Object&, const URL&, const URL&);
     Vector<ApplicationManifest::Icon> parseIcons(const JSON::Object&);
     URL parseId(const JSON::Object&, const URL&);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1244,12 +1244,15 @@ enum class WebCore::ScreenOrientationLockType : uint8_t {
 }
 
 struct WebCore::ApplicationManifest {
+    String rawJSON
     String name
     String shortName
     String description
     URL scope
+    bool isDefaultScope
     WebCore::ApplicationManifest::Display display
     std::optional<WebCore::ScreenOrientationLockType> orientation
+    URL manifestURL
     URL startURL
     URL id
     WebCore::Color backgroundColor

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -62,10 +62,13 @@ typedef NS_ENUM(NSInteger, _WKApplicationManifestIconPurpose) {
 WK_CLASS_AVAILABLE(macos(10.13.4), ios(11.3))
 @interface _WKApplicationManifest : NSObject <NSSecureCoding>
 
+@property (nonatomic, readonly, nullable, copy) NSString *rawJSON;
 @property (nonatomic, readonly, nullable, copy) NSString *name;
 @property (nonatomic, readonly, nullable, copy) NSString *shortName;
 @property (nonatomic, readonly, nullable, copy) NSString *applicationDescription;
 @property (nonatomic, readonly, nullable, copy) NSURL *scope;
+@property (nonatomic, readonly) BOOL isDefaultScope;
+@property (nonatomic, readonly, copy) NSURL *manifestURL;
 @property (nonatomic, readonly, copy) NSURL *startURL;
 @property (nonatomic, readonly, copy) NSURL *manifestId WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic, readonly) _WKApplicationManifestDisplayMode displayMode;


### PR DESCRIPTION
#### 716495eb9cb2520b3086b0ed0bcdb98856d1684e
<pre>
Provide raw JSON and whether a scope is default in application manifest
<a href="https://bugs.webkit.org/show_bug.cgi?id=262592">https://bugs.webkit.org/show_bug.cgi?id=262592</a>
rdar://101850992

Reviewed by Chris Dumez.

Expose the raw JSON and url of the web app manifest, as well as whether the scope is
default instead of developer-specified.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseManifest):
Set the raw JSON, manifest URL on the parsed manifest, and set the isDefaultScope flag to
true if the scope is default instead of developer-specified.

(WebCore::ApplicationManifestParser::parseScope):
Return an optional scope URL for the callsite to fall back to the default scope
and set the isDefaultScope accordingly.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
Same as above.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Serialize rawJSON, manifestURL, and isDefaultScope.

* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
Encode and decode rawJSON, manifestURL and isDefaultScope.

(-[_WKApplicationManifest rawJSON]):
Return the raw JSON from the wrapped manifest object.

(-[_WKApplicationManifest isDefaultScope]):
Return whether the scope is default instead of developer-specified from the wrapped
manifest object.

(-[_WKApplicationManifest manifestURL]):
Return the manifest URL from the wrapped manifest object.

* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(ApplicationManifestParserTest::testRawJSON):
Test to ensure the rawJSON property is correctly populated based on whether the JSON
is valid.

(ApplicationManifestParserTest::testManifestURL):
Test to ensure the manifest URL is returned as-is from what&apos;s passed into the API.

(ApplicationManifestParserTest::testScope):
In addition to testing the resolved scope value, also test the correctness of
isDefaultScope.

(TEST_F):
Run testRawJSON with both valid and invalid raw JSON inputs. Run testManifestURL.

Canonical link: <a href="https://commits.webkit.org/268875@main">https://commits.webkit.org/268875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74c4d39ec0ae7f0caf7da80038b06e6c5d89a048

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20927 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22817 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21512 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21150 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/20915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23674 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/18077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/18989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/19162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/23199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18997 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5022 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->