### PR TITLE
Terrible video quality when using TransformStream with Simulcast

### DIFF
--- a/LayoutTests/http/wpt/webrtc/video-script-transform-simulcast-expected.txt
+++ b/LayoutTests/http/wpt/webrtc/video-script-transform-simulcast-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS setup
+PASS videos are playing with the correct resolutions
+

--- a/LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html
+++ b/LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="/webrtc/third_party/sdp/sdp.js"></script>
+        <script src="/webrtc/simulcast/simulcast.js"></script>
+    </head>
+    <body>
+        <video id="videoL" controls autoplay playsInline></video>
+        <video id="videoM" controls autoplay playsInline></video>
+        <script>
+function waitForMessage(port, data)
+{
+    let gotMessage;
+    const promise = new Promise((resolve, reject) => {
+        gotMessage = resolve;
+        setTimeout(() => { reject("did not get " + data) }, 5000);
+    });
+    port.onmessage = event => {
+       if (event.data === data)
+           gotMessage();
+    };
+    return promise;
+}
+
+let worker;
+promise_test(async (test) => {
+    worker = new Worker('context-transform.js');
+    const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
+    assert_equals(data, "registered");
+
+    const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+
+    const senderChannel = new MessageChannel;
+    const receiverChannelL = new MessageChannel;
+    const receiverChannelM = new MessageChannel;
+    let sender, receiverM, receiverL;
+    const senderTransform = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'sender', port:senderChannel.port2}, [senderChannel.port2]);
+    const receiverTransformL = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'receiver', port:receiverChannelL.port2}, [receiverChannelL.port2]);
+    const receiverTransformM = new RTCRtpScriptTransform(worker, {name:'MockRTCRtpTransform', mediaType:'video', side:'receiver', port:receiverChannelM.port2}, [receiverChannelM.port2]);
+    senderTransform.port = senderChannel.port1;
+    receiverTransformL.port = receiverChannelL.port1;
+    receiverTransformM.port = receiverChannelM.port1;
+
+    const promise1 = waitForMessage(senderTransform.port, "started video sender");
+    const promise2 = waitForMessage(receiverTransformL.port, "started video receiver");
+    const promise3 = waitForMessage(receiverTransformM.port, "started video receiver");
+
+    await Promise.all([promise1, promise2, promise3]);
+
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    pc1.onicecandidate = e => {
+        const candidate = e.candidate;
+        if (!candidate)
+            return;
+        const newCandidate = { candidate: candidate.candidate, sdpMid: "l", sdpMLineIndex:candidate.sdpMLineIndex };
+        pc2.addIceCandidate(newCandidate);
+    }
+    pc2.onicecandidate = e => {
+        const candidate = e.candidate;
+        if (!candidate)
+            return;
+        const newCandidate = { candidate: candidate.candidate, sdpMid: "0", sdpMLineIndex:candidate.sdpMLineIndex };
+        pc1.addIceCandidate(newCandidate);
+    }
+
+    sender = pc1.addTransceiver("video", {sendEncodings: [{rid: "l", scaleResolutionDownBy: 2}, {rid: "m", scaleResolutionDownBy: 1}]}).sender;
+    sender.replaceTrack(localStream.getVideoTracks()[0]);
+    sender.setStreams(localStream);
+    sender.transform = senderTransform;
+
+    const streamPromise = new Promise((resolve, reject) => {
+        pc2.ontrack = (trackEvent) => {
+            if (!receiverL) {
+                receiverL = trackEvent.receiver;
+                receiverL.transform = receiverTransformL;
+                videoL.srcObject = trackEvent.streams[0];
+                return;
+            }
+
+            receiverM = trackEvent.receiver;
+            receiverM.transform = receiverTransformM;
+            videoM.srcObject = trackEvent.streams[0];
+            resolve();
+        };
+        setTimeout(() => reject("Getting stream timed out"), 5000);
+    });
+
+    const offer = await pc1.createOffer();
+    await pc1.setLocalDescription(offer);
+    await pc2.setRemoteDescription({
+        type: 'offer',
+        sdp: swapRidAndMidExtensionsInSimulcastOffer(offer, ["l", "m"]),
+    });
+    const answer = await pc2.createAnswer();
+    await pc2.setLocalDescription(answer);
+    await pc1.setRemoteDescription({
+        type: 'answer',
+        sdp: swapRidAndMidExtensionsInSimulcastAnswer(answer, pc1.localDescription, ["l", "m"]),
+    });
+
+    await streamPromise;
+}, "setup");
+
+async function waitForVideoSize(video, width, height)
+{
+    const max = 200
+    let counter = 0;
+    while (++counter < max && video.videoWidth != width && video.videoHeight != height)
+        await waitFor(50);
+
+    if (counter === max)
+        return Promise.reject("Video size not expected : " + video.videoWidth + " " + video.videoHeight);
+}
+
+promise_test(async () => {
+    await Promise.all([videoL.play(), videoM.play()]);
+    await waitForVideoSize(videoL, 320, 240);
+    await waitForVideoSize(videoM, 640, 480);
+}, "videos are playing with the correct resolutions");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1872,6 +1872,7 @@ webrtc/sframe-transform-buffer-source.html [ Skip ]
 webrtc/video-sframe.html [ Skip ]
 webkit.org/b/219825 webrtc/sframe-keys.html [ Skip ]
 webkit.org/b/229055 http/wpt/webrtc/sframe-transform-error.html [ Skip ]
+http/wpt/webrtc/video-script-transform-simulcast.html [ Skip ]
 
 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpTransceiver-headerExtensionControl.html [ Pass Failure ]
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.h
@@ -30,6 +30,7 @@
 #include "RTCRtpTransformBackend.h"
 #include <webrtc/api/scoped_refptr.h>
 #include <wtf/Lock.h>
+#include <wtf/StdUnorderedMap.h>
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -52,7 +53,9 @@ protected:
     MediaType mediaType() const final { return m_mediaType; }
 
 private:
-    void setOutputCallback(rtc::scoped_refptr<webrtc::TransformedFrameCallback>&&);
+    void sendFrameToOutput(std::unique_ptr<webrtc::TransformableFrameInterface>&&);
+    void addOutputCallback(rtc::scoped_refptr<webrtc::TransformedFrameCallback>&&, uint32_t ssrc);
+    void removeOutputCallback(uint32_t ssrc);
 
     // RTCRtpTransformBackend
     void processTransformedFrame(RTCRtpTransformableFrame&) final;
@@ -74,8 +77,8 @@ private:
     Lock m_inputCallbackLock;
     Callback m_inputCallback WTF_GUARDED_BY_LOCK(m_inputCallbackLock);
 
-    Lock m_outputCallbackLock;
-    rtc::scoped_refptr<webrtc::TransformedFrameCallback> m_outputCallback WTF_GUARDED_BY_LOCK(m_outputCallbackLock);
+    Lock m_outputCallbacksLock;
+    StdUnorderedMap<uint32_t, rtc::scoped_refptr<webrtc::TransformedFrameCallback>> m_outputCallbacks WTF_GUARDED_BY_LOCK(m_outputCallbacksLock);
 };
 
 inline LibWebRTCRtpTransformBackend::LibWebRTCRtpTransformBackend(MediaType mediaType, Side side)


### PR DESCRIPTION
#### 1fc26a73bcc7fe0b58abd15422048e7023650dcc
<pre>
Terrible video quality when using TransformStream with Simulcast
<a href="https://bugs.webkit.org/show_bug.cgi?id=257803">https://bugs.webkit.org/show_bug.cgi?id=257803</a>
rdar://110395571

Reviewed by Jean-Yves Avenard.

The libwebrtc backend provides one callback per ssrc generated by a sender.
In non simulcast cases, there is only one callback.
In simulcast case, there is one callback per simulcast encoding.
Before the patch, we would use one callback for all video encoded frames, thus sending all simulcast streams in the same ssrc.
This would confuse receivers and would lead to decoding failures, leading to sending PLI/FIR, thus leading to bad video quality.

We are now storing these callbacks in a map, and use the callback associated to the ssrc of the frame.
This allows to correctly send each simulcast stream with its associated ssrc.

Covered by added test case.

* LayoutTests/http/wpt/webrtc/video-script-transform-simulcast-expected.txt: Added.
* LayoutTests/http/wpt/webrtc/video-script-transform-simulcast.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.cpp:
(WebCore::LibWebRTCRtpTransformBackend::addOutputCallback):
(WebCore::LibWebRTCRtpTransformBackend::removeOutputCallback):
(WebCore::LibWebRTCRtpTransformBackend::sendFrameToOutput):
(WebCore::LibWebRTCRtpTransformBackend::processTransformedFrame):
(WebCore::LibWebRTCRtpTransformBackend::Transform):
(WebCore::LibWebRTCRtpTransformBackend::RegisterTransformedFrameCallback):
(WebCore::LibWebRTCRtpTransformBackend::RegisterTransformedFrameSinkCallback):
(WebCore::LibWebRTCRtpTransformBackend::UnregisterTransformedFrameCallback):
(WebCore::LibWebRTCRtpTransformBackend::UnregisterTransformedFrameSinkCallback):
(WebCore::LibWebRTCRtpTransformBackend::setOutputCallback): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformBackend.h:

Canonical link: <a href="https://commits.webkit.org/268912@main">https://commits.webkit.org/268912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e033a93240a954277a784f45689327a6c0f37acb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21588 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23757 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19062 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25341 "Found 1 new test failure: http/wpt/webrtc/video-script-transform-simulcast.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23270 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16831 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18894 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->