### PR TITLE
Mark RemoteLayerTreeDrawingArea virtual functions as `final` when possible

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -63,63 +63,63 @@ protected:
 
 private:
     // DrawingArea
-    void setNeedsDisplay() override;
-    void setNeedsDisplayInRect(const WebCore::IntRect&) override;
-    void scroll(const WebCore::IntRect& scrollRect, const WebCore::IntSize& scrollDelta) override;
-    void updateGeometry(const WebCore::IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight& fencePort, CompletionHandler<void()>&&) override;
+    void setNeedsDisplay() final;
+    void setNeedsDisplayInRect(const WebCore::IntRect&) final;
+    void scroll(const WebCore::IntRect& scrollRect, const WebCore::IntSize& scrollDelta) final;
+    void updateGeometry(const WebCore::IntSize& viewSize, bool flushSynchronously, const WTF::MachSendRight& fencePort, CompletionHandler<void()>&&) final;
 
-    WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
-    void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
+    WebCore::GraphicsLayerFactory* graphicsLayerFactory() final;
+    void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) final;
     void addRootFrame(WebCore::FrameIdentifier) final;
-    void triggerRenderingUpdate() override;
+    void triggerRenderingUpdate() final;
     bool scheduleRenderingUpdate() final;
     void renderingUpdateFramesPerSecondChanged() final;
-    void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) override;
+    void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) final;
 
     void dispatchAfterEnsuringDrawing(IPC::AsyncReplyID) final;
-    virtual void willCommitLayerTree(RemoteLayerTreeTransaction&) { };
+    virtual void willCommitLayerTree(RemoteLayerTreeTransaction&) { }
 
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) final;
     void setPreferredFramesPerSecond(WebCore::FramesPerSecond);
 
-    bool shouldUseTiledBackingForFrameView(const WebCore::LocalFrameView&) const override;
+    bool shouldUseTiledBackingForFrameView(const WebCore::LocalFrameView&) const final;
 
-    void updatePreferences(const WebPreferencesStore&) override;
+    void updatePreferences(const WebPreferencesStore&) final;
 
-    bool supportsAsyncScrolling() const override { return true; }
+    bool supportsAsyncScrolling() const final { return true; }
     bool usesDelegatedPageScaling() const override { return true; }
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
 
-    void setLayerTreeStateIsFrozen(bool) override;
-    bool layerTreeStateIsFrozen() const override { return m_isRenderingSuspended; }
+    void setLayerTreeStateIsFrozen(bool) final;
+    bool layerTreeStateIsFrozen() const final { return m_isRenderingSuspended; }
 
-    void forceRepaint() override;
-    void forceRepaintAsync(WebPage&, CompletionHandler<void()>&&) override;
+    void forceRepaint() final;
+    void forceRepaintAsync(WebPage&, CompletionHandler<void()>&&) final;
 
-    void setViewExposedRect(std::optional<WebCore::FloatRect>) override;
-    std::optional<WebCore::FloatRect> viewExposedRect() const override { return m_viewExposedRect; }
+    void setViewExposedRect(std::optional<WebCore::FloatRect>) final;
+    std::optional<WebCore::FloatRect> viewExposedRect() const final { return m_viewExposedRect; }
 
-    void acceleratedAnimationDidStart(WebCore::PlatformLayerIdentifier, const String& key, MonotonicTime startTime) override;
-    void acceleratedAnimationDidEnd(WebCore::PlatformLayerIdentifier, const String& key) override;
+    void acceleratedAnimationDidStart(WebCore::PlatformLayerIdentifier, const String& key, MonotonicTime startTime) final;
+    void acceleratedAnimationDidEnd(WebCore::PlatformLayerIdentifier, const String& key) final;
 
-    WebCore::FloatRect exposedContentRect() const override;
-    void setExposedContentRect(const WebCore::FloatRect&) override;
+    WebCore::FloatRect exposedContentRect() const final;
+    void setExposedContentRect(const WebCore::FloatRect&) final;
 
-    void displayDidRefresh() override;
+    void displayDidRefresh() final;
 
-    void setDeviceScaleFactor(float) override;
+    void setDeviceScaleFactor(float) final;
 
     void mainFrameContentSizeChanged(WebCore::FrameIdentifier, const WebCore::IntSize&) override;
 
-    void activityStateDidChange(OptionSet<WebCore::ActivityState> changed, ActivityStateChangeID, CompletionHandler<void()>&&) override;
+    void activityStateDidChange(OptionSet<WebCore::ActivityState> changed, ActivityStateChangeID, CompletionHandler<void()>&&) final;
 
-    bool addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone>) override;
+    bool addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone>) final;
 
     void updateRootLayers();
 
     void addCommitHandlers();
     void startRenderingUpdateTimer();
-    void didCompleteRenderingUpdateDisplay() override;
+    void didCompleteRenderingUpdateDisplay() final;
 
     TransactionID takeNextTransactionID() { return m_currentTransactionID.increment(); }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
@@ -41,22 +41,22 @@ public:
     virtual ~RemoteLayerTreeDrawingAreaMac();
 
 private:
-    WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
+    WebCore::DelegatedScrollingMode delegatedScrollingMode() const final;
 
-    void setColorSpace(std::optional<WebCore::DestinationColorSpace>) override;
-    std::optional<WebCore::DestinationColorSpace> displayColorSpace() const override;
+    void setColorSpace(std::optional<WebCore::DestinationColorSpace>) final;
+    std::optional<WebCore::DestinationColorSpace> displayColorSpace() const final;
 
     std::optional<WebCore::DestinationColorSpace> m_displayColorSpace;
 
     bool usesDelegatedPageScaling() const override { return false; }
 
-    void mainFrameContentSizeChanged(WebCore::FrameIdentifier, const WebCore::IntSize&) override;
+    void mainFrameContentSizeChanged(WebCore::FrameIdentifier, const WebCore::IntSize&) final;
 
-    void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;
-    void commitTransientZoom(double scale, WebCore::FloatPoint origin) override;
+    void adjustTransientZoom(double scale, WebCore::FloatPoint origin) final;
+    void commitTransientZoom(double scale, WebCore::FloatPoint origin) final;
     void applyTransientZoomToPage(double scale, WebCore::FloatPoint);
 
-    void willCommitLayerTree(RemoteLayerTreeTransaction&) override;
+    void willCommitLayerTree(RemoteLayerTreeTransaction&) final;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 3544bc8736460afe5b00ae246b231df865a3c1cf
<pre>
Mark RemoteLayerTreeDrawingArea virtual functions as `final` when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=262706">https://bugs.webkit.org/show_bug.cgi?id=262706</a>

Reviewed by Brent Fulgham.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::willCommitLayerTree):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h:

Canonical link: <a href="https://commits.webkit.org/268931@main">https://commits.webkit.org/268931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfad3e8ea3c79e789fb2cf7b8e8f289bff2c5274

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19609 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21640 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23810 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18186 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23318 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19856 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19127 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5053 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->