### PR TITLE
Reduce use of Vector::uncheckedAppend() in Source/WebKit

### DIFF
--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -39,14 +39,11 @@ Ref<PipelineLayout> Device::createPipelineLayout(const WGPUPipelineLayoutDescrip
 
     std::optional<Vector<Ref<BindGroupLayout>>> optionalBindGroupLayouts = std::nullopt;
     if (descriptor.bindGroupLayouts) {
-        Vector<Ref<BindGroupLayout>> bindGroupLayouts;
-        bindGroupLayouts.reserveInitialCapacity(descriptor.bindGroupLayoutCount);
-        for (uint32_t i = 0; i < descriptor.bindGroupLayoutCount; ++i) {
+        Vector<Ref<BindGroupLayout>> bindGroupLayouts(descriptor.bindGroupLayoutCount, [&](size_t i) {
             auto* bindGroupLayout = descriptor.bindGroupLayouts[i];
-            bindGroupLayouts.uncheckedAppend(WebGPU::fromAPI(bindGroupLayout));
-        }
-
-        optionalBindGroupLayouts = bindGroupLayouts;
+            return Ref<BindGroupLayout> { WebGPU::fromAPI(bindGroupLayout) };
+        });
+        optionalBindGroupLayouts = WTFMove(bindGroupLayouts);
     }
 
     return PipelineLayout::create(WTFMove(optionalBindGroupLayouts), *this);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2896,15 +2896,14 @@ bool NetworkProcess::shouldDisableCORSForRequestTo(PageIdentifier pageIdentifier
 
 void NetworkProcess::setCORSDisablingPatterns(NetworkConnectionToWebProcess& connection, PageIdentifier pageIdentifier, Vector<String>&& patterns)
 {
-    Vector<UserContentURLPattern> parsedPatterns;
-    parsedPatterns.reserveInitialCapacity(patterns.size());
-    for (auto&& pattern : WTFMove(patterns)) {
+    auto parsedPatterns = WTF::compactMap(WTFMove(patterns), [&](auto&& pattern) -> std::optional<UserContentURLPattern> {
         UserContentURLPattern parsedPattern(WTFMove(pattern));
         if (parsedPattern.isValid()) {
             connection.originAccessPatterns().allowAccessTo(parsedPattern);
-            parsedPatterns.uncheckedAppend(WTFMove(parsedPattern));
+            return parsedPattern;
         }
-    }
+        return std::nullopt;
+    });
 
     parsedPatterns.shrinkToFit();
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -405,13 +405,9 @@ NSArray *toAPIArray(HashSet<String>& set)
 
 Vector<String> toImpl(NSArray *array)
 {
-    Vector<String> result;
-    result.reserveInitialCapacity(array.count);
-
-    for (NSString *element in array)
-        result.uncheckedAppend(element);
-
-    return result;
+    return Vector<String>(array.count, [array](size_t i) {
+        return (NSString *)array[i];
+    });
 }
 
 HashSet<String> toImplSet(NSArray *array)

--- a/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm
@@ -75,11 +75,9 @@ static FloatQuad floatQuad(VKQuad *quad)
 
 static Vector<FloatQuad> floatQuads(NSArray<VKQuad *> *vkQuads)
 {
-    Vector<FloatQuad> quads;
-    quads.reserveInitialCapacity(vkQuads.count);
-    for (VKQuad *vkQuad in vkQuads)
-        quads.uncheckedAppend(floatQuad(vkQuad));
-    return quads;
+    return Vector<FloatQuad>(vkQuads.count, [vkQuads](size_t i) {
+        return floatQuad(vkQuads[i]);
+    });
 }
 
 TextRecognitionResult makeTextRecognitionResult(CocoaImageAnalysis *analysis)

--- a/Source/WebKit/Shared/API/c/WKArray.cpp
+++ b/Source/WebKit/Shared/API/c/WKArray.cpp
@@ -36,23 +36,17 @@ WKTypeID WKArrayGetTypeID()
 
 WKArrayRef WKArrayCreate(WKTypeRef* values, size_t numberOfValues)
 {
-    Vector<RefPtr<API::Object>> elements;
-    elements.reserveInitialCapacity(numberOfValues);
-
-    for (size_t i = 0; i < numberOfValues; ++i)
-        elements.uncheckedAppend(WebKit::toImpl(values[i]));
-
+    Vector<RefPtr<API::Object>> elements(numberOfValues, [values](size_t i) -> RefPtr<API::Object> {
+        return WebKit::toImpl(values[i]);
+    });
     return WebKit::toAPI(&API::Array::create(WTFMove(elements)).leakRef());
 }
 
 WKArrayRef WKArrayCreateAdoptingValues(WKTypeRef* values, size_t numberOfValues)
 {
-    Vector<RefPtr<API::Object>> elements;
-    elements.reserveInitialCapacity(numberOfValues);
-
-    for (size_t i = 0; i < numberOfValues; ++i)
-        elements.uncheckedAppend(adoptRef(WebKit::toImpl(values[i])));
-
+    Vector<RefPtr<API::Object>> elements(numberOfValues, [values](size_t i) {
+        return adoptRef(WebKit::toImpl(values[i]));
+    });
     return WebKit::toAPI(&API::Array::create(WTFMove(elements)).leakRef());
 }
 

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -237,13 +237,11 @@ auto SandboxExtension::createHandle(StringView path, Type type) -> std::optional
 
 template<typename Collection, typename Function> static Vector<SandboxExtension::Handle> createHandlesForResources(const Collection& resources, const Function& createFunction)
 {
-    Vector<SandboxExtension::Handle> handleArray;
-    handleArray.reserveInitialCapacity(std::size(resources));
-    for (const auto& resource : resources) {
+    return WTF::compactMap(resources, [&](auto& resource) -> std::optional<SandboxExtension::Handle> {
         if (auto handle = createFunction(resource))
-            handleArray.uncheckedAppend(WTFMove(*handle));
-    }
-    return handleArray;
+            return WTFMove(*handle);
+        return std::nullopt;
+    });
 }
 
 auto SandboxExtension::createReadOnlyHandlesForFiles(ASCIILiteral logLabel, const Vector<String>& paths) -> Vector<Handle>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2363,9 +2363,7 @@ static WebCore::TextManipulationTokenIdentifier coreTextManipulationTokenIdentif
     for (_WKTextManipulationToken *wkToken in item.tokens)
         tokens.append(WebCore::TextManipulationToken { coreTextManipulationTokenIdentifierFromString(wkToken.identifier), wkToken.content, std::nullopt });
 
-    Vector<WebCore::TextManipulationItem> coreItems;
-    coreItems.reserveInitialCapacity(1);
-    coreItems.uncheckedAppend(WebCore::TextManipulationItem { identifiers->frameID, false, false, identifiers->itemID, WTFMove(tokens) });
+    Vector<WebCore::TextManipulationItem> coreItems({ WebCore::TextManipulationItem { identifiers->frameID, false, false, identifiers->itemID, WTFMove(tokens) } });
     _page->completeTextManipulation(coreItems, [capturedCompletionBlock = makeBlockPtr(completionHandler)] (bool allFailed, auto& failures) {
         capturedCompletionBlock(!allFailed && failures.isEmpty());
     });
@@ -2425,10 +2423,10 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
     Vector<WebCore::TextManipulationItem> coreItems;
     coreItems.reserveInitialCapacity(items.count);
     for (_WKTextManipulationItem *wkItem in items) {
-        Vector<WebCore::TextManipulationToken> coreTokens;
-        coreTokens.reserveInitialCapacity(wkItem.tokens.count);
-        for (_WKTextManipulationToken *wkToken in wkItem.tokens)
-            coreTokens.uncheckedAppend(WebCore::TextManipulationToken { coreTextManipulationTokenIdentifierFromString(wkToken.identifier), wkToken.content, std::nullopt });
+        Vector<WebCore::TextManipulationToken> coreTokens(wkItem.tokens.count, [&](size_t i) {
+            _WKTextManipulationToken *wkToken = wkItem.tokens[i];
+            return WebCore::TextManipulationToken { coreTextManipulationTokenIdentifierFromString(wkToken.identifier), wkToken.content, std::nullopt };
+        });
         auto identifiers = coreTextManipulationItemIdentifierFromString(wkItem.identifier);
         WebCore::FrameIdentifier frameID;
         WebCore::TextManipulationItemIdentifier itemID;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -394,10 +394,10 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (void)_setCustomHeaderFields:(NSArray<_WKCustomHeaderFields *> *)fields
 {
-    Vector<WebCore::CustomHeaderFields> vector;
-    vector.reserveInitialCapacity(fields.count);
-    for (_WKCustomHeaderFields *element in fields)
-        vector.uncheckedAppend(static_cast<API::CustomHeaderFields&>([element _apiObject]).coreFields());
+    Vector<WebCore::CustomHeaderFields> vector(fields.count, [fields](size_t i) {
+        _WKCustomHeaderFields *element = fields[i];
+        return static_cast<API::CustomHeaderFields&>([element _apiObject]).coreFields();
+    });
     _websitePolicies->setCustomHeaderFields(WTFMove(vector));
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -721,10 +721,9 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 
 #if ENABLE(TRACKING_PREVENTION)
     _websiteDataStore->getAllStorageAccessEntries(webPageProxy->identifier(), [completionHandler = makeBlockPtr(completionHandler)](auto domains) {
-        Vector<RefPtr<API::Object>> apiDomains;
-        apiDomains.reserveInitialCapacity(domains.size());
-        for (auto& domain : domains)
-            apiDomains.uncheckedAppend(API::String::create(domain));
+        auto apiDomains = WTF::map(domains, [](auto& domain) -> RefPtr<API::Object> {
+            return API::String::create(domain);
+        });
         completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))));
     });
 #else
@@ -939,10 +938,9 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 {
 #if ENABLE(APP_BOUND_DOMAINS)
     _websiteDataStore->getAppBoundDomains([completionHandler = makeBlockPtr(completionHandler)](auto& domains) mutable {
-        Vector<RefPtr<API::Object>> apiDomains;
-        apiDomains.reserveInitialCapacity(domains.size());
-        for (auto& domain : domains)
-            apiDomains.uncheckedAppend(API::String::create(domain.string()));
+        auto apiDomains = WTF::map(domains, [](auto& domain) -> RefPtr<API::Object> {
+            return API::String::create(domain.string());
+        });
         completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))));
     });
 #else
@@ -954,10 +952,9 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 {
 #if ENABLE(APP_BOUND_DOMAINS)
     _websiteDataStore->getAppBoundSchemes([completionHandler = makeBlockPtr(completionHandler)](auto& schemes) mutable {
-        Vector<RefPtr<API::Object>> apiSchemes;
-        apiSchemes.reserveInitialCapacity(schemes.size());
-        for (auto& scheme : schemes)
-            apiSchemes.uncheckedAppend(API::String::create(scheme));
+        auto apiSchemes = WTF::map(schemes, [](auto& scheme) -> RefPtr<API::Object> {
+            return API::String::create(scheme);
+        });
         completionHandler(wrapper(API::Array::create(WTFMove(apiSchemes))));
     });
 #else

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -772,13 +772,10 @@ static WebCore::PublicKeyCredentialCreationOptions::UserEntity publicKeyCredenti
 
 static Vector<WebCore::PublicKeyCredentialCreationOptions::Parameters> publicKeyCredentialParameters(NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters)
 {
-    Vector<WebCore::PublicKeyCredentialCreationOptions::Parameters> result;
-    result.reserveInitialCapacity(publicKeyCredentialParamaters.count);
-
-    for (_WKPublicKeyCredentialParameters *param : publicKeyCredentialParamaters)
-        result.uncheckedAppend({ WebCore::PublicKeyCredentialType::PublicKey, param.algorithm.longLongValue });
-
-    return result;
+    return Vector<WebCore::PublicKeyCredentialCreationOptions::Parameters>(publicKeyCredentialParamaters.count, [publicKeyCredentialParamaters](size_t i) {
+        _WKPublicKeyCredentialParameters *param = publicKeyCredentialParamaters[i];
+        return WebCore::PublicKeyCredentialCreationOptions::Parameters { WebCore::PublicKeyCredentialType::PublicKey, param.algorithm.longLongValue };
+    });
 }
 
 static WebCore::AuthenticatorTransport authenticatorTransport(_WKWebAuthenticationTransport transport)
@@ -803,24 +800,18 @@ static WebCore::AuthenticatorTransport authenticatorTransport(_WKWebAuthenticati
 
 static Vector<WebCore::AuthenticatorTransport> authenticatorTransports(NSArray<NSNumber *> *transports)
 {
-    Vector<WebCore::AuthenticatorTransport> result;
-    result.reserveInitialCapacity(transports.count);
-
-    for (NSNumber *transport : transports)
-        result.uncheckedAppend(authenticatorTransport((_WKWebAuthenticationTransport)transport.intValue));
-
-    return result;
+    return Vector<WebCore::AuthenticatorTransport>(transports.count, [transports](size_t i) {
+        NSNumber *transport = transports[i];
+        return authenticatorTransport((_WKWebAuthenticationTransport)transport.intValue);
+    });
 }
 
 static Vector<WebCore::PublicKeyCredentialDescriptor> publicKeyCredentialDescriptors(NSArray<_WKPublicKeyCredentialDescriptor *> *credentials)
 {
-    Vector<WebCore::PublicKeyCredentialDescriptor> result;
-    result.reserveInitialCapacity(credentials.count);
-
-    for (_WKPublicKeyCredentialDescriptor *credential : credentials)
-        result.uncheckedAppend({ WebCore::PublicKeyCredentialType::PublicKey, WebCore::toBufferSource(credential.identifier), authenticatorTransports(credential.transports) });
-
-    return result;
+    return Vector<WebCore::PublicKeyCredentialDescriptor>(credentials.count, [credentials](size_t i) {
+        _WKPublicKeyCredentialDescriptor *credential = credentials[i];
+        return WebCore::PublicKeyCredentialDescriptor { WebCore::PublicKeyCredentialType::PublicKey, WebCore::toBufferSource(credential.identifier), authenticatorTransports(credential.transports) };
+    });
 }
 
 static std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment(_WKAuthenticatorAttachment attachment)

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -73,11 +73,9 @@ static const char* toString(const SOAuthorizationSession::InitiatingAction& acti
 
 static Vector<WebCore::Cookie> toCookieVector(NSArray<NSHTTPCookie *> *cookies)
 {
-    Vector<WebCore::Cookie> result;
-    result.reserveInitialCapacity(cookies.count);
-    for (id cookie in cookies)
-        result.uncheckedAppend(cookie);
-    return result;
+    return Vector<WebCore::Cookie>(cookies.count, [cookies](size_t i) {
+        return WebCore::Cookie { cookies[i] };
+    });
 }
 
 static bool isSameOrigin(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response)

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -197,10 +197,9 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
 
 - (void)contactPicker:(CNContactPickerViewController *)picker didSelectContacts:(NSArray<CNContact*> *)contacts
 {
-    Vector<WebCore::ContactInfo> info;
-    info.reserveInitialCapacity(contacts.count);
-    for (CNContact *contact in contacts)
-        info.uncheckedAppend([self _contactInfoFromCNContact:contact]);
+    Vector<WebCore::ContactInfo> info(contacts.count, [&](size_t i) {
+        return WebCore::ContactInfo { [self _contactInfoFromCNContact:contacts[i]] };
+    });
     [self _contactPickerDidDismissWithContactInfo:WTFMove(info)];
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
@@ -61,11 +61,9 @@ void WebExtensionContext::alarmsClear(const String& name, CompletionHandler<void
 
 void WebExtensionContext::alarmsGetAll(CompletionHandler<void(Vector<WebExtensionAlarmParameters>&&)>&& completionHandler)
 {
-    Vector<WebExtensionAlarmParameters> alarms;
-    alarms.reserveInitialCapacity(m_alarmMap.size());
-
-    for (auto& alarm : m_alarmMap.values())
-        alarms.uncheckedAppend(alarm->parameters());
+    auto alarms = WTF::map(m_alarmMap.values(), [](auto&& alarm) {
+        return alarm->parameters();
+    });
 
     completionHandler(WTFMove(alarms));
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1314,15 +1314,11 @@ void WebExtensionContext::populateWindowsAndTabs()
 
 WebExtensionContext::WindowVector WebExtensionContext::openWindows() const
 {
-    WindowVector result;
-    result.reserveInitialCapacity(m_openWindowIdentifiers.size());
-
-    for (auto& identifier : m_openWindowIdentifiers) {
+    return WTF::compactMap(m_openWindowIdentifiers, [&](auto& identifier) -> RefPtr<WebExtensionWindow> {
         if (auto window = m_windowMap.get(identifier))
-            result.uncheckedAppend(*window);
-    }
-
-    return result;
+            return window;
+        return nullptr;
+    });
 }
 
 RefPtr<WebExtensionWindow> WebExtensionContext::focusedWindow()

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -77,10 +77,9 @@ WebExtensionWindowParameters WebExtensionWindow::parameters(PopulateTabs populat
 
     if (populate == PopulateTabs::Yes) {
         auto tabs = this->tabs();
-        tabParameters.reserveInitialCapacity(tabs.size());
-
-        for (auto& tab : tabs)
-            tabParameters.uncheckedAppend(tab->parameters());
+        tabParameters = WTF::map(tabs, [](auto& tab) {
+            return tab->parameters();
+        });
     }
 
     auto frame = this->normalizedFrame();

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -314,14 +314,9 @@ static Vector<WebCore::SecurityOriginData> apiArrayToSecurityOrigins(API::Array*
     if (!origins)
         return { };
 
-    Vector<WebCore::SecurityOriginData> securityOrigins;
-    size_t size = origins->size();
-    securityOrigins.reserveInitialCapacity(size);
-
-    for (size_t i = 0; i < size; ++i)
-        securityOrigins.uncheckedAppend(origins->at<API::SecurityOrigin>(i)->securityOrigin());
-
-    return securityOrigins;
+    return Vector<WebCore::SecurityOriginData>(origins->size(), [origins](size_t i) {
+        return origins->at<API::SecurityOrigin>(i)->securityOrigin();
+    });
 }
 
 static Vector<String> apiArrayToSecurityOriginStrings(API::Array* origins)
@@ -329,14 +324,9 @@ static Vector<String> apiArrayToSecurityOriginStrings(API::Array* origins)
     if (!origins)
         return { };
 
-    Vector<String> originStrings;
-    size_t size = origins->size();
-    originStrings.reserveInitialCapacity(size);
-
-    for (size_t i = 0; i < size; ++i)
-        originStrings.uncheckedAppend(origins->at<API::SecurityOrigin>(i)->securityOrigin().toString());
-
-    return originStrings;
+    return Vector<String>(origins->size(), [origins](size_t i) {
+        return origins->at<API::SecurityOrigin>(i)->securityOrigin().toString();
+    });
 }
 
 void WebNotificationManagerProxy::providerDidUpdateNotificationPolicy(const API::SecurityOrigin* origin, bool enabled)

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -446,15 +446,11 @@ void WebBackForwardList::restoreFromState(BackForwardListState backForwardListSt
 
 Vector<BackForwardListItemState> WebBackForwardList::filteredItemStates(Function<bool(WebBackForwardListItem&)>&& functor) const
 {
-    Vector<BackForwardListItemState> itemStates;
-    itemStates.reserveInitialCapacity(m_entries.size());
-
-    for (const auto& entry : m_entries) {
+    return WTF::compactMap(m_entries, [&](auto& entry) -> std::optional<BackForwardListItemState> {
         if (functor(entry))
-            itemStates.uncheckedAppend(entry->itemState());
-    }
-
-    return itemStates;
+            return entry->itemState();
+        return std::nullopt;
+    });
 }
 
 Vector<BackForwardListItemState> WebBackForwardList::itemStates() const

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -648,9 +648,9 @@ void WebProcessPool::resolvePathsForSandboxExtensions()
 {
     m_resolvedPaths.injectedBundlePath = resolvePathForSandboxExtension(injectedBundlePath());
 
-    m_resolvedPaths.additionalWebProcessSandboxExtensionPaths.reserveCapacity(m_configuration->additionalReadAccessAllowedPaths().size());
-    for (const auto& path : m_configuration->additionalReadAccessAllowedPaths())
-        m_resolvedPaths.additionalWebProcessSandboxExtensionPaths.uncheckedAppend(resolvePathForSandboxExtension(path));
+    m_resolvedPaths.additionalWebProcessSandboxExtensionPaths = WTF::map(m_configuration->additionalReadAccessAllowedPaths(), [](auto& path) {
+        return resolvePathForSandboxExtension(path);
+    });
 
     platformResolvePathsForSandboxExtensions();
 }

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.cpp
@@ -74,12 +74,11 @@ void WebURLSchemeHandler::stopAllTasksForPage(WebPageProxy& page, WebProcessProx
         return;
 
     auto& tasksByPage = iterator->value;
-    Vector<WebCore::ResourceLoaderIdentifier> taskIdentifiersToStop;
-    taskIdentifiersToStop.reserveInitialCapacity(tasksByPage.size());
-    for (auto taskIdentifier : tasksByPage) {
+    auto taskIdentifiersToStop = WTF::compactMap(tasksByPage, [&](auto& taskIdentifier) -> std::optional<WebCore::ResourceLoaderIdentifier> {
         if (!process || processForTaskIdentifier(page, taskIdentifier) == process)
-            taskIdentifiersToStop.uncheckedAppend(taskIdentifier);
-    }
+            return taskIdentifier;
+        return std::nullopt;
+    });
 
     for (auto& taskIdentifier : taskIdentifiersToStop)
         stopTask(page, taskIdentifier);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -863,9 +863,7 @@ void WebsiteDataStore::removeData(OptionSet<WebsiteDataType> dataTypes, const Ve
                 for (auto& hostName : dataRecord.HSTSCacheHostNames)
                     HSTSCacheHostNames.append(hostName);
 #if ENABLE(TRACKING_PREVENTION)
-                registrableDomains.reserveCapacity(registrableDomains.size() + dataRecord.resourceLoadStatisticsRegistrableDomains.size());
-                for (auto& registrableDomain : dataRecord.resourceLoadStatisticsRegistrableDomains)
-                    registrableDomains.uncheckedAppend(registrableDomain);
+                registrableDomains.appendRange(dataRecord.resourceLoadStatisticsRegistrableDomains.begin(), dataRecord.resourceLoadStatisticsRegistrableDomains.end());
 #endif
             }
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -80,14 +80,11 @@ static JSObjectRef toJSArray(JSContextRef context, const Vector<T>& data, JSValu
     if (data.isEmpty())
         return JSObjectMakeArray(context, 0, nullptr, exception);
 
-    Vector<JSValueRef, 8> convertedData;
-    convertedData.reserveCapacity(data.size());
-
-    for (auto& originalValue : data) {
+    auto convertedData = WTF::map<8>(data, [&](auto& originalValue) {
         JSValueRef convertedValue = converter(context, originalValue);
         JSValueProtect(context, convertedValue);
-        convertedData.uncheckedAppend(convertedValue);
-    }
+        return convertedValue;
+    });
 
     JSObjectRef array = JSObjectMakeArray(context, convertedData.size(), convertedData.data(), exception);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -208,15 +208,13 @@ void RemoteRenderPassEncoderProxy::endOcclusionQuery()
 
 void RemoteRenderPassEncoderProxy::executeBundles(Vector<std::reference_wrapper<WebCore::WebGPU::RenderBundle>>&& renderBundles)
 {
-    Vector<WebGPUIdentifier> convertedRenderBundles;
-    convertedRenderBundles.reserveInitialCapacity(renderBundles.size());
-    for (auto renderBundle : renderBundles) {
+    auto convertedRenderBundles = WTF::compactMap(renderBundles, [&](auto& renderBundle) -> std::optional<WebGPUIdentifier> {
         auto convertedRenderBundle = m_convertToBackingContext->convertToBacking(renderBundle);
         ASSERT(convertedRenderBundle);
         if (!convertedRenderBundle)
-            return;
-        convertedRenderBundles.uncheckedAppend(convertedRenderBundle);
-    }
+            return std::nullopt;
+        return convertedRenderBundle;
+    });
 
     auto sendResult = send(Messages::RemoteRenderPassEncoder::ExecuteBundles(WTFMove(convertedRenderBundles)));
     UNUSED_VARIABLE(sendResult);

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -427,32 +427,32 @@ void SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegme
     segment.duration = segmentInfo.duration;
 
     m_prevTrackIdentifierMap.swap(m_trackIdentifierMap);
-    segment.audioTracks.reserveInitialCapacity(segmentInfo.audioTracks.size());
-    for (auto& audioTrack : segmentInfo.audioTracks) {
-        SourceBufferPrivateClient::InitializationSegment::AudioTrackInformation info;
-        info.track = m_mediaPlayerPrivate->audioTrackPrivateRemote(audioTrack.identifier);
-        info.description = RemoteMediaDescription::create(audioTrack.description);
-        segment.audioTracks.uncheckedAppend(info);
+    segment.audioTracks = WTF::map(segmentInfo.audioTracks, [&](auto& audioTrack) {
+        SourceBufferPrivateClient::InitializationSegment::AudioTrackInformation info {
+            RemoteMediaDescription::create(audioTrack.description),
+            m_mediaPlayerPrivate->audioTrackPrivateRemote(audioTrack.identifier)
+        };
         m_trackIdentifierMap.add(info.track->id(), audioTrack.identifier);
-    }
+        return info;
+    });
 
-    segment.videoTracks.reserveInitialCapacity(segmentInfo.videoTracks.size());
-    for (auto& videoTrack : segmentInfo.videoTracks) {
-        SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation info;
-        info.track = m_mediaPlayerPrivate->videoTrackPrivateRemote(videoTrack.identifier);
-        info.description = RemoteMediaDescription::create(videoTrack.description);
-        segment.videoTracks.uncheckedAppend(info);
+    segment.videoTracks = WTF::map(segmentInfo.videoTracks, [&](auto& videoTrack) {
+        SourceBufferPrivateClient::InitializationSegment::VideoTrackInformation info {
+            RemoteMediaDescription::create(videoTrack.description),
+            m_mediaPlayerPrivate->videoTrackPrivateRemote(videoTrack.identifier)
+        };
         m_trackIdentifierMap.add(info.track->id(), videoTrack.identifier);
-    }
+        return info;
+    });
 
-    segment.textTracks.reserveInitialCapacity(segmentInfo.textTracks.size());
-    for (auto& textTrack : segmentInfo.textTracks) {
-        SourceBufferPrivateClient::InitializationSegment::TextTrackInformation info;
-        info.track = m_mediaPlayerPrivate->textTrackPrivateRemote(textTrack.identifier);
-        info.description = RemoteMediaDescription::create(textTrack.description);
-        segment.textTracks.uncheckedAppend(info);
+    segment.textTracks = WTF::map(segmentInfo.textTracks, [&](auto& textTrack) {
+        SourceBufferPrivateClient::InitializationSegment::TextTrackInformation info {
+            RemoteMediaDescription::create(textTrack.description),
+            m_mediaPlayerPrivate->textTrackPrivateRemote(textTrack.identifier)
+        };
         m_trackIdentifierMap.add(info.track->id(), textTrack.identifier);
-    }
+        return info;
+    });
 
     m_client->sourceBufferPrivateDidReceiveInitializationSegment(WTFMove(segment), WTFMove(completionHandler));
 }


### PR DESCRIPTION
#### 0b86d6fe93fb09acdf376295705fda5e709051ab
<pre>
Reduce use of Vector::uncheckedAppend() in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=262674">https://bugs.webkit.org/show_bug.cgi?id=262674</a>

Reviewed by Timothy Hatcher.

Reduce use of Vector::uncheckedAppend() in Source/WebKit and use faster
alternatives now that uncheckedAppend() is an alias to append().

* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::Device::createPipelineLayout):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setCORSDisablingPatterns):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::Storage::remove):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::CacheStorageDiskStore::readAllRecordInfos):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::createResolver):
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::toImpl):
* Source/WebKit/Platform/cocoa/ImageAnalysisUtilities.mm:
(WebKit::floatQuads):
* Source/WebKit/Shared/API/c/WKArray.cpp:
(WKArrayCreate):
(WKArrayCreateAdoptingValues):
* Source/WebKit/Shared/APIWebArchive.mm:
(API::WebArchive::WebArchive):
(API::WebArchive::subresources):
(API::WebArchive::subframeArchives):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::createHandlesForResources):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _completeTextManipulation:completion:]):
(-[WKWebView _completeTextManipulationForItems:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setCustomHeaderFields:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _getAllStorageAccessEntriesFor:completionHandler:]):
(-[WKWebsiteDataStore _appBoundDomains:]):
(-[WKWebsiteDataStore _appBoundSchemes:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(publicKeyCredentialParameters):
(authenticatorTransports):
(publicKeyCredentialDescriptors):
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
(WebKit::SimulatedInputKeyFrame::keyFrameFromStateOfInputSources):
(WebKit::SimulatedInputKeyFrame::keyFrameToResetInputSources):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker contactPicker:didSelectContacts:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm:
(WebKit::WebExtensionContext::alarmsGetAll):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::openWindows const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::parameters const):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::apiArrayToSecurityOrigins):
(WebKit::apiArrayToSecurityOriginStrings):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::filteredItemStates const):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::resolvePathsForSandboxExtensions):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
* Source/WebKit/UIProcess/WebURLSchemeHandler.cpp:
(WebKit::WebURLSchemeHandler::stopAllTasksForPage):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::removeData):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::toJSArray):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::submit):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::executeBundles):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateDidReceiveInitializationSegment):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::dictationAlternativesAtSelection):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::parseAndAllowAccessToCORSDisablingPatterns):

Canonical link: <a href="https://commits.webkit.org/268921@main">https://commits.webkit.org/268921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a73a2776c4695d00cdd563707d8cdc76bc7e198e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19542 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20812 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23739 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18128 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25323 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23250 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16817 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19058 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5047 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->