### PR TITLE
Add invoketarget & invokeaction attributes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt
@@ -5,16 +5,16 @@ PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique
 PASS Element includes ChildNode: member names are unique
 PASS Element includes Slottable: member names are unique
-FAIL InvokeEvent interface: existence and properties of interface object assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
-FAIL InvokeEvent interface object length assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
-FAIL InvokeEvent interface object name assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
-FAIL InvokeEvent interface: existence and properties of interface prototype object assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
-FAIL InvokeEvent interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
-FAIL InvokeEvent interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
-FAIL InvokeEvent interface: attribute invoker assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
-FAIL InvokeEvent interface: attribute action assert_own_property: self does not have own property "InvokeEvent" expected property "InvokeEvent" missing
-FAIL InvokeEvent must be primary interface of new InvokeEvent("invoke") assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: InvokeEvent"
-FAIL Stringification of new InvokeEvent("invoke") assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: InvokeEvent"
-FAIL InvokeEvent interface: new InvokeEvent("invoke") must inherit property "invoker" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: InvokeEvent"
-FAIL InvokeEvent interface: new InvokeEvent("invoke") must inherit property "action" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "ReferenceError: Can't find variable: InvokeEvent"
+PASS InvokeEvent interface: existence and properties of interface object
+PASS InvokeEvent interface object length
+PASS InvokeEvent interface object name
+PASS InvokeEvent interface: existence and properties of interface prototype object
+PASS InvokeEvent interface: existence and properties of interface prototype object's "constructor" property
+PASS InvokeEvent interface: existence and properties of interface prototype object's @@unscopables property
+PASS InvokeEvent interface: attribute invoker
+PASS InvokeEvent interface: attribute action
+PASS InvokeEvent must be primary interface of new InvokeEvent("invoke")
+PASS Stringification of new InvokeEvent("invoke")
+PASS InvokeEvent interface: new InvokeEvent("invoke") must inherit property "invoker" with the proper type
+PASS InvokeEvent interface: new InvokeEvent("invoke") must inherit property "action" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
@@ -1,17 +1,15 @@
 
 
-FAIL invokeTargetElement reflects invokee HTML element assert_equals: expected (object) Element node <div id="invokee"></div> but got (undefined) undefined
-FAIL invokeTargetElement reflects set value assert_equals: expected "" but got "invokee"
-FAIL invokeTargetElement reflects set value across shadow root into light dom assert_equals: expected "" but got "invokee"
-FAIL invokeTargetElement does not reflect set value inside shadowroot assert_equals: expected null but got Element node <div></div>
-FAIL invokeTargetElement throws error on assignment of non Element assert_throws_js: invokeTargetElement attribute must be an instance of Element function "function () {
-        invoker.invokeTargetElement = {};
-      }" did not throw
-FAIL invokeAction reflects 'auto' when attribute not present assert_equals: expected (string) "auto" but got (undefined) undefined
-FAIL invokeAction reflects 'auto' when attribute empty assert_equals: expected (string) "auto" but got (undefined) undefined
-FAIL invokeAction reflects same casing assert_equals: expected "fooBarBaz" but got ""
-FAIL invokeAction reflects 'auto' when attribute empty 2 assert_equals: expected "auto" but got ""
-FAIL invokeAction reflects tostring value assert_equals: expected "1,2,3" but got ""
-FAIL invokeAction reflects 'auto' when attribute set to [] assert_equals: expected (string) "auto" but got (object) []
-FAIL invokeAction reflects tostring value 2 assert_equals: expected (string) "[object Object]" but got (object) object "[object Object]"
+PASS invokeTargetElement reflects invokee HTML element
+PASS invokeTargetElement reflects set value
+PASS invokeTargetElement reflects set value across shadow root into light dom
+PASS invokeTargetElement does not reflect set value inside shadowroot
+PASS invokeTargetElement throws error on assignment of non Element
+PASS invokeAction reflects 'auto' when attribute not present
+PASS invokeAction reflects 'auto' when attribute empty
+PASS invokeAction reflects same casing
+PASS invokeAction reflects 'auto' when attribute empty 2
+PASS invokeAction reflects tostring value
+PASS invokeAction reflects 'auto' when attribute set to []
+PASS invokeAction reflects tostring value 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL InvokeEvent propagates across shadow boundaries retargeting invoker Can't find variable: InvokeEvent
-FAIL cross shadow InvokeEvent retargets invoker to host element Can't find variable: InvokeEvent
+PASS InvokeEvent propagates across shadow boundaries retargeting invoker
+PASS cross shadow InvokeEvent retargets invoker to host element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
@@ -1,42 +1,25 @@
 
 
-FAIL action is a readonly defaulting to 'auto' Can't find variable: InvokeEvent
-FAIL invoker is readonly defaulting to null Can't find variable: InvokeEvent
-FAIL action reflects initialized attribute Can't find variable: InvokeEvent
-FAIL action set to undefined Can't find variable: InvokeEvent
-FAIL action set to null Can't find variable: InvokeEvent
-FAIL action set to false Can't find variable: InvokeEvent
-FAIL action explicitly set to empty string Can't find variable: InvokeEvent
-FAIL action set to true Can't find variable: InvokeEvent
-FAIL action set to a number Can't find variable: InvokeEvent
-FAIL action set to [] Can't find variable: InvokeEvent
-FAIL action set to [1, 2, 3] Can't find variable: InvokeEvent
-FAIL action set to an object Can't find variable: InvokeEvent
-FAIL action set to an object with a toString function Can't find variable: InvokeEvent
-FAIL InvokeEventInit properties set value Can't find variable: InvokeEvent
-FAIL InvokeEventInit properties set value 2 Can't find variable: InvokeEvent
-FAIL InvokeEventInit properties set value 3 Can't find variable: InvokeEvent
-FAIL invoker set to undefined Can't find variable: InvokeEvent
-FAIL invoker set to null Can't find variable: InvokeEvent
-FAIL invoker set to false assert_throws_js: invoker is not an object function "function () {
-        new InvokeEvent("test", { invoker: false });
-      }" threw object "ReferenceError: Can't find variable: InvokeEvent" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL invoker set to true assert_throws_js: invoker is not an object function "function () {
-        const event = new InvokeEvent("test", { invoker: true });
-      }" threw object "ReferenceError: Can't find variable: InvokeEvent" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL invoker set to {} assert_throws_js: invoker is not an object function "function () {
-        const event = new InvokeEvent("test", { invoker: {} });
-      }" threw object "ReferenceError: Can't find variable: InvokeEvent" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL invoker set to non-Element EventTarget assert_throws_js: invoker is not an Element function "function () {
-        const eventInit = { action: "closed", invoker: new XMLHttpRequest() };
-        const event = new InvokeEvent("toggle", eventInit);
-      }" threw object "ReferenceError: Can't find variable: InvokeEvent" ("ReferenceError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS action is a readonly defaulting to 'auto'
+PASS invoker is readonly defaulting to null
+PASS action reflects initialized attribute
+PASS action set to undefined
+PASS action set to null
+PASS action set to false
+PASS action explicitly set to empty string
+PASS action set to true
+PASS action set to a number
+PASS action set to []
+PASS action set to [1, 2, 3]
+PASS action set to an object
+PASS action set to an object with a toString function
+PASS InvokeEventInit properties set value
+PASS InvokeEventInit properties set value 2
+PASS InvokeEventInit properties set value 3
+PASS invoker set to undefined
+PASS invoker set to null
+PASS invoker set to false
+PASS invoker set to true
+PASS invoker set to {}
+PASS invoker set to non-Element EventTarget
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
@@ -1,8 +1,8 @@
 
 
-FAIL event dispatches on click promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: InvokeEvent"
-FAIL event action is set to invokeAction promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: InvokeEvent"
-FAIL event action is set to invokeaction attribute promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: InvokeEvent"
+PASS event dispatches on click
+PASS event action is set to invokeAction
+PASS event action is set to invokeaction attribute
 PASS event does not dispatch if click:preventDefault is called
 PASS event does not dispatch if invoker is disabled
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3461,6 +3461,20 @@ InvisibleAutoplayNotPermitted:
     WebCore:
       default: false
 
+InvokerAttributesEnabled:
+  type: bool
+  status: testable
+  category: html
+  humanReadableName: "HTML invoketarget & invokeaction attributes"
+  humanReadableDescription: "Enable HTML invoketarget & invokeaction attribute support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 IsAccessibilityIsolatedTreeEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1085,6 +1085,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/IdleRequestOptions.idl
     dom/InnerHTML.idl
     dom/InputEvent.idl
+    dom/InvokeEvent.idl
     dom/KeyboardEvent.idl
     dom/MessageChannel.idl
     dom/MessageEvent.idl
@@ -1246,6 +1247,7 @@ set(WebCore_NON_SVG_IDL_FILES
     html/ImageBitmapOptions.idl
     html/ImageData.idl
     html/ImageDataSettings.idl
+    html/InvokerElement.idl
     html/MediaController.idl
     html/MediaEncryptedEvent.idl
     html/MediaError.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1396,6 +1396,7 @@ $(PROJECT_DIR)/dom/IdleRequestCallback.idl
 $(PROJECT_DIR)/dom/IdleRequestOptions.idl
 $(PROJECT_DIR)/dom/InnerHTML.idl
 $(PROJECT_DIR)/dom/InputEvent.idl
+$(PROJECT_DIR)/dom/InvokeEvent.idl
 $(PROJECT_DIR)/dom/KeyboardEvent.idl
 $(PROJECT_DIR)/dom/MessageChannel.idl
 $(PROJECT_DIR)/dom/MessageEvent.idl
@@ -1565,6 +1566,7 @@ $(PROJECT_DIR)/html/ImageBitmap.idl
 $(PROJECT_DIR)/html/ImageBitmapOptions.idl
 $(PROJECT_DIR)/html/ImageData.idl
 $(PROJECT_DIR)/html/ImageDataSettings.idl
+$(PROJECT_DIR)/html/InvokerElement.idl
 $(PROJECT_DIR)/html/MediaController.idl
 $(PROJECT_DIR)/html/MediaEncryptedEvent.idl
 $(PROJECT_DIR)/html/MediaError.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1685,6 +1685,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIntersectionObserverCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIntersectionObserverCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIntersectionObserverEntry.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIntersectionObserverEntry.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInvokeEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSInvokeEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIterationCompositeOperation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIterationCompositeOperation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSJsonWebKey.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1093,6 +1093,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/IdleRequestOptions.idl \
     $(WebCore)/dom/InnerHTML.idl \
     $(WebCore)/dom/InputEvent.idl \
+    $(WebCore)/dom/InvokeEvent.idl \
     $(WebCore)/dom/KeyboardEvent.idl \
     $(WebCore)/dom/MessageChannel.idl \
     $(WebCore)/dom/MessageEvent.idl \
@@ -1249,6 +1250,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/ImageBitmapOptions.idl \
     $(WebCore)/html/ImageData.idl \
     $(WebCore)/html/ImageDataSettings.idl \
+    $(WebCore)/html/InvokerElement.idl \
     $(WebCore)/html/MediaController.idl \
     $(WebCore)/html/MediaEncryptedEvent.idl \
     $(WebCore)/html/MediaError.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -968,6 +968,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/GCReachableRef.h
     dom/ImageOverlay.h
     dom/InlineStyleSheetOwner.h
+    dom/InvokeEvent.h
     dom/KeyboardEvent.h
     dom/LiveNodeList.h
     dom/LiveNodeListInlines.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1113,6 +1113,7 @@ dom/ImageOverlay.cpp
 dom/InlineClassicScript.cpp
 dom/InlineStyleSheetOwner.cpp
 dom/InputEvent.cpp
+dom/InvokeEvent.cpp
 dom/KeyboardEvent.cpp
 dom/LiveNodeList.cpp
 dom/LoadableClassicScript.cpp
@@ -3797,6 +3798,7 @@ JSIntersectionObserver.cpp
 JSIntersectionObserverCallback.cpp
 JSIntersectionObserverEntry.cpp
 JSIterationCompositeOperation.cpp
+JSInvokeEvent.cpp
 JSJsonWebKey.cpp
 JSKeyboardEvent.cpp
 JSKeyframeAnimationOptions.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -272,6 +272,7 @@ namespace WebCore {
     macro(InputEvent) \
     macro(IntersectionObserver) \
     macro(IntersectionObserverEntry) \
+    macro(InvokeEvent) \
     macro(KeyframeEffect) \
     macro(Lock) \
     macro(LockManager) \

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2051,7 +2051,8 @@ static inline AtomString makeIdForStyleResolution(const AtomString& value, bool 
 bool Element::isElementReflectionAttribute(const Settings& settings, const QualifiedName& name)
 {
     return (settings.ariaReflectionForElementReferencesEnabled() && name == HTMLNames::aria_activedescendantAttr)
-        || (settings.popoverAttributeEnabled() && name == HTMLNames::popovertargetAttr);
+        || (settings.popoverAttributeEnabled() && name == HTMLNames::popovertargetAttr)
+        || (settings.invokerAttributesEnabled() && name == HTMLNames::invoketargetAttr);
 }
 
 bool Element::isElementsArrayReflectionAttribute(const Settings& settings, const QualifiedName& name)

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -111,6 +111,7 @@ public:
     virtual bool isErrorEvent() const { return false; }
     virtual bool isFocusEvent() const { return false; }
     virtual bool isInputEvent() const { return false; }
+    virtual bool isInvokeEvent() const { return false; }
     virtual bool isKeyboardEvent() const { return false; }
     virtual bool isMouseEvent() const { return false; }
     virtual bool isPointerEvent() const { return false; }

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -167,6 +167,7 @@ namespace WebCore {
     macro(inputsourceschange) \
     macro(install) \
     macro(invalid) \
+    macro(invoke) \
     macro(keydown) \
     macro(keypress) \
     macro(keystatuseschange) \

--- a/Source/WebCore/dom/EventNames.in
+++ b/Source/WebCore/dom/EventNames.in
@@ -29,6 +29,7 @@ FormDataEvent
 HashChangeEvent
 InputEvent
 InputEvents interfaceName=InputEvent
+InvokeEvent
 KeyboardEvent
 KeyboardEvents interfaceName=KeyboardEvent
 MediaQueryListEvent

--- a/Source/WebCore/dom/InvokeEvent.cpp
+++ b/Source/WebCore/dom/InvokeEvent.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InvokeEvent.h"
+
+#include "Element.h"
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(InvokeEvent);
+
+InvokeEvent::InvokeEvent(const AtomString& type, const InvokeEvent::Init& initializer, IsTrusted isTrusted)
+    : Event(type, initializer, isTrusted)
+    , m_invoker(initializer.invoker)
+    , m_action(initializer.action)
+{
+}
+
+Ref<InvokeEvent> InvokeEvent::create(const AtomString& eventType, const InvokeEvent::Init& init, IsTrusted isTrusted)
+{
+    return adoptRef(*new InvokeEvent(eventType, init, isTrusted));
+}
+
+Ref<InvokeEvent> InvokeEvent::createForBindings()
+{
+    return adoptRef(*new InvokeEvent);
+}
+
+EventInterface InvokeEvent::eventInterface() const
+{
+    return InvokeEventInterfaceType;
+}
+
+bool InvokeEvent::isInvokeEvent() const
+{
+    return true;
+}
+
+RefPtr<Element> InvokeEvent::invoker() const
+{
+    auto* invoker = m_invoker.get();
+    if (RefPtr target = dynamicDowncast<Node>(currentTarget())) {
+        auto& treeScope = target->treeScope();
+        auto node = treeScope.retargetToScope(*invoker);
+        return &downcast<Element>(node).get();
+    }
+    return invoker;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/InvokeEvent.h
+++ b/Source/WebCore/dom/InvokeEvent.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Event.h"
+#include "EventInit.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class HTMLElement;
+
+class InvokeEvent final : public Event {
+    WTF_MAKE_ISO_ALLOCATED(InvokeEvent);
+
+public:
+    struct Init : EventInit {
+        RefPtr<Element> invoker;
+        String action;
+    };
+
+    static Ref<InvokeEvent> create(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
+    static Ref<InvokeEvent> createForBindings();
+
+    RefPtr<Element> invoker() const;
+
+    String action() const { return m_action; }
+
+private:
+    InvokeEvent() = default;
+    InvokeEvent(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
+
+    EventInterface eventInterface() const final;
+    bool isInvokeEvent() const final;
+
+    void setInvoker(RefPtr<Element>&& invoker) { m_invoker = WTFMove(invoker); }
+
+    RefPtr<Element> m_invoker;
+    String m_action;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_EVENT(InvokeEvent)

--- a/Source/WebCore/dom/InvokeEvent.idl
+++ b/Source/WebCore/dom/InvokeEvent.idl
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=InvokerAttributesEnabled,
+    Exposed=Window
+] interface InvokeEvent : Event {
+    constructor([AtomString] DOMString type, optional InvokeEventInit eventInitDict);
+
+    readonly attribute Element? invoker;
+    readonly attribute DOMString action;
+};
+
+dictionary InvokeEventInit : EventInit {
+    Element? invoker = null;
+    DOMString action = "auto";
+};

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -163,6 +163,8 @@ inert
 inputmode
 integrity
 interactive
+invokeaction
+invoketarget
 is
 ismap
 keytype

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -155,6 +155,8 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
 
             if (m_type == SUBMIT || m_type == RESET)
                 event.setDefaultHandled();
+        } else if (invokeTargetElement()) {
+            handleInvokeAction();
         } else
             handlePopoverTargetAction();
     }

--- a/Source/WebCore/html/HTMLButtonElement.idl
+++ b/Source/WebCore/html/HTMLButtonElement.idl
@@ -45,3 +45,5 @@
 };
 
 HTMLButtonElement includes PopoverInvokerElement;
+
+HTMLButtonElement includes InvokerElement;

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -159,6 +159,8 @@ public:
     void setPopover(const AtomString& value) { setAttributeWithoutSynchronization(HTMLNames::popoverAttr, value); };
     void popoverAttributeChanged(const AtomString& value);
 
+    virtual void handleInvokeInternal(const AtomString&) { }
+
 #if PLATFORM(IOS_FAMILY)
     static SelectionRenderingBehavior selectionRenderingBehavior(const Node*);
 #endif

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -102,6 +102,10 @@ public:
     const AtomString& popoverTargetAction() const;
     void setPopoverTargetAction(const AtomString& value);
 
+    RefPtr<HTMLElement> invokeTargetElement() const;
+    const AtomString& invokeAction() const;
+    void setInvokeAction(const AtomString& value);
+
     using Node::ref;
     using Node::deref;
 
@@ -128,6 +132,8 @@ protected:
     void dispatchBlurEvent(RefPtr<Element>&& newFocusedElement) override;
 
     void handlePopoverTargetAction() const;
+
+    void handleInvokeAction();
 
 private:
     void refFormAssociatedElement() const final { ref(); }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1286,7 +1286,10 @@ void HTMLInputElement::defaultEventHandler(Event& event)
     // must dispatch a DOMActivate event - a click event will not do the job.
     if (event.type() == eventNames().DOMActivateEvent) {
         m_inputType->handleDOMActivateEvent(event);
-        handlePopoverTargetAction();
+        if (invokeTargetElement())
+            handleInvokeAction();
+        else
+            handlePopoverTargetAction();
         if (event.defaultHandled())
             return;
     }

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -98,3 +98,6 @@
 };
 
 HTMLInputElement includes PopoverInvokerElement;
+
+HTMLInputElement includes InvokerElement;
+

--- a/Source/WebCore/html/InvokerElement.idl
+++ b/Source/WebCore/html/InvokerElement.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[EnabledBySetting=InvokerAttributesEnabled]
+interface mixin InvokerElement {
+    [CEReactions=NotNeeded, Reflect=invoketarget] attribute Element? invokeTargetElement;
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString invokeAction;
+};


### PR DESCRIPTION
#### de91640478c442925d7cd283f91f1d1e334d1d77
<pre>
Add invoketarget &amp; invokeaction attributes

<a href="https://bugs.webkit.org/show_bug.cgi?id=262850">https://bugs.webkit.org/show_bug.cgi?id=262850</a>

Reviewed by Tim Nguyen.

This adds support for the experimental `invoketarget` and `invokeaction`
attributes, as specified in the open-ui &quot;Invokers&quot; explainer.

(<a href="https://open-ui.org/components/invokers.explainer/)">https://open-ui.org/components/invokers.explainer/)</a>

The `invoketarget` attribute maps to the IDL `invokeTargetElement`,
similar to `popoverTargetElement`, and the `invokeaction` is a freeform
string.

The Button behaviour checks for `invokeTargetElement` in its activation
behaviour, and dispatches an `InvokeEvent` if there is one.

This also adds some basic scaffolding for `handleInvokeInternal` which
will allow elements to provide their own invocation action algorithms.

Co-authored-by: Keith Cirkel &lt;keithamus@users.noreply.github.com&gt;

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isElementReflectionAttribute):
* Source/WebCore/dom/Event.h:
(WebCore::Event::isInvokeEvent const):
* Source/WebCore/dom/EventNames.h:
* Source/WebCore/dom/EventNames.in:
* Source/WebCore/dom/InvokeEvent.cpp: Added.
(WebCore::InvokeEvent::InvokeEvent):
(WebCore::InvokeEvent::create):
(WebCore::InvokeEvent::createForBindings):
(WebCore::InvokeEvent::eventInterface const):
(WebCore::InvokeEvent::isInvokeEvent const):
(WebCore::InvokeEvent::invoker const):
* Source/WebCore/dom/InvokeEvent.h: Added.
* Source/WebCore/dom/InvokeEvent.idl: Added.
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::defaultEventHandler):
* Source/WebCore/html/HTMLButtonElement.idl:
* Source/WebCore/html/HTMLElement.h:
(WebCore::HTMLElement::handleInvokeInternal):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::invokeTargetElement const):
(WebCore::HTMLFormControlElement::invokeAction const):
(WebCore::HTMLFormControlElement::setInvokeAction):
(WebCore::HTMLFormControlElement::handleInvokeAction):
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::defaultEventHandler):
* Source/WebCore/html/HTMLInputElement.idl:
* Source/WebCore/html/InvokerElement.idl: Added.

Canonical link: <a href="https://commits.webkit.org/271428@main">https://commits.webkit.org/271428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45478424edaab638033b7f0589a7a141c6785478

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28021 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23737 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23819 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28601 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22573 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29351 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25142 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27226 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4456 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32586 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6797 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3522 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7079 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->