### PR TITLE
Introduce 'rotateRadians' helper function and use across WebKit

### DIFF
--- a/Source/WebCore/html/canvas/CanvasPath.cpp
+++ b/Source/WebCore/html/canvas/CanvasPath.cpp
@@ -195,7 +195,7 @@ ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radiusX, float rad
 
     if ((!radiusX && !radiusY) || startAngle == endAngle) {
         AffineTransform transform;
-        transform.translate(x, y).rotate(rad2deg(rotation));
+        transform.translate(x, y).rotateRadians(rotation);
 
         lineTo(transform.mapPoint(FloatPoint(radiusX * cosf(startAngle), radiusY * sinf(startAngle))));
         return { };
@@ -203,7 +203,7 @@ ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radiusX, float rad
 
     if (!radiusX || !radiusY) {
         AffineTransform transform;
-        transform.translate(x, y).rotate(rad2deg(rotation));
+        transform.translate(x, y).rotateRadians(rotation);
 
         lineTo(transform.mapPoint(FloatPoint(radiusX * cosf(startAngle), radiusY * sinf(startAngle))));
 

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -126,7 +126,7 @@ void PathCG::addArc(const FloatPoint& center, float radius, float startAngle, fl
 void PathCG::addEllipse(const FloatPoint& center, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection direction)
 {
     AffineTransform transform;
-    transform.translate(center.x(), center.y()).rotate(rad2deg(rotation)).scale(radiusX, radiusY);
+    transform.translate(center.x(), center.y()).rotateRadians(rotation).scale(radiusX, radiusY);
 
     CGAffineTransform cgTransform = transform;
     // CG coordinates system increases the angle in the anticlockwise direction.

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2005, 2006 Apple Inc.  All rights reserved.
+ * Copyright (C) 2014 Google Inc.  All rights reserved.
  *               2010 Dirk Schulze <krit@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -128,7 +129,11 @@ AffineTransform& AffineTransform::multiply(const AffineTransform& other)
 AffineTransform& AffineTransform::rotate(double a)
 {
     // angle is in degree. Switch to radian
-    a = deg2rad(a);
+    return rotateRadians(deg2rad(a));
+}
+
+AffineTransform& AffineTransform::rotateRadians(double a)
+{
     double cosAngle = cos(a);
     double sinAngle = sin(a);
     AffineTransform rot(cosAngle, sinAngle, -sinAngle, cosAngle, 0, 0);
@@ -187,7 +192,7 @@ AffineTransform& AffineTransform::translate(const FloatSize& t)
 
 AffineTransform& AffineTransform::rotateFromVector(double x, double y)
 {
-    return rotate(rad2deg(atan2(y, x)));
+    return rotateRadians(atan2(y, x));
 }
 
 AffineTransform& AffineTransform::flipX()
@@ -408,7 +413,7 @@ bool AffineTransform::decompose(DecomposedType& decomp) const
     double angle = atan2(m.b(), m.a());
     
     // Remove rotation from matrix
-    m.rotate(rad2deg(-angle));
+    m.rotateRadians(-angle);
     
     // Return results    
     decomp.scaleX = sx;
@@ -432,7 +437,7 @@ void AffineTransform::recompose(const DecomposedType& decomp)
     this->setD(decomp.remainderD);
     this->setE(decomp.translateX);
     this->setF(decomp.translateY);
-    this->rotate(rad2deg(decomp.angle));
+    this->rotateRadians(decomp.angle);
     this->scale(decomp.scaleX, decomp.scaleY);
 }
 

--- a/Source/WebCore/platform/graphics/transforms/AffineTransform.h
+++ b/Source/WebCore/platform/graphics/transforms/AffineTransform.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2005-2016 Apple Inc.  All rights reserved.
+ * Copyright (C) 2014 Google Inc.  All rights reserved.
  *               2010 Dirk Schulze <krit@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -110,6 +111,7 @@ public:
     WEBCORE_EXPORT AffineTransform& scaleNonUniform(double sx, double sy); // Same as scale(sx, sy).
     WEBCORE_EXPORT AffineTransform& scale(const FloatSize&);
     WEBCORE_EXPORT AffineTransform& rotate(double);
+    WEBCORE_EXPORT AffineTransform& rotateRadians(double);
     AffineTransform& rotateFromVector(double x, double y);
     WEBCORE_EXPORT AffineTransform& translate(double tx, double ty);
     WEBCORE_EXPORT AffineTransform& translate(const FloatPoint&);

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -614,7 +614,7 @@ TransformationMatrix& TransformationMatrix::scale(double s)
 
 TransformationMatrix& TransformationMatrix::rotateFromVector(double x, double y)
 {
-    return rotate(rad2deg(atan2(y, x)));
+    return rotateRadians(atan2(y, x));
 }
 
 TransformationMatrix& TransformationMatrix::flipX()
@@ -986,7 +986,11 @@ TransformationMatrix& TransformationMatrix::rotate(double angle)
     if (!std::fmod(angle, 360))
         return *this;
 
-    angle = deg2rad(angle);
+    return rotateRadians(deg2rad(angle));
+}
+
+TransformationMatrix& TransformationMatrix::rotateRadians(double angle)
+{
     double sinZ = roundEpsilonToZero(sin(angle));
     double cosZ = roundEpsilonToZero(cos(angle));
     multiply({ cosZ, sinZ, -sinZ, cosZ, 0, 0 });

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -269,6 +269,7 @@ public:
 
     // Angle is in degrees.
     WEBCORE_EXPORT TransformationMatrix& rotate(double);
+    WEBCORE_EXPORT TransformationMatrix& rotateRadians(double);
     TransformationMatrix& rotateFromVector(double x, double y);
     WEBCORE_EXPORT TransformationMatrix& rotate3d(double rx, double ry, double rz);
     


### PR DESCRIPTION
#### 3f64447f2aa9d256ae17bd271e186aac0257f2f9
<pre>
Introduce &apos;rotateRadians&apos; helper function and use across WebKit

<a href="https://bugs.webkit.org/show_bug.cgi?id=262718">https://bugs.webkit.org/show_bug.cgi?id=262718</a>

Reviewed by Chris Dumez.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=167603 &amp;
<a href="https://src.chromium.org/viewvc/blink?revision=168929&amp">https://src.chromium.org/viewvc/blink?revision=168929&amp</a>;view=revision

Currently, rotate function takes an argument in only degrees.
In many cases, rotate function is often required radian value instead of degree value.
If we add new rotateRadians function, we will be able to reduce unnecessary operations.

 Before : rad -&gt; rad2deg -&gt; deg2rad -&gt; calc sinNcos
 After  : rad                       -&gt; calc sinNcos

As a result, we can reduce two multiplication and two division.

Additionally, we can use it across WebCore source instead of &apos;rotate(rad2deg)&apos;.

* Source/WebCore/platform/graphics/transforms/AffineTransform.cpp:
(AffineTransform::rotate):
(AffineTransform::rotateRadians):
(AffineTransform::rotateFromVector):
(AffineTransform::decompose):
* Source/WebCore/platform/graphics/transforms/AffineTransform.h: new &apos;rotateRadians&apos; function
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(PathCG::addEllipse):
* Source/WebCore/html/canvas/CanvasPath.cpp:
(CanvasPath::addEllipse):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(TransformationMatrix::rotateFromVector):
(TransformationMatrix::rotate):
(TransformationMatrix::rotateRadians):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h: new &apos;rotateRadians&apos; function

Canonical link: <a href="https://commits.webkit.org/268964@main">https://commits.webkit.org/268964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/683dfbcb41aac70e2d1fd0e63222b3d307323edc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19661 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21705 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23878 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25507 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23368 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16927 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19189 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5073 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->