### PR TITLE
uievents/mouse/cancel-mousedown-in-subframe.html WPT is failing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6239,7 +6239,6 @@ imported/w3c/web-platform-tests/streams/readable-byte-streams/general.any.worker
 imported/w3c/web-platform-tests/svg/animations/beginevents-1.html [ Skip ]
 imported/w3c/web-platform-tests/svg/linking/scripted/href-animate-element.html [ Skip ]
 imported/w3c/web-platform-tests/svg/linking/scripted/href-mpath-element.html [ Skip ]
-imported/w3c/web-platform-tests/uievents/mouse/cancel-mousedown-in-subframe.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/mouse/mouse_buttons_back_forward.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/order-of-events/focus-events/focus-management-expectations.html [ Skip ]
 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-before-xr-session.https.html [ Skip ]

--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame-expected.txt
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame-expected.txt
@@ -1,0 +1,4 @@
+This tests that dragging from an element that returns false from its mousedown handler will let the subsequent mousemove events be captured by the containing frame, and not by other frames.
+
+Drag Started
+PASS!

--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html
@@ -7,18 +7,16 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 
+var unexpectedMouseMove = false;
+var unexpectedMouseUp = false;
+
 function log(msg) {
     var msgNode = document.createTextNode(msg);
     var li = document.createElement("li");
     li.appendChild(msgNode);
-    document.getElementById("logElem").appendChild(li);
+    document.getElementById("log").appendChild(li);
 }
-function dragStarted() {
-    log("Drag Started");
-}
-window.onmouseup = function() {
-    log("Root frame received mouse up");
-}
+
 window.onload = function() {
     try {
         if (!frames[0] || !frames[0].document || !frames[0].document.getElementById("dragSource")) {
@@ -26,21 +24,27 @@ window.onload = function() {
         }
         
         if (!window.testRunner) {
-            log("This test needs to be run in DRT.  To test manually drag from the text 'Drag Me!' out into the parent frame.");
+            log("This test needs to be run in DRT.  To test manually drag from the text 'Drag Me!' out into the other frame.");
             return;
         }
+
         var dragSource = frames[0].document.getElementById("dragSource");
         var sourceFrame = document.getElementById("sourceFrame");
         var targetFrame = document.getElementById("targetFrame");
-        var x = dragSource.offsetLeft + sourceFrame.offsetLeft + 10;
-        var y = dragSource.offsetTop + sourceFrame.offsetTop + dragSource.offsetHeight / 2;
-        var x1 = targetFrame.offsetLeft + 10;
-        var y1 = targetFrame.offsetTop + 10;
-        eventSender.mouseMoveTo(x,y);
+        var startX = dragSource.offsetLeft + sourceFrame.offsetLeft + 10;
+        var startY = dragSource.offsetTop + sourceFrame.offsetTop + dragSource.offsetHeight / 2;
+        var endX = targetFrame.offsetLeft + 10;
+        var endY = targetFrame.offsetTop + 10;
+        eventSender.mouseMoveTo(startX, startY);
         eventSender.mouseDown();
-        eventSender.mouseMoveTo(x1, y1);
+        eventSender.mouseMoveTo(endX, endY);
         eventSender.mouseUp();
     } finally {
+        if (unexpectedMouseUp || unexpectedMouseMove)
+            log("FAIL! Received unexpected mouse event on other frame.");
+        else
+            log("PASS!");
+
         if (window.testRunner)
             testRunner.notifyDone();
     }
@@ -48,10 +52,10 @@ window.onload = function() {
 </script>
 </head>
 <body>
-    <div>This tests that dragging from an element that returns <emph>false</emph> from its mousedown handler will not let the subsequent mousemove events be captured by the containing frame, and allows the mouse move to get to other subframes.</div>
+    <div>This tests that dragging from an element that returns <emph>false</emph> from its mousedown handler will let the subsequent mousemove events be captured by the containing frame, and not by other frames.</div>
     <iframe id="sourceFrame" style="width: 100px; height: 50px;" src="resources/mouse-drag-from-frame-subframe.html"></iframe>
     <iframe id="targetFrame" style="width: 100px; height: 50px;" src="resources/mouse-drag-from-frame-target-subframe.html"></iframe>
-    <ul id="logElem">
+    <ul id="log">
     </ul>
 </body>
 </html>

--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame-expected.txt
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame-expected.txt
@@ -1,0 +1,7 @@
+This tests that dragging from an element that returns false from its mousedown handler will let the subsequent mousemove events be captured by the containing frame, and not by other frames.
+Drag Me!
+
+Drag started
+Root frame received mouse move
+Root frame received mouseup event
+PASS!

--- a/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html
+++ b/LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html
@@ -24,14 +24,10 @@ function dragStarted() {
     dragging = true;
 }
 
-window.onmousedown = function() {
-    log("Unexpected mousedown");
-}
-
 window.onmousemove = function() {
     if (!dragging || waitingForUp)
         return;
-    log("Received mouse move");
+    log("Root frame received mouse move");
     waitingForUp = true;
 }
 
@@ -40,27 +36,29 @@ window.onmouseup = function() {
         log("Unexpected mouseup");
         return;
     }
-    log("Received mouseup event")
+    log("Root frame received mouseup event");
     log("PASS!");
 }
 
 window.onload = function() {
     try {
-        if (!frames[0] || !frames[0].document || !frames[0].document.getElementById("dragSource")) {
+        if (!frames[0] || !frames[0].document) {
             log("Window.onload fired before subframe completed load.");
         }
         
         if (!window.testRunner) {
-            log("This test needs to be run in DRT.  To test manually drag from the text 'Drag Me!' out into the parent frame.");
+            log("This test needs to be run in DRT.  To test manually drag from the text 'Drag Me!' out into the child frame.");
             return;
         }
-        var dragSource = frames[0].document.getElementById("dragSource");
-        var sourceFrame = document.getElementById("sourceFrame");
-        var x = dragSource.offsetLeft + sourceFrame.offsetLeft + 10;
-        var y = dragSource.offsetTop + sourceFrame.offsetTop + dragSource.offsetHeight / 2;
-        eventSender.mouseMoveTo(x,y);
+        var dragSource = document.getElementById("dragSource");
+        var targetFrame = document.getElementById("targetFrame");
+        var startX = dragSource.offsetLeft + 10;
+        var startY = dragSource.offsetTop + dragSource.offsetHeight / 2;
+        var endX = targetFrame.offsetLeft + 10;
+        var endY = targetFrame.offsetTop + 10;
+        eventSender.mouseMoveTo(startX, startY);
         eventSender.mouseDown();
-        eventSender.mouseMoveTo(120, 120);
+        eventSender.mouseMoveTo(endX, endY);
         eventSender.mouseUp();
     } finally {
         if (window.testRunner)
@@ -70,8 +68,9 @@ window.onload = function() {
 </script>
 </head>
 <body>
-    <div>This tests that dragging from an element that returns <emph>false</emph> from its mousedown handler will not let the subsequent mousemove events be captured by the containing frame.</div>
-    <iframe id="sourceFrame" style="width: 100px; height: 50px;" src="resources/mouse-drag-from-frame-subframe.html"></iframe>
+    <div>This tests that dragging from an element that returns <emph>false</emph> from its mousedown handler will let the subsequent mousemove events be captured by the containing frame, and not by other frames.</div>
+    <div id="dragSource" onmousedown="parent.dragStarted(); return false;">Drag Me!</div>
+    <iframe id="targetFrame" style="width: 100px; height: 50px;" src="resources/mouse-drag-from-frame-target-subframe.html"></iframe>
     <ul id="log">
     </ul>
 </body>

--- a/LayoutTests/fast/events/mouse-drag-from-frame-expected.txt
+++ b/LayoutTests/fast/events/mouse-drag-from-frame-expected.txt
@@ -1,6 +1,0 @@
-This tests that dragging from an element that returns false from its mousedown handler will not let the subsequent mousemove events be captured by the containing frame.
-
-Drag started
-Received mouse move
-Received mouseup event
-PASS!

--- a/LayoutTests/fast/events/mouse-drag-from-frame-to-other-frame-expected.txt
+++ b/LayoutTests/fast/events/mouse-drag-from-frame-to-other-frame-expected.txt
@@ -1,5 +1,0 @@
-This tests that dragging from an element that returns false from its mousedown handler will not let the subsequent mousemove events be captured by the containing frame, and allows the mouse move to get to other subframes.
-
-Drag Started
-received mousemove
-received mouseup

--- a/LayoutTests/fast/events/resources/mouse-drag-from-frame-subframe.html
+++ b/LayoutTests/fast/events/resources/mouse-drag-from-frame-subframe.html
@@ -1,1 +1,1 @@
-<div id="dragSource" onmousedown="parent.dragStarted(); return false;" onmouseup="parent.log('Unexpected mouseup event')">Drag Me!</div>
+<div id="dragSource" onmousedown="parent.log('Drag Started'); return false;">Drag Me!</div>

--- a/LayoutTests/fast/events/resources/mouse-drag-from-frame-target-subframe.html
+++ b/LayoutTests/fast/events/resources/mouse-drag-from-frame-target-subframe.html
@@ -1,3 +1,3 @@
-<body onmousemove="if (!this.moved){ this.moved = true; parent.log('received mousemove') }" onmouseup="parent.log('received mouseup')">
+<body onmousemove="parent.log('Received unexpected mousemove'); parent.unexpectedMouseMove = true;" onmouseup="parent.log('Received unexpected mouseup'); parent.unexpectedMouseUp = true;">
 
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/cancel-mousedown-in-subframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/cancel-mousedown-in-subframe-expected.txt
@@ -1,8 +1,6 @@
 Dragging the mouse from child frame to parent frame causes both mousedown and mouseup events being dispatched to child frame, regardless of whether the mousedown event is canceled or not.
 
 
-Harness Error (TIMEOUT), message = null
-
 PASS Child frame receives mousedown/mouseup when mousedown is not-canceled
-TIMEOUT Child frame receives mousedown/mouseup when mousedown is canceled Test timed out
+PASS Child frame receives mousedown/mouseup when mousedown is canceled
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/cancel-mousedown-in-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/cancel-mousedown-in-subframe.html
@@ -57,8 +57,8 @@
           let mouseup_message   = await mouseup_promise;
 
           assert_equals(mousedown_message.param, mousedown_msg, "Child frame canceled mousedown?");
-          // assert_false(top_frame_mousedown, "Top frame received mousedown?");
-          // assert_false(top_frame_mouseup,   "Top frame received mouseup?");
+          assert_false(top_frame_mousedown, "Top frame received mousedown?");
+          assert_false(top_frame_mouseup,   "Top frame received mouseup?");
       }, "Child frame receives mousedown/mouseup when mousedown is " + mousedown_msg);
   });
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -542,8 +542,8 @@ fast/events/mouse-cursor-multiframecur.html [ Skip ]
 fast/events/mouse-cursor-no-mousemove.html [ Skip ]
 fast/events/mouse-cursor-udpate-during-raf.html [ Skip ]
 fast/events/mouse-cursor.html [ Skip ]
-fast/events/mouse-drag-from-frame-to-other-frame.html [ Skip ]
-fast/events/mouse-drag-from-frame.html [ Skip ]
+fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html [ Skip ]
+fast/events/cancel-mousedown-and-drag-to-frame.html [ Skip ]
 fast/events/mouse-focus-imagemap.html [ Skip ]
 fast/events/mouse-moved-remove-frame-crash.html [ Skip ]
 fast/events/mouse-relative-position.html [ Skip ]
@@ -3374,6 +3374,7 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode
 
 webkit.org/b/221466 imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys.html [ Skip ]
 webkit.org/b/221465 imported/w3c/web-platform-tests/uievents/keyboard/modifier-keys-combinations.html [ Skip ]
+webkit.org/b/262723 imported/w3c/web-platform-tests/uievents/mouse/cancel-mousedown-in-subframe.html [ Skip ]
 
 # iOS15 supports this emoji.
 fast/text/mending-heart.html [ Pass ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2690,3 +2690,6 @@ webkit.org/b/262340 [ Sonoma ] compositing/repaint/iframes/compositing-iframe-wi
 
 # rdar://113991102 (REGRESSION ( Sonoma ): [ Sonoma ] 10 fast/text/canvas-color-fonts/..COLR tests are a consistent image failure)
 [ Sonoma+ ] fast/text/canvas-color-fonts/stroke-gradient-COLR.html [ ImageOnlyFailure ]
+
+fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html [ Failure ]
+fast/events/cancel-mousedown-and-drag-to-frame.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -946,8 +946,8 @@ webkit.org/b/213717 fast/scrolling/overflow-scrollable-after-back.html [ Pass Ti
 
 webkit.org/b/216650 fast/events/mouse-cursor-multiframecur.html [ Failure Pass ]
 webkit.org/b/216650 fast/events/mouse-cursor.html [ Failure Pass ]
-webkit.org/b/216650 fast/events/mouse-drag-from-frame-to-other-frame.html [ Failure Pass ]
-webkit.org/b/216650 fast/events/mouse-drag-from-frame.html [ Failure Pass ]
+webkit.org/b/216650 fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html [ Failure Pass ]
+webkit.org/b/216650 fast/events/cancel-mousedown-and-drag-to-frame.html [ Failure Pass ]
 webkit.org/b/216650 fast/events/mouse-focus-imagemap.html [ Failure Pass ]
 webkit.org/b/216650 fast/events/mouse-moved-remove-frame-crash.html [ Timeout Pass ]
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -466,7 +466,7 @@ static ShouldIgnoreMouseEvent dispatchPointerEventIfNeeded(Element& element, con
     return ShouldIgnoreMouseEvent::No;
 }
 
-bool Element::dispatchMouseEvent(const PlatformMouseEvent& platformEvent, const AtomString& eventType, int detail, Element* relatedTarget, IsSyntheticClick isSyntheticClick)
+bool Element::dispatchMouseEvent(const PlatformMouseEvent& platformEvent, const AtomString& eventType, int detail, Element* relatedTarget, IsSyntheticClick isSyntheticClick, bool* isEventDefaultPrevented)
 {
     if (isDisabledFormControl() && !document().settings().sendMouseEventsToDisabledFormControlsEnabled())
         return false;
@@ -497,6 +497,8 @@ bool Element::dispatchMouseEvent(const PlatformMouseEvent& platformEvent, const 
 
     ASSERT(!mouseEvent->target() || mouseEvent->target() != relatedTarget);
     dispatchEvent(mouseEvent);
+    if (mouseEvent->defaultPrevented() && isEventDefaultPrevented)
+        *isEventDefaultPrevented = true;
     if (mouseEvent->defaultPrevented() || mouseEvent->defaultHandled())
         didNotSwallowEvent = false;
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -621,7 +621,8 @@ public:
     IntPoint savedLayerScrollPosition() const;
     void setSavedLayerScrollPosition(const IntPoint&);
 
-    bool dispatchMouseEvent(const PlatformMouseEvent&, const AtomString& eventType, int clickCount = 0, Element* relatedTarget = nullptr, IsSyntheticClick isSyntheticClick = IsSyntheticClick::No);
+    // FIXME: <https://webkit.org/b/263034> Indicate isEventDefaultPrevented through the return value instead of as an out-param.
+    bool dispatchMouseEvent(const PlatformMouseEvent& platformEvent, const AtomString& eventType, int clickCount = 0, Element* relatedTarget = nullptr, IsSyntheticClick = IsSyntheticClick::No, bool* isEventDefaultPrevented = nullptr);
     bool dispatchWheelEvent(const PlatformWheelEvent&, OptionSet<EventHandling>&, EventIsCancelable = EventIsCancelable::Yes);
     bool dispatchKeyEvent(const PlatformKeyboardEvent&);
     bool dispatchSimulatedClick(Event* underlyingEvent, SimulatedClickMouseEventOptions = SendNoEvents, SimulatedClickVisualOptions = ShowPressedLook);

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -532,7 +532,44 @@ private:
     
     void setFrameWasScrolledByUser();
 
-    bool capturesDragging() const { return m_capturesDragging; }
+    struct CapturesDragging {
+        enum class InabilityReason : bool {
+            MousePressIsCancelled,
+            Unknown,
+        };
+
+        CapturesDragging(bool capturesDragging)
+        {
+            *this = capturesDragging;
+        }
+
+        CapturesDragging(InabilityReason inabilityReason)
+            : m_state { unexpect, inabilityReason }
+        {
+        }
+
+        CapturesDragging& operator=(bool capturesDragging)
+        {
+            if (capturesDragging)
+                m_state = std::monostate { };
+            else
+                m_state = makeUnexpected(InabilityReason::Unknown);
+            return *this;
+        }
+
+        CapturesDragging& operator=(InabilityReason inabilityReason)
+        {
+            m_state = makeUnexpected(inabilityReason);
+            return *this;
+        }
+
+        operator bool() const { return m_state.has_value(); }
+        InabilityReason inabilityReason() const { return m_state.error(); }
+
+    private:
+        Expected<std::monostate, InabilityReason> m_state;
+    };
+    CapturesDragging capturesDragging() const { return m_capturesDragging; }
 
 #if PLATFORM(COCOA) && defined(__OBJC__)
     NSView *mouseDownViewIfStillGood();
@@ -561,7 +598,14 @@ private:
     bool mouseDownMayStartSelect() const;
 
     std::optional<RemoteMouseEventData> mouseEventDataForRemoteFrame(const RemoteFrame*, const IntPoint&);
-    
+
+    bool isCapturingMouseEventsElement() const { return m_capturingMouseEventsElement || m_isCapturingRootElementForMouseEvents; }
+    void resetCapturingMouseEventsElement()
+    {
+        m_capturingMouseEventsElement = nullptr;
+        m_isCapturingRootElementForMouseEvents = false;
+    }
+
     LocalFrame& m_frame;
     RefPtr<Node> m_mousePressNode;
     Timer m_hoverTimer;
@@ -574,7 +618,7 @@ private:
     double m_maxMouseMovedDuration { 0 };
 
     bool m_mousePressed { false };
-    bool m_capturesDragging { false };
+    CapturesDragging m_capturesDragging { false };
     bool m_mouseDownMayStartSelect { false };
     bool m_mouseDownDelegatedFocus { false };
     bool m_mouseDownWasSingleClickInSelection { false };
@@ -592,6 +636,7 @@ private:
     SelectionInitiationState m_selectionInitiationState { HaveNotStartedSelection };
     ImmediateActionStage m_immediateActionStage { ImmediateActionStage::None };
 
+    bool m_isCapturingRootElementForMouseEvents { false };
     RefPtr<Element> m_capturingMouseEventsElement;
     RefPtr<Element> m_elementUnderMouse;
     RefPtr<Element> m_lastElementUnderMouse;


### PR DESCRIPTION
#### e837c341a756a244e94b2b2cdd166aa02b92e217
<pre>
uievents/mouse/cancel-mousedown-in-subframe.html WPT is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=262691">https://bugs.webkit.org/show_bug.cgi?id=262691</a>
rdar://116516596

Reviewed by Wenson Hsieh.

This patch changes how we handle mouse events following preventDefault
on mousedown events. Following this patch, if we initiate a drag from a
cancelled mousedown event, we keep sending events to the originating
frame till the terminating mouseup corresponding to said drag gesture is
dispatched.

We do so by slightly adjusting our logic around the
`EventHandler::capturesDragging` state, which represents whether or not
we can capture the element under a mouse event during a drag.
Previously, for a mousedown event that was preventDefault-ed,
`capturesDragging` would be unconditionally set to false for the event
handler associated with said frame, which meant that we would not be
capturing the element under the mouse event in said frame, which
resulted in the bug (and the WPT failure).

Instead, this commit changes `capturesDragging` from a boolean flag to a
structure with a little more information. Namely, we keep track of the
reason why drag capture is not possible. This allows us to say that
`capturesDragging` is not possible _because_ the mousePress in question is
cancelled (`MousePressIsCancelled`). The main frame event handler can now
capture the right element when successfully passing a mouse press event to
a subframe. This is represented either as `localSubframe-&gt;ownerElement()`
or as the new boolean state `m_isCapturingRootElementForMouseEvent`;
since we now capture an element to keep sending events to when either
`capturesDragging` is true or when the reason drag capture is not possible is
`MousePressIsCancelled`.

This patch aligns our behavior with the Gecko engine, and gets us to pass
the `uievents/mouse/cancel-mousedown-in-subframe.html` web platform test.

* LayoutTests/TestExpectations:

Adjust test expectations now that we&apos;re passing the WPT.

* LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame-expected.txt: Added.
* LayoutTests/fast/events/cancel-mousedown-and-drag-from-frame-to-other-frame.html: Renamed from LayoutTests/fast/events/mouse-drag-from-frame-to-other-frame.html.
* LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame-expected.txt: Added.
* LayoutTests/fast/events/cancel-mousedown-and-drag-to-frame.html: Renamed from LayoutTests/fast/events/mouse-drag-from-frame.html.
* LayoutTests/fast/events/mouse-drag-from-frame-expected.txt: Removed.
* LayoutTests/fast/events/mouse-drag-from-frame-to-other-frame-expected.txt: Removed.
* LayoutTests/fast/events/resources/mouse-drag-from-frame-subframe.html:
* LayoutTests/fast/events/resources/mouse-drag-from-frame-target-subframe.html:
* LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/cancel-mousedown-in-subframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/cancel-mousedown-in-subframe.html:

Uncomment two assertion statements. This was probably an import mistake.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Update two layout tests fast/events/mouse-drag-from-frame.html and
fast/events/mouse-drag-from-frame-to-other-frame.html to reflect the new
event retention behavior change introduced by this PR.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchMouseEvent):
* Source/WebCore/dom/Element.h:

Introduce an overload for `dispatchMouseEvent` that accepts an outparam
`isEventCancelled` that a caller can use to learn if the provided mouse
event is preventDefault-ed.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::clear):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::clearDragState):
(WebCore::EventHandler::setCapturingMouseEventsElement):
(WebCore::EventHandler::dispatchMouseEvent):

Event retention behavior adjustment as described in the commit message
above.

* Source/WebCore/page/EventHandler.h:
(WebCore::EventHandler::CapturesDragging::CapturesDragging):
(WebCore::EventHandler::CapturesDragging::operator=):
(WebCore::EventHandler::CapturesDragging::operator bool const):
(WebCore::EventHandler::CapturesDragging::inabilityReason const):
(WebCore::EventHandler::capturesDragging const):
(WebCore::EventHandler::isCapturingMouseEventsElement const):
(WebCore::EventHandler::resetCapturingMouseEventsElement):

Update the capturesDragging variable to act as a boolean flag but also
contain a reason if capturesDragging::operator bool() returns false.
Moreover, introduce an additional boolean state that indicates when
we&apos;re capturing the root HTML element, and not some subframe, for this
event retention behavior. This is necessary so we can make a distinction
between a null element and the root element.

Canonical link: <a href="https://commits.webkit.org/269246@main">https://commits.webkit.org/269246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccd37fb8cfc14a40408d9a96d9bd3e1e46a021ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20382 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21448 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24753 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26211 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24078 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20609 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5246 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->