### PR TITLE
[WebXR] Display ARKit captured image in overlay view

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -596,6 +596,7 @@ UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
 
 UIProcess/XR/ios/PlatformXRARKit.mm
 UIProcess/XR/ios/PlatformXRSystemIOS.mm
+UIProcess/XR/ios/WKARPresentationSession.mm
 
 WebProcess/API/Cocoa/WKWebProcess.cpp
 

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -30,7 +30,12 @@
 
 #import "PlatformXRCoordinator.h"
 
+#import <wtf/RetainPtr.h>
+#import <wtf/Threading.h>
+#import <wtf/threads/BinarySemaphore.h>
+
 @class ARSession;
+@protocol WKARPresentationSession;
 
 namespace WebKit {
 
@@ -50,10 +55,13 @@ public:
     void submitFrame(WebPageProxy&) override;
 
 protected:
+    void createSessionIfNeeded();
     void currentSessionHasEnded();
+    void renderLoop();
 
 private:
     XRDeviceIdentifier m_deviceIdentifier = XRDeviceIdentifier::generate();
+    RetainPtr<ARSession> m_session;
 
     struct Idle {
     };
@@ -61,6 +69,9 @@ private:
         WebCore::PageIdentifier pageIdentifier;
         WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
         PlatformXR::Device::RequestFrameCallback onFrameUpdate;
+        RetainPtr<id<WKARPresentationSession>> presentationSession;
+        RefPtr<Thread> renderThread;
+        Box<BinarySemaphore> renderSemaphore;
     };
     struct Terminating {
         WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR) && USE(ARKITXR_IOS)
+
+#import <ARKit/ARKit.h>
+#import <Metal/Metal.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKARPresentationSessionDescriptor : NSObject <NSCopying>
+@property (nonatomic, nullable, weak, readwrite) UIViewController *presentingViewController;
+@end
+
+@protocol WKARPresentationSession <NSObject>
+@property (nonatomic, retain, readonly) ARSession *session;
+- (NSUInteger)startFrame;
+- (void)present;
+- (void)terminate;
+@end
+
+@interface ARSession(WKARPresentationSession)
+- (nullable id<WKARPresentationSession>)presentationSessionWithDescriptor:(WKARPresentationSessionDescriptor *)descriptor;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEBXR) && USE(ARKITXR_IOS)

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#import "WKARPresentationSession.h"
+
+#if ENABLE(WEBXR) && USE(ARKITXR_IOS)
+
+#import <Metal/Metal.h>
+#import <wtf/WeakObjCPtr.h>
+
+#undef USE_ARPRESENTATIONSESSION_NOISY_LOG
+#if USE(ARPRESENTATIONSESSION_NOISY_LOG)
+#define NOISY_RELEASE_LOG(channel, ...) RELEASE_LOG(channel, __VA_ARGS__)
+#else
+#define NOISY_RELEASE_LOG(channel, ...) ((void)0)
+#endif
+
+#pragma mark - WKARPresentationSessionDescriptor
+
+@implementation WKARPresentationSessionDescriptor {
+    WeakObjCPtr<UIViewController> _presentingViewController;
+}
+
+- (nonnull instancetype)copyWithZone:(nullable NSZone *)zone
+{
+    WKARPresentationSessionDescriptor* descriptor = [[[self class] allocWithZone:zone] init];
+    descriptor.presentingViewController = self.presentingViewController;
+
+    return descriptor;
+}
+
+- (nullable UIViewController*)presentingViewController
+{
+    return (UIViewController*) _presentingViewController;
+}
+
+- (void)setPresentingViewController:(nullable UIViewController*)presentingViewController
+{
+    _presentingViewController = presentingViewController;
+}
+
+@end
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface _WKARPresentationSession : UIViewController <WKARPresentationSession>
+- (instancetype)initWithSession:(ARSession*)session descriptor:(WKARPresentationSessionDescriptor*)descriptor;
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation ARSession(WKARPresentationSession)
+- (nullable id<WKARPresentationSession>)presentationSessionWithDescriptor:(nonnull WKARPresentationSessionDescriptor*)descriptor
+{
+    return [[_WKARPresentationSession alloc] initWithSession:self descriptor:descriptor];
+}
+@end
+
+#pragma mark - _WKARPresentationSession
+
+@implementation _WKARPresentationSession {
+    RetainPtr<ARSession> _session;
+    RetainPtr<WKARPresentationSessionDescriptor> _sessionDescriptor;
+
+    // View state
+    RetainPtr<UIView> _view;
+    WeakObjCPtr<CALayer> _cameraLayer;
+
+    // Camera image
+    RetainPtr<CVPixelBufferRef> _capturedImage;
+}
+
+- (nonnull instancetype)initWithSession:(nonnull ARSession*)session descriptor:(nonnull WKARPresentationSessionDescriptor*)descriptor
+{
+    self = [super init];
+    if (self) {
+        _session = session;
+        _sessionDescriptor = adoptNS([descriptor copy]);
+
+        [self _enterFullscreen];
+    }
+
+    return self;
+}
+
+#pragma mark - WKARPresentationSession
+-(nonnull ARSession *)session {
+    return (ARSession *) _session;
+}
+
+- (NSUInteger)startFrame
+{
+    NOISY_RELEASE_LOG(XR, "%s", __FUNCTION__);
+
+    ARFrame *currentFrame = [_session currentFrame];
+    if (!currentFrame) {
+        RELEASE_LOG(XR, "%s: no frame available", __FUNCTION__);
+        return 0;
+    }
+
+    _capturedImage = currentFrame.capturedImage;
+
+    return 1;
+}
+
+- (void)present
+{
+    NOISY_RELEASE_LOG(XR, "%s", __FUNCTION__);
+
+    [CATransaction begin];
+    {
+        [_cameraLayer setContents:(id) _capturedImage.get()];
+    }
+    [CATransaction commit];
+    [CATransaction flush];
+
+    _capturedImage = nil;
+}
+
+- (void)terminate
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+}
+
+#pragma mark - UIViewController
+- (void)loadView
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+    UIView *view = [[UIView alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    self.view = view;
+}
+
+- (void)viewDidLoad
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+    [super viewDidLoad];
+
+    _cameraLayer = [self.view layer];
+    [_cameraLayer setBackgroundColor:UIColor.whiteColor.CGColor];
+    [_cameraLayer setOpaque:YES];
+}
+
+#if !PLATFORM(VISION)
+- (BOOL)preferStatusBarHidden
+{
+    return YES;
+}
+#endif
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+    [super viewWillAppear:animated];
+
+    RetainPtr<ARWorldTrackingConfiguration> configuration = adoptNS([ARWorldTrackingConfiguration new]);
+    [_session runWithConfiguration:configuration.get()];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+    [_session pause];
+    [super viewWillDisappear:animated];
+}
+
+#pragma mark - Private
+- (void)_enterFullscreen
+{
+    ASSERT(RunLoop::isMain());
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+
+    UIViewController* presentingViewController = [_sessionDescriptor presentingViewController];
+    [presentingViewController presentViewController:self animated:NO completion:^(void) {
+        RELEASE_LOG(XR, "%s: presentViewController complete", __FUNCTION__);
+    }];
+}
+
+@end
+
+#undef NOISY_RELEASE_LOG
+
+#endif // ENABLE(WEBXR) && USE(ARKITXR_IOS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4634,6 +4634,8 @@
 		37FC19461850FBF2008CFA47 /* WKBrowsingContextLoadDelegatePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKBrowsingContextLoadDelegatePrivate.h; sourceTree = "<group>"; };
 		37FC194818510D6A008CFA47 /* WKNSURLAuthenticationChallenge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKNSURLAuthenticationChallenge.mm; sourceTree = "<group>"; };
 		37FC194918510D6A008CFA47 /* WKNSURLAuthenticationChallenge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKNSURLAuthenticationChallenge.h; sourceTree = "<group>"; };
+		3A5B68962AC266D400B11868 /* WKARPresentationSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKARPresentationSession.h; sourceTree = "<group>"; };
+		3A5B68972AC266D400B11868 /* WKARPresentationSession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKARPresentationSession.mm; sourceTree = "<group>"; };
 		3A7D62D229D35D9D00D57DAC /* WebSWRegistrationStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWRegistrationStore.cpp; sourceTree = "<group>"; };
 		3A7D62D329D38DD300D57DAC /* ServiceWorkerStorageManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerStorageManager.cpp; sourceTree = "<group>"; };
 		3A7D62D429D38DD300D57DAC /* ServiceWorkerStorageManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerStorageManager.h; sourceTree = "<group>"; };
@@ -10707,6 +10709,8 @@
 				3AEE89922AA595AC00D4DF44 /* PlatformXRARKit.h */,
 				3AEE89912AA595AC00D4DF44 /* PlatformXRARKit.mm */,
 				3AEE89932AA5966A00D4DF44 /* PlatformXRSystemIOS.mm */,
+				3A5B68962AC266D400B11868 /* WKARPresentationSession.h */,
+				3A5B68972AC266D400B11868 /* WKARPresentationSession.mm */,
 			);
 			path = ios;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### 6371344eac3bee4950ffe9516e098a6aa0f4dc03
<pre>
[WebXR] Display ARKit captured image in overlay view
<a href="https://bugs.webkit.org/show_bug.cgi?id=262773">https://bugs.webkit.org/show_bug.cgi?id=262773</a>
rdar://116502294

Reviewed by Dean Jackson.

Unlike other WebXR compositor systems, ARKit doesn&apos;t provide a framework for
rendering immersive AR content, just a series of captured camera images with
camera transformation, so we need to implement our own compositor.

This patch introduces WKARPresentationSession that is responsible for managing a
view and compositing the captured camera images with WebGL rendering. On
entering an immersive AR session, WKARPresentationSession creates a new
UIViewController and makes it the presenting view controller for UIKit. The
camera images, which are provided in CVPixelBuffers, are displayed by setting
them as the CALayer content of a UIView. In a following patch, the WebGL content
will be composited on top of the camera image.

Update of the captured camera image is driven off the main thread using the
setting of the animation frame callback from the page to trigger the update.

It is intended that the view should be fullscreen but currently it is rendered
as a small view to allow exiting an immersive AR session by touching outside the
view to dismiss it.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):
(WebKit::ARKitCoordinator::endSessionIfExists):
(WebKit::ARKitCoordinator::scheduleAnimationFrame):
(WebKit::ARKitCoordinator::createSessionIfNeeded):
(WebKit::ARKitCoordinator::renderLoop):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h: Added.
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm: Added.
(-[WKARPresentationSessionDescriptor copyWithZone:]):
(-[WKARPresentationSessionDescriptor presentingViewController]):
(-[WKARPresentationSessionDescriptor setPresentingViewController:]):
(-[ARSession presentationSessionWithDescriptor:]):
(-[_WKARPresentationSession initWithSession:descriptor:]):
(-[_WKARPresentationSession session]):
(-[_WKARPresentationSession startFrame]):
(-[_WKARPresentationSession present]):
(-[_WKARPresentationSession terminate]):
(-[_WKARPresentationSession loadView]):
(-[_WKARPresentationSession viewDidLoad]):
(-[_WKARPresentationSession preferStatusBarHidden]):
(-[_WKARPresentationSession viewWillAppear:]):
(-[_WKARPresentationSession viewWillDisappear:]):
(-[_WKARPresentationSession _enterFullscreen]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/269064@main">https://commits.webkit.org/269064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ef7c4b0e9ffedf17ce105295646e6d77429e934

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23372 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22061 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24223 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18559 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25804 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23653 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20185 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19503 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5131 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->