### PR TITLE
Reduce size of RenderText from 128 to 120 bytes on 64-bit

### DIFF
--- a/Source/WTF/wtf/Markable.h
+++ b/Source/WTF/wtf/Markable.h
@@ -76,6 +76,18 @@ struct IntegralMarkableTraits {
     }
 };
 
+struct FloatMarkableTraits {
+    constexpr static bool isEmptyValue(float value)
+    {
+        return value != value;
+    }
+
+    constexpr static float emptyValue()
+    {
+        return std::numeric_limits<float>::quiet_NaN();
+    }
+};
+
 // The goal of Markable is offering Optional without sacrificing storage efficiency.
 // Markable takes Traits, which should have isEmptyValue and emptyValue functions. By using
 // one value of T as an empty value, we can remove bool flag in Optional. This strategy is
@@ -128,6 +140,13 @@ public:
 
     constexpr const T& operator*() const& { return m_value; }
     constexpr T& operator*() & { return m_value; }
+
+    template <class U> constexpr T value_or(U&& fallback) const
+    {
+        if (bool(*this))
+            return m_value;
+        return static_cast<T>(std::forward<U>(fallback));
+    }
 
     operator std::optional<T>() &&
     {

--- a/Source/WebCore/platform/graphics/FontSizeAdjust.h
+++ b/Source/WebCore/platform/graphics/FontSizeAdjust.h
@@ -31,18 +31,6 @@
 
 namespace WebCore {
 
-struct FloatMarkableTraits {
-    constexpr static bool isEmptyValue(float value)
-    {
-        return value != value;
-    }
-
-    constexpr static float emptyValue()
-    {
-        return std::numeric_limits<float>::quiet_NaN();
-    }
-};
-
 struct FontSizeAdjust {
     friend bool operator==(const FontSizeAdjust&, const FontSizeAdjust&) = default;
 
@@ -55,7 +43,7 @@ struct FontSizeAdjust {
     };
     Metric metric { Metric::ExHeight };
     bool isFromFont { false };
-    Markable<float, FloatMarkableTraits> value { };
+    Markable<float, WTF::FloatMarkableTraits> value { };
 };
 
 inline void add(Hasher& hasher, const FontSizeAdjust& fontSizeAdjust)

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -84,16 +84,14 @@ using namespace WTF::Unicode;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderText);
 
 struct SameSizeAsRenderText : public RenderObject {
-    void* pointers[2];
-    uint32_t bitfields : 16;
 #if ENABLE(TEXT_AUTOSIZING)
     float candidateTextSize;
 #endif
-    float widths[2];
-    std::optional<float> minWidth;
-    std::optional<float> maxWidth;
-    std::optional<bool> canUseSimplifiedTextMeasuring;
+    float widths[4];
+    void* pointers[2];
     String text;
+    std::optional<bool> canUseSimplifiedTextMeasuring;
+    uint32_t bitfields : 16;
 };
 
 static_assert(sizeof(RenderText) == sizeof(SameSizeAsRenderText), "RenderText should stay small");
@@ -247,8 +245,8 @@ static unsigned offsetForPositionInRun(const InlineIterator::TextBox& textBox, f
 
 inline RenderText::RenderText(Type type, Node& node, const String& text)
     : RenderObject(type, node)
-    , m_containsOnlyASCII(text.impl()->containsOnlyASCII())
     , m_text(text)
+    , m_containsOnlyASCII(text.impl()->containsOnlyASCII())
 {
     ASSERT(!m_text.isNull());
     setIsText();


### PR DESCRIPTION
#### 728c278f57444c3efca0c1c0c342f6f03bd17d9c
<pre>
Reduce size of RenderText from 128 to 120 bytes on 64-bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=262655">https://bugs.webkit.org/show_bug.cgi?id=262655</a>

Reviewed by Simon Fraser.

Reduce size of RenderText from 128 to 120 bytes on 64-bit by leveraging Markable.

* Source/WTF/wtf/Markable.h:
(WTF::FloatMarkableTraits::isEmptyValue):
(WTF::FloatMarkableTraits::emptyValue):
(WTF::Markable::value_or const):
* Source/WebCore/platform/graphics/FontSizeAdjust.h:
(WebCore::FloatMarkableTraits::isEmptyValue): Deleted.
(WebCore::FloatMarkableTraits::emptyValue): Deleted.
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::RenderText):
* Source/WebCore/rendering/RenderText.h:

Canonical link: <a href="https://commits.webkit.org/268887@main">https://commits.webkit.org/268887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c263f07732fe35a158ed17d69b5a15e34e65df6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20940 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21521 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20926 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23685 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19001 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18248 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23206 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20369 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19756 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24350 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19007 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5772 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5030 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23328 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25613 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19580 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5598 "Found 1 new JSC stress test failure: microbenchmarks/array-from-object-func.js.lockdown (failure)") | 
<!--EWS-Status-Bubble-End-->