### PR TITLE
Introduce structure for quirking multiple sites for SSO

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -427,6 +427,9 @@
 /* Message for requesting cross-site cookie and website data access. */
 "Do you want to allow “%@” to use cookies and website data while browsing “%@”?" = "Do you want to allow “%@” to use cookies and website data while browsing “%@”?";
 
+/* Message for requesting cross-site cookie and website data access. */
+"Are you logging in to a “%@” site and do you want to allow them access to your website data across their sites?" = "Are you logging in to a “%@” site and do you want to allow them access to your website data across their sites?";
+
 /* Label for the donate with Apple Pay button. */
 "Donate with Apple Pay" = "Donate with Apple Pay";
 

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -97,13 +97,21 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
     if (frameName.isNull() && UNLIKELY(document().settings().needsFrameNameFallbackToIdQuirk()))
         frameName = getIdAttribute();
 
-    if (shouldLoadFrameLazily()) {
-        parentFrame->loader().subframeLoader().createFrameIfNecessary(*this, frameName);
-        return;
-    }
+    auto completeURL = document().completeURL(m_frameURL);
+    auto finishOpeningURL = [this, weakThis = WeakPtr { *this }, frameName, lockHistory, lockBackForwardList, parentFrame = WTFMove(parentFrame), completeURL] {
+        if (!weakThis)
+            return;
+        auto protectedThis = Ref { *this };
+        if (shouldLoadFrameLazily()) {
+            parentFrame->loader().subframeLoader().createFrameIfNecessary(protectedThis.get(), frameName);
+            return;
+        }
 
-    document().willLoadFrameElement(document().completeURL(m_frameURL));
-    parentFrame->loader().subframeLoader().requestFrame(*this, m_frameURL, frameName, lockHistory, lockBackForwardList);
+        document().willLoadFrameElement(completeURL);
+        parentFrame->loader().subframeLoader().requestFrame(*this, m_frameURL, frameName, lockHistory, lockBackForwardList);
+    };
+
+    document().quirks().triggerOptionalStorageAccessIframeQuirk(document().topOrigin(), completeURL, WTFMove(finishOpeningURL));
 }
 
 void HTMLFrameElementBase::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1131,6 +1131,11 @@ Quirks::StorageAccessResult Quirks::requestStorageAccessAndHandleClick(Completio
 }
 #endif
 
+void Quirks::triggerOptionalStorageAccessIframeQuirk(const SecurityOrigin&, const URL&, CompletionHandler<void()>&& completionHandler) const
+{
+    completionHandler();
+}
+
 // rdar://64549429
 Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& element, const PlatformMouseEvent& platformEvent, const AtomString& eventType, int detail, Element* relatedTarget, bool isParentProcessAFullWebBrowser, IsSyntheticClick isSyntheticClick) const
 {

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -125,6 +125,8 @@ public:
 
     enum StorageAccessResult : bool { ShouldNotCancelEvent, ShouldCancelEvent };
     enum ShouldDispatchClick : bool { No, Yes };
+
+    void triggerOptionalStorageAccessIframeQuirk(const SecurityOrigin& topOrigin, const URL& frameURL, CompletionHandler<void()>&&) const;
     StorageAccessResult triggerOptionalStorageAccessQuirk(Element&, const PlatformMouseEvent&, const AtomString& eventType, int, Element*, bool isParentProcessAFullWebBrowser, IsSyntheticClick) const;
 
     bool needsVP9FullRangeFlagQuirk() const;

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -462,6 +462,16 @@ std::optional<RegistrableDomain> NetworkStorageSession::findAdditionalLoginDomai
     return std::nullopt;
 }
 
+SSOQuirkOrganization NetworkStorageSession::knownSSODomainsRequiringQuirk(const TopFrameDomain&, const SubResourceDomain&)
+{
+    return SSOQuirkOrganization::None;
+}
+
+String NetworkStorageSession::knownSSODomainsRequiringQuirkString(const TopFrameDomain&, const SubResourceDomain&)
+{
+    return { };
+}
+
 #endif // ENABLE(TRACKING_PREVENTION)
 
 void NetworkStorageSession::deleteCookiesForHostnames(const Vector<String>& cookieHostNames, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -89,6 +89,7 @@ enum class SameSiteStrictEnforcementEnabled : bool { No, Yes };
 enum class FirstPartyWebsiteDataRemovalMode : uint8_t { AllButCookies, None, AllButCookiesLiveOnTestingTimeout, AllButCookiesReproTestingTimeout };
 enum class ApplyTrackingPrevention : bool { No, Yes };
 enum class ScriptWrittenCookiesOnly : bool { No, Yes };
+enum class SSOQuirkOrganization : uint8_t { None };
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
 class CookieChangeObserver : public CanMakeCheckedPtr {
@@ -226,6 +227,9 @@ public:
     WEBCORE_EXPORT static std::optional<HashSet<RegistrableDomain>> subResourceDomainsInNeedOfStorageAccessForFirstParty(const RegistrableDomain&);
     WEBCORE_EXPORT static bool loginDomainMatchesRequestingDomain(const TopFrameDomain&, const SubResourceDomain&);
     WEBCORE_EXPORT static std::optional<RegistrableDomain> findAdditionalLoginDomain(const TopFrameDomain&, const SubResourceDomain&);
+    WEBCORE_EXPORT static SSOQuirkOrganization knownSSODomainsRequiringQuirk(const TopFrameDomain& topDomain, const SubResourceDomain& subDomain);
+    WEBCORE_EXPORT static String knownSSODomainsRequiringQuirkString(const TopFrameDomain& topDomain, const SubResourceDomain& subDomain);
+
 
 #endif
     

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -440,6 +440,13 @@ void UIDelegate::UIClient::requestStorageAccessConfirm(WebPageProxy& webPageProx
         return;
     }
 
+    if (auto organization = WebCore::NetworkStorageSession::knownSSODomainsRequiringQuirkString(currentDomain, requestingDomain); !organization.isNull()) {
+#if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
+        presentStorageAccessAlertSSOQuirk(m_uiDelegate->m_webView.get().get(), organization, WTFMove(completionHandler));
+#endif
+        return;
+    }
+
     // Some sites have quirks where multiple login domains require storage access.
     if (auto additionalLoginDomain = WebCore::NetworkStorageSession::findAdditionalLoginDomain(currentDomain, requestingDomain)) {
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h
@@ -43,6 +43,7 @@ namespace WebKit {
 
 void presentStorageAccessAlert(WKWebView *, const WebCore::RegistrableDomain& requestingDomain, const WebCore::RegistrableDomain& currentDomain, CompletionHandler<void(bool)>&&);
 void presentStorageAccessAlertQuirk(WKWebView *, const WebCore::RegistrableDomain& firstRequestingDomain, const WebCore::RegistrableDomain& secondRequestingDomain, const WebCore::RegistrableDomain& current, CompletionHandler<void(bool)>&&);
+void presentStorageAccessAlertSSOQuirk(WKWebView *, const String& organizationName, CompletionHandler<void(bool)>&&);
 void displayStorageAccessAlert(WKWebView *, NSString *, NSString *, CompletionHandler<void(bool)>&&);
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
@@ -74,6 +74,12 @@ void presentStorageAccessAlertQuirk(WKWebView *webView, const WebCore::Registrab
     displayStorageAccessAlert(webView, alertTitle, informativeText, WTFMove(completionHandler));
 }
 
+void presentStorageAccessAlertSSOQuirk(WKWebView *webView, const String& organizationName, CompletionHandler<void(bool)>&& completionHandler)
+{
+    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Are you logging in to a “%@” site and do you want to allow them access to your website data across their sites?", @"Message for requesting cross-site cookie and website data access."), organizationName.createCFString().get()];
+    displayStorageAccessAlert(webView, alertTitle, nil, WTFMove(completionHandler));
+}
+
 void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSString *informativeText, CompletionHandler<void(bool)>&& completionHandler)
 {
     auto completionBlock = makeBlockPtr([completionHandler = WTFMove(completionHandler)](bool shouldAllow) mutable {
@@ -86,7 +92,8 @@ void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSStrin
 #if PLATFORM(MAC)
     auto alert = adoptNS([NSAlert new]);
     [alert setMessageText:alertTitle];
-    [alert setInformativeText:informativeText];
+    if (informativeText)
+        [alert setInformativeText:informativeText];
     [alert addButtonWithTitle:allowButtonString];
     [alert addButtonWithTitle:doNotAllowButtonString];
     [alert beginSheetModalForWindow:webView.window completionHandler:[completionBlock](NSModalResponse returnCode) {


### PR DESCRIPTION
#### 57f40017f06d8df26b638f0f201a34b88d0ad4d6
<pre>
Introduce structure for quirking multiple sites for SSO
<a href="https://bugs.webkit.org/show_bug.cgi?id=262744">https://bugs.webkit.org/show_bug.cgi?id=262744</a>
rdar://116190549

Reviewed by NOBODY (OOPS!).

Some Single Sign-On flows rely on syncing cookies across multiple domains that
are controlled by the same organization. These flows do not work when
third-party cookies are blocked. The Storage Access API (SAA) was introduced as
a mechanism for requesting access to cookies from a third-party context,
however in some situations cookies are needed in the first request. This
conflict may prevent adoption of the SAA.

WebKit can provide some assistance by automatically showing a SAA prompt for
the entire login flow when a particular condition is met, and this can
facilitate successfully logging in to these types of sites. This patch adds
support for showing the prompt when an iframe is loaded in a particular
context.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::openURL):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::triggerOptionalStorageAccessIframeQuirk const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::knownSSODomainsRequiringQuirk):
(WebCore::NetworkStorageSession::knownSSODomainsRequiringQuirkString):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::autoAllowStorageAccessForAdditionalDomains):
(WebKit::ResourceLoadStatisticsStore::grantStorageAccess):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::requestStorageAccessConfirm):
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h:
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(WebKit::presentStorageAccessAlertSSOQuirk):
(WebKit::displayStorageAccessAlert):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57f40017f06d8df26b638f0f201a34b88d0ad4d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19684 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23912 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25525 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23389 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16942 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->