### PR TITLE
Make GraphicsContextState use generated serialization

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6374,3 +6374,56 @@ class WebCore::UserScript {
     WebCore::UserContentInjectedFrames injectedFrames();
     WebCore::WaitForNotificationBeforeInjecting waitForNotificationBeforeInjecting();
 }
+
+header: <WebCore/GraphicsContextState.h>
+[Nested, OptionSet] enum class WebCore::GraphicsContextState::Change : uint32_t {
+    FillBrush,
+    FillRule,
+    StrokeBrush,
+    StrokeThickness,
+    StrokeStyle,
+    CompositeMode,
+    Style,
+    Alpha,
+    TextDrawingMode,
+    ImageInterpolationQuality,
+    ShouldAntialias,
+    ShouldSmoothFonts,
+    ShouldSubpixelQuantizeFonts,
+    ShadowsIgnoreTransforms,
+    DrawLuminanceMask,
+#if HAVE(OS_DARK_MODE_SUPPORT)
+    UseDarkAppearance,
+#endif
+};
+
+header: <WebCore/GraphicsContextState.h>
+[Nested] enum class WebCore::GraphicsContextState::Purpose : uint8_t {
+    Initial,
+    SaveRestore,
+    TransparencyLayer,
+};
+
+[LegacyPopulateFromEmptyConstructor, AdditionalEncoder=StreamConnectionEncoder] class WebCore::GraphicsContextState {
+    OptionSet<WebCore::GraphicsContextState::Change> m_changeFlags;
+    WebCore::SourceBrush m_fillBrush;
+    WebCore::WindRule m_fillRule;
+    WebCore::SourceBrush m_strokeBrush;
+    float m_strokeThickness;
+    WebCore::StrokeStyle m_strokeStyle;
+    WebCore::CompositeMode m_compositeMode;
+    std::optional<WebCore::GraphicsStyle> m_style;
+    float m_alpha;
+    WebCore::InterpolationQuality m_imageInterpolationQuality;
+    OptionSet<WebCore::TextDrawingMode> m_textDrawingMode;
+    bool m_shouldAntialias;
+    bool m_shouldSmoothFonts;
+    bool m_shouldSubpixelQuantizeFonts;
+    bool m_shadowsIgnoreTransforms;
+    bool m_drawLuminanceMask;
+#if HAVE(OS_DARK_MODE_SUPPORT)
+    bool m_useDarkAppearance;
+#endif
+
+    WebCore::GraphicsContextState::Purpose m_purpose;
+};


### PR DESCRIPTION
#### ab4ed2e78f90a5cf289cb1e49e7b7619c68e0c16
<pre>
Make GraphicsContextState use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262656">https://bugs.webkit.org/show_bug.cgi?id=262656</a>
rdar://116488200

Reviewed by Ryosuke Niwa.

This patch starts to use generated serialization for GrahpicsContextState instead
of manually specifying ::encode and ::decode. There may have been a performance optimization
in the previous manually written encode, decode. If this is still required, we should generate
this serializer and create an option to replicate the optimization later.

* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::encode const): Deleted.
(WebCore::GraphicsContextState::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/268938@main">https://commits.webkit.org/268938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a7bd262c8fd46453a42f11e20e869a8e533f364

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19627 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21663 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23833 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19125 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23333 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16893 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19150 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5055 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->