### PR TITLE
[WGSL] Fix how globals are passed to callees

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -780,6 +780,7 @@ void FunctionDefinitionWriter::visit(const Type* type)
             const char* addressSpace = nullptr;
             switch (reference.addressSpace) {
             case AddressSpace::Function:
+            case AddressSpace::Private:
                 addressSpace = "thread";
                 break;
             case AddressSpace::Workgroup:
@@ -792,7 +793,6 @@ void FunctionDefinitionWriter::visit(const Type* type)
                 addressSpace = "device";
                 break;
             case AddressSpace::Handle:
-            case AddressSpace::Private:
                 break;
             }
             if (!addressSpace) {

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -393,8 +393,10 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
         if (!result) {
             if (variable.flavor() == AST::VariableFlavor::Const)
                 result = initializerType;
-            else
+            else {
                 result = concretize(initializerType, m_types);
+                variable.maybeInitializer()->m_inferredType = result;
+            }
         } else if (unify(result, initializerType))
             variable.maybeInitializer()->m_inferredType = result;
         else

--- a/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
@@ -3,8 +3,9 @@
 
 var<private> x: i32;
 var<private> y: i32;
+override z = 42;
 
-// CHECK: int function\d\(int global\d\)
+// CHECK: int function\d\(thread int& global\d\)
 fn f() -> i32
 {
     //CHECK: global\d
@@ -16,17 +17,18 @@ fn f() -> i32
 fn g() -> i32
 {
     let y = 42;
-    return 0;
+    return y;
 }
 
-// CHECK: int function\d\(int global\d\)
+// CHECK: int function\d\(thread int& global\d, int global\d\)
 fn h() -> i32
 {
     _ = y;
+    _ = z;
     return 0;
 }
 
-// CHECK: int function\d\(int global\d\)
+// CHECK: int function\d\(thread int& global\d\)
 fn i() -> i32
 {
     // CHECK: function\d\(global\d\)
@@ -34,7 +36,7 @@ fn i() -> i32
     return 0;
 }
 
-// CHECK: float function\d\(float parameter\d, int global\d\)
+// CHECK: float function\d\(float parameter\d, thread int& global\d\)
 fn j(x: f32) -> f32
 {
     // CHECK: function\d\(global\d\)
@@ -55,7 +57,7 @@ fn main()
     // CHECK: function\d\(\)
     _ = g();
 
-    // CHECK: function\d\(global\d\)
+    // CHECK: function\d\(global\d, global\d\)
     _ = h();
 
     // CHECK: function\d\(global\d\)


### PR DESCRIPTION
#### b12e77a6e9e69bfe2332fcb32e28ee88c3002692
<pre>
[WGSL] Fix how globals are passed to callees
<a href="https://bugs.webkit.org/show_bug.cgi?id=262627">https://bugs.webkit.org/show_bug.cgi?id=262627</a>
rdar://116468140

Reviewed by Mike Wyrzykowski.

This patch fixes 3 issues on how globals are passed to callees:
- private variables were being passed by value, which effectively made them immutable
- for overrides without explicit type annotations, the inferred type of the initializer
  wasn&apos;t being updated with the concretized type
- the rewriter assumed that all globals would have type annotations, which is not
  necessarily true for overrides.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visitCallee):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
* Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl:

Canonical link: <a href="https://commits.webkit.org/268906@main">https://commits.webkit.org/268906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbca9a67e4788ded3671f7e8bf6990c23fd06a62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20748 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23631 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18040 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25248 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23157 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16748 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18951 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5040 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->