### PR TITLE
Follow up fix for 'selenium' version bump.

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py
@@ -73,7 +73,7 @@ AutoInstall.register(Package('redis', Version(3, 5, 3)))
 if sys.version_info < (3, 8):
     AutoInstall.register(Package('selenium', Version(3, 141, 0)))
 else:
-    AutoInstall.register(Package('selenium', Version(4, 12, 0)))
+    AutoInstall.register(Package('selenium', Version(4, 12, 0), wheel=True))
 AutoInstall.register(Package('service_identity', Version(21, 1, 0), pypi_name='service-identity'))
 AutoInstall.register(Package('sortedcontainers', Version(2, 4, 0)))
 AutoInstall.register(Package('tornado', Version(4, 5, 3)))

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -99,7 +99,7 @@ else:
 if sys.version_info < (3, 8):
     AutoInstall.register(Package('selenium', Version(3, 141, 0)))
 else:
-    AutoInstall.register(Package('selenium', Version(4, 12, 0)))
+    AutoInstall.register(Package('selenium', Version(4, 12, 0), wheel=True))
 
 AutoInstall.register(Package('toml', Version(0, 10, 1), implicit_deps=['pyparsing']))
 AutoInstall.register(Package('wcwidth', Version(0, 2, 5)))


### PR DESCRIPTION
#### e984700817499a22aa028f1c0564b313481fad0e
<pre>
Follow up fix for &apos;selenium&apos; version bump.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262669">https://bugs.webkit.org/show_bug.cgi?id=262669</a>
rdar://116428857

Reviewed by Jonathan Bedard.

This change fixes two bugs in order to use &apos;selenium==4.12.0&apos;.
First issue is that newer version of selenium need to be installed with &apos;wheel=True&apos;.
Second issue is autoinstalled uses ZipFile module to extract zipfile which does not
preserve file &apos;x&apos; permissions. Add code to preserve the file &apos;x&apos; permission during
zip and tar file extractions.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(Package.Archive.unpack):
* Tools/Scripts/webkitpy/__init__.py:

Canonical link: <a href="https://commits.webkit.org/268900@main">https://commits.webkit.org/268900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bafd21377665be854b89af4f8bd2483ba421f32a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22892 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21577 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23746 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/21199 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19050 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23259 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19796 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/20833 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19065 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5034 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->