### PR TITLE
Reduce indirection in Path / PathStream

### DIFF
--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -32,8 +32,8 @@
 #include "PathSegment.h"
 #include "PlatformPath.h"
 #include "WindRule.h"
+#include <wtf/DataRef.h>
 #include <wtf/FastMalloc.h>
-#include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
@@ -48,11 +48,11 @@ public:
     WEBCORE_EXPORT Path(PathSegment&&);
     WEBCORE_EXPORT Path(Vector<PathSegment>&&);
     explicit Path(const Vector<FloatPoint>& points);
-    Path(UniqueRef<PathImpl>&&);
+    Path(Ref<PathImpl>&&);
 
     WEBCORE_EXPORT Path(const Path&);
     Path(Path&&) = default;
-    WEBCORE_EXPORT Path& operator=(const Path&);
+    Path& operator=(const Path&) = default;
     Path& operator=(Path&&) = default;
 
     WEBCORE_EXPORT bool operator==(const Path&) const;
@@ -113,7 +113,7 @@ public:
 
 private:
     PlatformPathImpl& ensurePlatformPathImpl();
-    PathImpl& setImpl(UniqueRef<PathImpl>);
+    PathImpl& setImpl(Ref<PathImpl>&&);
     PathImpl& ensureImpl();
 
     PathSegment* asSingle() { return std::get_if<PathSegment>(&m_data); }
@@ -124,7 +124,7 @@ private:
 
     const PathMoveTo* asSingleMoveTo() const;
 
-    std::variant<std::monostate, PathSegment, UniqueRef<PathImpl>> m_data;
+    std::variant<std::monostate, PathSegment, DataRef<PathImpl>> m_data;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Path&);

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -29,11 +29,12 @@
 #include "PathElement.h"
 #include "PathSegment.h"
 #include <wtf/FastMalloc.h>
+#include <wtf/RefCounted.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
-class PathImpl {
+class PathImpl : public RefCounted<PathImpl> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~PathImpl() = default;
@@ -47,9 +48,7 @@ public:
 
     virtual bool isPathStream() const { return false; }
 
-    virtual UniqueRef<PathImpl> clone() const = 0;
-
-    virtual bool operator==(const PathImpl&) const = 0;
+    virtual Ref<PathImpl> copy() const = 0;
 
     virtual void moveTo(const FloatPoint&) = 0;
 

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -35,20 +35,12 @@ namespace WebCore {
 
 class PathStream final : public PathImpl {
 public:
-    static UniqueRef<PathStream> create();
-    static UniqueRef<PathStream> create(PathSegment&&);
-    static UniqueRef<PathStream> create(const Vector<FloatPoint>&);
-    static UniqueRef<PathStream> create(Vector<PathSegment>&&);
+    static Ref<PathStream> create();
+    static Ref<PathStream> create(PathSegment&&);
+    static Ref<PathStream> create(const Vector<FloatPoint>&);
+    static Ref<PathStream> create(Vector<PathSegment>&&);
 
-    PathStream();
-    PathStream(const PathStream&);
-    PathStream(PathSegment&&);
-    PathStream(Vector<PathSegment>&&);
-    PathStream(const Vector<PathSegment>&);
-
-    UniqueRef<PathImpl> clone() const final;
-
-    bool operator==(const PathImpl& other) const final;
+    Ref<PathImpl> copy() const final;
 
     void moveTo(const FloatPoint&) final;
 
@@ -65,7 +57,7 @@ public:
 
     void closeSubpath() final;
 
-    WEBCORE_EXPORT const Vector<PathSegment>& segments() const;
+    const Vector<PathSegment>& segments() const { return m_segments; }
 
     void applySegments(const PathSegmentApplier&) const final;
     bool applyElements(const PathElementApplier&) const final;
@@ -79,50 +71,12 @@ public:
     static FloatRect computeBoundingRect(std::span<const PathSegment>);
 
 private:
-    struct SegmentsData : public ThreadSafeRefCounted<SegmentsData> {
-        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    PathStream() = default;
+    PathStream(PathSegment&&);
+    PathStream(Vector<PathSegment>&&);
+    PathStream(const Vector<PathSegment>&);
 
-        static Ref<SegmentsData> create()
-        {
-            return adoptRef(*new SegmentsData);
-        }
-
-        static Ref<SegmentsData> create(PathSegment&& segment)
-        {
-            auto result = adoptRef(*new SegmentsData);
-            result->segments.append(WTFMove(segment));
-            return result;
-        }
-
-        static Ref<SegmentsData> create(Vector<PathSegment>&& segments)
-        {
-            auto result = adoptRef(*new SegmentsData);
-            result->segments = WTFMove(segments);
-            return result;
-        }
-
-        static Ref<SegmentsData> create(const Vector<PathSegment>& segments)
-        {
-            auto result = adoptRef(*new SegmentsData);
-            result->segments = segments;
-            return result;
-        }
-
-        Ref<SegmentsData> copy() const
-        {
-            return create(segments);
-        }
-
-        bool operator==(const SegmentsData& other) const
-        {
-            return segments == other.segments;
-        }
-
-        Vector<PathSegment> segments;
-    };
-
-    static UniqueRef<PathStream> create(const PathStream&);
-    static UniqueRef<PathStream> create(const Vector<PathSegment>&);
+    static Ref<PathStream> create(const Vector<PathSegment>&);
 
     const PathMoveTo* lastIfMoveTo() const;
 
@@ -137,14 +91,14 @@ private:
     std::optional<PathDataQuadCurve> singleQuadCurve() const final;
     std::optional<PathDataBezierCurve> singleBezierCurve() const final;
 
-    bool isEmpty() const final { return m_segmentsData->segments.isEmpty(); }
+    bool isEmpty() const final { return m_segments.isEmpty(); }
 
     bool isClosed() const final;
     FloatPoint currentPoint() const final;
 
-    Vector<PathSegment>& segments() { return m_segmentsData.access().segments; }
+    Vector<PathSegment>& segments() { return m_segments; }
 
-    DataRef<SegmentsData> m_segmentsData;
+    Vector<PathSegment> m_segments;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.h
@@ -39,16 +39,15 @@ class PathStream;
 
 class PathCairo final : public PathImpl {
 public:
-    static UniqueRef<PathCairo> create();
-    static UniqueRef<PathCairo> create(const PathStream&);
-    static UniqueRef<PathCairo> create(RefPtr<cairo_t>&&, std::unique_ptr<PathStream>&& = nullptr);
+    static Ref<PathCairo> create();
+    static Ref<PathCairo> create(const PathSegment&);
+    static Ref<PathCairo> create(const PathStream&);
+    static Ref<PathCairo> create(RefPtr<cairo_t>&&, RefPtr<PathStream>&& = nullptr);
 
     PathCairo();
-    PathCairo(RefPtr<cairo_t>&&, std::unique_ptr<PathStream>&&);
+    PathCairo(RefPtr<cairo_t>&&, RefPtr<PathStream>&&);
 
     PlatformPathPtr platformPath() const;
-
-    bool operator==(const PathImpl&) const final;
 
     void addPath(const PathCairo&, const AffineTransform&);
 
@@ -62,7 +61,7 @@ public:
     FloatRect strokeBoundingRect(const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
 
 private:
-    UniqueRef<PathImpl> clone() const final;
+    Ref<PathImpl> copy() const final;
 
     void moveTo(const FloatPoint&) final;
 
@@ -89,7 +88,7 @@ private:
     FloatRect boundingRect() const final;
 
     RefPtr<cairo_t> m_platformPath;
-    std::unique_ptr<PathStream> m_elementsStream;
+    RefPtr<PathStream> m_elementsStream;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -36,12 +36,19 @@
 
 namespace WebCore {
 
-UniqueRef<PathCG> PathCG::create()
+Ref<PathCG> PathCG::create()
 {
-    return makeUniqueRef<PathCG>();
+    return adoptRef(*new PathCG);
 }
 
-UniqueRef<PathCG> PathCG::create(const PathStream& stream)
+Ref<PathCG> PathCG::create(const PathSegment& segment)
+{
+    auto pathCG = PathCG::create();
+    pathCG->appendSegment(segment);
+    return pathCG;
+}
+
+Ref<PathCG> PathCG::create(const PathStream& stream)
 {
     auto pathCG = PathCG::create();
 
@@ -52,9 +59,9 @@ UniqueRef<PathCG> PathCG::create(const PathStream& stream)
     return pathCG;
 }
 
-UniqueRef<PathCG> PathCG::create(RetainPtr<CGMutablePathRef>&& platformPath)
+Ref<PathCG> PathCG::create(RetainPtr<CGMutablePathRef>&& platformPath)
 {
-    return makeUniqueRef<PathCG>(WTFMove(platformPath));
+    return adoptRef(*new PathCG(WTFMove(platformPath)));
 }
 
 PathCG::PathCG()
@@ -68,7 +75,7 @@ PathCG::PathCG(RetainPtr<CGMutablePathRef>&& platformPath)
     ASSERT(m_platformPath);
 }
 
-UniqueRef<PathImpl> PathCG::clone() const
+Ref<PathImpl> PathCG::copy() const
 {
     return create({ platformPath() });
 }
@@ -83,13 +90,6 @@ PlatformPathPtr PathCG::ensureMutablePlatformPath()
     if (CFGetRetainCount(m_platformPath.get()) > 1)
         m_platformPath = adoptCF(CGPathCreateMutableCopy(m_platformPath.get()));
     return m_platformPath.get();
-}
-
-bool PathCG::operator==(const PathImpl& other) const
-{
-    if (!is<PathCG>(other))
-        return false;
-    return m_platformPath == downcast<PathCG>(other).m_platformPath;
 }
 
 void PathCG::moveTo(const FloatPoint& point)

--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -39,14 +39,10 @@ class PathStream;
 
 class PathCG final : public PathImpl {
 public:
-    static UniqueRef<PathCG> create();
-    static UniqueRef<PathCG> create(const PathStream&);
-    static UniqueRef<PathCG> create(RetainPtr<CGMutablePathRef>&&);
-
-    PathCG();
-    PathCG(RetainPtr<CGMutablePathRef>&&);
-
-    bool operator==(const PathImpl&) const final;
+    static Ref<PathCG> create();
+    static Ref<PathCG> create(const PathSegment&);
+    static Ref<PathCG> create(const PathStream&);
+    static Ref<PathCG> create(RetainPtr<CGMutablePathRef>&&);
 
     PlatformPathPtr platformPath() const;
 
@@ -62,7 +58,10 @@ public:
     FloatRect strokeBoundingRect(const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
 
 private:
-    UniqueRef<PathImpl> clone() const final;
+    PathCG();
+    PathCG(RetainPtr<CGMutablePathRef>&&);
+
+    Ref<PathImpl> copy() const final;
 
     PlatformPathPtr ensureMutablePlatformPath();
 


### PR DESCRIPTION
#### 4905aa0e344500a0fcbbc873abed049ba6dd28c4
<pre>
Reduce indirection in Path / PathStream
<a href="https://bugs.webkit.org/show_bug.cgi?id=262623">https://bugs.webkit.org/show_bug.cgi?id=262623</a>

Reviewed by Simon Fraser.

Reduce indirection in Path / PathStream. PathStream now olds the vector of
segments directly instead of using another heap-allocated refcounted object
to hold the segment vector. This refcounted object was used to facilitate
sharing and copy on write. However, we can achieve the same thing by having
the Path objects sharing the same PathStream and cloning the PathStream only
on write.

Path::ensureImpl() was showing as a big source of fastMalloc() in profiles
and this should help with that.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::Path):
(WebCore::Path::operator== const):
(WebCore::Path::setImpl):
(WebCore::Path::asImpl):
(WebCore::Path::asImpl const):
(WebCore::Path::operator=): Deleted.
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/PathImpl.h:
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::create):
(WebCore::PathStream::PathStream):
(WebCore::PathStream::copy const):
(WebCore::PathStream::lastIfMoveTo const):
(WebCore::PathStream::applySegments const):
(WebCore::PathStream::applyElements const):
(WebCore::PathStream::transform):
(WebCore::PathStream::singleSegment const):
(WebCore::PathStream::isClosed const):
(WebCore::PathStream::currentPoint const):
(WebCore::PathStream::fastBoundingRect const):
(WebCore::PathStream::boundingRect const):
(WebCore::PathStream::clone const): Deleted.
(WebCore::PathStream::operator== const): Deleted.
(WebCore::PathStream::segments const): Deleted.
* Source/WebCore/platform/graphics/PathStream.h:
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::PathCG::create):
(WebCore::PathCG::copy const):
(WebCore::PathCG::clone const): Deleted.
(WebCore::PathCG::operator== const): Deleted.
* Source/WebCore/platform/graphics/cg/PathCG.h:

Canonical link: <a href="https://commits.webkit.org/268923@main">https://commits.webkit.org/268923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dd596d243f2b4637258df9f175734a96d88744f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20766 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23663 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25300 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23185 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16768 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18987 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5048 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->