### PR TITLE
[UnifiedPDF] Revert back to the fixed-size plugin

### DIFF
--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -75,13 +75,7 @@ Ref<HTMLStyleElement> PluginDocumentParser::createStyleElement(Document& documen
 {
     auto styleElement = HTMLStyleElement::create(document);
 
-    constexpr auto styleSheetContents = R"CONTENTS(
-html.plugin-fills-viewport, html.plugin-fills-viewport body, html.plugin-fills-viewport embed { width: 100%; height: 100%; }
-html.plugin-fills-viewport body { overflow: hidden; }
-body { margin: 0; }
-embed { width: 100%; }
-)CONTENTS"_s;
-
+    constexpr auto styleSheetContents = "html, body, embed { width: 100%; height: 100%; }\nbody { margin: 0; overflow: hidden; }\n"_s;
 #if PLATFORM(IOS_FAMILY)
     constexpr auto bodyBackgroundColorStyle = "body { background-color: rgb(217, 224, 233) }"_s;
 #else

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -78,8 +78,6 @@ public:
     virtual PlatformLayer* platformLayer() const { return nullptr; }
     virtual WebCore::GraphicsLayer* graphicsLayer() const { return nullptr; }
 
-    virtual bool pluginFillsViewport() const { return true; }
-
     virtual void setView(PluginView&);
 
     virtual void willDetachRenderer() { }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -46,8 +46,6 @@ private:
     WebCore::PluginLayerHostingStrategy layerHostingStrategy() const override { return WebCore::PluginLayerHostingStrategy::GraphicsLayer; }
     WebCore::GraphicsLayer* graphicsLayer() const override;
 
-    bool pluginFillsViewport() const override { return false; }
-
     void teardown() override;
 
     void createPDFDocument() override;
@@ -87,9 +85,9 @@ private:
 
     // GraphicsLayerClient
     void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
+    float deviceScaleFactor() const override;
 
-    void sizeToFitContents();
-    void udpateLayerHierarchy();
+    void updateLayerHierarchy();
 
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, GraphicsLayer::Type);
 


### PR DESCRIPTION
#### b4ec9b506ed23138c3b7dc1afad8767fc1ef0074
<pre>
[UnifiedPDF] Revert back to the fixed-size plugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=262831">https://bugs.webkit.org/show_bug.cgi?id=262831</a>
rdar://116609170

Reviewed by Tim Horton and Chris Dumez.

Undo some of 268697@main so that the UnifiedPDFPlugin once again is a fixed size; in future, it will
scroll internally as the PDFPlugin does.

So simplify the style in `PluginDocumentParser::createStyleElement()` to have the html, body and
embed all be width and height 100%, and make the document non-scrollable. Remove
`pluginFillsViewport()`. Resize the layers when we get `geometryDidChange()`.

Also ensure that the layer tree is updated when the plugin loads the PDF via a call to
`invalidateStyleAndLayerComposition()` in `PluginView::manualLoadDidFinishLoading()`.

Fix a spelling error in &quot;udpateLayerHierarchy&quot;.

* Source/WebCore/html/PluginDocument.cpp:
(WebCore::PluginDocumentParser::createStyleElement):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::pluginFillsViewport const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::deviceScaleFactor const):
(WebKit::UnifiedPDFPlugin::geometryDidChange):
(WebKit::UnifiedPDFPlugin::sizeToFitContents): Deleted.
(WebKit::UnifiedPDFPlugin::udpateLayerHierarchy): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::PluginView):
(WebKit::PluginView::manualLoadDidFinishLoading):
(WebKit::PluginView::updateDocumentForPluginSizingBehavior): Deleted.

Canonical link: <a href="https://commits.webkit.org/269048@main">https://commits.webkit.org/269048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b578419c54e43b27c625903d70511a6259a1cc07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21044 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24135 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25728 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17115 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19422 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5122 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->