### PR TITLE
JetStream harness: toScore() helper should properly handle zero

### DIFF
--- a/PerformanceTests/JetStream2/JetStreamDriver.js
+++ b/PerformanceTests/JetStream2/JetStreamDriver.js
@@ -139,7 +139,7 @@ function geomean(values) {
 }
 
 function toScore(timeValue) {
-    return 5000 / timeValue;
+    return 5000 / Math.max(timeValue, 1);
 }
 
 function toTimeValue(score) {

--- a/PerformanceTests/JetStream3/JetStreamDriver.js
+++ b/PerformanceTests/JetStream3/JetStreamDriver.js
@@ -139,7 +139,7 @@ function geomean(values) {
 }
 
 function toScore(timeValue) {
-    return 5000 / timeValue;
+    return 5000 / Math.max(timeValue, 1);
 }
 
 function toTimeValue(score) {


### PR DESCRIPTION
#### 236900cc68bc3de0120a1e17acc1c7d74a345214
<pre>
JetStream harness: toScore() helper should properly handle zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=262802">https://bugs.webkit.org/show_bug.cgi?id=262802</a>
&lt;rdar://107770601&gt;

Reviewed by Mark Lam.

This change fixes toScore() to produce the maximal score of 5000 in case of superfast test startup
time, rather than `Infinity`, which used to break Apple&apos;s internal tooling.

* PerformanceTests/JetStream2/JetStreamDriver.js:
(toScore):
* PerformanceTests/JetStream3/JetStreamDriver.js:
(toScore):

Canonical link: <a href="https://commits.webkit.org/269161@main">https://commits.webkit.org/269161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca963815e49b7802a21b5571bec18ca96eedf92f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19852 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21046 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24134 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18465 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25731 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23580 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17117 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19421 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23661 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2700 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->