### PR TITLE
Add support for startup and installed events for web extensions and

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -945,6 +945,7 @@ def headers_for_type(type):
         'WebKit::TapIdentifier': ['"IdentifierTypes.h"'],
         'WebKit::TextCheckerRequestID': ['"IdentifierTypes.h"'],
         'WebKit::WebEventType': ['"WebEvent.h"'],
+        'WebKit::WebExtensionContext::InstallReason': ['"WebExtensionContext.h"'],
         'WebKit::WebExtensionTab::ImageFormat': ['"WebExtensionTab.h"'],
         'WebKit::WebGPU::BindGroupDescriptor': ['"WebGPUBindGroupDescriptor.h"'],
         'WebKit::WebGPU::BindGroupEntry': ['"WebGPUBindGroupEntry.h"'],

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -172,6 +172,28 @@ void WebExtensionContext::runtimeConnectNative(const String& applicationID, WebE
     }).get()];
 }
 
+void WebExtensionContext::fireRuntimeStartupEventIfNeeded()
+{
+    // The background content is assumed to be loaded for this event.
+
+    RELEASE_LOG_DEBUG(Extensions, "Firing startup event");
+
+    constexpr auto type = WebExtensionEventListenerType::RuntimeOnStartup;
+    sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchRuntimeStartupEvent());
+}
+
+void WebExtensionContext::fireRuntimeInstalledEventIfNeeded()
+{
+    ASSERT(m_installReason != InstallReason::None);
+
+    // The background content is assumed to be loaded for this event.
+
+    RELEASE_LOG_DEBUG(Extensions, "Firing installed event");
+
+    constexpr auto type = WebExtensionEventListenerType::RuntimeOnInstalled;
+    sendToProcessesForEvent(type, Messages::WebExtensionContextProxy::DispatchRuntimeInstalledEvent(m_installReason, m_previousVersion));
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -54,7 +54,7 @@ namespace WebKit {
 
 String WebExtensionController::storageDirectory(WebExtensionContext& extensionContext) const
 {
-    if (m_configuration->storageIsPersistent() && extensionContext.storageIsPersistent())
+    if (m_configuration->storageIsPersistent() && extensionContext.hasCustomUniqueIdentifier())
         return FileSystem::pathByAppendingComponent(m_configuration->storageDirectory(), extensionContext.uniqueIdentifier());
     return nullString();
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -85,6 +85,7 @@ public:
     String storageDirectory(WebExtensionContext&) const;
 
     bool hasLoadedContexts() const { return !m_extensionContexts.isEmpty(); }
+    bool isFreshlyCreated() const { return m_freshlyCreated; }
 
     bool load(WebExtensionContext&, NSError ** = nullptr);
     bool unload(WebExtensionContext&, NSError ** = nullptr);
@@ -139,6 +140,7 @@ private:
     WebProcessPoolSet m_processPools;
     UserContentControllerProxySet m_userContentControllers;
     WebExtensionURLSchemeHandlerMap m_registeredSchemeHandlers;
+    bool m_freshlyCreated { true };
 };
 
 template<typename T>

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -79,13 +79,17 @@ public:
     RefPtr<WebExtensionAPIPort> connectNative(WebFrame*, JSContextRef, NSString *applicationID);
 
     WebExtensionAPIEvent& onConnect();
+    WebExtensionAPIEvent& onInstalled();
     WebExtensionAPIEvent& onMessage();
+    WebExtensionAPIEvent& onStartup();
 
 private:
     static bool parseConnectOptions(NSDictionary *, std::optional<String>& name, NSString *sourceKey, NSString **outExceptionString);
 
     RefPtr<WebExtensionAPIEvent> m_onConnect;
+    RefPtr<WebExtensionAPIEvent> m_onInstalled;
     RefPtr<WebExtensionAPIEvent> m_onMessage;
+    RefPtr<WebExtensionAPIEvent> m_onStartup;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
@@ -47,4 +47,7 @@
     readonly attribute WebExtensionAPIEvent onConnect;
     readonly attribute WebExtensionAPIEvent onMessage;
 
+    [MainWorldOnly] readonly attribute WebExtensionAPIEvent onStartup;
+    [MainWorldOnly] readonly attribute WebExtensionAPIEvent onInstalled;
+
 };

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -121,6 +121,8 @@ private:
     void internalDispatchRuntimeConnectEvent(WebCore::DOMWrapperWorld&, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
     void dispatchRuntimeMessageEvent(WebExtensionContentWorldType, const String& messageJSON, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(std::optional<String> replyJSON)>&&);
     void dispatchRuntimeConnectEvent(WebExtensionContentWorldType, WebExtensionPortChannelIdentifier, const String& name, std::optional<WebExtensionFrameIdentifier>, const WebExtensionMessageSenderParameters&, CompletionHandler<void(size_t firedEventCount)>&&);
+    void dispatchRuntimeInstalledEvent(WebExtensionContext::InstallReason, String previousVersion);
+    void dispatchRuntimeStartupEvent();
 
     // Tabs
     void dispatchTabsCreatedEvent(const WebExtensionTabParameters&);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -42,6 +42,8 @@ messages -> WebExtensionContextProxy {
     // Runtime
     DispatchRuntimeMessageEvent(WebKit::WebExtensionContentWorldType contentWorldType, String messageJSON, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (std::optional<String> replyJSON)
     DispatchRuntimeConnectEvent(WebKit::WebExtensionContentWorldType contentWorldType, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, std::optional<WebKit::WebExtensionFrameIdentifier> targetFrameIdentifier, struct WebKit::WebExtensionMessageSenderParameters senderParameters) -> (size_t firedEventCount)
+    DispatchRuntimeInstalledEvent(WebKit::WebExtensionContext::InstallReason installReason, String previousVersion)
+    DispatchRuntimeStartupEvent()
 
     // Tabs Events
     DispatchTabsCreatedEvent(WebKit::WebExtensionTabParameters tabParameters)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -60,6 +60,7 @@
 
 - (void)load;
 - (void)run;
+- (void)runForTimeInterval:(NSTimeInterval)interval;
 - (void)loadAndRun;
 - (void)done;
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -200,6 +200,17 @@
     TestWebKitAPI::Util::run(&_done);
 }
 
+- (void)runForTimeInterval:(NSTimeInterval)interval
+{
+    _done = false;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(interval * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        self->_done = true;
+    });
+
+    TestWebKitAPI::Util::run(&_done);
+}
+
 - (void)loadAndRun
 {
     [self load];


### PR DESCRIPTION
#### c3d35ed194578765a4a11e2f2b3d40acea5b6010
<pre>
Add support for startup and installed events for web extensions and
move Web Extension local storage (if base URL changed).
<a href="https://webkit.org/b/248889">https://webkit.org/b/248889</a>
<a href="https://webkit.org/b/248430">https://webkit.org/b/248430</a>
rdar://problem/105337393
rdar://problem/103261455

Reviewed by Brent Fulgham.

Added support for the runtime.onInstalled and runtime.onStartup events, as well as moving
the local storage if the base URL changes.

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::fireRuntimeStartupEventIfNeeded):
(WebKit::WebExtensionContext::fireRuntimeInstalledEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::currentState const):
(WebKit::WebExtensionContext::readStateFromStorage):
(WebKit::WebExtensionContext::moveLocalStorageIfNeeded):
(WebKit::WebExtensionContext::loadBackgroundWebViewDuringLoad):
(WebKit::WebExtensionContext::queueStartupAndInstallEventsForExtensionIfNecessary):
(WebKit::WebExtensionContext::loadBackgroundPageListenersFromStorage):
(WebKit::WebExtensionContext::saveBackgroundPageListenersToStorage):
(WebKit::WebExtensionContext::performTasksAfterBackgroundContentLoads):
(WebKit::WebExtensionContext::queueEventToFireAfterBackgroundContentLoads):
(WebKit::WebExtensionContext::loadBackgroundPageListenersVersionNumberFromStorage): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::storageDirectory const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::storageIsPersistent const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::WebExtensionController):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::isFreshlyCreated const):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::onInstalled):
(WebKit::WebExtensionAPIRuntime::onStartup):
(WebKit::toWebAPI):
(WebKit::WebExtensionContextProxy::dispatchRuntimeInstalledEvent):
(WebKit::WebExtensionContextProxy::dispatchRuntimeStartupEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager runForTimeInterval:]):

Canonical link: <a href="https://commits.webkit.org/268932@main">https://commits.webkit.org/268932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/758e0f4391c73f1169a239e8efb07de57f914dab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21109 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/22173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/22987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21349 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/24739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/21671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/22987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21333 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/24739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/22173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/23841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/21297 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/24739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/22173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/23841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/24739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/22173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/23841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/21671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/19158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/22173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2607 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/19733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->