### PR TITLE
Make FloatRect etc. constexpr and adopt nanRect to make it usable for "not-filled" FloatRect purpose

### DIFF
--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -57,18 +57,18 @@ class FloatRect;
 class FloatPoint {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    FloatPoint() { }
-    FloatPoint(float x, float y) : m_x(x), m_y(y) { }
+    constexpr FloatPoint() = default;
+    constexpr FloatPoint(float x, float y) : m_x(x), m_y(y) { }
     WEBCORE_EXPORT FloatPoint(const IntPoint&);
     explicit FloatPoint(const FloatSize& size) : m_x(size.width()), m_y(size.height()) { }
 
-    static FloatPoint zero() { return FloatPoint(); }
-    bool isZero() const { return !m_x && !m_y; }
+    static constexpr FloatPoint zero() { return FloatPoint(); }
+    constexpr bool isZero() const { return !m_x && !m_y; }
 
     WEBCORE_EXPORT static FloatPoint narrowPrecision(double x, double y);
 
-    float x() const { return m_x; }
-    float y() const { return m_y; }
+    constexpr float x() const { return m_x; }
+    constexpr float y() const { return m_y; }
 
     void setX(float x) { m_x = x; }
     void setY(float y) { m_y = y; }
@@ -121,30 +121,21 @@ public:
         m_y *= scaleY;
     }
 
-    FloatPoint scaled(float scale) const
+    constexpr FloatPoint scaled(float scale) const
     {
         return { m_x * scale, m_y * scale };
     }
 
-    FloatPoint scaled(float scaleX, float scaleY) const
+    constexpr FloatPoint scaled(float scaleX, float scaleY) const
     {
         return { m_x * scaleX, m_y * scaleY };
     }
 
-    void rotate(double angleInRadians, const FloatPoint& aboutPoint = { })
-    {
-        auto sinAngle = sin(angleInRadians);
-        auto cosAngle = cos(angleInRadians);
-        m_x -= aboutPoint.x();
-        m_y -= aboutPoint.y();
-        auto newX = m_x * cosAngle - m_y * sinAngle + aboutPoint.x();
-        m_y = m_x * sinAngle + m_y * cosAngle + aboutPoint.y();
-        m_x = newX;
-    }
+    void rotate(double angleInRadians, const FloatPoint& aboutPoint);
 
     WEBCORE_EXPORT void normalize();
 
-    float dot(const FloatPoint& a) const
+    constexpr float dot(const FloatPoint& a) const
     {
         return m_x * a.x() + m_y * a.y();
     }
@@ -156,7 +147,7 @@ public:
         return std::hypot(m_x, m_y);
     }
 
-    float lengthSquared() const
+    constexpr float lengthSquared() const
     {
         return m_x * m_x + m_y * m_y;
     }
@@ -165,17 +156,17 @@ public:
     
     WEBCORE_EXPORT FloatPoint constrainedWithin(const FloatRect&) const;
 
-    FloatPoint shrunkTo(const FloatPoint& other) const
+    constexpr FloatPoint shrunkTo(const FloatPoint& other) const
     {
         return { std::min(m_x, other.m_x), std::min(m_y, other.m_y) };
     }
 
-    FloatPoint expandedTo(const FloatPoint& other) const
+    constexpr FloatPoint expandedTo(const FloatPoint& other) const
     {
         return { std::max(m_x, other.m_x), std::max(m_y, other.m_y) };
     }
 
-    FloatPoint transposedPoint() const
+    constexpr FloatPoint transposedPoint() const
     {
         return { m_y, m_x };
     }
@@ -222,35 +213,46 @@ inline FloatPoint& operator-=(FloatPoint& a, const FloatSize& b)
     return a;
 }
 
-inline FloatPoint operator+(const FloatPoint& a, const FloatSize& b)
+constexpr FloatPoint operator+(const FloatPoint& a, const FloatSize& b)
 {
     return FloatPoint(a.x() + b.width(), a.y() + b.height());
 }
 
-inline FloatPoint operator+(const FloatPoint& a, const FloatPoint& b)
+constexpr FloatPoint operator+(const FloatPoint& a, const FloatPoint& b)
 {
     return FloatPoint(a.x() + b.x(), a.y() + b.y());
 }
 
-inline FloatSize operator-(const FloatPoint& a, const FloatPoint& b)
+constexpr FloatSize operator-(const FloatPoint& a, const FloatPoint& b)
 {
     return FloatSize(a.x() - b.x(), a.y() - b.y());
 }
 
-inline FloatPoint operator-(const FloatPoint& a, const FloatSize& b)
+constexpr FloatPoint operator-(const FloatPoint& a, const FloatSize& b)
 {
     return FloatPoint(a.x() - b.width(), a.y() - b.height());
 }
 
-inline FloatPoint operator-(const FloatPoint& a)
+constexpr FloatPoint operator-(const FloatPoint& a)
 {
     return FloatPoint(-a.x(), -a.y());
 }
 
-inline float operator*(const FloatPoint& a, const FloatPoint& b)
+constexpr float operator*(const FloatPoint& a, const FloatPoint& b)
 {
     // dot product
     return a.dot(b);
+}
+
+inline void FloatPoint::rotate(double angleInRadians, const FloatPoint& aboutPoint = { })
+{
+    auto sinAngle = sin(angleInRadians);
+    auto cosAngle = cos(angleInRadians);
+    m_x -= aboutPoint.x();
+    m_y -= aboutPoint.y();
+    auto newX = m_x * cosAngle - m_y * sinAngle + aboutPoint.x();
+    m_y = m_x * sinAngle + m_y * cosAngle + aboutPoint.y();
+    m_x = newX;
 }
 
 inline IntSize flooredIntSize(const FloatPoint& p)

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -65,42 +65,42 @@ public:
         InsideButNotOnStroke
     };
 
-    FloatRect() { }
-    FloatRect(const FloatPoint& location, const FloatSize& size)
+    constexpr FloatRect() = default;
+    constexpr FloatRect(const FloatPoint& location, const FloatSize& size)
         : m_location(location), m_size(size) { }
-    FloatRect(float x, float y, float width, float height)
+    constexpr FloatRect(float x, float y, float width, float height)
         : m_location(FloatPoint(x, y)), m_size(FloatSize(width, height)) { }
-    FloatRect(const FloatPoint& topLeft, const FloatPoint& bottomRight)
+    constexpr FloatRect(const FloatPoint& topLeft, const FloatPoint& bottomRight)
         : m_location(topLeft), m_size(FloatSize(bottomRight.x() - topLeft.x(), bottomRight.y() - topLeft.y())) { }
     WEBCORE_EXPORT FloatRect(const IntRect&);
 
     static FloatRect narrowPrecision(double x, double y, double width, double height);
 
-    FloatPoint location() const { return m_location; }
-    FloatSize size() const { return m_size; }
+    constexpr FloatPoint location() const { return m_location; }
+    constexpr FloatSize size() const { return m_size; }
 
     void setLocation(const FloatPoint& location) { m_location = location; }
     void setSize(const FloatSize& size) { m_size = size; }
 
-    float x() const { return m_location.x(); }
-    float y() const { return m_location.y(); }
-    float maxX() const { return x() + width(); }
-    float maxY() const { return y() + height(); }
-    float width() const { return m_size.width(); }
-    float height() const { return m_size.height(); }
+    constexpr float x() const { return m_location.x(); }
+    constexpr float y() const { return m_location.y(); }
+    constexpr float maxX() const { return x() + width(); }
+    constexpr float maxY() const { return y() + height(); }
+    constexpr float width() const { return m_size.width(); }
+    constexpr float height() const { return m_size.height(); }
 
-    float area() const { return m_size.area(); }
+    constexpr float area() const { return m_size.area(); }
 
     void setX(float x) { m_location.setX(x); }
     void setY(float y) { m_location.setY(y); }
     void setWidth(float width) { m_size.setWidth(width); }
     void setHeight(float height) { m_size.setHeight(height); }
 
-    bool isEmpty() const { return m_size.isEmpty(); }
-    bool isZero() const { return m_size.isZero(); }
+    constexpr bool isEmpty() const { return m_size.isEmpty(); }
+    constexpr bool isZero() const { return m_size.isZero(); }
     bool isExpressibleAsIntRect() const;
 
-    FloatPoint center() const { return location() + size() / 2; }
+    constexpr FloatPoint center() const { return location() + size() / 2; }
 
     void move(const FloatSize& delta) { m_location += delta; } 
     void moveBy(const FloatPoint& delta) { m_location.move(delta.x(), delta.y()); }
@@ -169,10 +169,10 @@ public:
         shiftMaxYEdgeTo(maxY() + delta);
     }
 
-    FloatPoint minXMinYCorner() const { return m_location; } // typically topLeft
-    FloatPoint maxXMinYCorner() const { return FloatPoint(m_location.x() + m_size.width(), m_location.y()); } // typically topRight
-    FloatPoint minXMaxYCorner() const { return FloatPoint(m_location.x(), m_location.y() + m_size.height()); } // typically bottomLeft
-    FloatPoint maxXMaxYCorner() const { return FloatPoint(m_location.x() + m_size.width(), m_location.y() + m_size.height()); } // typically bottomRight
+    constexpr FloatPoint minXMinYCorner() const { return m_location; } // typically topLeft
+    constexpr FloatPoint maxXMinYCorner() const { return FloatPoint(m_location.x() + m_size.width(), m_location.y()); } // typically topRight
+    constexpr FloatPoint minXMaxYCorner() const { return FloatPoint(m_location.x(), m_location.y() + m_size.height()); } // typically bottomLeft
+    constexpr FloatPoint maxXMaxYCorner() const { return FloatPoint(m_location.x() + m_size.width(), m_location.y() + m_size.height()); } // typically bottomRight
 
     WEBCORE_EXPORT bool intersects(const FloatRect&) const;
     WEBCORE_EXPORT bool inclusivelyIntersects(const FloatRect&) const;
@@ -188,11 +188,11 @@ public:
 
     // Note, this doesn't match what IntRect::contains(IntPoint&) does; the int version
     // is really checking for containment of 1x1 rect, but that doesn't make sense with floats.
-    bool contains(float px, float py) const
+    constexpr bool contains(float px, float py) const
         { return px >= x() && px <= maxX() && py >= y() && py <= maxY(); }
 
-    bool overlapsYRange(float y1, float y2) const { return !isEmpty() && y2 >= y1 && y2 >= y() && y1 <= maxY(); }
-    bool overlapsXRange(float x1, float x2) const { return !isEmpty() && x2 >= x1 && x2 >= x() && x1 <= maxX(); }
+    constexpr bool overlapsYRange(float y1, float y2) const { return !isEmpty() && y2 >= y1 && y2 >= y() && y1 <= maxY(); }
+    constexpr bool overlapsXRange(float x1, float x2) const { return !isEmpty() && x2 >= x1 && x2 >= x() && x1 <= maxX(); }
 
     void inflateX(float dx) {
         m_location.setX(m_location.x() - dx);
@@ -210,7 +210,7 @@ public:
     WEBCORE_EXPORT void scale(float sx, float sy);
     void scale(FloatSize size) { scale(size.width(), size.height()); }
 
-    FloatRect transposedRect() const { return FloatRect(m_location.transposedPoint(), m_size.transposedSize()); }
+    constexpr FloatRect transposedRect() const { return FloatRect(m_location.transposedPoint(), m_size.transposedSize()); }
 
 #if USE(CG)
     WEBCORE_EXPORT FloatRect(const CGRect&);
@@ -231,11 +231,14 @@ public:
     WEBCORE_EXPORT FloatRect(const RECT&);
 #endif
 
-    static FloatRect infiniteRect();
-    bool isInfinite() const;
+    static constexpr FloatRect infiniteRect();
+    constexpr bool isInfinite() const;
 
-    static FloatRect smallestRect();
-    bool isSmallest() const;
+    static constexpr FloatRect smallestRect();
+    constexpr bool isSmallest() const;
+
+    static constexpr FloatRect nanRect();
+    constexpr bool isNaN() const;
 
     WEBCORE_EXPORT String toJSONString() const;
     WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
@@ -276,11 +279,14 @@ inline FloatRect& operator+=(FloatRect& a, const FloatRect& b)
     return a;
 }
 
-inline FloatRect operator+(const FloatRect& a, const FloatRect& b)
+constexpr FloatRect operator+(const FloatRect& a, const FloatRect& b)
 {
-    FloatRect c = a;
-    c += b;
-    return c;
+    return FloatRect {
+        a.x() + b.x(),
+        a.y() + b.y(),
+        a.width() + b.width(),
+        a.height() + b.height(),
+    };
 }
 
 inline bool areEssentiallyEqual(const FloatRect& a, const FloatRect& b)
@@ -288,26 +294,49 @@ inline bool areEssentiallyEqual(const FloatRect& a, const FloatRect& b)
     return areEssentiallyEqual(a.location(), b.location()) && areEssentiallyEqual(a.size(), b.size());
 }
 
-inline FloatRect FloatRect::infiniteRect()
+constexpr FloatRect FloatRect::infiniteRect()
 {
-    static FloatRect infiniteRect(-std::numeric_limits<float>::max() / 2, -std::numeric_limits<float>::max() / 2, std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
-    return infiniteRect;
+    return {
+        -std::numeric_limits<float>::max() / 2,
+        -std::numeric_limits<float>::max() / 2,
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max()
+    };
 }
 
-inline bool FloatRect::isInfinite() const
+constexpr bool FloatRect::isInfinite() const
 {
     return *this == infiniteRect();
 }
 
-inline FloatRect FloatRect::smallestRect()
+constexpr FloatRect FloatRect::smallestRect()
 {
-    static FloatRect smallestRect(std::numeric_limits<float>::max() / 2, std::numeric_limits<float>::max() / 2, -std::numeric_limits<float>::max(), -std::numeric_limits<float>::max());
-    return smallestRect;
+    return {
+        std::numeric_limits<float>::max() / 2,
+        std::numeric_limits<float>::max() / 2,
+        -std::numeric_limits<float>::max(),
+        -std::numeric_limits<float>::max()
+    };
 }
 
-inline bool FloatRect::isSmallest() const
+constexpr bool FloatRect::isSmallest() const
 {
     return *this == smallestRect();
+}
+
+constexpr FloatRect FloatRect::nanRect()
+{
+    return {
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::quiet_NaN()
+    };
+}
+
+constexpr bool FloatRect::isNaN() const
+{
+    return isnan(x());
 }
 
 inline void FloatRect::inflate(float deltaX, float deltaY, float deltaMaxX, float deltaMaxY)

--- a/Source/WebCore/platform/graphics/FloatSize.cpp
+++ b/Source/WebCore/platform/graphics/FloatSize.cpp
@@ -45,11 +45,6 @@ FloatSize FloatSize::constrainedBetween(const FloatSize& min, const FloatSize& m
     };
 }
 
-bool FloatSize::isZero() const
-{
-    return std::abs(m_width) < std::numeric_limits<float>::epsilon() && std::abs(m_height) < std::numeric_limits<float>::epsilon();
-}
-
 bool FloatSize::isExpressibleAsIntSize() const
 {
     return isWithinIntRange(m_width) && isWithinIntRange(m_height);

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -75,7 +75,7 @@ public:
     void setHeight(float height) { m_height = height; }
 
     constexpr bool isEmpty() const { return m_width <= 0 || m_height <= 0; }
-    WEBCORE_EXPORT bool isZero() const;
+    constexpr bool isZero() const;
     bool isExpressibleAsIntSize() const;
 
     constexpr float aspectRatio() const { return m_width / m_height; }
@@ -162,6 +162,11 @@ private:
     float m_width { 0 };
     float m_height { 0 };
 };
+
+constexpr bool FloatSize::isZero() const
+{
+    return std::abs(m_width) < std::numeric_limits<float>::epsilon() && std::abs(m_height) < std::numeric_limits<float>::epsilon();
+}
 
 inline FloatSize& operator+=(FloatSize& a, const FloatSize& b)
 {

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp
@@ -582,9 +582,9 @@ static void checkCastRect(const WebCore::FloatRect& rect)
 
 TEST(FloatRect, Casting)
 {
+#if USE(CG)
     WebCore::FloatRect rect(10.0f, 20.0f, 30.0f, 40.0f);
 
-#if USE(CG)
     CGRect cgRect = rect;
 
     EXPECT_FLOAT_EQ(10.0f, cgRect.origin.x);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp
@@ -83,8 +83,6 @@ TEST(DisplayListTests, ReplayWithMissingResource)
 
 TEST(DisplayListTests, ItemValidationFailure)
 {
-    FloatRect contextBounds { 0, 0, contextWidth, contextHeight };
-
     auto colorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.get(), kCGImageAlphaPremultipliedLast));
     GraphicsContextCG context { cgContext.get() };


### PR DESCRIPTION
#### 4f828afc3acd38e21721463eeb2b303d2cbb1be6
<pre>
Make FloatRect etc. constexpr and adopt nanRect to make it usable for &quot;not-filled&quot; FloatRect purpose
<a href="https://bugs.webkit.org/show_bug.cgi?id=262636">https://bugs.webkit.org/show_bug.cgi?id=262636</a>
rdar://116476334

Reviewed by Justin Michaud and Mark Lam.

Use constexpr in FloatRect and related classes, and add `nanRect` concept to make it usable for &quot;not-filled&quot; FloatRect.
This is useful in subsequent SVG optimization instead of using `std::optional&lt;FloatRect&gt;`.

* Source/WebCore/platform/graphics/FloatPoint.h:
(WebCore::FloatPoint::FloatPoint):
(WebCore::FloatPoint::zero):
(WebCore::FloatPoint::isZero const):
(WebCore::FloatPoint::x const):
(WebCore::FloatPoint::y const):
(WebCore::FloatPoint::scaled const):
(WebCore::FloatPoint::dot const):
(WebCore::FloatPoint::lengthSquared const):
(WebCore::FloatPoint::shrunkTo const):
(WebCore::FloatPoint::expandedTo const):
(WebCore::FloatPoint::transposedPoint const):
(WebCore::operator+):
(WebCore::operator-):
(WebCore::operator*):
(WebCore::FloatPoint::rotate):
* Source/WebCore/platform/graphics/FloatRect.h:
(WebCore::FloatRect::FloatRect):
(WebCore::FloatRect::location const):
(WebCore::FloatRect::size const):
(WebCore::FloatRect::x const):
(WebCore::FloatRect::y const):
(WebCore::FloatRect::maxX const):
(WebCore::FloatRect::maxY const):
(WebCore::FloatRect::width const):
(WebCore::FloatRect::height const):
(WebCore::FloatRect::area const):
(WebCore::FloatRect::isEmpty const):
(WebCore::FloatRect::isZero const):
(WebCore::FloatRect::center const):
(WebCore::FloatRect::minXMinYCorner const):
(WebCore::FloatRect::maxXMinYCorner const):
(WebCore::FloatRect::minXMaxYCorner const):
(WebCore::FloatRect::maxXMaxYCorner const):
(WebCore::FloatRect::contains const):
(WebCore::FloatRect::overlapsYRange const):
(WebCore::FloatRect::overlapsXRange const):
(WebCore::FloatRect::transposedRect const):
(WebCore::operator+):
(WebCore::FloatRect::infiniteRect):
(WebCore::FloatRect::isInfinite const):
(WebCore::FloatRect::smallestRect):
(WebCore::FloatRect::isSmallest const):
(WebCore::FloatRect::nanRect):
(WebCore::FloatRect::isNaN const):
* Source/WebCore/platform/graphics/FloatSize.cpp:
(WebCore::FloatSize::isZero const): Deleted.
* Source/WebCore/platform/graphics/FloatSize.h:
(WebCore::FloatSize::isZero const):
* Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/cg/DisplayListTestsCG.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268866@main">https://commits.webkit.org/268866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a18d0cb451812a06246efcd7aec047aafd01dcc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19477 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21488 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23649 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18966 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19156 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/23174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18974 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2581 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->