### PR TITLE
[UnifiedPDF] Make it possible to host GraphicsLayers exposed for a plug-in

### DIFF
--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -35,12 +35,22 @@ typedef struct objc_object* id;
 namespace WebCore {
 
 class Element;
+class GraphicsLayer;
 class Scrollbar;
+
+enum class PluginLayerHostingStrategy : uint8_t {
+    None,
+    PlatformLayer,
+    GraphicsLayer
+};
 
 // FIXME: Move these virtual functions all into the Widget class and get rid of this class.
 class PluginViewBase : public Widget {
 public:
-    virtual PlatformLayer* platformLayer() const { return 0; }
+    virtual PluginLayerHostingStrategy layerHostingStrategy() const { return PluginLayerHostingStrategy::None; }
+    virtual PlatformLayer* platformLayer() const { return nullptr; }
+    virtual GraphicsLayer* graphicsLayer() const { return nullptr; }
+
 #if PLATFORM(IOS_FAMILY)
     virtual bool willProvidePluginLayer() const { return false; }
     virtual void attachPluginLayer() { }

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -109,11 +109,14 @@ bool RenderEmbeddedObject::requiresLayer() const
 
 bool RenderEmbeddedObject::allowsAcceleratedCompositing() const
 {
+    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    if (!pluginViewBase)
+        return false;
 #if PLATFORM(IOS_FAMILY)
     // The timing of layer creation is different on the phone, since the plugin can only be manipulated from the main thread.
-    return is<PluginViewBase>(widget()) && downcast<PluginViewBase>(*widget()).willProvidePluginLayer();
+    return pluginViewBase->willProvidePluginLayer();
 #else
-    return is<PluginViewBase>(widget()) && downcast<PluginViewBase>(*widget()).platformLayer();
+    return pluginViewBase->layerHostingStrategy() != PluginLayerHostingStrategy::None;
 #endif
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -273,6 +273,8 @@ public:
     GraphicsLayer* layerForScrollCorner() const { return m_layerForScrollCorner.get(); }
     GraphicsLayer* overflowControlsContainer() const { return m_overflowControlsContainer.get(); }
 
+    GraphicsLayer* layerForContents() const;
+
     void adjustOverflowControlsPositionRelativeToAncestor(const RenderLayer&);
 
     bool canCompositeFilters() const { return m_canCompositeFilters; }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1511,17 +1511,20 @@ void RenderLayerCompositor::updateBackingAndHierarchy(RenderLayer& layer, Vector
 
     if (layerBacking) {
         if (requireDescendantTraversal || requiresChildRebuild) {
-            bool parented = false;
+            bool parentedViaFrame = false;
             if (is<RenderWidget>(layer.renderer()))
-                parented = parentFrameContentLayers(downcast<RenderWidget>(layer.renderer()));
+                parentedViaFrame = parentFrameContentLayers(downcast<RenderWidget>(layer.renderer()));
 
-            if (!parented) {
+            if (!parentedViaFrame) {
                 // If the layer has a clipping layer the overflow controls layers will be siblings of the clipping layer.
                 // Otherwise, the overflow control layers are normal children.
                 if (!layerBacking->hasClippingLayer() && !layerBacking->hasScrollingLayer()) {
                     if (auto* overflowControlLayer = layerBacking->overflowControlsContainer())
                         layerChildren.append(*overflowControlLayer);
                 }
+
+                if (auto* contentsLayer = layerBacking->layerForContents())
+                    layerChildren.append(*contentsLayer);
 
                 adjustOverflowScrollbarContainerLayers(layer, compositedOverflowScrollLayers, layersClippedByScrollers, layerChildren);
                 layerBacking->parentForSublayers()->setChildren(WTFMove(layerChildren));

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -146,8 +146,6 @@ public:
     size_t decrementThreadsWaitingOnCallback() { return --m_threadsWaitingOnCallback; }
 #endif
 
-    CALayer *pluginLayer();
-
     WebCore::ScrollPosition scrollPositionForTesting() const { return scrollPosition(); }
     WebCore::Scrollbar* horizontalScrollbar() { return m_horizontalScrollbar.get(); }
     WebCore::Scrollbar* verticalScrollbar() { return m_verticalScrollbar.get(); }
@@ -189,6 +187,9 @@ private:
     String debugDescription() const override;
 
     // PDFPluginBase
+    WebCore::PluginLayerHostingStrategy layerHostingStrategy() const override { return WebCore::PluginLayerHostingStrategy::PlatformLayer; }
+    PlatformLayer* platformLayer() const override;
+
     void setView(PluginView&) override;
     void teardown() override;
     void willDetachRenderer() override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1901,7 +1901,7 @@ RefPtr<ShareableBitmap> PDFPlugin::snapshot()
     return bitmap;
 }
 
-CALayer *PDFPlugin::pluginLayer()
+PlatformLayer* PDFPlugin::platformLayer() const
 {
     return m_containerLayer.get();
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -31,6 +31,7 @@
 #include <WebCore/FindOptions.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/PluginData.h>
+#include <WebCore/PluginViewBase.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeTraits.h>
@@ -72,6 +73,10 @@ public:
 
     virtual bool isUnifiedPDFPlugin() const { return false; }
     virtual bool isLegacyPDFPlugin() const { return false; }
+
+    virtual WebCore::PluginLayerHostingStrategy layerHostingStrategy() const = 0;
+    virtual PlatformLayer* platformLayer() const { return nullptr; }
+    virtual WebCore::GraphicsLayer* graphicsLayer() const { return nullptr; }
 
     virtual bool pluginFillsViewport() const { return true; }
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -397,22 +397,41 @@ void PluginView::initializePlugin()
     }
 }
 
+PluginLayerHostingStrategy PluginView::layerHostingStrategy() const
+{
+    if (!m_isInitialized)
+        return PluginLayerHostingStrategy::None;
+
+    return m_plugin->layerHostingStrategy();
+}
+
 #if PLATFORM(COCOA)
 
 PlatformLayer* PluginView::platformLayer() const
 {
     if (!m_isInitialized)
-        return nil;
+        return nullptr;
 
 #if ENABLE(LEGACY_PDFKIT_PLUGIN)
-    if (is<PDFPlugin>(m_plugin))
-        return downcast<PDFPlugin>(m_plugin)->pluginLayer();
+    if (m_plugin->layerHostingStrategy() == PluginLayerHostingStrategy::PlatformLayer)
+        return m_plugin->platformLayer();
 #endif
 
     return nullptr;
 }
 
 #endif
+
+GraphicsLayer* PluginView::graphicsLayer() const
+{
+    if (!m_isInitialized)
+        return nullptr;
+
+    if (m_plugin->layerHostingStrategy() == PluginLayerHostingStrategy::GraphicsLayer)
+        return m_plugin->graphicsLayer();
+
+    return nullptr;
+}
 
 bool PluginView::scroll(ScrollDirection direction, ScrollGranularity granularity)
 {

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -124,7 +124,10 @@ private:
     void updateDocumentForPluginSizingBehavior();
 
     // WebCore::PluginViewBase
+    WebCore::PluginLayerHostingStrategy layerHostingStrategy() const final;
     PlatformLayer* platformLayer() const final;
+    WebCore::GraphicsLayer* graphicsLayer() const final;
+
     bool scroll(WebCore::ScrollDirection, WebCore::ScrollGranularity) final;
     WebCore::ScrollPosition scrollPositionForTesting() const final;
     WebCore::Scrollbar* horizontalScrollbar() final;


### PR DESCRIPTION
#### d02b4b36c7de77a71b82f8f39cf80e4c5fbf6c3d
<pre>
[UnifiedPDF] Make it possible to host GraphicsLayers exposed for a plug-in
<a href="https://bugs.webkit.org/show_bug.cgi?id=262819">https://bugs.webkit.org/show_bug.cgi?id=262819</a>
rdar://116601287

Reviewed by Tim Horton.

The UnifiedPDF plug-in will internally contain a GraphicsLayer hierarchy, and we need to connect
this with page GraphicsLayers. So have `PluginViewBase` expose a `PluginLayerHostingStrategy`, so
that clients can choose to access either the `platformLayer()` or the `graphicsLayer()`. Similarly,
have `PDFPluginBase` mirror this, and implement as appropriate in PDFPlugin and UnifiedPDFPlugin.

RenderLayerBacking currently expects clients to use of of the &quot;setContents&quot; functions when
a replaced object has layer contents, but now we need to parent a GraphicsLayer. We do this
in `RenderLayerCompositor::updateBackingAndHierarchy()`. This is preliminary; later changes will
ensure that we get the geometry, clipping etc correct.

* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::layerHostingStrategy const):
(WebCore::PluginViewBase::platformLayer const):
(WebCore::PluginViewBase::graphicsLayer const):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::allowsAcceleratedCompositing const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::layerForContents const):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBackingAndHierarchy):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::platformLayer const):
(WebKit::PDFPlugin::pluginLayer): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::platformLayer const):
(WebKit::PDFPluginBase::graphicsLayer const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::graphicsLayer const):
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::createGraphicsLayer):
(WebKit::UnifiedPDFPlugin::udpateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::paintContents):
(WebKit::UnifiedPDFPlugin::paint): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::layerHostingStrategy const):
(WebKit::PluginView::platformLayer const):
(WebKit::PluginView::graphicsLayer const):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/269029@main">https://commits.webkit.org/269029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3ae2f9d492fe90797976505ba131184221c7d27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/24972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21919 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24074 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25686 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23530 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20054 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19369 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5111 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/19957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->