### PR TITLE
Align UA Stylesheet by adding `writing-mode: horizontal-tb !important;` for all math elements in mathml.css

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/writing-mode/force-horizontal-tb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/writing-mode/force-horizontal-tb-expected.txt
@@ -1,70 +1,70 @@
 
 PASS writing-mode is forced to horizontal-tb on <math> element
 PASS logical properties interpreted in horizontal-tb on <math> element
-FAIL writing-mode is forced to horizontal-tb on <annotation> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <annotation> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <annotation-xml> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <annotation-xml> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <maction> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <maction> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <menclose> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <menclose> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <merror> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <merror> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mfrac> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mfrac> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mi> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mi> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mmultiscripts> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mmultiscripts> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mn> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mn> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mo> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mo> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mover> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mover> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mpadded> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mpadded> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mphantom> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mphantom> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mprescripts> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mprescripts> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mroot> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mroot> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mrow> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mrow> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <ms> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <ms> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mspace> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mspace> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <msqrt> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <msqrt> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mstyle> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mstyle> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <msub> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <msub> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <msubsup> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <msubsup> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <msup> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <msup> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <mtable> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mtable> element assert_equals: expected "20px" but got "10px"
+PASS writing-mode is forced to horizontal-tb on <annotation> element
+PASS logical properties interpreted in horizontal-tb on <annotation> element
+PASS writing-mode is forced to horizontal-tb on <annotation-xml> element
+PASS logical properties interpreted in horizontal-tb on <annotation-xml> element
+PASS writing-mode is forced to horizontal-tb on <maction> element
+PASS logical properties interpreted in horizontal-tb on <maction> element
+PASS writing-mode is forced to horizontal-tb on <menclose> element
+PASS logical properties interpreted in horizontal-tb on <menclose> element
+PASS writing-mode is forced to horizontal-tb on <merror> element
+PASS logical properties interpreted in horizontal-tb on <merror> element
+PASS writing-mode is forced to horizontal-tb on <mfrac> element
+PASS logical properties interpreted in horizontal-tb on <mfrac> element
+PASS writing-mode is forced to horizontal-tb on <mi> element
+PASS logical properties interpreted in horizontal-tb on <mi> element
+PASS writing-mode is forced to horizontal-tb on <mmultiscripts> element
+PASS logical properties interpreted in horizontal-tb on <mmultiscripts> element
+PASS writing-mode is forced to horizontal-tb on <mn> element
+PASS logical properties interpreted in horizontal-tb on <mn> element
+PASS writing-mode is forced to horizontal-tb on <mo> element
+PASS logical properties interpreted in horizontal-tb on <mo> element
+PASS writing-mode is forced to horizontal-tb on <mover> element
+PASS logical properties interpreted in horizontal-tb on <mover> element
+PASS writing-mode is forced to horizontal-tb on <mpadded> element
+PASS logical properties interpreted in horizontal-tb on <mpadded> element
+PASS writing-mode is forced to horizontal-tb on <mphantom> element
+PASS logical properties interpreted in horizontal-tb on <mphantom> element
+PASS writing-mode is forced to horizontal-tb on <mprescripts> element
+PASS logical properties interpreted in horizontal-tb on <mprescripts> element
+PASS writing-mode is forced to horizontal-tb on <mroot> element
+PASS logical properties interpreted in horizontal-tb on <mroot> element
+PASS writing-mode is forced to horizontal-tb on <mrow> element
+PASS logical properties interpreted in horizontal-tb on <mrow> element
+PASS writing-mode is forced to horizontal-tb on <ms> element
+PASS logical properties interpreted in horizontal-tb on <ms> element
+PASS writing-mode is forced to horizontal-tb on <mspace> element
+PASS logical properties interpreted in horizontal-tb on <mspace> element
+PASS writing-mode is forced to horizontal-tb on <msqrt> element
+PASS logical properties interpreted in horizontal-tb on <msqrt> element
+PASS writing-mode is forced to horizontal-tb on <mstyle> element
+PASS logical properties interpreted in horizontal-tb on <mstyle> element
+PASS writing-mode is forced to horizontal-tb on <msub> element
+PASS logical properties interpreted in horizontal-tb on <msub> element
+PASS writing-mode is forced to horizontal-tb on <msubsup> element
+PASS logical properties interpreted in horizontal-tb on <msubsup> element
+PASS writing-mode is forced to horizontal-tb on <msup> element
+PASS logical properties interpreted in horizontal-tb on <msup> element
+PASS writing-mode is forced to horizontal-tb on <mtable> element
+PASS logical properties interpreted in horizontal-tb on <mtable> element
 PASS writing-mode is forced to horizontal-tb on <mtd> element
 PASS logical properties interpreted in horizontal-tb on <mtd> element
-FAIL writing-mode is forced to horizontal-tb on <mtext> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <mtext> element assert_equals: expected "20px" but got "10px"
+PASS writing-mode is forced to horizontal-tb on <mtext> element
+PASS logical properties interpreted in horizontal-tb on <mtext> element
 PASS writing-mode is forced to horizontal-tb on <mtr> element
 PASS logical properties interpreted in horizontal-tb on <mtr> element
-FAIL writing-mode is forced to horizontal-tb on <munder> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <munder> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <munderover> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <munderover> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <none> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <none> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <semantics> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <semantics> element assert_equals: expected "20px" but got "10px"
-FAIL writing-mode is forced to horizontal-tb on <unknown> element assert_equals: expected "horizontal-tb" but got "vertical-lr"
-FAIL logical properties interpreted in horizontal-tb on <unknown> element assert_equals: expected "20px" but got "10px"
+PASS writing-mode is forced to horizontal-tb on <munder> element
+PASS logical properties interpreted in horizontal-tb on <munder> element
+PASS writing-mode is forced to horizontal-tb on <munderover> element
+PASS logical properties interpreted in horizontal-tb on <munderover> element
+PASS writing-mode is forced to horizontal-tb on <none> element
+PASS logical properties interpreted in horizontal-tb on <none> element
+PASS writing-mode is forced to horizontal-tb on <semantics> element
+PASS logical properties interpreted in horizontal-tb on <semantics> element
+PASS writing-mode is forced to horizontal-tb on <unknown> element
+PASS logical properties interpreted in horizontal-tb on <unknown> element
 
 
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt
@@ -1,6 +1,6 @@
 
 PASS maction preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL maction layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -88 +/- 1 but got -14
+FAIL maction layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -88 +/- 1 but got -8
 PASS maction preferred width calculation is not affected by white-space: normal;
 FAIL maction layout is not affected by white-space: normal; assert_approx_equals: inline position (child 1) expected -88 +/- 1 but got -8
 PASS maction preferred width calculation is not affected by float: right;
@@ -10,7 +10,7 @@ FAIL maction layout is not affected by align-content: end; justify-content: end;
 PASS maction preferred width calculation is not affected by align-self: end; justify-self: end;
 FAIL maction layout is not affected by align-self: end; justify-self: end; assert_approx_equals: inline position (child 1) expected -88 +/- 1 but got -8
 PASS menclose preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL menclose layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 7.96875 +/- 1 but got 3.984375
+PASS menclose layout is not affected by writing-mode: vertical-rl;
 PASS menclose preferred width calculation is not affected by white-space: normal;
 PASS menclose layout is not affected by white-space: normal;
 PASS menclose preferred width calculation is not affected by float: right;
@@ -20,7 +20,7 @@ PASS menclose layout is not affected by align-content: end; justify-content: end
 PASS menclose preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS menclose layout is not affected by align-self: end; justify-self: end;
 PASS merror preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL merror layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 9 +/- 1 but got 1
+PASS merror layout is not affected by writing-mode: vertical-rl;
 PASS merror preferred width calculation is not affected by white-space: normal;
 PASS merror layout is not affected by white-space: normal;
 PASS merror preferred width calculation is not affected by float: right;
@@ -30,7 +30,7 @@ PASS merror layout is not affected by align-content: end; justify-content: end;
 PASS merror preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS merror layout is not affected by align-self: end; justify-self: end;
 PASS mfrac preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mfrac layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 0 +/- 1 but got 11.8125
+PASS mfrac layout is not affected by writing-mode: vertical-rl;
 PASS mfrac preferred width calculation is not affected by white-space: normal;
 PASS mfrac layout is not affected by white-space: normal;
 PASS mfrac preferred width calculation is not affected by float: right;
@@ -40,7 +40,7 @@ PASS mfrac layout is not affected by align-content: end; justify-content: end;
 PASS mfrac preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mfrac layout is not affected by align-self: end; justify-self: end;
 PASS mi preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mi layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 80
+PASS mi layout is not affected by writing-mode: vertical-rl;
 PASS mi preferred width calculation is not affected by white-space: normal;
 PASS mi layout is not affected by white-space: normal;
 PASS mi preferred width calculation is not affected by float: right;
@@ -50,7 +50,7 @@ PASS mi layout is not affected by align-content: end; justify-content: end;
 PASS mi preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mi layout is not affected by align-self: end; justify-self: end;
 PASS mmultiscripts preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mmultiscripts layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.796875
+PASS mmultiscripts layout is not affected by writing-mode: vertical-rl;
 PASS mmultiscripts preferred width calculation is not affected by white-space: normal;
 PASS mmultiscripts layout is not affected by white-space: normal;
 PASS mmultiscripts preferred width calculation is not affected by float: right;
@@ -60,7 +60,7 @@ PASS mmultiscripts layout is not affected by align-content: end; justify-content
 PASS mmultiscripts preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mmultiscripts layout is not affected by align-self: end; justify-self: end;
 PASS mn preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mn layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 80
+PASS mn layout is not affected by writing-mode: vertical-rl;
 PASS mn preferred width calculation is not affected by white-space: normal;
 PASS mn layout is not affected by white-space: normal;
 PASS mn preferred width calculation is not affected by float: right;
@@ -70,7 +70,7 @@ PASS mn layout is not affected by align-content: end; justify-content: end;
 PASS mn preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mn layout is not affected by align-self: end; justify-self: end;
 PASS mo preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mo layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 80
+PASS mo layout is not affected by writing-mode: vertical-rl;
 PASS mo preferred width calculation is not affected by white-space: normal;
 PASS mo layout is not affected by white-space: normal;
 PASS mo preferred width calculation is not affected by float: right;
@@ -80,7 +80,7 @@ PASS mo layout is not affected by align-content: end; justify-content: end;
 PASS mo preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mo layout is not affected by align-self: end; justify-self: end;
 PASS mover preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mover layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 9.53125
+PASS mover layout is not affected by writing-mode: vertical-rl;
 PASS mover preferred width calculation is not affected by white-space: normal;
 PASS mover layout is not affected by white-space: normal;
 PASS mover preferred width calculation is not affected by float: right;
@@ -90,7 +90,7 @@ PASS mover layout is not affected by align-content: end; justify-content: end;
 PASS mover preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mover layout is not affected by align-self: end; justify-self: end;
 PASS mpadded preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mpadded layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8 +/- 1 but got 0
+PASS mpadded layout is not affected by writing-mode: vertical-rl;
 PASS mpadded preferred width calculation is not affected by white-space: normal;
 PASS mpadded layout is not affected by white-space: normal;
 PASS mpadded preferred width calculation is not affected by float: right;
@@ -100,7 +100,7 @@ PASS mpadded layout is not affected by align-content: end; justify-content: end;
 PASS mpadded preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mpadded layout is not affected by align-self: end; justify-self: end;
 PASS mphantom preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mphantom layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8 +/- 1 but got 0
+PASS mphantom layout is not affected by writing-mode: vertical-rl;
 PASS mphantom preferred width calculation is not affected by white-space: normal;
 PASS mphantom layout is not affected by white-space: normal;
 PASS mphantom preferred width calculation is not affected by float: right;
@@ -110,7 +110,7 @@ PASS mphantom layout is not affected by align-content: end; justify-content: end
 PASS mphantom preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mphantom layout is not affected by align-self: end; justify-self: end;
 PASS mroot preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mroot layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 17.625 +/- 1 but got 11.046875
+PASS mroot layout is not affected by writing-mode: vertical-rl;
 PASS mroot preferred width calculation is not affected by white-space: normal;
 PASS mroot layout is not affected by white-space: normal;
 PASS mroot preferred width calculation is not affected by float: right;
@@ -120,7 +120,7 @@ PASS mroot layout is not affected by align-content: end; justify-content: end;
 PASS mroot preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mroot layout is not affected by align-self: end; justify-self: end;
 PASS mrow preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mrow layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8 +/- 1 but got 0
+PASS mrow layout is not affected by writing-mode: vertical-rl;
 PASS mrow preferred width calculation is not affected by white-space: normal;
 PASS mrow layout is not affected by white-space: normal;
 PASS mrow preferred width calculation is not affected by float: right;
@@ -130,7 +130,7 @@ PASS mrow layout is not affected by align-content: end; justify-content: end;
 PASS mrow preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mrow layout is not affected by align-self: end; justify-self: end;
 PASS ms preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL ms layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 80
+PASS ms layout is not affected by writing-mode: vertical-rl;
 PASS ms preferred width calculation is not affected by white-space: normal;
 PASS ms layout is not affected by white-space: normal;
 PASS ms preferred width calculation is not affected by float: right;
@@ -150,7 +150,7 @@ PASS mspace layout is not affected by align-content: end; justify-content: end;
 PASS mspace preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mspace layout is not affected by align-self: end; justify-self: end;
 PASS msqrt preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msqrt layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 17.625 +/- 1 but got 11.046875
+PASS msqrt layout is not affected by writing-mode: vertical-rl;
 PASS msqrt preferred width calculation is not affected by white-space: normal;
 PASS msqrt layout is not affected by white-space: normal;
 PASS msqrt preferred width calculation is not affected by float: right;
@@ -160,7 +160,7 @@ PASS msqrt layout is not affected by align-content: end; justify-content: end;
 PASS msqrt preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msqrt layout is not affected by align-self: end; justify-self: end;
 PASS mstyle preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mstyle layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8 +/- 1 but got 0
+PASS mstyle layout is not affected by writing-mode: vertical-rl;
 PASS mstyle preferred width calculation is not affected by white-space: normal;
 PASS mstyle layout is not affected by white-space: normal;
 PASS mstyle preferred width calculation is not affected by float: right;
@@ -170,7 +170,7 @@ PASS mstyle layout is not affected by align-content: end; justify-content: end;
 PASS mstyle preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mstyle layout is not affected by align-self: end; justify-self: end;
 PASS msub preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msub layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 80 +/- 1 but got 6.1875
+PASS msub layout is not affected by writing-mode: vertical-rl;
 PASS msub preferred width calculation is not affected by white-space: normal;
 PASS msub layout is not affected by white-space: normal;
 PASS msub preferred width calculation is not affected by float: right;
@@ -180,7 +180,7 @@ PASS msub layout is not affected by align-content: end; justify-content: end;
 PASS msub preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msub layout is not affected by align-self: end; justify-self: end;
 PASS msubsup preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msubsup layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.796875
+PASS msubsup layout is not affected by writing-mode: vertical-rl;
 PASS msubsup preferred width calculation is not affected by white-space: normal;
 PASS msubsup layout is not affected by white-space: normal;
 PASS msubsup preferred width calculation is not affected by float: right;
@@ -190,7 +190,7 @@ PASS msubsup layout is not affected by align-content: end; justify-content: end;
 PASS msubsup preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msubsup layout is not affected by align-self: end; justify-self: end;
 PASS msup preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msup layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.796875
+PASS msup layout is not affected by writing-mode: vertical-rl;
 PASS msup preferred width calculation is not affected by white-space: normal;
 PASS msup layout is not affected by white-space: normal;
 PASS msup preferred width calculation is not affected by float: right;
@@ -210,7 +210,7 @@ PASS mtable layout is not affected by align-content: end; justify-content: end;
 PASS mtable preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mtable layout is not affected by align-self: end; justify-self: end;
 PASS mtext preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mtext layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 80
+PASS mtext layout is not affected by writing-mode: vertical-rl;
 PASS mtext preferred width calculation is not affected by white-space: normal;
 PASS mtext layout is not affected by white-space: normal;
 PASS mtext preferred width calculation is not affected by float: right;
@@ -230,7 +230,7 @@ PASS munder layout is not affected by align-content: end; justify-content: end;
 PASS munder preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS munder layout is not affected by align-self: end; justify-self: end;
 PASS munderover preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL munderover layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 9.53125
+PASS munderover layout is not affected by writing-mode: vertical-rl;
 PASS munderover preferred width calculation is not affected by white-space: normal;
 PASS munderover layout is not affected by white-space: normal;
 PASS munderover preferred width calculation is not affected by float: right;
@@ -240,7 +240,7 @@ PASS munderover layout is not affected by align-content: end; justify-content: e
 PASS munderover preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS munderover layout is not affected by align-self: end; justify-self: end;
 PASS semantics preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL semantics layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -88 +/- 1 but got -14
+FAIL semantics layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -88 +/- 1 but got -8
 PASS semantics preferred width calculation is not affected by white-space: normal;
 FAIL semantics layout is not affected by white-space: normal; assert_approx_equals: inline position (child 1) expected -88 +/- 1 but got -8
 PASS semantics preferred width calculation is not affected by float: right;

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt
@@ -1,6 +1,6 @@
 
 PASS maction preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL maction layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -15
+FAIL maction layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS maction preferred width calculation is not affected by white-space: normal;
 FAIL maction layout is not affected by white-space: normal; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS maction preferred width calculation is not affected by float: right;
@@ -10,7 +10,7 @@ FAIL maction layout is not affected by align-content: end; justify-content: end;
 PASS maction preferred width calculation is not affected by align-self: end; justify-self: end;
 FAIL maction layout is not affected by align-self: end; justify-self: end; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS menclose preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL menclose layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 7.96875 +/- 1 but got 3.984375
+PASS menclose layout is not affected by writing-mode: vertical-rl;
 PASS menclose preferred width calculation is not affected by white-space: normal;
 PASS menclose layout is not affected by white-space: normal;
 PASS menclose preferred width calculation is not affected by float: right;
@@ -20,7 +20,7 @@ PASS menclose layout is not affected by align-content: end; justify-content: end
 PASS menclose preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS menclose layout is not affected by align-self: end; justify-self: end;
 PASS merror preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL merror layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 9.875 +/- 1 but got 1
+PASS merror layout is not affected by writing-mode: vertical-rl;
 PASS merror preferred width calculation is not affected by white-space: normal;
 PASS merror layout is not affected by white-space: normal;
 PASS merror preferred width calculation is not affected by float: right;
@@ -30,7 +30,7 @@ PASS merror layout is not affected by align-content: end; justify-content: end;
 PASS merror preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS merror layout is not affected by align-self: end; justify-self: end;
 PASS mfrac preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mfrac layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 0 +/- 1 but got 18.71875
+PASS mfrac layout is not affected by writing-mode: vertical-rl;
 PASS mfrac preferred width calculation is not affected by white-space: normal;
 PASS mfrac layout is not affected by white-space: normal;
 PASS mfrac preferred width calculation is not affected by float: right;
@@ -40,7 +40,7 @@ PASS mfrac layout is not affected by align-content: end; justify-content: end;
 PASS mfrac preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mfrac layout is not affected by align-self: end; justify-self: end;
 PASS mi preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mi layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS mi layout is not affected by writing-mode: vertical-rl;
 PASS mi preferred width calculation is not affected by white-space: normal;
 PASS mi layout is not affected by white-space: normal;
 PASS mi preferred width calculation is not affected by float: right;
@@ -50,7 +50,7 @@ PASS mi layout is not affected by align-content: end; justify-content: end;
 PASS mi preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mi layout is not affected by align-self: end; justify-self: end;
 PASS mmultiscripts preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mmultiscripts layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.75
+PASS mmultiscripts layout is not affected by writing-mode: vertical-rl;
 PASS mmultiscripts preferred width calculation is not affected by white-space: normal;
 PASS mmultiscripts layout is not affected by white-space: normal;
 PASS mmultiscripts preferred width calculation is not affected by float: right;
@@ -60,7 +60,7 @@ PASS mmultiscripts layout is not affected by align-content: end; justify-content
 PASS mmultiscripts preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mmultiscripts layout is not affected by align-self: end; justify-self: end;
 PASS mn preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mn layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS mn layout is not affected by writing-mode: vertical-rl;
 PASS mn preferred width calculation is not affected by white-space: normal;
 PASS mn layout is not affected by white-space: normal;
 PASS mn preferred width calculation is not affected by float: right;
@@ -70,7 +70,7 @@ PASS mn layout is not affected by align-content: end; justify-content: end;
 PASS mn preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mn layout is not affected by align-self: end; justify-self: end;
 PASS mo preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mo layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS mo layout is not affected by writing-mode: vertical-rl;
 PASS mo preferred width calculation is not affected by white-space: normal;
 PASS mo layout is not affected by white-space: normal;
 PASS mo preferred width calculation is not affected by float: right;
@@ -80,7 +80,7 @@ PASS mo layout is not affected by align-content: end; justify-content: end;
 PASS mo preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mo layout is not affected by align-self: end; justify-self: end;
 PASS mover preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mover layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 9.875
+PASS mover layout is not affected by writing-mode: vertical-rl;
 PASS mover preferred width calculation is not affected by white-space: normal;
 PASS mover layout is not affected by white-space: normal;
 PASS mover preferred width calculation is not affected by float: right;
@@ -90,7 +90,7 @@ PASS mover layout is not affected by align-content: end; justify-content: end;
 PASS mover preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mover layout is not affected by align-self: end; justify-self: end;
 PASS mpadded preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mpadded layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8.875 +/- 1 but got 0
+PASS mpadded layout is not affected by writing-mode: vertical-rl;
 PASS mpadded preferred width calculation is not affected by white-space: normal;
 PASS mpadded layout is not affected by white-space: normal;
 PASS mpadded preferred width calculation is not affected by float: right;
@@ -100,7 +100,7 @@ PASS mpadded layout is not affected by align-content: end; justify-content: end;
 PASS mpadded preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mpadded layout is not affected by align-self: end; justify-self: end;
 PASS mphantom preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mphantom layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8.875 +/- 1 but got 0
+PASS mphantom layout is not affected by writing-mode: vertical-rl;
 PASS mphantom preferred width calculation is not affected by white-space: normal;
 PASS mphantom layout is not affected by white-space: normal;
 PASS mphantom preferred width calculation is not affected by float: right;
@@ -110,7 +110,7 @@ PASS mphantom layout is not affected by align-content: end; justify-content: end
 PASS mphantom preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mphantom layout is not affected by align-self: end; justify-self: end;
 PASS mroot preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mroot layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 20.21875 +/- 1 but got 11.671875
+PASS mroot layout is not affected by writing-mode: vertical-rl;
 PASS mroot preferred width calculation is not affected by white-space: normal;
 PASS mroot layout is not affected by white-space: normal;
 PASS mroot preferred width calculation is not affected by float: right;
@@ -120,7 +120,7 @@ PASS mroot layout is not affected by align-content: end; justify-content: end;
 PASS mroot preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mroot layout is not affected by align-self: end; justify-self: end;
 PASS mrow preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mrow layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8.875 +/- 1 but got 0
+PASS mrow layout is not affected by writing-mode: vertical-rl;
 PASS mrow preferred width calculation is not affected by white-space: normal;
 PASS mrow layout is not affected by white-space: normal;
 PASS mrow preferred width calculation is not affected by float: right;
@@ -130,7 +130,7 @@ PASS mrow layout is not affected by align-content: end; justify-content: end;
 PASS mrow preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mrow layout is not affected by align-self: end; justify-self: end;
 PASS ms preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL ms layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS ms layout is not affected by writing-mode: vertical-rl;
 PASS ms preferred width calculation is not affected by white-space: normal;
 PASS ms layout is not affected by white-space: normal;
 PASS ms preferred width calculation is not affected by float: right;
@@ -150,7 +150,7 @@ PASS mspace layout is not affected by align-content: end; justify-content: end;
 PASS mspace preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mspace layout is not affected by align-self: end; justify-self: end;
 PASS msqrt preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msqrt layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 20.21875 +/- 1 but got 11.671875
+PASS msqrt layout is not affected by writing-mode: vertical-rl;
 PASS msqrt preferred width calculation is not affected by white-space: normal;
 PASS msqrt layout is not affected by white-space: normal;
 PASS msqrt preferred width calculation is not affected by float: right;
@@ -160,7 +160,7 @@ PASS msqrt layout is not affected by align-content: end; justify-content: end;
 PASS msqrt preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msqrt layout is not affected by align-self: end; justify-self: end;
 PASS mstyle preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mstyle layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8.875 +/- 1 but got 0
+PASS mstyle layout is not affected by writing-mode: vertical-rl;
 PASS mstyle preferred width calculation is not affected by white-space: normal;
 PASS mstyle layout is not affected by white-space: normal;
 PASS mstyle preferred width calculation is not affected by float: right;
@@ -170,7 +170,7 @@ PASS mstyle layout is not affected by align-content: end; justify-content: end;
 PASS mstyle preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mstyle layout is not affected by align-self: end; justify-self: end;
 PASS msub preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msub layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 88.75 +/- 1 but got 5.359375
+PASS msub layout is not affected by writing-mode: vertical-rl;
 PASS msub preferred width calculation is not affected by white-space: normal;
 PASS msub layout is not affected by white-space: normal;
 PASS msub preferred width calculation is not affected by float: right;
@@ -180,7 +180,7 @@ PASS msub layout is not affected by align-content: end; justify-content: end;
 PASS msub preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msub layout is not affected by align-self: end; justify-self: end;
 PASS msubsup preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msubsup layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.75
+PASS msubsup layout is not affected by writing-mode: vertical-rl;
 PASS msubsup preferred width calculation is not affected by white-space: normal;
 PASS msubsup layout is not affected by white-space: normal;
 PASS msubsup preferred width calculation is not affected by float: right;
@@ -190,7 +190,7 @@ PASS msubsup layout is not affected by align-content: end; justify-content: end;
 PASS msubsup preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msubsup layout is not affected by align-self: end; justify-self: end;
 PASS msup preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msup layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.75
+PASS msup layout is not affected by writing-mode: vertical-rl;
 PASS msup preferred width calculation is not affected by white-space: normal;
 PASS msup layout is not affected by white-space: normal;
 PASS msup preferred width calculation is not affected by float: right;
@@ -210,7 +210,7 @@ PASS mtable layout is not affected by align-content: end; justify-content: end;
 PASS mtable preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mtable layout is not affected by align-self: end; justify-self: end;
 PASS mtext preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mtext layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS mtext layout is not affected by writing-mode: vertical-rl;
 PASS mtext preferred width calculation is not affected by white-space: normal;
 PASS mtext layout is not affected by white-space: normal;
 PASS mtext preferred width calculation is not affected by float: right;
@@ -230,7 +230,7 @@ PASS munder layout is not affected by align-content: end; justify-content: end;
 PASS munder preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS munder layout is not affected by align-self: end; justify-self: end;
 PASS munderover preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL munderover layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 9.875
+PASS munderover layout is not affected by writing-mode: vertical-rl;
 PASS munderover preferred width calculation is not affected by white-space: normal;
 PASS munderover layout is not affected by white-space: normal;
 PASS munderover preferred width calculation is not affected by float: right;
@@ -240,7 +240,7 @@ PASS munderover layout is not affected by align-content: end; justify-content: e
 PASS munderover preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS munderover layout is not affected by align-self: end; justify-self: end;
 PASS semantics preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL semantics layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -15
+FAIL semantics layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS semantics preferred width calculation is not affected by white-space: normal;
 FAIL semantics layout is not affected by white-space: normal; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS semantics preferred width calculation is not affected by float: right;

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt
@@ -1,6 +1,6 @@
 
 PASS maction preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL maction layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -14
+FAIL maction layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS maction preferred width calculation is not affected by white-space: normal;
 FAIL maction layout is not affected by white-space: normal; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS maction preferred width calculation is not affected by float: right;
@@ -10,7 +10,7 @@ FAIL maction layout is not affected by align-content: end; justify-content: end;
 PASS maction preferred width calculation is not affected by align-self: end; justify-self: end;
 FAIL maction layout is not affected by align-self: end; justify-self: end; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS menclose preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL menclose layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 7.96875 +/- 1 but got 3.984375
+PASS menclose layout is not affected by writing-mode: vertical-rl;
 PASS menclose preferred width calculation is not affected by white-space: normal;
 PASS menclose layout is not affected by white-space: normal;
 PASS menclose preferred width calculation is not affected by float: right;
@@ -20,7 +20,7 @@ PASS menclose layout is not affected by align-content: end; justify-content: end
 PASS menclose preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS menclose layout is not affected by align-self: end; justify-self: end;
 PASS merror preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL merror layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 9.875 +/- 1 but got 0
+PASS merror layout is not affected by writing-mode: vertical-rl;
 PASS merror preferred width calculation is not affected by white-space: normal;
 PASS merror layout is not affected by white-space: normal;
 PASS merror preferred width calculation is not affected by float: right;
@@ -30,7 +30,7 @@ PASS merror layout is not affected by align-content: end; justify-content: end;
 PASS merror preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS merror layout is not affected by align-self: end; justify-self: end;
 PASS mfrac preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mfrac layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 0 +/- 1 but got 18.71875
+PASS mfrac layout is not affected by writing-mode: vertical-rl;
 PASS mfrac preferred width calculation is not affected by white-space: normal;
 PASS mfrac layout is not affected by white-space: normal;
 PASS mfrac preferred width calculation is not affected by float: right;
@@ -40,7 +40,7 @@ PASS mfrac layout is not affected by align-content: end; justify-content: end;
 PASS mfrac preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mfrac layout is not affected by align-self: end; justify-self: end;
 PASS mi preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mi layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS mi layout is not affected by writing-mode: vertical-rl;
 PASS mi preferred width calculation is not affected by white-space: normal;
 PASS mi layout is not affected by white-space: normal;
 PASS mi preferred width calculation is not affected by float: right;
@@ -50,7 +50,7 @@ PASS mi layout is not affected by align-content: end; justify-content: end;
 PASS mi preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mi layout is not affected by align-self: end; justify-self: end;
 PASS mmultiscripts preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mmultiscripts layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.75
+PASS mmultiscripts layout is not affected by writing-mode: vertical-rl;
 PASS mmultiscripts preferred width calculation is not affected by white-space: normal;
 PASS mmultiscripts layout is not affected by white-space: normal;
 PASS mmultiscripts preferred width calculation is not affected by float: right;
@@ -60,7 +60,7 @@ PASS mmultiscripts layout is not affected by align-content: end; justify-content
 PASS mmultiscripts preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mmultiscripts layout is not affected by align-self: end; justify-self: end;
 PASS mn preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mn layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS mn layout is not affected by writing-mode: vertical-rl;
 PASS mn preferred width calculation is not affected by white-space: normal;
 PASS mn layout is not affected by white-space: normal;
 PASS mn preferred width calculation is not affected by float: right;
@@ -70,7 +70,7 @@ PASS mn layout is not affected by align-content: end; justify-content: end;
 PASS mn preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mn layout is not affected by align-self: end; justify-self: end;
 PASS mo preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mo layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS mo layout is not affected by writing-mode: vertical-rl;
 PASS mo preferred width calculation is not affected by white-space: normal;
 PASS mo layout is not affected by white-space: normal;
 PASS mo preferred width calculation is not affected by float: right;
@@ -80,7 +80,7 @@ PASS mo layout is not affected by align-content: end; justify-content: end;
 PASS mo preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mo layout is not affected by align-self: end; justify-self: end;
 PASS mover preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mover layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 9.875
+PASS mover layout is not affected by writing-mode: vertical-rl;
 PASS mover preferred width calculation is not affected by white-space: normal;
 PASS mover layout is not affected by white-space: normal;
 PASS mover preferred width calculation is not affected by float: right;
@@ -90,7 +90,7 @@ PASS mover layout is not affected by align-content: end; justify-content: end;
 PASS mover preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mover layout is not affected by align-self: end; justify-self: end;
 PASS mpadded preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mpadded layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8.875 +/- 1 but got 0
+PASS mpadded layout is not affected by writing-mode: vertical-rl;
 PASS mpadded preferred width calculation is not affected by white-space: normal;
 PASS mpadded layout is not affected by white-space: normal;
 PASS mpadded preferred width calculation is not affected by float: right;
@@ -100,7 +100,7 @@ PASS mpadded layout is not affected by align-content: end; justify-content: end;
 PASS mpadded preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mpadded layout is not affected by align-self: end; justify-self: end;
 PASS mphantom preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mphantom layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8.875 +/- 1 but got 0
+PASS mphantom layout is not affected by writing-mode: vertical-rl;
 PASS mphantom preferred width calculation is not affected by white-space: normal;
 PASS mphantom layout is not affected by white-space: normal;
 PASS mphantom preferred width calculation is not affected by float: right;
@@ -110,7 +110,7 @@ PASS mphantom layout is not affected by align-content: end; justify-content: end
 PASS mphantom preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mphantom layout is not affected by align-self: end; justify-self: end;
 PASS mroot preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mroot layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 20.21875 +/- 1 but got 11.671875
+PASS mroot layout is not affected by writing-mode: vertical-rl;
 PASS mroot preferred width calculation is not affected by white-space: normal;
 PASS mroot layout is not affected by white-space: normal;
 PASS mroot preferred width calculation is not affected by float: right;
@@ -120,7 +120,7 @@ PASS mroot layout is not affected by align-content: end; justify-content: end;
 PASS mroot preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mroot layout is not affected by align-self: end; justify-self: end;
 PASS mrow preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mrow layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8.875 +/- 1 but got 0
+PASS mrow layout is not affected by writing-mode: vertical-rl;
 PASS mrow preferred width calculation is not affected by white-space: normal;
 PASS mrow layout is not affected by white-space: normal;
 PASS mrow preferred width calculation is not affected by float: right;
@@ -130,7 +130,7 @@ PASS mrow layout is not affected by align-content: end; justify-content: end;
 PASS mrow preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mrow layout is not affected by align-self: end; justify-self: end;
 PASS ms preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL ms layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS ms layout is not affected by writing-mode: vertical-rl;
 PASS ms preferred width calculation is not affected by white-space: normal;
 PASS ms layout is not affected by white-space: normal;
 PASS ms preferred width calculation is not affected by float: right;
@@ -150,7 +150,7 @@ PASS mspace layout is not affected by align-content: end; justify-content: end;
 PASS mspace preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mspace layout is not affected by align-self: end; justify-self: end;
 PASS msqrt preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msqrt layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 20.21875 +/- 1 but got 11.671875
+PASS msqrt layout is not affected by writing-mode: vertical-rl;
 PASS msqrt preferred width calculation is not affected by white-space: normal;
 PASS msqrt layout is not affected by white-space: normal;
 PASS msqrt preferred width calculation is not affected by float: right;
@@ -160,7 +160,7 @@ PASS msqrt layout is not affected by align-content: end; justify-content: end;
 PASS msqrt preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msqrt layout is not affected by align-self: end; justify-self: end;
 PASS mstyle preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mstyle layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 8.875 +/- 1 but got 0
+PASS mstyle layout is not affected by writing-mode: vertical-rl;
 PASS mstyle preferred width calculation is not affected by white-space: normal;
 PASS mstyle layout is not affected by white-space: normal;
 PASS mstyle preferred width calculation is not affected by float: right;
@@ -170,7 +170,7 @@ PASS mstyle layout is not affected by align-content: end; justify-content: end;
 PASS mstyle preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mstyle layout is not affected by align-self: end; justify-self: end;
 PASS msub preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msub layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected 88.75 +/- 1 but got 5.359375
+PASS msub layout is not affected by writing-mode: vertical-rl;
 PASS msub preferred width calculation is not affected by white-space: normal;
 PASS msub layout is not affected by white-space: normal;
 PASS msub preferred width calculation is not affected by float: right;
@@ -180,7 +180,7 @@ PASS msub layout is not affected by align-content: end; justify-content: end;
 PASS msub preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msub layout is not affected by align-self: end; justify-self: end;
 PASS msubsup preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msubsup layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.75
+PASS msubsup layout is not affected by writing-mode: vertical-rl;
 PASS msubsup preferred width calculation is not affected by white-space: normal;
 PASS msubsup layout is not affected by white-space: normal;
 PASS msubsup preferred width calculation is not affected by float: right;
@@ -190,7 +190,7 @@ PASS msubsup layout is not affected by align-content: end; justify-content: end;
 PASS msubsup preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS msubsup layout is not affected by align-self: end; justify-self: end;
 PASS msup preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL msup layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 3.75
+PASS msup layout is not affected by writing-mode: vertical-rl;
 PASS msup preferred width calculation is not affected by white-space: normal;
 PASS msup layout is not affected by white-space: normal;
 PASS msup preferred width calculation is not affected by float: right;
@@ -210,7 +210,7 @@ PASS mtable layout is not affected by align-content: end; justify-content: end;
 PASS mtable preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS mtable layout is not affected by align-self: end; justify-self: end;
 PASS mtext preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL mtext layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline size expected 9 +/- 1 but got 76.8125
+PASS mtext layout is not affected by writing-mode: vertical-rl;
 PASS mtext preferred width calculation is not affected by white-space: normal;
 PASS mtext layout is not affected by white-space: normal;
 PASS mtext preferred width calculation is not affected by float: right;
@@ -230,7 +230,7 @@ PASS munder layout is not affected by align-content: end; justify-content: end;
 PASS munder preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS munder layout is not affected by align-self: end; justify-self: end;
 PASS munderover preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL munderover layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 0) expected 0 +/- 1 but got 9.875
+PASS munderover layout is not affected by writing-mode: vertical-rl;
 PASS munderover preferred width calculation is not affected by white-space: normal;
 PASS munderover layout is not affected by white-space: normal;
 PASS munderover preferred width calculation is not affected by float: right;
@@ -240,7 +240,7 @@ PASS munderover layout is not affected by align-content: end; justify-content: e
 PASS munderover preferred width calculation is not affected by align-self: end; justify-self: end;
 PASS munderover layout is not affected by align-self: end; justify-self: end;
 PASS semantics preferred width calculation is not affected by writing-mode: vertical-rl;
-FAIL semantics layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -14
+FAIL semantics layout is not affected by writing-mode: vertical-rl; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS semantics preferred width calculation is not affected by white-space: normal;
 FAIL semantics layout is not affected by white-space: normal; assert_approx_equals: inline position (child 1) expected -96.75 +/- 1 but got -8
 PASS semantics preferred width calculation is not affected by float: right;

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt
@@ -2,17 +2,17 @@
 FAIL Margin properties on the children of menclose assert_approx_equals: inline size expected 56.15625 +/- 1 but got 31.15625
 FAIL Margin properties on the children of merror assert_approx_equals: inline size expected 47 +/- 1 but got 22
 FAIL Margin properties on the children of mfrac assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of mmultiscripts assert_approx_equals: inline size expected 93.1875 +/- 1 but got 43.1875
+FAIL Margin properties on the children of mmultiscripts assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of mover assert_approx_equals: inline size expected 45 +/- 1 but got 20
 FAIL Margin properties on the children of mpadded assert_approx_equals: inline size expected 45 +/- 1 but got 20
 FAIL Margin properties on the children of mphantom assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 100.40625 +/- 1 but got 50.40625
+FAIL Margin properties on the children of mroot assert_approx_equals: inline size expected 105.0625 +/- 1 but got 55.0625
 FAIL Margin properties on the children of mrow assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of msqrt assert_approx_equals: inline size expected 59.84375 +/- 1 but got 34.84375
+FAIL Margin properties on the children of msqrt assert_approx_equals: inline size expected 64.390625 +/- 1 but got 39.390625
 FAIL Margin properties on the children of mstyle assert_approx_equals: inline size expected 45 +/- 1 but got 20
-FAIL Margin properties on the children of msub assert_approx_equals: inline size expected 93.1875 +/- 1 but got 43.1875
-FAIL Margin properties on the children of msubsup assert_approx_equals: inline size expected 93.1875 +/- 1 but got 43.1875
-FAIL Margin properties on the children of msup assert_approx_equals: inline size expected 93.1875 +/- 1 but got 43.1875
+FAIL Margin properties on the children of msub assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
+FAIL Margin properties on the children of msubsup assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
+FAIL Margin properties on the children of msup assert_approx_equals: inline size expected 90.625 +/- 1 but got 40.625
 FAIL Margin properties on the children of munder assert_approx_equals: inline size expected 45 +/- 1 but got 20
 FAIL Margin properties on the children of munderover assert_approx_equals: inline size expected 45 +/- 1 but got 20
 

--- a/Source/WebCore/css/mathml.css
+++ b/Source/WebCore/css/mathml.css
@@ -41,9 +41,14 @@
     outline: auto 5px -webkit-focus-ring-color
 }
 
+/* Universal rules */
+* {
+    writing-mode: horizontal-tb !important;
+}
+
+/* The <math> element */
 math {
     direction: ltr;
-    writing-mode: horizontal-tb !important;
     text-indent: 0;
     letter-spacing: normal;
     line-height: normal;


### PR DESCRIPTION
#### 5d7fe12c4bef511874385e66431f740f8bbfa539
<pre>
Align UA Stylesheet by adding `writing-mode: horizontal-tb !important;` for all math elements in mathml.css

<a href="https://bugs.webkit.org/show_bug.cgi?id=262697">https://bugs.webkit.org/show_bug.cgi?id=262697</a>

Reviewed by Tim Nguyen and Frédéric Wang.

This patch aligns WebKit with Web Specification [1]:

[1] <a href="https://w3c.github.io/mathml-core/#user-agent-stylesheet">https://w3c.github.io/mathml-core/#user-agent-stylesheet</a>

WebKit was using &apos;writing-mode: horizontal-tb !important;&apos; only on `math` but as per web standard,
it should be universal rule and used for all and this patch fixes it.

* Source/WebCore/css/mathml.css:
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/writing-mode/force-horizontal-tb-expected.txt: Rebaselined
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt: Rebaselined
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/mathml/relations/css-styling/padding-border-margin/margin-003-expected.txt: Rebaselined
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt: Rebaselined
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/mathml/relations/css-styling/ignored-properties-001-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/268977@main">https://commits.webkit.org/268977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcd207993a1b2d1bdecdadfaf857f507bd989037

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20893 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23871 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25443 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19314 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23361 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19901 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16920 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19183 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->