### PR TITLE
Stop using -[UITextInteractionAssistant inGesture] and -[UITextInteraction inGesture]

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1060,14 +1060,8 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 #endif
 
 @interface UITextInteractionAssistant (IPI)
-@property (nonatomic, readonly) BOOL inGesture;
-@property (nonatomic, readonly) UITextInteraction *interactions;
 - (void)willStartScrollingOrZooming;
 - (void)didEndScrollingOrZooming;
-@end
-
-@interface UITextInteraction (IPI)
-@property (nonatomic, readonly) BOOL inGesture;
 @end
 
 #if USE(UICONTEXTMENU)

--- a/Tools/TestWebKitAPI/Tests/ios/UIWKInteractionViewProtocol.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/UIWKInteractionViewProtocol.mm
@@ -126,12 +126,27 @@ TEST(UIWKInteractionViewProtocol, UpdateSelectionWithExtentPoint)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
     [webView synchronouslyLoadHTMLString:@"<body contenteditable style='font-size: 20px;'>Hello world</body>"];
 
+    auto setMouseTouchGestureState = ^(UIGestureRecognizerState state) {
+        for (UIGestureRecognizer *gestureRecognizer in [webView textInputContentView].gestureRecognizers) {
+            if ([gestureRecognizer.name isEqualToString:@"WKMouseTouch"]) {
+                gestureRecognizer.state = state;
+                break;
+            }
+        }
+    };
+
     [webView evaluateJavaScript:@"getSelection().setPosition(document.body, 1)" completionHandler:nil];
+    setMouseTouchGestureState(UIGestureRecognizerStateBegan);
+    setMouseTouchGestureState(UIGestureRecognizerStateEnded);
     [webView updateSelectionWithExtentPoint:CGPointMake(5, 20)];
+    setMouseTouchGestureState(UIGestureRecognizerStatePossible);
     EXPECT_WK_STREQ("Hello world", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
 
     [webView evaluateJavaScript:@"getSelection().setPosition(document.body, 0)" completionHandler:nil];
+    setMouseTouchGestureState(UIGestureRecognizerStateBegan);
+    setMouseTouchGestureState(UIGestureRecognizerStateEnded);
     [webView updateSelectionWithExtentPoint:CGPointMake(300, 20)];
+    setMouseTouchGestureState(UIGestureRecognizerStatePossible);
     EXPECT_WK_STREQ("Hello world", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
 }
 


### PR DESCRIPTION
#### 1927094ca4e021e490dfb3018c7d31a202cb52ff
<pre>
Stop using -[UITextInteractionAssistant inGesture] and -[UITextInteraction inGesture]
<a href="https://bugs.webkit.org/show_bug.cgi?id=262833">https://bugs.webkit.org/show_bug.cgi?id=262833</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Remove uses of `-[UITextInteractionAssistant inGesture]` and `-[UITextInteraction inGesture]`. We
currently use these methods to deduce whether `-updateSelectionWithExtentPoint:completionHandler:`
is being triggered by the floating cursor (i.e., when long pressing on the space bar in the software
keyboard while holding the shift key). From testing on iOS 17, the other ways to exercise this
codepath (outside of holding shift while using floating cursor) are:

• Shift-tapping to extend a selection.
• Shift-clicking with a trackpad to extend a selection.

We can distinguish these two cases from the floating cursor case by consulting gesture recognizer
state instead; that is, if any of the following gestures are in Began, Ended or Changed state while
updating the selection with an extent point:

• Text interaction variable delay loupe gesture.
• Text interaction multi-tap gesture.
• Mouse click gesture (`WKMouseTouchGestureRecognizer`).

...then we can assume that the selection is being changed by one of the above interactions;
otherwise, it&apos;s probably due to using the floating cursor.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView updateSelectionWithExtentPoint:completionHandler:]):
(-[UITextInteractionAssistant _wk_hasFloatingCursor]): Deleted.
* Tools/TestWebKitAPI/Tests/ios/UIWKInteractionViewProtocol.mm:
(TestWebKitAPI::TEST):

Adjust a test to simulate mouse clicks before calling `-updateSelectionWithExtentPoint:`.

Canonical link: <a href="https://commits.webkit.org/269044@main">https://commits.webkit.org/269044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3820d67fe6e939e4c2fcef9a57083457a6b6b11e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/21971 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24130 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25726 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23575 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17112 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19417 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5120 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23657 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->