### PR TITLE
[MediaStream] Add support for ImageCapture.getPhotoSettings

### DIFF
--- a/LayoutTests/fast/mediastream/image-capture-get-photo-settings-expected.txt
+++ b/LayoutTests/fast/mediastream/image-capture-get-photo-settings-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS getPhotoSettings() on an 'ended' track should throw "InvalidStateError"
+PASS "OperationError" should be thrown if the track ends before the promise resolves
+PASS Check getPhotoSettings()
+

--- a/LayoutTests/fast/mediastream/image-capture-get-photo-settings.html
+++ b/LayoutTests/fast/mediastream/image-capture-get-photo-settings.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>ImageCapture getPhotoSettings</title>
+    <script src='../../resources/testharness.js'></script>
+    <script src='../../resources/testharnessreport.js'></script>
+</head>
+<body>
+    <video controls autoplay width=640 height=480 playsInline id='video'></video>
+    <script>
+
+        promise_test(async (test) => {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            const [track] = stream.getVideoTracks();
+
+            assert_equals(track.readyState, 'live');
+            track.stop();
+            assert_equals(track.readyState, 'ended');
+
+            const imageCapture = new ImageCapture(track);
+            return promise_rejects_dom(test, 'InvalidStateError', imageCapture.getPhotoSettings())
+
+        }, `getPhotoSettings() on an 'ended' track should throw "InvalidStateError"`);
+
+        promise_test(async (test) => {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { width : 640 } });
+            const [track] = stream.getVideoTracks();
+
+            assert_equals(track.readyState, 'live');
+
+            const imageCapture = new ImageCapture(track);
+            const promise = imageCapture.getPhotoSettings();
+            
+            track.stop();
+            assert_equals(track.readyState, 'ended');
+            
+            return promise_rejects_dom(test, 'OperationError', promise);
+
+        }, `"OperationError" should be thrown if the track ends before the promise resolves`);
+
+        promise_test(async (test) => {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, torch : true } });
+            const [track] = stream.getVideoTracks();
+
+            const imageCapture = new ImageCapture(track);
+            let photoSettings = await imageCapture.getPhotoSettings();
+            const trackSettings = track.getSettings();
+
+            assert_equals(photoSettings.imageHeight, trackSettings.height);
+            assert_equals(photoSettings.imageWidth, trackSettings.width);
+            assert_equals(photoSettings.fillLightMode, 'flash');
+
+            await track.applyConstraints({ torch : false });
+            photoSettings = await imageCapture.getPhotoSettings();
+            assert_equals(photoSettings.fillLightMode, 'off');
+
+        }, `Check getPhotoSettings()`);
+
+    </script>
+</body>
+</html>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -459,6 +459,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediastream/OverconstrainedError.idl
     Modules/mediastream/OverconstrainedErrorEvent.idl
     Modules/mediastream/PhotoCapabilities.idl
+    Modules/mediastream/PhotoSettings.idl
     Modules/mediastream/RTCAnswerOptions.idl
     Modules/mediastream/RTCCertificate.idl
     Modules/mediastream/RTCConfiguration.idl

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -454,6 +454,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediastream/OverconstrainedError.idl \
     $(WebCore)/Modules/mediastream/OverconstrainedErrorEvent.idl \
     $(WebCore)/Modules/mediastream/PhotoCapabilities.idl \
+    $(WebCore)/Modules/mediastream/PhotoSettings.idl \
     $(WebCore)/Modules/mediastream/RedEyeReduction.idl \
     $(WebCore)/Modules/mediastream/RTCAnswerOptions.idl \
     $(WebCore)/Modules/mediastream/RTCCertificate.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2152,6 +2152,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/MediaStreamTrackPrivate.h
     platform/mediastream/MeteringMode.h
     platform/mediastream/PhotoCapabilities.h
+    platform/mediastream/PhotoSettings.h
     platform/mediastream/RedEyeReduction.h
     platform/mediastream/RTCDataChannelHandler.h
     platform/mediastream/RTCDataChannelHandlerClient.h

--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -63,6 +63,19 @@ void ImageCapture::getPhotoCapabilities(PhotoCapabilitiesPromise&& promise)
     m_track->getPhotoCapabilities(WTFMove(promise));
 }
 
+void ImageCapture::getPhotoSettings(PhotoSettingsPromise&& promise)
+{
+    if (m_track->readyState() == MediaStreamTrack::State::Ended) {
+        // https://w3c.github.io/mediacapture-image/#ref-for-dom-imagecapture-getphotosettings②
+        // If the readyState of track provided in the constructor is not live, return a promise
+        // rejected with a new DOMException whose name is InvalidStateError, and abort these steps.
+        promise.reject(Exception { InvalidStateError, "Track has ended"_s });
+        return;
+    }
+
+    m_track->getPhotoSettings(WTFMove(promise));
+}
+
 const char* ImageCapture::activeDOMObjectName() const
 {
     return "ImageCapture";

--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -32,6 +32,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "MediaStreamTrack.h"
 #include "PhotoCapabilities.h"
+#include "PhotoSettings.h"
 
 namespace WebCore {
 
@@ -44,6 +45,9 @@ public:
 
     using PhotoCapabilitiesPromise = DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>;
     void getPhotoCapabilities(PhotoCapabilitiesPromise&&);
+
+    using PhotoSettingsPromise = DOMPromiseDeferred<IDLDictionary<PhotoSettings>>;
+    void getPhotoSettings(PhotoSettingsPromise&&);
 
     Ref<MediaStreamTrack> track() const { return m_track; }
 

--- a/Source/WebCore/Modules/mediastream/ImageCapture.idl
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.idl
@@ -37,8 +37,7 @@
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=262467
     // Promise<Blob> takePhoto(optional PhotoSettings photoSettings = {});
 
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=262466
-    // Promise<PhotoSettings> getPhotoSettings();
+    Promise<PhotoSettings> getPhotoSettings();
 
     readonly attribute MediaStreamTrack track;
 };

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -39,6 +39,7 @@
 #include "MediaTrackCapabilities.h"
 #include "MediaTrackConstraints.h"
 #include "PhotoCapabilities.h"
+#include "PhotoSettings.h"
 #include "PlatformMediaSession.h"
 #include <wtf/LoggerHelper.h>
 
@@ -130,6 +131,7 @@ public:
     TrackCapabilities getCapabilities() const;
 
     void getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCapabilities>>&&) const;
+    void getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettings>>&&) const;
 
     const MediaTrackConstraints& getConstraints() const { return m_constraints; }
     void setConstraints(MediaTrackConstraints&& constraints) { m_constraints = WTFMove(constraints); }

--- a/Source/WebCore/Modules/mediastream/PhotoSettings.idl
+++ b/Source/WebCore/Modules/mediastream/PhotoSettings.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://w3c.github.io/mediacapture-image/#photosettings-section
+
+[
+    Conditional=MEDIA_STREAM,
+    JSGenerateToJSObject
+] dictionary PhotoSettings {
+    FillLightMode   fillLightMode;
+    double          imageHeight;
+    double          imageWidth;
+    boolean         redEyeReduction;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3966,6 +3966,7 @@ JSPermissionState.cpp
 JSPermissionStatus.cpp
 JSPermissions.cpp
 JSPhotoCapabilities.cpp
+JSPhotoSettings.cpp
 JSPictureInPictureEvent.cpp
 JSPictureInPictureWindow.cpp
 JSPlaneLayout.cpp

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -34,6 +34,7 @@
 #include "IntRect.h"
 #include "Logging.h"
 #include "PlatformMediaSessionManager.h"
+#include <wtf/NativePromise.h>
 #include <wtf/UUID.h>
 
 #if PLATFORM(COCOA)
@@ -186,6 +187,11 @@ const RealtimeMediaSourceCapabilities& MediaStreamTrackPrivate::capabilities() c
 void MediaStreamTrackPrivate::getPhotoCapabilities(RealtimeMediaSource::PhotoCapabilitiesHandler&& completion)
 {
     m_source->getPhotoCapabilities(WTFMove(completion));
+}
+
+Ref<RealtimeMediaSource::PhotoSettingsNativePromise> MediaStreamTrackPrivate::getPhotoSettings()
+{
+    return m_source->getPhotoSettings();
 }
 
 void MediaStreamTrackPrivate::applyConstraints(const MediaConstraints& constraints, RealtimeMediaSource::ApplyConstraintsHandler&& completionHandler)

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -111,6 +111,7 @@ public:
     const RealtimeMediaSourceCapabilities& capabilities() const;
 
     void getPhotoCapabilities(RealtimeMediaSource::PhotoCapabilitiesHandler&&);
+    Ref<RealtimeMediaSource::PhotoSettingsNativePromise> getPhotoSettings();
 
     void applyConstraints(const MediaConstraints&, RealtimeMediaSource::ApplyConstraintsHandler&&);
 

--- a/Source/WebCore/platform/mediastream/PhotoSettings.h
+++ b/Source/WebCore/platform/mediastream/PhotoSettings.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_STREAM)
+
+#include <optional>
+
+namespace WebCore {
+
+enum class FillLightMode : uint8_t;
+
+struct PhotoSettings {
+    std::optional<FillLightMode> fillLightMode;
+    std::optional<double> imageHeight;
+    std::optional<double> imageWidth;
+    std::optional<bool> redEyeReduction;
+};
+
+}
+
+#endif

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -45,6 +45,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/MainThread.h>
 #include <wtf/MediaTime.h>
+#include <wtf/NativePromise.h>
 #include <wtf/UUID.h>
 #include <wtf/text/StringHash.h>
 
@@ -1458,6 +1459,11 @@ void RealtimeMediaSource::setType(Type type)
 void RealtimeMediaSource::getPhotoCapabilities(PhotoCapabilitiesHandler&& completion)
 {
     completion(PhotoCapabilitiesOrError("Not supported"_s));
+}
+
+auto RealtimeMediaSource::getPhotoSettings() -> Ref<PhotoSettingsNativePromise>
+{
+    return PhotoSettingsNativePromise::createAndReject("Not supported"_s);
 }
 
 RealtimeMediaSource::Observer::~Observer()

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -41,6 +41,7 @@
 #include "MediaConstraints.h"
 #include "MediaDeviceHashSalts.h"
 #include "PhotoCapabilities.h"
+#include "PhotoSettings.h"
 #include "PlatformLayer.h"
 #include "RealtimeMediaSourceCapabilities.h"
 #include "RealtimeMediaSourceFactory.h"
@@ -48,6 +49,7 @@
 #include "VideoFrameTimeMetadata.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Forward.h>
 #include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -211,6 +213,9 @@ public:
 
     using PhotoCapabilitiesHandler = CompletionHandler<void(PhotoCapabilitiesOrError&&)>;
     virtual void getPhotoCapabilities(PhotoCapabilitiesHandler&&);
+
+    using PhotoSettingsNativePromise = NativePromise<PhotoSettings, String>;
+    virtual Ref<PhotoSettingsNativePromise> getPhotoSettings();
 
     struct ApplyConstraintsError {
         String badConstraint;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -85,6 +85,7 @@ private:
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
     void getPhotoCapabilities(PhotoCapabilitiesHandler&&) final;
+    Ref<PhotoSettingsNativePromise> getPhotoSettings() final;
     double facingModeFitnessScoreAdjustment() const final;
     void startProducingData() final;
     void stopProducingData() final;
@@ -147,6 +148,7 @@ private:
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
     std::optional<PhotoCapabilities> m_photoCapabilities;
+    std::optional<PhotoSettings> m_photoSettings;
     RetainPtr<WebCoreAVVideoCaptureSourceObserver> m_objcObserver;
     RetainPtr<AVCaptureSession> m_session;
     RetainPtr<AVCaptureDevice> m_device;

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -75,6 +75,7 @@ private:
     const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
     void getPhotoCapabilities(PhotoCapabilitiesHandler&&) final;
+    Ref<PhotoSettingsNativePromise> getPhotoSettings() final;
 
     void startProducingData() override;
     void stopProducingData() override;
@@ -124,6 +125,7 @@ private:
     std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     std::optional<PhotoCapabilities> m_photoCapabilities;
+    std::optional<PhotoSettings> m_photoSettings;
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
     Color m_fillColor { Color::black };
     Color m_fillColorWithZoom { Color::red };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5936,6 +5936,14 @@ header: <WebCore/PhotoCapabilities.h>
     std::optional<Vector<WebCore::FillLightMode>> fillLightMode;
 };
 
+header: <WebCore/PhotoSettings.h>
+[CustomHeader] struct WebCore::PhotoSettings {
+    std::optional<WebCore::FillLightMode> fillLightMode;
+    std::optional<double> imageHeight;
+    std::optional<double> imageWidth;
+    std::optional<bool> redEyeReduction;
+};
+
 header: <WebCore/RealtimeMediaSource.h>
 [CustomHeader] struct WebCore::PhotoCapabilitiesOrError {
     std::optional<WebCore::PhotoCapabilities> capabilities;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -98,7 +98,10 @@ private:
     void setIsInBackground(WebCore::RealtimeMediaSourceIdentifier, bool);
 
     using GetPhotoCapabilitiesCallback = CompletionHandler<void(WebCore::PhotoCapabilitiesOrError&&)>;
-    void getPhotoCapabilities(WebCore::RealtimeMediaSourceIdentifier, GetPhotoCapabilitiesCallback&& handler);
+    void getPhotoCapabilities(WebCore::RealtimeMediaSourceIdentifier, GetPhotoCapabilitiesCallback&&);
+
+    using GetPhotoSettingsCallback = CompletionHandler<void(Expected<WebCore::PhotoSettings, String>&&)>;
+    void getPhotoSettings(WebCore::RealtimeMediaSourceIdentifier, GetPhotoSettingsCallback&&);
 
     WebCore::CaptureSourceOrError createMicrophoneSource(const WebCore::CaptureDevice&, WebCore::MediaDeviceHashSalts&&, const WebCore::MediaConstraints*, WebCore::PageIdentifier);
     WebCore::CaptureSourceOrError createCameraSource(const WebCore::CaptureDevice&, WebCore::MediaDeviceHashSalts&&, WebCore::PageIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in
@@ -30,6 +30,7 @@ messages -> UserMediaCaptureManagerProxy NotRefCounted {
     RemoveSource(WebCore::RealtimeMediaSourceIdentifier id)
     ApplyConstraints(WebCore::RealtimeMediaSourceIdentifier id, struct WebCore::MediaConstraints constraints)
     GetPhotoCapabilities(WebCore::RealtimeMediaSourceIdentifier sourceID) -> (struct WebCore::PhotoCapabilitiesOrError result) Async
+    GetPhotoSettings(WebCore::RealtimeMediaSourceIdentifier sourceID) -> (Expected<WebCore::PhotoSettings, String> result) Async
     Clone(WebCore::RealtimeMediaSourceIdentifier clonedID, WebCore::RealtimeMediaSourceIdentifier cloneID, WebCore::PageIdentifier pageIdentifier)
     EndProducingData(WebCore::RealtimeMediaSourceIdentifier sourceID)
     SetShouldApplyRotation(WebCore::RealtimeMediaSourceIdentifier sourceID, bool shouldApplyRotation)

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -85,6 +85,11 @@ void RemoteRealtimeMediaSource::getPhotoCapabilities(PhotoCapabilitiesHandler&& 
     m_proxy.getPhotoCapabilities(WTFMove(callback));
 }
 
+Ref<RealtimeMediaSource::PhotoSettingsNativePromise> RemoteRealtimeMediaSource::getPhotoSettings()
+{
+    return m_proxy.getPhotoSettings();
+}
+
 void RemoteRealtimeMediaSource::configurationChanged(String&& persistentID, WebCore::RealtimeMediaSourceSettings&& settings, WebCore::RealtimeMediaSourceCapabilities&& capabilities)
 {
     setPersistentId(WTFMove(persistentID));

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -74,6 +74,7 @@ protected:
     const WebCore::RealtimeMediaSourceSettings& settings() final { return m_settings; }
     const WebCore::RealtimeMediaSourceCapabilities& capabilities() final { return m_capabilities; }
     void getPhotoCapabilities(PhotoCapabilitiesHandler&&) final;
+    Ref<PhotoSettingsNativePromise> getPhotoSettings() final;
 
 private:
     // RealtimeMediaSource

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/RealtimeMediaSourceCenter.h>
 #include <WebCore/WebAudioBufferList.h>
+#include <wtf/NativePromise.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -115,6 +116,17 @@ void RemoteRealtimeMediaSourceProxy::applyConstraints(const MediaConstraints& co
 void RemoteRealtimeMediaSourceProxy::getPhotoCapabilities(WebCore::RealtimeMediaSource::PhotoCapabilitiesHandler&& handler)
 {
     m_connection->sendWithAsyncReply(Messages::UserMediaCaptureManagerProxy::GetPhotoCapabilities(identifier()), WTFMove(handler));
+}
+
+Ref<WebCore::RealtimeMediaSource::PhotoSettingsNativePromise> RemoteRealtimeMediaSourceProxy::getPhotoSettings()
+{
+    return m_connection->sendWithPromisedReply(Messages::UserMediaCaptureManagerProxy::GetPhotoSettings(identifier()))->whenSettled(RunLoop::main(), [](Messages::UserMediaCaptureManagerProxy::GetPhotoSettings::Promise::Result&& result) {
+
+        if (result)
+            return WebCore::RealtimeMediaSource::PhotoSettingsNativePromise::createAndSettle(WTFMove(result.value()));
+
+        return WebCore::RealtimeMediaSource::PhotoSettingsNativePromise::createAndReject(String("IPC Connection closed"_s));
+    });
 }
 
 void RemoteRealtimeMediaSourceProxy::applyConstraintsSucceeded()

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -74,6 +74,7 @@ public:
     void endProducingData();
     void applyConstraints(const WebCore::MediaConstraints&, WebCore::RealtimeMediaSource::ApplyConstraintsHandler&&);
     void getPhotoCapabilities(WebCore::RealtimeMediaSource::PhotoCapabilitiesHandler&&);
+    Ref<WebCore::RealtimeMediaSource::PhotoSettingsNativePromise> getPhotoSettings();
 
     void whenReady(CompletionHandler<void(WebCore::CaptureSourceError&&)>&&);
     void setAsReady();


### PR DESCRIPTION
#### e3abeffd3a45dc0db29736fb462089f85c906a00
<pre>
[MediaStream] Add support for ImageCapture.getPhotoSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=262466">https://bugs.webkit.org/show_bug.cgi?id=262466</a>
rdar://116322614

Reviewed by Youenn Fablet.

Add ImageCapture.getPhotoSettings and implement support in MockRealtimeVideoSource and
AVVideoCaptureSource.

* LayoutTests/fast/mediastream/image-capture-get-photo-settings-expected.txt: Added.
* LayoutTests/fast/mediastream/image-capture-get-photo-settings.html: Added.
* Source/WebCore/DerivedSources.make:

* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::getPhotoSettings):
* Source/WebCore/Modules/mediastream/ImageCapture.h:
* Source/WebCore/Modules/mediastream/ImageCapture.idl:

* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getPhotoSettings const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:

* Source/WebCore/Modules/mediastream/PhotoSettings.idl: Added.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::getPhotoSettings):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:

* Source/WebCore/platform/mediastream/PhotoSettings.h: Added.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::getPhotoSettings):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
(WebCore::PhotoSettingsOrError::PhotoSettingsOrError):
(WebCore::PhotoSettingsOrError::operator bool const):

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::toFillLightMode):
(WebCore::AVVideoCaptureSource::getPhotoSettings):

* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::getPhotoSettings):
(WebCore::MockRealtimeVideoSource::settingsDidChange):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::getPhotoSettings):
(WebKit::UserMediaCaptureManagerProxy::getPhotoSettings):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.messages.in:

* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::getPhotoSettings):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:

* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoSettings):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h:

Canonical link: <a href="https://commits.webkit.org/268945@main">https://commits.webkit.org/268945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e98e8e779ad2c39bfad3fad5154dd4ad94efa5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21649 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23819 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25389 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19314 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23320 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16879 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18944 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5058 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->