### PR TITLE
[scroll-anchoring] Reenable scroll anchoring on some LayoutTests

### DIFF
--- a/LayoutTests/fast/dom/Element/body-scrollLeft-basics-quirks.html
+++ b/LayoutTests/fast/dom/Element/body-scrollLeft-basics-quirks.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
     <head>
         <style>

--- a/LayoutTests/fast/dom/Element/body-scrollTop-basics-quirks.html
+++ b/LayoutTests/fast/dom/Element/body-scrollTop-basics-quirks.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
     <head>
         <style>

--- a/LayoutTests/fast/dom/Window/window-scroll-arguments.html
+++ b/LayoutTests/fast/dom/Window/window-scroll-arguments.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>

--- a/LayoutTests/fast/dom/horizontal-scrollbar-when-dir-change.html
+++ b/LayoutTests/fast/dom/horizontal-scrollbar-when-dir-change.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useThreadedScrolling=false CSSScrollAnchoringEnabled=false ] -->
+<!-- webkit-test-runner [ useThreadedScrolling=false ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/fast/dom/vertical-scrollbar-when-dir-change.html
+++ b/LayoutTests/fast/dom/vertical-scrollbar-when-dir-change.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useThreadedScrolling=false CSSScrollAnchoringEnabled=false ] -->
+<!-- webkit-test-runner [ useThreadedScrolling=false ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/fast/repaint/absolute-position-changed.html
+++ b/LayoutTests/fast/repaint/absolute-position-changed.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <link rel="stylesheet" href="resources/default.css">

--- a/LayoutTests/fast/scrolling/ios/adjust-scroll-snap-during-gesture.html
+++ b/LayoutTests/fast/scrolling/ios/adjust-scroll-snap-during-gesture.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html
+++ b/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">

--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false showsScrollIndicators=false ] -->
+<!-- webkit-test-runner [ showsScrollIndicators=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false showsScrollIndicators=false ] -->
+<!-- webkit-test-runner [ showsScrollIndicators=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/scrolling/ios/mixing-user-and-programmatic-scroll-002.html
+++ b/LayoutTests/fast/scrolling/ios/mixing-user-and-programmatic-scroll-002.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Mixing user and programmatic scroll of iframe</title>

--- a/LayoutTests/fast/scrolling/ios/mixing-user-and-programmatic-scroll-003.html
+++ b/LayoutTests/fast/scrolling/ios/mixing-user-and-programmatic-scroll-003.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Mixing user and programmatic scroll of iframe</title>

--- a/LayoutTests/fast/scrolling/ios/mixing-user-and-programmatic-scroll-006.html
+++ b/LayoutTests/fast/scrolling/ios/mixing-user-and-programmatic-scroll-006.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Mixing user and programmatic scroll of iframe</title>

--- a/LayoutTests/fast/scrolling/ios/scroll-iframe-001.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-iframe-001.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Scrolling of iframe</title>

--- a/LayoutTests/fast/scrolling/ios/scroll-iframe-002.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-iframe-002.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Scrolling of iframe</title>

--- a/LayoutTests/fast/scrolling/ios/scroll-iframe-003.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-iframe-003.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
 <html>
   <head>
     <title>Scrolling of iframe</title>

--- a/LayoutTests/fast/scrolling/ios/scroll-to-beginning-and-end-of-document.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-to-beginning-and-end-of-document.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/jquery/offset.html
+++ b/LayoutTests/jquery/offset.html
@@ -1,3 +1,2 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <script src="resources/helper.js"></script>
 <iframe src="resources/test/index.html?offset"></iframe>


### PR DESCRIPTION
#### e8b2c8b9f620462989dfe351e10612df92eb43a2
<pre>
[scroll-anchoring] Reenable scroll anchoring on some LayoutTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=262712">https://bugs.webkit.org/show_bug.cgi?id=262712</a>
<a href="https://rdar.apple.com/116533047">rdar://116533047</a>

Reviewed by Tim Nguyen and Simon Fraser.

Reenable scroll anchoring on some LayoutTests.

* LayoutTests/fast/dom/Element/body-scrollLeft-basics-quirks.html:
* LayoutTests/fast/dom/Element/body-scrollTop-basics-quirks.html:
* LayoutTests/fast/dom/Window/window-scroll-arguments.html:
* LayoutTests/fast/dom/horizontal-scrollbar-when-dir-change.html:
* LayoutTests/fast/dom/vertical-scrollbar-when-dir-change.html:

Canonical link: <a href="https://commits.webkit.org/272299@main">https://commits.webkit.org/272299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf163f60ebfb7a9e2406a87d299813e8f6863ae9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32505 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27123 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/27162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6201 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/6385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32540 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30335 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8046 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/26482 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7051 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4067 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->