### PR TITLE
Make VisibleContentRectUpdateInfo use generated serialization

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -400,6 +400,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/TextFlags.serialization.in
     Shared/TextRecognitionResult.serialization.in
     Shared/UpdateInfo.serialization.in
+    Shared/VisibleContentRectUpdateInfo.serialization.in
     Shared/WTFArgumentCoders.serialization.in
     Shared/WebCoreArgumentCoders.serialization.in
     Shared/WebEvent.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -242,6 +242,7 @@ $(PROJECT_DIR)/Shared/TextFlags.serialization.in
 $(PROJECT_DIR)/Shared/TextRecognitionResult.serialization.in
 $(PROJECT_DIR)/Shared/UpdateInfo.serialization.in
 $(PROJECT_DIR)/Shared/UserInterfaceIdiom.serialization.in
+$(PROJECT_DIR)/Shared/VisibleContentRectUpdateInfo.serialization.in
 $(PROJECT_DIR)/Shared/WTFArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -546,6 +546,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/TextFlags.serialization.in \
 	Shared/TextRecognitionResult.serialization.in \
 	Shared/UserInterfaceIdiom.serialization.in \
+	Shared/VisibleContentRectUpdateInfo.serialization.in \
 	Shared/WTFArgumentCoders.serialization.in \
 	Shared/WebCoreArgumentCoders.serialization.in \
 	Shared/WebEvent.serialization.in \

--- a/Source/WebKit/Shared/VisibleContentRectUpdateInfo.cpp
+++ b/Source/WebKit/Shared/VisibleContentRectUpdateInfo.cpp
@@ -36,61 +36,6 @@
 namespace WebKit {
 using namespace WebCore;
 
-void VisibleContentRectUpdateInfo::encode(IPC::Encoder& encoder) const
-{
-    encoder << m_exposedContentRect;
-    encoder << m_unobscuredContentRect;
-    encoder << m_contentInsets;
-    encoder << m_unobscuredContentRectRespectingInputViewBounds;
-    encoder << m_unobscuredRectInScrollViewCoordinates;
-    encoder << m_layoutViewportRect;
-    encoder << m_obscuredInsets;
-    encoder << m_unobscuredSafeAreaInsets;
-    encoder << m_scrollVelocity;
-    encoder << m_lastLayerTreeTransactionID;
-    encoder << m_scale;
-    encoder << m_viewStability;
-    encoder << m_isFirstUpdateForNewViewSize;
-    encoder << m_allowShrinkToFit;
-    encoder << m_enclosedInScrollableAncestorView;
-}
-
-bool VisibleContentRectUpdateInfo::decode(IPC::Decoder& decoder, VisibleContentRectUpdateInfo& result)
-{
-    if (!decoder.decode(result.m_exposedContentRect))
-        return false;
-    if (!decoder.decode(result.m_unobscuredContentRect))
-        return false;
-    if (!decoder.decode(result.m_contentInsets))
-        return false;
-    if (!decoder.decode(result.m_unobscuredContentRectRespectingInputViewBounds))
-        return false;
-    if (!decoder.decode(result.m_unobscuredRectInScrollViewCoordinates))
-        return false;
-    if (!decoder.decode(result.m_layoutViewportRect))
-        return false;
-    if (!decoder.decode(result.m_obscuredInsets))
-        return false;
-    if (!decoder.decode(result.m_unobscuredSafeAreaInsets))
-        return false;
-    if (!decoder.decode(result.m_scrollVelocity))
-        return false;
-    if (!decoder.decode(result.m_lastLayerTreeTransactionID))
-        return false;
-    if (!decoder.decode(result.m_scale))
-        return false;
-    if (!decoder.decode(result.m_viewStability))
-        return false;
-    if (!decoder.decode(result.m_isFirstUpdateForNewViewSize))
-        return false;
-    if (!decoder.decode(result.m_allowShrinkToFit))
-        return false;
-    if (!decoder.decode(result.m_enclosedInScrollableAncestorView))
-        return false;
-
-    return true;
-}
-
 String VisibleContentRectUpdateInfo::dump() const
 {
     TextStream stream;

--- a/Source/WebKit/Shared/VisibleContentRectUpdateInfo.h
+++ b/Source/WebKit/Shared/VisibleContentRectUpdateInfo.h
@@ -58,7 +58,10 @@ class VisibleContentRectUpdateInfo {
 public:
     VisibleContentRectUpdateInfo() = default;
 
-    VisibleContentRectUpdateInfo(const WebCore::FloatRect& exposedContentRect, const WebCore::FloatRect& unobscuredContentRect, const WebCore::FloatBoxExtent& contentInsets, const WebCore::FloatRect& unobscuredRectInScrollViewCoordinates, const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds, const WebCore::FloatRect& layoutViewportRect, const WebCore::FloatBoxExtent& obscuredInsets, const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets, double scale, OptionSet<ViewStabilityFlag> viewStability, bool isFirstUpdateForNewViewSize, bool allowShrinkToFit, bool enclosedInScrollableAncestorView, const WebCore::VelocityData& scrollVelocity, TransactionID lastLayerTreeTransactionId)
+    VisibleContentRectUpdateInfo(const WebCore::FloatRect& exposedContentRect, const WebCore::FloatRect& unobscuredContentRect, const WebCore::FloatBoxExtent& contentInsets,
+        const WebCore::FloatRect& unobscuredRectInScrollViewCoordinates, const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds, const WebCore::FloatRect& layoutViewportRect,
+        const WebCore::FloatBoxExtent& obscuredInsets, const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets, double scale, OptionSet<ViewStabilityFlag> viewStability,
+        bool isFirstUpdateForNewViewSize, bool allowShrinkToFit, bool enclosedInScrollableAncestorView, const WebCore::VelocityData& scrollVelocity, TransactionID lastLayerTreeTransactionId)
         : m_exposedContentRect(exposedContentRect)
         , m_unobscuredContentRect(unobscuredContentRect)
         , m_contentInsets(contentInsets)
@@ -83,7 +86,6 @@ public:
     const WebCore::FloatRect& unobscuredRectInScrollViewCoordinates() const { return m_unobscuredRectInScrollViewCoordinates; }
     const WebCore::FloatRect& unobscuredContentRectRespectingInputViewBounds() const { return m_unobscuredContentRectRespectingInputViewBounds; }
     const WebCore::FloatRect& layoutViewportRect() const { return m_layoutViewportRect; }
-    const WebCore::VelocityData& scrollVelocity() const { return m_scrollVelocity; }
     const WebCore::FloatBoxExtent& obscuredInsets() const { return m_obscuredInsets; }
     const WebCore::FloatBoxExtent& unobscuredSafeAreaInsets() const { return m_unobscuredSafeAreaInsets; }
 
@@ -93,12 +95,10 @@ public:
     bool isFirstUpdateForNewViewSize() const { return m_isFirstUpdateForNewViewSize; }
     bool allowShrinkToFit() const { return m_allowShrinkToFit; }
     bool enclosedInScrollableAncestorView() const { return m_enclosedInScrollableAncestorView; }
+    const WebCore::VelocityData& scrollVelocity() const { return m_scrollVelocity; }
     TransactionID lastLayerTreeTransactionID() const { return m_lastLayerTreeTransactionID; }
 
     MonotonicTime timestamp() const { return m_scrollVelocity.lastUpdateTime; }
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, VisibleContentRectUpdateInfo&);
 
     String dump() const;
 
@@ -142,20 +142,5 @@ WTF::TextStream& operator<<(WTF::TextStream&, ViewStabilityFlag);
 WTF::TextStream& operator<<(WTF::TextStream&, const VisibleContentRectUpdateInfo&);
 
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::ViewStabilityFlag> {
-    using values = EnumValues<
-        WebKit::ViewStabilityFlag,
-        WebKit::ViewStabilityFlag::ScrollViewInteracting,
-        WebKit::ViewStabilityFlag::ScrollViewAnimatedScrollOrZoom,
-        WebKit::ViewStabilityFlag::ScrollViewRubberBanding,
-        WebKit::ViewStabilityFlag::ChangingObscuredInsetsInteractively,
-        WebKit::ViewStabilityFlag::UnstableForTesting
-    >;
-};
-
-} // namespace WTF
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/Shared/VisibleContentRectUpdateInfo.serialization.in
+++ b/Source/WebKit/Shared/VisibleContentRectUpdateInfo.serialization.in
@@ -1,0 +1,52 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(UI_SIDE_COMPOSITING)
+
+[OptionSet] enum class WebKit::ViewStabilityFlag : uint8_t {
+    ScrollViewInteracting,
+    ScrollViewAnimatedScrollOrZoom,
+    ScrollViewRubberBanding,
+    ChangingObscuredInsetsInteractively,
+    UnstableForTesting,
+};
+
+class WebKit::VisibleContentRectUpdateInfo {
+    WebCore::FloatRect exposedContentRect();
+    WebCore::FloatRect unobscuredContentRect();
+    WebCore::FloatBoxExtent contentInsets();
+    WebCore::FloatRect unobscuredRectInScrollViewCoordinates();
+    WebCore::FloatRect unobscuredContentRectRespectingInputViewBounds();
+    WebCore::FloatRect layoutViewportRect();
+    WebCore::FloatBoxExtent obscuredInsets();
+    WebCore::FloatBoxExtent unobscuredSafeAreaInsets();
+
+    double scale();
+    OptionSet<WebKit::ViewStabilityFlag> viewStability();
+    bool isFirstUpdateForNewViewSize();
+    bool allowShrinkToFit();
+    bool enclosedInScrollableAncestorView();
+    WebCore::VelocityData scrollVelocity();
+    WebKit::TransactionID lastLayerTreeTransactionID();
+};
+
+#endif


### PR DESCRIPTION
#### 145aa2bfa77908606c5440709ddb1cdb588386df
<pre>
Make VisibleContentRectUpdateInfo use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262739">https://bugs.webkit.org/show_bug.cgi?id=262739</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/VisibleContentRectUpdateInfo.cpp:
(WebKit::VisibleContentRectUpdateInfo::encode const): Deleted.
(WebKit::VisibleContentRectUpdateInfo::decode): Deleted.
* Source/WebKit/Shared/VisibleContentRectUpdateInfo.h:
(WebKit::VisibleContentRectUpdateInfo::VisibleContentRectUpdateInfo):
(WebKit::VisibleContentRectUpdateInfo::layoutViewportRect const):
(WebKit::VisibleContentRectUpdateInfo::scrollVelocity const):
* Source/WebKit/Shared/VisibleContentRectUpdateInfo.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/268967@main">https://commits.webkit.org/268967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c27ecca03270ab4324472faa24f221e04868beca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19681 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21731 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23909 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18258 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25524 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23388 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19216 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2624 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->