### PR TITLE
AttachmentElement uses AppKit in WebContent process

### DIFF
--- a/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContext.h
+++ b/Source/WebCore/platform/cocoa/LocalCurrentGraphicsContext.h
@@ -46,19 +46,6 @@ private:
     bool m_didSetGraphicsContext { false };
 };
 
-class ContextContainer {
-    WTF_MAKE_NONCOPYABLE(ContextContainer);
-public:
-    ContextContainer(GraphicsContext& graphicsContext)
-        : m_graphicsContext(graphicsContext.platformContext())
-    {
-    }
-
-    CGContextRef context() { return m_graphicsContext; }
-private:
-    CGContextRef m_graphicsContext;
-};
-
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm
@@ -47,10 +47,6 @@
 #import <pal/spi/ios/UIKitSPI.h>
 #endif
 
-#if PLATFORM(MAC)
-#import "LocalCurrentGraphicsContext.h"
-#endif
-
 @class NSColor;
 
 // FIXME: More of this should use CoreGraphics instead of AppKit.

--- a/Source/WebCore/platform/graphics/mac/IconMac.mm
+++ b/Source/WebCore/platform/graphics/mac/IconMac.mm
@@ -25,7 +25,6 @@
 
 #import "GraphicsContext.h"
 #import "IntRect.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "UTIUtilities.h"
 #import <AVFoundation/AVFoundation.h>
 #import <wtf/RefPtr.h>

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -384,8 +384,7 @@ void ControlMac::drawListButton(GraphicsContext& context, const FloatRect& rect,
     if (!comboBoxImageBuffer)
         return;
 
-    ContextContainer cgContextContainer(comboBoxImageBuffer->context());
-    CGContextRef cgContext = cgContextContainer.context();
+    CGContextRef cgContext = comboBoxImageBuffer->context().platformContext();
 
     NSString *coreUIState;
     if (style.states.containsAny({ ControlStyle::State::Presenting, ControlStyle::State::ListButtonPressed }))

--- a/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm
@@ -31,7 +31,6 @@
 #import "ColorSpaceCG.h"
 #import "FloatRoundedRect.h"
 #import "GraphicsContext.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "MenuListButtonPart.h"
 
 namespace WebCore {
@@ -73,8 +72,7 @@ static void mainGradientInterpolate(void*, const CGFloat* inData, CGFloat* outDa
 
 static void drawMenuListBackground(GraphicsContext& context, const FloatRect& rect, const FloatRoundedRect& borderRect, const ControlStyle&)
 {
-    ContextContainer cgContextContainer(context);
-    CGContextRef cgContext = cgContextContainer.context();
+    CGContextRef cgContext = context.platformContext();
 
     const auto& radii = borderRect.radii();
     int radius = radii.topLeft().width();
@@ -103,7 +101,6 @@ static void drawMenuListBackground(GraphicsContext& context, const FloatRect& re
         GraphicsContextStateSaver stateSaver(context);
         CGContextClipToRect(cgContext, rect);
         context.clipRoundedRect(borderRect);
-        cgContext = cgContextContainer.context();
         CGContextDrawShading(cgContext, mainShading.get());
     }
 
@@ -111,7 +108,6 @@ static void drawMenuListBackground(GraphicsContext& context, const FloatRect& re
         GraphicsContextStateSaver stateSaver(context);
         CGContextClipToRect(cgContext, topGradient);
         context.clipRoundedRect(FloatRoundedRect(enclosingIntRect(topGradient), radii.topLeft(), radii.topRight(), { }, { }));
-        cgContext = cgContextContainer.context();
         CGContextDrawShading(cgContext, topShading.get());
     }
 
@@ -119,7 +115,6 @@ static void drawMenuListBackground(GraphicsContext& context, const FloatRect& re
         GraphicsContextStateSaver stateSaver(context);
         CGContextClipToRect(cgContext, bottomGradient);
         context.clipRoundedRect(FloatRoundedRect(enclosingIntRect(bottomGradient), { }, { }, radii.bottomLeft(), radii.bottomRight()));
-        cgContext = cgContextContainer.context();
         CGContextDrawShading(cgContext, bottomShading.get());
     }
 
@@ -127,7 +122,6 @@ static void drawMenuListBackground(GraphicsContext& context, const FloatRect& re
         GraphicsContextStateSaver stateSaver(context);
         CGContextClipToRect(cgContext, rect);
         context.clipRoundedRect(borderRect);
-        cgContext = cgContextContainer.context();
         CGContextDrawShading(cgContext, leftShading.get());
         CGContextDrawShading(cgContext, rightShading.get());
     }

--- a/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm
@@ -108,8 +108,7 @@ void ProgressBarMac::draw(GraphicsContext& context, const FloatRoundedRect& bord
     if (!imageBuffer)
         return;
 
-    ContextContainer cgContextContainer(imageBuffer->context());
-    CGContextRef cgContext = cgContextContainer.context();
+    CGContextRef cgContext = imageBuffer->context().platformContext();
 
     auto& progressBarPart = owningProgressBarPart();
     auto controlSize = controlSizeForFont(style);

--- a/Source/WebCore/platform/mac/ThemeMac.mm
+++ b/Source/WebCore/platform/mac/ThemeMac.mm
@@ -35,7 +35,6 @@
 #import "GraphicsContextCG.h"
 #import "ImageBuffer.h"
 #import "LengthSize.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "ScrollView.h"
 #import <pal/spi/cocoa/NSButtonCellSPI.h>

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -43,7 +43,6 @@
 #import "Icon.h"
 #import "Image.h"
 #import "ImageControlsButtonMac.h"
-#import "LocalCurrentGraphicsContext.h"
 #import "LocalDefaultSystemAppearance.h"
 #import "LocalFrame.h"
 #import "LocalFrameView.h"
@@ -1614,7 +1613,6 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
         progress = progressString.toFloat(&validProgress);
 
     GraphicsContext& context = paintInfo.context();
-    LocalCurrentGraphicsContext localContext(context);
     GraphicsContextStateSaver saver(context);
 
     context.translate(toFloatSize(paintRect.location()));


### PR DESCRIPTION
#### 62439d6ff75ce918cff1584fde18e920eaac4901
<pre>
AttachmentElement uses AppKit in WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=262684">https://bugs.webkit.org/show_bug.cgi?id=262684</a>
rdar://116509223

Reviewed by Aditya Keerthi.

* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::paintAttachment):

Attachment painting is implemented using GraphicsContext.
It should not set the AppKit NSGraphicsContext. If the rendering mode
is GPUP, the LocalCurrentGraphicsContext is no-op since the
context does not have a platform context.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextCocoa.mm:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::ControlMac::drawListButton):
* Source/WebCore/platform/graphics/mac/controls/MenuListButtonMac.mm:
(WebCore::drawMenuListBackground):
* Source/WebCore/platform/graphics/mac/controls/ProgressBarMac.mm:
(WebCore::ProgressBarMac::draw):

Remove use of ContextContainer, it is no-op code.
Replace with direct GraphicsContext::platformContext() call.

* Source/WebCore/platform/graphics/mac/IconMac.mm:
* Source/WebCore/platform/mac/ThemeMac.mm:

Remove unused LocalCurrentGraphicsContext.h include.

Canonical link: <a href="https://commits.webkit.org/268978@main">https://commits.webkit.org/268978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adf6e2230514c50718d8159ed1a545722cd2ba3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19556 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20823 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23756 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25337 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23266 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16829 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19075 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5081 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19649 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->