### PR TITLE
Use Vector::uncheckedAppend() less in WebCore

### DIFF
--- a/Source/WebCore/platform/network/HTTPHeaderMap.h
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.h
@@ -75,6 +75,11 @@ public:
             std::optional<HTTPHeaderName> keyAsHTTPHeaderName;
             String value;
         };
+        using difference_type = ptrdiff_t;
+        using value_type = KeyValue;
+        using pointer = const KeyValue*;
+        using reference = const KeyValue&;
+        using iterator_category = std::forward_iterator_tag;
 
         const KeyValue* get() const
         {

--- a/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp
@@ -207,10 +207,11 @@ static void* formCreate(CFReadStreamRef stream, void* context)
     });
 
     // Append in reverse order since we remove elements from the end.
-    size_t size = newInfo->data.data().elements().size();
-    newInfo->remainingElements.reserveInitialCapacity(size);
-    for (size_t i = 0; i < size; ++i)
-        newInfo->remainingElements.uncheckedAppend(newInfo->data.data().elements()[size - i - 1]);
+    auto& elements = newInfo->data.data().elements();
+    size_t size = elements.size();
+    newInfo->remainingElements = Vector<FormDataElement>(size, [&](size_t i) {
+        return elements[size - i - 1];
+    });
 
     return newInfo;
 }

--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -33,13 +33,10 @@ namespace WebCore {
 
 static Vector<uint16_t> portVectorFromList(NSArray<NSNumber *> *portList)
 {
-    Vector<uint16_t> ports;
-    ports.reserveInitialCapacity(portList.count);
-
-    for (NSNumber *port : portList)
-        ports.uncheckedAppend(port.unsignedShortValue);
-
-    return ports;
+    return Vector<uint16_t>(portList.count, [portList](size_t i) {
+        NSNumber *port = portList[i];
+        return port.unsignedShortValue;
+    });
 }
 
 static NSString * _Nullable portStringFromVector(const Vector<uint16_t>& ports)

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -561,16 +561,13 @@ HTTPCookieAcceptPolicy NetworkStorageSession::cookieAcceptPolicy() const
 
 bool NetworkStorageSession::getRawCookies(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, Vector<Cookie>& rawCookies) const
 {
-    rawCookies.clear();
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     RetainPtr<NSArray> cookies = cookiesForURL(firstParty, sameSiteInfo, url, frameID, pageID, applyTrackingPrevention, shouldRelaxThirdPartyCookieBlocking);
     NSUInteger count = [cookies count];
-    rawCookies.reserveCapacity(count);
-    for (NSUInteger i = 0; i < count; ++i) {
-        NSHTTPCookie *cookie = (NSHTTPCookie *)[cookies objectAtIndex:i];
-        rawCookies.uncheckedAppend({ cookie });
-    }
+    rawCookies = Vector<Cookie>(count, [cookies](size_t i) {
+        return Cookie { (NSHTTPCookie *)[cookies objectAtIndex:i] };
+    });
 
     END_BLOCK_OBJC_EXCEPTIONS
     return true;

--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -188,11 +188,7 @@ std::unique_ptr<Vector<String>> LocaleICU::createLabelVector(const UDateFormat* 
 
 static std::unique_ptr<Vector<String>> createFallbackMonthLabels()
 {
-    auto labels = makeUnique<Vector<String>>();
-    labels->reserveInitialCapacity(std::size(WTF::monthFullName));
-    for (auto monthName : WTF::monthFullName)
-        labels->uncheckedAppend(monthName);
-    return labels;
+    return makeUnique<Vector<String>>(WTF::monthFullName, 12);
 }
 
 const Vector<String>& LocaleICU::monthLabels()

--- a/Source/WebCore/platform/text/LocaleNone.cpp
+++ b/Source/WebCore/platform/text/LocaleNone.cpp
@@ -71,9 +71,7 @@ const Vector<String>& LocaleNone::monthLabels()
 {
     if (!m_monthLabels.isEmpty())
         return m_monthLabels;
-    m_monthLabels.reserveCapacity(std::size(WTF::monthFullName));
-    for (unsigned i = 0; i < std::size(WTF::monthFullName); ++i)
-        m_monthLabels.uncheckedAppend(WTF::monthFullName[i]);
+    m_monthLabels = { WTF::monthFullName, std::size(WTF::monthFullName) };
     return m_monthLabels;
 }
 
@@ -116,9 +114,7 @@ const Vector<String>& LocaleNone::shortMonthLabels()
 {
     if (!m_shortMonthLabels.isEmpty())
         return m_shortMonthLabels;
-    m_shortMonthLabels.reserveCapacity(std::size(WTF::monthName));
-    for (auto* monthName : WTF::monthName)
-        m_shortMonthLabels.uncheckedAppend(monthName);
+    m_shortMonthLabels = { WTF::monthName, std::size(WTF::monthName) };
     return m_shortMonthLabels;
 }
 

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -112,9 +112,7 @@ const Vector<String>& LocaleCocoa::monthLabels()
         m_monthLabels = makeVector<String>(array);
         return m_monthLabels;
     }
-    m_monthLabels.reserveCapacity(12);
-    for (auto& name : WTF::monthFullName)
-        m_monthLabels.uncheckedAppend(String::fromLatin1(name));
+    m_monthLabels = { WTF::monthFullName, std::size(WTF::monthFullName) };
     return m_monthLabels;
 }
 
@@ -205,9 +203,7 @@ const Vector<String>& LocaleCocoa::shortMonthLabels()
         m_shortMonthLabels = makeVector<String>(array);
         return m_shortMonthLabels;
     }
-    m_shortMonthLabels.reserveCapacity(12);
-    for (auto& name : WTF::monthName)
-        m_shortMonthLabels.uncheckedAppend(name);
+    m_shortMonthLabels = { WTF::monthName, std::size(WTF::monthName) };
     return m_shortMonthLabels;
 }
 
@@ -242,10 +238,8 @@ const Vector<String>& LocaleCocoa::timeAMPMLabels()
 {
     if (!m_timeAMPMLabels.isEmpty())
         return m_timeAMPMLabels;
-    m_timeAMPMLabels.reserveCapacity(2);
     RetainPtr<NSDateFormatter> formatter = shortTimeFormatter();
-    m_timeAMPMLabels.uncheckedAppend([formatter AMSymbol]);
-    m_timeAMPMLabels.uncheckedAppend([formatter PMSymbol]);
+    m_timeAMPMLabels = { String([formatter AMSymbol]), String([formatter PMSymbol]) };
     return m_timeAMPMLabels;
 }
 

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -544,11 +544,10 @@ static Vector<LayoutRect> characterRects(const InlineIterator::TextBox& run, uns
         return { };
 
     if (auto* svgTextBox = dynamicDowncast<SVGInlineTextBox>(run.legacyInlineBox())) {
-        Vector<LayoutRect> rects;
-        rects.reserveInitialCapacity(clampedEnd - clampedStart);
-        for (auto index = clampedStart; index < clampedEnd; ++index)
-            rects.uncheckedAppend(svgTextBox->localSelectionRect(index, index + 1));
-        return rects;
+        return Vector<LayoutRect>(clampedEnd - clampedStart, [&, clampedStart = clampedStart](size_t i) {
+            size_t index = clampedStart + i;
+            return svgTextBox->localSelectionRect(index, index + 1);
+        });
     }
 
     auto lineSelectionRect = LineSelection::logicalRect(*run.lineBox());

--- a/Source/WebCore/rendering/style/StyleImageSet.cpp
+++ b/Source/WebCore/rendering/style/StyleImageSet.cpp
@@ -62,12 +62,9 @@ bool StyleImageSet::equals(const StyleImageSet& other) const
 
 Ref<CSSValue> StyleImageSet::computedStyleValue(const RenderStyle& style) const
 {
-    CSSValueListBuilder builder;
-    builder.reserveInitialCapacity(m_images.size());
-
-    for (auto& image : m_images)
-        builder.uncheckedAppend(CSSImageSetOptionValue::create(image.image->computedStyleValue(style), CSSPrimitiveValue::create(image.scaleFactor, CSSUnitType::CSS_DPPX), image.mimeType));
-
+    auto builder = WTF::map<4>(m_images, [&](auto& image) -> Ref<CSSValue> {
+        return CSSImageSetOptionValue::create(image.image->computedStyleValue(style), CSSPrimitiveValue::create(image.scaleFactor, CSSUnitType::CSS_DPPX), image.mimeType);
+    });
     return CSSImageSetValue::create(WTFMove(builder));
 }
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -452,9 +452,6 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
     if (dashes.isEmpty())
         context.setStrokeStyle(StrokeStyle::SolidStroke);
     else {
-        DashArray dashArray;
-        dashArray.reserveInitialCapacity(dashes.size());
-        bool canSetLineDash = false;
         float scaleFactor = 1;
 
         if (is<SVGGeometryElement>(element)) {
@@ -470,11 +467,13 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
             }
         }
         
-        for (auto& dash : dashes) {
-            dashArray.uncheckedAppend(dash.value(lengthContext) * scaleFactor);
-            if (dashArray.last() > 0)
+        bool canSetLineDash = false;
+        auto dashArray = WTF::map(dashes, [&](auto& dash) -> DashArrayElement {
+            auto value = dash.value(lengthContext) * scaleFactor;
+            if (value > 0)
                 canSetLineDash = true;
-        }
+            return value;
+        });
 
         if (canSetLineDash)
             context.setLineDash(dashArray, lengthContext.valueForLength(svgStyle.strokeDashOffset()) * scaleFactor);

--- a/Source/WebCore/storage/Storage.cpp
+++ b/Source/WebCore/storage/Storage.cpp
@@ -120,14 +120,9 @@ bool Storage::isSupportedPropertyName(const String& propertyName) const
 Vector<AtomString> Storage::supportedPropertyNames() const
 {
     unsigned length = m_storageArea->length();
-
-    Vector<AtomString> result;
-    result.reserveInitialCapacity(length);
-
-    for (unsigned i = 0; i < length; ++i)
-        result.uncheckedAppend(m_storageArea->key(i));
-
-    return result;
+    return Vector<AtomString>(length, [this](size_t i) {
+        return m_storageArea->key(i);
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/ClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/ClassChangeInvalidation.cpp
@@ -46,11 +46,9 @@ using ClassChangeVector = Vector<ClassChange, 4>;
 
 static ClassChangeVector collectClasses(const SpaceSplitString& classes, ClassChangeType changeType)
 {
-    ClassChangeVector result;
-    result.reserveInitialCapacity(classes.size());
-    for (unsigned i = 0; i < classes.size(); ++i)
-        result.uncheckedAppend({ classes[i].impl(), changeType });
-    return result;
+    return ClassChangeVector(classes.size(), [&](size_t i) {
+        return ClassChange { classes[i].impl(), changeType };
+    });
 }
 
 static ClassChangeVector computeClassChanges(const SpaceSplitString& oldClasses, const SpaceSplitString& newClasses)

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -352,10 +352,9 @@ void RuleSetBuilder::updateCascadeLayerPriorities()
 
     auto layerCount = m_ruleSet->m_cascadeLayers.size();
 
-    Vector<RuleSet::CascadeLayerIdentifier> layersInPriorityOrder;
-    layersInPriorityOrder.reserveInitialCapacity(layerCount);
-    for (RuleSet::CascadeLayerIdentifier identifier = 1; identifier <= layerCount; ++identifier)
-        layersInPriorityOrder.uncheckedAppend(identifier);
+    Vector<RuleSet::CascadeLayerIdentifier> layersInPriorityOrder(layerCount, [](size_t i) {
+        return i + 1;
+    });
 
     std::sort(layersInPriorityOrder.begin(), layersInPriorityOrder.end(), compare);
 
@@ -473,9 +472,9 @@ void RuleSetBuilder::MediaQueryCollector::pop(const MQ::MediaQueryList& mediaQue
 
     if (!dynamicContextStack.last().affectedRulePositions.isEmpty() || !collectDynamic) {
         RuleSet::DynamicMediaQueryRules rules;
-        rules.mediaQueries.reserveCapacity(rules.mediaQueries.size() + dynamicContextStack.size());
-        for (auto& context : dynamicContextStack)
-            rules.mediaQueries.uncheckedAppend(context.queries);
+        rules.mediaQueries = WTF::map(dynamicContextStack, [](auto& context) {
+            return context.queries;
+        });
 
         if (collectDynamic) {
             rules.affectedRulePositions.appendVector(dynamicContextStack.last().affectedRulePositions);

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1307,11 +1307,10 @@ inline void BuilderConverter::createImplicitNamedGridLinesFromGridArea(const Nam
 
 inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(BuilderState& builderState, const CSSValue& value)
 {
-    auto validateValueAndAppend = [&builderState](Vector<GridTrackSize>& trackSizes, const CSSValue& value) {
-        ASSERT(!value.isGridLineNamesValue());
-        ASSERT(!value.isGridAutoRepeatValue());
-        ASSERT(!value.isGridIntegerRepeatValue());
-        trackSizes.uncheckedAppend(convertGridTrackSize(builderState, value));
+    auto validateValue = [](const CSSValue& value) {
+        ASSERT_UNUSED(value, !value.isGridLineNamesValue());
+        ASSERT_UNUSED(value, !value.isGridAutoRepeatValue());
+        ASSERT_UNUSED(value, !value.isGridIntegerRepeatValue());
     };
 
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
@@ -1320,23 +1319,19 @@ inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(BuilderS
             return RenderStyle::initialGridAutoRows();
         }
         // Values coming from CSS Typed OM may not have been converted to a CSSValueList yet.
-        Vector<GridTrackSize> trackSizes;
-        trackSizes.reserveInitialCapacity(1);
-        validateValueAndAppend(trackSizes, *primitiveValue);
-        return trackSizes;
+        validateValue(*primitiveValue);
+        return Vector<GridTrackSize>({ convertGridTrackSize(builderState, *primitiveValue) });
     }
 
-    Vector<GridTrackSize> trackSizes;
     if (is<CSSValueList>(value))  {
         auto& valueList = downcast<CSSValueList>(value);
-        trackSizes.reserveInitialCapacity(valueList.length());
-        for (auto& currentValue : valueList)
-            validateValueAndAppend(trackSizes, currentValue);
-    } else {
-        trackSizes.reserveInitialCapacity(1);
-        validateValueAndAppend(trackSizes, value);
+        return WTF::map(valueList, [&](auto& currentValue) {
+            validateValue(currentValue);
+            return convertGridTrackSize(builderState, currentValue);
+        });
     }
-    return trackSizes;
+    validateValue(value);
+    return Vector<GridTrackSize>({ convertGridTrackSize(builderState, value) });
 }
 
 inline GridTrackSize BuilderConverter::convertGridTrackSize(BuilderState& builderState, const CSSValue& value)
@@ -1692,13 +1687,9 @@ inline SVGLengthValue BuilderConverter::convertSVGLengthValue(BuilderState& buil
 inline Vector<SVGLengthValue> BuilderConverter::convertSVGLengthVector(BuilderState& builderState, const CSSValue& value, ShouldConvertNumberToPxLength shouldConvertNumberToPxLength)
 {
     auto& valueList = downcast<CSSValueList>(value);
-
-    Vector<SVGLengthValue> svgLengths;
-    svgLengths.reserveInitialCapacity(valueList.length());
-    for (auto& item : valueList)
-        svgLengths.uncheckedAppend(convertSVGLengthValue(builderState, item, shouldConvertNumberToPxLength));
-
-    return svgLengths;
+    return WTF::map(valueList, [&](auto& item) {
+        return convertSVGLengthValue(builderState, item, shouldConvertNumberToPxLength);
+    });
 }
 
 inline Vector<SVGLengthValue> BuilderConverter::convertStrokeDashArray(BuilderState& builderState, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -978,8 +978,8 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
         families = Vector<AtomString>::from(WTFMove(family));
     } else {
         auto& valueList = downcast<CSSValueList>(value);
-        families.reserveInitialCapacity(valueList.length());
-        for (auto& item : valueList) {
+        bool isFirstFont = true;
+        families = WTF::compactMap(valueList, [&](auto& item) -> std::optional<AtomString> {
             auto& contentValue = downcast<CSSPrimitiveValue>(item);
             AtomString family;
             bool isGenericFamily = false;
@@ -993,11 +993,13 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
                 ASSERT(!family.isEmpty());
             }
             if (family.isNull())
-                continue;
-            if (families.isEmpty())
+                return std::nullopt;
+            if (isFirstFont) {
                 fontDescription.setIsSpecifiedFont(!isGenericFamily);
-            families.uncheckedAppend(WTFMove(family));
-        }
+                isFirstFont = false;
+            }
+            return family;
+        });
         if (families.isEmpty())
             return;
     }

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -294,15 +294,10 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
             }
         }
 
-        auto invalidationRuleSets = makeUnique<Vector<InvalidationRuleSet>>();
-        invalidationRuleSets->reserveInitialCapacity(invalidationRuleSetMap.size());
-
-        for (auto& invalidationRuleSet : invalidationRuleSetMap.values()) {
+        return makeUnique<Vector<InvalidationRuleSet>>(WTF::map(invalidationRuleSetMap.values(), [](auto&& invalidationRuleSet) {
             invalidationRuleSet.ruleSet->shrinkToFit();
-            invalidationRuleSets->uncheckedAppend(WTFMove(invalidationRuleSet));
-        }
-
-        return invalidationRuleSets;
+            return WTFMove(invalidationRuleSet);
+        }));
     }).iterator->value.get();
 }
 

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -127,9 +127,9 @@ RefPtr<FilterEffect> SVGFEColorMatrixElement::createFilterEffect(const FilterEff
         switch (filterType) {
         case FECOLORMATRIX_TYPE_MATRIX: {
             static constexpr unsigned matrixValueCount = 20;
-            filterValues.reserveInitialCapacity(matrixValueCount);
-            for (size_t i = 0; i < matrixValueCount; i++)
-                filterValues.uncheckedAppend((i % 6) ? 0 : 1);
+            filterValues = Vector<float>(matrixValueCount, [](size_t i) {
+                return (i % 6) ? 0.0 : 1.0;
+            });
             break;
         }
         case FECOLORMATRIX_TYPE_HUEROTATE:

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -142,11 +142,9 @@ Ref<FetchResponse> ServiceWorkerInternals::createOpaqueWithBlobBodyResponse(Scri
 
 Vector<String> ServiceWorkerInternals::fetchResponseHeaderList(FetchResponse& response)
 {
-    Vector<String> headerNames;
-    headerNames.reserveInitialCapacity(response.internalResponseHeaders().size());
-    for (auto keyValue : response.internalResponseHeaders())
-        headerNames.uncheckedAppend(keyValue.key);
-    return headerNames;
+    return WTF::map(response.internalResponseHeaders(), [](auto& keyValue) {
+        return keyValue.key;
+    });
 }
 
 #if !PLATFORM(MAC)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -54,9 +54,9 @@ BackgroundFetch::BackgroundFetch(SWServerRegistration& registration, const Strin
     , m_origin { m_registrationKey.topOrigin(), SecurityOriginData::fromURL(m_registrationKey.scope()) }
 {
     size_t index = 0;
-    m_records.reserveInitialCapacity(requests.size());
-    for (auto& request : requests)
-        m_records.uncheckedAppend(Record::create(*this, WTFMove(request), index++));
+    m_records = WTF::map(WTFMove(requests), [&](auto&& request) {
+        return Record::create(*this, WTFMove(request), index++);
+    });
 }
 
 BackgroundFetch::BackgroundFetch(SWServerRegistration& registration, String&& identifier, BackgroundFetchOptions&& options, Ref<BackgroundFetchStore>&& store, NotificationCallback&& notificationCallback, bool pausedFlag)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -819,11 +819,9 @@ String XMLHttpRequest::getAllResponseHeaders() const
         return emptyString();
 
     if (!m_allResponseHeaders) {
-        Vector<std::pair<String, String>> headers;
-        headers.reserveInitialCapacity(m_response.httpHeaderFields().size());
-
-        for (auto& header : m_response.httpHeaderFields())
-            headers.uncheckedAppend(std::make_pair(header.key, header.value));
+        auto headers = WTF::map(m_response.httpHeaderFields(), [](auto& header) {
+            return std::make_pair(header.key, header.value);
+        });
 
         std::sort(headers.begin(), headers.end(), [] (const std::pair<String, String>& x, const std::pair<String, String>& y) {
             unsigned xLength = x.first.length();


### PR DESCRIPTION
#### 4a0b13037eb2952053f57e5895df92d48aea5439
<pre>
Use Vector::uncheckedAppend() less in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=262761">https://bugs.webkit.org/show_bug.cgi?id=262761</a>

Reviewed by Darin Adler.

Use Vector::uncheckedAppend() less in WebCore and replace with faster alternatives
now that uncheckedAppend() has become an alias for append().

* Source/WebCore/platform/network/HTTPHeaderMap.h:
* Source/WebCore/platform/network/cf/FormDataStreamCFNet.cpp:
(WebCore::formCreate):
* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::portVectorFromList):
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::getRawCookies const):
* Source/WebCore/platform/text/LocaleICU.cpp:
(WebCore::createFallbackMonthLabels):
* Source/WebCore/platform/text/LocaleNone.cpp:
(WebCore::LocaleNone::monthLabels):
(WebCore::LocaleNone::shortMonthLabels):
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::LocaleCocoa::monthLabels):
(WebCore::LocaleCocoa::shortMonthLabels):
(WebCore::LocaleCocoa::timeAMPMLabels):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::characterRects):
* Source/WebCore/rendering/style/StyleImageSet.cpp:
(WebCore::StyleImageSet::computedStyleValue const):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::applyStrokeStyleToContext):
* Source/WebCore/storage/Storage.cpp:
(WebCore::Storage::supportedPropertyNames const):
* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::collectClasses):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::updateCascadeLayerPriorities):
(WebCore::Style::RuleSetBuilder::MediaQueryCollector::pop):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertGridTrackSizeList):
(WebCore::Style::BuilderConverter::convertSVGLengthVector):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueFontFamily):
* Source/WebCore/style/StyleResolveForFontRaw.cpp:
(WebCore::Style::resolveForFontRaw):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::createFilterEffect const):
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::fetchResponseHeaderList):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::backgroundFetchIdentifiers):
(WebCore::BackgroundFetchEngine::matchBackgroundFetch):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::getAllResponseHeaders const):

Canonical link: <a href="https://commits.webkit.org/269027@main">https://commits.webkit.org/269027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89bd32676411899bf6cff8bbbff2c70be073a19d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23223 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21920 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24075 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18412 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19360 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23532 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19370 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2650 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->