### PR TITLE
Fix scrolling of RenderListBox in vertical writing mode

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1467,6 +1467,10 @@ webkit.org/b/133057 fast/table/border-collapsing/collapsed-borders-adjoining-sec
 
 webkit.org/b/169075 editing/selection/extend-by-character-007.html [ Failure ]
 
+# <select> element vertical writing mode support is not yet enabled
+fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html [ Failure ]
+fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar.html [ ImageOnlyFailure ]
+
 # CSS Font Loading is not yet enabled on all platforms
 webkit.org/b/135390 fast/css/fontloader-download-error.html [ Skip ]
 webkit.org/b/135390 fast/css/fontloader-events.html [ Skip ]

--- a/LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar-expected.txt
+++ b/LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar-expected.txt
@@ -1,0 +1,24 @@
+Test that <select multiple> with a vertical writing mode can be scrolled by dragging a horizontal scrollbar
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial state
+PASS select.scrollTop is 0
+PASS select.scrollLeft is 0
+
+
+Attempt to drag as if vertical scrollbar was present
+PASS select.scrollTop is 0
+PASS select.scrollLeft is 0
+
+
+Drag horizontal scrollbar
+PASS select.scrollTop is 0
+PASS select.scrollLeft is 14
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<style>
+
+::-webkit-scrollbar {
+    width: 20px;
+    height: 20px;
+}
+
+::-webkit-scrollbar-button {
+    height: 20px;
+    width: 20px;
+    background-color: blue;
+}
+
+::-webkit-scrollbar-track-piece  {
+    background-color: gray;
+}
+
+::-webkit-scrollbar-thumb {
+    height: 20px;
+    width: 20px;
+    background-color: red;
+}
+
+select {
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+}
+
+</style>
+</head>
+<body>
+<select multiple>
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>
+</body>
+<script>
+
+description("Test that &lt;select multiple&gt; with a vertical writing mode can be scrolled by dragging a horizontal scrollbar");
+
+if (window.eventSender) {
+    var select = document.querySelector("select");
+
+    debug("Initial state");
+    shouldBeEqualToNumber("select.scrollTop", 0);
+    shouldBeEqualToNumber("select.scrollLeft", 0);
+    debug("\n");
+
+    debug("Attempt to drag as if vertical scrollbar was present");
+    eventSender.mouseMoveTo(select.offsetLeft + select.offsetWidth - 5, select.offsetTop + 5);
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(select.offsetLeft + select.offsetWidth - 5, select.offsetTop + 25);
+    eventSender.mouseUp();
+    shouldBeEqualToNumber("select.scrollTop", 0);
+    shouldBeEqualToNumber("select.scrollLeft", 0);
+    debug("\n");
+
+    debug("Drag horizontal scrollbar");
+    eventSender.mouseMoveTo(select.offsetLeft + 5, select.offsetTop + select.offsetHeight - 5);
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(select.offsetLeft + 25, select.offsetTop + select.offsetHeight - 5);
+    eventSender.mouseUp();
+    shouldBeEqualToNumber("select.scrollTop", 0);
+    shouldBeEqualToNumber("select.scrollLeft", 14);
+    debug("\n");
+}
+
+</script>

--- a/LayoutTests/fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar-expected.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar-expected.html
@@ -1,0 +1,44 @@
+<style>
+
+::-webkit-scrollbar {
+    width: 20px;
+    height: 20px;
+}
+
+::-webkit-scrollbar-button {
+    height: 20px;
+    width: 20px;
+    background-color: blue;
+}
+
+::-webkit-scrollbar-track-piece  {
+    background-color: gray;
+}
+
+::-webkit-scrollbar-thumb {
+    height: 20px;
+    width: 20px;
+    background-color: red;
+}
+
+#container {
+    overflow-x: scroll;
+    overflow-y: hidden;
+    writing-mode: vertical-lr;
+    border: 1px solid black;
+    inline-size: 72px;
+    block-size: 57px;
+    box-sizing: border-box;
+}
+
+#content {
+    inline-size: 10px;
+    block-size: 69px;
+}
+
+</style>
+<div id="container">
+    <div id="content">
+    </div>
+</div>
+

--- a/LayoutTests/fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar.html
+++ b/LayoutTests/fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar.html
@@ -1,0 +1,38 @@
+<style>
+
+::-webkit-scrollbar {
+    width: 20px;
+    height: 20px;
+}
+
+::-webkit-scrollbar-button {
+    height: 20px;
+    width: 20px;
+    background-color: blue;
+}
+
+::-webkit-scrollbar-track-piece  {
+    background-color: gray;
+}
+
+::-webkit-scrollbar-thumb {
+    height: 20px;
+    width: 20px;
+    background-color: red;
+}
+
+select {
+    writing-mode: vertical-lr;
+    color: Canvas;
+    border: 1px solid black;
+}
+
+</style>
+<select multiple>
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+    <option>Option 4</option>
+    <option>Option 5</option>
+</select>
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2398,6 +2398,8 @@ fast/scrolling/rtl-scrollbars-sticky-iframe.html [ ImageOnlyFailure ]
 fast/forms/listbox-padding-clip-selected.html [ ImageOnlyFailure ]
 fast/forms/listbox-respects-padding-bottom.html [ Failure ]
 fast/forms/listbox-top-padding-do-not-clip-items.html [ Failure ]
+fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html [ Failure ]
+fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar.html [ ImageOnlyFailure ]
 
 # No focusring on iOS.
 fast/images/image-map-outline-in-positioned-container.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -449,7 +449,7 @@ public:
     inline LayoutUnit availableHeight() const;
 
     WEBCORE_EXPORT virtual int verticalScrollbarWidth() const;
-    WEBCORE_EXPORT int horizontalScrollbarHeight() const;
+    WEBCORE_EXPORT virtual int horizontalScrollbarHeight() const;
     int intrinsicScrollbarLogicalWidth() const;
     inline int scrollbarLogicalWidth() const;
     inline int scrollbarLogicalHeight() const;

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -85,6 +85,8 @@ private:
 
     bool logicalScroll(ScrollLogicalDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr) override;
 
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
+
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
     void computePreferredLogicalWidths() override;
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const override;
@@ -102,12 +104,16 @@ private:
     void panScroll(const IntPoint&) override;
 
     int verticalScrollbarWidth() const override;
+    int horizontalScrollbarHeight() const override;
     int scrollLeft() const override;
     int scrollTop() const override;
     int scrollWidth() const override;
     int scrollHeight() const override;
     void setScrollLeft(int, const ScrollPositionChangeOptions&) override;
     void setScrollTop(int, const ScrollPositionChangeOptions&) override;
+
+    int logicalScrollTop() const;
+    void setLogicalScrollTop(int);
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 
@@ -129,7 +135,8 @@ private:
     IntRect convertFromContainingViewToScrollbar(const Scrollbar&, const IntRect&) const final;
     IntPoint convertFromScrollbarToContainingView(const Scrollbar&, const IntPoint&) const final;
     IntPoint convertFromContainingViewToScrollbar(const Scrollbar&, const IntPoint&) const final;
-    Scrollbar* verticalScrollbar() const final { return m_vBar.get(); }
+    Scrollbar* verticalScrollbar() const final;
+    Scrollbar* horizontalScrollbar() const final;
     IntSize contentsSize() const final;
     IntSize visibleSize() const final { return IntSize(width(), height()); }
     IntPoint lastKnownMousePositionInView() const final;
@@ -152,8 +159,8 @@ private:
     using PaintFunction = Function<void(PaintInfo&, const LayoutPoint&, int listItemIndex)>;
     void paintItem(PaintInfo&, const LayoutPoint&, const PaintFunction&);
 
-    void setHasVerticalScrollbar(bool hasScrollbar);
-    Ref<Scrollbar> createScrollbar();
+    void setHasScrollbar(ScrollbarOrientation);
+    Ref<Scrollbar> createScrollbar(ScrollbarOrientation);
     void destroyScrollbar();
 
     int maximumNumberOfItemsThatFitInPaddingAfterArea() const;
@@ -174,10 +181,14 @@ private:
 
     float deviceScaleFactor() const final;
 
-    void paintScrollbar(PaintInfo&, const LayoutPoint&);
+    LayoutRect rectForScrollbar(const Scrollbar&) const;
+
+    void paintScrollbar(PaintInfo&, const LayoutPoint&, Scrollbar&);
     void paintItemForeground(PaintInfo&, const LayoutPoint&, int listIndex);
     void paintItemBackground(PaintInfo&, const LayoutPoint&, int listIndex);
     void scrollToRevealSelection();
+
+    ScrollbarOrientation scrollbarOrientationForWritingMode() const;
 
     bool shouldPlaceVerticalScrollbarOnLeft() const final { return RenderBlockFlow::shouldPlaceVerticalScrollbarOnLeft(); }
 
@@ -188,7 +199,7 @@ private:
     bool m_inAutoscroll { false };
     int m_optionsLogicalWidth { 0 };
 
-    RefPtr<Scrollbar> m_vBar;
+    RefPtr<Scrollbar> m_scrollbar;
 
     // Note: This is based on item index rather than a pixel offset.
     ScrollPosition m_scrollPosition;


### PR DESCRIPTION
#### 29d2da526a2ed445aaea7715dacd131b46335f01
<pre>
Fix scrolling of RenderListBox in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=261803">https://bugs.webkit.org/show_bug.cgi?id=261803</a>
rdar://115766417

Reviewed by Simon Fraser.

The following changes are made to `RenderListBox`:
- Display a horizontal scrollbar when in vertical writing mode
- Support scrolling in the block direction
- Adjust the scroll origin for flipped blocks writing modes

Covered by the following web platform tests:
- css/css-writing-modes/forms/select-multiple-scrolling.optional.html
- css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional.html

The tests will be rebaselined once `&lt;select&gt;` is enabled under the vertical
form controls preference.

* LayoutTests/TestExpectations:

Mark the newly added tests as failures for now, since `&lt;select&gt;` is still forced
to `writing-mode: horizontal-tb`. Once `RenderListBox` fully supports vertical
writing mode, these tests can be marked as passing.

* LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar-expected.txt: Added.
* LayoutTests/fast/forms/vertical-writing-mode/listbox-drag-horizontal-scrollbar.html: Added.
* LayoutTests/fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar-expected.html: Added.
* LayoutTests/fast/forms/vertical-writing-mode/listbox-horizontal-scrollbar.html: Added.
* LayoutTests/platform/ios/TestExpectations:

`RenderListBox` is not used on iOS.

* Source/WebCore/rendering/RenderBox.h:

Make `horizontalScrollbarHeight` a virtual method so that `RenderListBox` can
report a horizontal scrollbar height.

* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::willBeDestroyed):
(WebCore::RenderListBox::updateFromElement):
(WebCore::RenderListBox::layout):

Adjust the scroll origin to support `vertical-rl`.

(WebCore::RenderListBox::styleDidChange):
(WebCore::RenderListBox::computeIntrinsicLogicalWidths const):
(WebCore::RenderListBox::itemBoundingBoxRect const):
(WebCore::RenderListBox::paintObject):
(WebCore::RenderListBox::paintScrollbar):
(WebCore::RenderListBox::isPointInOverflowControl):
(WebCore::RenderListBox::listIndexAtOffset const):
(WebCore::RenderListBox::panScroll):

`panScroll` is only supported on Windows. Given an inability to easily test,
the implementation is left as-is, and does not currently support vertical
writing modes.

(WebCore::RenderListBox::scrollToward):

Update logic to support scrolling as dragging occurs in the block direction.

(WebCore::RenderListBox::scrollToRevealElementAtListIndex):
(WebCore::RenderListBox::indexOffset const):
(WebCore::RenderListBox::maximumScrollPosition const):
(WebCore::RenderListBox::verticalScrollbarWidth const):
(WebCore::RenderListBox::horizontalScrollbarHeight const):
(WebCore::RenderListBox::verticalScrollbar const):
(WebCore::RenderListBox::horizontalScrollbar const):
(WebCore::RenderListBox::scrollbarOrientationForWritingMode const):
(WebCore::RenderListBox::scrollWidth const):
(WebCore::RenderListBox::scrollHeight const):
(WebCore::RenderListBox::scrollLeft const):
(WebCore::RenderListBox::setScrollLeft):
(WebCore::RenderListBox::scrollTop const):
(WebCore::RenderListBox::setScrollTop):
(WebCore::RenderListBox::logicalScrollTop const):
(WebCore::RenderListBox::setLogicalScrollTop):
(WebCore::RenderListBox::rectForScrollbar const):

Introduce a helper method to get the rect of the scrollbar relative to the renderer.

(WebCore::RenderListBox::invalidateScrollbarRect):
(WebCore::RenderListBox::convertFromScrollbarToContainingView const):
(WebCore::RenderListBox::convertFromContainingViewToScrollbar const):
(WebCore::RenderListBox::isScrollableOrRubberbandable):
(WebCore::RenderListBox::createScrollbar):

Introduce a common method to create a vertical/horizontal scrollbar depending
on the writing mode.

(WebCore::RenderListBox::destroyScrollbar):
(WebCore::RenderListBox::setHasScrollbar):
(WebCore::RenderListBox::setHasVerticalScrollbar): Deleted.
* Source/WebCore/rendering/RenderListBox.h:

Introduce a single scrollbar that represents a vertical or horizontal
scrollbar depending on the writing mode.

Canonical link: <a href="https://commits.webkit.org/268894@main">https://commits.webkit.org/268894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42354ecfa61c17bb11e50ee3235d8664f05dfa4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19517 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21535 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23701 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18098 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25297 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23214 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19765 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18850 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5032 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->