### PR TITLE
Make GPUProcessConnectionInfo use generated serialization

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -508,6 +508,8 @@ set(WebKit_SERIALIZATION_IN_FILES
 
     Shared/XR/XRSystem.serialization.in
 
+    WebProcess/GPU/GPUProcessConnectionInfo.serialization.in
+
     WebProcess/GPU/graphics/BufferIdentifierSet.serialization.in
     WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in
 

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -417,6 +417,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/WebExtensionContextProxy.messages.in
 $(PROJECT_DIR)/WebProcess/Extensions/WebExtensionControllerProxy.messages.in
 $(PROJECT_DIR)/WebProcess/FullScreen/WebFullScreenManager.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/GPUProcessConnection.messages.in
+$(PROJECT_DIR)/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in
 $(PROJECT_DIR)/WebProcess/GPU/graphics/BufferIdentifierSet.serialization.in
 $(PROJECT_DIR)/WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in
 $(PROJECT_DIR)/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -645,6 +645,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebGPU/WebGPUBlendComponent.serialization.in \
 	Shared/WebGPU/WebGPUBindGroupEntry.serialization.in \
 	Shared/XR/XRSystem.serialization.in \
+	WebProcess/GPU/GPUProcessConnectionInfo.serialization.in \
 	WebProcess/GPU/graphics/BufferIdentifierSet.serialization.in \
 	WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in \
 	WebProcess/GPU/media/RemoteCDMConfiguration.serialization.in \

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "ArgumentCoders.h"
 #include <optional>
 
 namespace WebKit {
@@ -40,39 +39,6 @@ struct GPUProcessConnectionInfo {
     bool hasVP9HardwareDecoder { false };
     bool hasVP9ExtensionSupport { false };
 #endif
-
-    void encode(IPC::Encoder& encoder) const
-    {
-#if HAVE(AUDIT_TOKEN)
-        encoder << auditToken;
-#endif
-#if ENABLE(VP9)
-        encoder << hasVP9HardwareDecoder;
-        encoder << hasVP9ExtensionSupport;
-#endif
-    }
-
-    static WARN_UNUSED_RETURN std::optional<GPUProcessConnectionInfo> decode(IPC::Decoder& decoder)
-    {
-#if HAVE(AUDIT_TOKEN)
-        auto auditToken = decoder.decode<std::optional<audit_token_t>>();
-#endif
-#if ENABLE(VP9)
-        auto hasVP9HardwareDecoder = decoder.decode<bool>();
-        auto hasVP9ExtensionSupport = decoder.decode<bool>();
-#endif
-        if (!decoder.isValid())
-            return std::nullopt;
-        return GPUProcessConnectionInfo {
-#if HAVE(AUDIT_TOKEN)
-            *auditToken,
-#endif
-#if ENABLE(VP9)
-            *hasVP9HardwareDecoder,
-            *hasVP9ExtensionSupport
-#endif
-        };
-    }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in
@@ -1,0 +1,38 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+struct WebKit::GPUProcessConnectionInfo {
+
+#if HAVE(AUDIT_TOKEN)
+    std::optional<audit_token_t> auditToken;
+#endif
+
+#if ENABLE(VP9)
+    bool hasVP9HardwareDecoder;
+    bool hasVP9ExtensionSupport;
+#endif
+
+}
+
+#endif


### PR DESCRIPTION
#### 2fb424e2dd698cbbe0892db0045520c9d7c38809
<pre>
Make GPUProcessConnectionInfo use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262767">https://bugs.webkit.org/show_bug.cgi?id=262767</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.h:
(WebKit::GPUProcessConnectionInfo::encode const): Deleted.
(WebKit::GPUProcessConnectionInfo::decode): Deleted.
* Source/WebKit/WebProcess/GPU/GPUProcessConnectionInfo.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/269007@main">https://commits.webkit.org/269007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75fecd8314423a1c716557cc06c7f917bc5dda38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19704 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20930 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/23946 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18285 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25579 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23416 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16959 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23516 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2638 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->