### PR TITLE
Add Vector::appendList() function which takes in a std::initializer_list

### DIFF
--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -47,9 +47,7 @@ ALWAYS_INLINE static void appendCodePoint(Vector<UChar>& destination, UChar32 co
         destination.append(static_cast<UChar>(codePoint));
         return;
     }
-    destination.reserveCapacity(destination.size() + 2);
-    destination.uncheckedAppend(U16_LEAD(codePoint));
-    destination.uncheckedAppend(U16_TRAIL(codePoint));
+    destination.appendList({ U16_LEAD(codePoint), U16_TRAIL(codePoint) });
 }
 
 enum URLCharacterClass {

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -862,6 +862,7 @@ public:
     template<typename U> ALWAYS_INLINE void append(const U* u, size_t size) { append<FailureAction::Crash>(u, size); }
     template<typename U> ALWAYS_INLINE bool tryAppend(const U* u, size_t size) { return append<FailureAction::Report>(u, size); }
     template<typename U> ALWAYS_INLINE void append(std::span<const U> span) { append(span.data(), span.size()); }
+    template<typename U> ALWAYS_INLINE void appendList(std::initializer_list<U> initializerList) { append(std::data(initializerList), initializerList.size()); }
     template<typename U, size_t otherCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc> void appendVector(const Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>&);
     template<typename U, size_t otherCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc> void appendVector(Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>&&);
 

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -1124,23 +1124,15 @@ static void appendDecimal(UChar32 c, Vector<uint8_t>& result)
 static void urlEncodedEntityUnencodableHandler(UChar32 c, Vector<uint8_t>& result)
 {
     result.reserveCapacity(result.size() + 9 + maxUChar32Digits);
-    result.uncheckedAppend('%');
-    result.uncheckedAppend('2');
-    result.uncheckedAppend('6');
-    result.uncheckedAppend('%');
-    result.uncheckedAppend('2');
-    result.uncheckedAppend('3');
+    result.appendList({ '%', '2', '6', '%', '2', '3' });
     appendDecimal(c, result);
-    result.uncheckedAppend('%');
-    result.uncheckedAppend('3');
-    result.uncheckedAppend('B');
+    result.appendList({ '%', '3', 'B' });
 }
 
 static void entityUnencodableHandler(UChar32 c, Vector<uint8_t>& result)
 {
     result.reserveCapacity(result.size() + 3 + maxUChar32Digits);
-    result.uncheckedAppend('&');
-    result.uncheckedAppend('#');
+    result.appendList({ '&', '#' });
     appendDecimal(c, result);
     result.uncheckedAppend(';');
 }

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp
@@ -486,10 +486,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
         if (hasOnlyBoundedSRGBColorStops(stops)) {
             for (const auto& stop : stops) {
                 auto [r, g, b, a] = stop.color.toColorTypeLossy<SRGBA<float>>().resolved();
-                colorComponents.uncheckedAppend(r);
-                colorComponents.uncheckedAppend(g);
-                colorComponents.uncheckedAppend(b);
-                colorComponents.uncheckedAppend(a);
+                colorComponents.appendList({ r, g, b, a });
 
                 locations.uncheckedAppend(stop.offset);
             }
@@ -499,10 +496,7 @@ GradientRendererCG::Strategy GradientRendererCG::makeGradient(ColorInterpolation
         using OutputSpaceColorType = std::conditional_t<HasCGColorSpaceMapping<ColorSpace::ExtendedSRGB>, ExtendedSRGBA<float>, SRGBA<float>>;
         for (const auto& stop : stops) {
             auto [r, g, b, a] = stop.color.toColorTypeLossy<OutputSpaceColorType>().resolved();
-            colorComponents.uncheckedAppend(r);
-            colorComponents.uncheckedAppend(g);
-            colorComponents.uncheckedAppend(b);
-            colorComponents.uncheckedAppend(a);
+            colorComponents.appendList({ r, g, b, a });
 
             locations.uncheckedAppend(stop.offset);
         }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -150,11 +150,7 @@ Vector<AtomString> CDMPrivateThunder::supportedInitDataTypes() const
     static std::once_flag onceFlag;
     static Vector<AtomString> supportedInitDataTypes;
     std::call_once(onceFlag, [] {
-        supportedInitDataTypes.reserveInitialCapacity(4);
-        supportedInitDataTypes.uncheckedAppend("keyids"_s);
-        supportedInitDataTypes.uncheckedAppend("cenc"_s);
-        supportedInitDataTypes.uncheckedAppend("webm"_s);
-        supportedInitDataTypes.uncheckedAppend("cbcs"_s);
+        supportedInitDataTypes.appendList({ "keyids"_s, "cenc"_s, "webm"_s, "cbcs"_s });
     });
     return supportedInitDataTypes;
 }

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -86,9 +86,7 @@ MockRealtimeVideoSource::MockRealtimeVideoSource(String&& deviceID, AtomString&&
     ASSERT(device);
     m_device = *device;
 
-    m_dashWidths.reserveInitialCapacity(2);
-    m_dashWidths.uncheckedAppend(6);
-    m_dashWidths.uncheckedAppend(6);
+    m_dashWidths.appendList({ 6, 6 });
 
     if (mockDisplay()) {
         auto& properties = std::get<MockDisplayProperties>(m_device.properties);

--- a/Source/WebCore/platform/text/LocaleNone.cpp
+++ b/Source/WebCore/platform/text/LocaleNone.cpp
@@ -136,9 +136,7 @@ const Vector<String>& LocaleNone::timeAMPMLabels()
 {
     if (!m_timeAMPMLabels.isEmpty())
         return m_timeAMPMLabels;
-    m_timeAMPMLabels.reserveCapacity(2);
-    m_timeAMPMLabels.uncheckedAppend("AM");
-    m_timeAMPMLabels.uncheckedAppend("PM");
+    m_timeAMPMLabels.appendList({ "AM"_s, "PM"_s });
     return m_timeAMPMLabels;
 }
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -195,8 +195,7 @@ Vector<uint8_t> NetworkRTCTCPSocketCocoa::createMessageBuffer(const uint8_t* dat
     // Prepend length.
     Vector<uint8_t> buffer;
     buffer.reserveInitialCapacity(size + 2);
-    buffer.uncheckedAppend((size >> 8) & 0xFF);
-    buffer.uncheckedAppend(size & 0xFF);
+    buffer.appendList({ (size >> 8) & 0xFF, size & 0xFF });
     buffer.append(data, size);
     return buffer;
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -339,6 +339,23 @@ TEST(WTF_Vector, ConstructorTakingLengthAndFunctor)
     EXPECT_EQ(vector[4], 4U);
 }
 
+TEST(WTF_Vector, AppendList)
+{
+    Vector<size_t> vector({ 1, 2, 3 });
+    EXPECT_EQ(vector.size(), 3U);
+    EXPECT_EQ(vector[0], 1U);
+    EXPECT_EQ(vector[1], 2U);
+    EXPECT_EQ(vector[2], 3U);
+    vector.appendList({ 4, 5, 6 });
+    EXPECT_EQ(vector.size(), 6U);
+    EXPECT_EQ(vector[0], 1U);
+    EXPECT_EQ(vector[1], 2U);
+    EXPECT_EQ(vector[2], 3U);
+    EXPECT_EQ(vector[3], 4U);
+    EXPECT_EQ(vector[4], 5U);
+    EXPECT_EQ(vector[5], 6U);
+}
+
 TEST(WTF_Vector, Reverse)
 {
     Vector<int> intVector;


### PR DESCRIPTION
#### c1c9b7014e95a86527bdc43271a0b2d688c02dc2
<pre>
Add Vector::appendList() function which takes in a std::initializer_list
<a href="https://bugs.webkit.org/show_bug.cgi?id=262598">https://bugs.webkit.org/show_bug.cgi?id=262598</a>

Reviewed by Brent Fulgham.

Add Vector::appendList() function which takes in a std::initializer_list
and use it in a few places.

Note that we already have a Vector constructor taking a std::initializer_list.

* Source/WTF/wtf/URLParser.cpp:
(WTF::appendCodePoint):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::appendList):
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::urlEncodedEntityUnencodableHandler):
(PAL::entityUnencodableHandler):
* Source/WebCore/platform/graphics/cg/GradientRendererCG.cpp:
(WebCore::GradientRendererCG::makeGradient const):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
(WebCore::CDMPrivateThunder::supportedInitDataTypes const):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
* Source/WebCore/platform/text/LocaleNone.cpp:
(WebCore::LocaleNone::timeAMPMLabels):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::NetworkRTCTCPSocketCocoa::createMessageBuffer):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268879@main">https://commits.webkit.org/268879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38d37f3394cea1ffc62d8c98a63f274d23d5d279

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22706 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20707 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23560 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25198 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18136 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23105 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20244 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16695 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24226 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18892 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5753 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23222 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25488 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2585 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19469 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5578 "Passed tests") | 
<!--EWS-Status-Bubble-End-->