### PR TITLE
Stop using -[UIScrollView handle(Pinch|Pan):] and -[UIGestureRecognizer _activeTouchesForEvent:]

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2489,3 +2489,6 @@ webkit.org/b/260224 imported/w3c/web-platform-tests/css/css-transforms/transform
 webkit.org/b/260322 imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-flat-tree.html [ Failure ]
 
 webkit.org/b/261957 media/audio-play-with-video-element-interrupted.html [ Pass Timeout ]
+
+# Requires the fix in rdar://108457321.
+css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html [ Skip ]

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -790,11 +790,6 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 
 @class BKSAnimationFenceHandle;
 
-@interface UIGestureRecognizer (SPI)
-- (NSSet<UITouch *> *)_activeTouchesForEvent:(UIEvent *)event;
-- (__kindof UIEvent *)_activeEventOfType:(UIEventType)type;
-@end
-
 @interface UIWindow ()
 + (BKSAnimationFenceHandle *)_synchronizedDrawingFence;
 + (mach_port_t)_synchronizeDrawingAcrossProcesses;
@@ -1134,8 +1129,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 - (BOOL)_canScrollWithoutBouncingY;
 - (void)_setContentOffsetWithDecelerationAnimation:(CGPoint)contentOffset;
 - (CGPoint)_adjustedContentOffsetForContentOffset:(CGPoint)contentOffset;
-- (void)handlePinch:(UIPinchGestureRecognizer *)gesture;
-- (void)handlePan:(UIPanGestureRecognizer *)gesture;
 
 @property (nonatomic) BOOL tracksImmediatelyWhileDecelerating;
 @property (nonatomic, getter=_avoidsJumpOnInterruptedBounce, setter=_setAvoidsJumpOnInterruptedBounce:) BOOL _avoidsJumpOnInterruptedBounce;

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -474,47 +474,6 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
     [super setZoomEnabled:(_zoomEnabledByClient && _zoomEnabledInternal)];
 }
 
-- (void)_sendPinchGestureActionEarlyIfNeeded
-{
-    static BOOL canHandlePinch = NO;
-    static std::once_flag flag;
-    std::call_once(flag, [] {
-        canHandlePinch = [UIScrollView instancesRespondToSelector:@selector(handlePinch:)];
-    });
-
-    if (UNLIKELY(!canHandlePinch)) {
-        static BOOL shouldLogFault = YES;
-        if (shouldLogFault) {
-            RELEASE_LOG_FAULT(Scrolling, "UIScrollView no longer responds to -handlePinch:.");
-            shouldLogFault = NO;
-        }
-        return;
-    }
-
-    if (!self.zooming)
-        return;
-
-    auto pinchGesture = self.pinchGestureRecognizer;
-    if (pinchGesture.state != UIGestureRecognizerStateEnded)
-        return;
-
-    auto activeTouchEvent = [pinchGesture _activeEventOfType:UIEventTypeTouches];
-    if (!activeTouchEvent)
-        return;
-
-    if ([pinchGesture _activeTouchesForEvent:activeTouchEvent].count)
-        return;
-
-    [self handlePinch:pinchGesture];
-}
-
-- (void)handlePan:(UIPanGestureRecognizer *)gesture
-{
-    [self _sendPinchGestureActionEarlyIfNeeded];
-
-    [super handlePan:gesture];
-}
-
 #if PLATFORM(WATCHOS)
 
 - (void)addGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer


### PR DESCRIPTION
#### 16db58a28a3e9243c2edba886fb9df4795fa0bfb
<pre>
Stop using -[UIScrollView handle(Pinch|Pan):] and -[UIGestureRecognizer _activeTouchesForEvent:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=262600">https://bugs.webkit.org/show_bug.cgi?id=262600</a>
rdar://115365651

Reviewed by Tim Horton.

Remove one workaround added to fix 263336@main, now that the underlying UIKit bug has been
addressed. This allows us to remove several now-unused IPI and SPI methods from `UIScrollView` and
`UIGestureRecognizer`.

* LayoutTests/platform/ios-wk2/TestExpectations:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _sendPinchGestureActionEarlyIfNeeded]): Deleted.
(-[WKScrollView handlePan:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/268830@main">https://commits.webkit.org/268830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5554ba7d12be661dcecde008e7ba50b503a65170

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22704 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19401 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21398 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23558 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25193 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23098 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19652 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18890 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4986 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->