### PR TITLE
[WGSL] Add support for constant division

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -109,6 +109,17 @@ static ConstantValue constantMultiply(const Type*, const FixedVector<ConstantVal
     }, lhs, rhs);
 }
 
+static ConstantValue constantDivide(const Type*, const FixedVector<ConstantValue>& arguments)
+{
+    ASSERT(arguments.size() == 2);
+
+    return scalarOrVector([&](const auto& left, auto& right) -> ConstantValue {
+        if (left.isInt() && right.isInt())
+            return left.toInt() / right.toInt();
+        return left.toDouble() / right.toDouble();
+    }, arguments[0], arguments[1]);
+}
+
 static ConstantValue zeroValue(const Type* type)
 {
     return WTF::switchOn(*type,

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -312,6 +312,7 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
     m_constantFunctions.add("pow"_s, constantPow);
     m_constantFunctions.add("-"_s, constantMinus);
     m_constantFunctions.add("*"_s, constantMultiply);
+    m_constantFunctions.add("/"_s, constantDivide);
     m_constantFunctions.add("vec2"_s, constantVector2);
     m_constantFunctions.add("vec2f"_s, constantVector2);
     m_constantFunctions.add("vec2i"_s, constantVector2);


### PR DESCRIPTION
#### ba50f138563b7ee18bbc83ed6daccaf3a4e95603
<pre>
[WGSL] Add support for constant division
<a href="https://bugs.webkit.org/show_bug.cgi?id=262790">https://bugs.webkit.org/show_bug.cgi?id=262790</a>
rdar://116583014

Reviewed by Mike Wyrzykowski.

Division is necessary for the A-buffer demo. Similar to constant multiplication,
but even simpler since it doesn&apos;t need to handle matrices.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::constantDivide):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):

Canonical link: <a href="https://commits.webkit.org/269070@main">https://commits.webkit.org/269070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/261064f046ed74686fe4ea1d955eb53af1a28b11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22077 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21384 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24241 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18580 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19666 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23667 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20201 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19518 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5138 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23758 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->