### PR TITLE
Fix keyboard selection of RenderListBox in vertical writing mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS select[multiple][style="writing-mode: horizontal-tb"] supports keyboard navigation
+FAIL select[multiple][style="writing-mode: vertical-lr"] supports keyboard navigation assert_equals: expected "Option 2" but got "Option 1"
+FAIL select[multiple][style="writing-mode: vertical-rl"] supports keyboard navigation assert_equals: expected "Option 2" but got "Option 1"
+FAIL select[multiple][style="writing-mode: sideways-lr"] supports keyboard navigation assert_equals: expected "Option 2" but got "Option 1"
+FAIL select[multiple][style="writing-mode: sideways-rl"] supports keyboard navigation assert_equals: expected "Option 2" but got "Option 1"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#the-select-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test &lt;select&gt; multiple keyboard selection</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<select multiple size="4"></select>
+<script>
+const select = document.querySelector("select");
+for (let i = 0; i < 5; i++) {
+    const option = document.createElement("option");
+    option.textContent = `Option ${i + 1}`;
+    select.appendChild(option);
+}
+
+const arrow_left = "\uE012";
+const arrow_up = "\uE013";
+const arrow_right = "\uE014";
+const arrow_down = "\uE015";
+
+for (const writingMode of ["horizontal-tb", "vertical-lr", "vertical-rl", "sideways-lr", "sideways-rl"]) {
+    if (!CSS.supports(`writing-mode: ${writingMode}`))
+        continue;
+
+    const isHorizontal = writingMode === "horizontal-tb";
+    const isReversedBlockFlowDirection = writingMode.endsWith("-rl");
+    const scrollBlockAxis = isHorizontal ? "scrollTop" : "scrollLeft";
+
+    let nextKey = isHorizontal ? arrow_down : arrow_right;
+    let previousKey = isHorizontal ? arrow_up : arrow_left;
+
+    if (isReversedBlockFlowDirection) {
+        [nextKey, previousKey] = [previousKey, nextKey];
+    }
+
+    promise_test(async function() {
+        select.selectedIndex = 0;
+        select.style.writingMode = writingMode;
+        this.add_cleanup(() => {
+            select.scrollTop = 0;
+            select.scrollLeft = 0;
+            select.removeAttribute("style");
+        });
+
+        assert_equals(select.value, "Option 1");
+        assert_equals(select[scrollBlockAxis], 0);
+
+        select.focus();
+
+        assert_equals(document.activeElement, select);
+
+        await test_driver.send_keys(document.activeElement, previousKey);
+        assert_equals(select.value, "Option 1");
+        assert_equals(select[scrollBlockAxis], 0);
+
+        await test_driver.send_keys(document.activeElement, nextKey);
+        assert_equals(select.value, "Option 2");
+        assert_equals(select[scrollBlockAxis], 0);
+
+        for (let i = 0; i < select.size - 1; i++) {
+            await test_driver.send_keys(document.activeElement, nextKey);
+        }
+
+        assert_equals(select.value, "Option 5");
+
+        if (!isReversedBlockFlowDirection) {
+            assert_true(select[scrollBlockAxis] > 0);
+        } else {
+            assert_true(select[scrollBlockAxis] < 0);
+        }
+
+        await test_driver.send_keys(document.activeElement, previousKey);
+        assert_equals(select.value, "Option 4");
+
+        if (!isReversedBlockFlowDirection) {
+            assert_true(select[scrollBlockAxis] > 0);
+        } else {
+            assert_true(select[scrollBlockAxis] < 0);
+        }
+    }, `select[multiple][style="writing-mode: ${writingMode}"] supports keyboard navigation`);
+};
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3943,6 +3943,7 @@ imported/w3c/web-platform-tests/css/css-writing-modes/forms/color-input-appearan
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-options-visual-order.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional.html [ Failure ]
 fast/forms/select/multiselect-in-listbox-mouse-release-outside.html [ Skip ]
 
 # To investigate: might need to relax the tests, or adapt native thumb appearance.


### PR DESCRIPTION
#### 8b80fb7e578a41ef2510bc60c95b8e6543b93710
<pre>
Fix keyboard selection of RenderListBox in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=261804">https://bugs.webkit.org/show_bug.cgi?id=261804</a>
rdar://115766451

Reviewed by Wenson Hsieh.

In horizontal writing mode, the down and up arrow keys can be used to select the
next and previous option respectively. Adjust the arrow keys used for vertical
writing mode.

The added test will pass once &lt;select&gt; is enabled under the vertical form controls feature.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-keyboard-selection.optional.html: Added.
* LayoutTests/platform/ios/TestExpectations:

`RenderListBox` is not used on iOS.

* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::listBoxDefaultEventHandler):

`vertical-lr`: Right and left arrow keys can be used for next and previous respectively.
`vertical-rl`: Left and right arrow keys can be used for next and previous respectively.
Canonical link: <a href="https://commits.webkit.org/268926@main">https://commits.webkit.org/268926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2347ee34be055c74d1dd66000a62f6be6fc9e1e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21633 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23803 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25377 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23307 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16868 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18931 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23422 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2605 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->