### PR TITLE
Fix Clock offset bug for setPlayRate

### DIFF
--- a/LayoutTests/media/media-controller-play-then-pause-expected.txt
+++ b/LayoutTests/media/media-controller-play-then-pause-expected.txt
@@ -1,0 +1,12 @@
+
+RUN(controller = video.controller)
+EVENT(canplaythrough)
+RUN(controller.play())
+EVENT(playing)
+RUN(controller.pause())
+EVENT(pause)
+RUN(controller.play())
+EVENT(play)
+EXPECTED (controller.playbackState == 'playing') OK
+END OF TEST
+

--- a/LayoutTests/media/media-controller-play-then-pause.html
+++ b/LayoutTests/media/media-controller-play-then-pause.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src=media-file.js></script>
+<script src=video-test.js></script>
+<script>
+var controller;
+var video2;
+
+function start() {
+    var videos = document.getElementsByTagName('video');
+	video = videos[0];
+	video2 = videos[1];
+	run('controller = video.controller');
+	controller.addEventListener('canplaythrough', canplaythrough, true);
+	var src = findMediaFile('video', 'content/test');
+	video.src = src;
+	video2.src = src;
+}
+
+function canplaythrough() {
+	consoleWrite("EVENT(canplaythrough)");
+	controller.removeEventListener('canplaythrough', canplaythrough, true);
+	controller.addEventListener('playing', playing, true);
+	run('controller.play()');
+}
+
+function playing() {
+	consoleWrite("EVENT(playing)");
+	controller.removeEventListener('playing', playing, true);
+	controller.addEventListener('pause', pause, true);
+	run('controller.pause()');
+}
+
+function pause() {
+	consoleWrite("EVENT(pause)");
+	controller.removeEventListener('pause', pause, true);
+	controller.addEventListener('play', playAgain, true);
+	run('controller.play()');
+}
+
+function playAgain() {
+	consoleWrite("EVENT(play)");
+	testExpected('controller.playbackState', 'playing');
+	controller.removeEventListener('play', playAgain, true);
+	endTest();
+}
+</script>
+</head>
+<body onload="start()">
+	<video mediaGroup="group" controls></video>
+	<video mediaGroup="group" controls></video>
+</body>
+</html>

--- a/Source/WebCore/PAL/pal/system/ClockGeneric.cpp
+++ b/Source/WebCore/PAL/pal/system/ClockGeneric.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 Apple Inc.  All rights reserved.
+ * Copyright (C) 2013 Google Inc.  All rights reserved.
  * Copyright (C) 2017 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -51,14 +52,12 @@ void ClockGeneric::setCurrentTime(double time)
 
 double ClockGeneric::currentTime() const
 {
-    if (m_running)
-        m_lastTime = now();
-    return ((m_lastTime - m_startTime).seconds() * m_rate) + m_offset;
+    return currentDelta() + m_offset;
 }
 
 void ClockGeneric::setPlayRate(double rate)
 {
-    m_offset = currentTime();
+    m_offset += currentDelta();
     m_lastTime = m_startTime = now();
     m_rate = rate;
 }
@@ -77,7 +76,7 @@ void ClockGeneric::stop()
     if (!m_running)
         return;
 
-    m_offset = currentTime();
+    m_offset += currentDelta();
     m_lastTime = m_startTime = now();
     m_running = false;
 }
@@ -85,6 +84,13 @@ void ClockGeneric::stop()
 MonotonicTime ClockGeneric::now() const
 {
     return MonotonicTime::now();
+}
+
+double ClockGeneric::currentDelta() const
+{
+    if (m_running)
+        m_lastTime = now();
+    return (m_lastTime - m_startTime).seconds() * m_rate;
 }
 
 }

--- a/Source/WebCore/PAL/pal/system/ClockGeneric.h
+++ b/Source/WebCore/PAL/pal/system/ClockGeneric.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011 Apple Inc.  All rights reserved.
+ * Copyright (C) 2013 Google Inc.  All rights reserved.
  * Copyright (C) 2017 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,6 +48,7 @@ private:
     bool isRunning() const override { return m_running; }
 
     MonotonicTime now() const;
+    double currentDelta() const;
 
     bool m_running;
     double m_rate;


### PR DESCRIPTION
#### 4f53db6c72686f745024a8dc9b6cecb9c83d48b1
<pre>
Fix Clock offset bug for setPlayRate

<a href="https://bugs.webkit.org/show_bug.cgi?id=262619">https://bugs.webkit.org/show_bug.cgi?id=262619</a>

Reviewed by Eric Carlson.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=159814

Stopping and then restarting a WebCore::ClockGeneric resulted in junk values on subsequent currentTime() calls,
this caused MediaController (the only user of Clock as far as I can tell) to lose the playback position when paused.

* Source/WebCore/PAL/pal/system/ClockGeneric.cpp:
(ClockGeneric::currentTime):
(ClockGeneric::setPlayRate):
(ClockGeneric::stop):
(ClockGeneric::currentDelta):
* Source/WebCore/PAL/pal/system/ClockGeneric.h:
* LayoutTests/media/media-controller-play-then-pause.html: Add Test Case
* LayoutTests/media/media-controller-play-then-pause-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/268865@main">https://commits.webkit.org/268865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d2c0a073f4234dffeef321daac958b831ad7693

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22767 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20744 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23621 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25243 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23147 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16744 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18776 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5014 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->