### PR TITLE
[WebXR] ARKitCoordinator enter/exit state management

### DIFF
--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -49,8 +49,25 @@ public:
     void scheduleAnimationFrame(WebPageProxy&, PlatformXR::Device::RequestFrameCallback&&) override;
     void submitFrame(WebPageProxy&) override;
 
+protected:
+    void currentSessionHasEnded();
+
 private:
     XRDeviceIdentifier m_deviceIdentifier = XRDeviceIdentifier::generate();
+
+    struct Idle {
+    };
+    struct Active {
+        WebCore::PageIdentifier pageIdentifier;
+        WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
+        PlatformXR::Device::RequestFrameCallback onFrameUpdate;
+    };
+    struct Terminating {
+        WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
+    };
+
+    using State = std::variant<Idle, Active, Terminating>;
+    State m_state;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 581471a69f32321409f5cbd38a34265769e9cd53
<pre>
[WebXR] ARKitCoordinator enter/exit state management
<a href="https://bugs.webkit.org/show_bug.cgi?id=262760">https://bugs.webkit.org/show_bug.cgi?id=262760</a>
rdar://116502232

Reviewed by Dean Jackson.

Implement basic state management for ARKitCoordinator to provide enough support
for immersive-ar-session.html to support starting and exiting an immersive AR
session and handle messages from the page.

* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):
(WebKit::ARKitCoordinator::endSessionIfExists):
(WebKit::ARKitCoordinator::scheduleAnimationFrame):
(WebKit::ARKitCoordinator::submitFrame):
(WebKit::ARKitCoordinator::currentSessionHasEnded):
(WebKit::ARKitCoordinator::didCompleteSessionSetup):

Canonical link: <a href="https://commits.webkit.org/269052@main">https://commits.webkit.org/269052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94d25b75b6ad96068c4e85200962baf2cdcfc8ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19881 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22007 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24166 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/18494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25758 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19582 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23608 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17144 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19450 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5123 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->