### PR TITLE
Make Fetch formData() consume multipart/form-data headers case-insensitively

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Consume empty response.formData() as FormData
 PASS Consume empty request.formData() as FormData
+PASS Consume multipart/form-data headers case-insensitively
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.js
@@ -12,3 +12,14 @@ promise_test(async t => {
   const fd = await req.formData();
   assert_true(fd instanceof FormData);
 }, 'Consume empty request.formData() as FormData');
+
+promise_test(async t => {
+  let formdata = new FormData();
+  formdata.append('foo', new Blob([JSON.stringify({ bar: "baz", })], { type: "application/json" }));
+  let blob = await new Response(formdata).blob();
+  let body = await blob.text();
+  blob = new Blob([body.toLowerCase()], { type: blob.type.toLowerCase() });
+  let formdataWithLowercaseBody = await new Response(blob).formData();
+  assert_true(formdataWithLowercaseBody.has("foo"));
+  assert_equals(formdataWithLowercaseBody.get("foo").type, "application/json");
+}, 'Consume multipart/form-data headers case-insensitively');

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.worker-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Consume empty response.formData() as FormData
 PASS Consume empty request.formData() as FormData
+PASS Consume multipart/form-data headers case-insensitively
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -151,8 +151,8 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
 
         String header = String::fromUTF8(headerBegin, headerLength);
 
-        constexpr auto contentDispositionCharacters = "Content-Disposition:"_s;
-        size_t contentDispositionBegin = header.find(contentDispositionCharacters);
+        constexpr auto contentDispositionCharacters = "content-disposition:"_s;
+        size_t contentDispositionBegin = header.findIgnoringASCIICase(contentDispositionCharacters);
         if (contentDispositionBegin == notFound)
             return false;
         size_t contentDispositionEnd = header.find("\r\n"_s, contentDispositionBegin);
@@ -170,9 +170,9 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         else {
             String contentType = "text/plain"_s;
 
-            constexpr auto contentTypeCharacters = "Content-Type:"_s;
+            constexpr auto contentTypeCharacters = "content-type:"_s;
             size_t contentTypePrefixLength = contentTypeCharacters.length();
-            size_t contentTypeBegin = header.find(contentTypeCharacters);
+            size_t contentTypeBegin = header.findIgnoringASCIICase(contentTypeCharacters);
             if (contentTypeBegin != notFound) {
                 size_t contentTypeEnd = header.find("\r\n"_s, contentTypeBegin);
                 contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).trim(isASCIIWhitespaceWithoutFF<UChar>).toString();


### PR DESCRIPTION
#### d0c370d532ad81f76fa32c14ec646eb56e91025b
<pre>
Make Fetch formData() consume multipart/form-data headers case-insensitively
<a href="https://bugs.webkit.org/show_bug.cgi?id=262635">https://bugs.webkit.org/show_bug.cgi?id=262635</a>

Reviewed by Youenn Fablet and Chris Dumez.

When consuming a Response body or Request body with formData() as
specified in <a href="https://fetch.spec.whatwg.org/#dom-body-formdata">https://fetch.spec.whatwg.org/#dom-body-formdata</a> for a
multipart/form-data MIME type, Gecko and Blink consume the
Content-Disposition and Content-Type header names case-insensitively.
This change causes WebKit to do the same.

Otherwise, without this change, WebKit consumes those header names
case-sensitively — resulting in lack of interoperability for this
particular behavior across all current major engines.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/body/formdata.any.worker-expected.txt:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):

Canonical link: <a href="https://commits.webkit.org/269144@main">https://commits.webkit.org/269144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d430b3675ecccfd11028235ad086c0bb326f1ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21701 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21942 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21244 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21928 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24419 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25941 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23801 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17325 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19672 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5180 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->