### PR TITLE
Reduce use of Vector::uncheckedAppend() throughout the code base

### DIFF
--- a/Source/WTF/wtf/cf/LanguageCF.cpp
+++ b/Source/WTF/wtf/cf/LanguageCF.cpp
@@ -101,12 +101,10 @@ Vector<String> platformUserPreferredLanguages(ShouldMinimizeLanguages shouldMini
     if (!platformLanguagesCount)
         return { "en"_s };
 
-    Vector<String> languages;
-    languages.reserveInitialCapacity(platformLanguagesCount);
-    for (CFIndex i = 0; i < platformLanguagesCount; i++) {
+    Vector<String> languages(platformLanguagesCount, [&](size_t i) {
         auto platformLanguage = static_cast<CFStringRef>(CFArrayGetValueAtIndex(platformLanguages.get(), i));
-        languages.uncheckedAppend(httpStyleLanguageCode(platformLanguage, shouldMinimizeLanguages));
-    }
+        return httpStyleLanguageCode(platformLanguage, shouldMinimizeLanguages);
+    });
 
     LOG_WITH_STREAM(Language, stream << "After passing through httpStyleLanguageCode: " << languages);
 

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
@@ -164,11 +164,7 @@ void BarcodeDetectorImpl::getSupportedFormats(CompletionHandler<void(Vector<Barc
     for (VNBarcodeSymbology symbology in supportedSymbologies)
         barcodeFormatsSet.add(convertSymbology(symbology));
 
-    Vector<BarcodeFormat> barcodeFormatsVector;
-    barcodeFormatsVector.reserveInitialCapacity(barcodeFormatsSet.size());
-    for (auto barcodeFormat : barcodeFormatsSet)
-        barcodeFormatsVector.uncheckedAppend(barcodeFormat);
-
+    auto barcodeFormatsVector = copyToVector(barcodeFormatsSet);
     std::sort(std::begin(barcodeFormatsVector), std::end(barcodeFormatsVector));
 
     completionHandler(WTFMove(barcodeFormatsVector));

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -54,13 +54,11 @@ void GPUQueue::setLabel(String&& label)
 
 void GPUQueue::submit(Vector<RefPtr<GPUCommandBuffer>>&& commandBuffers)
 {
-    Vector<std::reference_wrapper<WebGPU::CommandBuffer>> result;
-    result.reserveInitialCapacity(commandBuffers.size());
-    for (const auto& commandBuffer : commandBuffers) {
-        if (!commandBuffer)
-            continue;
-        result.uncheckedAppend(commandBuffer->backing());
-    }
+    auto result = WTF::compactMap(commandBuffers, [](auto& commandBuffer) -> std::optional<std::reference_wrapper<WebGPU::CommandBuffer>> {
+        if (commandBuffer)
+            return commandBuffer->backing();
+        return std::nullopt;
+    });
     m_backing->submit(WTFMove(result));
 }
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -147,13 +147,11 @@ void GPURenderPassEncoder::endOcclusionQuery()
 
 void GPURenderPassEncoder::executeBundles(Vector<RefPtr<GPURenderBundle>>&& bundles)
 {
-    Vector<std::reference_wrapper<WebGPU::RenderBundle>> result;
-    result.reserveInitialCapacity(bundles.size());
-    for (const auto& bundle : bundles) {
-        if (!bundle)
-            continue;
-        result.uncheckedAppend(bundle->backing());
-    }
+    auto result = WTF::compactMap(bundles, [](auto& bundle) -> std::optional<std::reference_wrapper<WebGPU::RenderBundle>> {
+        if (bundle)
+            return bundle->backing();
+        return std::nullopt;
+    });
     m_backing->executeBundles(WTFMove(result));
 }
 

--- a/Source/WebCore/Modules/gamepad/Gamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/Gamepad.cpp
@@ -46,9 +46,9 @@ Gamepad::Gamepad(Document* document, const PlatformGamepad& platformGamepad)
     , m_vibrationActuator(platformGamepad.supportedEffectTypes().contains(GamepadHapticEffectType::DualRumble) ? RefPtr { GamepadHapticActuator::create(document, GamepadHapticActuator::Type::DualRumble, *this) } : nullptr)
 {
     unsigned buttonCount = platformGamepad.buttonValues().size();
-    m_buttons.reserveInitialCapacity(buttonCount);
-    for (unsigned i = 0; i < buttonCount; ++i)
-        m_buttons.uncheckedAppend(GamepadButton::create());
+    m_buttons = Vector<Ref<GamepadButton>>(buttonCount, [](size_t) {
+        return GamepadButton::create();
+    });
 }
 
 Gamepad::~Gamepad() = default;

--- a/Source/WebCore/Modules/highlight/Highlight.cpp
+++ b/Source/WebCore/Modules/highlight/Highlight.cpp
@@ -54,11 +54,10 @@ Ref<Highlight> Highlight::create(FixedVector<std::reference_wrapper<WebCore::Abs
 
 Highlight::Highlight(FixedVector<std::reference_wrapper<WebCore::AbstractRange>>&& initialRanges)
 {
-    m_highlightRanges.reserveInitialCapacity(initialRanges.size());
-    for (auto& range : initialRanges) {
+    m_highlightRanges = WTF::map(initialRanges, [&](auto&& range) {
         repaintRange(range.get());
-        m_highlightRanges.uncheckedAppend(HighlightRange::create(Ref { range.get() }));
-    }
+        return HighlightRange::create(range.get());
+    });
 }
 
 void Highlight::initializeSetLike(DOMSetAdapter& set)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -691,10 +691,9 @@ static LibWebRTCMediaEndpointTransceiverState toLibWebRTCMediaEndpointTransceive
         firedDirection = toRTCRtpTransceiverDirection(*rtcFiredDirection);
 
     auto rtcStreamIds = transceiver.receiver()->stream_ids();
-    Vector<String> streamIds;
-    streamIds.reserveInitialCapacity(rtcStreamIds.size());
-    for (auto& streamId : rtcStreamIds)
-        streamIds.uncheckedAppend(fromStdString(streamId));
+    auto streamIds = WTF::map(rtcStreamIds, [](auto& streamId) {
+        return fromStdString(streamId);
+    });
 
     return { WTFMove(mid), WTFMove(streamIds), firedDirection };
 }
@@ -702,12 +701,9 @@ static LibWebRTCMediaEndpointTransceiverState toLibWebRTCMediaEndpointTransceive
 static Vector<LibWebRTCMediaEndpointTransceiverState> transceiverStatesFromPeerConnection(webrtc::PeerConnectionInterface& connection)
 {
     auto transceivers = connection.GetTransceivers();
-    Vector<LibWebRTCMediaEndpointTransceiverState> states;
-    states.reserveInitialCapacity(transceivers.size());
-    for (auto& transceiver : transceivers)
-        states.uncheckedAppend(toLibWebRTCMediaEndpointTransceiverState(*transceiver));
-
-    return states;
+    return WTF::map(transceivers, [](auto& transceiver) {
+        return toLibWebRTCMediaEndpointTransceiverState(*transceiver);
+    });
 }
 
 void LibWebRTCMediaEndpoint::setLocalSessionDescriptionSucceeded()

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
@@ -90,9 +90,9 @@ RTCEncodedAudioFrameMetadata LibWebRTCRtpTransformableFrame::audioMetadata() con
         auto* audioFrame = static_cast<webrtc::TransformableAudioFrameInterface*>(m_rtcFrame.get());
         auto& header = audioFrame->GetHeader();
         if (header.numCSRCs) {
-            cssrcs.reserveInitialCapacity(header.numCSRCs);
-            for (size_t cptr = 0; cptr < header.numCSRCs; ++cptr)
-                cssrcs.uncheckedAppend(header.arrOfCSRCs[cptr]);
+            cssrcs = Vector<uint32_t>(header.numCSRCs, [&](size_t cptr) {
+                return header.arrOfCSRCs[cptr];
+            });
         }
     }
     return { m_rtcFrame->GetSsrc(), WTFMove(cssrcs) };


### PR DESCRIPTION
#### f39857d5b7716637fa4f3ed71f5aa5df1ea19f7e
<pre>
Reduce use of Vector::uncheckedAppend() throughout the code base
<a href="https://bugs.webkit.org/show_bug.cgi?id=262602">https://bugs.webkit.org/show_bug.cgi?id=262602</a>

Reviewed by Brent Fulgham.

* Source/WTF/wtf/cf/LanguageCF.cpp:
(WTF::platformUserPreferredLanguages):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm:
(WebCore::ShapeDetection::BarcodeDetectorImpl::getSupportedFormats):
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::submit):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp:
(WebCore::GPURenderPassEncoder::executeBundles):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::createBindGroupLayout):
(WebCore::WebGPU::convertToBacking):
* Source/WebCore/Modules/entriesapi/DOMFileSystem.cpp:
(WebCore::listDirectoryWithMetadata):
(WebCore::toFileSystemEntries):
* Source/WebCore/Modules/gamepad/Gamepad.cpp:
* Source/WebCore/Modules/highlight/Highlight.cpp:
(WebCore::Highlight::Highlight):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::toLibWebRTCMediaEndpointTransceiverState):
(WebCore::transceiverStatesFromPeerConnection):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp:
(WebCore::LibWebRTCRtpTransformableFrame::audioMetadata const):

Canonical link: <a href="https://commits.webkit.org/268874@main">https://commits.webkit.org/268874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b691554b49f0a4f7566c707ec91a776718acfcad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20921 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22811 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21506 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23668 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18981 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25272 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18232 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23184 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/20353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24331 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18991 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5770 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5021 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25594 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19563 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5596 "Passed tests") | 
<!--EWS-Status-Bubble-End-->