### PR TITLE
Auto-expand “details” element for find-in-page and scrolling to fragments

### DIFF
--- a/LayoutTests/editing/text-iterator/find-in-page-in-closed-details-expected.txt
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-closed-details-expected.txt
@@ -1,0 +1,8 @@
+
+PASS auto-expand on find-in-page match: details-simple
+PASS auto-expand on find-in-page match: details-in-p
+PASS auto-expand on find-in-page match: details-in-table
+PASS auto-expand on find-in-page match: details-nested-simple
+PASS auto-expand on find-in-page match: details-nested-target-in-p
+PASS auto-expand on find-in-page match: details-nested-target-in-table
+

--- a/LayoutTests/editing/text-iterator/find-in-page-in-closed-details.html
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-closed-details.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><html lang><meta charset="utf-8">
+<title>find-in-page with closed details elements</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<hr>
+<script>
+findStringInDetails = (id, contents) => {
+    const t = async_test(`auto-expand on find-in-page match: ${id}`);
+    document.body.insertAdjacentHTML("beforeend", `<details id=${id}>${contents}</details>`);
+    const details = document.getElementById(id);
+    details.ontoggle = t.step_func_done(function(e) {
+        details.remove();
+        assert_equals(e.newState, "open", `newState is “open”: ${id}`);
+        assert_equals(e.oldState, "closed", `oldState was “closed”: ${id}`);
+        assert_true(details.open, `details element is open: ${id}`);
+    });
+    testRunner.findInPage(id, []);
+}
+let target;
+target = "details-simple"; findStringInDetails(target, target);
+target = "details-in-p"; findStringInDetails(target, `<p>${target}</p>`);
+target = "details-in-table"; findStringInDetails(target, `<table><tr><td>${target}</table>`);
+target = "details-nested-simple"; findStringInDetails(target, `<details>${target}</details>`);
+target = "details-nested-target-in-p"; findStringInDetails(target, `<details><p>${target}</p></details>`);
+target = "details-nested-target-in-table"; findStringInDetails(target, `<details><table><tr><td>${target}</table></details>`);
+</script>

--- a/LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details-expected.txt
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details-expected.txt
@@ -1,0 +1,4 @@
+
+PASS find-in-page with summary of closed details element: summary-simple
+PASS find-in-page with summary of closed details element: summary-nested-simple
+

--- a/LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details.html
+++ b/LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html><html lang><meta charset="utf-8">
+<title>find-in-page with summary of closed details element</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<details></details>
+<script>
+findStringInDetails = (id, contents) => {
+    const t = async_test(`find-in-page with summary of closed details element: ${id}`);
+    document.body.insertAdjacentHTML("beforeend", `<details id=${id}>${contents}</details>`);
+    const details = document.getElementById(id);
+    details.ontoggle = t.step_func_done(function(e) {
+        assert_unreached("toggle event fired on closed details element");
+    });
+    t.step_timeout(() => {
+        assert_true(!details.open);
+        details.remove();
+        t.done();
+    }, 3000);
+    testRunner.findInPage(id, []);
+}
+let target;
+target = "summary-simple"; findStringInDetails(target, `<summary>${target}</summary>`);
+target = "summary-nested-simple"; findStringInDetails(target, `<details><summary>${target}</summary></details>`);
+</script>

--- a/LayoutTests/http/tests/security/cross-origin-blob-transfer-expected.txt
+++ b/LayoutTests/http/tests/security/cross-origin-blob-transfer-expected.txt
@@ -14,4 +14,3 @@ Details
 Result	Test Name	Message
 Pass	Test for creating blob in iframe and then transferring it cross-origin.	
 Asserts run
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment-expected.txt
@@ -1,4 +1,4 @@
 spacer
 
-FAIL auto-expand-details-element-fragment assert_true: <details> should be opened by navigating to an element inside it. expected true got false
+PASS auto-expand-details-element-fragment
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1751,6 +1751,10 @@ http/tests/download/convert-cached-load-to-download.html [ Skip ]
 # Can't load application/octet-stream in WK1
 http/tests/mime/html-with-nosniff-html.html [ Skip ]
 
+# testRunner.findInPage function is WK2-only, not implemented for WK1
+editing/text-iterator/find-in-page-in-closed-details.html
+editing/text-iterator/find-in-page-in-summary-of-closed-details.html
+
 # dumpPolicyDelegateCallbacks is not supported in DumpRenderTree
 fast/loader/iframe-src-invalid-url.html [ Skip ]
 

--- a/LayoutTests/webrtc/legacy-api-expected.txt
+++ b/LayoutTests/webrtc/legacy-api-expected.txt
@@ -1,15 +1,3 @@
-Summary
-
-Harness status: OK
-
-Found 1 tests
-
-1 Pass
-Details
-
-Result	Test Name	Message
-Pass	Testing legacy API is not defined	
-Asserts run
 
 PASS Testing legacy API is not defined
 

--- a/LayoutTests/webrtc/legacy-api.html
+++ b/LayoutTests/webrtc/legacy-api.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
     </head>
     <body>
         <script>
@@ -25,6 +26,5 @@ promise_test(function() {
     });
 }, "Testing legacy API is not defined");
         </script>
-        <script src="../resources/testharnessreport.js"></script>
     </body>
 </html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2604,6 +2604,20 @@ DetachableMediaSourceEnabled:
     WebCore:
       default: false
 
+DetailsAutoExpandEnabled:
+  type: bool
+  status: preview
+  category: html
+  humanReadableName: "HTML auto-expanding <details>"
+  humanReadableDescription: "Enable HTML auto-expanding <details>"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DeveloperExtrasEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -37,6 +37,7 @@
 #include "DataTransfer.h"
 #include "DocumentInlines.h"
 #include "DocumentType.h"
+#include "ElementAncestorIteratorInlines.h"
 #include "ElementIterator.h"
 #include "ElementRareData.h"
 #include "ElementTraversal.h"
@@ -47,11 +48,13 @@
 #include "GCReachableRef.h"
 #include "HTMLAreaElement.h"
 #include "HTMLBodyElement.h"
+#include "HTMLDetailsElement.h"
 #include "HTMLDialogElement.h"
 #include "HTMLElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLSlotElement.h"
 #include "HTMLStyleElement.h"
+#include "HTMLSummaryElement.h"
 #include "InputEvent.h"
 #include "InspectorController.h"
 #include "InspectorInstrumentation.h"
@@ -2187,6 +2190,23 @@ Element* Node::enclosingLinkEventParentOrSelf()
     }
 
     return nullptr;
+}
+
+void Node::expandAllDetailsAncestors()
+{
+    if (!document().settings().detailsAutoExpandEnabled())
+        return;
+    Vector<RefPtr<HTMLDetailsElement>> detailsElements;
+    for (auto& element : lineageOfType<HTMLElement>(*this)) {
+        if (is<HTMLSummaryElement>(element))
+            break;
+        if (RefPtr details = dynamicDowncast<HTMLDetailsElement>(element)) {
+            if (!details->hasAttributeWithoutSynchronization(HTMLNames::openAttr))
+                detailsElements.append(details);
+        }
+    }
+    for (auto& element : detailsElements)
+        element->toggleOpen();
 }
 
 enum EventTargetInterfaceType Node::eventTargetInterface() const

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -341,6 +341,8 @@ public:
     // Returns the enclosing event parent Element (or self) that, when clicked, would trigger a navigation.
     WEBCORE_EXPORT Element* enclosingLinkEventParentOrSelf();
 
+    WEBCORE_EXPORT void expandAllDetailsAncestors();
+
     // These low-level calls give the caller responsibility for maintaining the integrity of the tree.
     void setPreviousSibling(Node* previous) { m_previousSibling = previous; }
     void setNextSibling(Node* next) { m_next = next; }

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -166,6 +166,8 @@ void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomS
                 }
             } else {
                 m_defaultSlot->setInlineStyleProperty(CSSPropertyContentVisibility, CSSValueHidden);
+                if (document().settings().detailsAutoExpandEnabled())
+                    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
                 queueDetailsToggleEventTask(ToggleState::Open, ToggleState::Closed);
             }
         }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2306,8 +2306,9 @@ bool LocalFrameView::scrollToFragmentInternal(StringView fragmentIdentifier)
         scrollPositionAnchor = m_frame->document();
     maintainScrollPositionAtAnchor(scrollPositionAnchor.get());
     
-    // If the anchor accepts keyboard focus, move focus there to aid users relying on keyboard navigation.
     if (anchorElement) {
+        anchorElement->expandAllDetailsAncestors();
+        // If the anchor accepts keyboard focus, move focus there to aid users relying on keyboard navigation.
         if (anchorElement->isFocusable())
             document.setFocusedElement(anchorElement.get(), { { }, { }, { }, { }, FocusVisibility::Visible });
         else {

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -28,6 +28,7 @@
 
 #include "DebugPageOverlays.h"
 #include "Document.h"
+#include "HTMLDetailsElement.h"
 #include "InspectorInstrumentation.h"
 #include "LayoutDisallowedScope.h"
 #include "LocalFrameView.h"
@@ -659,6 +660,20 @@ bool LocalFrameViewLayoutContext::isSkippedContentForLayout(const RenderElement&
 {
     if (needsSkippedContentLayout())
         return false;
+
+    // Per https://html.spec.whatwg.org/#interaction-with-details-and-hidden=until-found
+    // we need to prevent the contents of closed details elements from being treated as
+    // skipped content, because we want find-in-page to find matches in them. But without
+    // special-casing here, find-in-page won't work with them — because the contents of
+    // closed details elements all have their content-visibility set to "hidden", which
+    // for layout purposes would otherwise cause them to be treated as skipped content.
+    if (document()->settings().detailsAutoExpandEnabled()) {
+        for (auto& ancestor : ancestorsOfType<RenderElement>(renderer)) {
+            if (auto* element = dynamicDowncast<HTMLElement>(ancestor.element()); element && is<HTMLDetailsElement>(*element))
+                return false;
+        }
+    }
+
     return renderer.isSkippedContent();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -312,6 +312,9 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
         found = idOfFrameContainingString.has_value();
     }
 
+    if (RefPtr selectedFrame = frameWithSelection(m_webPage->corePage()); selectedFrame && found)
+        selectedFrame->selection().selection().start().anchorNode()->expandAllDetailsAncestors();
+
     if (found && !options.contains(FindOptions::DoNotSetSelection)) {
         didFindString();
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -154,6 +154,7 @@ interface TestRunner {
     // Text search testing.
     boolean findString(DOMString target, object optionsArray);
     undefined findStringMatchesInPage(DOMString target, object optionsArray);
+    undefined findInPage(DOMString target, object optionsArray);
     undefined replaceFindMatchesAtIndices(object matchIndicesArray, DOMString replacementText, boolean selectionOnly);
 
     // Evaluating script in a special context.

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -347,6 +347,16 @@ void TestRunner::findStringMatchesInPage(JSContextRef context, JSStringRef targe
     }
 }
 
+void TestRunner::findInPage(JSContextRef context, JSStringRef target, JSValueRef optionsArrayAsValue)
+{
+    if (auto options = findOptionsFromArray(context, optionsArrayAsValue)) {
+        postPageMessage("FindString", createWKDictionary({
+            { "String", toWK(target) },
+            { "FindOptions", toWK(*options) },
+        }));
+    }
+}
+
 void TestRunner::replaceFindMatchesAtIndices(JSContextRef context, JSValueRef matchIndicesAsValue, JSStringRef replacementText, bool selectionOnly)
 {
     auto& bundle = InjectedBundle::singleton();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -186,6 +186,7 @@ public:
     // Text search testing.
     bool findString(JSContextRef, JSStringRef, JSValueRef optionsArray);
     void findStringMatchesInPage(JSContextRef, JSStringRef, JSValueRef optionsArray);
+    void findInPage(JSContextRef, JSStringRef target, JSValueRef optionsArrayAsValue);
     void replaceFindMatchesAtIndices(JSContextRef, JSValueRef matchIndices, JSStringRef replacementText, bool selectionOnly);
 
     // Local storage

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -722,6 +722,14 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "FindString")) {
+        auto messageBodyDictionary = dictionaryValue(messageBody);
+        auto string = stringValue(messageBodyDictionary, "String");
+        auto findOptions = static_cast<WKFindOptions>(uint64Value(messageBodyDictionary, "FindOptions"));
+        WKPageFindString(TestController::singleton().mainWebView()->page(), string, findOptions, 0);
+        return;
+    }
+
     ASSERT_NOT_REACHED();
 }
 


### PR DESCRIPTION
#### 2118f670fe3b5d958686ed7f572dd24ce697f6c3
<pre>
Auto-expand “details” element for find-in-page and scrolling to fragments
<a href="https://bugs.webkit.org/show_bug.cgi?id=228843">https://bugs.webkit.org/show_bug.cgi?id=228843</a>
<a href="https://rdar.apple.com/81856620">rdar://81856620</a>

Reviewed by NOBODY (OOPS!).

This change causes any closed &lt;details&gt; element to be opened
automatically (auto-expanded) if either:

- the user is using find-in-page and a descendant node of the closed
  &lt;details&gt; element contains a match for the given search string
- the user is navigating to a fragment ID and the fragment ID is for a
  descendant element of the closed &lt;details&gt; element

…per the requirements in the HTML spec’s Find-in-page section at
<a href="https://html.spec.whatwg.org/#interaction-with-details-and-hidden=until-found">https://html.spec.whatwg.org/#interaction-with-details-and-hidden=until-found</a>

Otherwise, without this change, when a descendant node of a closed
&lt;details&gt; element contains a match for the given find-in-page search
string, or when navigating to a fragment ID for a descendant element of
a closed &lt;details&gt; element, the closed &lt;details&gt; element isn’t opened
automatically (not auto-expanded).

Further, per the requirements in the HTML spec’s Rendering section at
<a href="https://html.spec.whatwg.org/#the-details-and-summary-elements">https://html.spec.whatwg.org/#the-details-and-summary-elements</a>:the-details-element-6,
when the second slot of a &lt;details&gt; element has no “open” attribute,
this change causes that slot to have its “style” attribute set to
“display: block; content-visibility: hidden”.

Otherwise, without this change, when the “open” attribute is removed
from a &lt;details&gt; element, its second slot is removed from the DOM.

This change also introduces the DetailsAutoExpandEnabled preference
(disabled by default), for controlling whether &lt;details&gt; elements get
auto-expanded under the conditions described above.

And this also adds a testRunner.findInPage(target, options) function —
WK2-only — for testing the browser UI find-in-page feature, by calling
into the same code path that gets executed when that feature is used.

* LayoutTests/editing/text-iterator/find-in-page-in-closed-details-expected.txt: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-closed-details.html: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details-expected.txt: Added.
* LayoutTests/editing/text-iterator/find-in-page-in-summary-of-closed-details.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/webrtc/legacy-api-expected.txt:
* LayoutTests/webrtc/legacy-api.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::expandAllDetailsAncestors):
* Source/WebCore/dom/Node.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::attributeChanged):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFragmentInternal):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::isSkippedContentForLayout const):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::findString):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::findStringMatchesInPage):
(WTR::TestRunner::findInPage):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2118f670fe3b5d958686ed7f572dd24ce697f6c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18433 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69702 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27258 "Found 1 new test failure: http/tests/security/cross-origin-blob-transfer.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93583 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8013 "Found 2 new test failures: editing/text-iterator/find-in-page-in-closed-details.html http/tests/security/cross-origin-blob-transfer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50054 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7750 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36519 "Found 2 new test failures: http/tests/security/cross-origin-blob-transfer.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40494 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83392 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78069 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37587 "Found 3 new test failures: editing/text-iterator/find-in-page-in-closed-details.html http/tests/security/cross-origin-blob-transfer.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97422 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89362 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17774 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13079 "Found 3 new test failures: editing/text-iterator/find-in-page-in-closed-details.html http/tests/security/cross-origin-blob-transfer.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78727 "Found 3 new test failures: editing/text-iterator/find-in-page-in-closed-details.html http/tests/security/cross-origin-blob-transfer.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18032 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77973 "Exiting early after 10 failures. 118 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77927 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22365 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20988 "Found 3 new test failures: editing/text-iterator/find-in-page-in-closed-details.html http/tests/security/cross-origin-blob-transfer.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/auto-expand-details-element-fragment.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11096 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17784 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23116 "Built successfully") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111851 "Failed to checkout and rebase branch from PR 18785") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17523 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/111851 "Failed to checkout and rebase branch from PR 18785") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->