### PR TITLE
[WGSL] Fix struct type size calculation

### DIFF
--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -285,11 +285,12 @@ unsigned Type::size() const
         [&](const Struct& structure) -> unsigned {
             unsigned alignment = 0;
             unsigned size = 0;
-            for (auto& [_, field] : structure.fields) {
-                auto fieldAlignment = field->alignment();
+            for (auto& member : structure.structure.members()) {
+                auto* type = member.type().inferredType();
+                auto fieldAlignment = type->alignment();
                 alignment = std::max(alignment, fieldAlignment);
                 size = WTF::roundUpToMultipleOf(fieldAlignment, size);
-                size += field->size();
+                size += type->size();
             }
             return WTF::roundUpToMultipleOf(alignment, size);
         },


### PR DESCRIPTION
#### 4a81f6651e9847a9d823023304a1378c3db25a80
<pre>
[WGSL] Fix struct type size calculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=262792">https://bugs.webkit.org/show_bug.cgi?id=262792</a>
rdar://116583145

Reviewed by Mike Wyrzykowski.

Although the procedure for calculating the size and alignment was right, we
were visiting the fields out of order, which resulted in the wrong size.

* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::size const):

Canonical link: <a href="https://commits.webkit.org/269069@main">https://commits.webkit.org/269069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55cc82afde8bb7eca8f33acb050f6f9b6383e1c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19753 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/20969 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24006 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18349 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25640 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19500 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23479 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17027 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19303 "Hash 55cc82af for PR 18767 does not build (failure)") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5137 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->