### PR TITLE
Add Web Extension API to support conditionally allowing extensions in private windows and tabs.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -234,6 +234,16 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @property (nonatomic) BOOL requestedOptionalAccessToAllHosts;
 
 /*!
+ @abstract A Boolean value indicating if the extension has access to private browsing windows and tabs.
+ @discussion When this value is `YES`, the extension is granted permission to interact with private browsing windows and tabs.
+ This value should be saved and restored as needed. Access to private browsing should be explicitly allowed by the user before setting this property.
+ @note To ensure proper isolation between private and non-private browsing, web views associated with private browsing windows must
+ use a different `WKUserContentController`. Likewise, to be identified as a private web view and to ensure that cookies and other
+ website data is not shared, private web views must be configured to use a non-persistent `WKWebsiteDataStore`.
+ */
+@property (nonatomic) BOOL hasAccessInPrivateBrowsing;
+
+/*!
  @abstract The currently granted permissions that have not expired.
  @seealso grantedPermissions
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -252,6 +252,16 @@ static inline WebKit::WebExtensionContext::PermissionMatchPatternsMap toImpl(NSD
     return _webExtensionContext->setRequestedOptionalAccessToAllHosts(requested);
 }
 
+- (BOOL)hasAccessInPrivateBrowsing
+{
+    return _webExtensionContext->hasAccessInPrivateBrowsing();
+}
+
+- (void)setHasAccessInPrivateBrowsing:(BOOL)hasAccess
+{
+    return _webExtensionContext->setHasAccessInPrivateBrowsing(hasAccess);
+}
+
 static inline NSSet<_WKWebExtensionPermission> *toAPI(const WebKit::WebExtensionContext::PermissionsMap::KeysConstIteratorRange& permissions)
 {
     if (!permissions.size())
@@ -540,7 +550,7 @@ static inline NSArray *toAPI(const WebKit::WebExtensionContext::WindowVector& wi
 
 - (id<_WKWebExtensionWindow>)focusedWindow
 {
-    return toAPI(_webExtensionContext->focusedWindow());
+    return toAPI(_webExtensionContext->focusedWindow(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
 }
 
 static inline NSSet *toAPI(const WebKit::WebExtensionContext::TabMapValueIterator& tabs)
@@ -844,6 +854,15 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (void)setRequestedOptionalAccessToAllHosts:(BOOL)requested
+{
+}
+
+- (BOOL)hasAccessInPrivateBrowsing
+{
+    return NO;
+}
+
+- (void)setHasAccessInPrivateBrowsing:(BOOL)hasAccess
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h
@@ -109,7 +109,10 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called when the private browsing state of the window is needed.
  @param context The context in which the web extension is running.
  @return `YES` if the window is private, `NO` otherwise.
- @discussion Defaults to `NO` if not implemented.
+ @discussion Defaults to `NO` if not implemented. This value is cached and will not change for the duration of the window or its contained tabs.
+ @note To ensure proper isolation between private and non-private browsing, web views associated with private browsing windows must
+ use a different `WKUserContentController`. Likewise, to be identified as a private web view and to ensure that cookies and other
+ website data is not shared, private web views must be configured to use a non-persistent `WKWebsiteDataStore`.
  */
 - (BOOL)isUsingPrivateBrowsingForWebExtensionContext:(_WKWebExtensionContext *)context;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h
@@ -74,7 +74,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*! @abstract Indicates whether the new window should be focused. */
 @property (nonatomic, readonly) BOOL shouldFocus;
 
-/*! @abstract Indicates whether the new window should be using private browsing. */
+/*!
+ @abstract Indicates whether the new window should be using private browsing.
+ @note To ensure proper isolation between private and non-private browsing, web views associated with private browsing windows must
+ use a different `WKUserContentController`. Likewise, to be identified as a private web view and to ensure that cookies and other
+ website data is not shared, private web views must be configured to use a non-persistent `WKWebsiteDataStore`.
+ */
 @property (nonatomic, readonly) BOOL shouldUsePrivateBrowsing;
 
 @end

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -139,6 +139,7 @@ public:
     enum class WindowIsClosing : bool { No, Yes };
     enum class ReloadFromOrigin : bool { No, Yes };
     enum class UserTriggered : bool { No, Yes };
+    enum class IgnoreExtensionAccess : bool { No, Yes };
 
     enum class Error : uint8_t {
         Unknown = 1,
@@ -217,6 +218,9 @@ public:
     bool requestedOptionalAccessToAllHosts() const { return m_requestedOptionalAccessToAllHosts; }
     void setRequestedOptionalAccessToAllHosts(bool requested) { m_requestedOptionalAccessToAllHosts = requested; }
 
+    bool hasAccessInPrivateBrowsing() const { return m_hasAccessInPrivateBrowsing; }
+    void setHasAccessInPrivateBrowsing(bool hasAccess) { m_hasAccessInPrivateBrowsing = hasAccess; }
+
     void grantPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
     void denyPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
 
@@ -251,17 +255,17 @@ public:
     void clearCachedPermissionStates();
 
     Ref<WebExtensionWindow> getOrCreateWindow(_WKWebExtensionWindow *);
-    RefPtr<WebExtensionWindow> getWindow(WebExtensionWindowIdentifier, std::optional<WebPageProxyIdentifier> = std::nullopt);
+    RefPtr<WebExtensionWindow> getWindow(WebExtensionWindowIdentifier, std::optional<WebPageProxyIdentifier> = std::nullopt, IgnoreExtensionAccess = IgnoreExtensionAccess::No);
 
     Ref<WebExtensionTab> getOrCreateTab(_WKWebExtensionTab *);
-    RefPtr<WebExtensionTab> getTab(WebExtensionTabIdentifier);
-    RefPtr<WebExtensionTab> getTab(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> = std::nullopt);
+    RefPtr<WebExtensionTab> getTab(WebExtensionTabIdentifier, IgnoreExtensionAccess = IgnoreExtensionAccess::No);
+    RefPtr<WebExtensionTab> getTab(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier> = std::nullopt, IgnoreExtensionAccess = IgnoreExtensionAccess::No);
 
     WindowVector openWindows() const;
     TabMapValueIterator openTabs() const { return m_tabMap.values(); }
 
-    RefPtr<WebExtensionWindow> focusedWindow();
-    RefPtr<WebExtensionWindow> frontmostWindow();
+    RefPtr<WebExtensionWindow> focusedWindow(IgnoreExtensionAccess = IgnoreExtensionAccess::No);
+    RefPtr<WebExtensionWindow> frontmostWindow(IgnoreExtensionAccess = IgnoreExtensionAccess::No);
 
     void didOpenWindow(const WebExtensionWindow&);
     void didCloseWindow(const WebExtensionWindow&);
@@ -512,6 +516,7 @@ private:
     RetainPtr<NSMapTable> m_temporaryTabPermissionMatchPatterns;
 
     bool m_requestedOptionalAccessToAllHosts { false };
+    bool m_hasAccessInPrivateBrowsing { false };
 #ifdef NDEBUG
     bool m_testingMode { false };
 #else

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -75,6 +75,8 @@ public:
     using WebPageProxySet = WeakHashSet<WebPageProxy>;
     using UserContentControllerProxySet = WeakHashSet<WebUserContentControllerProxy>;
 
+    enum class ForPrivateBrowsing { No, Yes };
+
     WebExtensionControllerConfiguration& configuration() const { return m_configuration.get(); }
     WebExtensionControllerIdentifier identifier() const { return m_identifier; }
     WebExtensionControllerParameters parameters() const;
@@ -96,7 +98,12 @@ public:
     void removePage(WebPageProxy&);
 
     WebPageProxySet allPages() const { return m_pages; }
-    UserContentControllerProxySet allUserContentControllers() const { return m_userContentControllers; }
+
+    // Includes both regular and private browsing content controllers.
+    UserContentControllerProxySet allUserContentControllers() const { return m_allUserContentControllers; }
+
+    // Excludes private browsing content controllers.
+    UserContentControllerProxySet allNonPrivateUserContentControllers() const { return m_allNonPrivateUserContentControllers; }
 
     WebProcessPoolSet allProcessPools() const { return m_processPools; }
     WebProcessProxySet allProcesses() const;
@@ -122,7 +129,7 @@ private:
     void addProcessPool(WebProcessPool&);
     void removeProcessPool(WebProcessPool&);
 
-    void addUserContentController(WebUserContentControllerProxy&);
+    void addUserContentController(WebUserContentControllerProxy&, ForPrivateBrowsing);
     void removeUserContentController(WebUserContentControllerProxy&);
 
     // Web Navigation
@@ -138,7 +145,8 @@ private:
     WebExtensionContextBaseURLMap m_extensionContextBaseURLMap;
     WebPageProxySet m_pages;
     WebProcessPoolSet m_processPools;
-    UserContentControllerProxySet m_userContentControllers;
+    UserContentControllerProxySet m_allUserContentControllers;
+    UserContentControllerProxySet m_allNonPrivateUserContentControllers;
     WebExtensionURLSchemeHandlerMap m_registeredSchemeHandlers;
     bool m_freshlyCreated { true };
 };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -97,6 +97,7 @@ public:
     bool matches(const WebExtensionTabQueryParameters&, AssumeWindowMatches = AssumeWindowMatches::No, std::optional<WebPageProxyIdentifier> = std::nullopt) const;
 
     bool extensionHasAccess() const;
+    bool extensionHasPermission() const;
 
     RefPtr<WebExtensionWindow> window(SkipContainsCheck = SkipContainsCheck::No) const;
     size_t index() const;
@@ -170,6 +171,8 @@ private:
     WebExtensionTabIdentifier m_identifier;
     WeakPtr<WebExtensionContext> m_extensionContext;
     WeakObjCPtr<_WKWebExtensionTab> m_delegate;
+    mutable bool m_private : 1 { false };
+    mutable bool m_cachedPrivate : 1 { false };
     bool m_respondsToWindow : 1 { false };
     bool m_respondsToParentTab : 1 { false };
     bool m_respondsToSetParentTab : 1 { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -93,6 +93,8 @@ public:
     bool matches(OptionSet<TypeFilter>) const;
     bool matches(const WebExtensionTabQueryParameters&, std::optional<WebPageProxyIdentifier> = std::nullopt) const;
 
+    bool extensionHasAccess() const;
+
     TabVector tabs() const;
     RefPtr<WebExtensionTab> activeTab() const;
 
@@ -128,6 +130,8 @@ private:
     WebExtensionWindowIdentifier m_identifier;
     WeakPtr<WebExtensionContext> m_extensionContext;
     WeakObjCPtr<_WKWebExtensionWindow> m_delegate;
+    mutable bool m_private : 1 { false };
+    mutable bool m_cachedPrivate : 1 { false };
     bool m_respondsToTabs : 1 { false };
     bool m_respondsToActiveTab : 1 { false };
     bool m_respondsToWindowType : 1 { false };

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -53,6 +53,7 @@
 @property (nonatomic, readonly, copy) NSArray<TestWebExtensionWindow *> *windows;
 
 - (TestWebExtensionWindow *)openNewWindow;
+- (TestWebExtensionWindow *)openNewWindowUsingPrivateBrowsing:(BOOL)usesPrivateBrowsing;
 - (void)focusWindow:(TestWebExtensionWindow *)window;
 - (void)closeWindow:(TestWebExtensionWindow *)window;
 
@@ -93,7 +94,7 @@
 
 @interface TestWebExtensionWindow : NSObject <_WKWebExtensionWindow>
 
-- (instancetype)initWithExtensionController:(_WKWebExtensionController *)extensionController NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExtensionController:(_WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSArray<id<_WKWebExtensionTab>> *tabs;
 @property (nonatomic, strong) id<_WKWebExtensionTab> activeTab;
@@ -111,7 +112,7 @@
 @property (nonatomic) CGRect frame;
 @property (nonatomic) CGRect screenFrame;
 
-@property (nonatomic, getter=isUsingPrivateBrowsing) BOOL usingPrivateBrowsing;
+@property (nonatomic, readonly, getter=isUsingPrivateBrowsing) BOOL usingPrivateBrowsing;
 
 @property (nonatomic, copy) void (^didFocus)(void);
 @property (nonatomic, copy) void (^didClose)(void);


### PR DESCRIPTION
#### ba5431e64e76f654740b95a1f454ee55a1c3b58e
<pre>
Add Web Extension API to support conditionally allowing extensions in private windows and tabs.
<a href="https://webkit.org/b/262812">https://webkit.org/b/262812</a>
rdar://problem/116598191

Reviewed by Brian Weinstein.

- Added a `hasAccessInPrivateBrowsing` property to `_WKWebExtensionContext` so an extension can
  be given access to private windows and tabs or just normal windows and tabs.
- Segregate the `UserContentControllers` so we don&apos;t inject content into private tabs when the
  extension does not have access.
- Prevent returning the window when creating a private window.
- Don&apos;t fire events if the extension does not have access to that window or tab.
- Don&apos;t include tabs in `tabs.query` results when access isn&apos;t granted.
- Don&apos;t include windows in `windows.getAll` if access isn&apos;t granted.
- Also prevent getting a window or tab by ID if access isn&apos;t granted.
- Adopted `makeBlockPtr` in all delegate calls to avoid memory issues if the block escapes.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext hasAccessInPrivateBrowsing]): Added.
(-[_WKWebExtensionContext setHasAccessInPrivateBrowsing:]): Added.
(-[_WKWebExtensionContext focusedWindow]): Ignore access since this is native API.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindow.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionWindowCreationOptions.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsCreate):
(WebKit::WebExtensionContext::tabsCaptureVisibleTab):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getWindow):
(WebKit::WebExtensionContext::getTab):
(WebKit::WebExtensionContext::openWindows const):
(WebKit::WebExtensionContext::focusedWindow):
(WebKit::WebExtensionContext::frontmostWindow):
(WebKit::WebExtensionContext::didOpenWindow):
(WebKit::WebExtensionContext::didCloseWindow):
(WebKit::WebExtensionContext::didFocusWindow):
(WebKit::WebExtensionContext::didOpenTab):
(WebKit::WebExtensionContext::didCloseTab):
(WebKit::WebExtensionContext::didActivateTab):
(WebKit::WebExtensionContext::didSelectOrDeselectTabs):
(WebKit::WebExtensionContext::didMoveTab):
(WebKit::WebExtensionContext::didReplaceTab):
(WebKit::WebExtensionContext::didChangeTabProperties):
(WebKit::WebExtensionContext::addInjectedContent):
(WebKit::WebExtensionContext::removeInjectedContent):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addPage):
(WebKit::WebExtensionController::removePage):
(WebKit::WebExtensionController::addUserContentController):
(WebKit::WebExtensionController::removeUserContentController):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::parameters const):
(WebKit::WebExtensionTab::changedParameters const):
(WebKit::WebExtensionTab::matches const):
(WebKit::WebExtensionTab::extensionHasAccess const):
(WebKit::WebExtensionTab::extensionHasPermission const):
(WebKit::WebExtensionTab::setParentTab):
(WebKit::WebExtensionTab::pin):
(WebKit::WebExtensionTab::unpin):
(WebKit::WebExtensionTab::isPrivate const):
(WebKit::WebExtensionTab::toggleReaderMode):
(WebKit::WebExtensionTab::mute):
(WebKit::WebExtensionTab::unmute):
(WebKit::WebExtensionTab::setZoomFactor):
(WebKit::WebExtensionTab::detectWebpageLocale):
(WebKit::WebExtensionTab::loadURL):
(WebKit::WebExtensionTab::reload):
(WebKit::WebExtensionTab::reloadFromOrigin):
(WebKit::WebExtensionTab::goBack):
(WebKit::WebExtensionTab::goForward):
(WebKit::WebExtensionTab::activate):
(WebKit::WebExtensionTab::select):
(WebKit::WebExtensionTab::deselect):
(WebKit::WebExtensionTab::duplicate):
(WebKit::WebExtensionTab::close):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::matches const):
(WebKit::WebExtensionWindow::extensionHasAccess const):
(WebKit::WebExtensionWindow::setState):
(WebKit::WebExtensionWindow::focus):
(WebKit::WebExtensionWindow::isPrivate const):
(WebKit::WebExtensionWindow::setFrame):
(WebKit::WebExtensionWindow::close):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::hasAccessInPrivateBrowsing const):
(WebKit::WebExtensionContext::setHasAccessInPrivateBrowsing):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::allUserContentControllers const):
(WebKit::WebExtensionController::normalUserContentControllers const):
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:]):
(-[TestWebExtensionManager openNewWindow]):
(-[TestWebExtensionManager openNewWindowUsingPrivateBrowsing:]):
(userContentController):
(-[TestWebExtensionTab initWithWindow:extensionController:]):
(-[TestWebExtensionWindow init]):
(-[TestWebExtensionWindow initWithExtensionController:usesPrivateBrowsing:]):
(-[TestWebExtensionWindow initWithExtensionController:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/269022@main">https://commits.webkit.org/269022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bcc112c0f760916ca8bbcb28ece4519f6c8bb59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21370 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/22422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/23231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21610 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/24980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/21927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/23231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21594 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/24980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/22422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/24980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/22422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/24083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/24980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/22422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/21927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/19377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/22422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2645 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/19965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->