### PR TITLE
[macOS] Block IOKit related mig syscalls when IOKit is blocked

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2123,6 +2123,11 @@
     io_registry_entry_get_property_bin_buf
     io_registry_entry_get_registry_entry_id
     io_server_version
+    io_service_add_interest_notification_64
+    io_service_add_notification_bin_64
+    io_service_get_matching_service_bin
+    io_service_get_matching_services_bin
+    io_service_open_extended
     mach_memory_entry_ownership
     mach_port_get_refs
     mach_port_request_notification
@@ -2143,23 +2148,18 @@
     thread_suspend))
 
 (define (kernel-mig-routines-possibly-in-use) (kernel-mig-routine
-    io_connect_add_client
-    io_connect_async_method
-    io_connect_method
-    io_connect_method_var_output
-    io_connect_set_notification_port_64
     io_registry_entry_get_property_bytes
     mach_exception_raise
     mach_port_extract_right
     mach_port_get_context_from_user
     mach_vm_region))
 
-(define (kernel-mig-routines-iokit-service) (kernel-mig-routine
-    io_service_add_interest_notification_64
-    io_service_add_notification_bin_64
-    io_service_get_matching_service_bin
-    io_service_get_matching_services_bin
-    io_service_open_extended))
+(define (kernel-mig-routines-iokit) (kernel-mig-routine
+    io_connect_add_client
+    io_connect_async_method
+    io_connect_method
+    io_connect_method_var_output
+    io_connect_set_notification_port_64))
 
 (define (kernel-mig-routines-blocked-in-lockdown-mode) (kernel-mig-routine
     clock_get_time
@@ -2197,7 +2197,12 @@
 #endif
 
             (allow mach-message-send (kernel-mig-routines-in-use))
-            (allow mach-message-send (kernel-mig-routines-iokit-service))
+#if HAVE(SANDBOX_STATE_FLAGS)
+            (with-filter (require-not (state-flag "BlockIOKitInWebContentSandbox"))
+                (allow mach-message-send (kernel-mig-routines-iokit)))
+#else
+            (allow mach-message-send (kernel-mig-routines-iokit))
+#endif
             (allow mach-message-send (with report) (with telemetry) (kernel-mig-routines-possibly-in-use))
                 
 #if HAVE(SANDBOX_STATE_FLAGS) && HAVE(MACH_RANGE_CREATE)


### PR DESCRIPTION
#### 8f920520ed2b88446b00fd07e3c3337681b20205
<pre>
[macOS] Block IOKit related mig syscalls when IOKit is blocked
<a href="https://bugs.webkit.org/show_bug.cgi?id=262052">https://bugs.webkit.org/show_bug.cgi?id=262052</a>
rdar://problem/116000694

Reviewed by Chris Dumez.

Block IOKit connect mig syscalls in the WebContent process sandbox on macOS when IOKit is blocked.
We believe these syscalls are not required in this case, since all access to IOKit services and
clients is blocked in the sandbox already.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/269012@main">https://commits.webkit.org/269012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e8ebb12faec7a60498a0fa9f18d722dcf7ddb70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19749 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21842 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24002 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18345 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25630 "Found 2 new test failures: fast/block/positioning/fixed-container-with-sticky-parent.html, imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23469 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17023 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19299 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5102 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->