### PR TITLE
Cache total advance width on GlyphBuffer

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -313,10 +313,7 @@ float FontCascade::widthForSimpleText(StringView text, TextDirection textDirecti
         addGlyphsFromText(glyphBuffer, font, text.characters16(), text.length());
 
     auto initialAdvance = font.applyTransforms(glyphBuffer, 0, 0, enableKerning(), requiresShaping(), fontDescription().computedLocale(), text, textDirection);
-    auto width = 0.f;
-    for (size_t i = 0; i < glyphBuffer.size(); ++i)
-        width += WebCore::width(glyphBuffer.advanceAt(i));
-    width += WebCore::width(initialAdvance);
+    auto width = glyphBuffer.totalAdvanceWidth() + WebCore::width(initialAdvance);
 
     if (cacheEntry)
         *cacheEntry = width;


### PR DESCRIPTION
#### c115740423c0690bde3decdb6fd32c9fa0081fe3
<pre>
Cache total advance width on GlyphBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=262700">https://bugs.webkit.org/show_bug.cgi?id=262700</a>

Reviewed by NOBODY (OOPS!).

Cache total advance width on GlyphBuffer so that FontCascade::widthForSimpleText()
can get it cheaply. FontCascade::widthForSimpleText() is hot on profiles.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForSimpleText const):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::GlyphBuffer::clear):
(WebCore::GlyphBuffer::totalAdvanceWidth const):
(WebCore::GlyphBuffer::add):
(WebCore::GlyphBuffer::remove):
(WebCore::GlyphBuffer::deleteGlyphWithoutAffectingSize):
(WebCore::GlyphBuffer::expandAdvance):
(WebCore::GlyphBuffer::expandLastAdvance):
(WebCore::GlyphBuffer::shrink):
(WebCore::GlyphBuffer::flatten):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c115740423c0690bde3decdb6fd32c9fa0081fe3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21624 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21282 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21019 "Found 60 new test failures: animations/3d/matrix-transform-type-animation.html, compositing/compositing-visible-descendant.html, compositing/direct-image-compositing.html, compositing/generated-content.html, compositing/geometry/abs-position-inside-opacity.html, compositing/geometry/clipping-foreground.html, compositing/geometry/fixed-in-composited.html, compositing/geometry/fixed-position.html, compositing/geometry/root-layer-update.html, compositing/geometry/transfrom-origin-on-zero-size-layer.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23794 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18177 "Found 60 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/css3-border-image-repeat-repeat.html, imported/w3c/web-platform-tests/css/css-color/t421-rgb-clip-outside-gamut-b.xht, imported/w3c/web-platform-tests/css/css-color/t422-rgba-clip-outside-device-gamut-b.xht, imported/w3c/web-platform-tests/css/css-color/t424-hsl-clip-outside-gamut-b.xht, imported/w3c/web-platform-tests/css/css-color/t425-hsla-clip-outside-device-gamut-b.xht, imported/w3c/web-platform-tests/css/css-contain/contain-layout-001.html, imported/w3c/web-platform-tests/css/css-contain/contain-style-ol-ordinal-pseudo.html, imported/w3c/web-platform-tests/css/css-content/quotes-002.html, imported/w3c/web-platform-tests/css/css-content/quotes-003.html, imported/w3c/web-platform-tests/css/css-content/quotes-034.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19096 "Found 60 new test failures: accessibility/mac/bounds-for-range.html, animations/3d/matrix-transform-type-animation.html, compositing/compositing-visible-descendant.html, compositing/direct-image-compositing.html, compositing/generated-content.html, compositing/geometry/abs-position-inside-opacity.html, compositing/geometry/clipping-foreground.html, compositing/geometry/fixed-in-composited.html, compositing/geometry/fixed-position.html, compositing/iframes/composited-iframe-alignment.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25373 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19258 "Found 4 new API test failures: TestWebKitAPI.DragAndDropTests.BackgroundImageLinkToInput, TestWebKitAPI.DragAndDropTests.LinkToInput, TestWebKitAPI.AutocorrectionTests.FontAtCaretWhenUsingUICTFontTextStyle, TestWebKitAPI.DragAndDropTests.ImageInLinkToInput (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19297 "Found 60 new test failures: accessibility/display-contents/role-row-headers.html, accessibility/mac/bounds-for-range.html, animations/3d/matrix-transform-type-animation.html, compositing/clipping/border-radius-async-overflow-non-stacking.html, compositing/compositing-visible-descendant.html, compositing/direct-image-compositing.html, compositing/generated-content.html, compositing/geometry/abs-position-inside-opacity.html, compositing/geometry/clipping-foreground.html, compositing/geometry/fixed-in-composited.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23309 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19841 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16863 "Found 60 new test failures: accessibility/display-contents/role-row-headers.html, accessibility/mac/bounds-for-range.html, accessibility/mac/display-contents-relative-frame.html, accessibility/mac/dynamic-transform-relative-frame.html, animations/3d/matrix-transform-type-animation.html, compositing/compositing-visible-descendant.html, compositing/direct-image-compositing.html, compositing/generated-content.html, compositing/geometry/abs-position-inside-opacity.html, compositing/geometry/clipping-foreground.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->