### PR TITLE
Make InteractionInformationRequest use generated serialization

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -326,6 +326,7 @@ $(PROJECT_DIR)/Shared/WebsitePoliciesData.serialization.in
 $(PROJECT_DIR)/Shared/XR/XRSystem.serialization.in
 $(PROJECT_DIR)/Shared/ios/DynamicViewportSizeUpdate.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationAtPosition.serialization.in
+$(PROJECT_DIR)/Shared/ios/InteractionInformationRequest.serialization.in
 $(PROJECT_DIR)/Shared/ios/WebAutocorrectionContext.serialization.in
 $(PROJECT_DIR)/Shared/ios/WebAutocorrectionData.serialization.in
 $(PROJECT_DIR)/Shared/mac/PDFContextMenuItem.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -521,6 +521,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/GoToBackForwardItemParameters.serialization.in \
 	Shared/ios/DynamicViewportSizeUpdate.serialization.in \
 	Shared/ios/InteractionInformationAtPosition.serialization.in \
+	Shared/ios/InteractionInformationRequest.serialization.in \
 	Shared/ios/WebAutocorrectionContext.serialization.in \
 	Shared/ios/WebAutocorrectionData.serialization.in \
 	Shared/LayerTreeContext.serialization.in \

--- a/Source/WebKit/Shared/ios/InteractionInformationRequest.cpp
+++ b/Source/WebKit/Shared/ios/InteractionInformationRequest.cpp
@@ -33,51 +33,6 @@ namespace WebKit {
 
 #if PLATFORM(IOS_FAMILY)
 
-void InteractionInformationRequest::encode(IPC::Encoder& encoder) const
-{
-    encoder << point;
-    encoder << includeSnapshot;
-    encoder << includeLinkIndicator;
-    encoder << includeCaretContext;
-    encoder << includeHasDoubleClickHandler;
-    encoder << includeImageData;
-    encoder << gatherAnimations;
-    encoder << linkIndicatorShouldHaveLegacyMargins;
-    encoder << disallowUserAgentShadowContent;
-}
-
-bool InteractionInformationRequest::decode(IPC::Decoder& decoder, InteractionInformationRequest& result)
-{
-    if (!decoder.decode(result.point))
-        return false;
-
-    if (!decoder.decode(result.includeSnapshot))
-        return false;
-
-    if (!decoder.decode(result.includeLinkIndicator))
-        return false;
-
-    if (!decoder.decode(result.includeCaretContext))
-        return false;
-
-    if (!decoder.decode(result.includeHasDoubleClickHandler))
-        return false;
-
-    if (!decoder.decode(result.includeImageData))
-        return false;
-
-    if (!decoder.decode(result.gatherAnimations))
-        return false;
-
-    if (!decoder.decode(result.linkIndicatorShouldHaveLegacyMargins))
-        return false;
-
-    if (!decoder.decode(result.disallowUserAgentShadowContent))
-        return false;
-
-    return true;
-}
-
 bool InteractionInformationRequest::isValidForRequest(const InteractionInformationRequest& other, int radius) const
 {
     if (other.includeSnapshot && !includeSnapshot)

--- a/Source/WebKit/Shared/ios/InteractionInformationRequest.h
+++ b/Source/WebKit/Shared/ios/InteractionInformationRequest.h
@@ -51,15 +51,26 @@ struct InteractionInformationRequest {
 
     InteractionInformationRequest() { }
     explicit InteractionInformationRequest(WebCore::IntPoint point)
+        : point(point)
     {
-        this->point = point;
+    }
+
+    explicit InteractionInformationRequest(WebCore::IntPoint point, bool includeSnapshot, bool includeLinkIndicator, bool includeCaretContext, bool includeHasDoubleClickHandler,
+        bool includeImageData, bool gatherAnimations, bool linkIndicatorShouldHaveLegacyMargins, bool disallowUserAgentShadowContent)
+        : point(point)
+        , includeSnapshot(includeSnapshot)
+        , includeLinkIndicator(includeLinkIndicator)
+        , includeCaretContext(includeCaretContext)
+        , includeHasDoubleClickHandler(includeHasDoubleClickHandler)
+        , includeImageData(includeImageData)
+        , gatherAnimations(gatherAnimations)
+        , linkIndicatorShouldHaveLegacyMargins(linkIndicatorShouldHaveLegacyMargins)
+        , disallowUserAgentShadowContent(disallowUserAgentShadowContent)
+    {
     }
 
     bool isValidForRequest(const InteractionInformationRequest&, int radius = 0) const;
     bool isApproximatelyValidForRequest(const InteractionInformationRequest&, int radius) const;
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, InteractionInformationRequest&);
 };
 
 }

--- a/Source/WebKit/Shared/ios/InteractionInformationRequest.serialization.in
+++ b/Source/WebKit/Shared/ios/InteractionInformationRequest.serialization.in
@@ -1,0 +1,39 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(IOS_FAMILY)
+
+struct WebKit::InteractionInformationRequest {
+    WebCore::IntPoint point;
+
+    bool includeSnapshot;
+    bool includeLinkIndicator;
+    bool includeCaretContext;
+    bool includeHasDoubleClickHandler;
+    bool includeImageData;
+
+    bool gatherAnimations;
+    bool linkIndicatorShouldHaveLegacyMargins;
+    bool disallowUserAgentShadowContent;
+};
+
+#endif


### PR DESCRIPTION
#### b1787b8f7ddadd6efc3312f9a7dfdae460e142b6
<pre>
Make InteractionInformationRequest use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262639">https://bugs.webkit.org/show_bug.cgi?id=262639</a>

Reviewed by Alex Christensen.

Use the generated serialization for InteractionInformationRequest.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/ios/InteractionInformationRequest.cpp:
(WebKit::InteractionInformationRequest::encode const): Deleted.
(WebKit::InteractionInformationRequest::decode): Deleted.
* Source/WebKit/Shared/ios/InteractionInformationRequest.h:
(WebKit::InteractionInformationRequest::InteractionInformationRequest):
* Source/WebKit/Shared/ios/InteractionInformationRequest.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/268883@main">https://commits.webkit.org/268883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5886a06cba89c5ba75a7fc25978e507f340d0f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20924 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19495 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21509 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20773 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23671 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18071 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25271 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23216 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18994 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23316 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2587 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->