### PR TITLE
Make KeypressCommand use generated serialization

### DIFF
--- a/Source/WebCore/platform/KeypressCommand.h
+++ b/Source/WebCore/platform/KeypressCommand.h
@@ -35,8 +35,19 @@ namespace WebCore {
 
 struct KeypressCommand {
     KeypressCommand() { }
-    explicit KeypressCommand(const String& commandName) : commandName(commandName) { ASSERT(isASCIILower(commandName[0U])); }
-    KeypressCommand(const String& commandName, const String& text) : commandName(commandName), text(text) { ASSERT(commandName == "insertText:"_s); }
+
+    explicit KeypressCommand(const String& commandName)
+        : commandName(commandName)
+    {
+        ASSERT(isASCIILower(commandName[0U]));
+    }
+
+    KeypressCommand(const String& commandName, const String& text)
+        : commandName(commandName)
+        , text(text)
+    {
+        ASSERT(commandName == "insertText:"_s || text.isEmpty());
+    }
 
     String commandName; // Actually, a selector name - it may have a trailing colon, and a name that can be different from an editor command name.
     String text;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -131,7 +131,6 @@ class SystemImage;
 
 struct CompositionUnderline;
 struct DataDetectorElementInfo;
-struct KeypressCommand;
 struct Length;
 struct SoupNetworkProxySettings;
 struct TextRecognitionDataDetector;
@@ -210,15 +209,6 @@ template<> struct ArgumentCoder<WebCore::ResourceError> {
     static void encodePlatformData(Encoder&, const WebCore::ResourceError&);
     static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::ResourceError&);
 };
-
-#if PLATFORM(COCOA)
-
-template<> struct ArgumentCoder<WebCore::KeypressCommand> {
-    static void encode(Encoder&, const WebCore::KeypressCommand&);
-    static std::optional<WebCore::KeypressCommand> decode(Decoder&);
-};
-
-#endif // PLATFORM(COCOA)
 
 #if USE(APPKIT)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6457,3 +6457,10 @@ header: <WebCore/GraphicsContextState.h>
 
     WebCore::GraphicsContextState::Purpose m_purpose;
 };
+
+#if PLATFORM(COCOA)
+struct WebCore::KeypressCommand {
+    String commandName;
+    String text;
+}
+#endif

--- a/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
+++ b/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
@@ -204,29 +204,6 @@ bool ArgumentCoder<WebCore::Credential>::decodePlatformData(Decoder& decoder, We
     return true;
 }
 
-void ArgumentCoder<WebCore::KeypressCommand>::encode(Encoder& encoder, const WebCore::KeypressCommand& keypressCommand)
-{
-    encoder << keypressCommand.commandName << keypressCommand.text;
-}
-    
-std::optional<WebCore::KeypressCommand> ArgumentCoder<WebCore::KeypressCommand>::decode(Decoder& decoder)
-{
-    std::optional<String> commandName;
-    decoder >> commandName;
-    if (!commandName)
-        return std::nullopt;
-    
-    std::optional<String> text;
-    decoder >> text;
-    if (!text)
-        return std::nullopt;
-    
-    WebCore::KeypressCommand command;
-    command.commandName = WTFMove(*commandName);
-    command.text = WTFMove(*text);
-    return WTFMove(command);
-}
-
 #if ENABLE(VIDEO)
 void ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::encodePlatformData(Encoder& encoder, const WebCore::SerializedPlatformDataCueValue& value)
 {


### PR DESCRIPTION
#### aa1397cc875c6b4ebe265cfe63372a44fc8ba3f5
<pre>
Make KeypressCommand use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262682">https://bugs.webkit.org/show_bug.cgi?id=262682</a>

Reviewed by Alex Christensen.

* Source/WebCore/platform/KeypressCommand.h:
(WebCore::KeypressCommand::KeypressCommand):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
(IPC::ArgumentCoder&lt;WebCore::KeypressCommand&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::KeypressCommand&gt;::decode): Deleted.

Canonical link: <a href="https://commits.webkit.org/269006@main">https://commits.webkit.org/269006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/311a9ae8a4e6a00ee13a6d7ac3abc50a6ca52ecf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20932 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23947 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25580 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23417 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16960 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23517 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2637 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->