### PR TITLE
REGRESSION (266680@main): iOS PLUM ~0.75% increased memory use

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4914,6 +4914,22 @@ OffscreenCanvasInWorkersEnabled:
       "PLATFORM(COCOA)": true
       default: false
 
+# FIXME: Reenable this on iOS once we can mitigate impact on memory use.
+OpportunisticSweepingAndGarbageCollectionEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Opportunistic Sweeping and GC"
+  humanReadableDescription: "Enable Opportunistic Sweeping and GC"
+  category: javascript
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "PLATFORM(IOS_FAMILY)": false
+      default: true
+    WebCore:
+      default: false
+
 OpusDecoderEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -101,6 +101,9 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
     if (UNLIKELY(!page))
         return;
 
+    if (!page->settings().opportunisticSweepingAndGarbageCollectionEnabled())
+        return;
+
     page->performOpportunisticallyScheduledTasks(deadline);
 }
 


### PR DESCRIPTION
#### a776b382b039176264e7a49623eefc20bf87b4a2
<pre>
REGRESSION (266680@main): iOS PLUM ~0.75% increased memory use
<a href="https://bugs.webkit.org/show_bug.cgi?id=262575">https://bugs.webkit.org/show_bug.cgi?id=262575</a>
rdar://114845469

Reviewed by Per Arne Vollan and Ryosuke Niwa.

Add a runtime-enabled setting to control whether or not the opportunistic task scheduler should be
enabled for the purposes of opportunistic sweeping and GC. This currently causes a memory regression
on PLUM, specifically on certain iPhone models.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):

Canonical link: <a href="https://commits.webkit.org/268882@main">https://commits.webkit.org/268882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19e1ecccf2c040ff505b3f154192acbf50d661e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21499 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23660 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25268 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18225 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23180 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20344 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16765 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24324 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18984 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5025 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23308 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25586 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19556 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5592 "Passed tests") | 
<!--EWS-Status-Bubble-End-->