### PR TITLE
https://wpt.fyi/results/mst-content-hint/RTCRtpSendParameters-degradationEffect.html shows that degradationPreference is not unset initially

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2316,6 +2316,8 @@ imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-relay-canvas.https.html
 imported/w3c/web-platform-tests/webrtc/protocol/h264-profile-levels.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings.html [ Pass Failure ]
 
+imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect.html [ Failure ]
+
 # Skip timing out test
 imported/w3c/web-platform-tests/webrtc/RTCTrackEvent-fire.html [ Skip ]
 fast/mediastream/RTCPeerConnection-closed-state.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Maintain-framerate reduces resolution on bandwidth cut assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
+FAIL Maintain-framerate reduces resolution on bandwidth cut assert_true: failure in adaptation, measure is {"bandwidth":15191.278493557978,"fps":6.937561942517344,"width":640,"height":480} expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL setParameters with degradationPreference set should succeed on video transceiver assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
-FAIL setParameters with degradationPreference unset should succeed on video transceiver assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
+PASS setParameters with degradationPreference set should succeed on video transceiver
+PASS setParameters with degradationPreference unset should succeed on video transceiver
 PASS setParameters with invalid degradationPreference should throw TypeError on video transceiver
-FAIL setParameters with degradationPreference set should succeed on audio transceiver assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
-FAIL setParameters with degradationPreference unset should succeed on audio transceiver assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
+PASS setParameters with degradationPreference set should succeed on audio transceiver
+PASS setParameters with degradationPreference unset should succeed on audio transceiver
 PASS setParameters with invalid degradationPreference should throw TypeError on audio transceiver
 

--- a/LayoutTests/webrtc/video-getParameters.html
+++ b/LayoutTests/webrtc/video-getParameters.html
@@ -50,7 +50,7 @@ promise_test((test) => {
         assert_true(!!senderParameters.transactionId, "sender transaction");
         assert_array_equals(senderParameters.codecs, [], "sender codecs");
         assert_array_equals(senderParameters.headerExtensions, [], "sender header extensions");
-        assert_equals(senderParameters.degradationPreference, "balanced", "sender degradation");
+        assert_equals(senderParameters.degradationPreference, undefined, "sender degradation");
     });
 }, "Sender and receiver parameters");
         </script>

--- a/Source/WebCore/Modules/mediastream/RTCRtpSendParameters.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSendParameters.h
@@ -43,7 +43,7 @@ struct RTCRtpSendParameters : RTCRtpParameters {
 
     String transactionId;
     Vector<RTCRtpEncodingParameters> encodings;
-    RTCDegradationPreference degradationPreference { RTCDegradationPreference::Balanced };
+    std::optional<RTCDegradationPreference> degradationPreference;
 };
 
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSendParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSendParameters.idl
@@ -30,5 +30,5 @@
 ] dictionary RTCRtpSendParameters : RTCRtpParameters {
     required DOMString transactionId;
     required sequence<RTCRtpEncodingParameters> encodings;
-    RTCDegradationPreference degradationPreference = "balanced";
+    RTCDegradationPreference degradationPreference;
 };

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -270,16 +270,20 @@ void updateRTCRtpSendParameters(const RTCRtpSendParameters& parameters, webrtc::
         rtcParameters.header_extensions.push_back(fromRTCHeaderExtensionParameters(extension));
     // Codecs parameters are readonly
 
-    switch (parameters.degradationPreference) {
-    case RTCDegradationPreference::MaintainFramerate:
-        rtcParameters.degradation_preference = webrtc::DegradationPreference::MAINTAIN_FRAMERATE;
-        break;
-    case RTCDegradationPreference::MaintainResolution:
-        rtcParameters.degradation_preference = webrtc::DegradationPreference::MAINTAIN_RESOLUTION;
-        break;
-    case RTCDegradationPreference::Balanced:
-        rtcParameters.degradation_preference = webrtc::DegradationPreference::BALANCED;
-        break;
+    if (!parameters.degradationPreference)
+        rtcParameters.degradation_preference = { };
+    else {
+        switch (*parameters.degradationPreference) {
+        case RTCDegradationPreference::MaintainFramerate:
+            rtcParameters.degradation_preference = webrtc::DegradationPreference::MAINTAIN_FRAMERATE;
+            break;
+        case RTCDegradationPreference::MaintainResolution:
+            rtcParameters.degradation_preference = webrtc::DegradationPreference::MAINTAIN_RESOLUTION;
+            break;
+        case RTCDegradationPreference::Balanced:
+            rtcParameters.degradation_preference = webrtc::DegradationPreference::BALANCED;
+            break;
+        }
     }
 
     if (parameters.rtcp.reducedSize)


### PR DESCRIPTION
#### 455093e8095681827e95fdb560bf42e9b25584d0
<pre>
<a href="https://wpt.fyi/results/mst-content-hint/RTCRtpSendParameters-degradationEffect.html">https://wpt.fyi/results/mst-content-hint/RTCRtpSendParameters-degradationEffect.html</a> shows that degradationPreference is not unset initially
<a href="https://bugs.webkit.org/show_bug.cgi?id=262609">https://bugs.webkit.org/show_bug.cgi?id=262609</a>
rdar://116454410

Reviewed by Jean-Yves Avenard.

Update the WebIDL according <a href="https://w3c.github.io/mst-content-hint/#dom-rtcdegradationpreference.">https://w3c.github.io/mst-content-hint/#dom-rtcdegradationpreference.</a>
We remove the default value and make degradationPreference optional.

This improves some WPT tests, but we have to mark imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect.html as failing for now.
The failing messafge is changing everytime.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference-expected.txt:
* LayoutTests/webrtc/video-getParameters.html:
* Source/WebCore/Modules/mediastream/RTCRtpSendParameters.h:
(): Deleted.
* Source/WebCore/Modules/mediastream/RTCRtpSendParameters.idl:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
(WebCore::updateRTCRtpSendParameters):

Canonical link: <a href="https://commits.webkit.org/268911@main">https://commits.webkit.org/268911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14e79640d7e596b2657057e41e36ca63179db84b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19561 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21592 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23761 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19065 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25345 "Found 1 new test failure: imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23274 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16833 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5045 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23382 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->