### PR TITLE
Fix input[type=file] in vertical writing mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS horizontal-input block size should match height and inline size should match width
+PASS vertical-lr-input block size should match width and inline size should match height
+PASS vertical-rl-input block size should match width and inline size should match height
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes/#block-flow">
+<title>File input writing mode computed style</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input type="file" id="horizontal-input" style="writing-mode: horizontal-tb">
+<input type="file" id="vertical-lr-input" style="writing-mode: vertical-lr">
+<input type="file" id="vertical-rl-input" style="writing-mode: vertical-rl">
+
+<script>
+for (const element of document.querySelectorAll("[id^='horizontal-']")) {
+    test(() => {
+        const style = getComputedStyle(element);
+        const blockSize = parseInt(style.blockSize, 10);
+        const inlineSize = parseInt(style.inlineSize, 10);
+        assert_not_equals(blockSize, 0);
+        assert_not_equals(inlineSize, 0);
+        assert_greater_than(inlineSize, blockSize);
+        assert_equals(style.blockSize, style.height);
+        assert_equals(style.inlineSize, style.width);
+    }, `${element.id} block size should match height and inline size should match width`);
+}
+
+for (const element of document.querySelectorAll("[id^='vertical-']")) {
+    test(() => {
+        const style = getComputedStyle(element);
+        const blockSize = parseInt(style.blockSize, 10);
+        const inlineSize = parseInt(style.inlineSize, 10);
+        assert_not_equals(blockSize, 0);
+        assert_not_equals(inlineSize, 0);
+        assert_greater_than(inlineSize, blockSize);
+        assert_equals(style.blockSize, style.width);
+        assert_equals(style.inlineSize, style.height);
+    }, `${element.id} block size should match width and inline size should match height`);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-horizontal.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-horizontal.optional-expected-mismatch.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#file-upload-state-(type=file)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>File input writing mode vertical</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="file-input-vertical-rtl.optional.html">
+<link rel="mismatch" href="file-input-horizontal.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The file input below should match the correct writing mode.</p>
+<input type="file" style="writing-mode: vertical-lr">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-horizontal.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-horizontal.optional.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#file-upload-state-(type=file)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>File input writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="file-input-vertical.optional.html">
+<link rel="mismatch" href="file-input-vertical-rtl.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The file input below should match the correct writing mode.</p>
+<input type="file" style="writing-mode: horizontal-tb">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical-rtl.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical-rtl.optional-expected-mismatch.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#file-upload-state-(type=file)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>File input writing mode horizontal</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="file-input-vertical.optional.html">
+<link rel="mismatch" href="file-input-vertical-rtl.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The file input below should match the correct writing mode.</p>
+<input type="file" style="writing-mode: horizontal-tb">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical-rtl.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical-rtl.optional.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#file-upload-state-(type=file)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>File input writing mode vertical RTL</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="file-input-horizontal.optional.html">
+<link rel="mismatch" href="file-input-vertical.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The file input below should match the correct writing mode.</p>
+<input type="file" style="writing-mode: vertical-lr; direction: rtl;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical.optional-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical.optional-expected-mismatch.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#file-upload-state-(type=file)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>File input writing mode vertical RTL</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="file-input-horizontal.optional.html">
+<link rel="mismatch" href="file-input-vertical.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The file input below should match the correct writing mode.</p>
+<input type="file" style="writing-mode: vertical-lr; direction: rtl;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical.optional.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/#file-upload-state-(type=file)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>File input writing mode vertical</title>
+<meta charset="utf-8">
+<link rel="mismatch" href="file-input-vertical-rtl.optional.html">
+<link rel="mismatch" href="file-input-horizontal.optional.html">
+
+<!-- Note test description should be the same across all files to mismatch on. -->
+<p>The file input below should match the correct writing mode.</p>
+<input type="file" style="writing-mode: vertical-lr">

--- a/Source/WebCore/css/horizontalFormControls.css
+++ b/Source/WebCore/css/horizontalFormControls.css
@@ -25,6 +25,6 @@
 @namespace "http://www.w3.org/1999/xhtml";
 
 /* Every time a new control is supported in vertical writing mode, it should be added here and removed from the html.css rule */
-button, textarea, progress, meter, input:not([type="file"]) {
+button, textarea, progress, meter, input {
     writing-mode: horizontal-tb !important;
 }

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -400,7 +400,7 @@ button {
 }
 
 /* Every time a new control is supported in vertical writing mode, it should be removed from here and added in the horizontalFormControls.css rule */
-select, input[type="file"] {
+select {
     writing-mode: horizontal-tb !important;
 }
 

--- a/Source/WebCore/rendering/RenderFileUploadControl.h
+++ b/Source/WebCore/rendering/RenderFileUploadControl.h
@@ -52,8 +52,8 @@ private:
     void paintObject(PaintInfo&, const LayoutPoint&) override;
     void paintControl(PaintInfo&, const LayoutPoint&);
 
-    int maxFilenameWidth() const;
-    
+    int maxFilenameLogicalWidth() const;
+
     VisiblePosition positionForPoint(const LayoutPoint&, const RenderFragmentContainer*) override;
 
     HTMLInputElement* uploadButton() const;


### PR DESCRIPTION
#### d038fb76fc05cd36a01f061093a659f7f550f08d
<pre>
Fix input[type=file] in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248319">https://bugs.webkit.org/show_bug.cgi?id=248319</a>
rdar://102651599

Reviewed by Alan Baradlay.

Update `RenderFileUploadControl` to use logical positions and sizes to support
vertical writing mode.

Added new web platform tests for file inputs, since they are unique from buttons.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-computed-style.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-horizontal.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-horizontal.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical-rtl.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical-rtl.optional.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical.optional-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/file-input-vertical.optional.html: Added.
* Source/WebCore/css/horizontalFormControls.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
* Source/WebCore/css/html.css:
(select):
(select, input[type=&quot;file&quot;]): Deleted.
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::nodeLogicalWidth):
(WebCore::nodeLogicalHeight):
(WebCore::RenderFileUploadControl::maxFilenameLogicalWidth const):
(WebCore::RenderFileUploadControl::paintControl):

Use the ascent/descent of the font to correctly position the text. If in
vertical writing mode, rotate the context prior to drawing the text.

(WebCore::RenderFileUploadControl::computeIntrinsicLogicalWidths const):
(WebCore::RenderFileUploadControl::computePreferredLogicalWidths):
(WebCore::RenderFileUploadControl::fileTextValue const):
(WebCore::nodeWidth): Deleted.
(WebCore::nodeHeight): Deleted.
(WebCore::RenderFileUploadControl::maxFilenameWidth const): Deleted.
* Source/WebCore/rendering/RenderFileUploadControl.h:

Canonical link: <a href="https://commits.webkit.org/268948@main">https://commits.webkit.org/268948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8007ae3b39c0d885d6232ae589dfd23d77277c63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22985 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21669 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23839 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25404 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23336 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16898 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/18964 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5065 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23446 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->