### PR TITLE
Use Vector::uncheckedAppend() less in WebCore

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -84,11 +84,10 @@ ExceptionOr<Vector<Ref<ReadableStream>>> ReadableStream::tee(bool shouldClone)
 
     auto pair = result.releaseReturnValue();
 
-    Vector<Ref<ReadableStream>> sequence;
-    sequence.reserveInitialCapacity(2);
-    sequence.uncheckedAppend(ReadableStream::create(WTFMove(pair.first)));
-    sequence.uncheckedAppend(ReadableStream::create(WTFMove(pair.second)));
-    return sequence;
+    return Vector {
+        ReadableStream::create(WTFMove(pair.first)),
+        ReadableStream::create(WTFMove(pair.second))
+    };
 }
 
 JSC::JSValue JSReadableStream::cancel(JSC::JSGlobalObject& globalObject, JSC::CallFrame& callFrame)

--- a/Source/WebCore/Modules/webxr/WebXRHand.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRHand.cpp
@@ -49,11 +49,9 @@ WebXRHand::WebXRHand(const WebXRInputSource& inputSource)
         return;
 
     size_t jointCount = static_cast<size_t>(XRHandJoint::Count);
-    Vector<Ref<WebXRJointSpace>> joints;
-    joints.reserveInitialCapacity(jointCount);
-    for (size_t i = 0; i < jointCount; ++i)
-        joints.uncheckedAppend(WebXRJointSpace::create(*document, *this, static_cast<XRHandJoint>(i)));
-    m_joints = WTFMove(joints);
+    m_joints = Vector<Ref<WebXRJointSpace>>(jointCount, [&](size_t i) {
+        return WebXRJointSpace::create(*document, *this, static_cast<XRHandJoint>(i));
+    });
 }
 
 WebXRHand::~WebXRHand() = default;

--- a/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputContext.mm
@@ -97,11 +97,9 @@ Vector<OutputDevice> OutputContext::outputDevices() const
     }
 
     auto *avOutputDevices = [m_context outputDevices];
-    Vector<OutputDevice> outputDevices;
-    outputDevices.reserveInitialCapacity(avOutputDevices.count);
-    for (AVOutputDevice *device in avOutputDevices)
-        outputDevices.uncheckedAppend({ retainPtr(device) });
-    return outputDevices;
+    return Vector<OutputDevice>(avOutputDevices.count, [&](size_t i) {
+        return OutputDevice { retainPtr((AVOutputDevice *)avOutputDevices[i]) };
+    });
 }
 
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1123,14 +1123,11 @@ Vector<RefPtr<AXCoreObject>> AXObjectCache::objectsForIDs(const Vector<AXID>& ax
 {
     ASSERT(isMainThread());
 
-    Vector<RefPtr<AXCoreObject>> result;
-    result.reserveInitialCapacity(axIDs.size());
-    for (auto& axID : axIDs) {
+    return WTF::compactMap(axIDs, [&](auto& axID) -> std::optional<RefPtr<AXCoreObject>> {
         if (auto* object = objectForID(axID))
-            result.uncheckedAppend(object);
-    }
-    result.shrinkToFit();
-    return result;
+            return RefPtr { object };
+        return std::nullopt;
+    });
 }
 
 AXID AXObjectCache::getAXID(AccessibilityObject* object)

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -194,7 +194,7 @@ protected:
     bool isLabelable() const;
     AccessibilityObject* correspondingControlForLabelElement() const override;
     AccessibilityObject* correspondingLabelForControlElement() const override;
-    String textForLabelElements(Vector<HTMLLabelElement*>&&) const;
+    String textForLabelElements(Vector<Ref<HTMLLabelElement>>&&) const;
     HTMLLabelElement* labelElementContainer() const;
 
     String ariaAccessibilityDescription() const;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -471,12 +471,11 @@ const AXCoreObject::AccessibilityChildrenVector& AXIsolatedObject::children(bool
         protectedThis = this;
         updateBackingStore();
 
-        m_children.clear();
-        m_children.reserveInitialCapacity(m_childrenIDs.size());
-        for (const auto& childID : m_childrenIDs) {
+        m_children = WTF::compactMap(m_childrenIDs, [&](auto& childID) -> std::optional<RefPtr<AXCoreObject>> {
             if (RefPtr child = tree()->objectForID(childID))
-                m_children.uncheckedAppend(child);
-        }
+                return child;
+            return std::nullopt;
+        });
         ASSERT(m_children.size() == m_childrenIDs.size());
     }
     return m_children;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -350,14 +350,13 @@ Vector<AXIsolatedTree::NodeChange> AXIsolatedTree::resolveAppends()
     if (!cache)
         return { };
 
-    Vector<NodeChange> resolvedAppends;
-    resolvedAppends.reserveInitialCapacity(m_unresolvedPendingAppends.size());
-    for (const auto& unresolvedAppend : m_unresolvedPendingAppends) {
+    auto resolvedAppends = WTF::compactMap(m_unresolvedPendingAppends, [&](auto& unresolvedAppend) -> std::optional<NodeChange> {
         if (auto* axObject = cache->objectForID(unresolvedAppend.key)) {
             if (auto nodeChange = nodeChangeForObject(*axObject, unresolvedAppend.value))
-                resolvedAppends.uncheckedAppend(WTFMove(*nodeChange));
+                return *nodeChange;
         }
-    }
+        return std::nullopt;
+    });
     m_unresolvedPendingAppends.clear();
 
     return resolvedAppends;

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3958,16 +3958,13 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         if (!shorthand.length())
             continue;
 
-        Vector<AnimationPropertyWrapperBase*> longhandWrappers;
-        longhandWrappers.reserveInitialCapacity(shorthand.length());
-        for (auto longhand : shorthand) {
+        auto longhandWrappers = WTF::compactMap(shorthand, [&](auto longhand) -> std::optional<AnimationPropertyWrapperBase*> {
             unsigned wrapperIndex = indexFromPropertyID(longhand);
             if (wrapperIndex == cInvalidPropertyWrapperIndex)
-                continue;
+                return std::nullopt;
             ASSERT(m_propertyWrappers[wrapperIndex]);
-            longhandWrappers.uncheckedAppend(m_propertyWrappers[wrapperIndex].get());
-        }
-        longhandWrappers.shrinkToFit();
+            return m_propertyWrappers[wrapperIndex].get();
+        });
 
         m_propertyWrappers.uncheckedAppend(makeUnique<ShorthandPropertyWrapper>(propertyID, WTFMove(longhandWrappers)));
         indexFromPropertyID(propertyID) = animatableLonghandPropertiesCount + i;

--- a/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
@@ -182,8 +182,7 @@ static void addUniversalActionsToDFA(DFA& dfa, UniversalActionSet&& universalAct
     ASSERT(!root.actionsLength());
     unsigned actionsStart = dfa.actions.size();
     dfa.actions.reserveCapacity(dfa.actions.size() + universalActions.size());
-    for (uint64_t action : universalActions)
-        dfa.actions.uncheckedAppend(action);
+    dfa.actions.appendRange(universalActions.begin(), universalActions.end());
     unsigned actionsEnd = dfa.actions.size();
 
     unsigned actionsLength = actionsEnd - actionsStart;

--- a/Source/WebCore/contentextensions/DFAMinimizer.cpp
+++ b/Source/WebCore/contentextensions/DFAMinimizer.cpp
@@ -475,10 +475,7 @@ void DFAMinimizer::minimize(DFA& dfa)
     // Use every splitter to refine the node partitions.
     fullGraphPartition.splitByUniqueTransitions();
 
-    Vector<unsigned> relocationVector;
-    relocationVector.reserveInitialCapacity(dfa.nodes.size());
-    for (unsigned i = 0; i < dfa.nodes.size(); ++i)
-        relocationVector.uncheckedAppend(i);
+    Vector<unsigned> relocationVector(dfa.nodes.size(), [](size_t i) { return i; });
 
     // Update all the transitions.
     for (unsigned i = 0; i < dfa.nodes.size(); ++i) {

--- a/Source/WebCore/contentextensions/DFANode.cpp
+++ b/Source/WebCore/contentextensions/DFANode.cpp
@@ -38,11 +38,9 @@ namespace ContentExtensions {
 Vector<uint64_t> DFANode::actions(const DFA& dfa) const
 {
     // FIXME: Use iterators instead of copying the Vector elements.
-    Vector<uint64_t> vector;
-    vector.reserveInitialCapacity(m_actionsLength);
-    for (uint32_t i = m_actionsStart; i < m_actionsStart + m_actionsLength; ++i)
-        vector.uncheckedAppend(dfa.actions[i]);
-    return vector;
+    return Vector<uint64_t>(m_actionsLength, [&](size_t i) {
+        return dfa.actions[m_actionsStart + i];
+    });
 }
 
 bool DFANode::containsTransition(char transition, const DFA& dfa) const

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -211,11 +211,9 @@ bool CSSValueContainingVector::hasValue(CSSValueID otherValue) const
 
 CSSValueListBuilder CSSValueContainingVector::copyValues() const
 {
-    CSSValueListBuilder builder;
-    builder.reserveInitialCapacity(size());
-    for (auto& value : *this)
-        builder.uncheckedAppend(const_cast<CSSValue&>(value));
-    return builder;
+    return WTF::map<CSSValueListBuilderInlineCapacity>(*this, [](auto& value) -> Ref<CSSValue> {
+        return const_cast<CSSValue&>(value);
+    });
 }
 
 void CSSValueContainingVector::serializeItems(StringBuilder& builder) const

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -26,7 +26,8 @@
 
 namespace WebCore {
 
-using CSSValueListBuilder = Vector<Ref<CSSValue>, 4>;
+static constexpr size_t CSSValueListBuilderInlineCapacity = 4;
+using CSSValueListBuilder = Vector<Ref<CSSValue>, CSSValueListBuilderInlineCapacity>;
 
 class CSSValueContainingVector : public CSSValue {
 public:

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -63,12 +63,11 @@ CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSPars
     : m_context(context)
 {
     StringBuilder stringBuilder;
-    m_tokens.reserveInitialCapacity(range.end() - range.begin());
-    for (auto& token : range) {
-        m_tokens.uncheckedAppend(token);
+    m_tokens = WTF::map(range, [&](auto& token) {
         if (token.hasStringBacking())
             stringBuilder.append(token.value());
-    }
+        return token;
+    });
     if (!stringBuilder.isEmpty()) {
         m_backingString = stringBuilder.toString();
         if (m_backingString.is8Bit())

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4532,13 +4532,11 @@ Ref<CSSValueList> ComputedStyleExtractor::getCSSPropertyValuesForGridShorthand(c
 
 Ref<MutableStyleProperties> ComputedStyleExtractor::copyProperties(std::span<const CSSPropertyID> properties) const
 {
-    Vector<CSSProperty> vector;
-    vector.reserveInitialCapacity(properties.size());
-    for (auto property : properties) {
+    auto vector = WTF::compactMap(properties, [&](auto& property) -> std::optional<CSSProperty> {
         if (auto value = propertyValue(property))
-            vector.uncheckedAppend(CSSProperty(property, WTFMove(value), false));
-    }
-    vector.shrinkToFit();
+            return CSSProperty(property, WTFMove(value), false);
+        return std::nullopt;
+    });
     return MutableStyleProperties::create(WTFMove(vector));
 }
 

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -364,13 +364,11 @@ Ref<MutableStyleProperties> StyleProperties::mutableCopy() const
 
 Ref<MutableStyleProperties> StyleProperties::copyProperties(std::span<const CSSPropertyID> properties) const
 {
-    Vector<CSSProperty> vector;
-    vector.reserveInitialCapacity(properties.size());
-    for (auto property : properties) {
+    auto vector = WTF::compactMap(properties, [&](auto& property) -> std::optional<CSSProperty> {
         if (auto value = getPropertyCSSValue(property))
-            vector.uncheckedAppend(CSSProperty(property, WTFMove(value), false));
-    }
-    vector.shrinkToFit();
+            return CSSProperty(property, WTFMove(value), false);
+        return std::nullopt;
+    });
     return MutableStyleProperties::create(WTFMove(vector));
 }
 

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -56,6 +56,8 @@ public:
     bool atEnd() const { return m_first == m_last; }
     const CSSParserToken* end() const { return m_last; }
 
+    size_t size() const { return end() - begin(); }
+
     const CSSParserToken& peek(unsigned offset = 0) const
     {
         if (m_first + offset >= m_last)

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp
@@ -69,11 +69,10 @@ auto HashMapStylePropertyMapReadOnly::entries(ScriptExecutionContext* context) c
     if (!document)
         return { };
 
-    Vector<StylePropertyMapEntry> result;
-    result.reserveInitialCapacity(m_map.size());
-    for (auto& [propertyName, cssValue] : m_map)
-        result.uncheckedAppend(makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), cssPropertyID(propertyName), *document) }));
-    return result;
+    return WTF::map(m_map, [&](auto& entry) -> StylePropertyMapEntry {
+        auto& [propertyName, cssValue] = entry;
+        return makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), cssPropertyID(propertyName), *document) });
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
@@ -77,11 +77,9 @@ Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(RefPt
         return { StylePropertyMapReadOnly::reifyValue(WTFMove(value), propertyID, document) };
 
     auto& valueList = downcast<CSSValueList>(*value);
-    Vector<RefPtr<CSSStyleValue>> result;
-    result.reserveInitialCapacity(valueList.length());
-    for (auto& item : valueList)
-        result.uncheckedAppend(StylePropertyMapReadOnly::reifyValue(Ref { const_cast<CSSValue&>(item) }, propertyID, document));
-    return result;
+    return WTF::map(valueList, [&](auto& item) {
+        return StylePropertyMapReadOnly::reifyValue(Ref { const_cast<CSSValue&>(item) }, propertyID, document);
+    });
 }
 
 StylePropertyMapReadOnly::Iterator::Iterator(StylePropertyMapReadOnly& map, ScriptExecutionContext* context)

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -4168,13 +4168,11 @@ void SelectorCodeGenerator::generateElementIsNthChild(Assembler::JumpList& failu
 {
     generateNthChildRelationUpdate(fragment);
 
-    Vector<std::pair<int, int>, 32> validSubsetFilters;
-    validSubsetFilters.reserveInitialCapacity(fragment.nthChildFilters.size());
-    for (const auto& slot : fragment.nthChildFilters) {
+    auto validSubsetFilters = WTF::compactMap<32>(fragment.nthChildFilters, [&](auto& slot) -> std::optional<std::pair<int, int>> {
         if (nthFilterIsAlwaysSatisified(slot.first, slot.second))
-            continue;
-        validSubsetFilters.uncheckedAppend(slot);
-    }
+            return std::nullopt;
+        return slot;
+    });
     if (validSubsetFilters.isEmpty())
         return;
 
@@ -4296,13 +4294,11 @@ void SelectorCodeGenerator::generateElementIsNthLastChild(Assembler::JumpList& f
 {
     generateNthLastChildParentCheckAndRelationUpdate(failureCases, fragment);
 
-    Vector<std::pair<int, int>, 32> validSubsetFilters;
-    validSubsetFilters.reserveInitialCapacity(fragment.nthLastChildFilters.size());
-    for (const auto& slot : fragment.nthLastChildFilters) {
+    auto validSubsetFilters = WTF::compactMap<32>(fragment.nthLastChildFilters, [&](auto& slot) -> std::optional<std::pair<int, int>> {
         if (nthFilterIsAlwaysSatisified(slot.first, slot.second))
-            continue;
-        validSubsetFilters.uncheckedAppend(slot);
-    }
+            return std::nullopt;
+        return slot;
+    });
     if (validSubsetFilters.isEmpty())
         return;
 

--- a/Source/WebCore/dom/ComposedTreeIterator.h
+++ b/Source/WebCore/dom/ComposedTreeIterator.h
@@ -86,8 +86,8 @@ private:
 };
 
 inline ComposedTreeIterator::ComposedTreeIterator()
+    : m_contextStack({ Context { } })
 {
-    m_contextStack.uncheckedAppend({ });
 }
 
 inline ComposedTreeIterator& ComposedTreeIterator::traverseNext()

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -763,15 +763,13 @@ AtomString Element::getAttributeForBindings(const QualifiedName& name, ResolveUR
 
 Vector<String> Element::getAttributeNames() const
 {
-    Vector<String> attributesVector;
     if (!hasAttributes())
-        return attributesVector;
+        return { };
 
     auto attributes = attributesIterator();
-    attributesVector.reserveInitialCapacity(attributes.attributeCount());
-    for (auto& attribute : attributes)
-        attributesVector.uncheckedAppend(attribute.name().toString());
-    return attributesVector;
+    return WTF::map(attributes, [](auto& attribute) {
+        return attribute.name().toString();
+    });
 }
 
 bool Element::hasFocusableStyle() const

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -48,6 +48,13 @@ public:
     const Attribute& operator*() const { return m_array[m_offset]; }
     const Attribute* operator->() const { return &m_array[m_offset]; }
     AttributeConstIterator& operator++() { ++m_offset; return *this; }
+    AttributeConstIterator& operator--() { ++m_offset; return *this; }
+
+    using difference_type = ptrdiff_t;
+    using value_type = Attribute;
+    using pointer = const Attribute*;
+    using reference = const Attribute&;
+    using iterator_category = std::random_access_iterator_tag;
 
     bool operator==(const AttributeConstIterator& other) const { return m_offset == other.m_offset; }
 
@@ -67,6 +74,7 @@ public:
     AttributeConstIterator begin() const { return AttributeConstIterator(m_array, 0); }
     AttributeConstIterator end() const { return AttributeConstIterator(m_array, m_size); }
 
+    unsigned size() const { return m_size; }
     unsigned attributeCount() const { return m_size; }
 
 private:

--- a/Source/WebCore/dom/TouchList.h
+++ b/Source/WebCore/dom/TouchList.h
@@ -61,9 +61,9 @@ private:
 
     explicit TouchList(FixedVector<std::reference_wrapper<Touch>>&& touches)
     {
-        m_values.reserveInitialCapacity(touches.size());
-        for (auto& touch : touches)
-            m_values.uncheckedAppend(touch.get());
+        m_values = WTF::map(touches, [](auto& touch) -> Ref<Touch> {
+            return touch.get();
+        });
     }
 
     Vector<Ref<Touch>> m_values;

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -448,11 +448,9 @@ void FileInputType::filesChosen(const Vector<String>& paths, const Vector<String
 
     size_t size = element()->hasAttributeWithoutSynchronization(multipleAttr) ? paths.size() : 1;
 
-    Vector<FileChooserFileInfo> files;
-    files.reserveInitialCapacity(size);
-
-    for (size_t i = 0; i < size; ++i)
-        files.uncheckedAppend({ paths[i], i < replacementPaths.size() ? replacementPaths[i] : nullString(), { } });
+    Vector<FileChooserFileInfo> files(size, [&](size_t i) {
+        return FileChooserFileInfo { paths[i], i < replacementPaths.size() ? replacementPaths[i] : nullString(), { } };
+    });
 
     filesChosen(WTFMove(files));
 }

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -336,18 +336,15 @@ ExceptionOr<void> HTMLFormElement::requestSubmit(HTMLElement* submitter)
 
 StringPairVector HTMLFormElement::textFieldValues() const
 {
-    StringPairVector result;
-    result.reserveInitialCapacity(m_listedElements.size());
-    for (auto& weakElement : m_listedElements) {
+    return WTF::compactMap(m_listedElements, [](auto& weakElement) -> std::optional<std::pair<String, String>> {
         RefPtr element { weakElement.get() };
         if (!is<HTMLInputElement>(element))
-            continue;
+            return std::nullopt;
         auto& input = downcast<HTMLInputElement>(*element);
         if (!input.isTextField())
-            continue;
-        result.uncheckedAppend({ input.name().string(), input.value() });
-    }
-    return result;
+            return std::nullopt;
+        return std::pair { input.name().string(), input.value() };
+    });
 }
 
 RefPtr<HTMLFormControlElement> HTMLFormElement::findSubmitButton(HTMLFormControlElement* submitter, bool needButtonActivation)

--- a/Source/WebCore/html/LinkIconCollector.cpp
+++ b/Source/WebCore/html/LinkIconCollector.cpp
@@ -102,9 +102,10 @@ auto LinkIconCollector::iconsOfTypes(OptionSet<LinkIconType> iconTypes) -> Vecto
 
         Vector<std::pair<String, String>> attributes;
         if (linkElement.hasAttributes()) {
-            attributes.reserveInitialCapacity(linkElement.attributeCount());
-            for (auto& attribute : linkElement.attributesIterator())
-                attributes.uncheckedAppend({ attribute.localName(), attribute.value() });
+            auto attributesAccessor = linkElement.attributesIterator();
+            attributes = WTF::map(attributesAccessor, [](auto& attribute) -> std::pair<String, String> {
+                return { attribute.localName(), attribute.value() };
+            });
         }
 
         icons.append({ url, iconType, linkElement.type(), iconSize, WTFMove(attributes) });

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2596,14 +2596,12 @@ void DocumentLoader::setActiveContentRuleListActionPatterns(const HashMap<String
     MemoryCompactRobinHoodHashMap<String, Vector<UserContentURLPattern>> parsedPatternMap;
 
     for (auto& pair : patterns) {
-        Vector<UserContentURLPattern> patternVector;
-        patternVector.reserveInitialCapacity(pair.value.size());
-        for (auto& patternString : pair.value) {
+        auto patternVector = WTF::compactMap(pair.value, [](auto& patternString) -> std::optional<UserContentURLPattern> {
             UserContentURLPattern parsedPattern(patternString);
             if (parsedPattern.isValid())
-                patternVector.uncheckedAppend(WTFMove(parsedPattern));
-        }
-        patternVector.shrinkToFit();
+                return parsedPattern;
+            return std::nullopt;
+        });
         parsedPatternMap.set(pair.key, WTFMove(patternVector));
     }
 

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -162,12 +162,11 @@ void CachedRawResource::didAddClient(CachedResourceClient& c)
 {
     auto& client = downcast<CachedRawResourceClient>(c);
     size_t redirectCount = m_redirectChain.size();
-    Vector<std::pair<ResourceRequest, ResourceResponse>> redirectsInReverseOrder;
-    redirectsInReverseOrder.reserveInitialCapacity(redirectCount);
-    for (size_t i = 0; i < redirectCount; ++i) {
+    Vector<std::pair<ResourceRequest, ResourceResponse>> redirectsInReverseOrder(redirectCount, [&](size_t i) {
         const auto& pair = m_redirectChain[redirectCount - i - 1];
-        redirectsInReverseOrder.uncheckedAppend(std::make_pair(pair.m_request, pair.m_redirectResponse));
-    }
+        return std::pair<ResourceRequest, ResourceResponse> { pair.m_request, pair.m_redirectResponse };
+    });
+
     iterateRedirects(CachedResourceHandle<CachedRawResource>(this), client, WTFMove(redirectsInReverseOrder), [this, protectedThis = CachedResourceHandle<CachedRawResource>(this), client = WeakPtr { client }] (ResourceRequest&&) mutable {
         if (!client || !hasClient(*client))
             return;

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -401,14 +401,11 @@ void ServicesOverlayController::buildSelectionHighlight()
         if (!viewForRange)
             return;
 
-        Vector<CGRect> cgRects;
-        cgRects.reserveInitialCapacity(m_currentSelectionRects.size());
-
-        for (auto& rect : m_currentSelectionRects) {
+        auto cgRects = WTF::map(m_currentSelectionRects, [&](auto& rect) -> CGRect {
             IntRect currentRect = snappedIntRect(rect);
             currentRect.setLocation(mainFrameView->windowToContents(viewForRange->contentsToWindow(currentRect.location())));
-            cgRects.uncheckedAppend(currentRect);
-        }
+            return currentRect;
+        });
 
         if (!cgRects.isEmpty()) {
             CGRect visibleRect = mainFrameView->visibleContentRect();

--- a/Source/WebCore/platform/FileChooser.cpp
+++ b/Source/WebCore/platform/FileChooser.cpp
@@ -61,10 +61,9 @@ void FileChooser::chooseFiles(const Vector<String>& filenames, const Vector<Stri
     if (!m_client)
         return;
 
-    Vector<FileChooserFileInfo> files;
-    files.reserveInitialCapacity(filenames.size());
-    for (size_t i = 0, size = filenames.size(); i < size; ++i)
-        files.uncheckedAppend({ filenames[i], i < replacementNames.size() ? replacementNames[i] : nullString(), { } });
+    Vector<FileChooserFileInfo> files(filenames.size(), [&](size_t i) {
+        return FileChooserFileInfo { filenames[i], i < replacementNames.size() ? replacementNames[i] : nullString(), { } };
+    });
     m_client->filesChosen(WTFMove(files));
 }
 

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -253,9 +253,9 @@ Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::copy() const
         return m_segments.size() ? SharedBuffer::create(m_segments[0].segment.copyRef()) : SharedBuffer::create();
     Ref<FragmentedSharedBuffer> clone = adoptRef(*new FragmentedSharedBuffer);
     clone->m_size = m_size;
-    clone->m_segments.reserveInitialCapacity(m_segments.size());
-    for (const auto& element : m_segments)
-        clone->m_segments.uncheckedAppend({ element.beginPosition, element.segment.copyRef() });
+    clone->m_segments = WTF::map<1>(m_segments, [](auto& element) {
+        return DataSegmentVectorEntry { element.beginPosition, element.segment.copyRef() };
+    });
     ASSERT(clone->internallyConsistent());
     ASSERT(internallyConsistent());
     return clone;

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -42,9 +42,7 @@ AcceleratedEffectValues::AcceleratedEffectValues(const AcceleratedEffectValues& 
 
     auto& transformOperations = transform.operations();
     auto& srcTransformOperations = src.transform.operations();
-    transformOperations.reserveCapacity(srcTransformOperations.size());
-    for (auto& srcTransformOperation : srcTransformOperations)
-        transformOperations.uncheckedAppend(srcTransformOperation.copyRef());
+    transformOperations.appendVector(srcTransformOperations);
 
     translate = src.translate.copyRef();
     scale = src.scale.copyRef();

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -55,12 +55,9 @@ RefPtr<AudioBus> AudioBus::create(unsigned numberOfChannels, size_t length, bool
 AudioBus::AudioBus(unsigned numberOfChannels, size_t length, bool allocate)
     : m_length(length)
 {
-    m_channels.reserveInitialCapacity(numberOfChannels);
-
-    for (unsigned i = 0; i < numberOfChannels; ++i) {
-        auto channel = allocate ? makeUnique<AudioChannel>(length) : makeUnique<AudioChannel>(nullptr, length);
-        m_channels.uncheckedAppend(WTFMove(channel));
-    }
+    m_channels = Vector<std::unique_ptr<AudioChannel>>(numberOfChannels, [&](size_t) {
+        return allocate ? makeUnique<AudioChannel>(length) : makeUnique<AudioChannel>(nullptr, length);
+    });
 
     m_layout = LayoutCanonical; // for now this is the only layout we define
 }

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
@@ -56,9 +56,9 @@ void AudioDSPKernelProcessor::initialize()
         DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
 
         // Create processing kernels, one per channel.
-        m_kernels.reserveInitialCapacity(numberOfChannels());
-        for (unsigned i = 0; i < numberOfChannels(); ++i)
-            m_kernels.uncheckedAppend(createKernel());
+        m_kernels = Vector<std::unique_ptr<AudioDSPKernel>>(numberOfChannels(), [this](size_t) {
+            return createKernel();
+        });
     }
     m_initialized = true;
     m_hasJustReset = true;

--- a/Source/WebCore/platform/audio/AudioResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioResampler.cpp
@@ -42,9 +42,9 @@ AudioResampler::AudioResampler()
 
 AudioResampler::AudioResampler(unsigned numberOfChannels)
 {
-    m_kernels.reserveInitialCapacity(numberOfChannels);
-    for (unsigned i = 0; i < numberOfChannels; ++i)
-        m_kernels.uncheckedAppend(makeUnique<AudioResamplerKernel>(this));
+    m_kernels = Vector<std::unique_ptr<AudioResamplerKernel>>(numberOfChannels, [&](size_t) {
+        return makeUnique<AudioResamplerKernel>(this);
+    });
 
     m_sourceBus = AudioBus::create(numberOfChannels, 0, false);
 }

--- a/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
@@ -60,10 +60,9 @@ void DynamicsCompressorKernel::setNumberOfChannels(unsigned numberOfChannels)
     if (m_preDelayBuffers.size() == numberOfChannels)
         return;
 
-    m_preDelayBuffers.clear();
-    m_preDelayBuffers.reserveInitialCapacity(numberOfChannels);
-    for (unsigned i = 0; i < numberOfChannels; ++i)
-        m_preDelayBuffers.uncheckedAppend(makeUnique<AudioFloatArray>(MaxPreDelayFrames));
+    m_preDelayBuffers = Vector<std::unique_ptr<AudioFloatArray>>(numberOfChannels, [](size_t) {
+        return makeUnique<AudioFloatArray>(MaxPreDelayFrames);
+    });
 }
 
 void DynamicsCompressorKernel::setPreDelayTime(float preDelayTime)

--- a/Source/WebCore/platform/audio/MultiChannelResampler.cpp
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.cpp
@@ -54,9 +54,9 @@ MultiChannelResampler::MultiChannelResampler(double scaleFactor, unsigned number
     }
 
     // Create each channel's resampler.
-    m_kernels.reserveInitialCapacity(numberOfChannels);
-    for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex)
-        m_kernels.uncheckedAppend(makeUnique<SincResampler>(scaleFactor, requestFrames, std::bind(&MultiChannelResampler::provideInputForChannel, this, std::placeholders::_1, std::placeholders::_2, channelIndex)));
+    m_kernels = Vector<std::unique_ptr<SincResampler>>(numberOfChannels, [&](size_t channelIndex) {
+        return makeUnique<SincResampler>(scaleFactor, requestFrames, std::bind(&MultiChannelResampler::provideInputForChannel, this, std::placeholders::_1, std::placeholders::_2, channelIndex));
+    });
 }
 
 MultiChannelResampler::~MultiChannelResampler() = default;

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -152,20 +152,20 @@ void ComplexTextController::finishConstruction()
 
     if (!m_isLTROnly) {
         unsigned length = m_complexTextRuns.size();
-        m_runIndices.reserveInitialCapacity(length);
-        for (unsigned i = 0; i < length; ++i)
-            m_runIndices.uncheckedAppend(length - i - 1);
+        m_runIndices = Vector<unsigned, 16>(length, [&](size_t i) {
+            return length - i - 1;
+        });
         std::sort(m_runIndices.data(), m_runIndices.data() + length,
             [this](auto a, auto b) {
                 return stringBegin(*m_complexTextRuns[a]) < stringBegin(*m_complexTextRuns[b]);
             });
 
-        m_glyphCountFromStartToIndex.reserveInitialCapacity(length);
         unsigned glyphCountSoFar = 0;
-        for (unsigned i = 0; i < length; ++i) {
-            m_glyphCountFromStartToIndex.uncheckedAppend(glyphCountSoFar);
+        m_glyphCountFromStartToIndex = Vector<unsigned, 16>(length, [&](size_t i) {
+            auto glyphCountThisTime = glyphCountSoFar;
             glyphCountSoFar += m_complexTextRuns[i]->glyphCount();
-        }
+            return glyphCountThisTime;
+        });
     }
 }
 

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -317,12 +317,11 @@ void FontCache::purgeInactiveFontData(unsigned purgeCount)
         }
     };
 
-    Vector<FontPlatformDataCacheKey> keysToRemove;
-    keysToRemove.reserveInitialCapacity(m_fontDataCaches->platformData.size());
-    for (auto& entry : m_fontDataCaches->platformData) {
+    auto keysToRemove = WTF::compactMap(m_fontDataCaches->platformData, [&](auto& entry) -> std::optional<FontPlatformDataCacheKey> {
         if (entry.value && !m_fontDataCaches->data.contains(*entry.value))
-            keysToRemove.uncheckedAppend(entry.key);
-    }
+            return entry.key;
+        return std::nullopt;
+    });
 
     LOG(Fonts, " removing %lu keys", keysToRemove.size());
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -419,14 +419,12 @@ Vector<LayoutRect> FontCascade::characterSelectionRectsForText(const TextRun& ru
 
     bool rtl = run.rtl();
 
-    Vector<LayoutRect> characterRects;
-    characterRects.reserveInitialCapacity(to - from);
-
     // FIXME: We could further optimize this by using the simple text codepath when applicable.
     ComplexTextController controller(*this, run);
     controller.advance(from);
 
-    for (auto current = from + 1; current <= to; ++current) {
+    return Vector<LayoutRect>(to - from, [&](size_t i) {
+        auto current = from + i + 1;
         auto characterRect = selectionRect;
         auto beforeWidth = controller.runWidthSoFar();
 
@@ -435,10 +433,8 @@ Vector<LayoutRect> FontCascade::characterSelectionRectsForText(const TextRun& ru
 
         characterRect.move(rtl ? controller.totalAdvance().width() - afterWidth : beforeWidth, 0);
         characterRect.setWidth(LayoutUnit::fromFloatCeil(afterWidth - beforeWidth));
-        characterRects.uncheckedAppend(WTFMove(characterRect));
-    }
-
-    return characterRects;
+        return characterRect;
+    });
 }
 
 void FontCascade::adjustSelectionRectForText(const TextRun& run, LayoutRect& selectionRect, unsigned from, std::optional<unsigned> to) const

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -90,15 +90,13 @@ void FontCascadeCache::pruneSystemFallbackFonts()
 
 static FontCascadeCacheKey makeFontCascadeCacheKey(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
-    FontCascadeCacheKey key;
-    key.fontDescriptionKey = FontDescriptionKey(description);
     unsigned familyCount = description.familyCount();
-    key.families.reserveInitialCapacity(familyCount);
-    for (unsigned i = 0; i < familyCount; ++i)
-        key.families.uncheckedAppend(description.familyAt(i));
-    key.fontSelectorId = fontSelector ? fontSelector->uniqueId() : 0;
-    key.fontSelectorVersion = fontSelector ? fontSelector->version() : 0;
-    return key;
+    return FontCascadeCacheKey {
+        FontDescriptionKey(description),
+        Vector<FontFamilyName, 3>(familyCount, [&](size_t i) { return description.familyAt(i); }),
+        fontSelector ? fontSelector->uniqueId() : 0,
+        fontSelector ? fontSelector->version() : 0
+    };
 }
 
 Ref<FontCascadeFonts> FontCascadeCache::retrieveOrAddCachedFonts(const FontCascadeDescription& fontDescription, RefPtr<FontSelector>&& fontSelector)

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -227,9 +227,9 @@ public:
     KeyframeValueList(const KeyframeValueList& other)
         : m_property(other.property())
     {
-        m_values.reserveInitialCapacity(other.m_values.size());
-        for (auto& value : other.m_values)
-            m_values.uncheckedAppend(value->clone());
+        m_values = WTF::map(other.m_values, [](auto& value) -> std::unique_ptr<const AnimationValue> {
+            return value->clone();
+        });
     }
 
     KeyframeValueList(KeyframeValueList&&) = default;

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -309,9 +309,7 @@ Vector<Path> PathUtilities::pathsWithShrinkWrappedRects(const Vector<FloatRect>&
         return { WTFMove(path) };
     }
 
-    Vector<Path> paths;
-    paths.reserveInitialCapacity(polys.size());
-    for (auto& poly : polys) {
+    return WTF::map(polys, [&](auto& poly) {
         Path path;
         for (unsigned i = 0; i < poly.size(); ++i) {
             FloatPointGraph::Edge& toEdge = poly[i];
@@ -342,9 +340,8 @@ Vector<Path> PathUtilities::pathsWithShrinkWrappedRects(const Vector<FloatRect>&
             path.addArcTo(*fromEdge.second, *toEdge.first + toOffset, clampedRadius);
         }
         path.closeSubpath();
-        paths.uncheckedAppend(WTFMove(path));
-    }
-    return paths;
+        return path;
+    });
 }
 
 Path PathUtilities::pathWithShrinkWrappedRects(const Vector<FloatRect>& rects, float radius)

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -110,11 +110,9 @@ void SourceBufferPrivate::setBufferedRanges(PlatformTimeRanges&& timeRanges, Com
 
 Vector<PlatformTimeRanges> SourceBufferPrivate::trackBuffersRanges() const
 {
-    Vector<PlatformTimeRanges> trackBuffers;
-    trackBuffers.reserveInitialCapacity(m_trackBufferMap.size());
-    for (auto&& trackBuffer : m_trackBufferMap.values())
-        trackBuffers.uncheckedAppend(trackBuffer->buffered());
-    return trackBuffers;
+    return WTF::map(m_trackBufferMap.values(), [](auto& trackBuffer) {
+        return trackBuffer->buffered();
+    });
 }
 
 void SourceBufferPrivate::clientReadyStateChanged(bool sourceIsEnded)

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -106,22 +106,17 @@ static Vector<Ref<SharedBuffer>> extractSinfData(const SharedBuffer& buffer)
     if (!sinfArray)
         return { };
 
-    Vector<Ref<SharedBuffer>> sinfs;
-    sinfs.reserveInitialCapacity(sinfArray->length());
-
-    for (auto& value : *sinfArray) {
+    return WTF::compactMap(*sinfArray, [](auto& value) -> RefPtr<SharedBuffer> {
         auto keyID = value->asString();
         if (!keyID)
-            continue;
+            return nullptr;
 
         auto sinfData = base64Decode(keyID, Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
         if (!sinfData)
-            continue;
+            return nullptr;
 
-        sinfs.uncheckedAppend(SharedBuffer::create(WTFMove(*sinfData)));
-    }
-
-    return sinfs;
+        return SharedBuffer::create(WTFMove(*sinfData));
+    });
 }
 
 using SchemeAndKeyResult = Vector<std::pair<FourCC, Vector<uint8_t>>>;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1480,12 +1480,9 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::updateKeyStatuses(std::optional
 
 auto CDMInstanceSessionFairPlayStreamingAVFObjC::copyKeyStatuses() const -> KeyStatusVector
 {
-    KeyStatusVector copiedKeyStatuses;
-    copiedKeyStatuses.reserveInitialCapacity(m_keyStatuses.size());
-    for (auto& status : m_keyStatuses)
-        copiedKeyStatuses.uncheckedAppend({ status.first.copyRef(), status.second });
-    return copiedKeyStatuses;
-
+    return WTF::map(m_keyStatuses, [](auto& status) {
+        return std::pair<Ref<SharedBuffer>, KeyStatus> { status.first.copyRef(), status.second };
+    });
 }
 
 void CDMInstanceSessionFairPlayStreamingAVFObjC::outputObscuredDueToInsufficientExternalProtectionChanged(bool obscured)

--- a/Source/WebCore/rendering/style/StyleImageSet.cpp
+++ b/Source/WebCore/rendering/style/StyleImageSet.cpp
@@ -62,7 +62,7 @@ bool StyleImageSet::equals(const StyleImageSet& other) const
 
 Ref<CSSValue> StyleImageSet::computedStyleValue(const RenderStyle& style) const
 {
-    auto builder = WTF::map<4>(m_images, [&](auto& image) -> Ref<CSSValue> {
+    auto builder = WTF::map<CSSValueListBuilderInlineCapacity>(m_images, [&](auto& image) -> Ref<CSSValue> {
         return CSSImageSetOptionValue::create(image.image->computedStyleValue(style), CSSPrimitiveValue::create(image.scaleFactor, CSSUnitType::CSS_DPPX), image.mimeType);
     });
     return CSSImageSetValue::create(WTFMove(builder));


### PR DESCRIPTION
#### ba50d1bc34e9629af103d7bcdaf825f47b4cfc5e
<pre>
Use Vector::uncheckedAppend() less in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=262832">https://bugs.webkit.org/show_bug.cgi?id=262832</a>

Reviewed by Darin Adler.

Use Vector::uncheckedAppend() less in WebCore and use more efficient alternatives
now that uncheckedAppend() has become an alias for append().

* Source/WebCore/Modules/streams/ReadableStream.cpp:
(WebCore::ReadableStream::tee):
* Source/WebCore/Modules/webxr/WebXRHand.cpp:
(WebCore::WebXRHand::WebXRHand):
* Source/WebCore/PAL/pal/avfoundation/OutputContext.mm:
(PAL::OutputContext::outputDevices const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::objectsForIDs const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::labelsForNode):
(WebCore::labelForNode):
(WebCore::AccessibilityNodeObject::checkboxOrRadioRect const):
(WebCore::AccessibilityNodeObject::correspondingLabelForControlElement const):
(WebCore::AccessibilityNodeObject::textForLabelElements const):
(WebCore::AccessibilityNodeObject::titleUIElement const):
(): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::children):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::resolveAppends):
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::addUniversalActionsToDFA):
* Source/WebCore/contentextensions/DFAMinimizer.cpp:
(WebCore::ContentExtensions::DFAMinimizer::minimize):
* Source/WebCore/contentextensions/DFANode.cpp:
(WebCore::ContentExtensions::DFANode::actions const):
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueContainingVector::copyValues const):
* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::CSSVariableData):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::copyProperties const):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::copyProperties const):
* Source/WebCore/css/parser/CSSParserTokenRange.h:
(WebCore::CSSParserTokenRange::size const):
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.cpp:
(WebCore::HashMapStylePropertyMapReadOnly::entries const):
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp:
(WebCore::StylePropertyMapReadOnly::reifyValueToVector):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsNthChild):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsNthLastChild):
* Source/WebCore/dom/ComposedTreeIterator.h:
(WebCore::ComposedTreeIterator::ComposedTreeIterator):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::getAttributeNames const):
* Source/WebCore/dom/ElementData.h:
(WebCore::AttributeConstIterator::operator--):
(WebCore::AttributeIteratorAccessor::size const):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateWithTextRecognitionResult):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::SelectorDataList):
* Source/WebCore/dom/TouchList.h:
(WebCore::TouchList::TouchList):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::filesChosen):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::textFieldValues const):
* Source/WebCore/html/LinkIconCollector.cpp:
(WebCore::LinkIconCollector::iconsOfTypes):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setActiveContentRuleListActionPatterns):
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::didAddClient):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::replaceRangesWithText):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::buildSelectionHighlight):
* Source/WebCore/platform/FileChooser.cpp:
(WebCore::FileChooser::chooseFiles):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::copy const):
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::AudioBus):
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp:
(WebCore::AudioDSPKernelProcessor::initialize):
* Source/WebCore/platform/audio/AudioResampler.cpp:
(WebCore::AudioResampler::AudioResampler):
* Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp:
(WebCore::DynamicsCompressorKernel::setNumberOfChannels):
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::MultiChannelResampler):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::finishConstruction):
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::purgeInactiveFontData):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::characterSelectionRectsForText const):
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::makeFontCascadeCacheKey):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::KeyframeValueList::KeyframeValueList):
* Source/WebCore/platform/graphics/PathUtilities.cpp:
(WebCore::PathUtilities::pathsWithShrinkWrappedRects):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::trackBuffersRanges const):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::extractSinfData):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::copyKeyStatuses const):

Canonical link: <a href="https://commits.webkit.org/269062@main">https://commits.webkit.org/269062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19c226ba410cdf581b2277632b165ab15dd272bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21504 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19929 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22058 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24219 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19494 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23655 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20184 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19501 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5129 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->