### PR TITLE
Make MediaDeviceSandboxExtensions use generated serializations

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -525,6 +525,8 @@ set(WebKit_SERIALIZATION_IN_FILES
 
     WebProcess/GPU/webrtc/SharedVideoFrame.serialization.in
 
+    WebProcess/MediaStream/MediaDeviceSandboxExtensions.serialization.in
+
     WebProcess/Network/NetworkProcessConnectionInfo.serialization.in
 
     WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -460,6 +460,7 @@ $(PROJECT_DIR)/WebProcess/Inspector/WebInspectorInterruptDispatcher.messages.in
 $(PROJECT_DIR)/WebProcess/Inspector/WebInspectorUI.messages.in
 $(PROJECT_DIR)/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in
 $(PROJECT_DIR)/WebProcess/MediaSession/RemoteMediaSessionCoordinator.messages.in
+$(PROJECT_DIR)/WebProcess/MediaStream/MediaDeviceSandboxExtensions.serialization.in
 $(PROJECT_DIR)/WebProcess/Network/NetworkProcessConnection.messages.in
 $(PROJECT_DIR)/WebProcess/Network/NetworkProcessConnectionInfo.serialization.in
 $(PROJECT_DIR)/WebProcess/Network/WebResourceLoader.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -659,6 +659,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	WebProcess/GPU/media/RemoteMediaPlayerConfiguration.serialization.in \
 	WebProcess/GPU/media/RemoteMediaPlayerState.serialization.in \
 	WebProcess/GPU/webrtc/SharedVideoFrame.serialization.in \
+	WebProcess/MediaStream/MediaDeviceSandboxExtensions.serialization.in \
 	WebProcess/Network/NetworkProcessConnectionInfo.serialization.in \
 	WebProcess/WebCoreSupport/WebSpeechSynthesisVoice.serialization.in \
 #

--- a/Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.cpp
@@ -40,33 +40,6 @@ MediaDeviceSandboxExtensions::MediaDeviceSandboxExtensions(Vector<String> ids, V
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_ids.size() == m_handles.size());
 }
 
-void MediaDeviceSandboxExtensions::encode(IPC::Encoder& encoder) const
-{
-    encoder << m_ids;
-    encoder << m_handles;
-    encoder << m_machBootstrapHandle;
-}
-
-bool MediaDeviceSandboxExtensions::decode(IPC::Decoder& decoder, MediaDeviceSandboxExtensions& result)
-{
-    if (!decoder.decode(result.m_ids))
-        return false;
-
-    std::optional<Vector<SandboxExtension::Handle>> handles;
-    decoder >> handles;
-    if (!handles)
-        return false;
-    result.m_handles = WTFMove(*handles);
-
-    std::optional<SandboxExtension::Handle> machBootstrapHandle;
-    decoder >> machBootstrapHandle;
-    if (!machBootstrapHandle)
-        return false;
-    result.m_machBootstrapHandle = WTFMove(*machBootstrapHandle);
-
-    return true;
-}
-
 std::pair<String, RefPtr<SandboxExtension>> MediaDeviceSandboxExtensions::operator[](size_t i)
 {
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_ids.size() == m_handles.size());

--- a/Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.h
+++ b/Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.h
@@ -41,17 +41,18 @@ public:
     }
     MediaDeviceSandboxExtensions(MediaDeviceSandboxExtensions&&) = default;
     MediaDeviceSandboxExtensions& operator=(MediaDeviceSandboxExtensions&&) = default;
-    
+
     MediaDeviceSandboxExtensions(Vector<String> ids, Vector<SandboxExtension::Handle>&& handles, SandboxExtension::Handle&& machBootstrapHandle);
-    
+
     std::pair<String, RefPtr<SandboxExtension>> operator[](size_t i);
     size_t size() const;
-    
+
+    const Vector<String>& ids() const { return m_ids; }
+    const Vector<SandboxExtension::Handle>& handles() const { return m_handles; }
+    const SandboxExtension::Handle& machBootstrapHandle() const { return m_machBootstrapHandle; }
+
     RefPtr<SandboxExtension> machBootstrapExtension() { return SandboxExtension::create(WTFMove(m_machBootstrapHandle)); }
 
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, MediaDeviceSandboxExtensions&);
-    
 private:
     Vector<String> m_ids;
     Vector<SandboxExtension::Handle> m_handles;

--- a/Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.serialization.in
+++ b/Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(MEDIA_STREAM)
+
+class WebKit::MediaDeviceSandboxExtensions {
+    Vector<String> ids();
+    [Validator='ids->size() == handles->size()'] Vector<WebKit::SandboxExtension::Handle> handles();
+    WebKit::SandboxExtension::Handle machBootstrapHandle();
+}
+
+#endif


### PR DESCRIPTION
#### 238d2f5e32090fb225ebdd78a72201241cca7918
<pre>
Make MediaDeviceSandboxExtensions use generated serializations
<a href="https://bugs.webkit.org/show_bug.cgi?id=262823">https://bugs.webkit.org/show_bug.cgi?id=262823</a>

Reviewed by Alex Christensen.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.cpp:
(WebKit::MediaDeviceSandboxExtensions::encode const): Deleted.
(WebKit::MediaDeviceSandboxExtensions::decode): Deleted.
* Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.h:
(WebKit::MediaDeviceSandboxExtensions::ids const):
(WebKit::MediaDeviceSandboxExtensions::handles const):
(WebKit::MediaDeviceSandboxExtensions::machBootstrapHandle const):
* Source/WebKit/WebProcess/MediaStream/MediaDeviceSandboxExtensions.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/269121@main">https://commits.webkit.org/269121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/233f4002ccca358343bdf3cd1ee01c38fa5500af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21571 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23435 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19985 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21170 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24286 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18653 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25850 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19708 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23700 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17248 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23797 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2682 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->