### PR TITLE
[Nicosia] Notify async scrolling tree that a platform rendering update has completed

### DIFF
--- a/Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp
@@ -50,6 +50,11 @@ ScrollingCoordinatorNicosia::~ScrollingCoordinatorNicosia()
     ASSERT(!scrollingTree());
 }
 
+void ScrollingCoordinatorNicosia::didCompletePlatformRenderingUpdate()
+{
+    downcast<ThreadedScrollingTree>(scrollingTree())->didCompleteRenderingUpdate();
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(ASYNC_SCROLLING) && USE(NICOSIA)

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.h
@@ -37,6 +37,9 @@ class ScrollingCoordinatorNicosia final : public ThreadedScrollingCoordinator {
 public:
     explicit ScrollingCoordinatorNicosia(Page*);
     virtual ~ScrollingCoordinatorNicosia();
+
+private:
+    void didCompletePlatformRenderingUpdate() final;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e74fc9c77c9716e5bb968524a8e86f8136430a62
<pre>
[Nicosia] Notify async scrolling tree that a platform rendering update has completed
<a href="https://bugs.webkit.org/show_bug.cgi?id=262606">https://bugs.webkit.org/show_bug.cgi?id=262606</a>

Reviewed by Alejandro G. Castro.

Now that we implement didCompleteRenderingUpdateDisplay since
268770@main, we should notify the async scrolling tree.

* Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp:
(WebCore::ScrollingCoordinatorNicosia::didCompletePlatformRenderingUpdate):
* Source/WebCore/page/scrolling/nicosia/ScrollingCoordinatorNicosia.h:

Canonical link: <a href="https://commits.webkit.org/268843@main">https://commits.webkit.org/268843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4204e26a1bc21e1ece72f90410ea123a7a7c04b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19418 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21421 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23581 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25207 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23116 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16707 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18911 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23240 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2571 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->