### PR TITLE
Add MarkableTraits to FloatRect / FloatPoint / FloatSize

### DIFF
--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -771,7 +771,7 @@ inline uint32_t reverseBits32(uint32_t value)
 #endif
 }
 
-// FIXME: Replace with std::isnan() once std::isnan() is constexpr.
+// FIXME: Replace with std::isnan() once std::isnan() is constexpr. requires C++23
 template<typename T> constexpr typename std::enable_if_t<std::is_floating_point_v<T>, bool> isNaNConstExpr(T value)
 {
 #if COMPILER_HAS_CLANG_BUILTIN(__builtin_isnan)
@@ -786,6 +786,19 @@ template<typename T> constexpr typename std::enable_if_t<std::is_integral_v<T>, 
     return false;
 }
 
+// FIXME: Replace with std::fabs() once std::fabs() is constexpr. requires C++23
+template<typename T> constexpr bool fabsConstExpr(T value)
+{
+    static_assert(std::is_floating_point_v<T>);
+    if (value != value)
+        return value;
+    if (!value)
+        return 0.0; // -0.0 should be converted to +0.0
+    if (value < 0.0)
+        return -value;
+    return value;
+}
+
 } // namespace WTF
 
 using WTF::shuffleVector;
@@ -794,4 +807,5 @@ using WTF::ctz;
 using WTF::getLSBSet;
 using WTF::getMSBSet;
 using WTF::isNaNConstExpr;
+using WTF::fabsConstExpr;
 using WTF::reverseBits32;

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -184,10 +184,25 @@ public:
     WEBCORE_EXPORT FloatPoint matrixTransform(const TransformationMatrix&) const;
     WEBCORE_EXPORT FloatPoint matrixTransform(const AffineTransform&) const;
 
+    static constexpr FloatPoint nanPoint();
+    constexpr bool isNaN() const;
+
     WEBCORE_EXPORT String toJSONString() const;
     WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
 
     friend bool operator==(const FloatPoint&, const FloatPoint&) = default;
+
+    struct MarkableTraits {
+        constexpr static bool isEmptyValue(const FloatPoint& point)
+        {
+            return point.isNaN();
+        }
+
+        constexpr static FloatPoint emptyValue()
+        {
+            return FloatPoint::nanPoint();
+        }
+    };
 
 private:
     float m_x { 0 };
@@ -303,6 +318,19 @@ inline bool areEssentiallyEqual(const FloatPoint& a, const FloatPoint& b)
 inline void add(Hasher& hasher, const FloatPoint& point)
 {
     add(hasher, point.x(), point.y());
+}
+
+constexpr FloatPoint FloatPoint::nanPoint()
+{
+    return {
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::quiet_NaN()
+    };
+}
+
+constexpr bool FloatPoint::isNaN() const
+{
+    return isNaNConstExpr(x());
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FloatPoint&);

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -245,6 +245,18 @@ public:
 
     friend bool operator==(const FloatRect&, const FloatRect&) = default;
 
+    struct MarkableTraits {
+        constexpr static bool isEmptyValue(const FloatRect& rect)
+        {
+            return rect.isNaN();
+        }
+
+        constexpr static FloatRect emptyValue()
+        {
+            return FloatRect::nanRect();
+        }
+    };
+
 private:
     FloatPoint m_location;
     FloatSize m_size;
@@ -336,7 +348,7 @@ constexpr FloatRect FloatRect::nanRect()
 
 constexpr bool FloatRect::isNaN() const
 {
-    return isnan(x());
+    return isNaNConstExpr(x());
 }
 
 inline void FloatRect::inflate(float deltaX, float deltaY, float deltaMaxX, float deltaMaxY)

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -153,10 +153,25 @@ public:
     operator NSSize() const;
 #endif
 
+    static constexpr FloatSize nanSize();
+    constexpr bool isNaN() const;
+
     WEBCORE_EXPORT String toJSONString() const;
     WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
 
     friend bool operator==(const FloatSize&, const FloatSize&) = default;
+
+    struct MarkableTraits {
+        constexpr static bool isEmptyValue(const FloatSize& size)
+        {
+            return size.isNaN();
+        }
+
+        constexpr static FloatSize emptyValue()
+        {
+            return FloatSize::nanSize();
+        }
+    };
 
 private:
     float m_width { 0 };
@@ -165,7 +180,7 @@ private:
 
 constexpr bool FloatSize::isZero() const
 {
-    return std::abs(m_width) < std::numeric_limits<float>::epsilon() && std::abs(m_height) < std::numeric_limits<float>::epsilon();
+    return fabsConstExpr(m_width) < std::numeric_limits<float>::epsilon() && fabsConstExpr(m_height) < std::numeric_limits<float>::epsilon();
 }
 
 inline FloatSize& operator+=(FloatSize& a, const FloatSize& b)
@@ -250,6 +265,19 @@ inline IntSize expandedIntSize(const FloatSize& p)
 inline IntPoint flooredIntPoint(const FloatSize& p)
 {
     return IntPoint(clampToInteger(floorf(p.width())), clampToInteger(floorf(p.height())));
+}
+
+constexpr FloatSize FloatSize::nanSize()
+{
+    return {
+        std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::quiet_NaN()
+    };
+}
+
+constexpr bool FloatSize::isNaN() const
+{
+    return isNaNConstExpr(width());
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FloatSize&);

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatPointTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatPointTests.cpp
@@ -31,6 +31,7 @@
 #include <WebCore/IntPoint.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/TransformationMatrix.h>
+#include <wtf/Markable.h>
 
 #if USE(CG)
 #include <CoreGraphics/CoreGraphics.h>
@@ -575,6 +576,17 @@ TEST(FloatPoint, Casting)
     EXPECT_FLOAT_EQ(-22.3f, testCG.x());
     EXPECT_FLOAT_EQ(14.2f, testCG.y());
 #endif
+}
+
+TEST(FloatPoint, Markable)
+{
+    WebCore::FloatPoint point(1024.3f, 768.6f);
+    Markable<WebCore::FloatPoint, WebCore::FloatPoint::MarkableTraits> optional;
+    EXPECT_FALSE(optional) << "nullopt";
+    optional = point;
+    EXPECT_EQ((optional.value_or(WebCore::FloatPoint { })), point) << "retained";
+    optional = WebCore::FloatPoint::nanPoint();
+    EXPECT_FALSE(optional) << "nullopt";
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp
@@ -29,6 +29,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/IntRect.h>
+#include <wtf/Markable.h>
 
 #if USE(CG)
 #include <CoreGraphics/CoreGraphics.h>
@@ -733,6 +734,17 @@ TEST(FloatRect, RoundedIntRect)
     EXPECT_EQ(20, enclosed.y());
     EXPECT_EQ(1034, enclosed.maxX());
     EXPECT_EQ(789, enclosed.maxY());
+}
+
+TEST(FloatRect, Markable)
+{
+    WebCore::FloatRect rect(10.0f, 20.0f, 1024.3f, 768.6f);
+    Markable<WebCore::FloatRect, WebCore::FloatRect::MarkableTraits> optional;
+    EXPECT_FALSE(optional) << "nullopt";
+    optional = rect;
+    EXPECT_EQ((optional.value_or(WebCore::FloatRect { })), rect) << "retained";
+    optional = WebCore::FloatRect::nanRect();
+    EXPECT_FALSE(optional) << "nullopt";
 }
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatSizeTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatSizeTests.cpp
@@ -28,6 +28,7 @@
 #include <WebCore/FloatSize.h>
 #include <WebCore/IntPoint.h>
 #include <WebCore/IntSize.h>
+#include <wtf/Markable.h>
 
 #if USE(CG)
 #include <CoreGraphics/CoreGraphics.h>
@@ -327,6 +328,17 @@ TEST(FloatSize, Rounded)
 
     EXPECT_EQ(1025, expandedSize.width());
     EXPECT_EQ(769, expandedSize.height());
+}
+
+TEST(FloatSize, Markable)
+{
+    WebCore::FloatSize size(1024.3f, 768.6f);
+    Markable<WebCore::FloatSize, WebCore::FloatSize::MarkableTraits> optional;
+    EXPECT_FALSE(optional) << "nullopt";
+    optional = size;
+    EXPECT_EQ((optional.value_or(WebCore::FloatSize { })), size) << "retained";
+    optional = WebCore::FloatSize::nanSize();
+    EXPECT_FALSE(optional) << "nullopt";
 }
 
 }


### PR DESCRIPTION
#### a1e8662310da9aff0f6ca3e3fb9a32202bb88c29
<pre>
Add MarkableTraits to FloatRect / FloatPoint / FloatSize
<a href="https://bugs.webkit.org/show_bug.cgi?id=262766">https://bugs.webkit.org/show_bug.cgi?id=262766</a>
rdar://116562787

Reviewed by Chris Dumez.

This patch adds MarkableTraits to FloatRect / FloatPoint / FloatSize.
So that we can use Markable&lt;FloatRect, FloatRect::MarkableTraits&gt; easily.
We also add `fabsConstExpr` to ensure that this is becoming `constexpr`.
And use `isNaNConstExpr` too. Unfortunately they are not constexpr until C++23.

* Source/WTF/wtf/MathExtras.h:
(WTF::fabsConstExpr):
* Source/WebCore/platform/graphics/FloatPoint.h:
(WebCore::FloatPoint::MarkableTraits::isEmptyValue):
(WebCore::FloatPoint::MarkableTraits::emptyValue):
(WebCore::FloatPoint::nanPoint):
(WebCore::FloatPoint::isNaN const):
* Source/WebCore/platform/graphics/FloatRect.h:
(WebCore::FloatRect::MarkableTraits::isEmptyValue):
(WebCore::FloatRect::MarkableTraits::emptyValue):
(WebCore::FloatRect::isNaN const):
* Source/WebCore/platform/graphics/FloatSize.h:
(WebCore::FloatSize::MarkableTraits::isEmptyValue):
(WebCore::FloatSize::MarkableTraits::emptyValue):
(WebCore::FloatSize::isZero const):
(WebCore::FloatSize::nanSize):
(WebCore::FloatSize::isNaN const):
* Tools/TestWebKitAPI/Tests/WebCore/FloatPointTests.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/FloatSizeTests.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/268992@main">https://commits.webkit.org/268992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b19acb46cd1371bb1f712cfec951a7d660b65702

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19703 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20934 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23945 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25584 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18457 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23421 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20607 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16958 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24629 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19245 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5831 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23515 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/25897 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2632 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19833 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5655 "Passed tests") | 
<!--EWS-Status-Bubble-End-->