### PR TITLE
REGRESSION (266610@main): Download alert doesn’t respond to trackpad clicks until after pointer hides

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
@@ -56,21 +56,29 @@
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
+    self.state = UIGestureRecognizerStateBegan;
+
     [_interaction _updateMouseTouches:touches];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
+    self.state = UIGestureRecognizerStateChanged;
+
     [_interaction _updateMouseTouches:touches];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
+    self.state = UIGestureRecognizerStateEnded;
+
     [_interaction _updateMouseTouches:touches];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
+    self.state = UIGestureRecognizerStateCancelled;
+
     [_interaction _updateMouseTouches:touches];
 }
 
@@ -96,8 +104,14 @@
         return nil;
 
     _mouseTouchGestureRecognizer = adoptNS([[WKMouseTouchGestureRecognizer alloc] initWithInteraction:self]);
+    [_mouseTouchGestureRecognizer setName:@"WKMouseTouch"];
+
     _pencilHoverGestureRecognizer = adoptNS([[UIHoverGestureRecognizer alloc] initWithTarget:self action:@selector(_hoverGestureRecognized:)]);
+    [_pencilHoverGestureRecognizer setName:@"WKPencilHover"];
+
     _mouseHoverGestureRecognizer = adoptNS([[UIHoverGestureRecognizer alloc] initWithTarget:self action:@selector(_hoverGestureRecognized:)]);
+    [_mouseHoverGestureRecognizer setName:@"WKMouseHover"];
+
     [self _forEachGesture:^(UIGestureRecognizer *gesture) {
         gesture.delegate = self;
     }];


### PR DESCRIPTION
#### 105e0f1e80b0e8ff0be61f05cf8dd6e3f3926cb5
<pre>
REGRESSION (266610@main): Download alert doesn’t respond to trackpad clicks until after pointer hides
<a href="https://bugs.webkit.org/show_bug.cgi?id=262752">https://bugs.webkit.org/show_bug.cgi?id=262752</a>
rdar://116206313

Reviewed by Megan Gardner.

After the refactoring in 266610@main, `WKMouseGestureRecognizer` was split into three total
gestures: two to passively observe mouse and pencil hover, and `WKMouseTouchGestureRecognizer`,
which observes mouse events while the mouse is down. Currently, this mouse touch gesture remains in
`Possible` state while receiving pointer events (i.e. `-touches*:withEvent:`). This means that if
any other pointer-only gesture has failure requirements to this gesture, it could be blocked
indefinitely while waiting for the subgraph to reset.

When clicking on a download link, Safari overlays native alert UI which obscures the entire web
view. Prior to the above refactoring, we would receive a call to the SPI method `-_hoverExited:`
when the user moves their mouse over the dialog, causing us to immediately transition the gesture to
Ended state. This no longer happens, since we stopped relying on that SPI hook. As a result, other
pointer gestures that have failure requirements to `WKMouseTouchGestureRecognizer` get stuck waiting
for a reset that never happens.

Fix this by transitioning the `WKMouseTouchGestureRecognizer` through the normal gesture recognizer
states under the touch event subclassing hooks: `Began` upon beginning touches, `Changed` when
dragging, and `Cancelled` or `Ended` upon releasing the mouse (or otherwise cancelling the pointer
interaction).

Note that we can end `WKMouseTouchGestureRecognizer` upon mouseup (as opposed to how the former
`WKMouseGestureRecognizer` only transitioned to Ended after exiting the view), since the new class
only needs to recognize while the pointer is down.

* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(-[WKMouseTouchGestureRecognizer touchesBegan:withEvent:]):
(-[WKMouseTouchGestureRecognizer touchesMoved:withEvent:]):
(-[WKMouseTouchGestureRecognizer touchesEnded:withEvent:]):
(-[WKMouseTouchGestureRecognizer touchesCancelled:withEvent:]):

Add state transitions; see above for more information.

(-[WKMouseInteraction initWithDelegate:]):

Drive-by fix: also give these gestures more descriptive names, to make descriptions more informative
when logging (and also so that the API test harness below can find `WKMouseTouchGestureRecognizer`).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
(TestWebKitAPI::MouseEventTestHarness::MouseEventTestHarness):
(TestWebKitAPI::MouseEventTestHarness::mouseMove):
(TestWebKitAPI::MouseEventTestHarness::mouseDown):
(TestWebKitAPI::MouseEventTestHarness::mouseUp):
(TestWebKitAPI::MouseEventTestHarness::mouseCancel):

Refactor the test harness so that it calls into `UIGestureRecognizer` delegate methods when
simulating `mouseDown` or `mouseUp`, and additionally assert gesture recognizer states after doing
so.

(TestWebKitAPI::MouseEventTestHarness::activeTouches const):

Canonical link: <a href="https://commits.webkit.org/268971@main">https://commits.webkit.org/268971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05f58d9fe2fc88748d8e555f8275dad492317496

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23068 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21742 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23920 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25531 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23396 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/19934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19227 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5075 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->