### PR TITLE
Avoid % operator in frequent calls on GlyphPage

### DIFF
--- a/Source/WebCore/platform/graphics/GlyphPage.h
+++ b/Source/WebCore/platform/graphics/GlyphPage.h
@@ -75,10 +75,10 @@ public:
 
     static unsigned count() { return s_count; }
 
-    static const unsigned size = 16;
+    static const unsigned size = 1 << 8; // 256 wold be enough for fitting all Latin-1 chars.
 
-    static unsigned sizeForPageNumber(unsigned) { return 16; }
-    static unsigned indexForCodePoint(UChar32 c) { return c % size; }
+    static unsigned sizeForPageNumber(unsigned) { return size; }
+    static unsigned indexForCodePoint(UChar32 c) { return c & 0xFF; }
     static unsigned pageNumberForCodePoint(UChar32 c) { return c / size; }
     static UChar32 startingCodePointInPageNumber(unsigned pageNumber) { return pageNumber * size; }
     static bool pageNumberIsUsedForArabic(unsigned pageNumber) { return startingCodePointInPageNumber(pageNumber) >= 0x600 && startingCodePointInPageNumber(pageNumber) + sizeForPageNumber(pageNumber) < 0x700; }


### PR DESCRIPTION
#### d1919cac2180d203771f6907590cee9f6e6bd716
<pre>
Avoid % operator in frequent calls on GlyphPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=262620">https://bugs.webkit.org/show_bug.cgi?id=262620</a>
rdar://problem/116482301

Reviewed by NOBODY (OOPS!).

Since &apos;d&apos; is a power of 2 in r = (x % d)
we can optimize the operation by masking
x instead.

* Source/WebCore/platform/graphics/GlyphPage.h:
(WebCore::GlyphPage::sizeForPageNumber):
(WebCore::GlyphPage::indexForCodePoint):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1919cac2180d203771f6907590cee9f6e6bd716

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20769 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21148 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21067 "Found 53 new test failures: fast/dom/52776.html, fast/text/arabic-times-new-roman.html, fast/text/complex-grapheme-cluster-with-initial-advance.html, fast/text/international/arabic-justify.html, fast/text/international/bidi-AN-after-L.html, fast/text/international/bidi-AN-after-empty-run.html, fast/text/international/bidi-CS-after-AN.html, fast/text/international/bidi-mirror-he-ar.html, fast/text/international/bidi-neutral-run.html, svg/W3C-I18N/g-dirLTR-ubNone.svg ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23672 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18076 "Found 4 new test failures: imported/w3c/web-platform-tests/svg/import/text-intro-05-t-manual.svg, imported/w3c/web-platform-tests/svg/import/text-intro-07-t-manual.svg, imported/w3c/web-platform-tests/svg/import/text-intro-10-f-manual.svg, imported/w3c/web-platform-tests/svg/import/text-intro-11-t-manual.svg (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25275 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23187 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16895 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->