### PR TITLE
[WGSL] Pack nested structs

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -110,7 +110,9 @@ private:
     void packResource(AST::Variable&);
     void packArrayResource(AST::Variable&, const Types::Array*);
     void packStructResource(AST::Variable&, const Types::Struct*);
+    const Type* packType(const Type*);
     const Type* packStructType(const Types::Struct*);
+    const Type* packArrayType(const Types::Array*);
     void updateReference(AST::Variable&, AST::Expression&);
 
     enum Packing : uint8_t {
@@ -290,10 +292,10 @@ auto RewriteGlobalVariables::pack(Packing expectedPacking, AST::Expression& expr
             operation = packing == Packing::Packed ? "__unpack"_s : "__pack"_s;
         else if (std::holds_alternative<Types::Array>(*type)) {
             if (packing == Packing::Packed) {
-                operation = "__unpack_array"_s;
+                operation = "__unpack"_s;
                 m_callGraph.ast().setUsesUnpackArray();
             } else {
-                operation = "__pack_array"_s;
+                operation = "__pack"_s;
                 m_callGraph.ast().setUsesPackArray();
             }
         } else {
@@ -513,11 +515,11 @@ void RewriteGlobalVariables::packStructResource(AST::Variable& global, const Typ
 
 void RewriteGlobalVariables::packArrayResource(AST::Variable& global, const Types::Array* arrayType)
 {
-    auto* structType = std::get_if<Types::Struct>(arrayType->element);
-    if (!structType)
+    const Type* packedArrayType = packArrayType(arrayType);
+    if (!packedArrayType)
         return;
 
-    const Type* packedStructType = packStructType(structType);
+    const Type* packedStructType = std::get<Types::Array>(*packedArrayType).element;
     auto& packedType = m_callGraph.ast().astBuilder().construct<AST::IdentifierExpression>(
         SourceSpan::empty(),
         AST::Identifier::make(std::get<Types::Struct>(*packedStructType).structure.name().id())
@@ -530,7 +532,7 @@ void RewriteGlobalVariables::packArrayResource(AST::Variable& global, const Type
         &packedType,
         arrayTypeName.maybeElementCount()
     );
-    packedArrayTypeName.m_inferredType = m_callGraph.ast().types().arrayType(packedStructType, arrayType->size);
+    packedArrayTypeName.m_inferredType = packedArrayType;
 
     m_callGraph.ast().replace(arrayTypeName, packedArrayTypeName);
     updateReference(global, packedArrayTypeName);
@@ -556,15 +558,31 @@ void RewriteGlobalVariables::updateReference(AST::Variable& global, AST::Express
     m_callGraph.ast().replace(reference, packedTypeReference);
 }
 
+const Type* RewriteGlobalVariables::packType(const Type* type)
+{
+    if (auto* structType = std::get_if<Types::Struct>(type))
+        return packStructType(structType);
+    if (auto* arrayType = std::get_if<Types::Array>(type))
+        return packArrayType(arrayType);
+    return nullptr;
+}
+
 const Type* RewriteGlobalVariables::packStructType(const Types::Struct* structType)
 {
     if (structType->structure.role() == AST::StructureRole::UserDefinedResource)
         return m_packedStructTypes.get(structType);
 
+    m_callGraph.ast().setUsesPackedStructs();
+
     ASSERT(structType->structure.role() == AST::StructureRole::UserDefined);
     m_callGraph.ast().replace(&structType->structure.role(), AST::StructureRole::UserDefinedResource);
 
     String packedStructName = makeString("__", structType->structure.name(), "_Packed");
+
+    // Ensure we pack nested structs
+    for (auto& member : structType->structure.members())
+        packType(member.type().inferredType());
+
     auto& packedStruct = m_callGraph.ast().astBuilder().construct<AST::Structure>(
         SourceSpan::empty(),
         AST::Identifier::make(packedStructName),
@@ -577,6 +595,18 @@ const Type* RewriteGlobalVariables::packStructType(const Types::Struct* structTy
     const Type* packedStructType = m_callGraph.ast().types().structType(packedStruct);
     m_packedStructTypes.add(structType, packedStructType);
     return packedStructType;
+}
+
+const Type* RewriteGlobalVariables::packArrayType(const Types::Array* arrayType)
+{
+    auto* structType = std::get_if<Types::Struct>(arrayType->element);
+    if (!structType)
+        return nullptr;
+
+    m_callGraph.ast().setUsesUnpackArray();
+    m_callGraph.ast().setUsesPackArray();
+    const Type* packedStructType = packStructType(structType);
+    return m_callGraph.ast().types().arrayType(packedStructType, arrayType->size);
 }
 
 void RewriteGlobalVariables::visitEntryPoint(AST::Function& function, AST::StageAttribute::Stage stage, PipelineLayout& pipelineLayout)

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -68,6 +68,10 @@ public:
     void setUsesPackArray() { m_usesPackArray = true; }
     void clearUsesPackArray() { m_usesPackArray = false; }
 
+    bool usesPackedStructs() const { return m_usesPackedStructs; }
+    void setUsesPackedStructs() { m_usesPackedStructs = true; }
+    void clearUsesPackedStructs() { m_usesPackedStructs = false; }
+
     bool usesUnpackArray() const { return m_usesUnpackArray; }
     void setUsesUnpackArray() { m_usesUnpackArray = true; }
     void clearUsesUnpackArray() { m_usesUnpackArray = false; }
@@ -211,6 +215,7 @@ private:
     String m_source;
     bool m_usesExternalTextures { false };
     bool m_usesPackArray { false };
+    bool m_usesPackedStructs { false };
     bool m_usesUnpackArray { false };
     bool m_usesWorkgroupUniformLoad { false };
     Configuration m_configuration;

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -12,6 +12,11 @@ struct T {
     u: u32,
 }
 
+struct U {
+    // CHECK: array<type\d::PackedType, 4> ts
+    ts: array<T, 4>,
+}
+
 var<private> t: T;
 var<private> m2: mat2x2<f32>;
 var<private> m3: mat3x3<f32>;
@@ -25,6 +30,8 @@ var<private> m3: mat3x3<f32>;
 @group(0) @binding(4) var<storage, read_write> at1: array<T, 1>;
 @group(0) @binding(5) var<storage, read_write> at2: array<T, 1>;
 
+@group(0) @binding(8) var<storage, read_write> u1: U;
+
 fn testUnpacked() -> i32
 {
     _ = t.v3f * m3;
@@ -32,6 +39,10 @@ fn testUnpacked() -> i32
 
     _ = t1.v2f * m2;
     _ = m2 * t1.v2f;
+
+    _ = u1.ts[0].v3f * m3;
+    _ = m3 * u1.ts[0].v3f;
+
     return 0;
 }
 
@@ -46,11 +57,11 @@ fn testAssignment() -> i32
     t2 = t;
 
     // array of packed structs
-    // CHECK-NEXT: local\d+ = __unpack_array\(global\d+\);
+    // CHECK-NEXT: local\d+ = __unpack\(global\d+\);
     var at = at1;
     // CHECK-NEXT: global\d+ = global\d+;
     at1 = at2;
-    // CHECK-NEXT: global\d+ = __pack_array\(local\d+\);
+    // CHECK-NEXT: global\d+ = __pack\(local\d+\);
     at2 = at;
 
     return 0;
@@ -150,7 +161,7 @@ fn testFieldAccess() -> i32
 
 fn testIndexAccess() -> i32
 {
-    // CHECK: local\d+ = __unpack_array\(global\d+\);
+    // CHECK: local\d+ = __unpack\(global\d+\);
     // CHECK-NEXT: local\d+\[0\] = __unpack\(global\d+\[0\]\);
     // CHECK-NEXT: global\d+\[0\] = global\d+\[0\];
     // CHECK-NEXT: global\d+\[0\] = __pack\(local\d+\[0\]\);


### PR DESCRIPTION
#### c485e8898b6315153d2298a263f2c3ae95a33218
<pre>
[WGSL] Pack nested structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=262626">https://bugs.webkit.org/show_bug.cgi?id=262626</a>
rdar://116467765

Reviewed by Mike Wyrzykowski.

We were failing to pack structs referenced by other packed structs. In order to
avoid excessive rewriting of the AST, we simply generate the packed structs, but
leave it up to the code generator to update the struct fields.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::packArrayResource):
(WGSL::RewriteGlobalVariables::packType):
(WGSL::RewriteGlobalVariables::packStructType):
(WGSL::RewriteGlobalVariables::packArrayType):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::generatePackingHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesPackedStructs const):
(WGSL::ShaderModule::setUsesPackedStructs):
(WGSL::ShaderModule::clearUsesPackedStructs):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/268909@main">https://commits.webkit.org/268909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc6c869841efe8c8edfd02808907c55ca58ee941

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19455 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20746 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23630 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18038 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25250 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23159 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16745 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18949 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5041 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->