### PR TITLE
[WebXR] Rename XRDeviceInfo::features to XRDeviceInfo::vrFeatures

### DIFF
--- a/Source/WebKit/Shared/XR/XRDeviceInfo.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceInfo.cpp
@@ -34,7 +34,7 @@ namespace WebKit {
 
 void XRDeviceInfo::encode(IPC::Encoder& encoder) const
 {
-    encoder << identifier << supportsOrientationTracking << supportsStereoRendering << features << recommendedResolution;
+    encoder << identifier << supportsOrientationTracking << supportsStereoRendering << vrFeatures << recommendedResolution;
 }
 
 std::optional<XRDeviceInfo> XRDeviceInfo::decode(IPC::Decoder& decoder)
@@ -49,7 +49,7 @@ std::optional<XRDeviceInfo> XRDeviceInfo::decode(IPC::Decoder& decoder)
     if (!decoder.decode(deviceFeatures.supportsStereoRendering))
         return std::nullopt;
 
-    if (!decoder.decode(deviceFeatures.features))
+    if (!decoder.decode(deviceFeatures.vrFeatures))
         return std::nullopt;
 
     if (!decoder.decode(deviceFeatures.recommendedResolution))

--- a/Source/WebKit/Shared/XR/XRDeviceInfo.h
+++ b/Source/WebKit/Shared/XR/XRDeviceInfo.h
@@ -41,7 +41,7 @@ struct XRDeviceInfo {
     XRDeviceIdentifier identifier;
     bool supportsOrientationTracking { false };
     bool supportsStereoRendering { false };
-    PlatformXR::Device::FeatureList features;
+    PlatformXR::Device::FeatureList vrFeatures;
     WebCore::IntSize recommendedResolution { 0, 0 };
 
     void encode(IPC::Encoder&) const;

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -48,8 +48,8 @@ XRDeviceProxy::XRDeviceProxy(XRDeviceInfo&& deviceInfo, PlatformXRSystemProxy& x
     m_supportsStereoRendering = deviceInfo.supportsStereoRendering;
     m_supportsOrientationTracking = deviceInfo.supportsOrientationTracking;
     m_recommendedResolution = deviceInfo.recommendedResolution;
-    if (!deviceInfo.features.isEmpty())
-        setSupportedFeatures(SessionMode::ImmersiveVr, deviceInfo.features);
+    if (!deviceInfo.vrFeatures.isEmpty())
+        setSupportedFeatures(SessionMode::ImmersiveVr, deviceInfo.vrFeatures);
 }
 
 void XRDeviceProxy::sessionDidEnd()


### PR DESCRIPTION
#### 6edb28521a64317b8fb2da683f4d52feaeb21178
<pre>
[WebXR] Rename XRDeviceInfo::features to XRDeviceInfo::vrFeatures
<a href="https://bugs.webkit.org/show_bug.cgi?id=262676">https://bugs.webkit.org/show_bug.cgi?id=262676</a>
rdar://116503942

Reviewed by Dean Jackson.

Rename XRDeviceInfo::features to XRDeviceInfo::vrFeatures to better signify this
list represents the supported features for immersive-vr sessions.

* Source/WebKit/Shared/XR/XRDeviceInfo.cpp:
(WebKit::XRDeviceInfo::encode const):
(WebKit::XRDeviceInfo::decode):
* Source/WebKit/Shared/XR/XRDeviceInfo.h:
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::XRDeviceProxy):

Canonical link: <a href="https://commits.webkit.org/268907@main">https://commits.webkit.org/268907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb23af10cf1cdc54c0d0690223842bb34d9a3f35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19546 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21575 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23744 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18132 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25326 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23255 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19794 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19063 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5042 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->