### PR TITLE
AttachmentElement cannot be tested with MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/mac/AppDelegate.m
+++ b/Tools/MiniBrowser/mac/AppDelegate.m
@@ -263,6 +263,9 @@ static NSNumber *_currentBadge;
 
     configuration.suppressesIncrementalRendering = _settingsController.incrementalRenderingSuppressed;
     configuration.websiteDataStore._resourceLoadStatisticsEnabled = _settingsController.resourceLoadStatisticsEnabled;
+    configuration._attachmentElementEnabled = _settingsController.attachmentElementEnabled != AttachmentElementEnabledStateDisabled ? YES : NO;
+    configuration._attachmentWideLayoutEnabled = _settingsController.attachmentElementEnabled == AttachmentElementEnabledStateWideLayoutEnabled ? YES : NO;
+
     return configuration;
 }
 

--- a/Tools/MiniBrowser/mac/SettingsController.h
+++ b/Tools/MiniBrowser/mac/SettingsController.h
@@ -27,6 +27,12 @@
 
 extern NSString * const kUserAgentChangedNotificationName;
 
+typedef NS_ENUM(NSInteger, AttachmentElementEnabledState) {
+    AttachmentElementEnabledStateDisabled = 0,
+    AttachmentElementEnabledStateEnabled,
+    AttachmentElementEnabledStateWideLayoutEnabled,
+};
+
 @interface SettingsController : NSObject
 
 - (instancetype)initWithMenu:(NSMenu *)menu;
@@ -55,6 +61,7 @@ extern NSString * const kUserAgentChangedNotificationName;
 @property (nonatomic, readonly) BOOL useSystemAppearance;
 @property (nonatomic, readonly) BOOL dataDetectorsEnabled;
 @property (nonatomic, readonly) BOOL useMockCaptureDevices;
+@property (nonatomic, readonly) AttachmentElementEnabledState attachmentElementEnabled;
 @property (nonatomic, readonly) BOOL loadsAllSiteIcons;
 @property (nonatomic, readonly) BOOL usesGameControllerFramework;
 @property (nonatomic, readonly) BOOL networkCacheSpeculativeRevalidationDisabled;

--- a/Tools/MiniBrowser/mac/SettingsController.m
+++ b/Tools/MiniBrowser/mac/SettingsController.m
@@ -67,6 +67,7 @@ static NSString * const PunchOutWhiteBackgroundsInDarkModePreferenceKey = @"Punc
 static NSString * const UseSystemAppearancePreferenceKey = @"UseSystemAppearance";
 static NSString * const DataDetectorsEnabledPreferenceKey = @"DataDetectorsEnabled";
 static NSString * const UseMockCaptureDevicesPreferenceKey = @"UseMockCaptureDevices";
+static NSString * const AttachmentElementEnabledPreferenceKey = @"AttachmentElementEnabled";
 
 // This default name intentionally overlaps with the key that WebKit2 checks when creating a view.
 static NSString * const UseRemoteLayerTreeDrawingAreaPreferenceKey = @"WebKit2UseRemoteLayerTreeDrawingArea";
@@ -80,6 +81,12 @@ typedef NS_ENUM(NSInteger, DebugOverylayMenuItemTag) {
     InteractionRegionOverlayTag,
     ExperimentalFeatureTag,
     InternalDebugFeatureTag,
+};
+
+typedef NS_ENUM(NSInteger, AttachmentElementEnabledMenuItemTag) {
+    AttachmentElementDisabledTag = 100,
+    AttachmentElementEnabledTag,
+    AttachmentElementWideLayoutEnabledTag,
 };
 
 @implementation SettingsController
@@ -98,7 +105,7 @@ typedef NS_ENUM(NSInteger, DebugOverylayMenuItemTag) {
         WebViewFillsWindowKey,
         ResourceLoadStatisticsEnabledPreferenceKey,
     ];
-    
+
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     for (NSString *prefName in onByDefaultPrefs) {
         if (![userDefaults objectForKey:prefName])
@@ -156,7 +163,7 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     __auto_type addSubmenu = ^(NSString *title) {
         return addSubmenuToMenu(menu, title);
     };
-    
+
     addItem(@"Use WebKit2 By Default", @selector(toggleUseWebKit2ByDefault:));
     addItem(@"Create Editor By Default", @selector(toggleCreateEditorByDefault:));
     addItem(@"Set Default URL to Current URL", @selector(setDefaultURLToCurrentURL:));
@@ -182,6 +189,11 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     addItem(@"Use System Appearance", @selector(toggleUseSystemAppearance:));
     addItem(@"Enable Data Detectors", @selector(toggleDataDetectorsEnabled:));
     addItem(@"Use Mock Capture Devices", @selector(toggleUseMockCaptureDevices:));
+
+    NSMenu *attachmentElementMenu = addSubmenu(@"Enable Attachment Element");
+    addItemToMenu(attachmentElementMenu, @"Disabled", @selector(changeAttachmentElementEnabled:), NO, AttachmentElementDisabledTag);
+    addItemToMenu(attachmentElementMenu, @"Enable with default layout", @selector(changeAttachmentElementEnabled:), NO, AttachmentElementEnabledTag);
+    addItemToMenu(attachmentElementMenu, @"Enable with wide layout", @selector(changeAttachmentElementEnabled:), NO, AttachmentElementWideLayoutEnabledTag);
 
     addSeparator();
     addItem(@"WebKit2-only Settings", nil);
@@ -315,7 +327,7 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
 
     for (NSDictionary *userAgentData in SettingsController.userAgentData) {
         NSString *name = userAgentData[@"label"];
-        
+
         if ([name isEqualToString:@"-"]) {
             addSeparator();
             continue;
@@ -392,7 +404,8 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
             [menuItem setState:isCurrentUA ? NSControlStateValueOn : NSControlStateValueOff];
         } else
             [menuItem setState:NSControlStateValueOff];
-    }
+    } else if (action == @selector(changeAttachmentElementEnabled:))
+        [menuItem setState:[self attachmentElementEnabled:menuItem] ? NSControlStateValueOn : NSControlStateValueOff];
 
     WKPreferences *defaultPreferences = [[NSApplication sharedApplication] browserAppDelegate].defaultPreferences;
     if (menuItem.tag == ExperimentalFeatureTag) {
@@ -796,8 +809,41 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     NSString *uaIdentifier = userAgentDict[@"identifier"];
     if (uaIdentifier)
         [[NSUserDefaults standardUserDefaults] setObject:uaIdentifier forKey:CustomUserAgentPreferenceKey];
-        
+
     [[NSNotificationCenter defaultCenter] postNotificationName:kUserAgentChangedNotificationName object:self];
+}
+
+- (AttachmentElementEnabledState)attachmentElementEnabled
+{
+    return (AttachmentElementEnabledState)[[NSUserDefaults standardUserDefaults] integerForKey:AttachmentElementEnabledPreferenceKey];
+}
+
+- (NSInteger)preferenceValueForAttachmentElementEnabledTag:(NSUInteger)tag
+{
+    switch (tag) {
+    case AttachmentElementDisabledTag:
+        return AttachmentElementEnabledStateDisabled;
+
+    case AttachmentElementEnabledTag:
+        return AttachmentElementEnabledStateEnabled;
+
+    case AttachmentElementWideLayoutEnabledTag:
+        return AttachmentElementEnabledStateWideLayoutEnabled;
+    }
+    return AttachmentElementEnabledStateDisabled;
+}
+
+- (BOOL)attachmentElementEnabled:(NSMenuItem *)menuItem
+{
+    NSInteger value = [[NSUserDefaults standardUserDefaults] integerForKey:AttachmentElementEnabledPreferenceKey];
+    return [self preferenceValueForAttachmentElementEnabledTag:[menuItem tag]] == value ? YES : NO;
+}
+
+- (void)changeAttachmentElementEnabled:(id)sender
+{
+    NSInteger value = [self preferenceValueForAttachmentElementEnabledTag:[sender tag]];
+    [[NSUserDefaults standardUserDefaults] setInteger:value forKey:AttachmentElementEnabledPreferenceKey];
+    [[[NSApplication sharedApplication] browserAppDelegate] didChangeSettings];
 }
 
 - (NSString *)defaultURL

--- a/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK1BrowserWindowController.m
@@ -63,6 +63,7 @@
     SettingsController *settingsController = [[NSApplication sharedApplication] browserAppDelegate].settingsController;
     if (settingsController.customUserAgent)
         _webView.customUserAgent = settingsController.customUserAgent;
+    [[WebPreferences standardPreferences] setAttachmentElementEnabled: settingsController.attachmentElementEnabled != AttachmentElementEnabledStateDisabled ? YES : NO];
 
     [self didChangeSettings];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(userAgentDidChange:) name:kUserAgentChangedNotificationName object:nil];


### PR DESCRIPTION
#### 238cf2fd98964b7cd12b04f476c6739c1f975d03
<pre>
AttachmentElement cannot be tested with MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=262686">https://bugs.webkit.org/show_bug.cgi?id=262686</a>
rdar://116509843

Reviewed by Aditya Keerthi.

Add a menu entry to enable AttachmentElement.
The setting takes place for new windows only.

* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate defaultConfiguration]):
* Tools/MiniBrowser/mac/SettingsController.h:
* Tools/MiniBrowser/mac/SettingsController.m:
(-[SettingsController _populateMenu:]):
(-[SettingsController validateMenuItem:]):
(-[SettingsController attachmentElementEnabled]):
(-[SettingsController preferenceValueForAttachmentElementEnabledTag:]):
(-[SettingsController attachmentElementEnabled:]):
(-[SettingsController changeAttachmentElementEnabled:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController didChangeSettings]):

Canonical link: <a href="https://commits.webkit.org/269071@main">https://commits.webkit.org/269071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f4f42baca409d93bd94d1363278433cec572335

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20827 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23762 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25344 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23273 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16835 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19081 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5139 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->