### PR TITLE
Add support for browser.tabs script APIs.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
@@ -31,6 +31,7 @@ struct WebKit::WebExtensionScriptInjectionParameters {
     std::optional<Vector<String>> files;
     std::optional<Vector<WebKit::WebExtensionFrameIdentifier>> frameIDs;
 
+    std::optional<String> code;
     std::optional<String> css;
     std::optional<String> function;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h
@@ -38,6 +38,7 @@ struct WebExtensionScriptInjectionParameters {
     std::optional<Vector<String>> files;
     std::optional<Vector<WebExtensionFrameIdentifier>> frameIDs;
 
+    std::optional<String> code;
     std::optional<String> css;
     std::optional<String> function;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -136,6 +136,22 @@ void removeStyleSheets(SourcePairs styleSheetPairs, WebCore::UserContentInjected
     }
 }
 
+WebExtensionScriptInjectionResultParameters toInjectionResultParameters(id resultOfExecution, WKFrameInfo *info, NSString *errorMessage)
+{
+    WebExtensionScriptInjectionResultParameters parameters;
+
+    if (resultOfExecution)
+        parameters.result = resultOfExecution;
+
+    if (info)
+        parameters.frameID = toWebExtensionFrameIdentifier(info);
+
+    if (errorMessage)
+        parameters.error = errorMessage;
+
+    return parameters;
+}
+
 } // namespace WebExtensionDynamicScripts
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -452,6 +452,9 @@ private:
     void tabsGetZoom(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(std::optional<double>, WebExtensionTab::Error)>&&);
     void tabsSetZoom(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, double, CompletionHandler<void(WebExtensionTab::Error)>&&);
     void tabsRemove(Vector<WebExtensionTabIdentifier>, CompletionHandler<void(WebExtensionTab::Error)>&&);
+    void tabsExecuteScript(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, const WebExtensionScriptInjectionParameters&, CompletionHandler<void(std::optional<Vector<WebExtensionScriptInjectionResultParameters>>, WebExtensionTab::Error)>&&);
+    void tabsInsertCSS(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, const WebExtensionScriptInjectionParameters&, CompletionHandler<void(WebExtensionTab::Error)>&&);
+    void tabsRemoveCSS(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, const WebExtensionScriptInjectionParameters&, CompletionHandler<void(WebExtensionTab::Error)>&&);
     void fireTabsCreatedEventIfNeeded(const WebExtensionTabParameters&);
     void fireTabsUpdatedEventIfNeeded(const WebExtensionTabParameters&, const WebExtensionTabParameters& changedParameters);
     void fireTabsReplacedEventIfNeeded(WebExtensionTabIdentifier replacedTabIdentifier, WebExtensionTabIdentifier newTabIdentifier);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -88,6 +88,9 @@ messages -> WebExtensionContext {
     TabsGetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (std::optional<double> zoomFactor, WebKit::WebExtensionTab::Error error);
     TabsSetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, double zoomFactor) -> (WebKit::WebExtensionTab::Error error);
     TabsRemove(Vector<WebKit::WebExtensionTabIdentifier> tabIdentifiers) -> (WebKit::WebExtensionWindow::Error error);
+    TabsExecuteScript(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (std::optional<Vector<WebKit::WebExtensionScriptInjectionResultParameters>> results, WebKit::WebExtensionTab::Error error);
+    TabsInsertCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionTab::Error error);
+    TabsRemoveCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (WebKit::WebExtensionTab::Error error);
 
     // Test APIs
     TestResult(bool result, String message, String sourceURL, unsigned lineNumber);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -29,6 +29,7 @@
 
 #include "APIContentWorld.h"
 #include "WebExtensionFrameIdentifier.h"
+#include "WebExtensionScriptInjectionResultParameters.h"
 #include <wtf/Forward.h>
 
 OBJC_CLASS WKWebView;
@@ -39,7 +40,6 @@ namespace WebKit {
 
 class WebExtension;
 class WebExtensionContext;
-struct WebExtensionScriptInjectionResultParameters;
 
 namespace WebExtensionDynamicScripts {
 
@@ -49,13 +49,30 @@ using Error = std::optional<String>;
 using SourcePair = std::pair<String, std::optional<URL>>;
 using SourcePairs = Vector<std::optional<SourcePair>>;
 
+class InjectionResultHolder : public RefCounted<InjectionResultHolder> {
+    WTF_MAKE_NONCOPYABLE(InjectionResultHolder);
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    template<typename... Args>
+    static Ref<InjectionResultHolder> create(Args&&... args)
+    {
+        return adoptRef(*new InjectionResultHolder(std::forward<Args>(args)...));
+    }
+
+    InjectionResultHolder() { };
+
+    InjectionResults results;
+};
+
+std::optional<SourcePair> sourcePairForResource(String path, RefPtr<WebExtension>);
 SourcePairs getSourcePairsForResource(std::optional<Vector<String>> files, std::optional<String> code, RefPtr<WebExtension>);
 Vector<RetainPtr<_WKFrameTreeNode>> getFrames(_WKFrameTreeNode *, std::optional<Vector<WebExtensionFrameIdentifier>>);
 
-std::optional<SourcePair> sourcePairForResource(String path, RefPtr<WebExtension>);
-
 void injectStyleSheets(SourcePairs, WKWebView *, API::ContentWorld&, WebCore::UserContentInjectedFrames, WebExtensionContext&);
 void removeStyleSheets(SourcePairs, WebCore::UserContentInjectedFrames, WebExtensionContext&);
+
+WebExtensionScriptInjectionResultParameters toInjectionResultParameters(id resultOfExecution, WKFrameInfo *, NSString *errorMessage);
 
 } // namespace WebExtensionDynamicScripts
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -39,6 +39,7 @@ OBJC_CLASS NSString;
 namespace WebKit {
 
 class WebExtensionAPIPort;
+struct WebExtensionScriptInjectionParameters;
 struct WebExtensionTabParameters;
 struct WebExtensionTabQueryParameters;
 
@@ -75,6 +76,10 @@ public:
     void sendMessage(WebFrame*, double tabID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     RefPtr<WebExtensionAPIPort> connect(WebFrame*, JSContextRef, double tabID, NSDictionary *options, NSString **outExceptionString);
 
+    void executeScript(WebPage*, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void insertCSS(WebPage*, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void removeCSS(WebPage*, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+
     double tabIdentifierNone() const { return -1; }
 
     WebExtensionAPIEvent& onActivated();
@@ -95,6 +100,7 @@ private:
     static bool parseCaptureVisibleTabOptions(NSDictionary *, WebExtensionTab::ImageFormat&, uint8_t& imageQuality, NSString *sourceKey, NSString **outExceptionString);
     static bool parseSendMessageOptions(NSDictionary *, std::optional<WebExtensionFrameIdentifier>&, NSString *sourceKey, NSString **outExceptionString);
     static bool parseConnectOptions(NSDictionary *, std::optional<String>& name, std::optional<WebExtensionFrameIdentifier>&, NSString *sourceKey, NSString **outExceptionString);
+    static bool parseScriptOptions(NSDictionary *, WebExtensionScriptInjectionParameters&, NSString **outExceptionString);
 
     RefPtr<WebExtensionAPIEvent> m_onActivated;
     RefPtr<WebExtensionAPIEvent> m_onAttached;
@@ -110,6 +116,7 @@ private:
 
 bool isValid(std::optional<WebExtensionTabIdentifier>, NSString **outExceptionString);
 NSDictionary *toWebAPI(const WebExtensionTabParameters&);
+NSArray *toWebAPI(Vector<WebExtensionScriptInjectionResultParameters>& injectionResults);
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -54,9 +54,9 @@
 
     [RaisesException, NeedsPage] void captureVisibleTab([Optional] double windowID, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
 
-    // [RaisesException, Dynamic] void executeScript([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
-    // [RaisesException, Dynamic] void insertCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
-    // [RaisesException, Dynamic] void removeCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, NeedsPage] void executeScript([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, NeedsPage] void insertCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, NeedsPage] void removeCSS([Optional] double tabID, [NSDictionary] any details, [Optional, CallbackHandler] function callback);
 
     [ProcessArgumentsLeftToRight, RaisesException, NeedsFrame] void sendMessage(double tabID, [Serialization=JSON] any message, [Optional, NSDictionary] any options, [Optional, CallbackHandler] function callback);
     [RaisesException, NeedsFrame, NeedsScriptContext] WebExtensionAPIPort connect(double tabID, [Optional, NSDictionary] any options);


### PR DESCRIPTION
#### ea26ecd46cd6578b6dc5d66fddce4ac9664108c3
<pre>
Add support for browser.tabs script APIs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262816">https://bugs.webkit.org/show_bug.cgi?id=262816</a>

Reviewed by Timothy Hatcher.

This patch implements the tabs.executeScript(), tabs.insertCSS(), and tabs.removeCSS() APIs.

Testing:
- Calls to methods with an invalid tab results in an error.
- A result is returned from for each frame for scripting.executeScript().
- Injections execute in the top frame only if allFrames isn&apos;t specified or is false.

Will add more extensive tests in a follow up PR.

* Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionParameters.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsExecuteScript):
(WebKit::WebExtensionContext::tabsInsertCSS):
(WebKit::WebExtensionContext::tabsRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::toInjectionResultParameters):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
(WebKit::WebExtensionDynamicScripts::InjectionResultHolder::create):
(WebKit::WebExtensionDynamicScripts::InjectionResultHolder::InjectionResultHolder):
Created a ref counted class to hold the results of the script injections so that the data is still
valid when the callback aggregator is called.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPITabs::parseScriptOptions):
(WebKit::WebExtensionAPITabs::executeScript):
(WebKit::WebExtensionAPITabs::insertCSS):
(WebKit::WebExtensionAPITabs::removeCSS):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl:

Canonical link: <a href="https://commits.webkit.org/269028@main">https://commits.webkit.org/269028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cadd6b1ba35877a0ffecba1f8a2f61cb82bae05b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21377 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23238 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21932 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24090 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18419 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23541 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19382 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2651 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->