### PR TITLE
Add categories and shortcuts to _WKApplicationManifest

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -57,6 +57,12 @@ struct ApplicationManifest {
         OptionSet<Purpose> purposes;
     };
 
+    struct Shortcut {
+        String name;
+        URL url;
+        Vector<Icon> icons;
+    };
+
     String rawJSON;
     String name;
     String shortName;
@@ -70,7 +76,9 @@ struct ApplicationManifest {
     URL id;
     Color backgroundColor;
     Color themeColor;
+    Vector<String> categories;
     Vector<Icon> icons;
+    Vector<Shortcut> shortcuts;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -52,7 +52,9 @@ private:
     String parseDescription(const JSON::Object&);
     String parseShortName(const JSON::Object&);
     std::optional<URL> parseScope(const JSON::Object&, const URL&, const URL&);
+    Vector<String> parseCategories(const JSON::Object&);
     Vector<ApplicationManifest::Icon> parseIcons(const JSON::Object&);
+    Vector<ApplicationManifest::Shortcut> parseShortcuts(const JSON::Object&);
     URL parseId(const JSON::Object&, const URL&);
 
     Color parseColor(const JSON::Object&, const String& propertyName);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1243,6 +1243,12 @@ enum class WebCore::ScreenOrientationLockType : uint8_t {
     OptionSet<WebCore::ApplicationManifest::Icon::Purpose> purposes
 }
 
+[Nested] struct WebCore::ApplicationManifest::Shortcut {
+    String name
+    URL url
+    Vector<WebCore::ApplicationManifest::Icon> icons
+}
+
 struct WebCore::ApplicationManifest {
     String rawJSON
     String name
@@ -1257,7 +1263,9 @@ struct WebCore::ApplicationManifest {
     URL id
     WebCore::Color backgroundColor
     WebCore::Color themeColor
+    Vector<String> categories
     Vector<WebCore::ApplicationManifest::Icon> icons
+    Vector<WebCore::ApplicationManifest::Shortcut> shortcuts
 }
 #endif // ENABLE(APPLICATION_MANIFEST)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -32,6 +32,7 @@
 @class NSColor;
 #endif
 @class _WKApplicationManifestIcon;
+@class _WKApplicationManifestShortcut;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -72,7 +73,9 @@ WK_CLASS_AVAILABLE(macos(10.13.4), ios(11.3))
 @property (nonatomic, readonly, copy) NSURL *startURL;
 @property (nonatomic, readonly, copy) NSURL *manifestId WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic, readonly) _WKApplicationManifestDisplayMode displayMode;
+@property (nonatomic, readonly, copy) NSArray<NSString *> *categories WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestIcon *> *icons WK_API_AVAILABLE(macos(13.0), ios(16.0));
+@property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestShortcut *> *shortcuts WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly, nullable, copy) UIColor *backgroundColor WK_API_AVAILABLE(ios(17.0));
@@ -97,6 +100,15 @@ WK_CLASS_AVAILABLE(macos(13.0), ios(16.0))
 @property (nonatomic, readonly, copy) NSArray<NSString *> *sizes;
 @property (nonatomic, readonly, copy) NSString *type;
 @property (nonatomic, readonly) NSArray<NSNumber *> *purposes;
+
+@end
+
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@interface _WKApplicationManifestShortcut : NSObject <NSSecureCoding>
+
+@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy) NSURL *url;
+@property (nonatomic, readonly, copy) NSArray<_WKApplicationManifestIcon *> *icons;
 
 @end
 


### PR DESCRIPTION
#### a4ea62848c891ee3c0aaff18417e2cacfc3d064c
<pre>
Add categories and shortcuts to _WKApplicationManifest
<a href="https://bugs.webkit.org/show_bug.cgi?id=262654">https://bugs.webkit.org/show_bug.cgi?id=262654</a>
rdar://116486952

Reviewed by Wenson Hsieh, Sihui Liu and Chris Dumez.

Add two new properties, categories and shortcuts, to _WKApplicationManifest.
See rdar://116486952 for more detail.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
Add a new Shortcut struct that represents an individual shortcut, as well
as categories and shortcuts members on the manifest.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseManifest):
Parse the categories and shortcuts members of the manifest.

(WebCore::ApplicationManifestParser::parseCategories):
Parse categories by mapping its values into a vector of strings.

(WebCore::ApplicationManifestParser::parseShortcuts):
Parse shortcuts by mapping its values into a vector of shortcut items. For each
icon member inside each shortcut, use the existing parseIcons method to parse
them since they are in the same format as the top-level icons member.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
Header declaration for new methods that parse categories and shortcuts.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Serialize the parsed categories and shortcuts for XPC.

* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(makeVectorElement):
Method to convert an individual array element of _WKApplicationManifestShortcut
back into WebCore::ApplicationManifest::Shortcut. This is used when initializing
with coder. Remove the isKindOfClass check since dynamic_objc_cast already returns
nil if the class check fails.

(-[_WKApplicationManifestIcon initWithCoder:]):
(-[_WKApplicationManifestIcon initWithCoreIcon:]):
(-[_WKApplicationManifestIcon encodeWithCoder:]):
(-[_WKApplicationManifestIcon src]):
(-[_WKApplicationManifestIcon sizes]):
(-[_WKApplicationManifestIcon type]):
(-[_WKApplicationManifestIcon purposes]):
(-[_WKApplicationManifestIcon dealloc]):
Switch to using RetainPtr.

(+[_WKApplicationManifestShortcut supportsSecureCoding]):
Allow secure encoding of _WKApplicationManifestShortcut.

(-[_WKApplicationManifestShortcut initWithCoder:]):
Decode an encoded _WKApplicationManifestShortcut.

(-[_WKApplicationManifestShortcut name]):
(-[_WKApplicationManifestShortcut url]):
(-[_WKApplicationManifestShortcut icons]):
Getter for RetainPtr backed ivars.

(-[_WKApplicationManifestShortcut initWithCoreShortcut:]):
Initialize Obj-C wrapper object based on the WebCore shortcut object.

(-[_WKApplicationManifestShortcut encodeWithCoder:]):
Encode _WKApplicationManifestShortcut for on-disk persistence.

(-[_WKApplicationManifestShortcut dealloc]):
Deallocate _WKApplicationManifestShortcut.

(-[_WKApplicationManifest initWithCoder:]):
Decode categories and shortcuts.

(-[_WKApplicationManifest encodeWithCoder:]):
Encode categories and shortcuts.

(-[_WKApplicationManifest categories]):
Return categories as an array of NSString from the underlying manifest.

(-[_WKApplicationManifest shortcuts]):
Return shortcuts as an array of _WKApplicationManifestShortcut from the
underlying manifest.

* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(ApplicationManifestParserTest::parseShortcutFirstTopLevelProperty):
(ApplicationManifestParserTest::parseShortcutFirstTopLevelPropertyForURL):
Test whether shortcut property can be parsed correctly.

(ApplicationManifestParserTest::parseShortcutIconFirstTopLevelProperty):
(ApplicationManifestParserTest::parseShortcutIconFirstTopLevelPropertyForSrc):
Test whether an icon nested within a shortcut can be parsed correctly.

(ApplicationManifestParserTest::testCategories):
Test whether a set of categories can be parsed correctly.

(ApplicationManifestParserTest::testIconsSrc):
(ApplicationManifestParserTest::testIconsType):
(ApplicationManifestParserTest::testIconsSizes):
(ApplicationManifestParserTest::testIconsPurposes):
Update icon test methods to also test icons nested within shortcuts members.

(ApplicationManifestParserTest::testShortcutsURL):
(ApplicationManifestParserTest::testShortcutsName):
Test shortcuts url and name.

(TEST_F):
Run categories and shortcuts tests. Also make a drive-by test fix for Scope tests where
the expected isDefaultValue is incorrectly specified in the test file (the actual parsing
logic in ApplicationManifestParser for isDefaultValue is already correct).

Canonical link: <a href="https://commits.webkit.org/269021@main">https://commits.webkit.org/269021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c32a2323acb3d1698bae38257683cc81f0b0f53e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19772 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21880 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20983 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24032 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25665 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23506 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17045 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19330 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5109 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->