### PR TITLE
Make UserScript use generated serialization

### DIFF
--- a/Source/WebCore/page/UserScript.h
+++ b/Source/WebCore/page/UserScript.h
@@ -60,9 +60,6 @@ public:
     UserContentInjectedFrames injectedFrames() const { return m_injectedFrames; }
     WaitForNotificationBeforeInjecting waitForNotificationBeforeInjecting() const { return m_waitForNotificationBeforeInjecting; }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<UserScript> decode(Decoder&);
-
 private:
     String m_source;
     URL m_url;
@@ -72,66 +69,5 @@ private:
     UserContentInjectedFrames m_injectedFrames { UserContentInjectedFrames::InjectInAllFrames };
     WaitForNotificationBeforeInjecting m_waitForNotificationBeforeInjecting { WaitForNotificationBeforeInjecting::No };
 };
-
-template<class Encoder>
-void UserScript::encode(Encoder& encoder) const
-{
-    encoder << m_source;
-    encoder << m_url;
-    encoder << m_allowlist;
-    encoder << m_blocklist;
-    encoder << m_injectionTime;
-    encoder << m_injectedFrames;
-    encoder << m_waitForNotificationBeforeInjecting;
-}
-
-template<class Decoder>
-std::optional<UserScript> UserScript::decode(Decoder& decoder)
-{
-    std::optional<String> source;
-    decoder >> source;
-    if (!source)
-        return std::nullopt;
-    
-    std::optional<URL> url;
-    decoder >> url;
-    if (!url)
-        return std::nullopt;
-    
-    std::optional<Vector<String>> allowlist;
-    decoder >> allowlist;
-    if (!allowlist)
-        return std::nullopt;
-    
-    std::optional<Vector<String>> blocklist;
-    decoder >> blocklist;
-    if (!blocklist)
-        return std::nullopt;
-    
-    std::optional<UserScriptInjectionTime> injectionTime;
-    decoder >> injectionTime;
-    if (!injectionTime)
-        return std::nullopt;
-    
-    std::optional<UserContentInjectedFrames> injectedFrames;
-    decoder >> injectedFrames;
-    if (!injectedFrames)
-        return std::nullopt;
-    
-    std::optional<WaitForNotificationBeforeInjecting> waitForNotification;
-    decoder >> waitForNotification;
-    if (!waitForNotification)
-        return std::nullopt;
-    
-    return {{
-        WTFMove(*source),
-        WTFMove(*url),
-        WTFMove(*allowlist),
-        WTFMove(*blocklist),
-        WTFMove(*injectionTime),
-        WTFMove(*injectedFrames),
-        WTFMove(*waitForNotification)
-    }};
-}
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6299,3 +6299,19 @@ header: <WebCore/FontTaggedSettings.h>
 [Alias=class FontTaggedSettings<int>, CustomHeader, LegacyPopulateFromEmptyConstructor] class WebCore::FontFeatureSettings {
     Vector<WebCore::IntFontTaggedSetting> m_list;
 };
+
+enum class WebCore::UserScriptInjectionTime : bool;
+
+enum class WebCore::WaitForNotificationBeforeInjecting : bool;
+
+enum class WebCore::UserContentInjectedFrames : bool;
+
+class WebCore::UserScript {
+    String source();
+    URL url();
+    Vector<String> allowlist();
+    Vector<String> blocklist();
+    WebCore::UserScriptInjectionTime injectionTime();
+    WebCore::UserContentInjectedFrames injectedFrames();
+    WebCore::WaitForNotificationBeforeInjecting waitForNotificationBeforeInjecting();
+}


### PR DESCRIPTION
#### e483494b6eaea1bc17ee16146a0e385b74b055f1
<pre>
Make UserScript use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262643">https://bugs.webkit.org/show_bug.cgi?id=262643</a>
rdar://116483136

Reviewed by Alex Christensen.

This patch starts to use the generated serialization for UserScript instead
of manually specifying ::encode and ::decode.

* Source/WebCore/page/UserScript.h:
(WebCore::UserScript::encode const): Deleted.
(WebCore::UserScript::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268886@main">https://commits.webkit.org/268886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1708e246ff7fcde6da446e4308fb11a0812e29e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19497 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21511 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23673 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25274 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19746 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18996 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5029 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->