### PR TITLE
[IFC][Line grid] Implement -webkit-line-snap

### DIFF
--- a/LayoutTests/platform/ios/fast/line-grid/line-grid-contains-value-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-grid-contains-value-expected.txt
@@ -6,25 +6,25 @@ layer at (10,10) size 620x320
     RenderBlock {DIV} at (10,10) size 600x300 [color=#00FF00]
       RenderText {#text} at (0,5) size 612x37
         text run at (0,5) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,5) size 0x37
       RenderText {#text} at (0,48) size 612x37
         text run at (0,48) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,48) size 0x37
       RenderText {#text} at (0,91) size 612x37
         text run at (0,91) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,91) size 0x37
       RenderText {#text} at (0,134) size 612x37
         text run at (0,134) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,134) size 0x37
       RenderText {#text} at (0,177) size 612x37
         text run at (0,177) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,177) size 0x37
       RenderText {#text} at (0,220) size 612x37
         text run at (0,220) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,220) size 0x37
       RenderText {#text} at (0,263) size 612x37
         text run at (0,263) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,263) size 0x37
 layer at (0,0) size 800x600 layerType: foreground only
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/platform/ios/fast/line-grid/line-grid-floating-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-grid-floating-expected.txt
@@ -16,7 +16,7 @@ layer at (0,0) size 800x600
       RenderBlock (floating) {DIV} at (288,5) size 370x110 [border: (2px solid #000000)]
         RenderText {#text} at (12,13) size 307x41
           text run at (12,13) width 307: "This text should snap"
-        RenderBR {BR} at (318,12) size 1x41
+        RenderBR {BR} at (318,13) size 1x41
         RenderText {#text} at (12,56) size 345x41
           text run at (12,56) width 345: "to a 36px font-size grid."
-        RenderBR {BR} at (356,55) size 1x41
+        RenderBR {BR} at (356,56) size 1x41

--- a/LayoutTests/platform/ios/fast/line-grid/line-grid-inside-columns-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-grid-inside-columns-expected.txt
@@ -31,19 +31,19 @@ layer at (10,10) size 382x1625 backgroundClip at (0,0) size 1586x600 clip at (0,
           text run at (0,59) width 351: "should be on the 36px grid. The grid"
           text run at (0,129) width 345: "should reset at the top of the second"
           text run at (0,172) width 78: "column."
-        RenderBR {BR} at (77,171) size 1x28
+        RenderBR {BR} at (77,172) size 1x28
         RenderText {#text} at (0,215) size 373x157
           text run at (0,215) width 373: "All of this text even though it's smaller"
           text run at (0,258) width 351: "should be on the 36px grid. The grid"
           text run at (0,301) width 345: "should reset at the top of the second"
           text run at (0,344) width 78: "column."
-        RenderBR {BR} at (77,343) size 1x28
+        RenderBR {BR} at (77,344) size 1x28
         RenderText {#text} at (0,387) size 373x157
           text run at (0,387) width 373: "All of this text even though it's smaller"
           text run at (0,430) width 351: "should be on the 36px grid. The grid"
           text run at (0,473) width 345: "should reset at the top of the second"
           text run at (0,516) width 78: "column."
-        RenderBR {BR} at (77,515) size 1x28
+        RenderBR {BR} at (77,516) size 1x28
       RenderBlock {DIV} at (0,928) size 382x282
         RenderText {#text} at (0,27) size 379x82
           text run at (0,27) width 379: "All of this text even though it's smaller should be on the 36px grid. The grid should reset at the"

--- a/LayoutTests/platform/ios/fast/line-grid/line-grid-into-columns-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-grid-into-columns-expected.txt
@@ -5,43 +5,43 @@ layer at (0,0) size 800x540 scrollWidth 1216 scrollHeight 557
   RenderBlock (positioned) zI: -1 {DIV} at (0,0) size 800x540 [color=#00FF00]
     RenderText zI: -1 {#text} at (0,8) size 1216x33
       text run at (0,8) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,8) size 0x33
     RenderText zI: -1 {#text} at (0,51) size 1216x33
       text run at (0,51) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,51) size 0x33
     RenderText zI: -1 {#text} at (0,94) size 1216x33
       text run at (0,94) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,94) size 0x33
     RenderText zI: -1 {#text} at (0,137) size 1216x33
       text run at (0,137) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,137) size 0x33
     RenderText zI: -1 {#text} at (0,180) size 1216x33
       text run at (0,180) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,180) size 0x33
     RenderText zI: -1 {#text} at (0,223) size 1216x33
       text run at (0,223) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,223) size 0x33
     RenderText zI: -1 {#text} at (0,266) size 1216x33
       text run at (0,266) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,266) size 0x33
     RenderText zI: -1 {#text} at (0,309) size 1216x33
       text run at (0,309) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,309) size 0x33
     RenderText zI: -1 {#text} at (0,352) size 1216x33
       text run at (0,352) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,352) size 0x33
     RenderText zI: -1 {#text} at (0,395) size 1216x33
       text run at (0,395) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,395) size 0x33
     RenderText zI: -1 {#text} at (0,438) size 1216x33
       text run at (0,438) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,438) size 0x33
     RenderText zI: -1 {#text} at (0,481) size 1216x33
       text run at (0,481) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,481) size 0x33
     RenderText zI: -1 {#text} at (0,524) size 1216x33
       text run at (0,524) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,524) size 0x33
 layer at (0,0) size 800x600 layerType: foreground only
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
@@ -74,19 +74,19 @@ layer at (20,20) size 362x991 backgroundClip at (0,0) size 800x600 clip at (0,0)
         text run at (0,59) width 340: "smaller should be on the 36px grid."
         text run at (0,129) width 360: "The grid should reset at the top of the"
         text run at (0,172) width 151: "second column."
-      RenderBR {BR} at (150,171) size 1x28
+      RenderBR {BR} at (150,172) size 1x28
       RenderText {#text} at (0,215) size 360x157
         text run at (0,215) width 297: "All of this text even though it's"
         text run at (0,258) width 340: "smaller should be on the 36px grid."
         text run at (0,301) width 360: "The grid should reset at the top of the"
         text run at (0,344) width 151: "second column."
-      RenderBR {BR} at (150,343) size 1x28
+      RenderBR {BR} at (150,344) size 1x28
       RenderText {#text} at (0,387) size 360x157
         text run at (0,387) width 297: "All of this text even though it's"
         text run at (0,430) width 340: "smaller should be on the 36px grid."
         text run at (0,473) width 360: "The grid should reset at the top of the"
         text run at (0,516) width 151: "second column."
-      RenderBR {BR} at (150,515) size 1x28
+      RenderBR {BR} at (150,516) size 1x28
     RenderBlock {DIV} at (0,951) size 362x40
       RenderText {#text} at (0,27) size 268x12
         text run at (0,27) width 268: "All of this text even though it's smaller should be on the 36px grid."

--- a/LayoutTests/platform/ios/fast/line-grid/line-grid-into-floats-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-grid-into-floats-expected.txt
@@ -3,22 +3,22 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock (floating) {DIV} at (15,15) size 254x121 [border: (2px solid #000000)]
-        RenderText {#text} at (2,18) size 103x14
-          text run at (2,18) width 103: "This text should snap"
-        RenderBR {BR} at (104,18) size 1x14
-        RenderText {#text} at (2,61) size 115x14
-          text run at (2,61) width 115: "to a 36px font-size grid."
-        RenderBR {BR} at (116,61) size 1x14
-        RenderText {#text} at (2,104) size 250x14
-          text run at (2,104) width 250: "There should be lots of spacing between these lines."
-      RenderBlock (floating) {DIV} at (278,15) size 197x80 [border: (2px solid #000000)]
-        RenderText {#text} at (2,11) size 171x23
-          text run at (2,11) width 171: "This text should snap"
-        RenderBR {BR} at (172,11) size 1x23
-        RenderText {#text} at (2,54) size 192x23
-          text run at (2,54) width 192: "to a 36px font-size grid."
-        RenderBR {BR} at (193,54) size 1x23
+      RenderBlock (floating) {DIV} at (15,15) size 254x136 [border: (2px solid #000000)]
+        RenderText {#text} at (2,33) size 103x14
+          text run at (2,33) width 103: "This text should snap"
+        RenderBR {BR} at (104,33) size 1x14
+        RenderText {#text} at (2,76) size 115x14
+          text run at (2,76) width 115: "to a 36px font-size grid."
+        RenderBR {BR} at (116,76) size 1x14
+        RenderText {#text} at (2,119) size 250x14
+          text run at (2,119) width 250: "There should be lots of spacing between these lines."
+      RenderBlock (floating) {DIV} at (278,15) size 197x95 [border: (2px solid #000000)]
+        RenderText {#text} at (2,26) size 171x23
+          text run at (2,26) width 171: "This text should snap"
+        RenderBR {BR} at (172,26) size 1x23
+        RenderText {#text} at (2,69) size 192x23
+          text run at (2,69) width 192: "to a 36px font-size grid."
+        RenderBR {BR} at (193,69) size 1x23
       RenderText {#text} at (479,11) size 758x256
         text run at (479,11) width 289: "Here we can see the"
         text run at (479,54) width 256: "actual lines of the"

--- a/LayoutTests/platform/ios/fast/line-grid/line-grid-positioned-expected.txt
+++ b/LayoutTests/platform/ios/fast/line-grid/line-grid-positioned-expected.txt
@@ -18,7 +18,7 @@ layer at (350,10) size 369x110
   RenderBlock (positioned) {DIV} at (350,10) size 369x110 [border: (2px solid #000000)]
     RenderText {#text} at (12,13) size 307x41
       text run at (12,13) width 307: "This text should snap"
-    RenderBR {BR} at (318,12) size 1x41
+    RenderBR {BR} at (318,13) size 1x41
     RenderText {#text} at (12,56) size 345x41
       text run at (12,56) width 345: "to a 36px font-size grid."
-    RenderBR {BR} at (356,55) size 1x41
+    RenderBR {BR} at (356,56) size 1x41

--- a/LayoutTests/platform/mac/fast/line-grid/line-grid-contains-value-expected.txt
+++ b/LayoutTests/platform/mac/fast/line-grid/line-grid-contains-value-expected.txt
@@ -6,33 +6,33 @@ layer at (10,10) size 620x305
     RenderBlock {DIV} at (10,10) size 600x285 [color=#00FF00]
       RenderText {#text} at (0,3) size 612x36
         text run at (0,3) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,3) size 0x36
       RenderText {#text} at (0,44) size 612x36
         text run at (0,44) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,44) size 0x36
       RenderText {#text} at (0,85) size 612x36
         text run at (0,85) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,85) size 0x36
       RenderText {#text} at (0,126) size 612x36
         text run at (0,126) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,126) size 0x36
       RenderText {#text} at (0,167) size 612x36
         text run at (0,167) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,167) size 0x36
       RenderText {#text} at (0,208) size 612x36
         text run at (0,208) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,208) size 0x36
       RenderText {#text} at (0,249) size 612x36
         text run at (0,249) width 612: "xxxxxxxxxxxxxxxxx"
-      RenderBR {BR} at (0,0) size 0x0
+      RenderBR {BR} at (612,249) size 0x36
 layer at (0,0) size 800x600 layerType: foreground only
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
 layer at (10,10) size 620x301
   RenderBlock (positioned) {DIV} at (10,10) size 620x301
     RenderBlock {DIV} at (10,10) size 600x151
-      RenderText {#text} at (0,13) size 598x138
-        text run at (0,13) width 598: "This header should be centered"
+      RenderText {#text} at (0,14) size 598x137
+        text run at (0,14) width 598: "This header should be centered"
         text run at (0,95) width 312: "in the grid lines."
     RenderBlock {DIV} at (10,160) size 600x131
       RenderText {#text} at (0,34) size 103x14

--- a/LayoutTests/platform/mac/fast/line-grid/line-grid-into-columns-expected.txt
+++ b/LayoutTests/platform/mac/fast/line-grid/line-grid-into-columns-expected.txt
@@ -5,43 +5,43 @@ layer at (0,0) size 800x540 scrollWidth 1216
   RenderBlock (positioned) zI: -1 {DIV} at (0,0) size 800x540 [color=#00FF00]
     RenderText zI: -1 {#text} at (0,6) size 1216x32
       text run at (0,6) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,6) size 0x32
     RenderText zI: -1 {#text} at (0,47) size 1216x32
       text run at (0,47) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,47) size 0x32
     RenderText zI: -1 {#text} at (0,88) size 1216x32
       text run at (0,88) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,88) size 0x32
     RenderText zI: -1 {#text} at (0,129) size 1216x32
       text run at (0,129) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,129) size 0x32
     RenderText zI: -1 {#text} at (0,170) size 1216x32
       text run at (0,170) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,170) size 0x32
     RenderText zI: -1 {#text} at (0,211) size 1216x32
       text run at (0,211) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,211) size 0x32
     RenderText zI: -1 {#text} at (0,252) size 1216x32
       text run at (0,252) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,252) size 0x32
     RenderText zI: -1 {#text} at (0,293) size 1216x32
       text run at (0,293) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,293) size 0x32
     RenderText zI: -1 {#text} at (0,334) size 1216x32
       text run at (0,334) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,334) size 0x32
     RenderText zI: -1 {#text} at (0,375) size 1216x32
       text run at (0,375) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,375) size 0x32
     RenderText zI: -1 {#text} at (0,416) size 1216x32
       text run at (0,416) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,416) size 0x32
     RenderText zI: -1 {#text} at (0,457) size 1216x32
       text run at (0,457) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,457) size 0x32
     RenderText zI: -1 {#text} at (0,498) size 1216x32
       text run at (0,498) width 1216: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    RenderBR {BR} at (0,0) size 0x0
+    RenderBR {BR} at (1216,498) size 0x32
 layer at (0,0) size 800x600 layerType: foreground only
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1678,3 +1678,5 @@ imported/w3c/web-platform-tests/css/filter-effects/effect-reference-rename-002.h
 imported/w3c/web-platform-tests/css/filter-effects/svg-mutation-function-to-url.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-filter.html [ ImageOnlyFailure ]
+
+fast/line-grid [ Skip ]

--- a/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Font.h"
 #include "PlacedFloats.h"
 
 namespace WebCore {
@@ -46,8 +47,14 @@ public:
     using TextBoxTrim = OptionSet<TextBoxTrimSide>;
 
     struct LineGrid {
-        LayoutSize logicalOffset;
+        LayoutSize layoutOffset;
+        LayoutSize gridOffset;
         InlineLayoutUnit columnWidth;
+        LayoutUnit rowHeight;
+        LayoutUnit topRowOffset;
+        Ref<const Font> primaryFont;
+        std::optional<LayoutSize> paginationOrigin;
+        LayoutUnit pageLogicalTop;
     };
 
     BlockLayoutState(PlacedFloats&, std::optional<LineClamp> = { }, TextBoxTrim = { }, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom = { }, std::optional<LineGrid> lineGrid = { });

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -65,6 +65,10 @@ LineBox LineBoxBuilder::build(size_t lineIndex)
     adjustInlineBoxHeightsForLineBoxContainIfApplicable(lineBox);
     computeLineBoxGeometry(lineBox);
     adjustOutsideListMarkersPosition(lineBox);
+
+    if (auto adjustment = formattingContext().quirks().adjustmentForLineGridLineSnap(lineBox))
+        expandAboveRootInlineBox(lineBox, *adjustment);
+
     return lineBox;
 }
 
@@ -735,6 +739,14 @@ void LineBoxBuilder::adjustMarginStartForListMarker(const ElementBox& listMarker
     // Make sure that the line content does not get pulled in to logical left direction due to
     // the large negative margin (i.e. this ensures that logical left of the list content stays at the line start)
     listMarkerGeometry.setHorizontalMargin({ listMarkerGeometry.marginStart() + nestedListMarkerMarginStart - LayoutUnit { rootInlineBoxOffset }, listMarkerGeometry.marginEnd() - nestedListMarkerMarginStart + LayoutUnit { rootInlineBoxOffset } });
+}
+
+void LineBoxBuilder::expandAboveRootInlineBox(LineBox& lineBox, InlineLayoutUnit expansion) const
+{
+    lineBox.rootInlineBox().setLogicalTop(lineBox.rootInlineBox().logicalTop() + expansion);
+    auto lineBoxRect = lineBox.logicalRect();
+    lineBoxRect.expandVertically(expansion);
+    lineBox.setLogicalRect(lineBoxRect);
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
@@ -55,6 +55,7 @@ private:
     void constructInlineLevelBoxes(LineBox&);
     void adjustIdeographicBaselineIfApplicable(LineBox&);
     void adjustOutsideListMarkersPosition(LineBox&);
+    void expandAboveRootInlineBox(LineBox&, InlineLayoutUnit) const;
 
     bool isFirstLine() const { return lineLayoutResult().isFirstLast.isFirstFormattedLine != LineLayoutResult::IsFirstLast::FirstFormattedLine::No; }
     bool isLastLine() const { return lineLayoutResult().isFirstLast.isLastLineWithInlineContent; }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -27,6 +27,7 @@
 #include "InlineQuirks.h"
 
 #include "InlineFormattingContext.h"
+#include "InlineLineBox.h"
 #include "LayoutBoxGeometry.h"
 #include "RenderStyleInlines.h"
 
@@ -128,7 +129,7 @@ std::optional<InlineRect> InlineQuirks::adjustedRectForLineGridLineAlign(const I
     // This implement the legacy -webkit-line-align property.
     // It snaps line edges to a grid defined by an ancestor box.
     auto& lineGrid = *parentBlockLayoutState.lineGrid();
-    auto offset = InlineLayoutUnit { lineGrid.logicalOffset.width() };
+    auto offset = InlineLayoutUnit { lineGrid.layoutOffset.width() + lineGrid.gridOffset.width() };
     auto columnWidth = lineGrid.columnWidth;
     auto leftShift = fmodf(columnWidth - fmodf(rect.left() + offset, columnWidth), columnWidth);
     auto rightShift = -fmodf(rect.right() + offset, columnWidth);
@@ -141,6 +142,68 @@ std::optional<InlineRect> InlineQuirks::adjustedRectForLineGridLineAlign(const I
         return { };
 
     return adjustedRect;
+}
+
+std::optional<InlineLayoutUnit> InlineQuirks::adjustmentForLineGridLineSnap(const LineBox& lineBox) const
+{
+    auto& rootBoxStyle = formattingContext().root().style();
+    auto& inlineLayoutState = formattingContext().inlineLayoutState();
+
+    if (rootBoxStyle.lineSnap() == LineSnap::None)
+        return { };
+    if (!inlineLayoutState.parentBlockLayoutState().lineGrid())
+        return { };
+
+    // This implement the legacy -webkit-line-snap property.
+    // It snaps line baselines to a grid defined by an ancestor box.
+
+    auto& lineGrid = *inlineLayoutState.parentBlockLayoutState().lineGrid();
+
+    auto gridLineHeight = lineGrid.rowHeight;
+    if (!roundToInt(gridLineHeight))
+        return { };
+
+    auto& gridFontMetrics = lineGrid.primaryFont->fontMetrics();
+    auto lineGridFontAscent = gridFontMetrics.ascent(lineBox.baselineType());
+    auto lineGridFontHeight = gridFontMetrics.height();
+    auto lineGridHalfLeading = (gridLineHeight - lineGridFontHeight) / 2;
+
+    auto firstLineTop = lineGrid.topRowOffset + lineGrid.gridOffset.height();
+
+    if (lineGrid.paginationOrigin && lineGrid.pageLogicalTop > firstLineTop)
+        firstLineTop = lineGrid.paginationOrigin->height() + lineGrid.pageLogicalTop;
+
+    auto firstTextTop = firstLineTop + lineGridHalfLeading;
+    auto firstBaselinePosition = firstTextTop + lineGridFontAscent;
+
+    auto rootInlineBoxTop = lineBox.logicalRect().top() + lineBox.logicalRectForRootInlineBox().top();
+
+    auto ascent = lineBox.rootInlineBox().ascent();
+    auto logicalHeight = ascent + lineBox.rootInlineBox().descent();
+    auto currentBaselinePosition = rootInlineBoxTop + ascent + lineGrid.layoutOffset.height();
+
+    if (rootBoxStyle.lineSnap() == LineSnap::Contain) {
+        if (logicalHeight <= lineGridFontHeight)
+            firstTextTop += (lineGridFontHeight - logicalHeight) / 2;
+        else {
+            LayoutUnit numberOfLinesWithLeading { ceilf(static_cast<float>(logicalHeight - lineGridFontHeight) / gridLineHeight) };
+            LayoutUnit totalHeight = lineGridFontHeight + numberOfLinesWithLeading * gridLineHeight;
+            firstTextTop += (totalHeight - logicalHeight) / 2;
+        }
+        firstBaselinePosition = firstTextTop + ascent;
+    }
+
+    // If we're above the first line, just push to the first line.
+    if (currentBaselinePosition < firstBaselinePosition)
+        return firstBaselinePosition - currentBaselinePosition;
+
+    // Otherwise we're in the middle of the grid somewhere. Just push to the next line.
+    auto baselineOffset = currentBaselinePosition - firstBaselinePosition;
+    auto remainder = roundToInt(baselineOffset) % roundToInt(gridLineHeight);
+    if (!remainder)
+        return { };
+
+    return gridLineHeight - remainder;
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h
@@ -31,6 +31,7 @@ namespace WebCore {
 namespace Layout {
 
 class InlineFormattingContext;
+class LineBox;
 
 class InlineQuirks {
 public:
@@ -42,6 +43,7 @@ public:
     static bool lineBreakBoxAffectsParentInlineBox(const LineBox&);
     std::optional<LayoutUnit> initialLetterAlignmentOffset(const Box& floatBox, const RenderStyle& lineBoxStyle) const;
     std::optional<InlineRect> adjustedRectForLineGridLineAlign(const InlineRect&) const;
+    std::optional<InlineLayoutUnit> adjustmentForLineGridLineSnap(const LineBox&) const;
 
 private:
     const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -474,7 +474,7 @@ bool TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout(cons
         return false;
     if (rootStyle.textWrap() == TextWrap::Balance)
         return false;
-    if (rootStyle.lineAlign() != LineAlign::None)
+    if (rootStyle.lineAlign() != LineAlign::None || rootStyle.lineSnap() != LineSnap::None)
         return false;
 
     return true;

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -53,16 +53,6 @@
 namespace WebCore {
 namespace LayoutIntegration {
 
-static std::optional<AvoidanceReason> canUseForBlockStyle(const RenderBlockFlow& blockContainer)
-{
-    ASSERT(is<RenderBlockFlow>(blockContainer));
-
-    auto& style = blockContainer.style();
-    if (style.lineSnap() != LineSnap::None)
-        return AvoidanceReason::FlowHasLineSnap;
-    return { };
-}
-
 static std::optional<AvoidanceReason> canUseForChild(const RenderObject& child)
 {
     if (is<RenderText>(child)) {
@@ -121,7 +111,7 @@ static std::optional<AvoidanceReason> canUseForLineLayoutWithReason(const Render
         if (auto childReason = canUseForChild(child))
             return *childReason;
     }
-    return canUseForBlockStyle(flow);
+    return { };
 }
 
 bool canUseForLineLayout(const RenderBlockFlow& flow)

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
@@ -39,7 +39,6 @@ class LineLayout;
 enum class AvoidanceReason : uint8_t {
     ContentIsRuby,
     ContentIsSVG,
-    FlowHasLineSnap,
     FlowIsInitialContainingBlock,
     FeatureIsDisabled
 };

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -150,7 +150,7 @@ private:
     void prepareLayoutState();
     void preparePlacedFloats();
     FloatRect constructContent(const Layout::InlineLayoutState&, Layout::InlineLayoutResult&&);
-    Vector<LineAdjustment> adjustContent();
+    Vector<LineAdjustment> adjustContent(const Layout::BlockLayoutState&);
     void updateRenderTreePositions(const Vector<LineAdjustment>&);
 
     InlineContent& ensureInlineContent();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h
@@ -32,6 +32,7 @@ namespace WebCore {
 class RenderBlockFlow;
 
 namespace Layout {
+class BlockLayoutState;
 class PlacedFloats;
 }
 
@@ -42,7 +43,7 @@ struct LineAdjustment {
     bool isFirstAfterPageBreak { false };
 };
 
-Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent&, const Layout::PlacedFloats&, RenderBlockFlow&);
+Vector<LineAdjustment> computeAdjustmentsForPagination(const InlineContent&, const Layout::PlacedFloats&, const Layout::BlockLayoutState&, RenderBlockFlow&);
 void adjustLinePositionsForPagination(InlineContent&, const Vector<LineAdjustment>&);
 
 }


### PR DESCRIPTION
#### 34e6ff8e9195fcced456c6da082d86e94f9c255e
<pre>
[IFC][Line grid] Implement -webkit-line-snap
<a href="https://bugs.webkit.org/show_bug.cgi?id=262615">https://bugs.webkit.org/show_bug.cgi?id=262615</a>
&lt;rdar://problem/116460973&gt;

Reviewed by Alan Baradlay.

This legacy property adjust line positions so they snap to a grid.
The patch implements it for IFC by porting some legacy code.

* LayoutTests/platform/mac/fast/line-grid/line-grid-contains-value-expected.txt:
* LayoutTests/platform/mac/fast/line-grid/line-grid-into-columns-expected.txt:
* Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::build):

Apply the line snap adjustment if needed.

(WebCore::Layout::LineBoxBuilder::expandAboveRootInlineBox const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
(WebCore::Layout::InlineQuirks::adjustedRectForLineGridLineAlign const):
(WebCore::Layout::InlineQuirks::adjustmentForLineGridLineSnap const):

Compute the adjustment. This is based on LegacyRootInlineBox::lineSnapAdjustment code.

* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h:
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::isEligibleForSimplifiedTextOnlyInlineLayout):

Not eglible for the simplified builder.

* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):
(WebCore::LayoutIntegration::canUseForBlockStyle): Deleted.

Enable in IFC.

* Source/WebCore/layout/integration/LayoutIntegrationCoverage.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::lineGrid):

Pass more data in LineGrid struct.

(WebCore::LayoutIntegration::LineLayout::layout):
(WebCore::LayoutIntegration::LineLayout::adjustContent):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.cpp:
(WebCore::LayoutIntegration::computeFirstLineSnapAdjustment):
(WebCore::LayoutIntegration::computeAdjustmentsForPagination):

Deal with snapping the first line that gets paginated to a new page.

* Source/WebCore/layout/integration/inline/LayoutIntegrationPagination.h:

Canonical link: <a href="https://commits.webkit.org/268862@main">https://commits.webkit.org/268862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40b4fc358d2ce278a8547d11c654b3707c7d49c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22791 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21486 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21122 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/20891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23647 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18963 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25257 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23168 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18972 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5012 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->