### PR TITLE
[WGSL] Generate the correct code for arrayLength

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -33,6 +33,7 @@
 #include "ASTVariableQualifier.h"
 
 namespace WGSL {
+class RewriteGlobalVariables;
 class TypeChecker;
 struct Type;
 
@@ -47,7 +48,9 @@ enum class VariableFlavor : uint8_t {
 
 class Variable final : public Declaration {
     WGSL_AST_BUILDER_NODE(Variable);
+    friend RewriteGlobalVariables;
     friend TypeChecker;
+
 public:
     using Ref = std::reference_wrapper<Variable>;
     using List = ReferenceWrapperVector<Variable>;

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1267,6 +1267,11 @@ static void emitAtomicExchange(FunctionDefinitionWriter* writer, AST::CallExpres
     atomicFunction("atomic_exchange_explicit", writer, call);
 }
 
+static void emitArrayLength(FunctionDefinitionWriter* writer, AST::CallExpression& call)
+{
+    writer->visit(call.arguments()[0]);
+    writer->stringBuilder().append(".size()");
+}
 
 void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call)
 {
@@ -1299,6 +1304,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
 
     if (is<AST::IdentifierExpression>(call.target())) {
         static constexpr std::pair<ComparableASCIILiteral, void(*)(FunctionDefinitionWriter*, AST::CallExpression&)> builtinMappings[] {
+            { "arrayLength", emitArrayLength },
             { "atomicAdd", emitAtomicAdd },
             { "atomicExchange", emitAtomicExchange },
             { "atomicLoad", emitAtomicLoad },

--- a/Source/WebGPU/WGSL/tests/valid/array-length.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/array-length.wgsl
@@ -1,0 +1,39 @@
+// RUN: %metal-compile main
+
+struct S {
+  x: array<f32>,
+}
+
+struct Packed {
+  x: vec3<f32>
+}
+
+
+struct T {
+  x: array<Packed>,
+}
+
+@group(0) @binding(0) var<storage, read_write> x: array<f32>;
+@group(0) @binding(1) var<storage, read_write> y: S;
+@group(0) @binding(2) var<storage, read_write> z: T;
+
+fn f() -> u32 {
+    let x1 = arrayLength(&x);
+    let y1 = arrayLength(&y.x);
+    let z1 = arrayLength(&z.x);
+
+    let xptr = &x;
+    let yptr = &y.x;
+    let zptr = &z.x;
+
+    let x2 = arrayLength(xptr);
+    let y2 = arrayLength(yptr);
+    let z2 = arrayLength(zptr);
+
+    return x1 + y1 + z1 + x2 + y2 + z2;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn main() {
+    let x = f();
+}


### PR DESCRIPTION
#### 8f8094467d6c459615e10bbd06efa26ed9755c93
<pre>
[WGSL] Generate the correct code for arrayLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=262703">https://bugs.webkit.org/show_bug.cgi?id=262703</a>
rdar://116524838

Reviewed by Mike Wyrzykowski.

As of 268884@main, the API now exposes the size of runtime-sized arrays at the
end of the argument buffer. This patch updates the compiler to match this argument
buffer layout and rewrite calls to arrayLength to read these sizes.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::containsRuntimeArray):
(WGSL::RewriteGlobalVariables::packArrayType):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitArrayLength):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/array-length.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/268995@main">https://commits.webkit.org/268995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4091e2876de204a5d35293a96dba4a92370f1dbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19740 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21832 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23991 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18332 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25618 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23456 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19989 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19288 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5093 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->