### PR TITLE
Make MediaOverridesForTesting use generated serialization

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -514,6 +514,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     WebProcess/GPU/graphics/BufferIdentifierSet.serialization.in
     WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in
 
+    WebProcess/GPU/media/MediaOverridesForTesting.serialization.in
     WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
     WebProcess/GPU/media/RemoteCDMConfiguration.serialization.in
     WebProcess/GPU/media/RemoteCDMInstanceConfiguration.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -426,6 +426,7 @@ $(PROJECT_DIR)/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.messages.in
+$(PROJECT_DIR)/WebProcess/GPU/media/MediaOverridesForTesting.serialization.in
 $(PROJECT_DIR)/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/MediaSourcePrivateRemote.messages.in
 $(PROJECT_DIR)/WebProcess/GPU/media/RemoteAudioHardwareListener.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -650,6 +650,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	WebProcess/GPU/GPUProcessConnectionInfo.serialization.in \
 	WebProcess/GPU/graphics/BufferIdentifierSet.serialization.in \
 	WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in \
+	WebProcess/GPU/media/MediaOverridesForTesting.serialization.in \
 	WebProcess/GPU/media/RemoteCDMConfiguration.serialization.in \
 	WebProcess/GPU/media/RemoteCDMInstanceConfiguration.serialization.in \
 	WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in \

--- a/Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.h
@@ -38,53 +38,6 @@ struct MediaOverridesForTesting {
     std::optional<bool> vp9HardwareDecoderDisabled;
     std::optional<bool> vp9DecoderDisabled;
     std::optional<WebCore::ScreenDataOverrides> vp9ScreenSizeAndScale;
-
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        encoder << systemHasAC;
-        encoder << systemHasBattery;
-        encoder << vp9HardwareDecoderDisabled;
-        encoder << vp9DecoderDisabled;
-        encoder << vp9ScreenSizeAndScale;
-    }
-
-    template <class Decoder>
-    static std::optional<MediaOverridesForTesting> decode(Decoder& decoder)
-    {
-        std::optional<std::optional<bool>> systemHasAC;
-        decoder >> systemHasAC;
-        if (!systemHasAC)
-            return std::nullopt;
-
-        std::optional<std::optional<bool>> systemHasBattery;
-        decoder >> systemHasBattery;
-        if (!systemHasBattery)
-            return std::nullopt;
-
-        std::optional<std::optional<bool>> vp9HardwareDecoderDisabled;
-        decoder >> vp9HardwareDecoderDisabled;
-        if (!vp9HardwareDecoderDisabled)
-            return std::nullopt;
-        
-        std::optional<std::optional<bool>> vp9DecoderDisabled;
-        decoder >> vp9DecoderDisabled;
-        if (!vp9DecoderDisabled)
-            return std::nullopt;
-
-        std::optional<std::optional<WebCore::ScreenDataOverrides>> vp9ScreenSizeAndScale;
-        decoder >> vp9ScreenSizeAndScale;
-        if (!vp9ScreenSizeAndScale)
-            return std::nullopt;
-
-        return {{
-            *systemHasAC,
-            *systemHasBattery,
-            *vp9HardwareDecoderDisabled,
-            *vp9DecoderDisabled,
-            *vp9ScreenSizeAndScale,
-        }};
-    }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.serialization.in
@@ -1,0 +1,34 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+struct WebKit::MediaOverridesForTesting {
+    std::optional<bool> systemHasAC;
+    std::optional<bool> systemHasBattery;
+
+    std::optional<bool> vp9HardwareDecoderDisabled;
+    std::optional<bool> vp9DecoderDisabled;
+    std::optional<WebCore::ScreenDataOverrides> vp9ScreenSizeAndScale;
+};
+
+#endif


### PR DESCRIPTION
#### ab5e902c92d167158b82a14d0f74ff5e34660197
<pre>
Make MediaOverridesForTesting use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262769">https://bugs.webkit.org/show_bug.cgi?id=262769</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.h:
(WebKit::MediaOverridesForTesting::encode const): Deleted.
(WebKit::MediaOverridesForTesting::decode): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaOverridesForTesting.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/269024@main">https://commits.webkit.org/269024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea20af10ba81df207919d308b66ed98d32cd7c6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19766 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21869 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20980 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24026 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18370 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25649 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19324 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23578 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2647 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->