### PR TITLE
Make DebuggableInfoData use generated serialization

### DIFF
--- a/Source/WebCore/inspector/InspectorDebuggableType.h
+++ b/Source/WebCore/inspector/InspectorDebuggableType.h
@@ -36,18 +36,3 @@ enum class DebuggableType : uint8_t {
 };
 
 } // namespace Inspector
-
-namespace WTF {
-
-template<> struct EnumTraits<Inspector::DebuggableType> {
-    using values = EnumValues<
-    Inspector::DebuggableType,
-    Inspector::DebuggableType::ITML,
-    Inspector::DebuggableType::JavaScript,
-    Inspector::DebuggableType::Page,
-    Inspector::DebuggableType::ServiceWorker,
-    Inspector::DebuggableType::WebPage
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -369,6 +369,7 @@ set(WebKit_SERIALIZATION_IN_FILES
 
     Shared/BackgroundFetchState.serialization.in
     Shared/CallbackID.serialization.in
+    Shared/DebuggableInfoData.serialization.in
     Shared/DisplayListArgumentCoders.serialization.in
     Shared/EditingRange.serialization.in
     Shared/EditorState.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -186,6 +186,7 @@ $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
 $(PROJECT_DIR)/Shared/Databases/IndexedDB/WebIDBResult.serialization.in
+$(PROJECT_DIR)/Shared/DebuggableInfoData.serialization.in
 $(PROJECT_DIR)/Shared/DisplayListArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/EditingRange.serialization.in
 $(PROJECT_DIR)/Shared/EditorState.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -500,6 +500,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \
 	Shared/CallbackID.serialization.in \
 	Shared/BackgroundFetchState.serialization.in \
+	Shared/DebuggableInfoData.serialization.in \
 	Shared/DisplayListArgumentCoders.serialization.in \
 	Shared/EditingRange.serialization.in \
 	Shared/EditorState.serialization.in \

--- a/Source/WebKit/Shared/DebuggableInfoData.cpp
+++ b/Source/WebKit/Shared/DebuggableInfoData.cpp
@@ -42,49 +42,4 @@ DebuggableInfoData DebuggableInfoData::empty()
     };
 }
 
-void DebuggableInfoData::encode(IPC::Encoder& encoder) const
-{
-    encoder << debuggableType;
-    encoder << targetPlatformName;
-    encoder << targetBuildVersion;
-    encoder << targetProductVersion;
-    encoder << targetIsSimulator;
-}
-
-std::optional<DebuggableInfoData> DebuggableInfoData::decode(IPC::Decoder& decoder)
-{
-    std::optional<Inspector::DebuggableType> debuggableType;
-    decoder >> debuggableType;
-    if (!debuggableType)
-        return std::nullopt;
-
-    std::optional<String> targetPlatformName;
-    decoder >> targetPlatformName;
-    if (!targetPlatformName)
-        return std::nullopt;
-
-    std::optional<String> targetBuildVersion;
-    decoder >> targetBuildVersion;
-    if (!targetBuildVersion)
-        return std::nullopt;
-
-    std::optional<String> targetProductVersion;
-    decoder >> targetProductVersion;
-    if (!targetProductVersion)
-        return std::nullopt;
-
-    std::optional<bool> targetIsSimulator;
-    decoder >> targetIsSimulator;
-    if (!targetIsSimulator)
-        return std::nullopt;
-
-    return {{
-        *debuggableType,
-        *targetPlatformName,
-        *targetBuildVersion,
-        *targetProductVersion,
-        *targetIsSimulator
-    }};
-}
-
 } // namespace WebKit

--- a/Source/WebKit/Shared/DebuggableInfoData.h
+++ b/Source/WebKit/Shared/DebuggableInfoData.h
@@ -27,12 +27,6 @@
 
 #include <wtf/text/WTFString.h>
 
-
-namespace IPC {
-class Decoder;
-class Encoder;
-}
-
 namespace Inspector {
 enum class DebuggableType : uint8_t;
 }
@@ -47,9 +41,6 @@ struct DebuggableInfoData {
     bool targetIsSimulator { false };
 
     static DebuggableInfoData empty();
-
-    void encode(IPC::Encoder&) const;
-    static std::optional<DebuggableInfoData> decode(IPC::Decoder&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/DebuggableInfoData.serialization.in
+++ b/Source/WebKit/Shared/DebuggableInfoData.serialization.in
@@ -1,0 +1,37 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+enum class Inspector::DebuggableType : uint8_t {
+    ITML,
+    JavaScript,
+    Page,
+    ServiceWorker,
+    WebPage,
+}
+
+struct WebKit::DebuggableInfoData {
+    Inspector::DebuggableType debuggableType;
+    String targetPlatformName;
+    String targetBuildVersion;
+    String targetProductVersion;
+    bool targetIsSimulator;
+}


### PR DESCRIPTION
#### aa70b905fe20139ca6cc95de9101f698f1a2645f
<pre>
Make DebuggableInfoData use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262658">https://bugs.webkit.org/show_bug.cgi?id=262658</a>

Reviewed by Alex Christensen.

Use generated serializers for DebuggableInfoData.

* Source/WebCore/inspector/InspectorDebuggableType.h:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/DebuggableInfoData.cpp:
(WebKit::DebuggableInfoData::encode const): Deleted.
(WebKit::DebuggableInfoData::decode): Deleted.
* Source/WebKit/Shared/DebuggableInfoData.h:
* Source/WebKit/Shared/DebuggableInfoData.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/268896@main">https://commits.webkit.org/268896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf098f19e3bd2a86d2c3ef08571f72747e44a49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23693 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25290 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23204 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16791 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19015 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23333 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2595 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->