### PR TITLE
[IFC][Integration] Allow RenderView layout by IFC

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -95,7 +95,7 @@ BoxTree::BoxTree(RenderBlock& rootRenderer)
 
     if (is<RenderBlockFlow>(rootRenderer)) {
         rootBox->setIsInlineIntegrationRoot();
-        rootBox->setIsFirstChildForIntegration(rootRenderer.parent()->firstChild() == &rootRenderer);
+        rootBox->setIsFirstChildForIntegration(!rootRenderer.parent() || rootRenderer.parent()->firstChild() == &rootRenderer);
         buildTreeForInlineContent();
     } else if (is<RenderFlexibleBox>(rootRenderer))
         buildTreeForFlexContent();

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -97,8 +97,6 @@ static std::optional<AvoidanceReason> canUseForLineLayoutWithReason(const Render
 {
     if (!DeprecatedGlobalSettings::inlineFormattingContextIntegrationEnabled())
         return AvoidanceReason::FeatureIsDisabled;
-    if (flow.isRenderView())
-        return AvoidanceReason::FlowIsInitialContainingBlock;
     if (!flow.firstChild()) {
         // Non-SVG code does not call into layoutInlineChildren with no children anymore.
         ASSERT(is<RenderSVGBlock>(flow));

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.h
@@ -39,7 +39,6 @@ class LineLayout;
 enum class AvoidanceReason : uint8_t {
     ContentIsRuby,
     ContentIsSVG,
-    FlowIsInitialContainingBlock,
     FeatureIsDisabled
 };
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -100,6 +100,8 @@ RenderView::RenderView(Document& document, RenderStyle&& style)
 RenderView::~RenderView()
 {
     ASSERT_WITH_MESSAGE(m_rendererCount == 1, "All other renderers in this render tree should have been destroyed");
+
+    deleteLines();
 }
 
 void RenderView::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -238,6 +238,7 @@ private:
     // Include this RenderView.
     uint64_t m_rendererCount { 1 };
 
+    // Note that currently RenderView::layoutBox(), if it exists, is a child of m_initialContainingBlock.
     UniqueRef<Layout::InitialContainingBlock> m_initialContainingBlock;
     UniqueRef<Layout::LayoutState> m_layoutState;
 


### PR DESCRIPTION
#### d0f46be6d47ee24ab4a015d8fcc577ea71c0062b
<pre>
[IFC][Integration] Allow RenderView layout by IFC
<a href="https://bugs.webkit.org/show_bug.cgi?id=262705">https://bugs.webkit.org/show_bug.cgi?id=262705</a>
rdar://116525525

Reviewed by Alan Baradlay.

In some cases (like if the document element has display:inline) root content will be laid out by IFC.

We currently use the LFC initial containing block box as a place to parent subtrees that are not
fully connected via ancestor chain (because we don&apos;t yet create layout boxes for all blocks).
Because of this the natural solution of just making RenderView::layoutBox() same as
RenderView::initialContainBlock() does not work. Instead this patch makes RenderView::layoutBox()
return a separate box parented to the initial containing block box.

* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::BoxTree::BoxTree):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForLineLayoutWithReason):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::~RenderView):

Ensure we delete line layout if it exits before we delete the initial containing block.

* Source/WebCore/rendering/RenderView.h:

Canonical link: <a href="https://commits.webkit.org/268927@main">https://commits.webkit.org/268927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bd45f0db783e600f91c6320c759090f2b904dc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21636 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23806 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19104 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16873 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19123 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5049 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->