### PR TITLE
Update serialization for CAAudioStreamDescription

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
@@ -65,29 +65,11 @@ public:
     const AudioStreamBasicDescription& streamDescription() const;
     AudioStreamBasicDescription& streamDescription();
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<CAAudioStreamDescription> decode(Decoder&);
-
 private:
     AudioStreamBasicDescription m_streamDescription;
     mutable PlatformDescription m_platformDescription;
     mutable PCMFormat m_format { None };
 };
-
-template<class Encoder>
-void CAAudioStreamDescription::encode(Encoder& encoder) const
-{
-    encoder.encodeObject(m_streamDescription);
-}
-
-template<class Decoder>
-std::optional<CAAudioStreamDescription> CAAudioStreamDescription::decode(Decoder& decoder)
-{
-    auto asbd = decoder.template decodeObject<AudioStreamBasicDescription>();
-    if (!asbd)
-        return std::nullopt;
-    return CAAudioStreamDescription { *asbd };
-}
 
 inline CAAudioStreamDescription toCAAudioStreamDescription(const AudioStreamDescription& description)
 {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2546,6 +2546,24 @@ header: <WebCore/KeyboardScroll.h>
     WebCore::TransformationMatrix matrix();
 }
 
+#if PLATFORM(COCOA)
+struct AudioStreamBasicDescription {
+    double  mSampleRate;
+    UInt32  mFormatID;
+    UInt32  mFormatFlags;
+    UInt32  mBytesPerPacket;
+    UInt32  mFramesPerPacket;
+    UInt32  mBytesPerFrame;
+    UInt32  mChannelsPerFrame;
+    UInt32  mBitsPerChannel;
+    UInt32  mReserved;
+};
+
+class WebCore::CAAudioStreamDescription {
+    AudioStreamBasicDescription streamDescription();
+}
+#endif
+
 class WebCore::TransformOperations {
     Vector<RefPtr<WebCore::TransformOperation>> operations();
 }


### PR DESCRIPTION
#### c21cfe3709acfe4dfc78981d230b7e4e0a0a6dc7
<pre>
Update serialization for CAAudioStreamDescription
<a href="https://bugs.webkit.org/show_bug.cgi?id=262698">https://bugs.webkit.org/show_bug.cgi?id=262698</a>
rdar://116521284

Reviewed by Alex Christensen.

* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h:
(WebCore::CAAudioStreamDescription::encode const): Deleted.
(WebCore::CAAudioStreamDescription::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/269005@main">https://commits.webkit.org/269005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16db49160ab84992c3b4f2adab6e1265e8497a83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19639 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20880 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21057 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23850 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25410 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23345 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16906 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19165 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5098 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->