### PR TITLE
Add support for more browser.extension incognito Web Extension APIs.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIExtensionCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,34 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "JSWebExtensionAPIExtension.h"
-#include "WebExtensionAPIObject.h"
-
-OBJC_CLASS NSString;
-OBJC_CLASS NSURL;
-
 namespace WebKit {
 
-class WebPage;
-
-class WebExtensionAPIExtension : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIExtension, extension);
-
-public:
-#if PLATFORM(COCOA)
-    bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
-
-    bool isInIncognitoContext(WebPage*);
-    void isAllowedFileSchemeAccess(Ref<WebExtensionCallbackHandler>&&);
-    void isAllowedIncognitoAccess(Ref<WebExtensionCallbackHandler>&&);
-
-    NSURL *getURL(NSString *resourcePath, NSString **errorString);
-#endif
-};
+void WebExtensionContext::extensionIsAllowedIncognitoAccess(CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(hasAccessInPrivateBrowsing());
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -205,12 +205,18 @@ void WebExtensionController::addUserContentController(WebUserContentControllerPr
 {
     if (forPrivateBrowsing == ForPrivateBrowsing::No)
         m_allNonPrivateUserContentControllers.add(userContentController);
+    else
+        m_allPrivateUserContentControllers.add(userContentController);
 
     if (!m_allUserContentControllers.add(userContentController))
         return;
 
-    for (auto& context : m_extensionContexts)
+    for (auto& context : m_extensionContexts) {
+        if (!context->hasAccessInPrivateBrowsing() && forPrivateBrowsing == ForPrivateBrowsing::Yes)
+            continue;
+
         context->addInjectedContent(userContentController);
+    }
 }
 
 void WebExtensionController::removeUserContentController(WebUserContentControllerProxy& userContentController)
@@ -225,6 +231,7 @@ void WebExtensionController::removeUserContentController(WebUserContentControlle
         context->removeInjectedContent(userContentController);
 
     m_allNonPrivateUserContentControllers.remove(userContentController);
+    m_allPrivateUserContentControllers.remove(userContentController);
     m_allUserContentControllers.remove(userContentController);
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -58,7 +58,7 @@ WebExtensionContext::WebExtensionContext()
 
 WebExtensionContextParameters WebExtensionContext::parameters() const
 {
-    return WebExtensionContextParameters {
+    return {
         identifier(),
         baseURL(),
         uniqueIdentifier(),
@@ -71,6 +71,9 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
 
 bool WebExtensionContext::pageListensForEvent(const WebPageProxy& page, WebExtensionEventListenerType type, WebExtensionContentWorldType contentWorldType) const
 {
+    if (!hasAccessInPrivateBrowsing() && page.sessionID().isEphemeral())
+        return false;
+
     auto pagesEntry = m_eventListenerPages.find({ type, contentWorldType });
     if (pagesEntry == m_eventListenerPages.end())
         return false;
@@ -89,6 +92,9 @@ WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(WebExtens
 
     WebProcessProxySet result;
     for (auto entry : pagesEntry->value) {
+        if (!hasAccessInPrivateBrowsing() && entry.key.sessionID().isEphemeral())
+            continue;
+
         Ref process = entry.key.process();
         if (process->canSendMessage())
             result.add(WTFMove(process));

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -219,7 +219,7 @@ public:
     void setRequestedOptionalAccessToAllHosts(bool requested) { m_requestedOptionalAccessToAllHosts = requested; }
 
     bool hasAccessInPrivateBrowsing() const { return m_hasAccessInPrivateBrowsing; }
-    void setHasAccessInPrivateBrowsing(bool hasAccess) { m_hasAccessInPrivateBrowsing = hasAccess; }
+    void setHasAccessInPrivateBrowsing(bool);
 
     void grantPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
     void denyPermissions(PermissionsSet&&, WallTime expirationDate = WallTime::infinity());
@@ -227,11 +227,11 @@ public:
     void grantPermissionMatchPatterns(MatchPatternSet&&, WallTime expirationDate = WallTime::infinity());
     void denyPermissionMatchPatterns(MatchPatternSet&&, WallTime expirationDate = WallTime::infinity());
 
-    void removeGrantedPermissions(PermissionsSet&);
-    void removeGrantedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly);
+    bool removeGrantedPermissions(PermissionsSet&);
+    bool removeGrantedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly);
 
-    void removeDeniedPermissions(PermissionsSet&);
-    void removeDeniedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly);
+    bool removeDeniedPermissions(PermissionsSet&);
+    bool removeDeniedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly);
 
     PermissionsMap::KeysConstIteratorRange currentPermissions() { return grantedPermissions().keys(); }
     PermissionMatchPatternsMap::KeysConstIteratorRange currentPermissionMatchPatterns() { return grantedPermissionMatchPatterns().keys(); }
@@ -343,8 +343,8 @@ private:
     void postAsyncNotification(NSString *notificationName, PermissionsSet&);
     void postAsyncNotification(NSString *notificationName, MatchPatternSet&);
 
-    void removePermissions(PermissionsMap&, PermissionsSet&, WallTime& nextExpirationDate, NSString *notificationName);
-    void removePermissionMatchPatterns(PermissionMatchPatternsMap&, MatchPatternSet&, EqualityOnly, WallTime& nextExpirationDate, NSString *notificationName);
+    bool removePermissions(PermissionsMap&, PermissionsSet&, WallTime& nextExpirationDate, NSString *notificationName);
+    bool removePermissionMatchPatterns(PermissionMatchPatternsMap&, MatchPatternSet&, EqualityOnly, WallTime& nextExpirationDate, NSString *notificationName);
 
     PermissionsMap& removeExpired(PermissionsMap&, WallTime& nextExpirationDate, NSString *notificationName = nil);
     PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, WallTime& nextExpirationDate, NSString *notificationName = nil);
@@ -400,6 +400,9 @@ private:
     // Event APIs
     void addListener(WebPageProxyIdentifier, WebExtensionEventListenerType, WebExtensionContentWorldType);
     void removeListener(WebPageProxyIdentifier, WebExtensionEventListenerType, WebExtensionContentWorldType, size_t removedCount);
+
+    // Extension APIs
+    void extensionIsAllowedIncognitoAccess(CompletionHandler<void(bool)>&&);
 
     // Permissions APIs
     void permissionsGetAll(CompletionHandler<void(Vector<String> permissions, Vector<String> origins)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ messages -> WebExtensionContext {
     // Event APIs
     AddListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType);
     RemoveListener(WebKit::WebPageProxyIdentifier identifier, WebKit::WebExtensionEventListenerType type, WebKit::WebExtensionContentWorldType contentWorldType, size_t removedCount);
+
+    // Extensions APIs
+    ExtensionIsAllowedIncognitoAccess() -> (bool result);
 
     // Permissions APIs
     PermissionsGetAll() -> (Vector<String> permissions, Vector<String> origins);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -99,11 +99,10 @@ public:
 
     WebPageProxySet allPages() const { return m_pages; }
 
-    // Includes both regular and private browsing content controllers.
+    // Includes both non-private and private browsing content controllers.
     UserContentControllerProxySet allUserContentControllers() const { return m_allUserContentControllers; }
-
-    // Excludes private browsing content controllers.
     UserContentControllerProxySet allNonPrivateUserContentControllers() const { return m_allNonPrivateUserContentControllers; }
+    UserContentControllerProxySet allPrivateUserContentControllers() const { return m_allPrivateUserContentControllers; }
 
     WebProcessPoolSet allProcessPools() const { return m_processPools; }
     WebProcessProxySet allProcesses() const;
@@ -147,6 +146,7 @@ private:
     WebProcessPoolSet m_processPools;
     UserContentControllerProxySet m_allUserContentControllers;
     UserContentControllerProxySet m_allNonPrivateUserContentControllers;
+    UserContentControllerProxySet m_allPrivateUserContentControllers;
     WebExtensionURLSchemeHandlerMap m_registeredSchemeHandlers;
     bool m_freshlyCreated { true };
 };

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 		1C7316792AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7316782AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C73167B2AC1E676007FADA4 /* WebExtensionMessagePort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C73167A2AC1E676007FADA4 /* WebExtensionMessagePort.h */; };
 		1C73167F2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C73167E2AC1EA27007FADA4 /* WebExtensionMessagePortCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C78656E2AD1FD4F00EF3082 /* WebExtensionContextAPIExtensionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C78656D2AD1FD4F00EF3082 /* WebExtensionContextAPIExtensionCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C891D6619B124FF00BA79DD /* WebInspectorUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C891D6319B124FF00BA79DD /* WebInspectorUI.h */; };
 		1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C8E28201275D15400BC7BD0 /* WebInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E281E1275D15400BC7BD0 /* WebInspector.h */; };
@@ -3659,6 +3660,7 @@
 		1C739E852347BCF600C621EC /* CoreTextHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreTextHelpers.mm; sourceTree = "<group>"; };
 		1C739E872347BD0F00C621EC /* CoreTextHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreTextHelpers.h; sourceTree = "<group>"; };
 		1C77C1951288A872006A742F /* WebInspectorUIProxy.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebInspectorUIProxy.messages.in; sourceTree = "<group>"; };
+		1C78656D2AD1FD4F00EF3082 /* WebExtensionContextAPIExtensionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIExtensionCocoa.mm; sourceTree = "<group>"; };
 		1C891D6219B124FF00BA79DD /* WebInspectorUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorUI.cpp; sourceTree = "<group>"; };
 		1C891D6319B124FF00BA79DD /* WebInspectorUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorUI.h; sourceTree = "<group>"; };
 		1C891D6419B124FF00BA79DD /* WebInspectorUI.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebInspectorUI.messages.in; sourceTree = "<group>"; };
@@ -8819,6 +8821,7 @@
 				1CC94E592AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm */,
 				1C2B4D3E2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm */,
 				B6544F9E2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm */,
+				1C78656D2AD1FD4F00EF3082 /* WebExtensionContextAPIExtensionCocoa.mm */,
 				B65DA1DC294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm */,
 				1C9A15D22ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm */,
 				1C4A14C72ABBBA3900A1018C /* WebExtensionContextAPIRuntimeCocoa.mm */,
@@ -18088,6 +18091,7 @@
 				1CC94E5A2AC941C40045F269 /* WebExtensionContextAPIActionCocoa.mm in Sources */,
 				1C2B4D3F2A815ACC00C528A1 /* WebExtensionContextAPIAlarmsCocoa.mm in Sources */,
 				B6544F9F2939457C00034EB0 /* WebExtensionContextAPIEventCocoa.mm in Sources */,
+				1C78656E2AD1FD4F00EF3082 /* WebExtensionContextAPIExtensionCocoa.mm in Sources */,
 				B65DA1DD294BDE4700DB503A /* WebExtensionContextAPIPermissionsCocoa.mm in Sources */,
 				1C9A15D32ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm in Sources */,
 				1C4A14C82ABBBA3900A1018C /* WebExtensionContextAPIRuntimeCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,5 +29,10 @@
 ] interface WebExtensionAPIExtension {
 
     [URL, ConvertNullStringTo=Null, RaisesException, Dynamic] DOMString getURL(DOMString resourcePath);
+
+    [ImplementedAs=isInIncognitoContext, NeedsPage] readonly attribute boolean inIncognitoContext;
+
+    [MainWorldOnly] void isAllowedIncognitoAccess([Optional, CallbackHandler] function callback);
+    [MainWorldOnly] void isAllowedFileSchemeAccess([Optional, CallbackHandler] function callback);
 
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
@@ -27,9 +27,29 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "HTTPServer.h"
 #import "WebExtensionUtilities.h"
 
 namespace TestWebKitAPI {
+
+static auto *extensionManifest = @{
+    @"manifest_version": @3,
+
+    @"name": @"Extension Test",
+    @"description": @"Extension Test",
+    @"version": @"1",
+
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO,
+    },
+
+    @"content_scripts": @[ @{
+        @"js": @[ @"content.js" ],
+        @"matches": @[ @"*://localhost/*" ],
+    } ],
+};
 
 TEST(WKWebExtensionAPIExtension, GetURL)
 {
@@ -91,6 +111,137 @@ TEST(WKWebExtensionAPIExtension, GetURL)
     manifest = @{ @"manifest_version": @3, @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
 
     Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIExtension, InIncognitoContext)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertFalse(browser.extension.inIncognitoContext, 'Should not be in incognito in background script')"
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"if (browser.extension.inIncognitoContext)",
+        @"  browser.test.yield('Content Script is Incognito')",
+        @"else",
+        @"  browser.test.yield('Content Script is Not Incognito')"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:extensionManifest resources:@{ @"background.js": backgroundScript, @"content.js": contentScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    manager.get().context.hasAccessInPrivateBrowsing = YES;
+
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Content Script is Not Incognito");
+
+    [manager closeWindow:manager.get().defaultWindow];
+
+    auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
+    auto *privateTab = privateWindow.tabs.firstObject;
+
+    [privateTab.mainWebView loadRequest:urlRequest];
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Content Script is Incognito");
+}
+
+TEST(WKWebExtensionAPIExtension, InIncognitoContextWithoutPrivateAccess)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertFalse(browser.extension.inIncognitoContext, 'Should not be in incognito in background script')"
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"if (browser.extension.inIncognitoContext)",
+        @"  browser.test.yield('Content Script is Incognito')",
+        @"else",
+        @"  browser.test.yield('Content Script is Not Incognito')"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:extensionManifest resources:@{ @"background.js": backgroundScript, @"content.js": contentScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Content Script is Not Incognito");
+
+    [manager closeWindow:manager.get().defaultWindow];
+
+    auto *privateWindow = [manager openNewWindowUsingPrivateBrowsing:YES];
+    auto *privateTab = privateWindow.tabs.firstObject;
+
+    [privateTab.mainWebView loadRequest:urlRequest];
+
+    // The content script should not run in the private tab, so timeout after waiting for 3 seconds.
+    [manager runForTimeInterval:3];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"");
+}
+
+TEST(WKWebExtensionAPIExtension, IsAllowedIncognitoAccess)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const allowed = await browser.extension.isAllowedIncognitoAccess()",
+        @"browser.test.yield(allowed ? 'Allowed Incognito Access' : 'Not Allowed Incognito Access')",
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:extensionManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().context.hasAccessInPrivateBrowsing = YES;
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Allowed Incognito Access");
+}
+
+TEST(WKWebExtensionAPIExtension, IsAllowedIncognitoAccessWithoutPrivateAccess)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const allowed = await browser.extension.isAllowedIncognitoAccess()",
+        @"browser.test.yield(allowed ? 'Allowed Incognito Access' : 'Not Allowed Incognito Access')",
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:extensionManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Not Allowed Incognito Access");
+}
+
+TEST(WKWebExtensionAPIExtension, IsAllowedFileSchemeAccess)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const allowed = await browser.extension.isAllowedFileSchemeAccess()",
+        @"browser.test.yield(allowed ? 'Allowed File Access' : 'Not Allowed File Access')",
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:extensionManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager loadAndRun];
+
+    EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Not Allowed File Access");
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -244,7 +244,7 @@ TEST(WKWebExtensionAPITabs, Duplicate)
     auto *tab = manager.get().defaultTab;
     auto originalDuplicate = tab.duplicate;
 
-    tab.duplicate = ^(_WKWebExtensionTabCreationOptions *options, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
+    tab.duplicate = ^(_WKWebExtensionTabCreationOptions *options, void (^completionHandler)(TestWebExtensionTab *, NSError *)) {
         EXPECT_NS_EQUAL(options.desiredWindow, window);
         EXPECT_EQ(options.desiredIndex, window.tabs.count);
 
@@ -290,7 +290,7 @@ TEST(WKWebExtensionAPITabs, DuplicateWithOptions)
     auto *tab = manager.get().defaultTab;
     auto originalDuplicate = tab.duplicate;
 
-    tab.duplicate = ^(_WKWebExtensionTabCreationOptions *options, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *)) {
+    tab.duplicate = ^(_WKWebExtensionTabCreationOptions *options, void (^completionHandler)(TestWebExtensionTab *, NSError *)) {
         EXPECT_NS_EQUAL(options.desiredWindow, window);
         EXPECT_EQ(options.desiredIndex, 1lu);
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -69,12 +69,12 @@
 
 @interface TestWebExtensionTab : NSObject <_WKWebExtensionTab>
 
-- (instancetype)initWithWindow:(id<_WKWebExtensionWindow>)window extensionController:(_WKWebExtensionController *)extensionController NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithWindow:(TestWebExtensionWindow *)window extensionController:(_WKWebExtensionController *)extensionController NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, weak) id<_WKWebExtensionWindow> window;
+@property (nonatomic, weak) TestWebExtensionWindow * window;
 @property (nonatomic, strong) WKWebView *mainWebView;
 
-@property (nonatomic, weak) id<_WKWebExtensionTab> parentTab;
+@property (nonatomic, weak) TestWebExtensionTab *parentTab;
 
 @property (nonatomic, getter=isPinned) bool pinned;
 @property (nonatomic, getter=isMuted) bool muted;
@@ -88,7 +88,7 @@
 @property (nonatomic, copy) void (^reloadFromOrigin)(void);
 @property (nonatomic, copy) void (^goBack)(void);
 @property (nonatomic, copy) void (^goForward)(void);
-@property (nonatomic, copy) void (^duplicate)(_WKWebExtensionTabCreationOptions *, void (^completionHandler)(id<_WKWebExtensionTab>, NSError *));
+@property (nonatomic, copy) void (^duplicate)(_WKWebExtensionTabCreationOptions *, void (^completionHandler)(TestWebExtensionTab *, NSError *));
 
 @end
 
@@ -96,15 +96,16 @@
 
 - (instancetype)initWithExtensionController:(_WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, copy) NSArray<id<_WKWebExtensionTab>> *tabs;
-@property (nonatomic, strong) id<_WKWebExtensionTab> activeTab;
+@property (nonatomic, copy) NSArray<TestWebExtensionTab *> *tabs;
+@property (nonatomic, strong) TestWebExtensionTab * activeTab;
 
 - (TestWebExtensionTab *)openNewTab;
 - (TestWebExtensionTab *)openNewTabAtIndex:(NSUInteger)index;
 
-- (void)closeTab:(id<_WKWebExtensionTab>)tab;
-- (void)replaceTab:(id<_WKWebExtensionTab>)oldTab withTab:(id<_WKWebExtensionTab>)newTab;
-- (void)moveTab:(id<_WKWebExtensionTab>)oldTab toIndex:(NSUInteger)newIndex;
+- (void)closeTab:(TestWebExtensionTab *)tab;
+- (void)closeTab:(TestWebExtensionTab *)tab windowIsClosing:(BOOL)windowIsClosing;
+- (void)replaceTab:(TestWebExtensionTab *)oldTab withTab:(TestWebExtensionTab *)newTab;
+- (void)moveTab:(TestWebExtensionTab *)oldTab toIndex:(NSUInteger)newIndex;
 
 @property (nonatomic) _WKWebExtensionWindowState windowState;
 @property (nonatomic) _WKWebExtensionWindowType windowType;


### PR DESCRIPTION
#### 2713dbbe432dc19ca160330e3a76ac4296021d7c
<pre>
Add support for more browser.extension incognito Web Extension APIs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262848">https://bugs.webkit.org/show_bug.cgi?id=262848</a>
rdar://problem/116629181

Reviewed by Brady Eidson.

- Fixes some more cases that needed to check if content can be injected in private tabs.
- Added support for the incognito APIs on browser.extension.
- Added support for file scheme API that always return false.
- Added better window and tab test support, specifically for closing windows and tabs.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIExtensionCocoa.mm: Added.
(WebKit::WebExtensionContext::extensionIsAllowedIncognitoAccess):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::setHasAccessInPrivateBrowsing): Added.
(WebKit::WebExtensionContext::removeGrantedPermissions): Return a bool.
(WebKit::WebExtensionContext::removeGrantedPermissionMatchPatterns): Ditto.
(WebKit::WebExtensionContext::removeDeniedPermissions): Ditto.
(WebKit::WebExtensionContext::removeDeniedPermissionMatchPatterns): Ditto.
(WebKit::WebExtensionContext::removePermissions): Ditto.
(WebKit::WebExtensionContext::removePermissionMatchPatterns): Ditto.
(WebKit::WebExtensionContext::removeExpired): Call updateInjectedContent to remove scripts from expired patterns.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addUserContentController): Track private controllers too. Only add injected content
if the extension has access to that controller.
(WebKit::WebExtensionController::removeUserContentController): Remove from private controller set.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const): Infer return type.
(WebKit::WebExtensionContext::pageListensForEvent const): Check hasAccessInPrivateBrowsing().
(WebKit::WebExtensionContext::processes const): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::setHasAccessInPrivateBrowsing): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::allUserContentControllers const):
(WebKit::WebExtensionController::allPrivateUserContentControllers const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::getURL):
(WebKit::WebExtensionAPIExtension::isInIncognitoContext): Added.
(WebKit::WebExtensionAPIExtension::isAllowedFileSchemeAccess): Added.
(WebKit::WebExtensionAPIExtension::isAllowedIncognitoAccess): Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm:
(TestWebKitAPI::TEST): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST): Use class tab type.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:]): Default to an empty yield message.
(-[TestWebExtensionManager closeWindow:]): Close all tabs, set defaultWindow to the next window and focus it.
(-[TestWebExtensionManager run]): Clear yield message.
(-[TestWebExtensionManager runForTimeInterval:]): Ditto.
(-[TestWebExtensionManager _webExtensionController:recordTestYieldedWithMessage:andSourceURL:lineNumber:forExtensionContext:]):
Always set a non-nil yield message.
(-[TestWebExtensionTab initWithWindow:extensionController:]): Use class type.
(-[TestWebExtensionTab activateForWebExtensionContext:completionHandler:]): Ditto.
(-[TestWebExtensionTab isSelectedForWebExtensionContext:]): Ditto.
(-[TestWebExtensionTab closeForWebExtensionContext:completionHandler:]): Ditto.
(-[TestWebExtensionWindow tabs]): Ditto.
(-[TestWebExtensionWindow setTabs:]): Close and open tabs as needed.
(-[TestWebExtensionWindow openNewTabAtIndex:]): Use class type.
(-[TestWebExtensionWindow closeTab:]): Call closeTab:windowIsClosing:.
(-[TestWebExtensionWindow closeTab:windowIsClosing:]): Added. Close the web view. Update activeTab if needed.
(-[TestWebExtensionWindow replaceTab:withTab:]): Close the web view on the replaced tab.
(-[TestWebExtensionWindow moveTab:toIndex:]): Use class type.

Canonical link: <a href="https://commits.webkit.org/269087@main">https://commits.webkit.org/269087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c19bfd204a5eff548e0956cabea04fb95f99fae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21586 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/22635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/23449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/21829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/25214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/22131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/23449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/21813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/25214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/22635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/25214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/22635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/24299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/25214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/22635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/22131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/19570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/22635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2673 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/20156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->