### PR TITLE
Import WPT mst-content-hint tests up to dfda991

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Maintain-framerate reduces resolution on bandwidth cut assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="timeout" content="long">
+<title>RTCRtpSendParameters degradationPreference effect</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../webrtc/RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+// This file contains tests that check that degradation preference
+// actually has the desired effect. These tests take a long time to run.
+
+// Returns incoming bandwidth usage between stats1 and stats2
+// in bits per second.
+function bandwidth(stats1, stats2) {
+  const transport1 = [...stats1.values()].filter(({type}) => type === 'transport')[0];
+  const transport2 = [...stats2.values()].filter(({type}) => type === 'transport')[0];
+  const bytes = transport2.bytesReceived - transport1.bytesReceived;
+  // Multiply by 1000 to get per second, divide by 8 to get bits.
+  const bandwidth = 1000 * 8 * bytes /
+        (transport2.timestamp - transport1.timestamp);
+  return bandwidth;
+}
+
+// Returns tuple of { bandwidth, fps, x-res, y-res }
+async function measureStuff(t, pc, intervalMs) {
+  const stats1 = await pc.getStats();
+  await new Promise(r => t.step_timeout(r, intervalMs));
+  const stats2 = await pc.getStats();
+  // RTCInboundStreamStats
+  const inboundRtp1List = [...stats1.values()].filter(({type}) => type === 'inbound-rtp');
+  const inboundRtp2List = [...stats2.values()].filter(({type}) => type === 'inbound-rtp');
+  const inboundRtp1 = inboundRtp1List[0];
+  const inboundRtp2 = inboundRtp2List[0];
+  const fps = 1000 * (inboundRtp2.framesReceived - inboundRtp1.framesReceived) /
+        (inboundRtp2.timestamp - inboundRtp1.timestamp);
+  const result = {
+    bandwidth: bandwidth(stats1, stats2),
+    fps: fps,
+    width: inboundRtp2.frameWidth,
+    height: inboundRtp2.frameHeight
+  };
+  // Unbreak for debugging.
+  // con sole.log('Measure: ', performance.now(), " ", JSON.stringify(result));
+  return result;
+}
+
+// Wait for a certain condition to be true on the traffic measures
+// on the PC. Will typically be conditions on resolution, framerate
+// or bandwidth.
+async function waitForCondition(t, pc, condition, maxWait, stepName) {
+  let counter = 1;
+  let measure = await measureStuff(t, pc, 1000);
+  while (counter < maxWait && !condition(measure)) {
+    measure = await measureStuff(t, pc, 1000);
+    counter += 1;
+  }
+  assert_true(condition(measure),
+              `failure in ${stepName}, measure is ${JSON.stringify(measure)}`);
+  return condition(measure);
+}
+
+promise_test(async t => {
+  const pc1 = new RTCPeerConnection();
+  t.add_cleanup(() => pc1.close());
+  const stream = await getNoiseStream({video: true});
+  t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+  const track = stream.getTracks()[0];
+  const { sender } = pc1.addTransceiver(track);
+
+  let param = sender.getParameters();
+
+  assert_equals(param.degradationPreference, undefined,
+    'Expect initial param.degradationPreference to be undefined');
+
+  param.degradationPreference = 'maintain-framerate';
+  await sender.setParameters(param);
+
+  const pc2 = new RTCPeerConnection();
+  t.add_cleanup(() => pc2.close());
+
+  exchangeIceCandidates(pc1, pc2);
+  await exchangeOfferAnswer(pc1, pc2);
+  await listenToConnected(pc1);
+  // Wait a few seconds to allow things to settle (rampup)
+  // We know that the generator is supposed to produce 640x480
+  // at 10 fps with a bandwidth exceeding 30 kbits/second.
+  assert_true(await waitForCondition(t, pc2, (measure) => {
+    return (measure.bandwidth > 30000 &&
+            measure.width == 640 &&
+            measure.fps > 9);
+  }, 60, 'preconditions'));
+
+  // Measure BW, resolution and frame rate over one second
+  const stats1 = await measureStuff(t, pc2, 1000);
+
+  // Constrain BW to 1/2 of measured value
+  const newBandwidth = stats1.bandwidth / 2;
+
+  const parameters = sender.getParameters();
+  parameters.encodings[0].maxBitrate = newBandwidth;
+  await sender.setParameters(parameters);
+  // Wait until the expected result happens.
+  let stats2 = await measureStuff(t, pc2, 1000);
+  let counter = 1;
+  const maxWaitCount = 20;
+  const kBandwidthMargin = 1.3;
+  // It takes time to adapt to a new bandwidth, time to scale down,
+  // and time to acknowledge that framerate should not be reduced.
+  // Measured time is around 16 seconds.
+  assert_true(await waitForCondition(t, pc2, (measure) => {
+    return (measure.bandwidth < newBandwidth * kBandwidthMargin &&
+            measure.width < stats1.width &&
+            measure.fps > stats1.fps * 0.9);
+  }, 60, 'adaptation'),
+             `Target bandwidth ${newBandwidth * kBandwidthMargin}, target min FPS ${stats1.fps * 0.9}`);
+}, 'Maintain-framerate reduces resolution on bandwidth cut', { timeout: 35000 });
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference-expected.txt
@@ -1,0 +1,8 @@
+
+FAIL setParameters with degradationPreference set should succeed on video transceiver assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
+FAIL setParameters with degradationPreference unset should succeed on video transceiver assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
+PASS setParameters with invalid degradationPreference should throw TypeError on video transceiver
+FAIL setParameters with degradationPreference set should succeed on audio transceiver assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
+FAIL setParameters with degradationPreference unset should succeed on audio transceiver assert_equals: Expect initial param.degradationPreference to be undefined expected (undefined) undefined but got (string) "balanced"
+PASS setParameters with invalid degradationPreference should throw TypeError on audio transceiver
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpSendParameters degradationPreference</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  'use strict';
+
+promise_test(async t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+  const { sender } = pc.addTransceiver('video');
+
+  let param = sender.getParameters();
+
+  assert_equals(param.degradationPreference, undefined,
+    'Expect initial param.degradationPreference to be undefined');
+
+  param.degradationPreference = 'maintain-framerate';
+  await sender.setParameters(param);
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, 'maintain-framerate');
+
+  param.degradationPreference = 'maintain-resolution';
+  await sender.setParameters(param);
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, 'maintain-resolution');
+
+  param.degradationPreference = 'balanced';
+  await sender.setParameters(param);
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, 'balanced');
+
+  param.degradationPreference = undefined;
+  await sender.setParameters(param);
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, undefined);
+}, 'setParameters with degradationPreference set should succeed on video transceiver');
+
+promise_test(async t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+  const { sender } = pc.addTransceiver('video');
+
+  let param = sender.getParameters();
+
+  assert_equals(param.degradationPreference, undefined,
+    'Expect initial param.degradationPreference to be undefined');
+
+  param.degradationPreference = undefined;
+
+  await sender.setParameters(param);
+
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, undefined);
+}, 'setParameters with degradationPreference unset should succeed on video transceiver');
+
+promise_test(async t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+  const { sender } = pc.addTransceiver('video');
+
+  let param = sender.getParameters();
+  param.degradationPreference = 'invalid';
+
+  return promise_rejects_js(t, TypeError, sender.setParameters(param));
+}, 'setParameters with invalid degradationPreference should throw TypeError on video transceiver');
+
+promise_test(async t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+  const { sender } = pc.addTransceiver('audio');
+
+  let param = sender.getParameters();
+
+  assert_equals(param.degradationPreference, undefined,
+    'Expect initial param.degradationPreference to be undefined');
+
+  param.degradationPreference = 'maintain-framerate';
+  await sender.setParameters(param);
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, 'maintain-framerate');
+
+  param.degradationPreference = 'maintain-resolution';
+  await sender.setParameters(param);
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, 'maintain-resolution');
+
+  param.degradationPreference = 'balanced';
+  await sender.setParameters(param);
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, 'balanced');
+
+  param.degradationPreference = undefined;
+  await sender.setParameters(param);
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, undefined);
+}, 'setParameters with degradationPreference set should succeed on audio transceiver');
+
+promise_test(async t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+  const { sender } = pc.addTransceiver('audio');
+
+  let param = sender.getParameters();
+
+  assert_equals(param.degradationPreference, undefined,
+    'Expect initial param.degradationPreference to be undefined');
+
+  param.degradationPreference = undefined;
+
+  await sender.setParameters(param);
+
+  param = sender.getParameters();
+  assert_equals(param.degradationPreference, undefined);
+}, 'setParameters with degradationPreference unset should succeed on audio transceiver');
+
+promise_test(async t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+  const { sender } = pc.addTransceiver('audio');
+
+  let param = sender.getParameters();
+  param.degradationPreference = 'invalid';
+
+  return promise_rejects_js(t, TypeError, sender.setParameters(param));
+}, 'setParameters with invalid degradationPreference should throw TypeError on audio transceiver');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/idlharness.window-expected.txt
@@ -3,7 +3,8 @@ PASS idl_test setup
 PASS idl_test validation
 PASS Partial interface MediaStreamTrack: original interface defined
 PASS Partial interface MediaStreamTrack: member names are unique
-FAIL Partial dictionary RTCRtpSendParameters: original dictionary defined assert_true: Original dictionary should be defined expected true got false
+PASS Partial dictionary RTCRtpSendParameters: original dictionary defined
+PASS Partial dictionary RTCRtpSendParameters: member names are unique
 PASS MediaStreamTrack interface: attribute contentHint
 PASS MediaStreamTrack interface: audioTrack must inherit property "contentHint" with the proper type
 PASS MediaStreamTrack interface: videoTrack must inherit property "contentHint" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/idlharness.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/idlharness.window.js
@@ -6,7 +6,7 @@
 
 idl_test(
   ['mst-content-hint'],
-  ['mediacapture-streams', 'dom'],
+  ['mediacapture-streams', 'webrtc', 'dom'],
   async idl_array => {
     idl_array.add_objects({
       MediaStreamTrack: ['audioTrack', 'videoTrack'],

--- a/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/w3c-import.log
@@ -16,4 +16,6 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/MediaStreamTrack-contentHint.html
+/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect.html
+/LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference.html
 /LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/idlharness.window.js

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -5120,6 +5120,9 @@
     "imported/w3c/web-platform-tests/mixed-content/gen/worker-module.http-rp/unset/xhr.https.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html": [
         "slow"
     ],


### PR DESCRIPTION
#### bcd78ce36b23231fc94bfc5e2580dc6a8cb627da
<pre>
Import WPT mst-content-hint tests up to dfda991
<a href="https://bugs.webkit.org/show_bug.cgi?id=262614">https://bugs.webkit.org/show_bug.cgi?id=262614</a>
rdar://116460764

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationEffect.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/idlharness.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/idlharness.window.js:
* LayoutTests/imported/w3c/web-platform-tests/mst-content-hint/w3c-import.log:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/268899@main">https://commits.webkit.org/268899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efa91c8facac27c774b647285f30fea780540e1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22749 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19436 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20723 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23603 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18013 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25223 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23134 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16721 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5035 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->