### PR TITLE
[PointerEvents] preventsCompatibilityMouseEvents is not being reset on Pointer[Up/Cancel] dispatch

### DIFF
--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -454,7 +454,8 @@ void PointerCaptureController::pointerEventWasDispatched(const PointerEvent& eve
     // override for the pointerId of the pointerup or pointercancel event that was just dispatched, and then run Process Pending
     // Pointer Capture steps to fire lostpointercapture if necessary.
     // https://w3c.github.io/pointerevents/#implicit-release-of-pointer-capture
-    if (event.type() == eventNames().pointerupEvent) {
+    if (event.type() == eventNames().pointerupEvent || event.type() == eventNames().pointercancelEvent) {
+        capturingData->preventsCompatibilityMouseEvents = false;
         capturingData->pendingTargetOverride = nullptr;
         processPendingPointerCapture(event.pointerId());
     }


### PR DESCRIPTION
#### f75162278f73eeaba5e511636367a411963a57c9
<pre>
[PointerEvents] preventsCompatibilityMouseEvents is not being reset on Pointer[Up/Cancel] dispatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=262661">https://bugs.webkit.org/show_bug.cgi?id=262661</a>
rdar://116490176

Reviewed by NOBODY (OOPS!).

The Pointer Events spec prescribes that upon dispatching a
pointerup/pointercancel event, the PREVENT MOUSE EVENT flag (i.e.
`preventsCompatibilityMouseEvents`) should be cleared. Not doing so
represents a tiny inconformity against the spec, which this commit
addresses.

* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::pointerEventWasDispatched):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f75162278f73eeaba5e511636367a411963a57c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21552 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20804 "Found 1 new test failure: pointerevents/mouse/compatibility-mouse-events-prevention-mouse-pressed.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23721 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18114 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19034 "Found 2 new test failures: imported/w3c/web-platform-tests/pointerevents/pointerevent_suppress_compat_events_on_click.html, imported/w3c/web-platform-tests/pointerevents/pointerevent_suppress_compat_events_on_drag_mouse.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25316 "Found 4 new test failures: imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_mouse-pointer-preventdefault.html, imported/w3c/web-platform-tests/pointerevents/pointerevent_suppress_compat_events_on_click.html, imported/w3c/web-platform-tests/pointerevents/pointerevent_suppress_compat_events_on_drag_mouse.html, pointerevents/mouse/compatibility-mouse-events-prevention-mouse-pressed.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19199 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19235 "Found 4 new test failures: imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_mouse-pointer-preventdefault.html, imported/w3c/web-platform-tests/pointerevents/pointerevent_suppress_compat_events_on_click.html, imported/w3c/web-platform-tests/pointerevents/pointerevent_suppress_compat_events_on_drag_mouse.html, pointerevents/mouse/compatibility-mouse-events-prevention-mouse-pressed.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19781 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16809 "Found 4 new test failures: imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_mouse-pointer-preventdefault.html, imported/w3c/web-platform-tests/pointerevents/pointerevent_suppress_compat_events_on_click.html, imported/w3c/web-platform-tests/pointerevents/pointerevent_suppress_compat_events_on_drag_mouse.html, pointerevents/mouse/compatibility-mouse-events-prevention-mouse-pressed.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->