### PR TITLE
[WGSL] Incomplete function visiting in name mangling and global rewriting

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -54,6 +54,7 @@ public:
 
     void visit(AST::Function&) override;
     void visit(AST::Variable&) override;
+    void visit(AST::Parameter&) override;
 
     void visit(AST::CompoundStatement&) override;
     void visit(AST::AssignmentStatement&) override;
@@ -213,11 +214,14 @@ void RewriteGlobalVariables::visit(AST::Function& function)
     m_reads = WTFMove(reads);
     m_defs.clear();
 
-    for (auto& parameter : function.parameters())
-        def(parameter.name(), nullptr);
+    def(function.name(), nullptr);
+    AST::Visitor::visit(function);
+}
 
-    // FIXME: detect when we shadow a global that a callee needs
-    visit(function.body());
+void RewriteGlobalVariables::visit(AST::Parameter& parameter)
+{
+    def(parameter.name(), nullptr);
+    AST::Visitor::visit(parameter);
 }
 
 void RewriteGlobalVariables::visit(AST::Variable& variable)

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -78,6 +78,7 @@ public:
     void run();
 
     void visit(AST::Function&) override;
+    void visit(AST::Parameter&) override;
     void visit(AST::VariableStatement&) override;
     void visit(AST::Structure&) override;
     void visit(AST::Variable&) override;
@@ -124,19 +125,13 @@ void NameManglerVisitor::run()
 void NameManglerVisitor::visit(AST::Function& function)
 {
     ContextScope functionScope(this);
+    AST::Visitor::visit(function);
+}
 
-    for (auto& parameter : function.parameters()) {
-        AST::Visitor::visit(parameter.typeName());
-        introduceVariable(parameter.name(), MangledName::Parameter);
-    }
-
-    // It's important that we call the base visitor here directly, otherwise
-    // our overwritten visitor will introduce a new ContextScope for the compound
-    // statement, which would allow shadowing the function's parameters
-    AST::Visitor::visit(function.body());
-
-    if (function.maybeReturnType())
-        AST::Visitor::visit(*function.maybeReturnType());
+void NameManglerVisitor::visit(AST::Parameter& parameter)
+{
+    AST::Visitor::visit(parameter.typeName());
+    introduceVariable(parameter.name(), MangledName::Parameter);
 }
 
 void NameManglerVisitor::visit(AST::Structure& structure)


### PR DESCRIPTION
#### e8585e2a185b30c39a2821360714a5b157bec1e0
<pre>
[WGSL] Incomplete function visiting in name mangling and global rewriting
<a href="https://bugs.webkit.org/show_bug.cgi?id=262621">https://bugs.webkit.org/show_bug.cgi?id=262621</a>
rdar://116466577

Reviewed by Mike Wyrzykowski.

Both the name mangling pass and the global rewring pass were not visiting function
attributes. In order to make it less error prone, I changed it to use thet default
AST::Visitor implementation. Unfortunatelly, I couldn&apos;t find a way to test it with
our current infrastructure, but it&apos;s easily reproducible in the samples whenever
there is an override variable being used in the workgroup_size attribute.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::visit):

Canonical link: <a href="https://commits.webkit.org/268904@main">https://commits.webkit.org/268904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4eec294d56e2d5019e293c3d7346d3f4c1d0288

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22764 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19451 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20742 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23618 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18034 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25241 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23144 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16742 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18945 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5038 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->