### PR TITLE
Make selection focus work with site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/resources/selected-text.html
+++ b/LayoutTests/http/tests/site-isolation/resources/selected-text.html
@@ -1,0 +1,5 @@
+<p id="text">ABC</p>
+<script>
+document.getSelection().setBaseAndExtent(text.firstChild, 0, text.firstChild, 3);
+window.parent.postMessage("", "*");
+</script>

--- a/LayoutTests/http/tests/site-isolation/selection-focus-expected.html
+++ b/LayoutTests/http/tests/site-isolation/selection-focus-expected.html
@@ -1,0 +1,10 @@
+<script>
+    function setFocus() {
+        frame.focus();
+    }
+
+    addEventListener("message", (event) => {
+        document.body.focus();
+    });
+</script>
+<iframe onload="setFocus()" id="frame" src="http://127.0.0.1:8000/site-isolation/resources/selected-text.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/selection-focus.html
+++ b/LayoutTests/http/tests/site-isolation/selection-focus.html
@@ -1,0 +1,11 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+    function setFocus() {
+        frame.focus();
+    }
+
+    addEventListener("message", (event) => {
+        document.body.focus();
+    });
+</script>
+<iframe onload="setFocus()" id="frame" src="http://localhost:8000/site-isolation/resources/selected-text.html"></iframe>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4596,6 +4596,7 @@ imported/w3c/web-platform-tests/css/css-lists/list-style-image-gradients.html [ 
 imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-disc.html [ Skip ]
 
 webkit.org/b/257904 http/tests/site-isolation/basic-iframe.html [ Skip ]
+webkit.org/b/257904 http/tests/site-isolation/selection-focus.html [ Skip ]
 
 # This test can't be enabled on iOS until EventSenderProxyIOS::keyDown() is implemented.
 http/tests/site-isolation/key-events.html [ Skip ]

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -439,7 +439,7 @@ FocusController::FocusController(Page& page, OptionSet<ActivityState> activitySt
 {
 }
 
-void FocusController::setFocusedFrame(Frame* frame)
+void FocusController::setFocusedFrame(Frame* frame, bool broadcastFocusedFrame)
 {
     ASSERT(!frame || frame->page() == &m_page);
     if (m_focusedFrame == frame || m_isChangingFocusedFrame)
@@ -480,7 +480,8 @@ void FocusController::setFocusedFrame(Frame* frame)
 #endif
     }
 
-    m_page.chrome().focusedFrameChanged(frame);
+    if (broadcastFocusedFrame)
+        m_page.chrome().focusedFrameChanged(frame);
 
     m_isChangingFocusedFrame = false;
 }

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -54,8 +54,7 @@ class FocusController : public CanMakeCheckedPtr {
 public:
     explicit FocusController(Page&, OptionSet<ActivityState>);
 
-    WEBCORE_EXPORT void setFocusedFrame(Frame*);
-    void updateFocusedFrame(Frame* frame) { m_focusedFrame = frame; }
+    WEBCORE_EXPORT void setFocusedFrame(Frame*, bool broadcastFocusedFrame = true);
     Frame* focusedFrame() const { return m_focusedFrame.get(); }
     LocalFrame* focusedLocalFrame() const { return dynamicDowncast<LocalFrame>(m_focusedFrame.get()); }
     WEBCORE_EXPORT LocalFrame& focusedOrMainFrame() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8949,7 +8949,7 @@ void WebPage::frameWasFocusedInAnotherProcess(WebCore::FrameIdentifier frameID)
     auto* frame = WebProcess::singleton().webFrame(frameID);
     if (!frame)
         return;
-    m_page->focusController().updateFocusedFrame(frame->coreFrame());
+    m_page->focusController().setFocusedFrame(frame->coreFrame(), false);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### d496225829b3f96f82bce1d5bf2e847a7fab6769
<pre>
Make selection focus work with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=262653">https://bugs.webkit.org/show_bug.cgi?id=262653</a>
rdar://116486773

Reviewed by Alex Christensen.

In 268570@main I added `FocusController::updateFocusedFrame()` to avoid an IPC loop when broadcasting the
focused frame to other site-isolated frames. `FocusController::setFocusedFrame()` sets other things that
should also be kept up to date in all web processes such as selection focus, so we should just keep using
that. Avoid the IPC loop by adding a `broadcastFocusedFrame` bool that we set to false when we don’t need
to notify the UI process that a frame was updated.

* LayoutTests/http/tests/site-isolation/resources/selected-text.html: Added.
* LayoutTests/http/tests/site-isolation/selection-focus-expected.html: Added.
* LayoutTests/http/tests/site-isolation/selection-focus.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):
* Source/WebCore/page/FocusController.h:
(WebCore::FocusController::updateFocusedFrame): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameWasFocusedInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/268919@main">https://commits.webkit.org/268919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a73b19a35cb2398a6e9a3a409647c39a9dfe635

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20799 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23717 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25309 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19230 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23230 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16802 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18862 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23349 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2602 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->