### PR TITLE
Add lockdown mode logging

### DIFF
--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -89,7 +89,7 @@ Ref<CSSFontFaceSrcResourceValue> CSSFontFaceSrcResourceValue::create(ResolvedURL
 std::unique_ptr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(ScriptExecutionContext& context, bool isInitiatingElementInUserAgentShadowTree)
 {
     if (m_cachedFont)
-        return makeUnique<CachedFontLoadRequest>(*m_cachedFont);
+        return makeUnique<CachedFontLoadRequest>(*m_cachedFont, context);
 
     bool isFormatSVG;
     if (m_format.isEmpty()) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3240,7 +3240,7 @@ void Document::implicitOpen()
 std::unique_ptr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
     auto* cachedFont = m_fontLoader->cachedFont(completeURL(url), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
-    return cachedFont ? makeUnique<CachedFontLoadRequest>(*cachedFont) : nullptr;
+    return cachedFont ? makeUnique<CachedFontLoadRequest>(*cachedFont, *this) : nullptr;
 }
 
 void Document::beginLoadingFontSoon(FontLoadRequest& request)

--- a/Source/WebCore/loader/cache/AllowedFonts.cpp
+++ b/Source/WebCore/loader/cache/AllowedFonts.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "AllowedFonts.h"
+#include "Logging.h"
 
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/NeverDestroyed.h>
@@ -851,7 +852,10 @@ bool isFontBinaryAllowed(const void* data, size_t size, DownloadableBinaryFontAl
         return false;
     case DownloadableBinaryFontAllowedTypes::Restricted: {
         auto sha = hashForFontData(data, size);
-        return allowedFontHashesInLockdownMode().contains(sha);
+        auto allowedFontHashes = allowedFontHashesInLockdownMode().contains(sha);
+        if (!allowedFontHashes)
+            RELEASE_LOG(Fonts, "[Lockdown Mode] A font with a forbidden type has been blocked.");
+        return allowedFontHashes;
     }
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -83,6 +83,8 @@ void CachedFont::finishLoading(const FragmentedSharedBuffer* data, const Network
     if (data) {
         auto dataContiguous = data->makeContiguous();
         if (!shouldAllowCustomFont(dataContiguous)) {
+            // fonts are blocked, we set a flag to signal it in CachedFontLoadRequest.h
+            m_didRefuseToLoadCustomFont = true;
             setErrorAndDeleteData();
             return;
         }

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -59,6 +59,8 @@ public:
 
     virtual RefPtr<Font> createFont(const FontDescription&, bool syntheticBold, bool syntheticItalic, const FontCreationContext&);
 
+    bool didRefuseToLoadCustomFont() const { return m_didRefuseToLoadCustomFont; }
+
 protected:
     FontPlatformData platformDataFromCustomData(const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
@@ -83,6 +85,8 @@ private:
 
     bool m_loadInitiated;
     bool m_hasCreatedFontDataWrappingResource;
+
+    bool m_didRefuseToLoadCustomFont { false };
 
     RefPtr<FontCustomPlatformData> m_fontCustomPlatformData;
 

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -31,6 +31,7 @@
 #include "CachedResourceHandle.h"
 #include "FontLoadRequest.h"
 #include "FontSelectionAlgorithm.h"
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 
@@ -39,8 +40,9 @@ class FontCreationContext;
 class CachedFontLoadRequest final : public FontLoadRequest, public CachedFontClient {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
-    CachedFontLoadRequest(CachedFont& font)
+    CachedFontLoadRequest(CachedFont& font, ScriptExecutionContext& context)
         : m_font(&font)
+        , m_context(context)
     {
     }
 
@@ -82,10 +84,16 @@ private:
         ASSERT_UNUSED(font, &font == m_font.get());
         if (m_fontLoadRequestClient)
             m_fontLoadRequestClient->fontLoaded(*this);
+
+        if (m_font->didRefuseToLoadCustomFont() && m_context) {
+            auto message = makeString("[Lockdown Mode] This font has been blocked: ", m_font->url().string());
+            m_context->addConsoleMessage(MessageSource::Security, MessageLevel::Info, message);
+        }
     }
 
     CachedResourceHandle<CachedFont> m_font;
     FontLoadRequestClient* m_fontLoadRequestClient { nullptr };
+    WeakPtr<ScriptExecutionContext> m_context;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 72d690ca074069922d8088c78ba5b2ab8fc9872e
<pre>
Add lockdown mode logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=262518">https://bugs.webkit.org/show_bug.cgi?id=262518</a>
rdar://114657783

Reviewed by Chris Dumez.

When activated Lockdown mode is reducing some of the features
accessible to a Webpage. This creates breakages which can be
sometimes a bit hard to identify. The goal of this change is
to improve the findability of the type of issues by adding logging
for engineers to understand what type of breakage is going on.

Currently we only target fonts which have not been loaded. It seems,
for now, these are the main source of breakage. We initially wanted
to log the URL of the fonts being logged in syslog, but this create
significant issues in terms of privacy, as it would share URLs which
will be private to the user context, such as intranet systems. Logging
the name of the fonts might also create issues with inline nameless
fonts and we would only know the name given to the font at the CSS
parsing time, as the blocked fonts are not being downloaded.

This also adds logging in the Web Inspector console for fonts URLs
being blocked by Lockdown mode. Being private to the user context,
this is helpful for the Web developer to determine what fonts are
missing and gives the opportunity for them to share at their will
the issue in a bug report.

We might, in the future, add more engineering logging for other
features.

If you need to learn more about lockdown mode, see
<a href="https://support.apple.com/en-us/HT212650">https://support.apple.com/en-us/HT212650</a>

* Source/WebCore/loader/cache/AllowedFonts.cpp:
(WebCore::isFontBinaryAllowed):
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::fontLoadRequest):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::fontLoadRequest):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::finishLoading):
* Source/WebCore/loader/cache/CachedFont.h:
(WebCore::CachedFont::didRefuseToLoadCustomFont const):
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:

Co-authored-by: Chris Dumez &lt;cdumez@apple.com&gt;
Co-authored-by: Brent Fulgham &lt;bfulgham@webkit.org&gt;
Canonical link: <a href="https://commits.webkit.org/269238@main">https://commits.webkit.org/269238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82beba7006691a1b55e6b3a9312c1ffb5c6ccfbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23820 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21397 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24672 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/22118 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26143 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19071 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24017 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21313 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20536 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17496 "Found 1 new test failure: js/for-in-to-text.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25356 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/21749 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19687 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5984 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5241 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24094 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26629 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20487 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5816 "Passed tests") | 
<!--EWS-Status-Bubble-End-->