### PR TITLE
Add support for grouping source map loading errors.

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -411,6 +411,7 @@ localizedStrings["Connection Closed"] = "Connection Closed";
 localizedStrings["Connection ID"] = "Connection ID";
 localizedStrings["Connection:"] = "Connection:";
 localizedStrings["Console"] = "Console";
+localizedStrings["Console:"] = "Console:";
 localizedStrings["Console Evaluation"] = "Console Evaluation";
 localizedStrings["Console Evaluation %d"] = "Console Evaluation %d";
 localizedStrings["Console Profile Recorded"] = "Console Profile Recorded";
@@ -826,6 +827,7 @@ localizedStrings["Group by Event @ Node Event Listeners"] = "Group by Event";
 /* Group DOM event listeners by DOM node */
 localizedStrings["Group by Target @ Node Event Listeners"] = "Group by Target";
 localizedStrings["Grouping Method"] = "Grouping Method";
+localizedStrings["Group source map network errors"] = "Group source map network errors";
 localizedStrings["HAR Export (%s)"] = "HAR Export (%s)";
 localizedStrings["HAR Import"] = "HAR Import";
 localizedStrings["HAR Import Error: %s"] = "HAR Import Error: %s";
@@ -1555,6 +1557,7 @@ localizedStrings["Sort Ascending"] = "Sort Ascending";
 localizedStrings["Sort Descending"] = "Sort Descending";
 localizedStrings["Source"] = "Source";
 localizedStrings["Source Maps:"] = "Source Maps:";
+localizedStrings["Source Map loading errors"] = "Source Map loading errors";
 localizedStrings["Sources"] = "Sources";
 /* Name of Sources Tab */
 localizedStrings["Sources Tab Name"] = "Sources";

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -238,6 +238,7 @@ WI.settings = {
     experimentalAllowInspectingInspector: new WI.Setting("experimental-allow-inspecting-inspector", false),
     experimentalCSSSortPropertyNameAutocompletionByUsage: new WI.Setting("experimental-css-sort-property-name-autocompletion-by-usage", true),
     experimentalEnableNetworkEmulatedCondition: new WI.Setting("experimental-enable-network-emulated-condition", false),
+    experimentalGroupSourceMapErrors: new WI.Setting("experimental-group-source-map-errors", true),
     experimentalLimitSourceCodeHighlighting: new WI.Setting("engineering-limit-source-code-highlighting", false),
 
     // Protocol

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -44,6 +44,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         this._snippets = new Set;
         this._restoringSnippets = false;
 
+        this._failedSourceMapConsoleMessages = new Set;
+
         WI.ConsoleSnippet.addEventListener(WI.SourceCode.Event.ContentDidChange, this._handleSnippetContentChanged, this);
 
         WI.Frame.addEventListener(WI.Frame.Event.MainResourceDidChange, this._mainResourceDidChange, this);
@@ -88,6 +90,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
     get errorCount() { return this._errorCount; }
     get snippets() { return this._snippets; }
     get customLoggingChannels() { return this._customLoggingChannels; }
+    get failedSourceMapConsoleMessages() { return this._failedSourceMapConsoleMessages; }
 
     issuesForSourceCode(sourceCode)
     {
@@ -163,6 +166,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
             this._issues.push(issue);
 
             this.dispatchEventToListeners(WI.ConsoleManager.Event.IssueAdded, {issue});
+
+            this._collectFailedSourceMapConsoleMessage(message);
         }
     }
 
@@ -270,6 +275,18 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         this._lastMessageLevel = null;
 
         this.dispatchEventToListeners(WI.ConsoleManager.Event.Cleared);
+    }
+    
+    _collectFailedSourceMapConsoleMessage(message)
+    {
+        if (!WI.settings.experimentalGroupSourceMapErrors.value)
+            return;
+    
+        if (message.source !== WI.ConsoleMessage.MessageSource.Network && message.level !== WI.ConsoleMessage.MessageLevel.Error)
+            return;
+    
+        if (WI.networkManager.isSourceMapURL(message.url))
+            this._failedSourceMapConsoleMessages.add(message);
     }
 
     _delayedMessagesCleared()

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -42,6 +42,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
         this._sourceMapURLMap = new Map;
         this._downloadingSourceMaps = new Set;
+        this._failedSourceMapURLs = new Set;
 
         this._localResourceOverrides = [];
         this._harImportLocalResourceMap = new Set;
@@ -326,6 +327,11 @@ WI.NetworkManager = class NetworkManager extends WI.Object
         }
 
         loadAndParseSourceMap();
+    }
+
+    isSourceMapURL(url)
+    {
+        return this._downloadingSourceMaps.has(url) || this._failedSourceMapURLs.has(url);
     }
 
     get bootstrapScriptEnabled()
@@ -1561,6 +1567,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
     _sourceMapLoadAndParseFailed(sourceMapURL)
     {
         this._downloadingSourceMaps.delete(sourceMapURL);
+        this._failedSourceMapURLs.add(sourceMapURL);
     }
 
     _sourceMapLoadAndParseSucceeded(sourceMapURL, sourceMap)
@@ -1663,6 +1670,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
         this._sourceMapURLMap.clear();
         this._downloadingSourceMaps.clear();
+        this._failedSourceMapURLs.clear();
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -704,6 +704,7 @@
     <script src="Views/ConsoleGroup.js"></script>
     <script src="Views/ConsolePrompt.js"></script>
     <script src="Views/ConsoleSession.js"></script>
+    <script src="Views/ConsoleSourceMapMessageGroup.js"></script>
     <script src="Views/ConsoleSnippetTreeElement.js"></script>
     <script src="Views/ContentViewContainer.js"></script>
     <script src="Views/ContextMenu.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleGroup.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleGroup.js
@@ -34,10 +34,13 @@ WI.ConsoleGroup = class ConsoleGroup extends WI.Object
         super();
 
         this._parentGroup = parentGroup;
+        this._element = null;
     }
 
     // Public
 
+    get element() { return this._element; }
+    
     get parentGroup()
     {
         return this._parentGroup;
@@ -47,8 +50,7 @@ WI.ConsoleGroup = class ConsoleGroup extends WI.Object
     {
         var groupElement = document.createElement("div");
         groupElement.className = "console-group";
-        groupElement.group = this;
-        this.element = groupElement;
+        this._element = groupElement;
 
         var titleElement = messageView.element;
         titleElement.classList.add(WI.LogContentView.ItemWrapperStyleClassName);
@@ -79,6 +81,35 @@ WI.ConsoleGroup = class ConsoleGroup extends WI.Object
     {
         this._messagesElement.appendChild(messageOrGroupElement);
     }
+    
+    // FIXME: <https://webkit.org/b/264489> We should merge this logic with `WI.ConsoleMessageView.prototype.render`
+    setMessageLevel(messageLevel)
+    {
+        console.assert(this._element);
+  
+        switch (messageLevel) {
+        case WI.ConsoleMessage.MessageLevel.Log:
+            this._element.classList.add("console-log-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Log: "));
+            break;
+        case WI.ConsoleMessage.MessageLevel.Info:
+            this._element.classList.add("console-info-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Info: "));
+            break;
+        case WI.ConsoleMessage.MessageLevel.Debug:
+            this._element.classList.add("console-debug-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Debug: "));
+            break;
+        case WI.ConsoleMessage.MessageLevel.Warning:
+            this._element.classList.add("console-warning-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Warning: "));
+            break;
+        case WI.ConsoleMessage.MessageLevel.Error:
+            this._element.classList.add("console-error-level");
+            this._element.setAttribute("data-labelprefix", WI.UIString("Error: "));
+            break;
+        }
+    }
 
     // Private
 
@@ -93,10 +124,7 @@ WI.ConsoleGroup = class ConsoleGroup extends WI.Object
         if (groupTitleElement) {
             var groupElement = groupTitleElement.closest(".console-group");
             if (groupElement)
-                if (groupElement.classList.contains("collapsed"))
-                    groupElement.classList.remove("collapsed");
-                else
-                    groupElement.classList.add("collapsed");
+                groupElement.classList.toggle("collapsed");
             groupTitleElement.scrollIntoViewIfNeeded(true);
         }
     }

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleSourceMapMessageGroup.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleSourceMapMessageGroup.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.ConsoleSourceMapMessageGroup = class ConsoleSourceMapMessageGroup extends WI.ConsoleGroup
+{
+    constructor()
+    {
+        super();
+
+        this._messageCount = 0;
+        
+        // Create a WI.ConsoleMessage as an error message to use as a title for the group
+        let titleConsoleMessage = new WI.ConsoleMessage(WI.mainTarget, WI.ConsoleMessage.MessageSource.Other, WI.ConsoleMessage.MessageLevel.Error, WI.UIString("Source Map loading errors"), WI.ConsoleMessage.MessageType.StartGroupCollapsed);
+
+        this._titleConsoleMessageView = new WI.ConsoleMessageView(titleConsoleMessage);
+        this._titleConsoleMessageView.render();
+
+        this.render(this._titleConsoleMessageView);
+        this.setMessageLevel(WI.ConsoleMessage.MessageLevel.Error);
+    }
+
+    // Public
+
+    addMessageView(messageView)
+    {
+        super.addMessageView(messageView);
+
+        this._messageCount++;
+        this._titleConsoleMessageView.repeatCount = this._messageCount;
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
@@ -158,11 +158,21 @@
     border-top-color: hsl(40, 100%, 90%);
 }
 
-.console-item::before {
+.console-item::before,
+.console-group::before {
     position: absolute;
     left: 4px;
     height: 12px;
     width: 12px;
+    z-index: 1;
+}
+
+.console-group::before {
+    top: 4px;
+}
+
+.console-group:is(.console-warning-level, .console-error-level, .console-log-level, .console-info-level, .console-debug-level) {
+    padding-inline-start: 16px;
 }
 
 .console-item.selected::after {
@@ -218,6 +228,18 @@
     inset-inline-start: 4px;
     width: 13px;
     height: 13px;
+}
+
+.console-group-title > .console-error-level {
+    display: inline-block;
+    margin-inline-end: 4px;
+    height: 12px;
+    width: 12px;    
+}
+
+.console-group-title > .console-error-level::before {
+    position: relative;
+    top: 2px;
 }
 
 body[dir=rtl] .console-group-title::before {
@@ -389,6 +411,10 @@ body[dir=rtl] .console-group-title::before {
 
     .console-warning-level:not(.filtered-out, .filtered-out-by-search), .console-warning-level:not(.filtered-out, .filtered-out-by-search) + .console-item {
         border-top-color: var(--border-color-warning);
+    }
+    
+    .console-group-sourcemap-errors {
+        background-color: var(--error-background-color-secondary);
     }
 
     .search-in-progress .console-item:not(.filtered-out-by-search) .highlighted {

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -402,6 +402,12 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         let experimentalSettingsView = new WI.SettingsView("experimental", WI.UIString("Experimental"));
 
         let initialValues = new Map;
+        
+        let consoleGroup = experimentalSettingsView.addGroup(WI.UIString("Console:"));
+        consoleGroup.addSetting(WI.settings.experimentalGroupSourceMapErrors, WI.UIString("Group source map network errors"));
+        
+        experimentalSettingsView.addSeparator();
+
 
         let hasCSSDomain = InspectorBackend.hasDomain("CSS");
         if (hasCSSDomain) {


### PR DESCRIPTION
#### 869419c2de211c08fe24d0077a09d5289c06dc4f
<pre>
Add support for grouping source map loading errors.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256683">https://bugs.webkit.org/show_bug.cgi?id=256683</a>
<a href="https://rdar.apple.com/problem/109239646">rdar://problem/109239646</a>

Reviewed by Devin Rousso.

This feature is behind an experimental Web Inspector setting
available in the Settings tab, under Experimental. When enabled and
more than one source map loading error occurs, network error messages
with a URL that matches a known source map URL are collected into an
expandable group with a counter showing the number of messages.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager):
(WI.ConsoleManager.prototype.get failedSourceMapConsoleMessages):
(WI.ConsoleManager.prototype.messageWasAdded):
(WI.ConsoleManager.prototype._handleSourceMapErrorMessage):
* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js:
(WI.JavaScriptLogViewController):
(WI.JavaScriptLogViewController.prototype.startNewSession):
(WI.JavaScriptLogViewController.prototype._didRenderConsoleMessageView):
(WI.JavaScriptLogViewController.prototype._handleFailedSourceMapMessageGrouping):
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.get failedSourceMapURLs):
(WI.NetworkManager.prototype.get downloadingSourceMaps):
(WI.NetworkManager.prototype.isDownloadingSourceMapURL):
(WI.NetworkManager.prototype._sourceMapLoadAndParseFailed):
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(.console-sourcemap-errors-group .errors-count,):
(.console-message .console-sourcemap-failures-container,):
(.console-message.expandable.expanded .console-sourcemap-failures-container,):
(.console-message .repeat-count): Deleted.
(.console-message .console-message-extra-parameters-container,): Deleted.
(.console-message.expandable.expanded .console-message-extra-parameters-container,): Deleted.
* Source/WebInspectorUI/UserInterface/Views/ConsoleSourceMapMessageGroup.js: Added.
(WI.ConsoleSourceMapMessageGroup):
(WI.ConsoleSourceMapMessageGroup.prototype.render):
(WI.ConsoleSourceMapMessageGroup.prototype.addMessageView):
(WI.ConsoleSourceMapMessageGroup.prototype.toggle):
(WI.ConsoleSourceMapMessageGroup.prototype._renderMessageCount):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:

Canonical link: <a href="https://commits.webkit.org/270834@main">https://commits.webkit.org/270834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/216389df241d9419339236cac0e6fef3cd85e81a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24296 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2588 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/24253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26826 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/4011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/22824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3532 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/3574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/23810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24225 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/24209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/29841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3610 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/1813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27736 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/5046 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6371 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->