### PR TITLE
[MSE][GStreamer] Fix non-seeking flushes

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -292,6 +292,7 @@ void MediaPlayerPrivateGStreamerMSE::sourceSetup(GstElement* sourceElement)
 {
     ASSERT(WEBKIT_IS_MEDIA_SRC(sourceElement));
     GST_DEBUG_OBJECT(pipeline(), "Source %p setup (old was: %p)", sourceElement, m_source.get());
+    webKitMediaSrcSetPlayer(WEBKIT_MEDIA_SRC(sourceElement), WeakPtr { *this });
     m_source = sourceElement;
 
     if (m_mediaSourcePrivate->hasAllTracks())

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -87,6 +87,8 @@ struct WebKitMediaSrcPrivate {
 
     // Only used by URI Handler API implementation.
     GUniquePtr<char> uri;
+
+    WeakPtr<MediaPlayerPrivateGStreamerMSE> player;
 };
 
 static void webKitMediaSrcUriHandlerInit(gpointer, gpointer);
@@ -98,6 +100,7 @@ static void webKitMediaSrcTearDownStream(WebKitMediaSrc* source, const AtomStrin
 static void webKitMediaSrcGetProperty(GObject*, unsigned propId, GValue*, GParamSpec*);
 static void webKitMediaSrcStreamFlush(Stream*, bool isSeekingFlush);
 static gboolean webKitMediaSrcSendEvent(GstElement*, GstEvent*);
+static MediaPlayerPrivateGStreamerMSE* webKitMediaSrcPlayer(WebKitMediaSrc*);
 
 #define webkit_media_src_parent_class parent_class
 
@@ -334,6 +337,16 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<Media
         gst_element_add_pad(GST_ELEMENT(source), GST_PAD(stream->pad.get()));
     }
     GST_DEBUG_OBJECT(source, "All pads added");
+}
+
+static MediaPlayerPrivateGStreamerMSE* webKitMediaSrcPlayer(WebKitMediaSrc* source)
+{
+    return source->priv->player.get();
+}
+
+void webKitMediaSrcSetPlayer(WebKitMediaSrc* source, WeakPtr<MediaPlayerPrivateGStreamerMSE>&& player)
+{
+    source->priv->player = WTFMove(player);
 }
 
 static void webKitMediaSrcTearDownStream(WebKitMediaSrc* source, const AtomString& name)
@@ -633,20 +646,22 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         GstClockTime pipelineStreamTime;
         gst_element_query_position(findPipeline(GRefPtr<GstElement>(GST_ELEMENT(stream->source))).get(), GST_FORMAT_TIME,
             reinterpret_cast<gint64*>(&pipelineStreamTime));
-        GST_DEBUG_OBJECT(stream->source, "pipelineStreamTime from position query: %" GST_TIME_FORMAT, GST_TIME_ARGS(pipelineStreamTime));
         // GST_CLOCK_TIME_NONE is returned when the pipeline is not yet pre-rolled (e.g. just after a seek). In this case
         // we don't need to adjust the segment though, as running time has not advanced.
         if (GST_CLOCK_TIME_IS_VALID(pipelineStreamTime)) {
-            DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
-            // We need to increase the base by the running time accumulated during the previous segment.
-
-            GstClockTime pipelineRunningTime = gst_segment_to_running_time(&streamingMembers->segment, GST_FORMAT_TIME, pipelineStreamTime);
-            assert(GST_CLOCK_TIME_IS_VALID(pipelineRunningTime));
-            GST_DEBUG_OBJECT(stream->source, "Resetting segment to current pipeline running time (%" GST_TIME_FORMAT") and stream time (%" GST_TIME_FORMAT ")",
-                GST_TIME_ARGS(pipelineRunningTime), GST_TIME_ARGS(pipelineStreamTime));
-            streamingMembers->segment.base = pipelineRunningTime;
-
-            streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
+            MediaPlayerPrivateGStreamerMSE* player = webKitMediaSrcPlayer(stream->source);
+            if (player) {
+                MediaTime streamTime = player->currentMediaTime();
+                pipelineStreamTime = toGstClockTime(streamTime);
+                DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
+                // We need to increase the base by the running time accumulated during the previous segment.
+                GstClockTime pipelineRunningTime = gst_segment_to_running_time(&streamingMembers->segment, GST_FORMAT_TIME, pipelineStreamTime);
+                assert(GST_CLOCK_TIME_IS_VALID(pipelineRunningTime));
+                GST_DEBUG_OBJECT(stream->source, "Resetting segment to current pipeline running time (%" GST_TIME_FORMAT ", valid %s) and stream time (%" GST_TIME_FORMAT " = %s)",
+                    GST_TIME_ARGS(pipelineRunningTime), boolForPrinting(GST_CLOCK_TIME_IS_VALID(pipelineRunningTime)), GST_TIME_ARGS(pipelineStreamTime), streamTime.toString().ascii().data());
+                streamingMembers->segment.base = pipelineRunningTime;
+                streamingMembers->segment.start = streamingMembers->segment.time = static_cast<GstClockTime>(pipelineStreamTime);
+            }
         }
     }
 
@@ -678,6 +693,11 @@ static void webKitMediaSrcStreamFlush(Stream* stream, bool isSeekingFlush)
         // Since FLUSH_STOP is a synchronized event, we send it while we still hold the stream lock of the pad.
         gst_pad_push_event(stream->pad.get(), gst_event_new_flush_stop(isSeekingFlush));
         GST_DEBUG_OBJECT(stream->pad.get(), "FLUSH_STOP sent.");
+
+        {
+            DataMutexLocker streamingMembers { stream->streamingMembersDataMutex };
+            streamingMembers->hasPoppedFirstObject = false;
+        }
 
         GST_DEBUG_OBJECT(stream->pad.get(), "Starting webKitMediaSrcLoop task and releasing the STREAM_LOCK.");
         gst_pad_start_task(stream->pad.get(), webKitMediaSrcLoop, stream->pad.get(), nullptr);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
@@ -65,6 +65,8 @@ void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<WebCo
 
 void webKitMediaSrcFlush(WebKitMediaSrc*, const AtomString& streamName);
 
+void webKitMediaSrcSetPlayer(WebKitMediaSrc*, WeakPtr<WebCore::MediaPlayerPrivateGStreamerMSE>&&);
+
 G_END_DECLS
 
 namespace WTF {


### PR DESCRIPTION
#### e2decf8f9003e7c520e44afb59e6d4ffec9b44e4
<pre>
[MSE][GStreamer] Fix non-seeking flushes
<a href="https://bugs.webkit.org/show_bug.cgi?id=262693">https://bugs.webkit.org/show_bug.cgi?id=262693</a>

Reviewed by NOBODY (OOPS!).

This reverts <a href="https://commits.webkit.org/269358@main">https://commits.webkit.org/269358@main</a> . Problem is that you can screw quality changes as they require a
non seeking flush with an updated segment.

We still need to change the segment to use the proper playback position and we can do it by using the player&apos;s position.

Besides, as a fly-by-fix, we are solving the problem of position going back to 0 when the sinks can&apos;t provide a proper
position while it is prerolling. For that, we use the cached position of the player even if it was supposed to be
invalidated already as a best effort.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::playbackPosition const):
(WebCore::MediaPlayerPrivateGStreamer::didEnd):
(WebCore::MediaPlayerPrivateGStreamer::setCachedPosition const):
(WebCore::MediaPlayerPrivateGStreamer::invalidateCachedPosition const):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::sourceSetup):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcPlayer):
(webKitMediaSrcSetPlayer):
(webKitMediaSrcStreamFlush):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h:
</pre>