### PR TITLE
[ macOS wk2 debug ] fast/mediastream/device-change-event-2.html is a flaky failure.

### DIFF
--- a/LayoutTests/fast/mediastream/device-change-event-2.html
+++ b/LayoutTests/fast/mediastream/device-change-event-2.html
@@ -77,25 +77,37 @@
 
         await setup(test);
 
-        let eventCount = 0;
-        await new Promise((resolve, reject) => {
-            navigator.mediaDevices.ondevicechange = (evt) => {
-                ++eventCount;
+        async function doEventCoalescingTest() {
+            let eventCount = 0;
+            await new Promise((resolve, reject) => {
+                navigator.mediaDevices.ondevicechange = (evt) => {
+                    ++eventCount;
+                    setTimeout(() => {
+                        resolve();
+                    }, 500);
+                }
+
                 setTimeout(() => {
+                    console.log("navigator.mediaDevices.ondevicechange took too long");
                     resolve();
-                }, 500);
-            }
+                }, 4000);
 
-            setTimeout(() => {
-                console.log("navigator.mediaDevices.ondevicechange took too long");
-                resolve();
-            }, 4000);
+                testRunner.addMockMicrophoneDevice("id4", "microphone 3");
+                testRunner.addMockMicrophoneDevice("id5", "microphone 4");
+            });
+            return eventCount;
+        }
 
-            testRunner.addMockMicrophoneDevice("id4", "microphone 3");
-            testRunner.addMockMicrophoneDevice("id5", "microphone 4");
-        });
-        assert_equals(eventCount, 1, "one event fired");
-
+        // Coalescing may not always happen on slow bots, let's retry until we are successful.
+        let count = 0;
+        while (count++ < 100) {
+            const eventCount = await doEventCoalescingTest();
+            if (eventCount == 1)
+                break;
+            testRunner.removeMockMediaDevice("id4");
+            testRunner.removeMockMediaDevice("id5");
+        }
+        assert_less_than(count, 100);
     }, "'devicechange' events fired quickly are coalesced");
 
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2648,7 +2648,7 @@ compositing/backing/solid-color-with-paints-into-ancestor.html [ Pass ImageOnlyF
 fast/forms/password-scrolled-after-caps-lock-toggled.html [ Timeout ]
 
 # rdar://111398769 (REGRESSION (265250@main): [ macOS ] fast/mediastream/device-change-event-2.html is a consistent failure)
-fast/mediastream/device-change-event-2.html [ Failure ]
+fast/mediastream/device-change-event-2.html [ Skip ]
 
 # Initial css/compositing test import
 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-text.html [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1103,9 +1103,6 @@ webkit.org/b/212091 platform/mac/media/media-source/media-source-change-source.h
 
 webkit.org/b/212413 fast/mediastream/mock-media-source-webaudio.html [ Pass Timeout ]
 
-webkit.org/b/261356 [ Release ] fast/mediastream/device-change-event-2.html [ Pass Timeout ] # old: webkit.org/b/188924
-webkit.org/b/261356 [ Debug ] fast/mediastream/device-change-event-2.html [ Pass Timeout Failure ]
-
 webkit.org/b/212721 svg/custom/textPath-change-id.svg [ Pass ImageOnlyFailure ]
 
 webkit.org/b/212042 [ Debug ] fast/scrolling/mac/scrollbars/select-overlay-scrollbar-reveal.html [ Pass Timeout ]


### PR DESCRIPTION
#### ebcddfddefbd74812888a962a36f8b4a6284bd62
<pre>
[ macOS wk2 debug ] fast/mediastream/device-change-event-2.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=261356">https://bugs.webkit.org/show_bug.cgi?id=261356</a>
rdar://115192271

Reviewed by Eric Carlson.

The test is flaky on debug bots as coalescing of events is by nature flaky.
To make the test more robust, we are repeating the coalescing test until we at least get one coalesced event.
We disable the test in WK1 since getUserMedia et al is not supported in WK1.

* LayoutTests/fast/mediastream/device-change-event-2.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/268976@main">https://commits.webkit.org/268976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f18c95d5e84b7b7ab93a4f3fb5e5f845c53c9e71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22930 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19584 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20839 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23784 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25361 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16853 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18917 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5079 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->