### PR TITLE
Save frameset resources to disk

### DIFF
--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -38,6 +38,7 @@
 #include "ElementInlines.h"
 #include "FrameLoader.h"
 #include "HTMLElement.h"
+#include "HTMLFrameElement.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLNames.h"
 #include "HTMLTemplateElement.h"
@@ -558,11 +559,11 @@ LocalFrame* MarkupAccumulator::frameForAttributeReplacement(const Element& eleme
         return nullptr;
 
     auto* currentElement = const_cast<Element*>(&element);
-    if (!is<HTMLIFrameElement>(currentElement))
+    if (!is<HTMLFrameElementBase>(currentElement))
         return nullptr;
 
-    auto& iframeElement = downcast<HTMLIFrameElement>(*currentElement);
-    return dynamicDowncast<LocalFrame>(iframeElement.contentFrame());
+    auto& frameElement = downcast<HTMLFrameElementBase>(*currentElement);
+    return dynamicDowncast<LocalFrame>(frameElement.contentFrame());
 }
 
 Attribute MarkupAccumulator::replaceAttributeIfNecessary(const Element& element, const Attribute& attribute)


### PR DESCRIPTION
#### 39c171e29d8e5b00086a7834b93784ca417bc955
<pre>
Save frameset resources to disk
<a href="https://bugs.webkit.org/show_bug.cgi?id=262666">https://bugs.webkit.org/show_bug.cgi?id=262666</a>
rdar://116492501

Reviewed by Ryosuke Niwa.

Add support for saving resources of frameset element to disk, like what we do for iframe element (268858@main).

Test: WebArchive.SaveResourcesFrame

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::frameForAttributeReplacement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/268937@main">https://commits.webkit.org/268937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b905082f5d642560d83889cf7b5874e9956759a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21080 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19612 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23816 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25383 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23330 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19133 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5054 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->