### PR TITLE
Add hasUAVisualTransition attribute to popState event

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/PopStateEvent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/PopStateEvent-expected.txt
@@ -1,5 +1,7 @@
 
+PASS PopStateEvent constructor called as normal function
 PASS initPopStateEvent
 PASS Initial value of PopStateEvent.state must be null
+PASS Initial value of PopStateEvent.hasUAVisualTransition must be false
 PASS Dispatching a synthetic PopStateEvent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
@@ -5,6 +5,14 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
+test(function() {
+  assert_throws_js(
+    TypeError,
+    () => PopStateEvent(''),
+    "Calling PopStateEvent constructor without 'new' must throw"
+  );
+}, "PopStateEvent constructor called as normal function");
+
 test(function () {
   assert_false('initPopStateEvent' in PopStateEvent.prototype,
                'There should be no PopStateEvent#initPopStateEvent');
@@ -16,15 +24,24 @@ test(function () {
 }, "Initial value of PopStateEvent.state must be null");
 
 test(function () {
+  var popStateEvent = new PopStateEvent("popstate");
+  assert_false(popStateEvent.hasUAVisualTransition, "the PopStateEvent.hasUAVisualTransition");
+}, "Initial value of PopStateEvent.hasUAVisualTransition must be false");
+
+test(function () {
   var state = history.state;
   var data;
+  var hasUAVisualTransition = false;
   window.addEventListener('popstate', function (e) {
     data = e.state;
+    hasUAVisualTransition = e.hasUAVisualTransition;
   });
   window.dispatchEvent(new PopStateEvent('popstate', {
-    'state': {testdata:true}
+    'state': {testdata:true},
+    'hasUAVisualTransition': true
   }));
   assert_true(data.testdata,'state data was corrupted');
   assert_equals(history.state, state, "history.state was NOT set by dispatching the event");
+  assert_true(hasUAVisualTransition, 'hasUAVisualTransition not set correctly');
 }, 'Dispatching a synthetic PopStateEvent');
 </script>

--- a/Source/WebCore/dom/PopStateEvent.cpp
+++ b/Source/WebCore/dom/PopStateEvent.cpp
@@ -39,6 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(PopStateEvent);
 PopStateEvent::PopStateEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
     : Event(type, initializer, isTrusted)
     , m_state(initializer.state)
+    , m_hasUAVisualTransition(initializer.hasUAVisualTransition)
 {
 }
 

--- a/Source/WebCore/dom/PopStateEvent.h
+++ b/Source/WebCore/dom/PopStateEvent.h
@@ -42,6 +42,7 @@ public:
 
     struct Init : EventInit {
         JSC::JSValue state;
+        bool hasUAVisualTransition { false };
     };
 
     static Ref<PopStateEvent> create(const AtomString&, const Init&, IsTrusted = IsTrusted::No);
@@ -54,6 +55,8 @@ public:
     
     History* history() const { return m_history.get(); }
 
+    bool hasUAVisualTransition() const { return m_hasUAVisualTransition; }
+
 private:
     PopStateEvent() = default;
     PopStateEvent(const AtomString&, const Init&, IsTrusted);
@@ -64,6 +67,7 @@ private:
     JSValueInWrappedObject m_state;
     RefPtr<SerializedScriptValue> m_serializedState;
     bool m_triedToSerialize { false };
+    bool m_hasUAVisualTransition { false };
     RefPtr<History> m_history;
 };
 

--- a/Source/WebCore/dom/PopStateEvent.idl
+++ b/Source/WebCore/dom/PopStateEvent.idl
@@ -31,8 +31,10 @@
     constructor([AtomString] DOMString type, optional PopStateEventInit eventInitDict);
 
     [CachedAttribute, CustomGetter] readonly attribute any state;
+    readonly attribute boolean hasUAVisualTransition;
 };
 
 dictionary PopStateEventInit : EventInit {
     any state = null;
+    boolean hasUAVisualTransition = false;
 };


### PR DESCRIPTION
#### f034bb9b9246d75317a80d37f3f59e6f7520938d
<pre>
Add hasUAVisualTransition attribute to popState event
<a href="https://bugs.webkit.org/show_bug.cgi?id=259793">https://bugs.webkit.org/show_bug.cgi?id=259793</a>

Reviewed by Brent Fulgham.

Add hasUAVisualTransition attribute to popState event as specified:
<a href="https://html.spec.whatwg.org/#dom-popstateeventinit-hasuavisualtransition">https://html.spec.whatwg.org/#dom-popstateeventinit-hasuavisualtransition</a>

Also sync history-traversal/PopStateEvent.html *based on 17eb11d8d9) in order to test the attribute initial value.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/PopStateEvent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html:
* Source/WebCore/dom/PopStateEvent.cpp:
(WebCore::PopStateEvent::PopStateEvent):
* Source/WebCore/dom/PopStateEvent.h:
* Source/WebCore/dom/PopStateEvent.idl:

Canonical link: <a href="https://commits.webkit.org/270589@main">https://commits.webkit.org/270589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/609dd1db66f910f83b3013a3cd46c63f199dc9f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23669 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1887 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/23761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28530 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29291 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27167 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1219 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6214 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->