### PR TITLE
Implement window.location for site-isolated iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/window-properties-child-2.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-properties-child-2.html
@@ -1,0 +1,3 @@
+<script>
+    window.parent.postMessage("child successfully navigated by cross-origin grandchild", "*")
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/window-properties-grandchild.html
+++ b/LayoutTests/http/tests/site-isolation/resources/window-properties-grandchild.html
@@ -1,4 +1,8 @@
 <script>
     window.parent.top.postMessage("top children: " + window.parent.top.length + ", parent children: " + window.parent.length + ", parent parent is top: " + (window.parent.parent === window.top), "*");
     window.parent.top.customFunction();
+
+    try { loc = window.parent.location } catch (e) { window.parent.top.postMessage("unexpected error: " + e) }
+    try { h = loc.href } catch (e) { window.parent.top.postMessage("expected error: " + e) }
+    try { loc.href = "http://localhost:8000/site-isolation/resources/window-properties-child-2.html" } catch (e) { window.parent.top.postMessage("unexpected error: " + e) }
 </script>

--- a/LayoutTests/http/tests/site-isolation/window-properties-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-properties-expected.txt
@@ -1,3 +1,5 @@
 ALERT: custom function called
 ALERT: postMessage received: top children: 1, parent children: 1, parent parent is top: true
+ALERT: postMessage received: expected error: SecurityError: The operation is insecure.
+ALERT: postMessage received: child successfully navigated by cross-origin grandchild
 

--- a/LayoutTests/http/tests/site-isolation/window-properties.html
+++ b/LayoutTests/http/tests/site-isolation/window-properties.html
@@ -5,9 +5,11 @@ if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
+messagesReceived = 0;
 addEventListener("message", (e) => {
     alert("postMessage received: " + e.data);
-    if (window.testRunner) { testRunner.notifyDone() }
+    messagesReceived = messagesReceived + 1;
+    if (messagesReceived == 3 && window.testRunner) { testRunner.notifyDone() }
 });
 window.customFunction = function() {
     alert("custom function called");

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
@@ -109,6 +109,16 @@ bool BindingSecurity::shouldAllowAccessToDOMWindow(JSC::JSGlobalObject* lexicalG
     return target && shouldAllowAccessToDOMWindow(lexicalGlobalObject, *target, reportingOption);
 }
 
+bool BindingSecurity::shouldAllowAccessToDOMWindow(JSC::JSGlobalObject* lexicalGlobalObject, DOMWindow* window, SecurityReportingOption reportingOption)
+{
+    return shouldAllowAccessToDOMWindow(lexicalGlobalObject, dynamicDowncast<LocalDOMWindow>(window), reportingOption);
+}
+
+bool BindingSecurity::shouldAllowAccessToDOMWindow(JSC::JSGlobalObject& lexicalGlobalObject, DOMWindow* window, String& message)
+{
+    return shouldAllowAccessToDOMWindow(lexicalGlobalObject, dynamicDowncast<LocalDOMWindow>(window), message);
+}
+
 bool BindingSecurity::shouldAllowAccessToFrame(JSC::JSGlobalObject* lexicalGlobalObject, LocalFrame* target, SecurityReportingOption reportingOption)
 {
     return target && canAccessDocument(lexicalGlobalObject, target->document(), reportingOption);

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.h
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.h
@@ -33,6 +33,7 @@ class JSGlobalObject;
 
 namespace WebCore {
 
+class DOMWindow;
 class LocalDOMWindow;
 class LocalFrame;
 class Node;
@@ -52,6 +53,8 @@ bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject*, LocalDOMWindow&, Securit
 bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject&, LocalDOMWindow&, String& message);
 bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject*, LocalDOMWindow*, SecurityReportingOption = LogSecurityError);
 bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject&, LocalDOMWindow*, String& message);
+bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject*, DOMWindow*, SecurityReportingOption = LogSecurityError);
+bool shouldAllowAccessToDOMWindow(JSC::JSGlobalObject&, DOMWindow*, String& message);
 bool shouldAllowAccessToFrame(JSC::JSGlobalObject*, LocalFrame*, SecurityReportingOption = LogSecurityError);
 bool shouldAllowAccessToFrame(JSC::JSGlobalObject&, LocalFrame&, String& message);
 bool shouldAllowAccessToNode(JSC::JSGlobalObject&, Node*);

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -28,7 +28,9 @@
 
 #include "Document.h"
 #include "HTTPParsers.h"
+#include "Location.h"
 #include "SecurityOrigin.h"
+#include "WebCoreOpaqueRoot.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -69,6 +71,18 @@ ExceptionOr<RefPtr<SecurityOrigin>> DOMWindow::createTargetOriginForPostMessage(
             return Exception { SyntaxError };
     }
     return targetSecurityOrigin;
+}
+
+Location& DOMWindow::location()
+{
+    if (!m_location)
+        m_location = Location::create(*this);
+    return *m_location;
+}
+
+WebCoreOpaqueRoot root(DOMWindow* window)
+{
+    return WebCoreOpaqueRoot { window };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -34,7 +34,11 @@ namespace WebCore {
 
 class Document;
 class Frame;
+class LocalDOMWindow;
+class Location;
 class SecurityOrigin;
+class WebCoreOpaqueRoot;
+enum class SetLocationLocking : bool { LockHistoryBasedOnGestureState, LockHistoryAndBackForwardList };
 
 class DOMWindow : public RefCounted<DOMWindow>, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(DOMWindow);
@@ -52,6 +56,9 @@ public:
     using RefCounted::ref;
     using RefCounted::deref;
 
+    WEBCORE_EXPORT Location& location();
+    virtual void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking = SetLocationLocking::LockHistoryBasedOnGestureState) = 0;
+
 protected:
     explicit DOMWindow(GlobalWindowIdentifier&&);
 
@@ -63,6 +70,9 @@ protected:
 
 private:
     GlobalWindowIdentifier m_identifier;
+    RefPtr<Location> m_location;
 };
+
+WebCoreOpaqueRoot root(DOMWindow*);
 
 } // namespace WebCore

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -26,4 +26,5 @@
 interface mixin DOMWindow {
     [CallWith=CurrentGlobalObject&IncumbentWindow, DoNotCheckSecurity] undefined postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
     [CallWith=CurrentGlobalObject&IncumbentWindow, DoNotCheckSecurity] undefined postMessage(any message, optional WindowPostMessageOptions options);
+    [DoNotCheckSecurity, PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
 };

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -779,13 +779,6 @@ ReducedResolutionSeconds LocalDOMWindow::frozenNowTimestamp() const
     return m_frozenNowTimestamp.value_or(nowTimestamp());
 }
 
-Location& LocalDOMWindow::location()
-{
-    if (!m_location)
-        m_location = Location::create(*this);
-    return *m_location;
-}
-
 VisualViewport& LocalDOMWindow::visualViewport()
 {
     if (!m_visualViewport)
@@ -2469,8 +2462,8 @@ void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& comple
         return;
 
     // We want a new history item if we are processing a user gesture.
-    LockHistory lockHistory = (locking != LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
-    LockBackForwardList lockBackForwardList = (locking != LockHistoryBasedOnGestureState) ? LockBackForwardList::Yes : LockBackForwardList::No;
+    LockHistory lockHistory = (locking != SetLocationLocking::LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
+    LockBackForwardList lockBackForwardList = (locking != SetLocationLocking::LockHistoryBasedOnGestureState) ? LockBackForwardList::Yes : LockBackForwardList::No;
     frame->navigationScheduler().scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(),
         // FIXME: What if activeDocument()->frame() is 0?
         completedURL, activeDocument->frame()->loader().outgoingReferrer(),
@@ -2771,11 +2764,6 @@ void LocalDOMWindow::eventListenersDidChange()
         else
             windowsInterestedInStorageEvents().remove(*this);
     }
-}
-
-WebCoreOpaqueRoot root(LocalDOMWindow* window)
-{
-    return WebCoreOpaqueRoot { window };
 }
 
 CookieStore& LocalDOMWindow::cookieStore()

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -100,7 +100,6 @@ struct ImageBitmapOptions;
 struct MessageWithMessagePorts;
 struct WindowFeatures;
 
-enum SetLocationLocking { LockHistoryBasedOnGestureState, LockHistoryAndBackForwardList };
 enum class IncludeTargetOrigin : bool { No, Yes };
 
 class LocalDOMWindow final
@@ -178,9 +177,6 @@ public:
     WEBCORE_EXPORT bool hasTransientActivation() const;
     bool hasStickyActivation() const;
     WEBCORE_EXPORT bool consumeTransientActivation();
-
-    WEBCORE_EXPORT Location& location();
-    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking = LockHistoryBasedOnGestureState);
 
     DOMSelection* getSelection();
 
@@ -416,6 +412,7 @@ private:
     bool isLocalDOMWindow() const final { return true; }
     bool isRemoteDOMWindow() const final { return false; }
     void eventListenersDidChange() final;
+    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking) final;
 
     bool allowedToChangeWindowGeometry() const;
 
@@ -455,7 +452,6 @@ private:
     mutable RefPtr<DOMSelection> m_selection;
     mutable RefPtr<BarProp> m_statusbar;
     mutable RefPtr<BarProp> m_toolbar;
-    mutable RefPtr<Location> m_location;
     mutable RefPtr<VisualViewport> m_visualViewport;
 
     String m_status;
@@ -502,8 +498,6 @@ inline String LocalDOMWindow::status() const
 {
     return m_status;
 }
-
-WebCoreOpaqueRoot root(LocalDOMWindow*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/page/LocalDOMWindow.idl
+++ b/Source/WebCore/page/LocalDOMWindow.idl
@@ -50,7 +50,6 @@
     [Replaceable, DoNotCheckSecurityOnGetter, CustomGetter] readonly attribute WindowProxy self;
     [LegacyUnforgeable] readonly attribute Document document;
     attribute [AtomString] DOMString name;
-    [DoNotCheckSecurity, PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
     readonly attribute History history;
     [ImplementedAs=ensureCustomElementRegistry] readonly attribute CustomElementRegistry customElements;
     [Replaceable] readonly attribute BarProp locationbar;

--- a/Source/WebCore/page/Location.h
+++ b/Source/WebCore/page/Location.h
@@ -30,17 +30,19 @@
 
 #include "DOMStringList.h"
 #include "ExceptionOr.h"
-#include "LocalDOMWindowProperty.h"
 #include "ScriptWrappable.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
+class DOMWindow;
+class Frame;
 class LocalDOMWindow;
 
-class Location final : public ScriptWrappable, public RefCounted<Location>, public LocalDOMWindowProperty {
+class Location final : public ScriptWrappable, public RefCounted<Location> {
     WTF_MAKE_ISO_ALLOCATED(Location);
 public:
-    static Ref<Location> create(LocalDOMWindow& window) { return adoptRef(*new Location(window)); }
+    static Ref<Location> create(DOMWindow& window) { return adoptRef(*new Location(window)); }
 
     ExceptionOr<void> setHref(LocalDOMWindow& incumbentWindow, LocalDOMWindow& firstWindow, const String&);
     String href() const;
@@ -69,12 +71,18 @@ public:
 
     Ref<DOMStringList> ancestorOrigins() const;
 
+    DOMWindow* window() { return m_window.get(); }
+
 private:
-    explicit Location(LocalDOMWindow&);
+    explicit Location(DOMWindow&);
 
     ExceptionOr<void> setLocation(LocalDOMWindow& incumbentWindow, LocalDOMWindow& firstWindow, const String&);
 
     const URL& url() const;
+    Frame* frame();
+    const Frame* frame() const;
+
+    WeakPtr<DOMWindow, WeakPtrImplWithEventTargetData> m_window;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -60,7 +60,6 @@ public:
 
     // DOM API exposed cross-origin.
     WindowProxy* self() const;
-    Location* location() const;
     void close(Document&);
     bool closed() const;
     void focus(LocalDOMWindow& incumbentWindow);
@@ -80,6 +79,7 @@ private:
 
     bool isRemoteDOMWindow() const final { return true; }
     bool isLocalDOMWindow() const final { return false; }
+    void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking) final;
 
     WeakPtr<RemoteFrame> m_frame;
 };

--- a/Source/WebCore/page/RemoteDOMWindow.idl
+++ b/Source/WebCore/page/RemoteDOMWindow.idl
@@ -43,7 +43,6 @@
 ] interface RemoteDOMWindow {
     [LegacyUnforgeable, ImplementedAs=self] readonly attribute WindowProxy window;
     [Replaceable] readonly attribute WindowProxy self;
-    [PutForwards=href, LegacyUnforgeable] readonly attribute Location? location; // FIXME: Should not be nullable. <rdar://116203895>
     [CallWith=IncumbentDocument] undefined close();
     readonly attribute boolean closed;
     [CallWith=IncumbentWindow] undefined focus();


### PR DESCRIPTION
#### 194c42fd694410278bc8a19d998239cfe043667f
<pre>
Implement window.location for site-isolated iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=262634">https://bugs.webkit.org/show_bug.cgi?id=262634</a>
rdar://116203895

Reviewed by Pascoe.

window.location needs to be accessible on a RemoteDOMWindow, but its accessors need to throw security exceptions.
However, setting the location should navigate the frame.  I added tests that verify this is the case.
I moved the Location getter and setter from LocalDOMWindow to DOMWindow to share code when possible.

* LayoutTests/http/tests/site-isolation/resources/window-properties-child-2.html: Added.
* LayoutTests/http/tests/site-isolation/resources/window-properties-grandchild.html:
* LayoutTests/http/tests/site-isolation/window-properties-expected.txt:
* LayoutTests/http/tests/site-isolation/window-properties.html:
* Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp:
(WebCore::BindingSecurity::shouldAllowAccessToDOMWindow):
* Source/WebCore/bindings/js/JSDOMBindingSecurity.h:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::location):
(WebCore::root):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::location): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalDOMWindow.idl:
* Source/WebCore/page/Location.cpp:
(WebCore::Location::Location):
(WebCore::Location::frame):
(WebCore::Location::frame const):
(WebCore::Location::url const):
(WebCore::Location::setProtocol):
(WebCore::Location::setHost):
(WebCore::Location::setHostname):
(WebCore::Location::setPort):
(WebCore::Location::setPathname):
(WebCore::Location::setSearch):
(WebCore::Location::setHash):
(WebCore::Location::replace):
(WebCore::Location::reload):
(WebCore::Location::setLocation):
* Source/WebCore/page/Location.h:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::location const): Deleted.
* Source/WebCore/page/RemoteDOMWindow.h:
* Source/WebCore/page/RemoteDOMWindow.idl:

Canonical link: <a href="https://commits.webkit.org/268918@main">https://commits.webkit.org/268918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/327002dde9f0a8ff51c2d97fae462497455c1e0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20809 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23729 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25322 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23247 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16814 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18872 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23359 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2601 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->