### PR TITLE
[GStreamer][DMABuf] DRM modifiers handling

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -48,7 +48,17 @@ GST_DEBUG_CATEGORY_STATIC(webkit_dmabuf_video_sink_debug);
 #define GST_CAT_DEFAULT webkit_dmabuf_video_sink_debug
 
 #define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV21, Y444, Y41B, Y42B, VUYA, P010_10LE, P010_10BE, P016_LE, P016BE }"
-static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+
+#define GST_WEBKIT_DMABUF_SINK_DRM_FORMAT_LIST "{ (string) P010:0x0100000000000002, (string) NV12:0x0100000000000002, (string) P010, (string) NV12 }"
+
+static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
+    GST_STATIC_CAPS(
+#if GST_CHECK_VERSION(1, 23, 0)
+        GST_VIDEO_DMA_DRM_CAPS_MAKE ", drm-format = " GST_WEBKIT_DMABUF_SINK_DRM_FORMAT_LIST
+#else
+        GST_VIDEO_CAPS_MAKE(GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST)
+#endif
+        ));
 
 // TODO: this is a list of remaining YUV formats we want to support, but don't currently work (due to improper handling in TextureMapper):
 //     YUY2, YVYU, UYVY, VYUY, AYUV
@@ -94,16 +104,20 @@ static void webKitDMABufVideoSinkConstructed(GObject* object)
     // MediaPlayerPrivateGStreamer). The format list corresponds to the formats we are able to then handle in the graphics pipeline.
     // In case of dmabuf data, that dmabuf is handled most optimally and just relayed to the graphics pipeline.
     // In case of raw data, dmabuf objects are produced on the spot and filled with that data, and then pushed to the graphics pipeline.
-    static GstStaticCaps s_dmabufCaps = GST_STATIC_CAPS(
-        GST_VIDEO_CAPS_MAKE_WITH_FEATURES(GST_CAPS_FEATURE_MEMORY_DMABUF, GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST));
+#if GST_CHECK_VERSION(1, 23, 0)
+#define DMABUF_CAPS GST_VIDEO_DMA_DRM_CAPS_MAKE ", drm-format = " GST_WEBKIT_DMABUF_SINK_DRM_FORMAT_LIST
+#else
+#define DMABUF_CAPS GST_VIDEO_CAPS_MAKE_WITH_FEATURES(GST_CAPS_FEATURE_MEMORY_DMABUF, GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST)
+#endif
+    static GstStaticCaps s_dmabufCaps = GST_STATIC_CAPS(DMABUF_CAPS);
     static GstStaticCaps s_fallbackCaps = GST_STATIC_CAPS(GST_VIDEO_CAPS_MAKE(GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST));
+#undef DMABUF_CAPS
 
     GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_empty());
     {
-        if (forcedFallbackCapsFormat()) {
-            caps = gst_caps_new_simple("video/x-raw",
-                "format", G_TYPE_STRING, forcedFallbackCapsFormat(), nullptr);
-        } else {
+        if (forcedFallbackCapsFormat())
+            caps = gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, forcedFallbackCapsFormat(), nullptr);
+        else {
             gst_caps_append(caps.get(), gst_static_caps_get(&s_dmabufCaps));
             gst_caps_append(caps.get(), gst_static_caps_get(&s_fallbackCaps));
         }


### PR DESCRIPTION
#### bcbbe4ae86b2361d75d48b80fc0959ba8180bcb9
<pre>
[GStreamer][DMABuf] DRM modifiers handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=262838">https://bugs.webkit.org/show_bug.cgi?id=262838</a>

Reviewed by Xabier Rodriguez-Calvar.

In the upcoming GStreamer 1.24 release the video decoders can expose DRM modifiers during caps
negotiation. So in this build configuration (new API required) we can passthrough those modifiers to
the TextureMapper.

* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkConstructed):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushDMABufToCompositor):

Canonical link: <a href="https://commits.webkit.org/269067@main">https://commits.webkit.org/269067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd34b2f478d1eeffb7a788206a9b372a3d042699

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23348 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21104 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24199 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25787 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23636 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17171 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19483 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5136 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20070 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->