### PR TITLE
[SVG] Move marker related code from LegacyRenderSVGShape to LegacyRenderSVGPath

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -50,6 +50,7 @@ void RenderSVGEllipse::updateShapeFromElement()
 {
     // Before creating a new object we need to clear the cached bounding box
     // to avoid using garbage.
+    m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
     m_strokeBoundingBox = FloatRect();
     m_center = FloatPoint();
@@ -61,6 +62,11 @@ void RenderSVGEllipse::updateShapeFromElement()
     // Spec: "A negative value is illegal. A value of zero disables rendering of the element."
     if (m_radii.isEmpty())
         return;
+
+    if (m_radii.width() == m_radii.height())
+        m_shapeType = ShapeType::Circle;
+    else
+        m_shapeType = ShapeType::Ellipse;
 
     if (hasNonScalingStroke()) {
         // Fallback to RenderSVGShape if shape has a non-scaling stroke.
@@ -119,8 +125,8 @@ bool RenderSVGEllipse::shapeDependentStrokeContains(const FloatPoint& point, Poi
 {
     // The optimized code below does not support non-smooth strokes so we need to
     // fall back to RenderSVGShape::shapeDependentStrokeContains in these cases.
-    if (!hasSmoothStroke() && !hasPath())
-        RenderSVGShape::updateShapeFromElement();
+    if (!hasSmoothStroke())
+        ensurePath();
 
     if (hasPath())
         return RenderSVGShape::shapeDependentStrokeContains(point, pointCoordinateSpace);

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -37,11 +37,13 @@ public:
     RenderSVGPath(SVGGraphicsElement&, RenderStyle&&);
     virtual ~RenderSVGPath();
 
+    FloatRect computeMarkerBoundingBox(const SVGBoundingBoxComputation::DecorationOptions&) const;
+
 private:
     ASCIILiteral renderName() const override { return "RenderSVGPath"_s; }
 
     void updateShapeFromElement() override;
-    FloatRect calculateUpdatedStrokeBoundingBox() const;
+    FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(FloatRect strokeBoundingBox) const;
 
     void strokeShape(GraphicsContext&) const override;
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;
@@ -52,9 +54,14 @@ private:
     void updateZeroLengthSubpaths();
     void strokeZeroLengthSubpaths(GraphicsContext&) const;
 
+    void processMarkerPositions();
+    bool shouldGenerateMarkerPositions() const;
+    void drawMarkers(PaintInfo&) override;
+
     bool isRenderingDisabled() const override;
 
     Vector<FloatPoint> m_zeroLengthLinecapLocations;
+    Vector<MarkerPosition> m_markerPositions;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -55,6 +55,7 @@ void RenderSVGRect::updateShapeFromElement()
 {
     // Before creating a new object we need to clear the cached bounding box
     // to avoid using garbage.
+    m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
     m_innerStrokeRect = FloatRect();
     m_outerStrokeRect = FloatRect();
@@ -67,7 +68,12 @@ void RenderSVGRect::updateShapeFromElement()
     if (boundingBoxSize.isEmpty())
         return;
 
-    if (rectElement().rx().value(lengthContext) > 0 || rectElement().ry().value(lengthContext) > 0 || hasNonScalingStroke()) {
+    if (rectElement().rx().value(lengthContext) > 0 || rectElement().ry().value(lengthContext) > 0)
+        m_shapeType = ShapeType::RoundedRectangle;
+    else
+        m_shapeType = ShapeType::Rectangle;
+
+    if (m_shapeType != ShapeType::Rectangle || hasNonScalingStroke()) {
         // Fall back to RenderSVGShape
         RenderSVGShape::updateShapeFromElement();
         return;
@@ -137,8 +143,8 @@ bool RenderSVGRect::shapeDependentStrokeContains(const FloatPoint& point, PointC
 {
     // The optimized code below does not support non-smooth strokes so we need
     // to fall back to RenderSVGShape::shapeDependentStrokeContains in these cases.
-    if (!hasSmoothStroke() && !hasPath())
-        RenderSVGShape::updateShapeFromElement();
+    if (!hasSmoothStroke())
+        ensurePath();
 
     if (hasPath())
         return RenderSVGShape::shapeDependentStrokeContains(point, pointCoordinateSpace);

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -47,6 +47,16 @@ class SVGGraphicsElement;
 class RenderSVGShape : public RenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGShape);
 public:
+    enum class ShapeType : uint8_t {
+        Empty,
+        Path,
+        Line,
+        Rectangle,
+        RoundedRectangle,
+        Ellipse,
+        Circle,
+    };
+
     enum PointCoordinateSpace {
         GlobalCoordinateSpace,
         LocalCoordinateSpace
@@ -76,11 +86,11 @@ public:
     }
     void clearPath() { m_path = nullptr; }
 
+    ShapeType shapeType() const { return m_shapeType; }
+
     FloatRect objectBoundingBox() const final { return m_fillBoundingBox; }
     FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
-
-    FloatRect computeMarkerBoundingBox(const SVGBoundingBoxComputation::DecorationOptions&) const;
 
     bool needsHasSVGTransformFlags() const final;
 
@@ -88,6 +98,8 @@ public:
 
 protected:
     void element() const = delete;
+
+    void ensurePath();
 
     virtual void updateShapeFromElement();
     virtual bool isEmpty() const;
@@ -122,24 +134,23 @@ private:
 
     bool setupNonScalingStrokeContext(AffineTransform&, GraphicsContextStateSaver&);
 
-    bool shouldGenerateMarkerPositions() const;
     
     std::unique_ptr<Path> createPath() const;
-    void processMarkerPositions();
 
     void fillShape(const RenderStyle&, GraphicsContext&);
     void strokeShapeInternal(const RenderStyle&, GraphicsContext&);
     void strokeShape(const RenderStyle&, GraphicsContext&);
     void fillStrokeMarkers(PaintInfo&);
-    void drawMarkers(PaintInfo&);
+    virtual void drawMarkers(PaintInfo&) { }
 
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;
 
 private:
     bool m_needsShapeUpdate { true };
-
+protected:
+    ShapeType m_shapeType : 3 { ShapeType::Empty };
+private:
     std::unique_ptr<Path> m_path;
-    Vector<MarkerPosition> m_markerPositions;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -30,6 +30,7 @@
 #include "RenderSVGHiddenContainer.h"
 #include "RenderSVGImage.h"
 #include "RenderSVGInline.h"
+#include "RenderSVGPath.h"
 #include "RenderSVGResourceFilter.h"
 #include "RenderSVGResourceMarker.h"
 #include "RenderSVGResourceMasker.h"
@@ -107,11 +108,11 @@ FloatRect SVGBoundingBoxComputation::handleShapeOrTextOrInline(const SVGBounding
     //     or is not an "a", "g", "svg" or "switch" element, then continue to the next descendant graphics element.
     //   - Otherwise, set box to be the union of box and the result of invoking the algorithm to compute a bounding box with child as
     //     the element, space as the target coordinate space, true for fill, stroke and markers, and clipped for clipped.
-    if (options.contains(DecorationOption::IncludeMarkers) && is<RenderSVGShape>(m_renderer)) {
+    if (options.contains(DecorationOption::IncludeMarkers) && is<RenderSVGPath>(m_renderer)) {
         DecorationOptions optionsForMarker = { DecorationOption::IncludeFillShape, DecorationOption::IncludeStrokeShape, DecorationOption::IncludeMarkers };
         if (options.contains(DecorationOption::IncludeClippers))
             optionsForMarker.add(DecorationOption::IncludeClippers);
-        box.unite(downcast<RenderSVGShape>(m_renderer).computeMarkerBoundingBox(options));
+        box.unite(downcast<RenderSVGPath>(m_renderer).computeMarkerBoundingBox(options));
     }
 
     // 6. If clipped is true and the value of clip-path on element is not none, then set box to be the tightest rectangle

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -49,6 +49,7 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
 {
     // Before creating a new object we need to clear the cached bounding box
     // to avoid using garbage.
+    m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
     m_strokeBoundingBox = FloatRect();
     m_center = FloatPoint();
@@ -123,8 +124,8 @@ bool LegacyRenderSVGEllipse::shapeDependentStrokeContains(const FloatPoint& poin
 {
     // The optimized code below does not support non-smooth strokes so we need to
     // fall back to LegacyRenderSVGShape::shapeDependentStrokeContains in these cases.
-    if (!hasSmoothStroke() && !hasPath())
-        LegacyRenderSVGShape::updateShapeFromElement();
+    if (!hasSmoothStroke())
+        ensurePath();
 
     if (hasPath())
         return LegacyRenderSVGShape::shapeDependentStrokeContains(point, pointCoordinateSpace);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -49,27 +49,31 @@ LegacyRenderSVGPath::~LegacyRenderSVGPath() = default;
 
 void LegacyRenderSVGPath::updateShapeFromElement()
 {
+    m_shapeType = ShapeType::Empty;
     LegacyRenderSVGShape::updateShapeFromElement();
+    processMarkerPositions();
     updateZeroLengthSubpaths();
 
-    m_strokeBoundingBox = calculateUpdatedStrokeBoundingBox();
+    m_strokeBoundingBox = adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(m_strokeBoundingBox);
 
     ASSERT(hasPath());
     if (path().isEmpty())
-        m_shapeType = ShapeType::Empty;
-    else if (path().definitelySingleLine())
+        return;
+    if (path().definitelySingleLine())
         m_shapeType = ShapeType::Line;
     else
         m_shapeType = ShapeType::Path;
 }
 
-FloatRect LegacyRenderSVGPath::calculateUpdatedStrokeBoundingBox() const
+FloatRect LegacyRenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(FloatRect strokeBoundingBox) const
 {
-    FloatRect strokeBoundingBox = m_strokeBoundingBox;
+    float strokeWidth = this->strokeWidth();
+
+    if (!m_markerPositions.isEmpty())
+        strokeBoundingBox.unite(markerRect(strokeWidth));
 
     if (style().svgStyle().hasStroke()) {
         // FIXME: zero-length subpaths do not respect vector-effect = non-scaling-stroke.
-        float strokeWidth = this->strokeWidth();
         for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i)
             strokeBoundingBox.unite(zeroLengthSubpathRect(m_zeroLengthLinecapLocations[i], strokeWidth));
     }
@@ -177,6 +181,96 @@ void LegacyRenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) con
             usePath = nonScalingStrokePath(usePath, nonScalingTransform);
         context.fillPath(*usePath);
     }
+}
+
+static inline RenderSVGResourceMarker* markerForType(SVGMarkerType type, RenderSVGResourceMarker* markerStart, RenderSVGResourceMarker* markerMid, RenderSVGResourceMarker* markerEnd)
+{
+    switch (type) {
+    case StartMarker:
+        return markerStart;
+    case MidMarker:
+        return markerMid;
+    case EndMarker:
+        return markerEnd;
+    }
+
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+bool LegacyRenderSVGPath::shouldGenerateMarkerPositions() const
+{
+    if (!style().svgStyle().hasMarkers())
+        return false;
+
+    if (!graphicsElement().supportsMarkers())
+        return false;
+
+    auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*this);
+    if (!resources)
+        return false;
+
+    return resources->markerStart() || resources->markerMid() || resources->markerEnd();
+}
+
+void LegacyRenderSVGPath::drawMarkers(PaintInfo& paintInfo)
+{
+    if (m_markerPositions.isEmpty())
+        return;
+
+    auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*this);
+    if (!resources)
+        return;
+
+    RenderSVGResourceMarker* markerStart = resources->markerStart();
+    RenderSVGResourceMarker* markerMid = resources->markerMid();
+    RenderSVGResourceMarker* markerEnd = resources->markerEnd();
+    if (!markerStart && !markerMid && !markerEnd)
+        return;
+
+    float strokeWidth = this->strokeWidth();
+    unsigned size = m_markerPositions.size();
+    for (unsigned i = 0; i < size; ++i) {
+        if (RenderSVGResourceMarker* marker = markerForType(m_markerPositions[i].type, markerStart, markerMid, markerEnd))
+            marker->draw(paintInfo, marker->markerTransformation(m_markerPositions[i].origin, m_markerPositions[i].angle, strokeWidth));
+    }
+}
+
+FloatRect LegacyRenderSVGPath::markerRect(float strokeWidth) const
+{
+    ASSERT(!m_markerPositions.isEmpty());
+
+    auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*this);
+    ASSERT(resources);
+
+    RenderSVGResourceMarker* markerStart = resources->markerStart();
+    RenderSVGResourceMarker* markerMid = resources->markerMid();
+    RenderSVGResourceMarker* markerEnd = resources->markerEnd();
+    ASSERT(markerStart || markerMid || markerEnd);
+
+    FloatRect boundaries;
+    unsigned size = m_markerPositions.size();
+    for (unsigned i = 0; i < size; ++i) {
+        if (RenderSVGResourceMarker* marker = markerForType(m_markerPositions[i].type, markerStart, markerMid, markerEnd))
+            boundaries.unite(marker->markerBoundaries(marker->markerTransformation(m_markerPositions[i].origin, m_markerPositions[i].angle, strokeWidth)));
+    }
+    return boundaries;
+}
+
+void LegacyRenderSVGPath::processMarkerPositions()
+{
+    m_markerPositions.clear();
+
+    if (!shouldGenerateMarkerPositions())
+        return;
+
+    ASSERT(hasPath());
+
+    SVGMarkerData markerData(m_markerPositions, SVGResourcesCache::cachedResourcesForRenderer(*this)->markerReverseStart());
+    path().applyElements([&markerData](const PathElement& pathElement) {
+        SVGMarkerData::updateFromPathElement(markerData, pathElement);
+    });
+    markerData.pathIsDone();
 }
 
 bool LegacyRenderSVGPath::isRenderingDisabled() const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
@@ -35,11 +35,13 @@ public:
     LegacyRenderSVGPath(SVGGraphicsElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGPath();
 
+    void drawMarkers(PaintInfo&) final;
+
 private:
     ASCIILiteral renderName() const override { return "RenderSVGPath"_s; }
 
     void updateShapeFromElement() override;
-    FloatRect calculateUpdatedStrokeBoundingBox() const;
+    FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(FloatRect strokeBoundingBox) const;
 
     void strokeShape(GraphicsContext&) const override;
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;
@@ -50,9 +52,14 @@ private:
     void updateZeroLengthSubpaths();
     void strokeZeroLengthSubpaths(GraphicsContext&) const;
 
+    bool shouldGenerateMarkerPositions() const;
+    void processMarkerPositions();
+    FloatRect markerRect(float strokeWidth) const;
+
     bool isRenderingDisabled() const override;
 
     Vector<FloatPoint> m_zeroLengthLinecapLocations;
+    Vector<MarkerPosition> m_markerPositions;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -52,6 +52,7 @@ void LegacyRenderSVGRect::updateShapeFromElement()
 {
     // Before creating a new object we need to clear the cached bounding box
     // to avoid using garbage.
+    m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
     m_innerStrokeRect = FloatRect();
     m_outerStrokeRect = FloatRect();
@@ -64,9 +65,10 @@ void LegacyRenderSVGRect::updateShapeFromElement()
     if (boundingBoxSize.isEmpty())
         return;
 
-    m_shapeType = ShapeType::Rectangle;
     if (rectElement().rx().value(lengthContext) > 0 || rectElement().ry().value(lengthContext) > 0)
         m_shapeType = ShapeType::RoundedRectangle;
+    else
+        m_shapeType = ShapeType::Rectangle;
 
     if (m_shapeType != ShapeType::Rectangle || hasNonScalingStroke()) {
         // Fall back to LegacyRenderSVGShape
@@ -138,8 +140,8 @@ bool LegacyRenderSVGRect::shapeDependentStrokeContains(const FloatPoint& point, 
 {
     // The optimized code below does not support non-smooth strokes so we need to
     // fall back to LegacyRenderSVGShape::shapeDependentStrokeContains in these cases.
-    if (!hasSmoothStroke() && !hasPath())
-        LegacyRenderSVGShape::updateShapeFromElement();
+    if (!hasSmoothStroke())
+        ensurePath();
 
     if (hasPath())
         return LegacyRenderSVGShape::shapeDependentStrokeContains(point, pointCoordinateSpace);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -88,6 +88,8 @@ public:
 protected:
     void element() const = delete;
 
+    void ensurePath();
+
     virtual void updateShapeFromElement();
     virtual bool isEmpty() const;
     virtual bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace);
@@ -128,18 +130,15 @@ private:
     void updateRepaintBoundingBox();
 
     bool setupNonScalingStrokeContext(AffineTransform&, GraphicsContextStateSaver&);
-
-    bool shouldGenerateMarkerPositions() const;
-    FloatRect markerRect(float strokeWidth) const;
     
     std::unique_ptr<Path> createPath() const;
-    void processMarkerPositions();
 
     void fillShape(const RenderStyle&, GraphicsContext&);
     void strokeShapeInternal(const RenderStyle&, GraphicsContext&);
     void strokeShape(const RenderStyle&, GraphicsContext&);
     void fillStrokeMarkers(PaintInfo&);
-    void drawMarkers(PaintInfo&);
+
+    virtual void drawMarkers(PaintInfo&) { }
 
 private:
     FloatRect m_repaintBoundingBox;
@@ -153,7 +152,6 @@ protected:
 private:
     AffineTransform m_localTransform;
     std::unique_ptr<Path> m_path;
-    Vector<MarkerPosition> m_markerPositions;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 95664cfd77a025b5154b8fc6dd52a6cbd9c0f544
<pre>
[SVG] Move marker related code from LegacyRenderSVGShape to LegacyRenderSVGPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=262756">https://bugs.webkit.org/show_bug.cgi?id=262756</a>
rdar://116557017

Reviewed by Cameron McCormack.

This is one step of the patch series implementing approximate repainting rect for SVG path, derived from blink&apos;s work[1].

This change moves marker related code from LegacyRenderSVGShape to LegacyRenderSVGPath
because only LegacyRenderSVGPath can have markers. `&lt;path&gt;`, `&lt;line&gt;`, `&lt;polyline&gt;` and `&lt;polygon&gt;`
can have that and all creates LegacyRenderSVGPath.

1. This makes LegacyRenderSVGShape::updateShapeFromElement more concise. This now only creates path, and computes two bounding boxes.
2. Previously we were calling LegacyRenderSVGShape::updateShapeFromElement from various places to update path. But this is not a good
   way since it updates m_fillBoundingBox and m_strokeBoundingBox while the class&apos; updateShapeFromElement already filled that.
   Since now LegacyRenderSVGShape::updateShapeFromElement is just creating a path and computing these two bounding boxes, we introduce
   ensurePath and use it in the places which is not overriding LegacyRenderSVGShape::updateShapeFromElement. This avoids accidentally
   updating already computed m_fillBoundingBox / m_strokeBoundingBox computing again. If they gets different, then it becomes a bug.
   (If newly path-based computed m_strokeBoundingBox is different from m_strokeBoundingBox computed in the class&apos;s updateShapeFromElement,
   getBBox etc. can return different value at different timing). This change makes m_strokeBoundingBox and m_fillBoundingBox more consistent.
3. We duplicate the change in LBSE.

[1]: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=435097">https://bugs.chromium.org/p/chromium/issues/detail?id=435097</a>

* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
(WebCore::RenderSVGEllipse::updateShapeFromElement):
(WebCore::RenderSVGEllipse::shapeDependentStrokeContains):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::updateShapeFromElement):
(WebCore::RenderSVGPath::calculateUpdatedStrokeBoundingBox const):
(WebCore::markerForType):
(WebCore::RenderSVGPath::shouldGenerateMarkerPositions const):
(WebCore::RenderSVGPath::drawMarkers):
(WebCore::RenderSVGPath::computeMarkerBoundingBox const):
(WebCore::RenderSVGPath::processMarkerPositions):
* Source/WebCore/rendering/svg/RenderSVGPath.h:
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::updateShapeFromElement):
(WebCore::RenderSVGRect::shapeDependentStrokeContains):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::updateShapeFromElement):
(WebCore::RenderSVGShape::fillStrokeMarkers):
(WebCore::RenderSVGShape::ensurePath):
(WebCore::RenderSVGShape::shouldGenerateMarkerPositions const): Deleted.
(WebCore::markerForType): Deleted.
(WebCore::RenderSVGShape::computeMarkerBoundingBox const): Deleted.
(WebCore::RenderSVGShape::drawMarkers): Deleted.
(WebCore::RenderSVGShape::processMarkerPositions): Deleted.
* Source/WebCore/rendering/svg/RenderSVGShape.h:
(WebCore::RenderSVGShape::shapeType const):
(WebCore::RenderSVGShape::drawMarkers):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleShapeOrTextOrInline const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
(WebCore::LegacyRenderSVGEllipse::updateShapeFromElement):
(WebCore::LegacyRenderSVGEllipse::shapeDependentStrokeContains):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::updateShapeFromElement):
(WebCore::LegacyRenderSVGPath::calculateUpdatedStrokeBoundingBox const):
(WebCore::markerForType):
(WebCore::LegacyRenderSVGPath::shouldGenerateMarkerPositions const):
(WebCore::LegacyRenderSVGPath::drawMarkers):
(WebCore::LegacyRenderSVGPath::markerRect const):
(WebCore::LegacyRenderSVGPath::processMarkerPositions):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
(WebCore::LegacyRenderSVGRect::updateShapeFromElement):
(WebCore::LegacyRenderSVGRect::shapeDependentStrokeContains):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::updateShapeFromElement):
(WebCore::LegacyRenderSVGShape::layout):
(WebCore::LegacyRenderSVGShape::fillStrokeMarkers):
(WebCore::LegacyRenderSVGShape::calculateStrokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::ensurePath):
(WebCore::LegacyRenderSVGShape::shouldGenerateMarkerPositions const): Deleted.
(WebCore::markerForType): Deleted.
(WebCore::LegacyRenderSVGShape::markerRect const): Deleted.
(WebCore::LegacyRenderSVGShape::drawMarkers): Deleted.
(WebCore::LegacyRenderSVGShape::processMarkerPositions): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
(WebCore::LegacyRenderSVGShape::drawMarkers):

Canonical link: <a href="https://commits.webkit.org/269245@main">https://commits.webkit.org/269245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e99d3d83fe396c476ba0ac9959dcc514ec151ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22233 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/21887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24738 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/19000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/19944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20595 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19949 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24154 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2735 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20546 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->