### PR TITLE
Add another test case for managed origins

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking-expected.txt
@@ -1,0 +1,30 @@
+Tests that third-party cookies are blocked when managed domains added.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Before adding a managed domain, should receive no cookies.
+Did not receive cookie named 'firstPartyCookie'.
+Client-side document.cookie:
+
+--------
+Frame: '<!--frame2-->'
+--------
+After adding an unrelated managed domain, should still not receive cookies.
+Did not receive cookie named 'firstPartyCookie'.
+Client-side document.cookie:
+
+--------
+Frame: '<!--frame3-->'
+--------
+Should receive both cookies.
+Received cookie named 'firstPartyCookie'.
+Client-side document.cookie: firstPartyCookie=value

--- a/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="../resources/util.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that third-party cookies are blocked when managed domains added.");
+    jsTestIsAsync = true;
+
+    const firstPartyOrigin = "http://127.0.0.1:8000";
+    const thirdPartyOrigin = "http://localhost:8000";
+    const thirdPartyResourceUrl = thirdPartyOrigin + "/resourceLoadStatistics/resources";
+    const firstPartyCookieName = "firstPartyCookie";
+    const subPathToSetFirstPartyCookie = "/set-cookie.py?name=" + firstPartyCookieName + "&value=value";
+    const returnUrl = firstPartyOrigin + "/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking.html";
+    const subPathToGetCookies = "/get-cookies.py?name1=" + firstPartyCookieName;
+
+    function openIframe(url, onLoadHandler) {
+        const element = document.createElement("iframe");
+        element.src = url;
+        if (onLoadHandler) {
+            element.onload = onLoadHandler;
+        }
+        document.body.appendChild(element);
+    }
+
+    function runTest() {
+        switch (document.location.hash) {
+            case "#step1":
+                // Set first-party cookie for localhost.
+                document.location.href = thirdPartyResourceUrl + subPathToSetFirstPartyCookie + "#" + returnUrl + "#step2";
+                break;
+            case "#step2":
+                // Check that the localhost first party cookie doesn't get sent for 127.0.0.1
+                document.location.hash = "step3";
+                openIframe(thirdPartyResourceUrl + subPathToGetCookies + "&message=Before adding a managed domain, should receive no cookies.", function() {
+                    runTest();
+                });
+                break;
+            case "#step3":
+                // Making the third party origin a managed domain still doesn't grant 127.0.0.1 permission to get the cookie in a third party context.
+                document.location.hash = "step4";
+                testRunner.setManagedDomains([ thirdPartyOrigin ], function() {
+                    // Check that the cookie is still blocked for localhost under 127.0.0.1.
+                    openIframe(thirdPartyResourceUrl + subPathToGetCookies +  "&message=After adding an unrelated managed domain, should still not receive cookies.", function() {
+                        runTest();
+                    });
+                });
+                break;
+            case "#step4":
+                // If 127.0.0.1 is a managed domain, now it can get the localhost cookie.
+                document.location.hash = "step5";
+                testRunner.setManagedDomains([ firstPartyOrigin, thirdPartyOrigin ], function() {
+                    openIframe(thirdPartyResourceUrl + subPathToGetCookies +  "&message=Should receive both cookies.", function() {
+                        runTest();
+                    });
+                });
+                break;
+            case "#step5":
+                testRunner.setStatisticsShouldBlockThirdPartyCookies(false, function() {
+                    setEnableFeature(false, finishJSTest);
+                });
+                break;
+        }
+    }
+
+    if (document.location.hash === "") {
+        setEnableFeature(true, function () {
+            if (testRunner.isStatisticsPrevalentResource(thirdPartyOrigin))
+                testFailed("Localhost was classified as prevalent resource before the test starts.");
+            testRunner.dumpChildFramesAsText();
+            document.location.hash = "step1";
+            testRunner.setStatisticsShouldBlockThirdPartyCookies(true, runTest);
+        });
+    } else {
+        runTest();
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 271bf5cc9d335fc900b09e58fd338b8a8ff804ed
<pre>
Add another test case for managed origins
<a href="https://bugs.webkit.org/show_bug.cgi?id=262749">https://bugs.webkit.org/show_bug.cgi?id=262749</a>
&lt;rdar://problem/116551713&gt;

Reviewed by Sihui Liu.

This PR adds a test case that should have been included in Bug 262749. It just confirms that adjustment
to the CFNetwork API does not impact the normal third party cookie blocking behavior.

* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/exemptDomains/third-party-cookie-blocking.html: Added.

Canonical link: <a href="https://commits.webkit.org/269083@main">https://commits.webkit.org/269083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61103bdbcb32410ce07d5bcda66b18f7fa4d9cbf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19674 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23900 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25518 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23381 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19012 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5147 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19790 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->