### PR TITLE
[SVG] Add ShapeType to LegacyRenderSVGShape

### DIFF
--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -421,6 +421,11 @@ bool Path::isEmpty() const
     return false;
 }
 
+bool Path::definitelySingleLine() const
+{
+    return !!singleDataLine();
+}
+
 PlatformPathPtr Path::platformPath() const
 {
     return const_cast<Path&>(*this).ensurePlatformPathImpl().platformPath();

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -92,6 +92,7 @@ public:
     std::optional<PathDataBezierCurve> singleBezierCurve() const;
 
     WEBCORE_EXPORT bool isEmpty() const;
+    bool definitelySingleLine() const;
     WEBCORE_EXPORT PlatformPathPtr platformPath() const;
 
     const PathSegment* singleSegmentIfExists() const { return asSingle(); }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -61,6 +61,11 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
     if (m_radii.isEmpty())
         return;
 
+    if (m_radii.width() == m_radii.height())
+        m_shapeType = ShapeType::Circle;
+    else
+        m_shapeType = ShapeType::Ellipse;
+
     if (hasNonScalingStroke()) {
         // Fallback to LegacyRenderSVGShape if shape has a non-scaling stroke.
         LegacyRenderSVGShape::updateShapeFromElement();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -53,6 +53,14 @@ void LegacyRenderSVGPath::updateShapeFromElement()
     updateZeroLengthSubpaths();
 
     m_strokeBoundingBox = calculateUpdatedStrokeBoundingBox();
+
+    ASSERT(hasPath());
+    if (path().isEmpty())
+        m_shapeType = ShapeType::Empty;
+    else if (path().definitelySingleLine())
+        m_shapeType = ShapeType::Line;
+    else
+        m_shapeType = ShapeType::Path;
 }
 
 FloatRect LegacyRenderSVGPath::calculateUpdatedStrokeBoundingBox() const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -64,7 +64,11 @@ void LegacyRenderSVGRect::updateShapeFromElement()
     if (boundingBoxSize.isEmpty())
         return;
 
-    if (rectElement().rx().value(lengthContext) > 0 || rectElement().ry().value(lengthContext) > 0 || hasNonScalingStroke()) {
+    m_shapeType = ShapeType::Rectangle;
+    if (rectElement().rx().value(lengthContext) > 0 || rectElement().ry().value(lengthContext) > 0)
+        m_shapeType = ShapeType::RoundedRectangle;
+
+    if (m_shapeType != ShapeType::Rectangle || hasNonScalingStroke()) {
         // Fall back to LegacyRenderSVGShape
         LegacyRenderSVGShape::updateShapeFromElement();
         return;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -151,6 +151,7 @@ void LegacyRenderSVGShape::layout()
     bool updateCachedBoundariesInParents = false;
 
     if (m_needsShapeUpdate || m_needsBoundariesUpdate) {
+        m_shapeType = ShapeType::Empty;
         updateShapeFromElement();
         m_needsShapeUpdate = false;
         updateRepaintBoundingBox();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -42,6 +42,16 @@ class SVGGraphicsElement;
 class LegacyRenderSVGShape : public LegacyRenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGShape);
 public:
+    enum class ShapeType : uint8_t {
+        Empty,
+        Path,
+        Line,
+        Rectangle,
+        RoundedRectangle,
+        Ellipse,
+        Circle,
+    };
+
     enum PointCoordinateSpace {
         GlobalCoordinateSpace,
         LocalCoordinateSpace
@@ -72,6 +82,8 @@ public:
         return *m_path;
     }
     void clearPath() { m_path = nullptr; }
+
+    ShapeType shapeType() const { return m_shapeType; }
 
 protected:
     void element() const = delete;
@@ -136,7 +148,9 @@ private:
     bool m_needsBoundariesUpdate : 1;
     bool m_needsShapeUpdate : 1;
     bool m_needsTransformUpdate : 1;
-
+protected:
+    ShapeType m_shapeType : 3 { ShapeType::Empty };
+private:
     AffineTransform m_localTransform;
     std::unique_ptr<Path> m_path;
     Vector<MarkerPosition> m_markerPositions;


### PR DESCRIPTION
#### d6714182b3ab453ce39eee1ec18e3b5032dffec0
<pre>
[SVG] Add ShapeType to LegacyRenderSVGShape
<a href="https://bugs.webkit.org/show_bug.cgi?id=262724">https://bugs.webkit.org/show_bug.cgi?id=262724</a>
rdar://116538506

Reviewed by Simon Fraser.

This patch adds ShapeType to LegacyRenderSVGShape, which tells shape type of LegacyRenderSVGShape.
This enum will be used for efficient dispatch / behavior change for approximate repainting bounding box computation.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::isSingleDataLine const):
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
(WebCore::LegacyRenderSVGEllipse::updateShapeFromElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::updateShapeFromElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
(WebCore::LegacyRenderSVGRect::updateShapeFromElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::layout):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
(WebCore::LegacyRenderSVGShape::shapeType const):

Canonical link: <a href="https://commits.webkit.org/268961@main">https://commits.webkit.org/268961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/148e7c6414817d48a450b8ef0932cf9af589efda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21694 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23865 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25423 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23359 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16916 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23464 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2620 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->