### PR TITLE
Expose the CFNetworkNetworkLoaderEnabled preference as testable with a tri-state

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -841,9 +841,9 @@ BuiltInNotificationsEnabled:
 
 CFNetworkNetworkLoaderEnabled:
   type: bool
-  status: unstable
+  status: testable
   category: networking
-  humanReadableName: "Experimental network loader"
+  humanReadableName: "Enable experimental network loader"
   humanReadableDescription: "Enable experimental network loader"
   webcoreBinding: none
   condition: HAVE(NETWORK_LOADER)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -103,7 +103,7 @@ struct NetworkSessionCreationParameters {
     std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue;
     bool preventsSystemHTTPProxyAuthentication { false };
     bool appHasRequestedCrossWebsiteTrackingPermission { false };
-    bool useNetworkLoader { false };
+    std::optional<bool> useNetworkLoader { std::nullopt };
     bool allowsHSTSWithUntrustedRootCertificate { false };
     String pcmMachServiceName;
     String webPushMachServiceName;

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -70,7 +70,7 @@
     std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue;
     bool preventsSystemHTTPProxyAuthentication;
     bool appHasRequestedCrossWebsiteTrackingPermission;
-    bool useNetworkLoader;
+    std::optional<bool> useNetworkLoader;
     bool allowsHSTSWithUntrustedRootCertificate;
     String pcmMachServiceName;
     String webPushMachServiceName;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1410,8 +1410,10 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
 #endif
 
 #if HAVE(NETWORK_LOADER)
-    RELEASE_LOG_IF(parameters.useNetworkLoader, NetworkSession, "Using experimental network loader.");
-    configuration._usesNWLoader = parameters.useNetworkLoader;
+    if (parameters.useNetworkLoader) {
+        RELEASE_LOG_IF(*parameters.useNetworkLoader, NetworkSession, "Using experimental network loader.");
+        configuration._usesNWLoader = *parameters.useNetworkLoader;
+    }
 #endif
 
     if (parameters.allowsHSTSWithUntrustedRootCertificate && [configuration respondsToSelector:@selector(_allowsHSTSWithUntrustedRootCertificate)])

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -88,13 +88,18 @@ static std::atomic<bool> hasInitializedManagedDomains = false;
 static std::atomic<bool> managedKeyExists = false;
 #endif
 
-bool experimentalFeatureEnabled(const String& key, bool defaultValue)
+static std::optional<bool> optionalExperimentalFeatureEnabled(const String& key, std::optional<bool> defaultValue = false)
 {
     auto defaultsKey = adoptNS([[NSString alloc] initWithFormat:@"WebKitExperimental%@", static_cast<NSString *>(key)]);
     if ([[NSUserDefaults standardUserDefaults] objectForKey:defaultsKey.get()] != nil)
         return [[NSUserDefaults standardUserDefaults] boolForKey:defaultsKey.get()];
 
     return defaultValue;
+}
+
+bool experimentalFeatureEnabled(const String& key, bool defaultValue)
+{
+    return *optionalExperimentalFeatureEnabled(key, defaultValue);
 }
 
 static NSString* applicationOrProcessIdentifier()
@@ -212,10 +217,10 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
     parameters.networkSessionParameters.enablePrivateClickMeasurementDebugMode = experimentalFeatureEnabled(WebPreferencesKey::privateClickMeasurementDebugModeEnabledKey());
 }
 
-bool WebsiteDataStore::useNetworkLoader()
+std::optional<bool> WebsiteDataStore::useNetworkLoader()
 {
 #if HAVE(NETWORK_LOADER)
-    return experimentalFeatureEnabled(WebPreferencesKey::cFNetworkNetworkLoaderEnabledKey());
+    return optionalExperimentalFeatureEnabled(WebPreferencesKey::cFNetworkNetworkLoaderEnabledKey(), std::nullopt);
 #else
     return false;
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -308,7 +308,7 @@ public:
     void dispatchOnQueue(Function<void()>&&);
 
 #if PLATFORM(COCOA)
-    static bool useNetworkLoader();
+    static std::optional<bool> useNetworkLoader();
 #endif
 
 #if USE(CURL)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1070,6 +1070,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         if (enableAllExperimentalFeatures) {
             WKPreferencesEnableAllExperimentalFeatures(preferences);
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("SiteIsolationEnabled").get());
+            WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("CFNetworkNetworkLoaderEnabled").get());
         }
 
         WKPreferencesResetAllInternalDebugFeatures(preferences);


### PR DESCRIPTION
#### 7a0c84628901b577cd5e312d0cdb98aa22819324
<pre>
Expose the CFNetworkNetworkLoaderEnabled preference as testable with a tri-state
<a href="https://bugs.webkit.org/show_bug.cgi?id=262810">https://bugs.webkit.org/show_bug.cgi?id=262810</a>
<a href="https://rdar.apple.com/104615596">rdar://104615596</a>

Reviewed by Alex Christensen.

This patch accomplishes two tasks:
1) Move the preference to &quot;testable&quot; status
2) Define the preference as a tri-state: { unset, false, true }

Task (1) is a simple change, and the preference is disabled in
WebKitTestRunner. The remainder of the patch accomplishes (2) by plumbing the
preferences current state as a std::optional&lt;bool&gt;.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::optionalExperimentalFeatureEnabled):
(WebKit::experimentalFeatureEnabled):
(WebKit::WebsiteDataStore::useNetworkLoader):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/271812@main">https://commits.webkit.org/271812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5852ebcb8ee2041dcac83704aac3f1873f92e98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/8400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/31042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/32242 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/30362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26903 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/30019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5976 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33578 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/25530 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32322 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/29930 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/4265 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30104 "Found 1 new API test failure: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-save-load (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7814 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/36306 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7056 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6819 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7833 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->