### PR TITLE
[GTK] 2.42.0 doesn't support WebGL with GBM disabled under X11

### DIFF
--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp
@@ -117,6 +117,10 @@ EGLDisplay PlatformDisplayX11::gtkEGLDisplay()
     if (m_eglDisplay != EGL_NO_DISPLAY) {
         m_eglDisplayOwned = false;
         PlatformDisplay::initializeEGLDisplay();
+#if ENABLE(WEBGL)
+        m_anglePlatform = EGL_PLATFORM_X11_KHR;
+        m_angleNativeDisplay = m_display;
+#endif
         return m_eglDisplay;
     }
 #endif
@@ -141,6 +145,11 @@ void PlatformDisplayX11::initializeEGLDisplay()
         m_eglDisplay = eglGetDisplay(m_display);
 
     PlatformDisplay::initializeEGLDisplay();
+
+#if ENABLE(WEBGL)
+    m_anglePlatform = EGL_PLATFORM_X11_KHR;
+    m_angleNativeDisplay = m_display;
+#endif
 }
 #endif // USE(EGL)
 


### PR DESCRIPTION
#### 84145be4284be1d8e3894f0444bf0f14e1c2bef8
<pre>
[GTK] 2.42.0 doesn&apos;t support WebGL with GBM disabled under X11
<a href="https://bugs.webkit.org/show_bug.cgi?id=261653">https://bugs.webkit.org/show_bug.cgi?id=261653</a>

Reviewed by Alejandro G. Castro.

Initialize m_anglePlatform and m_angleNativeDisplay on X11 too.

* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp:
(WebCore::PlatformDisplayX11::gtkEGLDisplay):
(WebCore::PlatformDisplayX11::initializeEGLDisplay):

Canonical link: <a href="https://commits.webkit.org/268844@main">https://commits.webkit.org/268844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb7f06b9939b38876973d0d7dbfcc2a4a55fc993

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21433 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23593 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25213 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19681 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23251 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2572 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->