### PR TITLE
[css-grid] Consider sum of non-orthogonal nested subgrids' margin,

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt
@@ -11,9 +11,7 @@ PASS .item 3
 PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div data-offset-y="41" class="item small first"></div>
-offsetTop expected 41 but got 21
+PASS .item 7
 FAIL .item 8 assert_equals:
 <div data-offset-y="110" class="item small last"></div>
 offsetTop expected 110 but got 120

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
@@ -5,11 +5,7 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div data-offset-x="514" class="item first">
-        <span></span><br><span></span>
-      </div>
-offsetLeft expected 514 but got 512
+PASS .item 1
 PASS .item 2
 FAIL .item 3 assert_equals:
 <div data-offset-x="387" class="item first">
@@ -25,7 +21,7 @@ offsetLeft expected 242 but got 227
 PASS .item 6
 FAIL .item 7 assert_equals:
 <div data-offset-x="534" class="item small first"></div>
-offsetLeft expected 534 but got 567
+offsetLeft expected 534 but got 549
 FAIL .item 8 assert_equals:
 <div data-offset-x="465" class="item small last"></div>
 offsetLeft expected 465 but got 470

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt
@@ -5,11 +5,7 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div data-offset-y="36" class="item first">
-        <span></span><br><span></span>
-      </div>
-offsetTop expected 36 but got 48
+PASS .item 1
 FAIL .item 2 assert_equals:
 <div data-offset-y="58" class="item last">
         <span></span><br><span></span>
@@ -31,9 +27,7 @@ FAIL .item 6 assert_equals:
       <span></span><br><span></span>
     </div>
 offsetTop expected 321 but got 266
-FAIL .item 7 assert_equals:
-<div data-offset-y="11" class="item small first"></div>
-offsetTop expected 11 but got 3
+PASS .item 7
 PASS .item 8
 FAIL .item 9 assert_equals:
 <div data-offset-y="126" class="item small first"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
@@ -9,7 +9,7 @@ FAIL .item 1 assert_equals:
 <div data-offset-x="514" class="item first">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 514 but got 492
+offsetLeft expected 514 but got 512
 FAIL .item 2 assert_equals:
 <div data-offset-x="428" class="item last">
         <span></span><br><span></span>

--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -82,16 +82,19 @@ LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxi
         if (position == ItemPosition::LastBaseline || baselineAxis == GridAxis::GridRowAxis)
             return 0_lu;
 
-        if (const auto* subgrid = dynamicDowncast<RenderGrid>(child.parent()); subgrid && subgrid->isSubgridRows()) {
+        auto offset = 0_lu;
+        const auto* currentSubgrid = dynamicDowncast<RenderGrid>(child.parent());
+        while (currentSubgrid && currentSubgrid->isSubgridRows()) {
             auto isPlacedAtFirstTrackInSubgrid = [&] {
-                return !subgrid->gridSpanForChild(child, GridTrackSizingDirection::ForRows).startLine();
+                return !currentSubgrid->gridSpanForChild(child, GridTrackSizingDirection::ForRows).startLine();
             }();
 
-            if (!isPlacedAtFirstTrackInSubgrid || GridLayoutFunctions::isOrthogonalParent(*subgrid, *subgrid->parent()))
+            if (!isPlacedAtFirstTrackInSubgrid || GridLayoutFunctions::isOrthogonalParent(*currentSubgrid, *currentSubgrid->parent()))
                 return 0_lu;
-            return subgrid->marginAndBorderAndPaddingBefore();
+            offset += currentSubgrid->marginAndBorderAndPaddingBefore();
+            currentSubgrid = dynamicDowncast<RenderGrid>(currentSubgrid->parent());
         }
-        return 0_lu;
+        return offset;
     }();
 
     return subgridOffset + margin + baseline;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -982,6 +982,7 @@ LayoutUnit GridTrackSizingAlgorithm::baselineOffsetForChild(const RenderBox& chi
     if (!participateInBaselineAlignment(child, baselineAxis))
         return LayoutUnit();
 
+    ASSERT_IMPLIES(baselineAxis == GridAxis::GridColumnAxis, !m_renderGrid->isSubgridRows());
     ItemPosition align = m_renderGrid->selfAlignmentForChild(baselineAxis, child).position();
     const auto& span = m_renderGrid->gridSpanForChild(child, gridDirectionForAxis(baselineAxis));
     auto alignmentContext = GridLayoutFunctions::alignmentContextForBaselineAlignment(span, align);


### PR DESCRIPTION
#### 94edbaabbf368aa6ffa9a0d21601c668a0ba095a
<pre>
[css-grid] Consider sum of non-orthogonal nested subgrids&apos; margin,
border,  and padding for first baseline alignment in the column axis.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262605">https://bugs.webkit.org/show_bug.cgi?id=262605</a>
rdar://problem/116443747

Reviewed by Matt Woodrow.

To compute the extra layer of margin for subridded items in this
scenario, we will simply walk up the subgrid ancestors until we reach
the outermost parent grid. For each subgrid, we will take its mbp and
add it to a cumulative offset value. By the time we reach the outermost
parent grid we should have a sum of all of the nested subgrid margin,
border, and padding values.

If at any point we run into an orthogonal subgrid we will return 0 to
fallback to previous behavior.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt:
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::ascentForChild const):

Canonical link: <a href="https://commits.webkit.org/268928@main">https://commits.webkit.org/268928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/335303fa0c8680c81730c3db7292755cfc1e5cdc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19510 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20781 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23689 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25287 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23201 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16789 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19011 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5050 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->