### PR TITLE
[Media] Rename VideoFullscreenManager and friends to VideoPresentationManager*

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -314,7 +314,7 @@ platform/cocoa/TextRecognitionResultCocoa.mm
 platform/cocoa/ThemeCocoa.mm
 platform/cocoa/ThermalMitigationNotifier.mm
 platform/cocoa/UserAgentCocoa.mm
-platform/cocoa/VideoFullscreenModelVideoElement.mm
+platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/cocoa/VideoToolboxSoftLink.cpp
 platform/cocoa/WebCoreAdditions.mm @no-unify
 platform/cocoa/WebCoreNSErrorExtras.mm

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -187,7 +187,7 @@
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-#include "VideoFullscreenModel.h"
+#include "VideoPresentationModel.h"
 #endif
 
 #if ENABLE(MEDIA_SESSION)
@@ -9076,6 +9076,6 @@ bool HTMLMediaElement::shouldDisableHDR() const
     return !screenSupportsHighDynamicRange(document().view());
 }
 
-}
+} // namespace WebCore
 
-#endif
+#endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -52,7 +52,7 @@
 #include <wtf/text/TextStream.h>
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-#include "VideoFullscreenModel.h"
+#include "VideoPresentationModel.h"
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
@@ -668,6 +668,6 @@ void HTMLVideoElement::mediaPlayerEngineUpdated()
         player()->startVideoFrameMetadataGathering();
 }
 
-}
+} // namespace WebCore
 
-#endif
+#endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -49,14 +49,14 @@ class MachSendRight;
 
 namespace WebCore {
 
-class VideoFullscreenModelClient;
+class VideoPresentationModelClient;
 
-class VideoFullscreenModel
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoFullscreenModel> {
+class VideoPresentationModel
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoPresentationModel> {
 public:
-    virtual ~VideoFullscreenModel() = default;
-    virtual void addClient(VideoFullscreenModelClient&) = 0;
-    virtual void removeClient(VideoFullscreenModelClient&)= 0;
+    virtual ~VideoPresentationModel() = default;
+    virtual void addClient(VideoPresentationModelClient&) = 0;
+    virtual void removeClient(VideoPresentationModelClient&)= 0;
 
     virtual void requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false) = 0;
     virtual void setVideoLayerFrame(FloatRect) = 0;
@@ -98,9 +98,9 @@ public:
 #endif
 };
 
-class VideoFullscreenModelClient : public CanMakeWeakPtr<VideoFullscreenModelClient>, public CanMakeCheckedPtr {
+class VideoPresentationModelClient : public CanMakeWeakPtr<VideoPresentationModelClient>, public CanMakeCheckedPtr {
 public:
-    virtual ~VideoFullscreenModelClient() = default;
+    virtual ~VideoPresentationModelClient() = default;
     virtual void hasVideoChanged(bool) { }
     virtual void videoDimensionsChanged(const FloatSize&) { }
     virtual void willEnterPictureInPicture() { }
@@ -111,7 +111,6 @@ public:
     virtual void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) { }
 };
     
-}
+} // namespace WebCore
 
-#endif
-
+#endif // ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -23,7 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #pragma once
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
@@ -34,7 +33,7 @@
 #include "MediaPlayerEnums.h"
 #include "MediaPlayerIdentifier.h"
 #include "PlatformLayer.h"
-#include "VideoFullscreenModel.h"
+#include "VideoPresentationModel.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
@@ -43,18 +42,19 @@
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
 class AudioTrack;
 class HTMLVideoElement;
 class TextTrack;
 class PlaybackSessionModelMediaElement;
 
-class VideoFullscreenModelVideoElement final : public VideoFullscreenModel {
+class VideoPresentationModelVideoElement final : public VideoPresentationModel {
 public:
-    static RefPtr<VideoFullscreenModelVideoElement> create()
+    static RefPtr<VideoPresentationModelVideoElement> create()
     {
-        return adoptRef(*new VideoFullscreenModelVideoElement());
+        return adoptRef(*new VideoPresentationModelVideoElement());
     }
-    WEBCORE_EXPORT ~VideoFullscreenModelVideoElement();
+    WEBCORE_EXPORT ~VideoPresentationModelVideoElement();
     WEBCORE_EXPORT void setVideoElement(HTMLVideoElement*);
     HTMLVideoElement* videoElement() const { return m_videoElement.get(); }
     WEBCORE_EXPORT RetainPtr<PlatformLayer> createVideoFullscreenLayer();
@@ -62,8 +62,8 @@ public:
     WEBCORE_EXPORT void willExitFullscreen() final;
     WEBCORE_EXPORT void waitForPreparedForInlineThen(Function<void()>&& completionHandler);
 
-    WEBCORE_EXPORT void addClient(VideoFullscreenModelClient&) final;
-    WEBCORE_EXPORT void removeClient(VideoFullscreenModelClient&) final;
+    WEBCORE_EXPORT void addClient(VideoPresentationModelClient&) final;
+    WEBCORE_EXPORT void removeClient(VideoPresentationModelClient&) final;
     WEBCORE_EXPORT void requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false) final;
     WEBCORE_EXPORT void setVideoLayerFrame(FloatRect) final;
     WEBCORE_EXPORT void setVideoLayerGravity(MediaPlayerEnums::VideoGravity) final;
@@ -79,25 +79,25 @@ public:
     const Logger* loggerPtr() const final;
     WEBCORE_EXPORT const void* logIdentifier() const final;
     WEBCORE_EXPORT const void* nextChildIdentifier() const final;
-    const char* logClassName() const { return "VideoFullscreenModelVideoElement"; }
+    const char* logClassName() const { return "VideoPresentationModelVideoElement"; }
     WTFLogChannel& logChannel() const;
 #endif
 
 protected:
-    WEBCORE_EXPORT VideoFullscreenModelVideoElement();
+    WEBCORE_EXPORT VideoPresentationModelVideoElement();
 
 private:
     class VideoListener final : public EventListener {
     public:
-        static Ref<VideoListener> create(VideoFullscreenModelVideoElement& parent)
+        static Ref<VideoListener> create(VideoPresentationModelVideoElement& parent)
         {
             return adoptRef(*new VideoListener(parent));
         }
         void handleEvent(WebCore::ScriptExecutionContext&, WebCore::Event&) final;
     private:
-        explicit VideoListener(VideoFullscreenModelVideoElement&);
+        explicit VideoListener(VideoPresentationModelVideoElement&);
 
-        ThreadSafeWeakPtr<VideoFullscreenModelVideoElement> m_parent;
+        ThreadSafeWeakPtr<VideoPresentationModelVideoElement> m_parent;
     };
 
     void setHasVideo(bool);
@@ -120,7 +120,7 @@ private:
     RefPtr<HTMLVideoElement> m_videoElement;
     RetainPtr<PlatformLayer> m_videoFullscreenLayer;
     bool m_isListening { false };
-    HashSet<CheckedPtr<VideoFullscreenModelClient>> m_clients;
+    HashSet<CheckedPtr<VideoPresentationModelClient>> m_clients;
     bool m_hasVideo { false };
     FloatSize m_videoDimensions;
     FloatRect m_videoFrame;
@@ -133,7 +133,6 @@ private:
 #endif
 };
 
-}
+} // namespace WebCore
 
-#endif
-
+#endif // ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import "VideoFullscreenModelVideoElement.h"
+#import "VideoPresentationModelVideoElement.h"
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 
@@ -49,29 +49,29 @@
 
 namespace WebCore {
 
-VideoFullscreenModelVideoElement::VideoListener::VideoListener(VideoFullscreenModelVideoElement& parent)
+VideoPresentationModelVideoElement::VideoListener::VideoListener(VideoPresentationModelVideoElement& parent)
     : EventListener(EventListener::CPPEventListenerType)
     , m_parent(parent)
 {
 }
 
-void VideoFullscreenModelVideoElement::VideoListener::handleEvent(WebCore::ScriptExecutionContext&, WebCore::Event& event)
+void VideoPresentationModelVideoElement::VideoListener::handleEvent(WebCore::ScriptExecutionContext&, WebCore::Event& event)
 {
     if (auto parent = m_parent.get())
         parent->updateForEventName(event.type());
 }
 
-VideoFullscreenModelVideoElement::VideoFullscreenModelVideoElement()
+VideoPresentationModelVideoElement::VideoPresentationModelVideoElement()
     : m_videoListener(VideoListener::create(*this))
 {
 }
 
-VideoFullscreenModelVideoElement::~VideoFullscreenModelVideoElement()
+VideoPresentationModelVideoElement::~VideoPresentationModelVideoElement()
 {
     cleanVideoListeners();
 }
 
-void VideoFullscreenModelVideoElement::cleanVideoListeners()
+void VideoPresentationModelVideoElement::cleanVideoListeners()
 {
     if (!m_isListening)
         return;
@@ -82,7 +82,7 @@ void VideoFullscreenModelVideoElement::cleanVideoListeners()
         m_videoElement->removeEventListener(eventName, m_videoListener, false);
 }
 
-void VideoFullscreenModelVideoElement::setVideoElement(HTMLVideoElement* videoElement)
+void VideoPresentationModelVideoElement::setVideoElement(HTMLVideoElement* videoElement)
 {
     if (m_videoElement == videoElement)
         return;
@@ -107,7 +107,7 @@ void VideoFullscreenModelVideoElement::setVideoElement(HTMLVideoElement* videoEl
     updateForEventName(eventNameAll());
 }
 
-void VideoFullscreenModelVideoElement::updateForEventName(const WTF::AtomString& eventName)
+void VideoPresentationModelVideoElement::updateForEventName(const WTF::AtomString& eventName)
 {
     if (m_clients.isEmpty())
         return;
@@ -141,14 +141,14 @@ void VideoFullscreenModelVideoElement::updateForEventName(const WTF::AtomString&
     }
 }
 
-void VideoFullscreenModelVideoElement::willExitFullscreen()
+void VideoPresentationModelVideoElement::willExitFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_videoElement)
         m_videoElement->willExitFullscreen();
 }
 
-RetainPtr<PlatformLayer> VideoFullscreenModelVideoElement::createVideoFullscreenLayer()
+RetainPtr<PlatformLayer> VideoPresentationModelVideoElement::createVideoFullscreenLayer()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_videoElement)
@@ -156,7 +156,7 @@ RetainPtr<PlatformLayer> VideoFullscreenModelVideoElement::createVideoFullscreen
     return nullptr;
 }
 
-void VideoFullscreenModelVideoElement::setVideoFullscreenLayer(PlatformLayer* videoLayer, WTF::Function<void()>&& completionHandler)
+void VideoPresentationModelVideoElement::setVideoFullscreenLayer(PlatformLayer* videoLayer, WTF::Function<void()>&& completionHandler)
 {
     if (m_videoFullscreenLayer == videoLayer) {
         completionHandler();
@@ -181,7 +181,7 @@ void VideoFullscreenModelVideoElement::setVideoFullscreenLayer(PlatformLayer* vi
     m_videoElement->setVideoFullscreenLayer(m_videoFullscreenLayer.get(), WTFMove(completionHandler));
 }
 
-void VideoFullscreenModelVideoElement::waitForPreparedForInlineThen(WTF::Function<void()>&& completionHandler)
+void VideoPresentationModelVideoElement::waitForPreparedForInlineThen(WTF::Function<void()>&& completionHandler)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (!m_videoElement) {
@@ -192,7 +192,7 @@ void VideoFullscreenModelVideoElement::waitForPreparedForInlineThen(WTF::Functio
     m_videoElement->waitForPreparedForInlineThen(WTFMove(completionHandler));
 }
 
-void VideoFullscreenModelVideoElement::requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode mode, bool finishedWithMedia)
+void VideoPresentationModelVideoElement::requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode mode, bool finishedWithMedia)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, mode, ", finishedWithMedia: ", finishedWithMedia);
     if (m_videoElement)
@@ -206,7 +206,7 @@ void VideoFullscreenModelVideoElement::requestFullscreenMode(HTMLMediaElementEnu
     }
 }
 
-void VideoFullscreenModelVideoElement::setVideoLayerFrame(FloatRect rect)
+void VideoPresentationModelVideoElement::setVideoLayerFrame(FloatRect rect)
 {
     INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, rect.size());
     m_videoFrame = rect;
@@ -215,7 +215,7 @@ void VideoFullscreenModelVideoElement::setVideoLayerFrame(FloatRect rect)
         m_videoElement->setVideoFullscreenFrame(rect);
 }
 
-void VideoFullscreenModelVideoElement::setVideoSizeFenced(const FloatSize& size, WTF::MachSendRight&& fence)
+void VideoPresentationModelVideoElement::setVideoSizeFenced(const FloatSize& size, WTF::MachSendRight&& fence)
 {
     if (!m_videoElement)
         return;
@@ -226,26 +226,26 @@ void VideoFullscreenModelVideoElement::setVideoSizeFenced(const FloatSize& size,
 
 }
 
-void VideoFullscreenModelVideoElement::setVideoLayerGravity(MediaPlayer::VideoGravity gravity)
+void VideoPresentationModelVideoElement::setVideoLayerGravity(MediaPlayer::VideoGravity gravity)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, gravity);
     if (m_videoElement)
         m_videoElement->setVideoFullscreenGravity(gravity);
 }
 
-std::span<const AtomString> VideoFullscreenModelVideoElement::observedEventNames()
+std::span<const AtomString> VideoPresentationModelVideoElement::observedEventNames()
 {
     static NeverDestroyed names = std::array { eventNames().resizeEvent, eventNames().loadstartEvent, eventNames().loadedmetadataEvent };
     return names.get();
 }
 
-const AtomString& VideoFullscreenModelVideoElement::eventNameAll()
+const AtomString& VideoPresentationModelVideoElement::eventNameAll()
 {
     static MainThreadNeverDestroyed<const AtomString> sEventNameAll = "allEvents"_s;
     return sEventNameAll;
 }
 
-void VideoFullscreenModelVideoElement::fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode)
+void VideoPresentationModelVideoElement::fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, videoFullscreenMode);
     if (m_videoElement) {
@@ -254,25 +254,25 @@ void VideoFullscreenModelVideoElement::fullscreenModeChanged(HTMLMediaElementEnu
     }
 }
 
-void VideoFullscreenModelVideoElement::requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&& completionHandler)
+void VideoPresentationModelVideoElement::requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&& completionHandler)
 {
     auto& session = AudioSession::sharedSession();
     completionHandler(session.routeSharingPolicy(), session.routingContextUID());
 }
 
-void VideoFullscreenModelVideoElement::addClient(VideoFullscreenModelClient& client)
+void VideoPresentationModelVideoElement::addClient(VideoPresentationModelClient& client)
 {
     ASSERT(!m_clients.contains(&client));
     m_clients.add(&client);
 }
 
-void VideoFullscreenModelVideoElement::removeClient(VideoFullscreenModelClient& client)
+void VideoPresentationModelVideoElement::removeClient(VideoPresentationModelClient& client)
 {
     ASSERT(m_clients.contains(&client));
     m_clients.remove(&client);
 }
 
-void VideoFullscreenModelVideoElement::setHasVideo(bool hasVideo)
+void VideoPresentationModelVideoElement::setHasVideo(bool hasVideo)
 {
     if (hasVideo == m_hasVideo)
         return;
@@ -284,7 +284,7 @@ void VideoFullscreenModelVideoElement::setHasVideo(bool hasVideo)
         client->hasVideoChanged(m_hasVideo);
 }
 
-void VideoFullscreenModelVideoElement::setVideoDimensions(const FloatSize& videoDimensions)
+void VideoPresentationModelVideoElement::setVideoDimensions(const FloatSize& videoDimensions)
 {
     if (m_videoDimensions == videoDimensions)
         return;
@@ -296,7 +296,7 @@ void VideoFullscreenModelVideoElement::setVideoDimensions(const FloatSize& video
         client->videoDimensionsChanged(m_videoDimensions);
 }
 
-void VideoFullscreenModelVideoElement::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
+void VideoPresentationModelVideoElement::setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier)
 {
     if (m_playerIdentifier == identifier)
         return;
@@ -307,35 +307,35 @@ void VideoFullscreenModelVideoElement::setPlayerIdentifier(std::optional<MediaPl
         client->setPlayerIdentifier(identifier);
 }
 
-void VideoFullscreenModelVideoElement::willEnterPictureInPicture()
+void VideoPresentationModelVideoElement::willEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
         client->willEnterPictureInPicture();
 }
 
-void VideoFullscreenModelVideoElement::didEnterPictureInPicture()
+void VideoPresentationModelVideoElement::didEnterPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
         client->didEnterPictureInPicture();
 }
 
-void VideoFullscreenModelVideoElement::failedToEnterPictureInPicture()
+void VideoPresentationModelVideoElement::failedToEnterPictureInPicture()
 {
     ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
         client->failedToEnterPictureInPicture();
 }
 
-void VideoFullscreenModelVideoElement::willExitPictureInPicture()
+void VideoPresentationModelVideoElement::willExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
         client->willExitPictureInPicture();
 }
 
-void VideoFullscreenModelVideoElement::didExitPictureInPicture()
+void VideoPresentationModelVideoElement::didExitPictureInPicture()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
@@ -343,22 +343,22 @@ void VideoFullscreenModelVideoElement::didExitPictureInPicture()
 }
 
 #if !RELEASE_LOG_DISABLED
-const Logger* VideoFullscreenModelVideoElement::loggerPtr() const
+const Logger* VideoPresentationModelVideoElement::loggerPtr() const
 {
     return m_videoElement ? &m_videoElement->logger() : nullptr;
 }
 
-const void* VideoFullscreenModelVideoElement::logIdentifier() const
+const void* VideoPresentationModelVideoElement::logIdentifier() const
 {
     return m_videoElement ? m_videoElement->logIdentifier() : nullptr;
 }
 
-const void* VideoFullscreenModelVideoElement::nextChildIdentifier() const
+const void* VideoPresentationModelVideoElement::nextChildIdentifier() const
 {
     return LoggerHelper::childLogIdentifier(logIdentifier(), ++m_childIdentifierSeed);
 }
 
-WTFLogChannel& VideoFullscreenModelVideoElement::logChannel() const
+WTFLogChannel& VideoPresentationModelVideoElement::logChannel() const
 {
     return LogFullscreen;
 }
@@ -366,4 +366,4 @@ WTFLogChannel& VideoFullscreenModelVideoElement::logChannel() const
 
 } // namespace WebCore
 
-#endif
+#endif // ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
@@ -36,13 +36,13 @@ OBJC_CLASS NSDictionary;
 OBJC_CLASS NSString;
 
 namespace WebCore {
-class VideoFullscreenModel;
+class VideoPresentationModel;
 }
 
 WEBCORE_EXPORT @interface WebAVPlayerLayer : CALayer
 @property (nonatomic, retain, nullable) NSString *videoGravity;
 @property (nonatomic, getter=isReadyForDisplay) BOOL readyForDisplay;
-@property (nonatomic, assign, nullable) WebCore::VideoFullscreenModel* fullscreenModel;
+@property (nonatomic, assign, nullable) WebCore::VideoPresentationModel* presentationModel;
 @property (nonatomic, retain, nonnull) AVPlayerController *playerController;
 @property (nonatomic, retain, nonnull) CALayer *videoSublayer;
 @property (nonatomic, copy, nullable) NSDictionary *pixelBufferAttributes;
@@ -51,4 +51,3 @@ WEBCORE_EXPORT @interface WebAVPlayerLayer : CALayer
 @end
 
 #endif // HAVE(AVKIT)
-

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -31,7 +31,7 @@
 #import "GeometryUtilities.h"
 #import "LayoutRect.h"
 #import "Logging.h"
-#import "VideoFullscreenModel.h"
+#import "VideoPresentationModel.h"
 #import "WebAVPlayerController.h"
 #import <wtf/LoggerHelper.h>
 #import <wtf/RunLoop.h>
@@ -57,10 +57,10 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, __AVPlayerLayerView)
 #endif
 
 namespace WebCore {
-class WebAVPlayerLayerFullscreenModelClient : public VideoFullscreenModelClient {
-    WTF_MAKE_FAST_ALLOCATED(WebAVPlayerLayerFullscreenModelClient);
+class WebAVPlayerLayerPresentationModelClient : public VideoPresentationModelClient {
+    WTF_MAKE_FAST_ALLOCATED(WebAVPlayerLayerPresentationModelClient);
 public:
-    WebAVPlayerLayerFullscreenModelClient(WebAVPlayerLayer* playerLayer)
+    WebAVPlayerLayerPresentationModelClient(WebAVPlayerLayer* playerLayer)
         : m_playerLayer(playerLayer)
     {
     }
@@ -75,14 +75,14 @@ private:
 }
 
 @implementation WebAVPlayerLayer {
-    ThreadSafeWeakPtr<VideoFullscreenModel> _fullscreenModel;
+    ThreadSafeWeakPtr<VideoPresentationModel> _presentationModel;
     RetainPtr<WebAVPlayerController> _playerController;
     RetainPtr<CALayer> _videoSublayer;
     FloatRect _targetVideoFrame;
     CGSize _videoDimensions;
     RetainPtr<NSString> _videoGravity;
     RetainPtr<NSString> _previousVideoGravity;
-    std::unique_ptr<WebAVPlayerLayerFullscreenModelClient> _fullscreenModelClient;
+    std::unique_ptr<WebAVPlayerLayerPresentationModelClient> _presentationModelClient;
 #if !RELEASE_LOG_DISABLED
     const void* _logIdentifier;
 #endif
@@ -97,7 +97,7 @@ private:
         _videoGravity = AVLayerVideoGravityResizeAspect;
         _previousVideoGravity = AVLayerVideoGravityResizeAspect;
         self.name = @"WebAVPlayerLayer";
-        _fullscreenModelClient = WTF::makeUnique<WebAVPlayerLayerFullscreenModelClient>(self);
+        _presentationModelClient = WTF::makeUnique<WebAVPlayerLayerPresentationModelClient>(self);
     }
     return self;
 }
@@ -106,33 +106,33 @@ private:
 {
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(resolveBounds) object:nil];
     [_pixelBufferAttributes release];
-    if (auto model = _fullscreenModel.get())
-        model->removeClient(*_fullscreenModelClient);
+    if (auto model = _presentationModel.get())
+        model->removeClient(*_presentationModelClient);
     [super dealloc];
 }
 
-- (VideoFullscreenModel*)fullscreenModel
+- (VideoPresentationModel*)presentationModel
 {
-    return _fullscreenModel.get().get();
+    return _presentationModel.get().get();
 }
 
-- (void)setFullscreenModel:(VideoFullscreenModel*)fullscreenModel
+- (void)setPresentationModel:(VideoPresentationModel*)presentationModel
 {
-    auto model = _fullscreenModel.get();
-    if (model == fullscreenModel)
+    auto model = _presentationModel.get();
+    if (model == presentationModel)
         return;
 
     if (model)
-        model->removeClient(*_fullscreenModelClient);
+        model->removeClient(*_presentationModelClient);
 
-    _fullscreenModel = fullscreenModel;
+    _presentationModel = presentationModel;
 
-    if (fullscreenModel)
-        fullscreenModel->addClient(*_fullscreenModelClient);
+    if (presentationModel)
+        presentationModel->addClient(*_presentationModelClient);
 
-    self.videoDimensions = fullscreenModel ? fullscreenModel->videoDimensions() : CGSizeZero;
+    self.videoDimensions = presentationModel ? presentationModel->videoDimensions() : CGSizeZero;
 #if !RELEASE_LOG_DISABLED
-    _logIdentifier = fullscreenModel ? fullscreenModel->nextChildIdentifier() : nullptr;
+    _logIdentifier = presentationModel ? presentationModel->nextChildIdentifier() : nullptr;
 #endif
 }
 
@@ -288,7 +288,7 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
 
     OBJC_DEBUG_LOG(OBJC_LOGIDENTIFIER, _targetVideoFrame);
 
-    if (auto model = _fullscreenModel.get()) {
+    if (auto model = _presentationModel.get()) {
         FloatRect targetVideoBounds { { }, _targetVideoFrame.size() };
         model->setVideoLayerFrame(targetVideoBounds);
     }
@@ -328,7 +328,7 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
 
     OBJC_INFO_LOG(OBJC_LOGIDENTIFIER, videoGravity);
 
-    if (auto model = _fullscreenModel.get())
+    if (auto model = _presentationModel.get())
         model->setVideoLayerGravity(gravity);
 
     [self setNeedsLayout];
@@ -370,7 +370,7 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
 
 - (const Logger*)loggerPtr
 {
-    if (auto model = _fullscreenModel.get())
+    if (auto model = _presentationModel.get())
         return model->loggerPtr();
     return nullptr;
 }

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -100,7 +100,7 @@ static void WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerV
     auto *playerLayer = (WebAVPlayerLayer *)[playerLayerView playerLayer];
     auto *pipPlayerLayer = (WebAVPlayerLayer *)[pipView layer];
     [playerLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
-    [pipPlayerLayer setFullscreenModel:playerLayer.fullscreenModel];
+    [pipPlayerLayer setPresentationModel:playerLayer.presentationModel];
     [pipPlayerLayer setVideoSublayer:playerLayer.videoSublayer];
     [pipPlayerLayer setVideoDimensions:playerLayer.videoDimensions];
     [pipPlayerLayer setVideoGravity:playerLayer.videoGravity];

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoFullscreenInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoFullscreenInterface.h
@@ -29,12 +29,12 @@
 
 #include "NullPlaybackSessionInterface.h"
 #include "VideoFullscreenCaptions.h"
-#include "VideoFullscreenModel.h"
+#include "VideoPresentationModel.h"
 
 namespace WebCore {
 
 class NullVideoFullscreenInterface final
-    : public VideoFullscreenModelClient
+    : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
     , public RefCounted<NullVideoFullscreenInterface> {
@@ -48,7 +48,7 @@ public:
     NullPlaybackSessionInterface& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
 
-    void setVideoFullscreenModel(VideoFullscreenModel* model) { m_videoFullscreenModel = model; }
+    void setVideoPresentationModel(VideoPresentationModel* model) { m_videoPresentationModel = model; }
     void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) { }
     void enterFullscreen() { }
     bool exitFullscreen(const FloatRect& finalRect) { return false; }
@@ -72,7 +72,7 @@ public:
     std::optional<MediaPlayerIdentifier> playerIdentifier() const { return std::nullopt; }
     bool changingStandbyOnly() { return false; }
 
-    // VideoFullscreenModelClient
+    // VideoPresentationModelClient
     void hasVideoChanged(bool) final { }
     void videoDimensionsChanged(const FloatSize&) final { }
     void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) final { }
@@ -87,9 +87,9 @@ private:
     }
 
     Ref<NullPlaybackSessionInterface> m_playbackSessionInterface;
-    ThreadSafeWeakPtr<VideoFullscreenModel> m_videoFullscreenModel;
+    ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;
 };
 
-}
+} // namespace WebCore
 
-#endif
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
@@ -35,7 +35,7 @@
 #include "PlatformLayer.h"
 #include "PlaybackSessionInterfaceAVKit.h"
 #include "VideoFullscreenCaptions.h"
-#include "VideoFullscreenModel.h"
+#include "VideoPresentationModel.h"
 #include <objc/objc.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
@@ -57,22 +57,23 @@ OBJC_CLASS WebAVPlayerViewControllerDelegate;
 OBJC_CLASS NSError;
 
 namespace WebCore {
+
 class FloatRect;
 class FloatSize;
 
 class VideoFullscreenInterfaceAVKit final
-    : public VideoFullscreenModelClient
+    : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoFullscreenInterfaceAVKit, WTF::DestructionThread::MainRunLoop> {
 public:
     WEBCORE_EXPORT static Ref<VideoFullscreenInterfaceAVKit> create(PlaybackSessionInterfaceAVKit&);
     virtual ~VideoFullscreenInterfaceAVKit();
-    WEBCORE_EXPORT void setVideoFullscreenModel(VideoFullscreenModel*);
+    WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
     PlaybackSessionInterfaceAVKit& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
 
-    // VideoFullscreenModelClient
+    // VideoPresentationModelClient
     WEBCORE_EXPORT void hasVideoChanged(bool) final;
     WEBCORE_EXPORT void videoDimensionsChanged(const FloatSize&) final;
     WEBCORE_EXPORT void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) final;
@@ -129,7 +130,7 @@ public:
         bool hasVideo() const { return m_mode & (HTMLMediaElementEnums::VideoFullscreenModeStandard | HTMLMediaElementEnums::VideoFullscreenModePictureInPicture); }
     };
 
-    RefPtr<VideoFullscreenModel> videoFullscreenModel() const { return m_videoFullscreenModel.get(); }
+    RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel.get(); }
     bool shouldExitFullscreenWithReason(ExitFullScreenReason);
     HTMLMediaElementEnums::VideoFullscreenMode mode() const { return m_currentMode.mode(); }
     bool allowsPictureInPicturePlayback() const { return m_allowsPictureInPicturePlayback; }
@@ -195,7 +196,7 @@ private:
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
     RetainPtr<WebAVPlayerViewControllerDelegate> m_playerViewControllerDelegate;
     RetainPtr<WebAVPlayerViewController> m_playerViewController;
-    ThreadSafeWeakPtr<VideoFullscreenModel> m_videoFullscreenModel;
+    ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;
 
     // These are only used when fullscreen is presented in a separate window.
     RetainPtr<UIWindow> m_window;
@@ -244,6 +245,6 @@ private:
     bool m_exitingPictureInPicture { false };
 };
 
-}
+} // namespace WebCore
 
 #endif // PLATFORM(IOS_FAMILY) && HAVE(AVKIT)

--- a/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.h
@@ -32,7 +32,7 @@
 #include "PlaybackSessionInterfaceMac.h"
 #include "PlaybackSessionModel.h"
 #include "VideoFullscreenCaptions.h"
-#include "VideoFullscreenModel.h"
+#include "VideoPresentationModel.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -42,13 +42,13 @@ OBJC_CLASS NSWindow;
 OBJC_CLASS WebVideoFullscreenInterfaceMacObjC;
 
 namespace WebCore {
+
 class IntRect;
 class FloatSize;
 class PlaybackSessionInterfaceMac;
-class VideoFullscreenModelAndObserver;
 
 class VideoFullscreenInterfaceMac
-    : public VideoFullscreenModelClient
+    : public VideoPresentationModelClient
     , private PlaybackSessionModelClient
     , public VideoFullscreenCaptions
     , public RefCounted<VideoFullscreenInterfaceMac> {
@@ -60,16 +60,16 @@ public:
     }
     virtual ~VideoFullscreenInterfaceMac();
     PlaybackSessionInterfaceMac& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
-    RefPtr<VideoFullscreenModel> videoFullscreenModel() const { return m_videoFullscreenModel.get(); }
+    RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
-    WEBCORE_EXPORT void setVideoFullscreenModel(VideoFullscreenModel*);
+    WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
 
     // PlaybackSessionModelClient
     WEBCORE_EXPORT void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) override;
     WEBCORE_EXPORT void externalPlaybackChanged(bool  enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String& localizedDeviceName) override;
     WEBCORE_EXPORT void ensureControlsManager() override;
 
-    // VideoFullscreenModelClient
+    // VideoPresentationModelClient
     WEBCORE_EXPORT void hasVideoChanged(bool) final;
     WEBCORE_EXPORT void videoDimensionsChanged(const FloatSize&) final;
     void setPlayerIdentifier(std::optional<MediaPlayerIdentifier> identifier) final { m_playerIdentifier = identifier; }
@@ -112,12 +112,11 @@ private:
     WEBCORE_EXPORT VideoFullscreenInterfaceMac(PlaybackSessionInterfaceMac&);
     Ref<PlaybackSessionInterfaceMac> m_playbackSessionInterface;
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
-    ThreadSafeWeakPtr<VideoFullscreenModel> m_videoFullscreenModel;
+    ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;
     HTMLMediaElementEnums::VideoFullscreenMode m_mode { HTMLMediaElementEnums::VideoFullscreenModeNone };
     RetainPtr<WebVideoFullscreenInterfaceMacObjC> m_webVideoFullscreenInterfaceObjC;
 };
 
-}
+} // namespace WebCore
 
-#endif
-
+#endif // PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm
@@ -33,7 +33,7 @@
 #import "PictureInPictureSupport.h"
 #import "PlaybackSessionInterfaceMac.h"
 #import "TimeRanges.h"
-#import "VideoFullscreenModel.h"
+#import "VideoPresentationModel.h"
 #import "WebAVPlayerLayer.h"
 #import "WebPlaybackControlsManager.h"
 #import <AVFoundation/AVTime.h>
@@ -59,7 +59,7 @@ SOFT_LINK_CLASS_OPTIONAL(PIP, PIPViewController)
 
 @end
 
-using WebCore::VideoFullscreenModel;
+using WebCore::VideoPresentationModel;
 using WebCore::HTMLMediaElementEnums;
 using WebCore::MediaPlayerEnums;
 using WebCore::VideoFullscreenInterfaceMac;
@@ -199,7 +199,7 @@ enum class PIPState {
     [_pipViewController setUserCanResize:YES];
     [_pipViewController setPlaying:_playing];
     [self setVideoDimensions:NSEqualSizes(_videoDimensions, NSZeroSize) ? frame.size : _videoDimensions];
-    auto model = _videoFullscreenInterfaceMac ? _videoFullscreenInterfaceMac->videoFullscreenModel() : nullptr;
+    auto model = _videoFullscreenInterfaceMac ? _videoFullscreenInterfaceMac->videoPresentationModel() : nullptr;
     if (model)
         model->setVideoLayerGravity(MediaPlayerEnums::VideoGravity::ResizeAspectFill);
 
@@ -212,7 +212,7 @@ enum class PIPState {
     _playerLayer = adoptNS([[WebAVPlayerLayer alloc] init]);
     [[_videoViewContainer layer] addSublayer:_playerLayer.get()];
     [_playerLayer setFrame:[_videoViewContainer layer].bounds];
-    [_playerLayer setFullscreenModel:model.get()];
+    [_playerLayer setPresentationModel:model.get()];
     [_playerLayer setVideoSublayer:videoView.layer];
     [_playerLayer setVideoDimensions:_videoDimensions];
     [_playerLayer setAutoresizingMask:(kCALayerWidthSizable | kCALayerHeightSizable)];
@@ -275,7 +275,7 @@ enum class PIPState {
         // as an indication that entering picture-in-picture is completed.
         _pipState = PIPState::InPIP;
 
-        if (auto model = _videoFullscreenInterfaceMac->videoFullscreenModel()) {
+        if (auto model = _videoFullscreenInterfaceMac->videoPresentationModel()) {
             model->didEnterPictureInPicture();
             model->didEnterFullscreen((WebCore::FloatSize)[_videoViewContainer bounds].size);
         }
@@ -306,7 +306,7 @@ enum class PIPState {
     if (!_videoFullscreenInterfaceMac)
         return YES;
     
-    if (auto model = _videoFullscreenInterfaceMac->videoFullscreenModel())
+    if (auto model = _videoFullscreenInterfaceMac->videoPresentationModel())
         model->fullscreenMayReturnToInline();
 
     _videoFullscreenInterfaceMac->requestHideAndExitPiP();
@@ -327,7 +327,7 @@ enum class PIPState {
         [self pipActionStop:pip];
     }
 
-    if (auto model = _videoFullscreenInterfaceMac->videoFullscreenModel()) {
+    if (auto model = _videoFullscreenInterfaceMac->videoPresentationModel()) {
         if (_videoViewContainer && _returningWindow && !NSEqualRects(_returningRect, NSZeroRect)) {
             [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
                 context.allowsImplicitAnimation = NO;
@@ -394,15 +394,15 @@ VideoFullscreenInterfaceMac::~VideoFullscreenInterfaceMac()
 {
     if (auto* model = m_playbackSessionInterface->playbackSessionModel())
         model->removeClient(*this);
-    if (auto model = videoFullscreenModel())
+    if (auto model = videoPresentationModel())
         model->removeClient(*this);
 }
 
-void VideoFullscreenInterfaceMac::setVideoFullscreenModel(VideoFullscreenModel* model)
+void VideoFullscreenInterfaceMac::setVideoPresentationModel(VideoPresentationModel* model)
 {
-    if (auto model = videoFullscreenModel())
+    if (auto model = videoPresentationModel())
         model->removeClient(*this);
-    m_videoFullscreenModel = model;
+    m_videoPresentationModel = model;
     if (model)
         model->addClient(*this);
 }
@@ -414,7 +414,7 @@ void VideoFullscreenInterfaceMac::setMode(HTMLMediaElementEnums::VideoFullscreen
         return;
 
     m_mode = newMode;
-    if (auto model = videoFullscreenModel())
+    if (auto model = videoPresentationModel())
         model->fullscreenModeChanged(m_mode);
 }
 
@@ -425,7 +425,7 @@ void VideoFullscreenInterfaceMac::clearMode(HTMLMediaElementEnums::VideoFullscre
         return;
 
     m_mode = newMode;
-    if (auto model = videoFullscreenModel())
+    if (auto model = videoPresentationModel())
         model->fullscreenModeChanged(m_mode);
 }
 
@@ -459,7 +459,7 @@ void VideoFullscreenInterfaceMac::setupFullscreen(NSView& layerHostedView, const
     [videoFullscreenInterfaceObjC() setUpPIPForVideoView:&layerHostedView withFrame:(NSRect)initialRect inWindow:parentWindow];
 
     RunLoop::main().dispatch([protectedThis = Ref { *this }, this] {
-        if (auto model = videoFullscreenModel())
+        if (auto model = videoPresentationModel())
             model->didSetupFullscreen();
     });
 }
@@ -469,7 +469,7 @@ void VideoFullscreenInterfaceMac::enterFullscreen()
     LOG(Fullscreen, "VideoFullscreenInterfaceMac::enterFullscreen(%p)", this);
 
     if (mode() == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) {
-        if (auto model = videoFullscreenModel())
+        if (auto model = videoPresentationModel())
             model->willEnterPictureInPicture();
         [m_webVideoFullscreenInterfaceObjC enterPIP];
 
@@ -504,7 +504,7 @@ void VideoFullscreenInterfaceMac::exitFullscreenWithoutAnimationToMode(HTMLMedia
 #endif
 
     bool isExitingToStandardFullscreen = mode == HTMLMediaElementEnums::VideoFullscreenModeStandard;
-    // On Mac, standard fullscreen is handled by the Fullscreen API and not by VideoFullscreenManager.
+    // On Mac, standard fullscreen is handled by the Fullscreen API and not by VideoPresentationManager.
     // Just update m_mode directly to HTMLMediaElementEnums::VideoFullscreenModeStandard in that case to keep
     // m_mode in sync with the fullscreen mode in HTMLMediaElement.
     if (isExitingToStandardFullscreen)
@@ -521,7 +521,7 @@ void VideoFullscreenInterfaceMac::cleanupFullscreen()
     [m_webVideoFullscreenInterfaceObjC exitPIP];
     [m_webVideoFullscreenInterfaceObjC invalidateFullscreenState];
 
-    if (auto model = videoFullscreenModel())
+    if (auto model = videoPresentationModel())
         model->didCleanupFullscreen();
 }
 
@@ -529,7 +529,7 @@ void VideoFullscreenInterfaceMac::invalidate()
 {
     LOG(Fullscreen, "VideoFullscreenInterfaceMac::invalidate(%p)", this);
 
-    m_videoFullscreenModel = nullptr;
+    m_videoPresentationModel = nullptr;
 
     cleanupFullscreen();
 
@@ -539,7 +539,7 @@ void VideoFullscreenInterfaceMac::invalidate()
 
 void VideoFullscreenInterfaceMac::requestHideAndExitPiP()
 {
-    auto model = videoFullscreenModel();
+    auto model = videoPresentationModel();
     if (!model)
         return;
 
@@ -615,4 +615,4 @@ bool supportsPictureInPicture()
 
 }
 
-#endif
+#endif // PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -336,7 +336,7 @@ $(PROJECT_DIR)/UIProcess/Automation/Automation.json
 $(PROJECT_DIR)/UIProcess/Automation/WebAutomationSession.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
-$(PROJECT_DIR)/UIProcess/Cocoa/VideoFullscreenManagerProxy.messages.in
+$(PROJECT_DIR)/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Downloads/DownloadProxy.messages.in
 $(PROJECT_DIR)/UIProcess/DrawingAreaProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -484,7 +484,7 @@ $(PROJECT_DIR)/WebProcess/cocoa/AudioCaptureSampleManager.messages.in
 $(PROJECT_DIR)/WebProcess/cocoa/PlaybackSessionManager.messages.in
 $(PROJECT_DIR)/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
 $(PROJECT_DIR)/WebProcess/cocoa/UserMediaCaptureManager.messages.in
-$(PROJECT_DIR)/WebProcess/cocoa/VideoFullscreenManager.messages.in
+$(PROJECT_DIR)/WebProcess/cocoa/VideoPresentationManager.messages.in
 $(PROJECT_DIR)/WebProcess/com.apple.WebProcess.sb.in
 $(PROJECT_DIR)/webpushd/PushClientConnection.messages.in
 $(PROJECT_DIR)/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -362,10 +362,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/UserMediaCaptureManagerMessageReceiv
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/UserMediaCaptureManagerMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/UserMediaCaptureManagerProxyMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/UserMediaCaptureManagerProxyMessages.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/VideoFullscreenManagerMessageReceiver.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/VideoFullscreenManagerMessages.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/VideoFullscreenManagerProxyMessageReceiver.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/VideoFullscreenManagerProxyMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/VideoPresentationManagerMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/VideoPresentationManagerMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/VideoPresentationManagerProxyMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/VideoPresentationManagerProxyMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/ViewGestureControllerMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/ViewGestureControllerMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/ViewGestureGeometryCollectorMessageReceiver.cpp

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -176,7 +176,7 @@ MESSAGE_RECEIVERS = \
 	UIProcess/WebPermissionControllerProxy \
 	UIProcess/Cocoa/PlaybackSessionManagerProxy \
 	UIProcess/Cocoa/UserMediaCaptureManagerProxy \
-	UIProcess/Cocoa/VideoFullscreenManagerProxy \
+	UIProcess/Cocoa/VideoPresentationManagerProxy \
 	UIProcess/ViewGestureController \
 	UIProcess/WebProcessProxy \
 	UIProcess/Automation/WebAutomationSession \
@@ -245,7 +245,7 @@ MESSAGE_RECEIVERS = \
 	WebProcess/cocoa/PlaybackSessionManager \
 	WebProcess/cocoa/RemoteCaptureSampleManager \
 	WebProcess/cocoa/UserMediaCaptureManager \
-	WebProcess/cocoa/VideoFullscreenManager \
+	WebProcess/cocoa/VideoPresentationManager \
 	WebProcess/Geolocation/WebGeolocationManager \
 	WebProcess/Automation/WebAutomationSessionProxy \
 	WebProcess/FullScreen/WebFullScreenManager \

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -406,7 +406,7 @@ UIProcess/Cocoa/UIProcessLogInitializationCocoa.mm
 UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
 UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
 UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
-UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+UIProcess/Cocoa/VideoPresentationManagerProxy.mm
 UIProcess/Cocoa/WebGeolocationManagerProxyCocoa.cpp
 UIProcess/Cocoa/WebPageProxyCocoa.mm
 UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -608,7 +608,7 @@ WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
 WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
 WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
 WebProcess/cocoa/UserMediaCaptureManager.cpp
-WebProcess/cocoa/VideoFullscreenManager.mm
+WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm
 
 WebProcess/EntryPoint/Cocoa/XPCService/WebContentServiceEntryPoint.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -58,7 +58,7 @@
 #import "SafeBrowsingWarning.h"
 #import "SessionStateCoding.h"
 #import "UIDelegate.h"
-#import "VideoFullscreenManagerProxy.h"
+#import "VideoPresentationManagerProxy.h"
 #import "ViewGestureController.h"
 #import "WKBackForwardListInternal.h"
 #import "WKBackForwardListItemInternal.h"
@@ -990,8 +990,8 @@ static bool validateArgument(id argument)
     auto callbackAggregator = CallbackAggregator::create(WTFMove(completionHandler));
 
 #if ENABLE(FULLSCREEN_API)
-    if (auto videoFullscreenManager = _page->videoFullscreenManager()) {
-        videoFullscreenManager->forEachSession([callbackAggregator] (auto& model, auto& interface) mutable {
+    if (auto videoPresentationManager = _page->videoPresentationManager()) {
+        videoPresentationManager->forEachSession([callbackAggregator] (auto& model, auto& interface) mutable {
             model.requestCloseAllMediaPresentations(false, [callbackAggregator] { });
         });
     }
@@ -3194,9 +3194,9 @@ static void convertAndAddHighlight(Vector<Ref<WebKit::SharedMemory>>& buffers, N
 {
 #if ENABLE(FULLSCREEN_API)
     bool hasOpenMediaPresentations = false;
-    if (auto videoFullscreenManager = _page->videoFullscreenManager()) {
-        hasOpenMediaPresentations = videoFullscreenManager->hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture)
-            || videoFullscreenManager->hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard);
+    if (auto videoPresentationManager = _page->videoPresentationManager()) {
+        hasOpenMediaPresentations = videoPresentationManager->hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture)
+            || videoPresentationManager->hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard);
     }
 
     if (!hasOpenMediaPresentations && _page->fullScreenManager() && _page->fullScreenManager()->isFullScreen())

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -39,7 +39,7 @@
 #import "ScrollingTreeScrollingNodeDelegateIOS.h"
 #import "TapHandlingResult.h"
 #import "UIKitUtilities.h"
-#import "VideoFullscreenManagerProxy.h"
+#import "VideoPresentationManagerProxy.h"
 #import "ViewGestureController.h"
 #import "VisibleContentRectUpdateInfo.h"
 #import "WKBackForwardListItemInternal.h"
@@ -226,10 +226,10 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
 - (BOOL)_isShowingVideoPictureInPicture
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    if (!_page || !_page->videoFullscreenManager())
+    if (!_page || !_page->videoPresentationManager())
         return false;
 
-    return _page->videoFullscreenManager()->hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture);
+    return _page->videoPresentationManager()->hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture);
 #else
     return false;
 #endif
@@ -238,10 +238,10 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
 - (BOOL)_mayAutomaticallyShowVideoPictureInPicture
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    if (!_page || !_page->videoFullscreenManager())
+    if (!_page || !_page->videoPresentationManager())
         return false;
 
-    return _page->videoFullscreenManager()->mayAutomaticallyShowVideoPictureInPicture();
+    return _page->videoPresentationManager()->mayAutomaticallyShowVideoPictureInPicture();
 #else
     return false;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -79,7 +79,7 @@ public:
 
 private:
     friend class PlaybackSessionManagerProxy;
-    friend class VideoFullscreenModelContext;
+    friend class VideoPresentationModelContext;
 
     PlaybackSessionModelContext(PlaybackSessionManagerProxy&, PlaybackSessionContextIdentifier);
 
@@ -197,7 +197,7 @@ public:
 
 private:
     friend class PlaybackSessionModelContext;
-    friend class VideoFullscreenManagerProxy;
+    friend class VideoPresentationManagerProxy;
 
     explicit PlaybackSessionManagerProxy(WebPageProxy&);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -260,7 +260,7 @@ private:
 
     const Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "VideoFullscreenManagerProxy"; }
+    const char* logClassName() const { return "VideoPresentationManagerProxy"; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -36,7 +36,7 @@
 #include <WebCore/PlatformLayer.h>
 #include <WebCore/PlatformVideoFullscreenInterface.h>
 #include <WebCore/PlatformView.h>
-#include <WebCore/VideoFullscreenModel.h>
+#include <WebCore/VideoPresentationModel.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Observer.h>
@@ -57,16 +57,16 @@ constexpr size_t DefaultMockPictureInPictureWindowHeight = 100;
 class WebPageProxy;
 class PlaybackSessionManagerProxy;
 class PlaybackSessionModelContext;
-class VideoFullscreenManagerProxy;
+class VideoPresentationManagerProxy;
 
-class VideoFullscreenModelContext final
-    : public WebCore::VideoFullscreenModel  {
+class VideoPresentationModelContext final
+    : public WebCore::VideoPresentationModel  {
 public:
-    static Ref<VideoFullscreenModelContext> create(VideoFullscreenManagerProxy& manager, PlaybackSessionModelContext& playbackSessionModel, PlaybackSessionContextIdentifier contextId)
+    static Ref<VideoPresentationModelContext> create(VideoPresentationManagerProxy& manager, PlaybackSessionModelContext& playbackSessionModel, PlaybackSessionContextIdentifier contextId)
     {
-        return adoptRef(*new VideoFullscreenModelContext(manager, playbackSessionModel, contextId));
+        return adoptRef(*new VideoPresentationModelContext(manager, playbackSessionModel, contextId));
     }
-    virtual ~VideoFullscreenModelContext();
+    virtual ~VideoPresentationModelContext();
 
     PlatformView *layerHostView() const { return m_layerHostView.get(); }
     void setLayerHostView(RetainPtr<PlatformView>&& layerHostView) { m_layerHostView = WTFMove(layerHostView); }
@@ -85,14 +85,14 @@ public:
     void requestCloseAllMediaPresentations(bool finishedWithMedia, CompletionHandler<void()>&&);
 
 private:
-    friend class VideoFullscreenManagerProxy;
-    VideoFullscreenModelContext(VideoFullscreenManagerProxy&, PlaybackSessionModelContext&, PlaybackSessionContextIdentifier);
+    friend class VideoPresentationManagerProxy;
+    VideoPresentationModelContext(VideoPresentationManagerProxy&, PlaybackSessionModelContext&, PlaybackSessionContextIdentifier);
 
     void setVideoDimensions(const WebCore::FloatSize&);
 
-    // VideoFullscreenModel
-    void addClient(WebCore::VideoFullscreenModelClient&) override;
-    void removeClient(WebCore::VideoFullscreenModelClient&) override;
+    // VideoPresentationModel
+    void addClient(WebCore::VideoPresentationModelClient&) override;
+    void removeClient(WebCore::VideoPresentationModelClient&) override;
     void requestFullscreenMode(WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false) override;
     void setVideoLayerFrame(WebCore::FloatRect) override;
     void setVideoLayerGravity(WebCore::MediaPlayerEnums::VideoGravity) override;
@@ -127,11 +127,11 @@ private:
     const void* nextChildIdentifier() const final;
     const Logger* loggerPtr() const final;
 
-    const char* logClassName() const { return "VideoFullscreenModelContext"; };
+    const char* logClassName() const { return "VideoPresentationModelContext"; };
     WTFLogChannel& logChannel() const;
 #endif
 
-    WeakPtr<VideoFullscreenManagerProxy> m_manager;
+    WeakPtr<VideoPresentationManagerProxy> m_manager;
     Ref<PlaybackSessionModelContext> m_playbackSessionModel;
     PlaybackSessionContextIdentifier m_contextId;
     RetainPtr<PlatformView> m_layerHostView;
@@ -142,7 +142,7 @@ private:
     RetainPtr<WKVideoView> m_videoView;
 #endif
 
-    WeakHashSet<WebCore::VideoFullscreenModelClient> m_clients;
+    WeakHashSet<WebCore::VideoPresentationModelClient> m_clients;
     WebCore::FloatSize m_videoDimensions;
     bool m_hasVideo { false };
 
@@ -151,17 +151,17 @@ private:
 #endif
 };
 
-class VideoFullscreenManagerProxy
-    : public RefCounted<VideoFullscreenManagerProxy>
-    , public CanMakeWeakPtr<VideoFullscreenManagerProxy>
+class VideoPresentationManagerProxy
+    : public RefCounted<VideoPresentationManagerProxy>
+    , public CanMakeWeakPtr<VideoPresentationManagerProxy>
     , private IPC::MessageReceiver {
 public:
-    using CanMakeWeakPtr<VideoFullscreenManagerProxy>::WeakPtrImplType;
-    using CanMakeWeakPtr<VideoFullscreenManagerProxy>::WeakValueType;
-    using CanMakeWeakPtr<VideoFullscreenManagerProxy>::weakPtrFactory;
+    using CanMakeWeakPtr<VideoPresentationManagerProxy>::WeakPtrImplType;
+    using CanMakeWeakPtr<VideoPresentationManagerProxy>::WeakValueType;
+    using CanMakeWeakPtr<VideoPresentationManagerProxy>::weakPtrFactory;
 
-    static Ref<VideoFullscreenManagerProxy> create(WebPageProxy&, PlaybackSessionManagerProxy&);
-    virtual ~VideoFullscreenManagerProxy();
+    static Ref<VideoPresentationManagerProxy> create(WebPageProxy&, PlaybackSessionManagerProxy&);
+    virtual ~VideoPresentationManagerProxy();
 
     void invalidate();
 
@@ -181,7 +181,7 @@ public:
     using VideoInPictureInPictureDidChangeObserver = WTF::Observer<void(bool)>;
     void addVideoInPictureInPictureDidChangeObserver(const VideoInPictureInPictureDidChangeObserver&);
 
-    void forEachSession(Function<void(VideoFullscreenModelContext&, WebCore::PlatformVideoFullscreenInterface&)>&&);
+    void forEachSession(Function<void(VideoPresentationModelContext&, WebCore::PlatformVideoFullscreenInterface&)>&&);
 
     void requestBitmapImageForCurrentTime(PlaybackSessionContextIdentifier, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&&);
 
@@ -195,15 +195,15 @@ public:
     void willRemoveLayerForID(PlaybackSessionContextIdentifier);
 
 private:
-    friend class VideoFullscreenModelContext;
+    friend class VideoPresentationModelContext;
 
-    explicit VideoFullscreenManagerProxy(WebPageProxy&, PlaybackSessionManagerProxy&);
+    explicit VideoPresentationManagerProxy(WebPageProxy&, PlaybackSessionManagerProxy&);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    typedef std::tuple<RefPtr<VideoFullscreenModelContext>, RefPtr<WebCore::PlatformVideoFullscreenInterface>> ModelInterfaceTuple;
+    typedef std::tuple<RefPtr<VideoPresentationModelContext>, RefPtr<WebCore::PlatformVideoFullscreenInterface>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);
     ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
-    VideoFullscreenModelContext& ensureModel(PlaybackSessionContextIdentifier);
+    VideoPresentationModelContext& ensureModel(PlaybackSessionContextIdentifier);
     WebCore::PlatformVideoFullscreenInterface& ensureInterface(PlaybackSessionContextIdentifier);
     WebCore::PlatformVideoFullscreenInterface* findInterface(PlaybackSessionContextIdentifier) const;
     void ensureClientForContext(PlaybackSessionContextIdentifier);
@@ -214,7 +214,7 @@ private:
 
     RetainPtr<WKLayerHostView> createLayerHostViewWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatSize& initialSize, float hostingScaleFactor);
 
-    // Messages from VideoFullscreenManager
+    // Messages from VideoPresentationManager
     void setupFullscreenWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatRect& screenRect, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& videoDimensions, float hostingScaleFactor, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
     void setInlineRect(PlaybackSessionContextIdentifier, const WebCore::FloatRect& inlineRect, bool visible);
     void setHasVideoContentLayer(PlaybackSessionContextIdentifier, bool value);
@@ -231,7 +231,7 @@ private:
     void textTrackRepresentationSetContentsScale(PlaybackSessionContextIdentifier, float scale);
     void textTrackRepresentationSetHidden(PlaybackSessionContextIdentifier, bool hidden);
 
-    // Messages to VideoFullscreenManager
+    // Messages to VideoPresentationManager
     void requestFullscreenMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia = false);
     void requestUpdateInlineRect(PlaybackSessionContextIdentifier);
     void requestVideoContentLayer(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-messages -> VideoFullscreenManagerProxy {
+messages -> VideoPresentationManagerProxy {
     SetHasVideo(WebKit::PlaybackSessionContextIdentifier contextId, bool hasVideo)
     SetVideoDimensions(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatSize videoDimensions)
     SetupFullscreenWithID(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, WebCore::FloatRect screenRect, WebCore::FloatSize initialSize, WebCore::FloatSize videoDimensions, float hostingScaleFactor, WebCore::HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -44,7 +44,7 @@
 #import "SafeBrowsingWarning.h"
 #import "SharedBufferReference.h"
 #import "SynapseSPI.h"
-#import "VideoFullscreenManagerProxy.h"
+#import "VideoPresentationManagerProxy.h"
 #import "WKErrorInternal.h"
 #import "WKWebView.h"
 #import "WebContextMenuProxy.h"
@@ -576,30 +576,30 @@ void WebPageProxy::updateFullscreenVideoTextRecognition()
         return;
 
 #if PLATFORM(IOS_FAMILY)
-    if (RetainPtr controller = m_videoFullscreenManager->playerViewController(*internals().currentFullscreenVideoSessionIdentifier))
+    if (RetainPtr controller = m_videoPresentationManager->playerViewController(*internals().currentFullscreenVideoSessionIdentifier))
         pageClient().cancelTextRecognitionForFullscreenVideo(controller.get());
 #endif
 }
 
 void WebPageProxy::fullscreenVideoTextRecognitionTimerFired()
 {
-    if (!internals().currentFullscreenVideoSessionIdentifier || !m_videoFullscreenManager)
+    if (!internals().currentFullscreenVideoSessionIdentifier || !m_videoPresentationManager)
         return;
 
     auto identifier = *internals().currentFullscreenVideoSessionIdentifier;
-    m_videoFullscreenManager->requestBitmapImageForCurrentTime(identifier, [identifier, weakThis = WeakPtr { *this }](std::optional<ShareableBitmap::Handle>&& imageHandle) {
+    m_videoPresentationManager->requestBitmapImageForCurrentTime(identifier, [identifier, weakThis = WeakPtr { *this }](std::optional<ShareableBitmap::Handle>&& imageHandle) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || protectedThis->internals().currentFullscreenVideoSessionIdentifier != identifier)
             return;
 
-        auto fullscreenManager = protectedThis->m_videoFullscreenManager;
-        if (!fullscreenManager)
+        auto presentationManager = protectedThis->m_videoPresentationManager;
+        if (!presentationManager)
             return;
         if (!imageHandle)
             return;
 
 #if PLATFORM(IOS_FAMILY)
-        if (RetainPtr controller = fullscreenManager->playerViewController(identifier))
+        if (RetainPtr controller = presentationManager->playerViewController(identifier))
             protectedThis->pageClient().beginTextRecognitionForFullscreenVideo(WTFMove(*imageHandle), controller.get());
 #endif
     });

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -31,7 +31,7 @@
 #import "RemoteLayerTreePropertyApplier.h"
 #import "RemoteLayerTreeTransaction.h"
 #import "ShareableBitmap.h"
-#import "VideoFullscreenManagerProxy.h"
+#import "VideoPresentationManagerProxy.h"
 #import "WKAnimationDelegate.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
@@ -254,7 +254,7 @@ void RemoteLayerTreeHost::layerWillBeRemoved(WebCore::PlatformLayerIdentifier la
 #if HAVE(AVKIT)
     auto videoLayerIter = m_videoLayers.find(layerID);
     if (videoLayerIter != m_videoLayers.end()) {
-        if (auto videoManager = m_drawingArea->page().videoFullscreenManager())
+        if (auto videoManager = m_drawingArea->page().videoPresentationManager())
             videoManager->willRemoveLayerForID(videoLayerIter->value);
         m_videoLayers.remove(videoLayerIter);
     }
@@ -409,7 +409,7 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
 
 #if HAVE(AVKIT)
         if (properties.videoElementData) {
-            if (auto videoManager = m_drawingArea->page().videoFullscreenManager()) {
+            if (auto videoManager = m_drawingArea->page().videoPresentationManager()) {
                 m_videoLayers.add(properties.layerID, properties.videoElementData->playerIdentifier);
                 return makeWithLayer(videoManager->createLayerWithID(properties.videoElementData->playerIdentifier, properties.hostingContextID(), properties.videoElementData->initialSize, properties.videoElementData->naturalSize, properties.hostingDeviceScaleFactor()));
             }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -31,7 +31,7 @@
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreeViews.h"
 #import "UIKitSPI.h"
-#import "VideoFullscreenManagerProxy.h"
+#import "VideoPresentationManagerProxy.h"
 #import "WKVideoView.h"
 #import "WebPageProxy.h"
 #import <UIKit/UIScrollView.h>
@@ -77,7 +77,7 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
 
 #if HAVE(AVKIT)
         if (properties.videoElementData) {
-            if (auto videoManager = m_drawingArea->page().videoFullscreenManager()) {
+            if (auto videoManager = m_drawingArea->page().videoPresentationManager()) {
                 m_videoLayers.add(properties.layerID, properties.videoElementData->playerIdentifier);
                 return makeWithView(videoManager->createViewWithID(properties.videoElementData->playerIdentifier, properties.hostingContextID(), properties.videoElementData->initialSize, properties.videoElementData->naturalSize, properties.hostingDeviceScaleFactor()));
             }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -251,8 +251,8 @@
 #include "RemoteLayerTreeDrawingAreaProxy.h"
 #include "RemoteLayerTreeScrollingPerformanceData.h"
 #include "UserMediaCaptureManagerProxy.h"
-#include "VideoFullscreenManagerProxy.h"
-#include "VideoFullscreenManagerProxyMessages.h"
+#include "VideoPresentationManagerProxy.h"
+#include "VideoPresentationManagerProxyMessages.h"
 #include "WebPrivacyHelpers.h"
 #include <WebCore/AttributedString.h>
 #include <WebCore/CoreAudioCaptureDeviceManager.h>
@@ -1238,10 +1238,10 @@ void WebPageProxy::didAttachToRunningProcess()
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     ASSERT(!m_playbackSessionManager);
     m_playbackSessionManager = PlaybackSessionManagerProxy::create(*this);
-    ASSERT(!m_videoFullscreenManager);
-    m_videoFullscreenManager = VideoFullscreenManagerProxy::create(*this, *m_playbackSessionManager);
-    if (m_videoFullscreenManager)
-        m_videoFullscreenManager->setMockVideoPresentationModeEnabled(m_mockVideoPresentationModeEnabled);
+    ASSERT(!m_videoPresentationManager);
+    m_videoPresentationManager = VideoPresentationManagerProxy::create(*this, *m_playbackSessionManager);
+    if (m_videoPresentationManager)
+        m_videoPresentationManager->setMockVideoPresentationModeEnabled(m_mockVideoPresentationModeEnabled);
 #endif
 
 #if ENABLE(APPLE_PAY)
@@ -2497,8 +2497,8 @@ void WebPageProxy::viewDidLeaveWindow()
     closeOverlayedViews();
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // When leaving the current page, close the video fullscreen.
-    if (m_videoFullscreenManager && m_videoFullscreenManager->hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard))
-        m_videoFullscreenManager->requestHideAndExitFullscreen();
+    if (m_videoPresentationManager && m_videoPresentationManager->hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard))
+        m_videoPresentationManager->requestHideAndExitFullscreen();
 #endif
 }
 
@@ -7058,8 +7058,8 @@ void WebPageProxy::exitFullscreenImmediately()
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    if (videoFullscreenManager())
-        videoFullscreenManager()->requestHideAndExitFullscreen();
+    if (videoPresentationManager())
+        videoPresentationManager()->requestHideAndExitFullscreen();
 #endif
 }
 
@@ -7784,16 +7784,16 @@ PlaybackSessionManagerProxy* WebPageProxy::playbackSessionManager()
     return m_playbackSessionManager.get();
 }
 
-VideoFullscreenManagerProxy* WebPageProxy::videoFullscreenManager()
+VideoPresentationManagerProxy* WebPageProxy::videoPresentationManager()
 {
-    return m_videoFullscreenManager.get();
+    return m_videoPresentationManager.get();
 }
 
 void WebPageProxy::setMockVideoPresentationModeEnabled(bool enabled)
 {
     m_mockVideoPresentationModeEnabled = enabled;
-    if (m_videoFullscreenManager)
-        m_videoFullscreenManager->setMockVideoPresentationModeEnabled(enabled);
+    if (m_videoPresentationManager)
+        m_videoPresentationManager->setMockVideoPresentationModeEnabled(enabled);
 }
 
 #endif
@@ -9208,9 +9208,9 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
         m_playbackSessionManager->invalidate();
         m_playbackSessionManager = nullptr;
     }
-    if (m_videoFullscreenManager) {
-        m_videoFullscreenManager->invalidate();
-        m_videoFullscreenManager = nullptr;
+    if (m_videoPresentationManager) {
+        m_videoPresentationManager->invalidate();
+        m_videoPresentationManager = nullptr;
     }
 #endif
 
@@ -11132,7 +11132,7 @@ void WebPageProxy::handleControlledElementIDResponse(const String& identifier) c
 bool WebPageProxy::isPlayingVideoInEnhancedFullscreen() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    return m_videoFullscreenManager && m_videoFullscreenManager->isPlayingVideoInEnhancedFullscreen();
+    return m_videoPresentationManager && m_videoPresentationManager->isPlayingVideoInEnhancedFullscreen();
 #else
     return false;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -367,7 +367,7 @@ class SystemPreviewController;
 class UserData;
 class UserMediaPermissionRequestManagerProxy;
 class UserMediaPermissionRequestProxy;
-class VideoFullscreenManagerProxy;
+class VideoPresentationManagerProxy;
 class ViewSnapshot;
 class VisibleContentRectUpdateInfo;
 class VisitedLinkStore;
@@ -622,7 +622,7 @@ public:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     PlaybackSessionManagerProxy* playbackSessionManager();
-    VideoFullscreenManagerProxy* videoFullscreenManager();
+    VideoPresentationManagerProxy* videoPresentationManager();
     void setMockVideoPresentationModeEnabled(bool);
 #endif
 
@@ -2931,7 +2931,7 @@ private:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RefPtr<PlaybackSessionManagerProxy> m_playbackSessionManager;
-    RefPtr<VideoFullscreenManagerProxy> m_videoFullscreenManager;
+    RefPtr<VideoPresentationManagerProxy> m_videoPresentationManager;
     bool m_mockVideoPresentationModeEnabled { false };
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -57,7 +57,7 @@
 #import "TapHandlingResult.h"
 #import "UIKitSPI.h"
 #import "UserData.h"
-#import "VideoFullscreenManagerProxy.h"
+#import "VideoPresentationManagerProxy.h"
 #import "ViewUpdateDispatcherMessages.h"
 #import "WKBrowsingContextControllerInternal.h"
 #import "WebAutocorrectionContext.h"
@@ -692,8 +692,8 @@ void WebPageProxy::applicationWillEnterForegroundForMedia()
 void WebPageProxy::applicationDidBecomeActive()
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    if (m_videoFullscreenManager)
-        m_videoFullscreenManager->applicationDidBecomeActive();
+    if (m_videoPresentationManager)
+        m_videoPresentationManager->applicationDidBecomeActive();
 #endif
     m_process->send(Messages::WebPage::ApplicationDidBecomeActive(), webPageID());
 }

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -24,14 +24,14 @@
  */
 
 #import "config.h"
+#import "WKFullScreenViewController.h"
 
 #if ENABLE(FULLSCREEN_API) && PLATFORM(IOS_FAMILY)
-#import "WKFullScreenViewController.h"
 
 #import "FullscreenTouchSecheuristic.h"
 #import "PlaybackSessionManagerProxy.h"
 #import "UIKitUtilities.h"
-#import "VideoFullscreenManagerProxy.h"
+#import "VideoPresentationManagerProxy.h"
 #import "WKFullscreenStackView.h"
 #import "WKWebViewIOS.h"
 #import "WebFullScreenManagerProxy.h"
@@ -372,8 +372,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     ASSERT(_valid);
     auto page = [self._webView _page];
-    auto* videoFullscreenManager = page ? page->videoFullscreenManager() : nullptr;
-    auto* videoFullscreenInterface = videoFullscreenManager ? videoFullscreenManager->controlsManagerInterface() : nullptr;
+    auto* videoPresentationManager = page ? page->videoPresentationManager() : nullptr;
+    auto* videoFullscreenInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr;
     auto* playbackSessionInterface = videoFullscreenInterface ? &videoFullscreenInterface->playbackSessionInterface() : nullptr;
 
     _playbackClient.setInterface(playbackSessionInterface);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -949,8 +949,8 @@
 		3AB0C59429C8162300141B5E /* NetworkQuotaManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB0C59229C8162200141B5E /* NetworkQuotaManager.h */; };
 		3AE104C029CBC8BB00661165 /* OriginQuotaManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */; };
 		3CAECB6627465AE400AB78D0 /* UnifiedSource113.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */; };
-		3F418EF91887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F418EF51887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp */; };
-		3F418EFB1887BD97002795FD /* VideoFullscreenManagerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F418EF71887BD97002795FD /* VideoFullscreenManagerProxyMessageReceiver.cpp */; };
+		3F418EF91887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F418EF51887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp */; };
+		3F418EFB1887BD97002795FD /* VideoPresentationManagerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F418EF71887BD97002795FD /* VideoPresentationManagerProxyMessageReceiver.cpp */; };
 		3F87B9BE158940190090FF62 /* WebColorChooser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F87B9BB15893F630090FF62 /* WebColorChooser.h */; };
 		3F87B9C0158940D80090FF62 /* WebColorPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F87B9BF158940D80090FF62 /* WebColorPicker.h */; };
 		3FB08E431F60B240005E5312 /* iOS.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3FB08E421F60B240005E5312 /* iOS.xcassets */; };
@@ -1219,7 +1219,7 @@
 		52CDC5C82731DA0D00A3E3EB /* VirtualService.h in Headers */ = {isa = PBXBuildFile; fileRef = 52CDC5C12731DA0C00A3E3EB /* VirtualService.h */; };
 		52CDC5C92731DA0D00A3E3EB /* VirtualLocalConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52CDC5C22731DA0C00A3E3EB /* VirtualLocalConnection.mm */; };
 		52CDC5CA2731DA0D00A3E3EB /* VirtualAuthenticatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 52CDC5C32731DA0C00A3E3EB /* VirtualAuthenticatorManager.h */; };
-		52D5A1B01C57495A00DE34A3 /* VideoFullscreenManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 52D5A1AA1C57494E00DE34A3 /* VideoFullscreenManagerProxy.h */; };
+		52D5A1B01C57495A00DE34A3 /* VideoPresentationManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 52D5A1AA1C57494E00DE34A3 /* VideoPresentationManagerProxy.h */; };
 		52EDB40328C2B8DD002DCF33 /* AuthenticatorManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57DCED852147363A0016B847 /* AuthenticatorManager.cpp */; settings = {COMPILER_FLAGS = "-DRELEASE_WITHOUT_OPTIMIZATIONS -O0"; }; };
 		52EDB40428C2B8FD002DCF33 /* WebAuthenticatorCoordinatorProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DCBF4D926E2ED3200EA0E07 /* WebAuthenticatorCoordinatorProxy.mm */; settings = {COMPILER_FLAGS = "-DRELEASE_WITHOUT_OPTIMIZATIONS -O0"; }; };
 		52F060E11654318500F3281B /* NetworkContentRuleListManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F060DD1654317500F3281B /* NetworkContentRuleListManagerMessageReceiver.cpp */; };
@@ -4665,10 +4665,10 @@
 		3AF5B4732A244FDC004C3D4D /* RemoteGraphicsContextGLProxyMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLProxyMessages.h; sourceTree = "<group>"; };
 		3AF5B4742A244FDD004C3D4D /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource113.cpp; sourceTree = "<group>"; };
-		3F418EF51887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoFullscreenManagerMessageReceiver.cpp; sourceTree = "<group>"; };
-		3F418EF61887BD97002795FD /* VideoFullscreenManagerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoFullscreenManagerMessages.h; sourceTree = "<group>"; };
-		3F418EF71887BD97002795FD /* VideoFullscreenManagerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoFullscreenManagerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
-		3F418EF81887BD97002795FD /* VideoFullscreenManagerProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoFullscreenManagerProxyMessages.h; sourceTree = "<group>"; };
+		3F418EF51887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoPresentationManagerMessageReceiver.cpp; sourceTree = "<group>"; };
+		3F418EF61887BD97002795FD /* VideoPresentationManagerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoPresentationManagerMessages.h; sourceTree = "<group>"; };
+		3F418EF71887BD97002795FD /* VideoPresentationManagerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoPresentationManagerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
+		3F418EF81887BD97002795FD /* VideoPresentationManagerProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoPresentationManagerProxyMessages.h; sourceTree = "<group>"; };
 		3F87B9BA15893F630090FF62 /* WebColorChooser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorChooser.cpp; sourceTree = "<group>"; };
 		3F87B9BB15893F630090FF62 /* WebColorChooser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebColorChooser.h; sourceTree = "<group>"; };
 		3F87B9BF158940D80090FF62 /* WebColorPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebColorPicker.h; sourceTree = "<group>"; };
@@ -5283,12 +5283,12 @@
 		52CDC5C12731DA0C00A3E3EB /* VirtualService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VirtualService.h; sourceTree = "<group>"; };
 		52CDC5C22731DA0C00A3E3EB /* VirtualLocalConnection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualLocalConnection.mm; sourceTree = "<group>"; };
 		52CDC5C32731DA0C00A3E3EB /* VirtualAuthenticatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VirtualAuthenticatorManager.h; sourceTree = "<group>"; };
-		52D5A1AA1C57494E00DE34A3 /* VideoFullscreenManagerProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoFullscreenManagerProxy.h; sourceTree = "<group>"; };
-		52D5A1AB1C57494E00DE34A3 /* VideoFullscreenManagerProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VideoFullscreenManagerProxy.messages.in; sourceTree = "<group>"; };
-		52D5A1AC1C57494E00DE34A3 /* VideoFullscreenManagerProxy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoFullscreenManagerProxy.mm; sourceTree = "<group>"; };
-		52D5A1B21C5749F200DE34A3 /* VideoFullscreenManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoFullscreenManager.h; sourceTree = "<group>"; };
-		52D5A1B31C5749F200DE34A3 /* VideoFullscreenManager.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VideoFullscreenManager.messages.in; sourceTree = "<group>"; };
-		52D5A1B41C5749F200DE34A3 /* VideoFullscreenManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoFullscreenManager.mm; sourceTree = "<group>"; };
+		52D5A1AA1C57494E00DE34A3 /* VideoPresentationManagerProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoPresentationManagerProxy.h; sourceTree = "<group>"; };
+		52D5A1AB1C57494E00DE34A3 /* VideoPresentationManagerProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VideoPresentationManagerProxy.messages.in; sourceTree = "<group>"; };
+		52D5A1AC1C57494E00DE34A3 /* VideoPresentationManagerProxy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoPresentationManagerProxy.mm; sourceTree = "<group>"; };
+		52D5A1B21C5749F200DE34A3 /* VideoPresentationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoPresentationManager.h; sourceTree = "<group>"; };
+		52D5A1B31C5749F200DE34A3 /* VideoPresentationManager.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = VideoPresentationManager.messages.in; sourceTree = "<group>"; };
+		52D5A1B41C5749F200DE34A3 /* VideoPresentationManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoPresentationManager.mm; sourceTree = "<group>"; };
 		52EB68CB279E2145005C98D9 /* ARKitSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARKitSoftLink.h; sourceTree = "<group>"; };
 		52EB68CC279E2145005C98D9 /* ARKitSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ARKitSoftLink.mm; sourceTree = "<group>"; };
 		52F060DD1654317500F3281B /* NetworkContentRuleListManagerMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkContentRuleListManagerMessageReceiver.cpp; sourceTree = "<group>"; };
@@ -8688,9 +8688,9 @@
 				CD491B111E73482100009066 /* UserMediaCaptureManagerProxy.h */,
 				CD491B141E7349F300009066 /* UserMediaCaptureManagerProxy.messages.in */,
 				070259BE2522841C00153405 /* UserMediaPermissionRequestManagerProxy.mm */,
-				52D5A1AA1C57494E00DE34A3 /* VideoFullscreenManagerProxy.h */,
-				52D5A1AB1C57494E00DE34A3 /* VideoFullscreenManagerProxy.messages.in */,
-				52D5A1AC1C57494E00DE34A3 /* VideoFullscreenManagerProxy.mm */,
+				52D5A1AA1C57494E00DE34A3 /* VideoPresentationManagerProxy.h */,
+				52D5A1AB1C57494E00DE34A3 /* VideoPresentationManagerProxy.messages.in */,
+				52D5A1AC1C57494E00DE34A3 /* VideoPresentationManagerProxy.mm */,
 				46DA285727B73E760089D339 /* WebGeolocationManagerProxyCocoa.cpp */,
 				C18F3A13256332A600797E66 /* WebInspectorPreferenceObserver.h */,
 				C18F3A142563334300797E66 /* WebInspectorPreferenceObserver.mm */,
@@ -11866,9 +11866,9 @@
 				CD491B051E70D05F00009066 /* UserMediaCaptureManager.cpp */,
 				CD491B061E70D05F00009066 /* UserMediaCaptureManager.h */,
 				CD491B0A1E732D1200009066 /* UserMediaCaptureManager.messages.in */,
-				52D5A1B21C5749F200DE34A3 /* VideoFullscreenManager.h */,
-				52D5A1B31C5749F200DE34A3 /* VideoFullscreenManager.messages.in */,
-				52D5A1B41C5749F200DE34A3 /* VideoFullscreenManager.mm */,
+				52D5A1B21C5749F200DE34A3 /* VideoPresentationManager.h */,
+				52D5A1B31C5749F200DE34A3 /* VideoPresentationManager.messages.in */,
+				52D5A1B41C5749F200DE34A3 /* VideoPresentationManager.mm */,
 				7C6E70F918B2D4A000F24E2E /* WebProcessCocoa.mm */,
 			);
 			path = cocoa;
@@ -13899,10 +13899,10 @@
 				CD491B0C1E732E4D00009066 /* UserMediaCaptureManagerMessages.h */,
 				CD491B151E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp */,
 				CD491B161E73525500009066 /* UserMediaCaptureManagerProxyMessages.h */,
-				3F418EF51887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp */,
-				3F418EF61887BD97002795FD /* VideoFullscreenManagerMessages.h */,
-				3F418EF71887BD97002795FD /* VideoFullscreenManagerProxyMessageReceiver.cpp */,
-				3F418EF81887BD97002795FD /* VideoFullscreenManagerProxyMessages.h */,
+				3F418EF51887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp */,
+				3F418EF61887BD97002795FD /* VideoPresentationManagerMessages.h */,
+				3F418EF71887BD97002795FD /* VideoPresentationManagerProxyMessageReceiver.cpp */,
+				3F418EF81887BD97002795FD /* VideoPresentationManagerProxyMessages.h */,
 				2D1B5D5B185869C8006C6596 /* ViewGestureControllerMessageReceiver.cpp */,
 				2D1B5D5C185869C8006C6596 /* ViewGestureControllerMessages.h */,
 				2D819B9F1862800E001F03D1 /* ViewGestureGeometryCollectorMessageReceiver.cpp */,
@@ -15238,7 +15238,7 @@
 				4A3CC18B19B0640F00D14AEF /* UserMediaPermissionRequestManagerProxy.h in Headers */,
 				4A3CC18D19B0641900D14AEF /* UserMediaPermissionRequestProxy.h in Headers */,
 				074E75FE1DF2211900D318EC /* UserMediaProcessManager.h in Headers */,
-				52D5A1B01C57495A00DE34A3 /* VideoFullscreenManagerProxy.h in Headers */,
+				52D5A1B01C57495A00DE34A3 /* VideoPresentationManagerProxy.h in Headers */,
 				2D125C5E1857EA05003BA3CB /* ViewGestureController.h in Headers */,
 				2D1B5D5E185869C8006C6596 /* ViewGestureControllerMessages.h in Headers */,
 				2D819BA21862800E001F03D1 /* ViewGestureGeometryCollectorMessages.h in Headers */,
@@ -17967,8 +17967,8 @@
 				5C411DA727CED4220068241A /* UnifiedSource130.cpp in Sources */,
 				CD491B0D1E732E4D00009066 /* UserMediaCaptureManagerMessageReceiver.cpp in Sources */,
 				CD491B171E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp in Sources */,
-				3F418EF91887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp in Sources */,
-				3F418EFB1887BD97002795FD /* VideoFullscreenManagerProxyMessageReceiver.cpp in Sources */,
+				3F418EF91887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp in Sources */,
+				3F418EFB1887BD97002795FD /* VideoPresentationManagerProxyMessageReceiver.cpp in Sources */,
 				2D1B5D5D185869C8006C6596 /* ViewGestureControllerMessageReceiver.cpp in Sources */,
 				2D819BA11862800E001F03D1 /* ViewGestureGeometryCollectorMessageReceiver.cpp in Sources */,
 				2684055218B86ED60022C38B /* ViewUpdateDispatcherMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -22,6 +22,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include "config.h"
 #include "WebFullScreenManager.h"
 
@@ -51,7 +52,7 @@
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
 #include "PlaybackSessionManager.h"
-#include "VideoFullscreenManager.h"
+#include "VideoPresentationManager.h"
 #endif
 
 namespace WebKit {
@@ -208,7 +209,7 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element)
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
     isVideoElement = is<HTMLVideoElement>(element);
 
-    if (m_page->videoFullscreenManager().videoElementInPictureInPicture() && m_element->document().quirks().blocksEnteringStandardFullscreenFromPictureInPictureQuirk())
+    if (m_page->videoPresentationManager().videoElementInPictureInPicture() && m_element->document().quirks().blocksEnteringStandardFullscreenFromPictureInPictureQuirk())
         return;
 
     if (auto* currentPlaybackControlsElement = m_page->playbackSessionManager().currentPlaybackControlsElement())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -122,7 +122,7 @@
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-#include "VideoFullscreenManager.h"
+#include "VideoPresentationManager.h"
 #endif
 
 #if ENABLE(ASYNC_SCROLLING)
@@ -1161,22 +1161,22 @@ std::unique_ptr<ScrollbarsController> WebChromeClient::createScrollbarsControlle
 
 void WebChromeClient::prepareForVideoFullscreen()
 {
-    protectedPage()->videoFullscreenManager();
+    protectedPage()->videoPresentationManager();
 }
 
 bool WebChromeClient::canEnterVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode) const
 {
-    return protectedPage()->videoFullscreenManager().canEnterVideoFullscreen(mode);
+    return protectedPage()->videoPresentationManager().canEnterVideoFullscreen(mode);
 }
 
 bool WebChromeClient::supportsVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
-    return protectedPage()->videoFullscreenManager().supportsVideoFullscreen(mode);
+    return protectedPage()->videoPresentationManager().supportsVideoFullscreen(mode);
 }
 
 bool WebChromeClient::supportsVideoFullscreenStandby()
 {
-    return protectedPage()->videoFullscreenManager().supportsVideoFullscreenStandby();
+    return protectedPage()->videoPresentationManager().supportsVideoFullscreenStandby();
 }
 
 void WebChromeClient::setMockVideoPresentationModeEnabled(bool enabled)
@@ -1191,12 +1191,12 @@ void WebChromeClient::enterVideoFullscreenForVideoElement(HTMLVideoElement& vide
 #else
     ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 #endif
-    protectedPage()->videoFullscreenManager().enterVideoFullscreenForVideoElement(videoElement, mode, standby);
+    protectedPage()->videoPresentationManager().enterVideoFullscreenForVideoElement(videoElement, mode, standby);
 }
 
 void WebChromeClient::exitVideoFullscreenForVideoElement(HTMLVideoElement& videoElement, CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedPage()->videoFullscreenManager().exitVideoFullscreenForVideoElement(videoElement, WTFMove(completionHandler));
+    protectedPage()->videoPresentationManager().exitVideoFullscreenForVideoElement(videoElement, WTFMove(completionHandler));
 }
 
 void WebChromeClient::setUpPlaybackControlsManager(HTMLMediaElement& mediaElement)
@@ -1237,7 +1237,7 @@ void WebChromeClient::removeMediaUsageManagerSession(MediaSessionIdentifier iden
 
 void WebChromeClient::exitVideoFullscreenToModeWithoutAnimation(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode targetMode)
 {
-    protectedPage()->videoFullscreenManager().exitVideoFullscreenToModeWithoutAnimation(videoElement, targetMode);
+    protectedPage()->videoPresentationManager().exitVideoFullscreenToModeWithoutAnimation(videoElement, targetMode);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -32,7 +32,7 @@
 #import "RemoteLayerTreeDrawingArea.h"
 #import "RemoteLayerTreeTransaction.h"
 #import "RemoteLayerWithRemoteRenderingBackingStoreCollection.h"
-#import "VideoFullscreenManager.h"
+#import "VideoPresentationManager.h"
 #import "WebFrame.h"
 #import "WebPage.h"
 #import "WebProcess.h"
@@ -140,7 +140,7 @@ void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, 
         videoElement.naturalSize()
     };
 
-    m_webPage.videoFullscreenManager().setupRemoteLayerHosting(videoElement);
+    m_webPage.videoPresentationManager().setupRemoteLayerHosting(videoElement);
     m_videoLayers.add(layerID, videoElement.identifier());
 
     m_createdLayers.add(layerID, WTFMove(creationProperties));
@@ -156,7 +156,7 @@ void RemoteLayerTreeContext::layerWillLeaveContext(PlatformCALayerRemote& layer)
 #if HAVE(AVKIT)
     auto videoLayerIter = m_videoLayers.find(layerID);
     if (videoLayerIter != m_videoLayers.end()) {
-        m_webPage.videoFullscreenManager().willRemoveLayerForID(videoLayerIter->value);
+        m_webPage.videoPresentationManager().willRemoveLayerForID(videoLayerIter->value);
         m_videoLayers.remove(videoLayerIter);
     }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -330,7 +330,7 @@
 #include "RemoteLayerTreeTransaction.h"
 #include "RemoteObjectRegistryMessages.h"
 #include "TextCheckingControllerProxy.h"
-#include "VideoFullscreenManager.h"
+#include "VideoPresentationManager.h"
 #include "WKStringCF.h"
 #include "WebRemoteObjectRegistry.h"
 #include <WebCore/LegacyWebArchive.h>
@@ -1278,8 +1278,8 @@ WebPage::~WebPage()
     if (m_playbackSessionManager)
         m_playbackSessionManager->invalidate();
 
-    if (m_videoFullscreenManager)
-        m_videoFullscreenManager->invalidate();
+    if (m_videoPresentationManager)
+        m_videoPresentationManager->invalidate();
 #endif
 
     for (auto& completionHandler : std::exchange(m_markLayersAsVolatileCompletionHandlers, { }))
@@ -3168,7 +3168,7 @@ void WebPage::updateDrawingAreaLayerTreeFreezeState()
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     // When the browser is in the background, we should not freeze the layer tree
     // if the page has a video playing in picture-in-picture.
-    if (m_videoFullscreenManager && m_videoFullscreenManager->hasVideoPlayingInPictureInPicture() && m_layerTreeFreezeReasons.hasExactlyOneBitSet() && m_layerTreeFreezeReasons.contains(LayerTreeFreezeReason::BackgroundApplication)) {
+    if (m_videoPresentationManager && m_videoPresentationManager->hasVideoPlayingInPictureInPicture() && m_layerTreeFreezeReasons.hasExactlyOneBitSet() && m_layerTreeFreezeReasons.contains(LayerTreeFreezeReason::BackgroundApplication)) {
         m_drawingArea->setLayerTreeStateIsFrozen(false);
         return;
     }
@@ -4892,11 +4892,11 @@ PlaybackSessionManager& WebPage::playbackSessionManager()
     return *m_playbackSessionManager;
 }
 
-VideoFullscreenManager& WebPage::videoFullscreenManager()
+VideoPresentationManager& WebPage::videoPresentationManager()
 {
-    if (!m_videoFullscreenManager)
-        m_videoFullscreenManager = VideoFullscreenManager::create(*this, playbackSessionManager());
-    return *m_videoFullscreenManager;
+    if (!m_videoPresentationManager)
+        m_videoPresentationManager = VideoPresentationManager::create(*this, playbackSessionManager());
+    return *m_videoPresentationManager;
 }
 
 void WebPage::videoControlsManagerDidChange()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -328,7 +328,7 @@ class WebEvent;
 class WebFoundTextRangeController;
 class WebHistoryItemClient;
 class PlaybackSessionManager;
-class VideoFullscreenManager;
+class VideoPresentationManager;
 class WebBackForwardListItem;
 class WebFrame;
 class WebFullScreenManager;
@@ -489,7 +489,7 @@ public:
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    VideoFullscreenManager& videoFullscreenManager();
+    VideoPresentationManager& videoPresentationManager();
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -2256,7 +2256,7 @@ private:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RefPtr<PlaybackSessionManager> m_playbackSessionManager;
-    RefPtr<VideoFullscreenManager> m_videoFullscreenManager;
+    RefPtr<VideoPresentationManager> m_videoPresentationManager;
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -68,7 +68,7 @@ public:
     void invalidate() { m_manager = nullptr; }
 
 private:
-    friend class VideoFullscreenInterfaceContext;
+    friend class VideoPresentationInterfaceContext;
 
     // PlaybackSessionModelClient
     void durationChanged(double) final;
@@ -116,7 +116,7 @@ public:
 
 private:
     friend class PlaybackSessionInterfaceContext;
-    friend class VideoFullscreenManager;
+    friend class VideoPresentationManager;
 
     explicit PlaybackSessionManager(WebPage&);
 
@@ -173,7 +173,7 @@ private:
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
     const void* logIdentifier() const { return m_logIdentifier; }
-    const char* logClassName() const { return "VideoFullscreenManager"; }
+    const char* logClassName() const { return "VideoPresentationManager"; }
     WTFLogChannel& logChannel() const;
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/EventTarget.h>
 #include <WebCore/TextTrackRepresentationCocoa.h>
 
 namespace WebCore {

--- a/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm
@@ -24,12 +24,12 @@
  */
 
 #import "config.h"
-
-#if ENABLE(VIDEO_PRESENTATION_MODE)
 #import "TextTrackRepresentationCocoa.h"
 
-#import "VideoFullscreenManager.h"
-#import "VideoFullscreenManagerProxyMessages.h"
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+
+#import "VideoPresentationManager.h"
+#import "VideoPresentationManagerProxyMessages.h"
 #import "WebPage.h"
 #import <WebCore/GraphicsContext.h>
 #import <WebCore/HTMLVideoElement.h>
@@ -50,7 +50,7 @@ void WebTextTrackRepresentationCocoa::update()
 {
     if (!m_page)
         return;
-    Ref fullscreenManager = m_page->videoFullscreenManager();
+    Ref fullscreenManager = m_page->videoPresentationManager();
     if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
         return;
     
@@ -77,7 +77,7 @@ void WebTextTrackRepresentationCocoa::setContentScale(float scale)
     WebCore::TextTrackRepresentationCocoa::setContentScale(scale);
     if (!m_page)
         return;
-    Ref fullscreenManager = m_page->videoFullscreenManager();
+    Ref fullscreenManager = m_page->videoPresentationManager();
     if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
         return;
     Ref videoElement = downcast<WebCore::HTMLVideoElement>(*m_mediaElement);
@@ -89,7 +89,7 @@ void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
     WebCore::TextTrackRepresentationCocoa::setHidden(hidden);
     if (!m_page)
         return;
-    Ref fullscreenManager = m_page->videoFullscreenManager();
+    Ref fullscreenManager = m_page->videoPresentationManager();
     if (!m_mediaElement || !is<WebCore::HTMLVideoElement>(m_mediaElement))
         return;
     Ref videoElement = downcast<WebCore::HTMLVideoElement>(*m_mediaElement);
@@ -98,5 +98,4 @@ void WebTextTrackRepresentationCocoa::setHidden(bool hidden) const
 
 } // namespace WebKit
 
-#endif
-
+#endif // ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -33,7 +33,7 @@
 #include <WebCore/EventListener.h>
 #include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/PlatformCALayer.h>
-#include <WebCore/VideoFullscreenModelVideoElement.h>
+#include <WebCore/VideoPresentationModelVideoElement.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
@@ -64,17 +64,17 @@ class WebPage;
 class PlaybackSessionInterfaceContext;
 class PlaybackSessionManager;
 class ShareableBitmapHandle;
-class VideoFullscreenManager;
+class VideoPresentationManager;
 
-class VideoFullscreenInterfaceContext
-    : public RefCounted<VideoFullscreenInterfaceContext>
-    , public WebCore::VideoFullscreenModelClient {
+class VideoPresentationInterfaceContext
+    : public RefCounted<VideoPresentationInterfaceContext>
+    , public WebCore::VideoPresentationModelClient {
 public:
-    static Ref<VideoFullscreenInterfaceContext> create(VideoFullscreenManager& manager, PlaybackSessionContextIdentifier contextId)
+    static Ref<VideoPresentationInterfaceContext> create(VideoPresentationManager& manager, PlaybackSessionContextIdentifier contextId)
     {
-        return adoptRef(*new VideoFullscreenInterfaceContext(manager, contextId));
+        return adoptRef(*new VideoPresentationInterfaceContext(manager, contextId));
     }
-    virtual ~VideoFullscreenInterfaceContext();
+    virtual ~VideoPresentationInterfaceContext();
 
     LayerHostingContext* layerHostingContext() { return m_layerHostingContext.get(); }
     void setLayerHostingContext(std::unique_ptr<LayerHostingContext>&&);
@@ -99,14 +99,14 @@ public:
     void setRootLayer(RetainPtr<CALayer>);
 
 private:
-    // VideoFullscreenModelClient
+    // VideoPresentationModelClient
     void hasVideoChanged(bool) override;
     void videoDimensionsChanged(const WebCore::FloatSize&) override;
     void setPlayerIdentifier(std::optional<WebCore::MediaPlayerIdentifier>) final;
 
-    VideoFullscreenInterfaceContext(VideoFullscreenManager&, PlaybackSessionContextIdentifier);
+    VideoPresentationInterfaceContext(VideoPresentationManager&, PlaybackSessionContextIdentifier);
 
-    WeakPtr<VideoFullscreenManager> m_manager;
+    WeakPtr<VideoPresentationManager> m_manager;
     PlaybackSessionContextIdentifier m_contextId;
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     AnimationType m_animationType { AnimationType::None };
@@ -117,17 +117,17 @@ private:
     RetainPtr<CALayer> m_rootLayer;
 };
 
-class VideoFullscreenManager
-    : public RefCounted<VideoFullscreenManager>
-    , public CanMakeWeakPtr<VideoFullscreenManager>
+class VideoPresentationManager
+    : public RefCounted<VideoPresentationManager>
+    , public CanMakeWeakPtr<VideoPresentationManager>
     , private IPC::MessageReceiver {
 public:
-    using CanMakeWeakPtr<VideoFullscreenManager>::WeakPtrImplType;
-    using CanMakeWeakPtr<VideoFullscreenManager>::WeakValueType;
-    using CanMakeWeakPtr<VideoFullscreenManager>::weakPtrFactory;
+    using CanMakeWeakPtr<VideoPresentationManager>::WeakPtrImplType;
+    using CanMakeWeakPtr<VideoPresentationManager>::WeakValueType;
+    using CanMakeWeakPtr<VideoPresentationManager>::weakPtrFactory;
 
-    static Ref<VideoFullscreenManager> create(WebPage&, PlaybackSessionManager&);
-    virtual ~VideoFullscreenManager();
+    static Ref<VideoPresentationManager> create(WebPage&, PlaybackSessionManager&);
+    virtual ~VideoPresentationManager();
 
     void invalidate();
 
@@ -153,25 +153,25 @@ public:
     bool videoElementInPictureInPicture() const { return !!m_videoElementInPictureInPicture; }
 
 protected:
-    friend class VideoFullscreenInterfaceContext;
+    friend class VideoPresentationInterfaceContext;
 
-    explicit VideoFullscreenManager(WebPage&, PlaybackSessionManager&);
+    explicit VideoPresentationManager(WebPage&, PlaybackSessionManager&);
 
-    typedef std::tuple<RefPtr<WebCore::VideoFullscreenModelVideoElement>, RefPtr<VideoFullscreenInterfaceContext>> ModelInterfaceTuple;
+    typedef std::tuple<RefPtr<WebCore::VideoPresentationModelVideoElement>, RefPtr<VideoPresentationInterfaceContext>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier, bool createLayerHostingContext);
     ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier, bool createLayerHostingContext = true);
-    WebCore::VideoFullscreenModelVideoElement& ensureModel(PlaybackSessionContextIdentifier);
-    VideoFullscreenInterfaceContext& ensureInterface(PlaybackSessionContextIdentifier);
+    WebCore::VideoPresentationModelVideoElement& ensureModel(PlaybackSessionContextIdentifier);
+    VideoPresentationInterfaceContext& ensureInterface(PlaybackSessionContextIdentifier);
     void removeContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);
 
-    // Interface to VideoFullscreenInterfaceContext
+    // Interface to VideoPresentationInterfaceContext
     void hasVideoChanged(PlaybackSessionContextIdentifier, bool hasVideo);
     void videoDimensionsChanged(PlaybackSessionContextIdentifier, const WebCore::FloatSize&);
     void setPlayerIdentifier(PlaybackSessionContextIdentifier, std::optional<WebCore::MediaPlayerIdentifier>);
 
-    // Messages from VideoFullscreenManagerProxy
+    // Messages from VideoPresentationManagerProxy
     void requestFullscreenMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool finishedWithMedia);
     void requestUpdateInlineRect(PlaybackSessionContextIdentifier);
     void requestVideoContentLayer(PlaybackSessionContextIdentifier);
@@ -190,7 +190,7 @@ protected:
     void fullscreenMayReturnToInline(PlaybackSessionContextIdentifier, bool isPageVisible);
     void requestRouteSharingPolicyAndContextUID(PlaybackSessionContextIdentifier, CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&&);
 
-    void setCurrentlyInFullscreen(VideoFullscreenInterfaceContext&, bool);
+    void setCurrentlyInFullscreen(VideoPresentationInterfaceContext&, bool);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-messages -> VideoFullscreenManager {
+messages -> VideoPresentationManager {
     RequestFullscreenMode(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode, bool finishedWithMedia)
     RequestUpdateInlineRect(WebKit::PlaybackSessionContextIdentifier contextId)
     RequestVideoContentLayer(WebKit::PlaybackSessionContextIdentifier contextId)


### PR DESCRIPTION
#### 3611be9d6e54e0767daf5778c655028bb1ac64d2
<pre>
[Media] Rename VideoFullscreenManager and friends to VideoPresentationManager*
<a href="https://bugs.webkit.org/show_bug.cgi?id=262603">https://bugs.webkit.org/show_bug.cgi?id=262603</a>
rdar://116443401

Reviewed by Simon Fraser.

To better reflect their use for more than just fullscreen video, renamed the following:
- VideoFullscreenInterfaceContext -&gt; VideoPresentationInterfaceContext
- VideoFullscreenModel -&gt; VideoPresentationModel
- VideoFullscreenModelClient -&gt; VideoPresentationModelClient
- VideoFullscreenModelContext -&gt; VideoPresentationModelContext
- VideoFullscreenModelVideoElement -&gt; VideoPresentationModelVideoElement
- VideoFullscreenManager -&gt; VideoPresentationManager
- VideoFullscreenManagerProxy -&gt; VideoPresentationManagerProxy

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/html/HTMLVideoElement.cpp:
* Source/WebCore/platform/cocoa/VideoPresentationModel.h: Renamed from Source/WebCore/platform/cocoa/VideoFullscreenModel.h.
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h: Renamed from Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h.
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm: Renamed from Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm.
(WebCore::VideoPresentationModelVideoElement::VideoListener::VideoListener):
(WebCore::VideoPresentationModelVideoElement::VideoListener::handleEvent):
(WebCore::VideoPresentationModelVideoElement::VideoPresentationModelVideoElement):
(WebCore::VideoPresentationModelVideoElement::~VideoPresentationModelVideoElement):
(WebCore::VideoPresentationModelVideoElement::cleanVideoListeners):
(WebCore::VideoPresentationModelVideoElement::setVideoElement):
(WebCore::VideoPresentationModelVideoElement::updateForEventName):
(WebCore::VideoPresentationModelVideoElement::willExitFullscreen):
(WebCore::VideoPresentationModelVideoElement::createVideoFullscreenLayer):
(WebCore::VideoPresentationModelVideoElement::setVideoFullscreenLayer):
(WebCore::VideoPresentationModelVideoElement::waitForPreparedForInlineThen):
(WebCore::VideoPresentationModelVideoElement::requestFullscreenMode):
(WebCore::VideoPresentationModelVideoElement::setVideoLayerFrame):
(WebCore::VideoPresentationModelVideoElement::setVideoSizeFenced):
(WebCore::VideoPresentationModelVideoElement::setVideoLayerGravity):
(WebCore::VideoPresentationModelVideoElement::observedEventNames):
(WebCore::VideoPresentationModelVideoElement::eventNameAll):
(WebCore::VideoPresentationModelVideoElement::fullscreenModeChanged):
(WebCore::VideoPresentationModelVideoElement::requestRouteSharingPolicyAndContextUID):
(WebCore::VideoPresentationModelVideoElement::addClient):
(WebCore::VideoPresentationModelVideoElement::removeClient):
(WebCore::VideoPresentationModelVideoElement::setHasVideo):
(WebCore::VideoPresentationModelVideoElement::setVideoDimensions):
(WebCore::VideoPresentationModelVideoElement::setPlayerIdentifier):
(WebCore::VideoPresentationModelVideoElement::willEnterPictureInPicture):
(WebCore::VideoPresentationModelVideoElement::didEnterPictureInPicture):
(WebCore::VideoPresentationModelVideoElement::failedToEnterPictureInPicture):
(WebCore::VideoPresentationModelVideoElement::willExitPictureInPicture):
(WebCore::VideoPresentationModelVideoElement::didExitPictureInPicture):
(WebCore::VideoPresentationModelVideoElement::loggerPtr const):
(WebCore::VideoPresentationModelVideoElement::logIdentifier const):
(WebCore::VideoPresentationModelVideoElement::nextChildIdentifier const):
(WebCore::VideoPresentationModelVideoElement::logChannel const):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(WebCore::WebAVPlayerLayerPresentationModelClient::WebAVPlayerLayerPresentationModelClient):
(-[WebAVPlayerLayer init]):
(-[WebAVPlayerLayer dealloc]):
(-[WebAVPlayerLayer presentationModel]):
(-[WebAVPlayerLayer setPresentationModel:]):
(-[WebAVPlayerLayer resolveBounds]):
(-[WebAVPlayerLayer setVideoGravity:]):
(-[WebAVPlayerLayer loggerPtr]):
(WebCore::WebAVPlayerLayerFullscreenModelClient::WebAVPlayerLayerFullscreenModelClient): Deleted.
(WebCore::WebAVPlayerLayerFullscreenModelClient::videoDimensionsChanged): Deleted.
(-[WebAVPlayerLayer fullscreenModel]): Deleted.
(-[WebAVPlayerLayer setFullscreenModel:]): Deleted.
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerView):
* Source/WebCore/platform/graphics/cocoa/NullVideoFullscreenInterface.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::~VideoFullscreenInterfaceAVKit):
(VideoFullscreenInterfaceAVKit::setVideoPresentationModel):
(VideoFullscreenInterfaceAVKit::presentingViewController):
(VideoFullscreenInterfaceAVKit::exitFullscreen):
(VideoFullscreenInterfaceAVKit::cleanupFullscreen):
(VideoFullscreenInterfaceAVKit::invalidate):
(VideoFullscreenInterfaceAVKit::requestHideAndExitFullscreen):
(VideoFullscreenInterfaceAVKit::preparedToExitFullscreen):
(VideoFullscreenInterfaceAVKit::prepareForPictureInPictureStop):
(VideoFullscreenInterfaceAVKit::willStartPictureInPicture):
(VideoFullscreenInterfaceAVKit::failedToStartPictureInPicture):
(VideoFullscreenInterfaceAVKit::willStopPictureInPicture):
(VideoFullscreenInterfaceAVKit::didStopPictureInPicture):
(VideoFullscreenInterfaceAVKit::shouldExitFullscreenWithReason):
(VideoFullscreenInterfaceAVKit::doSetup):
(VideoFullscreenInterfaceAVKit::finalizeSetup):
(VideoFullscreenInterfaceAVKit::doEnterFullscreen):
(VideoFullscreenInterfaceAVKit::doExitFullscreen):
(VideoFullscreenInterfaceAVKit::returnToStandby):
(VideoFullscreenInterfaceAVKit::setMode):
(VideoFullscreenInterfaceAVKit::clearMode):
(VideoFullscreenInterfaceAVKit::setVideoFullscreenModel): Deleted.
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::~VideoFullscreenControllerContext):
(VideoFullscreenControllerContext::requestVideoContentLayer):
(VideoFullscreenControllerContext::returnVideoContentLayer):
(VideoFullscreenControllerContext::didSetupFullscreen):
(VideoFullscreenControllerContext::willExitFullscreen):
(VideoFullscreenControllerContext::didExitFullscreen):
(VideoFullscreenControllerContext::didCleanupFullscreen):
(VideoFullscreenControllerContext::hasVideoChanged):
(VideoFullscreenControllerContext::videoDimensionsChanged):
(VideoFullscreenControllerContext::addClient):
(VideoFullscreenControllerContext::removeClient):
(VideoFullscreenControllerContext::requestFullscreenMode):
(VideoFullscreenControllerContext::setVideoLayerFrame):
(VideoFullscreenControllerContext::setVideoLayerGravity):
(VideoFullscreenControllerContext::fullscreenModeChanged):
(VideoFullscreenControllerContext::hasVideo const):
(VideoFullscreenControllerContext::willEnterPictureInPicture):
(VideoFullscreenControllerContext::didEnterPictureInPicture):
(VideoFullscreenControllerContext::failedToEnterPictureInPicture):
(VideoFullscreenControllerContext::willExitPictureInPicture):
(VideoFullscreenControllerContext::didExitPictureInPicture):
(VideoFullscreenControllerContext::videoDimensions const):
(VideoFullscreenControllerContext::setUpFullscreen):
* Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.h:
(WebCore::VideoFullscreenInterfaceMac::videoPresentationModel const):
(WebCore::VideoFullscreenInterfaceMac::videoFullscreenModel const): Deleted.
* Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm:
(-[WebVideoFullscreenInterfaceMacObjC setUpPIPForVideoView:withFrame:inWindow:]):
(-[WebVideoFullscreenInterfaceMacObjC boundsDidChangeForVideoViewContainer:]):
(-[WebVideoFullscreenInterfaceMacObjC pipShouldClose:]):
(-[WebVideoFullscreenInterfaceMacObjC pipDidClose:]):
(WebCore::VideoFullscreenInterfaceMac::~VideoFullscreenInterfaceMac):
(WebCore::VideoFullscreenInterfaceMac::setVideoPresentationModel):
(WebCore::VideoFullscreenInterfaceMac::setMode):
(WebCore::VideoFullscreenInterfaceMac::clearMode):
(WebCore::VideoFullscreenInterfaceMac::setupFullscreen):
(WebCore::VideoFullscreenInterfaceMac::enterFullscreen):
(WebCore::VideoFullscreenInterfaceMac::exitFullscreenWithoutAnimationToMode):
(WebCore::VideoFullscreenInterfaceMac::cleanupFullscreen):
(WebCore::VideoFullscreenInterfaceMac::invalidate):
(WebCore::VideoFullscreenInterfaceMac::requestHideAndExitPiP):
(WebCore::VideoFullscreenInterfaceMac::setVideoFullscreenModel): Deleted.
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView closeAllMediaPresentationsWithCompletionHandler:]):
(-[WKWebView _allMediaPresentationsClosed]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _isShowingVideoPictureInPicture]):
(-[WKWebView _mayAutomaticallyShowVideoPictureInPicture]):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
(WebKit::PlaybackSessionManagerProxy::logClassName const):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h: Renamed from Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h.
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in: Renamed from Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.messages.in.
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm: Renamed from Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm.
(WebKit::VideoPresentationManagerProxy::create):
(WebKit::VideoPresentationManagerProxy::invalidate):
(WebKit::VideoPresentationManagerProxy::hasMode const):
(WebKit::VideoPresentationManagerProxy::mayAutomaticallyShowVideoPictureInPicture const):
(WebKit::VideoPresentationManagerProxy::requestHideAndExitFullscreen):
(WebKit::VideoPresentationManagerProxy::applicationDidBecomeActive):
(WebKit::VideoPresentationModelContext::VideoPresentationModelContext):
(WebKit::VideoPresentationModelContext::addClient):
(WebKit::VideoPresentationModelContext::removeClient):
(WebKit::VideoPresentationModelContext::setPlayerLayer):
(WebKit::VideoPresentationModelContext::setVideoDimensions):
(WebKit::VideoPresentationModelContext::requestCloseAllMediaPresentations):
(WebKit::VideoPresentationModelContext::requestFullscreenMode):
(WebKit::VideoPresentationModelContext::setVideoLayerFrame):
(WebKit::VideoPresentationModelContext::setVideoLayerGravity):
(WebKit::VideoPresentationModelContext::fullscreenModeChanged):
(WebKit::VideoPresentationModelContext::presentingViewController):
(WebKit::VideoPresentationModelContext::createVideoFullscreenViewController):
(WebKit::VideoPresentationModelContext::requestUpdateInlineRect):
(WebKit::VideoPresentationModelContext::requestVideoContentLayer):
(WebKit::VideoPresentationModelContext::returnVideoContentLayer):
(WebKit::VideoPresentationModelContext::returnVideoView):
(WebKit::VideoPresentationModelContext::didSetupFullscreen):
(WebKit::VideoPresentationModelContext::failedToEnterFullscreen):
(WebKit::VideoPresentationModelContext::didEnterFullscreen):
(WebKit::VideoPresentationModelContext::willExitFullscreen):
(WebKit::VideoPresentationModelContext::didExitFullscreen):
(WebKit::VideoPresentationModelContext::didCleanupFullscreen):
(WebKit::VideoPresentationModelContext::fullscreenMayReturnToInline):
(WebKit::VideoPresentationModelContext::requestRouteSharingPolicyAndContextUID):
(WebKit::VideoPresentationModelContext::didEnterPictureInPicture):
(WebKit::VideoPresentationModelContext::didExitPictureInPicture):
(WebKit::VideoPresentationModelContext::willEnterPictureInPicture):
(WebKit::VideoPresentationModelContext::failedToEnterPictureInPicture):
(WebKit::VideoPresentationModelContext::willExitPictureInPicture):
(WebKit::VideoPresentationModelContext::logIdentifier const):
(WebKit::VideoPresentationModelContext::nextChildIdentifier const):
(WebKit::VideoPresentationModelContext::loggerPtr const):
(WebKit::VideoPresentationModelContext::logChannel const):
(WebKit::VideoPresentationManagerProxy::VideoPresentationManagerProxy):
(WebKit::VideoPresentationManagerProxy::~VideoPresentationManagerProxy):
(WebKit::VideoPresentationManagerProxy::isPlayingVideoInEnhancedFullscreen const):
(WebKit::VideoPresentationManagerProxy::controlsManagerInterface):
(WebKit::VideoPresentationManagerProxy::requestRouteSharingPolicyAndContextUID):
(WebKit::VideoPresentationManagerProxy::createModelAndInterface):
(WebKit::VideoPresentationManagerProxy::ensureModelAndInterface):
(WebKit::VideoPresentationManagerProxy::ensureModel):
(WebKit::VideoPresentationManagerProxy::ensureInterface):
(WebKit::VideoPresentationManagerProxy::findInterface const):
(WebKit::VideoPresentationManagerProxy::ensureClientForContext):
(WebKit::VideoPresentationManagerProxy::addClientForContext):
(WebKit::VideoPresentationManagerProxy::removeClientForContext):
(WebKit::VideoPresentationManagerProxy::forEachSession):
(WebKit::VideoPresentationManagerProxy::requestBitmapImageForCurrentTime):
(WebKit::VideoPresentationManagerProxy::addVideoInPictureInPictureDidChangeObserver):
(WebKit::VideoPresentationManagerProxy::hasVideoInPictureInPictureDidChange):
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
(WebKit::VideoPresentationManagerProxy::willRemoveLayerForID):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::setPlayerIdentifier):
(WebKit::VideoPresentationManagerProxy::setHasVideo):
(WebKit::VideoPresentationManagerProxy::setVideoDimensions):
(WebKit::VideoPresentationManagerProxy::enterFullscreen):
(WebKit::VideoPresentationManagerProxy::exitFullscreen):
(WebKit::VideoPresentationManagerProxy::exitFullscreenWithoutAnimationToMode):
(WebKit::VideoPresentationManagerProxy::setInlineRect):
(WebKit::VideoPresentationManagerProxy::setHasVideoContentLayer):
(WebKit::VideoPresentationManagerProxy::cleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::preparedToReturnToInline):
(WebKit::VideoPresentationManagerProxy::preparedToExitFullscreen):
(WebKit::VideoPresentationManagerProxy::textTrackRepresentationUpdate):
(WebKit::VideoPresentationManagerProxy::textTrackRepresentationSetContentsScale):
(WebKit::VideoPresentationManagerProxy::textTrackRepresentationSetHidden):
(WebKit::VideoPresentationManagerProxy::callCloseCompletionHandlers):
(WebKit::VideoPresentationManagerProxy::requestCloseAllMediaPresentations):
(WebKit::VideoPresentationManagerProxy::requestFullscreenMode):
(WebKit::VideoPresentationManagerProxy::requestUpdateInlineRect):
(WebKit::VideoPresentationManagerProxy::requestVideoContentLayer):
(WebKit::VideoPresentationManagerProxy::returnVideoContentLayer):
(WebKit::VideoPresentationManagerProxy::returnVideoView):
(WebKit::VideoPresentationManagerProxy::didSetupFullscreen):
(WebKit::VideoPresentationManagerProxy::willExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didEnterFullscreen):
(WebKit::VideoPresentationManagerProxy::failedToEnterFullscreen):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
(WebKit::VideoPresentationManagerProxy::setVideoLayerGravity):
(WebKit::VideoPresentationManagerProxy::fullscreenModeChanged):
(WebKit::VideoPresentationManagerProxy::fullscreenMayReturnToInline):
(WebKit::VideoPresentationManagerProxy::playerViewController const):
(WebKit::VideoPresentationManagerProxy::logger const):
(WebKit::VideoPresentationManagerProxy::logIdentifier const):
(WebKit::VideoPresentationManagerProxy::logClassName const):
(WebKit::VideoPresentationManagerProxy::logChannel const):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::updateFullscreenVideoTextRecognition):
(WebKit::WebPageProxy::fullscreenVideoTextRecognitionTimerFired):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::viewDidLeaveWindow):
(WebKit::WebPageProxy::exitFullscreenImmediately):
(WebKit::WebPageProxy::videoPresentationManager):
(WebKit::WebPageProxy::setMockVideoPresentationModeEnabled):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::isPlayingVideoInEnhancedFullscreen const):
(WebKit::WebPageProxy::videoFullscreenManager): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::applicationDidBecomeActive):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController videoControlsManagerDidChange]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController _completedExitFullScreen]):
(-[WKFullScreenWindowController didExitPictureInPicture]):
(-[WKFullScreenWindowController _videoPresentationManager]):
(-[WKFullScreenWindowController _videoFullscreenManager]): Deleted.
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController clearVideoPresentationManagerObserver]):
(-[WKFullScreenWindowController setVideoPresentationManagerObserver]):
(-[WKFullScreenWindowController didExitPictureInPicture]):
(-[WKFullScreenWindowController windowDidEnterFullScreen:]):
(-[WKFullScreenWindowController windowDidFailToExitFullScreen:]):
(-[WKFullScreenWindowController windowDidExitFullScreen:]):
(-[WKFullScreenWindowController _videoPresentationManager]):
(-[WKFullScreenWindowController clearVideoFullscreenManagerObserver]): Deleted.
(-[WKFullScreenWindowController setVideoFullscreenManagerObserver]): Deleted.
(-[WKFullScreenWindowController _videoFullscreenManager]): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::prepareForVideoFullscreen):
(WebKit::WebChromeClient::canEnterVideoFullscreen const):
(WebKit::WebChromeClient::supportsVideoFullscreen):
(WebKit::WebChromeClient::supportsVideoFullscreenStandby):
(WebKit::WebChromeClient::enterVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::exitVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::exitVideoFullscreenToModeWithoutAnimation):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::layerDidEnterContext):
(WebKit::RemoteLayerTreeContext::layerWillLeaveContext):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::~WebPage):
(WebKit::WebPage::updateDrawingAreaLayerTreeFreezeState):
(WebKit::WebPage::videoPresentationManager):
(WebKit::WebPage::videoFullscreenManager): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
(WebKit::PlaybackSessionManager::logClassName const):
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.h:
* Source/WebKit/WebProcess/cocoa/TextTrackRepresentationCocoa.mm:
(WebKit::WebTextTrackRepresentationCocoa::update):
(WebKit::WebTextTrackRepresentationCocoa::setContentScale):
(WebKit::WebTextTrackRepresentationCocoa::setHidden const):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h: Renamed from Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h.
(WebKit::VideoPresentationInterfaceContext::create):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.messages.in: Renamed from Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.messages.in.
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm: Renamed from Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm.
(WebKit::VideoPresentationInterfaceContext::VideoPresentationInterfaceContext):
(WebKit::VideoPresentationInterfaceContext::~VideoPresentationInterfaceContext):
(WebKit::VideoPresentationInterfaceContext::setLayerHostingContext):
(WebKit::VideoPresentationInterfaceContext::setRootLayer):
(WebKit::VideoPresentationInterfaceContext::hasVideoChanged):
(WebKit::VideoPresentationInterfaceContext::videoDimensionsChanged):
(WebKit::VideoPresentationInterfaceContext::setPlayerIdentifier):
(WebKit::VideoPresentationManager::create):
(WebKit::VideoPresentationManager::VideoPresentationManager):
(WebKit::VideoPresentationManager::~VideoPresentationManager):
(WebKit::VideoPresentationManager::invalidate):
(WebKit::VideoPresentationManager::hasVideoPlayingInPictureInPicture const):
(WebKit::VideoPresentationManager::createModelAndInterface):
(WebKit::VideoPresentationManager::ensureModelAndInterface):
(WebKit::VideoPresentationManager::ensureModel):
(WebKit::VideoPresentationManager::ensureInterface):
(WebKit::VideoPresentationManager::removeContext):
(WebKit::VideoPresentationManager::addClientForContext):
(WebKit::VideoPresentationManager::removeClientForContext):
(WebKit::VideoPresentationManager::canEnterVideoFullscreen const):
(WebKit::VideoPresentationManager::supportsVideoFullscreen const):
(WebKit::VideoPresentationManager::supportsVideoFullscreenStandby const):
(WebKit::VideoPresentationManager::setupRemoteLayerHosting):
(WebKit::VideoPresentationManager::willRemoveLayerForID):
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoPresentationManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoPresentationManager::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::VideoPresentationManager::hasVideoChanged):
(WebKit::VideoPresentationManager::videoDimensionsChanged):
(WebKit::VideoPresentationManager::setPlayerIdentifier):
(WebKit::VideoPresentationManager::requestFullscreenMode):
(WebKit::VideoPresentationManager::fullscreenModeChanged):
(WebKit::VideoPresentationManager::requestUpdateInlineRect):
(WebKit::VideoPresentationManager::requestVideoContentLayer):
(WebKit::VideoPresentationManager::returnVideoContentLayer):
(WebKit::VideoPresentationManager::didSetupFullscreen):
(WebKit::VideoPresentationManager::willExitFullscreen):
(WebKit::VideoPresentationManager::didEnterFullscreen):
(WebKit::VideoPresentationManager::failedToEnterFullscreen):
(WebKit::VideoPresentationManager::didExitFullscreen):
(WebKit::VideoPresentationManager::didCleanupFullscreen):
(WebKit::VideoPresentationManager::setVideoLayerGravityEnum):
(WebKit::VideoPresentationManager::fullscreenMayReturnToInline):
(WebKit::VideoPresentationManager::requestRouteSharingPolicyAndContextUID):
(WebKit::VideoPresentationManager::setCurrentlyInFullscreen):
(WebKit::VideoPresentationManager::setVideoLayerFrameFenced):
(WebKit::VideoPresentationManager::updateTextTrackRepresentationForVideoElement):
(WebKit::VideoPresentationManager::setTextTrackRepresentationContentScaleForVideoElement):
(WebKit::VideoPresentationManager::setTextTrackRepresentationIsHiddenForVideoElement):
(WebKit::VideoPresentationManager::logger const):
(WebKit::VideoPresentationManager::logIdentifier const):
(WebKit::VideoPresentationManager::logClassName const):
(WebKit::VideoPresentationManager::logChannel const):

Canonical link: <a href="https://commits.webkit.org/268850@main">https://commits.webkit.org/268850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cc3761182dbe50b72859ca71184be9caff6163a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21455 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20857 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23615 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25232 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19101 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/23153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19700 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18942 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5000 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->