### PR TITLE
[WebXR] Display WebGL content over camera feed

### DIFF
--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -27,16 +27,25 @@
 
 #if ENABLE(WEBXR) && USE(ARKITXR_IOS)
 
+#import <Metal/Metal.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class ARSession;
 
 @interface WKARPresentationSessionDescriptor : NSObject <NSCopying>
+@property (nonatomic, readwrite) MTLPixelFormat colorFormat;
+@property (nonatomic, readwrite) MTLTextureUsage colorUsage;
+@property (nonatomic, readwrite) NSUInteger rasterSampleCount;
 @property (nonatomic, nullable, weak, readwrite) UIViewController *presentingViewController;
 @end
 
 @protocol WKARPresentationSession <NSObject>
 @property (nonatomic, retain, readonly) ARSession *session;
+@property (nonatomic, nonnull, retain, readonly) id<MTLSharedEvent> completionEvent;
+@property (nonatomic, nullable, retain, readonly) id<MTLTexture> colorTexture;
+@property (nonatomic, readonly) NSUInteger renderingFrameIndex;
+
 - (NSUInteger)startFrame;
 - (void)present;
 - (void)terminate;


### PR DESCRIPTION
#### bdfa9ed9f0f101f60a166ad8ce90ae1fa4656d80
<pre>
[WebXR] Display WebGL content over camera feed
<a href="https://bugs.webkit.org/show_bug.cgi?id=262774">https://bugs.webkit.org/show_bug.cgi?id=262774</a>
<a href="https://rdar.apple.com/116502727">rdar://116502727</a>

Reviewed by Dean Jackson.

WebGL content compositing is implemented by creating a CAMetalLayer sublayer
positioned on top of the CALayer containing the captured camera
image. MTLSharedTexture and MTLSharedEvents are passed via MachSendRight to
WebXROpaqueFramebuffer, which passes those objects to the process that handles
WebGL rendering. Presentation of the WebGL content and associated camera images
is fenced on the signalling of the MTLSharedEvent passed to WebGL.

* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::makeMachSendRight):
(WebKit::ARKitCoordinator::submitFrame):
(WebKit::ARKitCoordinator::renderLoop):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h:
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm:
(-[WKARPresentationSessionDescriptor init]):
(-[WKARPresentationSessionDescriptor copyWithZone:]):
(-[_WKARPresentationSession initWithSession:descriptor:]):
(-[_WKARPresentationSession completionEvent]):
(-[_WKARPresentationSession colorTexture]):
(-[_WKARPresentationSession startFrame]):
(-[_WKARPresentationSession present]):
(-[_WKARPresentationSession viewDidLoad]):
(-[_WKARPresentationSession _loadMetal]):

Canonical link: <a href="https://commits.webkit.org/270362@main">https://commits.webkit.org/270362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc3470d22cd5454c5adad379dd15d413a63af5cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23088 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23335 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27857 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2414 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28778 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26602 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/661 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3714 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6057 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2805 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2700 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->