### PR TITLE
Use more smart pointers in editing code

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -245,7 +245,7 @@ void Clipboard::getType(ClipboardItem& item, const String& type, Ref<DeferredPro
     if (type == "text/html"_s) {
         WebContentMarkupReader markupReader { *frame };
         activePasteboard().read(markupReader, WebContentReadingPolicy::OnlyRichTextTypes, itemIndex);
-        resultAsString = WTFMove(markupReader.markup);
+        resultAsString = markupReader.takeMarkup();
     }
 
     // FIXME: Support reading custom data.

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3524,7 +3524,7 @@ CharacterOffset AXObjectCache::startCharacterOffsetOfParagraph(const CharacterOf
     auto highestRoot = highestEditableRoot(firstPositionInOrBeforeNode(&startNode));
     Position::AnchorType type = Position::PositionIsOffsetInAnchor;
     
-    auto& node = *findStartOfParagraph(&startNode, highestRoot.get(), startBlock.get(), offset, type, boundaryCrossingRule);
+    Ref node = *findStartOfParagraph(&startNode, highestRoot.get(), startBlock.get(), offset, type, boundaryCrossingRule);
     
     if (type == Position::PositionIsOffsetInAnchor)
         return characterOffsetForNodeAndOffset(node, offset, TraverseOptionIncludeStart);
@@ -3546,9 +3546,9 @@ CharacterOffset AXObjectCache::endCharacterOffsetOfParagraph(const CharacterOffs
     auto highestRoot = highestEditableRoot(firstPositionInOrBeforeNode(startNode.get()));
     Position::AnchorType type = Position::PositionIsOffsetInAnchor;
     
-    auto& node = *findEndOfParagraph(startNode.get(), highestRoot.get(), stayInsideBlock.get(), offset, type, boundaryCrossingRule);
+    Ref node = *findEndOfParagraph(startNode.get(), highestRoot.get(), stayInsideBlock.get(), offset, type, boundaryCrossingRule);
     if (type == Position::PositionIsOffsetInAnchor) {
-        if (node.isTextNode()) {
+        if (node->isTextNode()) {
             CharacterOffset startOffset = startOrEndCharacterOffsetForRange(rangeForNodeContents(node), true);
             offset -= startOffset.startIndex;
         }

--- a/Source/WebCore/dom/BoundaryPoint.cpp
+++ b/Source/WebCore/dom/BoundaryPoint.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "BoundaryPoint.h"
 #include "ContainerNode.h"
+#include "Document.h"
 
 namespace WebCore {
 
@@ -107,6 +108,11 @@ TextStream& operator<<(TextStream& stream, const BoundaryPoint& boundaryPoint)
     stream.dumpProperty("node", boundaryPoint.container->debugDescription());
     stream.dumpProperty("offset", boundaryPoint.offset);
     return stream;
+}
+
+Ref<Document> BoundaryPoint::protectedDocument() const
+{
+    return document();
 }
 
 }

--- a/Source/WebCore/dom/BoundaryPoint.h
+++ b/Source/WebCore/dom/BoundaryPoint.h
@@ -36,6 +36,7 @@ struct BoundaryPoint {
     BoundaryPoint(Ref<Node>&&, unsigned);
 
     Document& document() const;
+    Ref<Document> protectedDocument() const;
 };
 
 bool operator==(const BoundaryPoint&, const BoundaryPoint&);

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -216,7 +216,7 @@ String DataTransfer::readStringFromPasteboard(Document& document, const String& 
             return { };
         WebContentMarkupReader reader { *document.frame() };
         m_pasteboard->read(reader, policy);
-        return reader.markup;
+        return reader.takeMarkup();
     }
 
     if (!is<StaticPasteboard>(*m_pasteboard) && lowercaseType == "text/uri-list"_s) {

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -272,7 +272,8 @@ public:
     Node* nonBoundaryShadowTreeRootNode();
 
     // Node's parent or shadow tree host.
-    ContainerNode* parentOrShadowHostNode() const; // Defined in ShadowRoot.h
+    inline ContainerNode* parentOrShadowHostNode() const; // Defined in ShadowRoot.h
+    inline RefPtr<ContainerNode> protectedParentOrShadowHostNode() const; // Defined in ShadowRoot.h
     ContainerNode* parentInComposedTree() const;
     Element* parentElementInComposedTree() const;
     Element* parentOrShadowHostElement() const;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -177,6 +177,11 @@ inline ContainerNode* Node::parentOrShadowHostNode() const
     return parentNode();
 }
 
+inline RefPtr<ContainerNode> Node::protectedParentOrShadowHostNode() const
+{
+    return parentOrShadowHostNode();
+}
+
 inline bool hasShadowRootParent(const Node& node)
 {
     return node.parentNode() && node.parentNode()->isShadowRoot();

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -113,6 +113,7 @@ public:
     void apply();
     bool isFirstCommand(EditCommand* command) { return !m_commands.isEmpty() && m_commands.first() == command; }
     EditCommandComposition* composition() const;
+    RefPtr<EditCommandComposition> protectedComposition() const { return composition(); }
     EditCommandComposition& ensureComposition();
 
     virtual bool isCreateLinkCommand() const;

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -125,6 +125,8 @@ private:
     ReplacementFragment* ensureReplacementFragment();
     bool performTrivialReplace(const ReplacementFragment&);
 
+    RefPtr<DocumentFragment> protectedDocumentFragment() const { return m_documentFragment; }
+
     VisibleSelection m_visibleSelectionForInsertedText;
     Position m_startOfInsertedContent;
     Position m_endOfInsertedContent;

--- a/Source/WebCore/editing/SelectionGeometryGatherer.cpp
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.cpp
@@ -68,12 +68,12 @@ SelectionGeometryGatherer::Notifier::Notifier(SelectionGeometryGatherer& gathere
 
 SelectionGeometryGatherer::Notifier::~Notifier()
 {
-    auto page = m_gatherer.m_renderView.view().frame().page();
+    CheckedPtr page = m_gatherer.m_renderView->view().frame().page();
     if (!page)
         return;
 
     page->servicesOverlayController().selectionRectsDidChange(m_gatherer.boundingRects(), m_gatherer.m_gapRects, m_gatherer.isTextOnly());
-    page->imageOverlayController().selectionQuadsDidChange(m_gatherer.m_renderView.frame(), m_gatherer.m_quads);
+    page->imageOverlayController().selectionQuadsDidChange(m_gatherer.m_renderView->frame(), m_gatherer.m_quads);
 }
 
 Vector<LayoutRect> SelectionGeometryGatherer::boundingRects() const

--- a/Source/WebCore/editing/SelectionGeometryGatherer.h
+++ b/Source/WebCore/editing/SelectionGeometryGatherer.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(SERVICE_CONTROLS)
 
+#include <wtf/CheckedRef.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
 
@@ -66,7 +67,7 @@ public:
 private:
     Vector<LayoutRect> boundingRects() const;
 
-    RenderView& m_renderView;
+    CheckedRef<RenderView> m_renderView;
 
     // All rects are in RenderView coordinates.
     Vector<FloatQuad> m_quads;

--- a/Source/WebCore/editing/SetNodeAttributeCommand.cpp
+++ b/Source/WebCore/editing/SetNodeAttributeCommand.cpp
@@ -42,21 +42,21 @@ SetNodeAttributeCommand::SetNodeAttributeCommand(Ref<Element>&& element, const Q
 
 void SetNodeAttributeCommand::doApply()
 {
-    m_oldValue = m_element->getAttribute(m_attribute);
-    m_element->setAttribute(m_attribute, m_value);
+    auto element = protectedElement();
+    m_oldValue = element->getAttribute(m_attribute);
+    element->setAttribute(m_attribute, m_value);
 }
 
 void SetNodeAttributeCommand::doUnapply()
 {
-    m_element->setAttribute(m_attribute, m_oldValue);
-    AtomStringImpl* nullString = nullptr;
-    m_oldValue = nullString;
+    protectedElement()->setAttribute(m_attribute, m_oldValue);
+    m_oldValue = { };
 }
 
 #ifndef NDEBUG
 void SetNodeAttributeCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
 {
-    addNodeAndDescendants(m_element.ptr(), nodes);
+    addNodeAndDescendants(protectedElement().ptr(), nodes);
 }
 #endif
 

--- a/Source/WebCore/editing/SetNodeAttributeCommand.h
+++ b/Source/WebCore/editing/SetNodeAttributeCommand.h
@@ -47,6 +47,8 @@ private:
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif
 
+    Ref<Element> protectedElement() const { return m_element; }
+
     Ref<Element> m_element;
     QualifiedName m_attribute;
     AtomString m_value;

--- a/Source/WebCore/editing/SimplifyMarkupCommand.cpp
+++ b/Source/WebCore/editing/SimplifyMarkupCommand.cpp
@@ -43,7 +43,7 @@ SimplifyMarkupCommand::SimplifyMarkupCommand(Ref<Document>&& document, Node* fir
     
 void SimplifyMarkupCommand::doApply()
 {
-    Node* rootNode = m_firstNode->parentNode();
+    RefPtr rootNode = m_firstNode->parentNode();
     Vector<Ref<Node>> nodesToRemove;
     
     document().updateLayoutIgnorePendingStylesheets();
@@ -52,26 +52,26 @@ void SimplifyMarkupCommand::doApply()
     // without affecting the style. The goal is to produce leaner markup even when starting
     // from a verbose fragment.
     // We look at inline elements as well as non top level divs that don't have attributes. 
-    for (Node* node = m_firstNode.get(); node && node != m_nodeAfterLast; node = NodeTraversal::next(*node)) {
+    for (RefPtr node = m_firstNode.get(); node && node != m_nodeAfterLast; node = NodeTraversal::next(*node)) {
         if (node->firstChild() || (node->isTextNode() && node->nextSibling()) || !node->parentNode())
             continue;
         
-        Node* startingNode = node->parentNode();
+        RefPtr startingNode = node->parentNode();
         auto* startingStyle = startingNode->renderStyle();
         if (!startingStyle)
             continue;
-        Node* currentNode = startingNode;
-        Node* topNodeWithStartingStyle = nullptr;
+        RefPtr currentNode = startingNode;
+        RefPtr<Node> topNodeWithStartingStyle;
         while (currentNode != rootNode) {
-            if (currentNode->parentNode() != rootNode && isRemovableBlock(currentNode))
+            if (currentNode->parentNode() != rootNode && isRemovableBlock(currentNode.get()))
                 nodesToRemove.append(*currentNode);
             
             currentNode = currentNode->parentNode();
             if (!currentNode)
                 break;
 
-            auto* renderer = currentNode->renderer();
-            if (!is<RenderInline>(renderer) || downcast<RenderInline>(*renderer).mayAffectLayout())
+            CheckedPtr renderer = currentNode->renderer();
+            if (!is<RenderInline>(renderer.get()) || downcast<RenderInline>(*renderer).mayAffectLayout())
                 continue;
             
             if (currentNode->firstChild() != currentNode->lastChild()) {
@@ -85,7 +85,7 @@ void SimplifyMarkupCommand::doApply()
             
         }
         if (topNodeWithStartingStyle) {
-            for (Node* node = startingNode; node && node != topNodeWithStartingStyle; node = node->parentNode())
+            for (RefPtr node = startingNode; node && node != topNodeWithStartingStyle; node = node->parentNode())
                 nodesToRemove.append(*node);
         }
     }
@@ -111,8 +111,8 @@ int SimplifyMarkupCommand::pruneSubsequentAncestorsToRemove(Vector<Ref<Node>>& n
             break;
     }
 
-    Node* highestAncestorToRemove = nodesToRemove[pastLastNodeToRemove - 1].ptr();
-    RefPtr<ContainerNode> parent = highestAncestorToRemove->parentNode();
+    Ref highestAncestorToRemove = nodesToRemove[pastLastNodeToRemove - 1].get();
+    RefPtr parent = highestAncestorToRemove->parentNode();
     if (!parent) // Parent has already been removed.
         return -1;
     
@@ -120,8 +120,8 @@ int SimplifyMarkupCommand::pruneSubsequentAncestorsToRemove(Vector<Ref<Node>>& n
         return 0;
 
     removeNode(nodesToRemove[startNodeIndex], AssumeContentIsAlwaysEditable);
-    insertNodeBefore(nodesToRemove[startNodeIndex].copyRef(), *highestAncestorToRemove, AssumeContentIsAlwaysEditable);
-    removeNode(*highestAncestorToRemove, AssumeContentIsAlwaysEditable);
+    insertNodeBefore(nodesToRemove[startNodeIndex].copyRef(), highestAncestorToRemove, AssumeContentIsAlwaysEditable);
+    removeNode(highestAncestorToRemove, AssumeContentIsAlwaysEditable);
 
     return pastLastNodeToRemove - startNodeIndex - 1;
 }

--- a/Source/WebCore/editing/SpellChecker.h
+++ b/Source/WebCore/editing/SpellChecker.h
@@ -30,6 +30,7 @@
 #include "SimpleRange.h"
 #include "TextChecking.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 
 namespace WebCore {
@@ -59,7 +60,7 @@ private:
 
     SpellCheckRequest(const SimpleRange& checkingRange, const SimpleRange& automaticReplacementRange, const SimpleRange& paragraphRange, const String&, OptionSet<TextCheckingType>, TextCheckingProcessType);
 
-    SpellChecker* m_checker { nullptr };
+    CheckedPtr<SpellChecker> m_checker;
     SimpleRange m_checkingRange;
     SimpleRange m_automaticReplacementRange;
     SimpleRange m_paragraphRange;
@@ -67,7 +68,7 @@ private:
     TextCheckingRequestData m_requestData;
 };
 
-class SpellChecker {
+class SpellChecker : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     friend class SpellCheckRequest;
@@ -93,7 +94,9 @@ private:
     void didCheckCancel(TextCheckingRequestIdentifier);
     void didCheck(TextCheckingRequestIdentifier, const Vector<TextCheckingResult>&);
 
-    Document& m_document;
+    Ref<Document> protectedDocument() const { return m_document.get(); }
+
+    CheckedRef<Document> m_document;
     TextCheckingRequestIdentifier m_lastRequestIdentifier;
     TextCheckingRequestIdentifier m_lastProcessedIdentifier;
 

--- a/Source/WebCore/editing/SpellingCorrectionCommand.cpp
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.cpp
@@ -65,7 +65,7 @@ private:
     void doUnapply() override
     {
         if (!m_hasBeenUndone) {
-            document().editor().unappliedSpellCorrection(startingSelection(), m_corrected, m_correction);
+            protectedDocument()->editor().unappliedSpellCorrection(startingSelection(), m_corrected, m_correction);
             m_hasBeenUndone = true;
         }
         
@@ -108,15 +108,16 @@ void SpellingCorrectionCommand::doApply()
     if (!m_corrected.length())
         return;
 
-    if (!document().selection().shouldChangeSelection(m_selectionToBeCorrected))
+    Ref document = protectedDocument();
+    if (!document->selection().shouldChangeSelection(m_selectionToBeCorrected))
         return;
 
     applyCommandToComposite(SetSelectionCommand::create(m_selectionToBeCorrected, FrameSelection::defaultSetSelectionOptions() | FrameSelection::SetSelectionOption::SpellCorrectionTriggered));
 #if USE(AUTOCORRECTION_PANEL)
-    applyCommandToComposite(SpellingCorrectionRecordUndoCommand::create(document(), m_corrected, m_correction));
+    applyCommandToComposite(SpellingCorrectionRecordUndoCommand::create(document.copyRef(), m_corrected, m_correction));
 #endif
 
-    applyCommandToComposite(ReplaceSelectionCommand::create(document(), m_correctionFragment.copyRef(), ReplaceSelectionCommand::MatchStyle, EditAction::Paste));
+    applyCommandToComposite(ReplaceSelectionCommand::create(WTFMove(document), protectedCorrectionFragment(), ReplaceSelectionCommand::MatchStyle, EditAction::Paste));
 }
 
 String SpellingCorrectionCommand::inputEventData() const
@@ -135,7 +136,7 @@ Vector<RefPtr<StaticRange>> SpellingCorrectionCommand::targetRanges() const
 RefPtr<DataTransfer> SpellingCorrectionCommand::inputEventDataTransfer() const
 {
     if (!isEditingTextAreaOrTextInput())
-        return DataTransfer::createForInputEvent(m_correction, serializeFragment(*m_correctionFragment, SerializedNodes::SubtreeIncludingNode));
+        return DataTransfer::createForInputEvent(m_correction, serializeFragment(*protectedCorrectionFragment(), SerializedNodes::SubtreeIncludingNode));
 
     return CompositeEditCommand::inputEventDataTransfer();
 }

--- a/Source/WebCore/editing/SpellingCorrectionCommand.h
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.h
@@ -45,6 +45,8 @@ private:
     Vector<RefPtr<StaticRange>> targetRanges() const final;
     RefPtr<DataTransfer> inputEventDataTransfer() const final;
 
+    RefPtr<DocumentFragment> protectedCorrectionFragment() const { return m_correctionFragment; }
+
     SimpleRange m_rangeToBeCorrected;
     VisibleSelection m_selectionToBeCorrected;
     RefPtr<DocumentFragment> m_correctionFragment;

--- a/Source/WebCore/editing/SplitElementCommand.h
+++ b/Source/WebCore/editing/SplitElementCommand.h
@@ -48,6 +48,9 @@ private:
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif
 
+    RefPtr<Element> protectedElement1() const { return m_element1; }
+    Ref<Element> protectedElement2() const { return m_element2; }
+
     RefPtr<Element> m_element1;
     Ref<Element> m_element2;
     Ref<Node> m_atChild;

--- a/Source/WebCore/editing/SplitTextNodeCommand.h
+++ b/Source/WebCore/editing/SplitTextNodeCommand.h
@@ -50,6 +50,9 @@ private:
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif
 
+    RefPtr<Text> protectedText1() const { return m_text1; }
+    Ref<Text> protectedText2() const { return m_text2; }
+
     RefPtr<Text> m_text1;
     Ref<Text> m_text2;
     unsigned m_offset;

--- a/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
@@ -48,17 +48,17 @@ void SplitTextNodeContainingElementCommand::doApply()
 
     splitTextNode(m_text, m_offset);
 
-    Element* parent = m_text->parentElement();
+    RefPtr parent = m_text->parentElement();
     if (!parent || !parent->parentElement() || !parent->parentElement()->hasEditableStyle())
         return;
 
-    RenderElement* parentRenderer = parent->renderer();
+    CheckedPtr parentRenderer = parent->renderer();
     if (!parentRenderer || !parentRenderer->isInline()) {
         wrapContentsInDummySpan(*parent);
-        Node* firstChild = parent->firstChild();
+        RefPtr firstChild = parent->firstChild();
         if (!is<Element>(firstChild))
             return;
-        parent = downcast<Element>(firstChild);
+        parent = downcast<Element>(WTFMove(firstChild));
     }
 
     splitElement(*parent, m_text);

--- a/Source/WebCore/editing/TextInsertionBaseCommand.cpp
+++ b/Source/WebCore/editing/TextInsertionBaseCommand.cpp
@@ -60,11 +60,11 @@ String dispatchBeforeTextInsertedEvent(const String& text, const VisibleSelectio
         return text;
 
     String newText = text;
-    if (Node* startNode = selectionForInsertion.start().containerNode()) {
+    if (RefPtr startNode = selectionForInsertion.start().containerNode()) {
         if (startNode->rootEditableElement()) {
             // Send BeforeTextInsertedEvent. The event handler will update text if necessary.
-            Ref<BeforeTextInsertedEvent> event = BeforeTextInsertedEvent::create(text);
-            startNode->rootEditableElement()->dispatchEvent(event);
+            Ref event = BeforeTextInsertedEvent::create(text);
+            RefPtr { startNode->rootEditableElement() }->dispatchEvent(event);
             newText = event->text();
         }
     }
@@ -73,11 +73,11 @@ String dispatchBeforeTextInsertedEvent(const String& text, const VisibleSelectio
 
 bool canAppendNewLineFeedToSelection(const VisibleSelection& selection)
 {
-    Node* node = selection.rootEditableElement();
+    RefPtr node = selection.rootEditableElement();
     if (!node)
         return false;
     
-    Ref<BeforeTextInsertedEvent> event = BeforeTextInsertedEvent::create("\n"_s);
+    Ref event = BeforeTextInsertedEvent::create("\n"_s);
     node->dispatchEvent(event);
     return event->text().length();
 }

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -126,6 +126,8 @@ private:
 
     Node* baseNodeForEmittingNewLine() const;
 
+    RefPtr<Node> protectedStartContainer() const { return m_startContainer; }
+
     const TextIteratorBehaviors m_behaviors;
 
     // Current position, not necessarily of the text being returned, but position as we walk through the DOM tree.

--- a/Source/WebCore/editing/TypingCommand.h
+++ b/Source/WebCore/editing/TypingCommand.h
@@ -26,10 +26,11 @@
 #pragma once
 
 #include "TextInsertionBaseCommand.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
-class TypingCommand final : public TextInsertionBaseCommand {
+class TypingCommand final : public TextInsertionBaseCommand, public CanMakeCheckedPtr {
 public:
     enum class Type : uint8_t {
         DeleteSelection,

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -83,45 +83,45 @@ static Node* nextLeafWithSameEditability(Node* node, EditableType editableType)
 // FIXME: consolidate with code in previousLinePosition.
 static Position previousLineCandidatePosition(Node* node, const VisiblePosition& visiblePosition, EditableType editableType)
 {
-    auto highestRoot = highestEditableRoot(visiblePosition.deepEquivalent(), editableType);
-    Node* previousNode = previousLeafWithSameEditability(node, editableType);
+    RefPtr highestRoot = highestEditableRoot(visiblePosition.deepEquivalent(), editableType);
+    RefPtr previousNode = previousLeafWithSameEditability(node, editableType);
 
-    while (previousNode && (!previousNode->renderer() || inSameLine(firstPositionInOrBeforeNode(previousNode), visiblePosition)))
-        previousNode = previousLeafWithSameEditability(previousNode, editableType);
+    while (previousNode && (!previousNode->renderer() || inSameLine(firstPositionInOrBeforeNode(previousNode.get()), visiblePosition)))
+        previousNode = previousLeafWithSameEditability(previousNode.get(), editableType);
 
     while (previousNode && !previousNode->isShadowRoot()) {
-        if (highestEditableRoot(firstPositionInOrBeforeNode(previousNode), editableType) != highestRoot)
+        if (highestEditableRoot(firstPositionInOrBeforeNode(previousNode.get()), editableType) != highestRoot)
             break;
 
-        Position pos = previousNode->hasTagName(brTag) ? positionBeforeNode(previousNode) :
-            makeDeprecatedLegacyPosition(previousNode, caretMaxOffset(*previousNode));
+        Position pos = previousNode->hasTagName(brTag) ? positionBeforeNode(previousNode.get()) :
+            makeDeprecatedLegacyPosition(previousNode.get(), caretMaxOffset(*previousNode));
         
         if (pos.isCandidate())
             return pos;
 
-        previousNode = previousLeafWithSameEditability(previousNode, editableType);
+        previousNode = previousLeafWithSameEditability(previousNode.get(), editableType);
     }
     return Position();
 }
 
 static Position nextLineCandidatePosition(Node* node, const VisiblePosition& visiblePosition, EditableType editableType)
 {
-    auto highestRoot = highestEditableRoot(visiblePosition.deepEquivalent(), editableType);
-    Node* nextNode = nextLeafWithSameEditability(node, editableType);
-    while (nextNode && (!nextNode->renderer() || inSameLine(firstPositionInOrBeforeNode(nextNode), visiblePosition)))
-        nextNode = nextLeafWithSameEditability(nextNode, ContentIsEditable);
+    RefPtr highestRoot = highestEditableRoot(visiblePosition.deepEquivalent(), editableType);
+    RefPtr nextNode = nextLeafWithSameEditability(node, editableType);
+    while (nextNode && (!nextNode->renderer() || inSameLine(firstPositionInOrBeforeNode(nextNode.get()), visiblePosition)))
+        nextNode = nextLeafWithSameEditability(nextNode.get(), ContentIsEditable);
 
     while (nextNode && !nextNode->isShadowRoot()) {
-        if (highestEditableRoot(firstPositionInOrBeforeNode(nextNode), editableType) != highestRoot)
+        if (highestEditableRoot(firstPositionInOrBeforeNode(nextNode.get()), editableType) != highestRoot)
             break;
 
         Position pos;
-        pos = makeDeprecatedLegacyPosition(nextNode, caretMinOffset(*nextNode));
+        pos = makeDeprecatedLegacyPosition(nextNode.get(), caretMinOffset(*nextNode));
         
         if (pos.isCandidate())
             return pos;
 
-        nextNode = nextLeafWithSameEditability(nextNode, editableType);
+        nextNode = nextLeafWithSameEditability(nextNode.get(), editableType);
     }
     return Position();
 }
@@ -178,12 +178,12 @@ static const InlineIterator::LeafBoxIterator logicallyPreviousBox(const VisibleP
             return previousBox;
     }
 
-    while (1) {
-        auto* startNode = startBox->renderer().nonPseudoNode();
+    while (true) {
+        RefPtr startNode = startBox->renderer().nonPseudoNode();
         if (!startNode)
             break;
 
-        Position position = previousLineCandidatePosition(startNode, visiblePosition, ContentIsEditable);
+        Position position = previousLineCandidatePosition(startNode.get(), visiblePosition, ContentIsEditable);
         if (position.isNull())
             break;
 
@@ -216,12 +216,12 @@ static const InlineIterator::LeafBoxIterator logicallyNextBox(const VisiblePosit
             return nextBox;
     }
 
-    while (1) {
-        auto* startNode = startBox->renderer().nonPseudoNode();
+    while (true) {
+        RefPtr startNode = startBox->renderer().nonPseudoNode();
         if (!startNode)
             break;
 
-        Position position = nextLineCandidatePosition(startNode, visiblePosition, ContentIsEditable);
+        Position position = nextLineCandidatePosition(startNode.get(), visiblePosition, ContentIsEditable);
         if (position.isNull())
             break;
 
@@ -587,11 +587,11 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
 static VisiblePosition nextBoundary(const VisiblePosition& c, BoundarySearchFunction searchFunction)
 {
     Position pos = c.deepEquivalent();
-    Node* boundary = pos.parentEditingBoundary();
+    RefPtr boundary = pos.parentEditingBoundary();
     if (!boundary)
         return VisiblePosition();
 
-    Document& boundaryDocument = boundary->document();
+    Ref boundaryDocument = boundary->document();
 
     Vector<UChar, 1024> string;
     unsigned prefixLength = 0;
@@ -752,7 +752,7 @@ static VisiblePosition startPositionForLine(const VisiblePosition& c, LineEndpoi
 
     InlineIterator::LineLogicalOrderCache orderCache;
 
-    Node* startNode = nullptr;
+    RefPtr<Node> startNode;
     auto startBox = mode == UseLogicalOrdering ? InlineIterator::firstLeafOnLineInLogicalOrderWithNode(lineBox, orderCache) : lineBox->firstLeafBox();
     // Generated content (e.g. list markers and CSS :before and :after pseudoelements) have no corresponding DOM element,
     // and so cannot be represented by a VisiblePosition. Use whatever follows instead.
@@ -770,8 +770,8 @@ static VisiblePosition startPositionForLine(const VisiblePosition& c, LineEndpoi
             startBox.traverseNextOnLine();
     }
 
-    return is<Text>(*startNode) ? Position(downcast<Text>(startNode), downcast<InlineIterator::TextBox>(*startBox).start())
-        : positionBeforeNode(startNode);
+    return is<Text>(*startNode) ? Position(downcast<Text>(startNode.releaseNonNull()), downcast<InlineIterator::TextBox>(*startBox).start())
+        : positionBeforeNode(startNode.get());
 }
 
 static VisiblePosition startOfLine(const VisiblePosition& c, LineEndpointComputationMode mode, bool* reachedBoundary)
@@ -824,7 +824,7 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
 
     InlineIterator::LineLogicalOrderCache orderCache;
 
-    Node* endNode = nullptr;
+    RefPtr<Node> endNode;
     auto endBox = mode == UseLogicalOrdering ? InlineIterator::lastLeafOnLineInLogicalOrder(lineBox, orderCache) : lineBox->lastLeafBox();
     // Generated content (e.g. list markers and CSS :before and :after pseudoelements) have no corresponding DOM element,
     // and so cannot be represented by a VisiblePosition. Use whatever precedes instead.
@@ -844,15 +844,15 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
 
     Position pos;
     if (is<HTMLBRElement>(*endNode))
-        pos = positionBeforeNode(endNode);
+        pos = positionBeforeNode(endNode.get());
     else if (is<InlineIterator::TextBox>(*endBox) && is<Text>(*endNode)) {
         auto& endTextBox = downcast<InlineIterator::TextBox>(*endBox);
         int endOffset = endTextBox.start();
         if (!endTextBox.isLineBreak())
             endOffset += endTextBox.length();
-        pos = Position(downcast<Text>(endNode), endOffset);
+        pos = Position(downcast<Text>(endNode.releaseNonNull()), endOffset);
     } else
-        pos = positionAfterNode(endNode);
+        pos = positionAfterNode(endNode.get());
     
     return VisiblePosition(pos, Affinity::Upstream);
 }
@@ -879,7 +879,7 @@ static VisiblePosition endOfLine(const VisiblePosition& c, LineEndpointComputati
         if (!inSameLogicalLine(c, visPos))
             visPos = visPos.previous();
 
-        if (auto editableRoot = highestEditableRoot(c.deepEquivalent())) {
+        if (RefPtr editableRoot = highestEditableRoot(c.deepEquivalent())) {
             if (!editableRoot->contains(visPos.deepEquivalent().containerNode())) {
                 VisiblePosition newPosition = lastPositionInNode(editableRoot.get());
                 if (reachedBoundary)
@@ -963,9 +963,9 @@ VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, Lay
     if (!node)
         return VisiblePosition();
     
-    node->document().updateLayoutIgnorePendingStylesheets();
+    node->protectedDocument()->updateLayoutIgnorePendingStylesheets();
     
-    RenderObject* renderer = node->renderer();
+    CheckedPtr renderer = node->renderer();
     if (!renderer)
         return VisiblePosition();
 
@@ -994,20 +994,20 @@ VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, Lay
         auto box = closestBoxForHorizontalPosition(*lineBox, lineBox->isHorizontal() ? pointInLine.x() : pointInLine.y(), isEditablePosition(p));
         if (!box)
             return VisiblePosition();
-        auto& renderer = box->renderer();
-        Node* node = renderer.node();
+        CheckedRef renderer = box->renderer();
+        RefPtr node = renderer->node();
         if (node && editingIgnoresContent(*node))
-            return positionInParentBeforeNode(node);
-        return const_cast<RenderObject&>(renderer).positionForPoint(pointInLine, nullptr);
+            return positionInParentBeforeNode(node.get());
+        return const_cast<RenderObject&>(renderer.get()).positionForPoint(pointInLine, nullptr);
     }
     
     // Could not find a previous line. This means we must already be on the first line.
     // Move to the start of the content in this block, which effectively moves us
     // to the start of the line we're on.
-    Element* rootElement = rootEditableOrDocumentElement(*node, editableType);
+    RefPtr rootElement = rootEditableOrDocumentElement(*node, editableType);
     if (!rootElement)
         return VisiblePosition();
-    return firstPositionInNode(rootElement);
+    return firstPositionInNode(rootElement.get());
 }
 
 VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutUnit lineDirectionPoint, EditableType editableType)
@@ -1017,7 +1017,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
     if (!node)
         return VisiblePosition();
     
-    node->document().updateLayoutIgnorePendingStylesheets();
+    node->protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
     if (!node->renderer())
         return VisiblePosition();
@@ -1033,8 +1033,10 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
 
     if (!lineBox) {
         // FIXME: We need do the same in previousLinePosition.
-        Node* child = node->traverseToChildAt(p.deprecatedEditingOffset());
-        node = child ? child : node->lastDescendant();
+        if (RefPtr child = node->traverseToChildAt(p.deprecatedEditingOffset()))
+            node = WTFMove(child);
+        else
+            node = node->lastDescendant();
         Position position = nextLineCandidatePosition(node.get(), visiblePosition, editableType);
         if (position.isNotNull()) {
             RenderedPosition renderedPosition(position);
@@ -1050,20 +1052,20 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
         auto box = closestBoxForHorizontalPosition(*lineBox, lineBox->isHorizontal() ? pointInLine.x() : pointInLine.y(), isEditablePosition(p));
         if (!box)
             return VisiblePosition();
-        auto& renderer = box->renderer();
-        Node* node = renderer.node();
+        CheckedRef renderer = box->renderer();
+        RefPtr node = renderer->node();
         if (node && editingIgnoresContent(*node))
-            return positionInParentBeforeNode(node);
-        return const_cast<RenderObject&>(renderer).positionForPoint(pointInLine, nullptr);
+            return positionInParentBeforeNode(node.get());
+        return const_cast<RenderObject&>(renderer.get()).positionForPoint(pointInLine, nullptr);
     }
 
     // Could not find a next line. This means we must already be on the last line.
     // Move to the end of the content in this block, which effectively moves us
     // to the end of the line we're on.
-    Element* rootElement = rootEditableOrDocumentElement(*node, editableType);
+    RefPtr rootElement = rootEditableOrDocumentElement(*node, editableType);
     if (!rootElement)
         return VisiblePosition();
-    return lastPositionInNode(rootElement);
+    return lastPositionInNode(rootElement.get());
 }
 
 // ---------
@@ -1114,13 +1116,13 @@ VisiblePosition nextSentencePosition(const VisiblePosition& position)
     return position.honorEditingBoundaryAtOrAfter(nextBoundary(position, nextSentencePositionBoundary));
 }
 
-Node* findStartOfParagraph(Node* startNode, Node* highestRoot, Node* startBlock, int& offset, Position::AnchorType& type, EditingBoundaryCrossingRule boundaryCrossingRule)
+RefPtr<Node> findStartOfParagraph(Node* startNode, Node* highestRoot, Node* startBlock, int& offset, Position::AnchorType& type, EditingBoundaryCrossingRule boundaryCrossingRule)
 {
-    Node* node = startNode;
-    Node* n = startNode;
+    RefPtr node = startNode;
+    RefPtr n = startNode;
     bool startNodeIsEditable = startNode->hasEditableStyle();
     while (n) {
-        if (boundaryCrossingRule == CannotCrossEditingBoundary && !Position::nodeIsUserSelectAll(n) && n->hasEditableStyle() != startNodeIsEditable)
+        if (boundaryCrossingRule == CannotCrossEditingBoundary && !Position::nodeIsUserSelectAll(n.get()) && n->hasEditableStyle() != startNodeIsEditable)
             break;
         if (boundaryCrossingRule == CanSkipOverEditingBoundary) {
             while (n && n->hasEditableStyle() != startNodeIsEditable)
@@ -1128,7 +1130,7 @@ Node* findStartOfParagraph(Node* startNode, Node* highestRoot, Node* startBlock,
             if (!n || !n->isDescendantOf(highestRoot))
                 break;
         }
-        RenderObject* r = n->renderer();
+        CheckedPtr r = n->renderer();
         if (!r) {
             n = NodeTraversal::previousPostOrder(*n, startBlock);
             continue;
@@ -1161,7 +1163,7 @@ Node* findStartOfParagraph(Node* startNode, Node* highestRoot, Node* startBlock,
             node = n;
             offset = 0;
             n = NodeTraversal::previousPostOrder(*n, startBlock);
-        } else if (editingIgnoresContent(*n) || isRenderedTable(n)) {
+        } else if (editingIgnoresContent(*n) || isRenderedTable(n.get())) {
             node = n;
             type = Position::PositionIsBeforeAnchor;
             n = n->previousSibling() ? n->previousSibling() : NodeTraversal::previousPostOrder(*n, startBlock);
@@ -1172,13 +1174,13 @@ Node* findStartOfParagraph(Node* startNode, Node* highestRoot, Node* startBlock,
     return node;
 }
 
-Node* findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayInsideBlock, int& offset, Position::AnchorType& type, EditingBoundaryCrossingRule boundaryCrossingRule)
+RefPtr<Node> findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayInsideBlock, int& offset, Position::AnchorType& type, EditingBoundaryCrossingRule boundaryCrossingRule)
 {
-    Node* node = startNode;
-    Node* n = startNode;
+    RefPtr node = startNode;
+    RefPtr n = startNode;
     bool startNodeIsEditable = startNode->hasEditableStyle();
     while (n) {
-        if (boundaryCrossingRule == CannotCrossEditingBoundary && !Position::nodeIsUserSelectAll(n) && n->hasEditableStyle() != startNodeIsEditable)
+        if (boundaryCrossingRule == CannotCrossEditingBoundary && !Position::nodeIsUserSelectAll(n.get()) && n->hasEditableStyle() != startNodeIsEditable)
             break;
         if (boundaryCrossingRule == CanSkipOverEditingBoundary) {
             while (n && n->hasEditableStyle() != startNodeIsEditable)
@@ -1187,7 +1189,7 @@ Node* findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayInsideBlo
                 break;
         }
 
-        RenderObject* r = n->renderer();
+        CheckedPtr r = n->renderer();
         if (!r) {
             n = NodeTraversal::next(*n, stayInsideBlock);
             continue;
@@ -1220,7 +1222,7 @@ Node* findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayInsideBlo
             node = n;
             offset = r->caretMaxOffset();
             n = NodeTraversal::next(*n, stayInsideBlock);
-        } else if (editingIgnoresContent(*n) || isRenderedTable(n)) {
+        } else if (editingIgnoresContent(*n) || isRenderedTable(n.get())) {
             node = n;
             type = Position::PositionIsAfterAnchor;
             n = NodeTraversal::nextSkippingChildren(*n, stayInsideBlock);
@@ -1273,7 +1275,7 @@ VisiblePosition endOfParagraph(const VisiblePosition& c, EditingBoundaryCrossing
     
     RefPtr stayInsideBlock = enclosingBlock(startNode.get());
     
-    auto highestRoot = highestEditableRoot(p);
+    RefPtr highestRoot = highestEditableRoot(p);
     int offset = p.deprecatedEditingOffset();
     Position::AnchorType type = p.anchorType();
     
@@ -1389,7 +1391,8 @@ VisiblePosition startOfDocument(const Node* node)
     // The canonicalization of the position at (documentElement, 0) can turn the visible
     // position to null, even when there's a valid candidate to be had, because the root HTML element
     // is not content editable.  So we construct directly from the valid candidate.
-    Position firstCandidate = nextCandidate(makeDeprecatedLegacyPosition(node->document().documentElement(), 0));
+    RefPtr documentElement = node->document().documentElement();
+    Position firstCandidate = nextCandidate(makeDeprecatedLegacyPosition(documentElement.get(), 0));
     if (firstCandidate.isNull())
         return VisiblePosition();
     return VisiblePosition(firstCandidate);
@@ -1397,7 +1400,7 @@ VisiblePosition startOfDocument(const Node* node)
 
 VisiblePosition startOfDocument(const VisiblePosition& c)
 {
-    return startOfDocument(c.deepEquivalent().deprecatedNode());
+    return startOfDocument(c.deepEquivalent().protectedDeprecatedNode().get());
 }
 
 VisiblePosition endOfDocument(const Node* node)
@@ -1408,7 +1411,8 @@ VisiblePosition endOfDocument(const Node* node)
     // (As above, in startOfDocument.)  The canonicalization can reject valid visible positions
     // when descending from the root element, so we construct the visible position directly from a
     // valid candidate.
-    Position lastPosition = makeDeprecatedLegacyPosition(node->document().documentElement(), node->document().documentElement()->countChildNodes());
+    RefPtr documentElement = node->document().documentElement();
+    Position lastPosition = makeDeprecatedLegacyPosition(documentElement.get(), documentElement->countChildNodes());
     Position lastCandidate = previousCandidate(lastPosition);
     if (lastCandidate.isNull())
         return VisiblePosition();
@@ -1417,17 +1421,17 @@ VisiblePosition endOfDocument(const Node* node)
 
 VisiblePosition endOfDocument(const VisiblePosition& c)
 {
-    return endOfDocument(c.deepEquivalent().deprecatedNode());
+    return endOfDocument(c.deepEquivalent().protectedDeprecatedNode().get());
 }
 
 bool inSameDocument(const VisiblePosition& a, const VisiblePosition& b)
 {
     Position ap = a.deepEquivalent();
-    Node* an = ap.deprecatedNode();
+    RefPtr an = ap.deprecatedNode();
     if (!an)
         return false;
     Position bp = b.deepEquivalent();
-    Node* bn = bp.deprecatedNode();
+    RefPtr bn = bp.deprecatedNode();
     if (an == bn)
         return true;
 
@@ -1448,13 +1452,13 @@ bool isEndOfDocument(const VisiblePosition& p)
 
 VisiblePosition startOfEditableContent(const VisiblePosition& visiblePosition)
 {
-    auto highestRoot = highestEditableRoot(visiblePosition.deepEquivalent());
+    RefPtr highestRoot = highestEditableRoot(visiblePosition.deepEquivalent());
     return highestRoot ? firstPositionInNode(highestRoot.get()) : VisiblePosition { };
 }
 
 VisiblePosition endOfEditableContent(const VisiblePosition& visiblePosition)
 {
-    auto highestRoot = highestEditableRoot(visiblePosition.deepEquivalent());
+    RefPtr highestRoot = highestEditableRoot(visiblePosition.deepEquivalent());
     return highestRoot ? lastPositionInNode(highestRoot.get()) : VisiblePosition { };
 }
 

--- a/Source/WebCore/editing/VisibleUnits.h
+++ b/Source/WebCore/editing/VisibleUnits.h
@@ -123,7 +123,7 @@ unsigned suffixLengthForRange(const SimpleRange&, Vector<UChar, 1024>&);
 unsigned prefixLengthForRange(const SimpleRange&, Vector<UChar, 1024>&);
 unsigned backwardSearchForBoundaryWithTextIterator(SimplifiedBackwardsTextIterator&, Vector<UChar, 1024>&, unsigned, BoundarySearchFunction);
 unsigned forwardSearchForBoundaryWithTextIterator(TextIterator&, Vector<UChar, 1024>&, unsigned, BoundarySearchFunction);
-Node* findStartOfParagraph(Node*, Node*, Node*, int&, Position::AnchorType&, EditingBoundaryCrossingRule);
-Node* findEndOfParagraph(Node*, Node*, Node*, int&, Position::AnchorType&, EditingBoundaryCrossingRule);
+RefPtr<Node> findStartOfParagraph(Node*, Node*, Node*, int&, Position::AnchorType&, EditingBoundaryCrossingRule);
+RefPtr<Node> findEndOfParagraph(Node*, Node*, Node*, int&, Position::AnchorType&, EditingBoundaryCrossingRule);
 
 } // namespace WebCore

--- a/Source/WebCore/editing/WebContentReader.cpp
+++ b/Source/WebCore/editing/WebContentReader.cpp
@@ -33,27 +33,28 @@ namespace WebCore {
 
 void WebContentReader::addFragment(Ref<DocumentFragment>&& newFragment)
 {
-    if (!fragment)
-        fragment = WTFMove(newFragment);
+    if (!m_fragment)
+        m_fragment = WTFMove(newFragment);
     else
-        fragment->appendChild(newFragment.get());
+        protectedFragment()->appendChild(newFragment);
 }
 
 bool FrameWebContentReader::shouldSanitize() const
 {
-    ASSERT(frame.document());
-    return frame.document()->originIdentifierForPasteboard() != contentOrigin;
+    RefPtr document = m_frame->document();
+    ASSERT(document);
+    return document->originIdentifierForPasteboard() != contentOrigin();
 }
 
 MSOListQuirks FrameWebContentReader::msoListQuirksForMarkup() const
 {
-    return contentOrigin.isNull() ? MSOListQuirks::CheckIfNeeded : MSOListQuirks::Disabled;
+    return contentOrigin().isNull() ? MSOListQuirks::CheckIfNeeded : MSOListQuirks::Disabled;
 }
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)
 bool WebContentReader::readFilePaths(const Vector<String>& paths)
 {
-    if (paths.isEmpty() || !frame.document())
+    if (paths.isEmpty() || !frame().document())
         return false;
 
     for (auto& path : paths)

--- a/Source/WebCore/editing/WebContentReader.h
+++ b/Source/WebCore/editing/WebContentReader.h
@@ -30,6 +30,7 @@
 #include "Pasteboard.h"
 #include "SimpleRange.h"
 #include "markup.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -37,35 +38,36 @@ class ArchiveResource;
 
 class FrameWebContentReader : public PasteboardWebContentReader {
 public:
-    LocalFrame& frame;
-
     FrameWebContentReader(LocalFrame& frame)
-        : frame(frame)
+        : m_frame(frame)
     {
     }
+
+    LocalFrame& frame() const { return m_frame.get(); }
+    Ref<LocalFrame> protectedFrame() const { return m_frame.get(); }
 
 protected:
     bool shouldSanitize() const;
     MSOListQuirks msoListQuirksForMarkup() const;
+
+private:
+    CheckedRef<LocalFrame> m_frame;
 };
 
 class WebContentReader final : public FrameWebContentReader {
 public:
-    const SimpleRange context;
-    const bool allowPlainText;
-
-    RefPtr<DocumentFragment> fragment;
-    bool madeFragmentFromPlainText;
-
     WebContentReader(LocalFrame& frame, const SimpleRange& context, bool allowPlainText)
         : FrameWebContentReader(frame)
-        , context(context)
-        , allowPlainText(allowPlainText)
-        , madeFragmentFromPlainText(false)
+        , m_context(context)
+        , m_allowPlainText(allowPlainText)
     {
     }
 
     void addFragment(Ref<DocumentFragment>&&);
+    RefPtr<DocumentFragment> takeFragment() { return std::exchange(m_fragment, nullptr); }
+    RefPtr<DocumentFragment> protectedFragment() const { return m_fragment; }
+
+    bool madeFragmentFromPlainText() const { return m_madeFragmentFromPlainText; }
 
 private:
 #if PLATFORM(COCOA) || PLATFORM(GTK)
@@ -83,16 +85,22 @@ private:
     bool readRTF(SharedBuffer&) override;
     bool readDataBuffer(SharedBuffer&, const String& type, const AtomString& name, PresentationSize preferredPresentationSize = { }) override;
 #endif
+
+    const SimpleRange m_context;
+    const bool m_allowPlainText;
+
+    RefPtr<DocumentFragment> m_fragment;
+    bool m_madeFragmentFromPlainText { false };
 };
 
 class WebContentMarkupReader final : public FrameWebContentReader {
 public:
-    String markup;
-
     explicit WebContentMarkupReader(LocalFrame& frame)
         : FrameWebContentReader(frame)
     {
     }
+
+    String takeMarkup() { return std::exchange(m_markup, { }); }
 
 private:
 #if PLATFORM(COCOA) || PLATFORM(GTK)
@@ -110,6 +118,8 @@ private:
     bool readRTF(SharedBuffer&) override;
     bool readDataBuffer(SharedBuffer&, const String&, const AtomString&, PresentationSize = { }) override { return false; }
 #endif
+
+    String m_markup;
 };
 
 #if PLATFORM(COCOA) && defined(__OBJC__)

--- a/Source/WebCore/editing/WebCorePasteboardFileReader.cpp
+++ b/Source/WebCore/editing/WebCorePasteboardFileReader.cpp
@@ -36,12 +36,13 @@ WebCorePasteboardFileReader::~WebCorePasteboardFileReader() = default;
 
 void WebCorePasteboardFileReader::readFilename(const String& filename)
 {
-    files.append(File::create(context.get(), filename));
+    files.append(File::create(protectedContext().get(), filename));
 }
 
 void WebCorePasteboardFileReader::readBuffer(const String& filename, const String& type, Ref<SharedBuffer>&& buffer)
 {
-    files.append(File::create(context.get(), Blob::create(context.get(), buffer->extractData(), type), filename));
+    auto protectedContext = this->protectedContext();
+    files.append(File::create(protectedContext.get(), Blob::create(protectedContext.get(), buffer->extractData(), type), filename));
 }
 
 }

--- a/Source/WebCore/editing/WebCorePasteboardFileReader.h
+++ b/Source/WebCore/editing/WebCorePasteboardFileReader.h
@@ -43,6 +43,8 @@ struct WebCorePasteboardFileReader final : PasteboardFileReader {
     void readFilename(const String&) final;
     void readBuffer(const String& filename, const String& type, Ref<SharedBuffer>&&) final;
 
+    RefPtr<ScriptExecutionContext> protectedContext() const { return context; }
+
     RefPtr<ScriptExecutionContext> context;
     Vector<Ref<File>> files;
 };

--- a/Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp
+++ b/Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp
@@ -39,40 +39,47 @@ WrapContentsInDummySpanCommand::WrapContentsInDummySpanCommand(Element& element)
 void WrapContentsInDummySpanCommand::executeApply()
 {
     Vector<Ref<Node>> children;
-    for (Node* child = m_element->firstChild(); child; child = child->nextSibling())
+    Ref element = protectedElement();
+    for (RefPtr child = element->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
+    auto dummySpan = protectedDummySpan();
     for (auto& child : children)
-        m_dummySpan->appendChild(child);
+        dummySpan->appendChild(child);
 
-    m_element->appendChild(*m_dummySpan);
+    element->appendChild(*dummySpan);
 }
 
 void WrapContentsInDummySpanCommand::doApply()
 {
-    m_dummySpan = createStyleSpanElement(document());
+    m_dummySpan = createStyleSpanElement(protectedDocument());
     
     executeApply();
 }
     
 void WrapContentsInDummySpanCommand::doUnapply()
 {
-    if (!m_dummySpan || !m_element->hasEditableStyle())
+    if (!m_dummySpan)
+        return;
+
+    Ref element = protectedElement();
+    if (!element->hasEditableStyle())
         return;
 
     Vector<Ref<Node>> children;
-    for (Node* child = m_dummySpan->firstChild(); child; child = child->nextSibling())
+    auto dummySpan = protectedDummySpan();
+    for (RefPtr child = dummySpan->firstChild(); child; child = child->nextSibling())
         children.append(*child);
 
     for (auto& child : children)
-        m_element->appendChild(child);
+        element->appendChild(child);
 
-    m_dummySpan->remove();
+    dummySpan->remove();
 }
 
 void WrapContentsInDummySpanCommand::doReapply()
-{    
-    if (!m_dummySpan || !m_element->hasEditableStyle())
+{
+    if (!m_dummySpan || !protectedElement()->hasEditableStyle())
         return;
 
     executeApply();
@@ -81,8 +88,8 @@ void WrapContentsInDummySpanCommand::doReapply()
 #ifndef NDEBUG
 void WrapContentsInDummySpanCommand::getNodesInCommand(HashSet<Ref<Node>>& nodes)
 {
-    addNodeAndDescendants(m_element.ptr(), nodes);
-    addNodeAndDescendants(m_dummySpan.get(), nodes);
+    addNodeAndDescendants(protectedElement().ptr(), nodes);
+    addNodeAndDescendants(protectedDummySpan().get(), nodes);
 }
 #endif
     

--- a/Source/WebCore/editing/WrapContentsInDummySpanCommand.h
+++ b/Source/WebCore/editing/WrapContentsInDummySpanCommand.h
@@ -46,6 +46,9 @@ private:
     void doReapply() override;
     void executeApply();
 
+    RefPtr<HTMLElement> protectedDummySpan() const { return m_dummySpan; }
+    Ref<Element> protectedElement() const { return m_element; }
+
 #ifndef NDEBUG
     void getNodesInCommand(HashSet<Ref<Node>>&) override;
 #endif

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -275,8 +275,8 @@ RefPtr<DocumentFragment> Editor::webContentFromPasteboard(Pasteboard& pasteboard
 {
     WebContentReader reader(*document().frame(), context, allowPlainText);
     pasteboard.read(reader);
-    chosePlainText = reader.madeFragmentFromPlainText;
-    return WTFMove(reader.fragment);
+    chosePlainText = reader.madeFragmentFromPlainText();
+    return reader.takeFragment();
 }
 
 void Editor::takeFindStringFromSelection()

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -504,57 +504,57 @@ static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destination
 
 bool WebContentReader::readWebArchive(SharedBuffer& buffer)
 {
-    if (frame.settings().preferMIMETypeForImages() || !frame.document())
+    Ref frame = this->frame();
+    if (frame->settings().preferMIMETypeForImages() || !frame->document())
         return false;
 
     DeferredLoadingScope scope(frame);
     auto result = extractMarkupAndArchive(buffer, [&] (const String& type) {
-        return frame.loader().client().canShowMIMETypeAsHTML(type);
+        return frame->loader().client().canShowMIMETypeAsHTML(type);
     });
     if (!result)
         return false;
     
+    Ref frameDocument = *frame->document();
     if (!DeprecatedGlobalSettings::customPasteboardDataEnabled()) {
-        fragment = createFragmentFromMarkup(*frame.document(), result->markup, result->mainResource->url().string(), { });
-        if (DocumentLoader* loader = frame.loader().documentLoader())
+        m_fragment = createFragmentFromMarkup(frameDocument, result->markup, result->mainResource->url().string(), { });
+        if (DocumentLoader* loader = frame->loader().documentLoader())
             loader->addAllArchiveResources(result->archive.get());
         return true;
     }
 
     if (!shouldSanitize()) {
-        fragment = createFragmentFromMarkup(*frame.document(), result->markup, result->mainResource->url().string(), { });
+        m_fragment = createFragmentFromMarkup(frameDocument, result->markup, result->mainResource->url().string(), { });
         return true;
     }
 
-    String sanitizedMarkup = sanitizeMarkupWithArchive(frame, *frame.document(), *result, msoListQuirksForMarkup(), [&] (const String& type) {
-        return frame.loader().client().canShowMIMETypeAsHTML(type);
+    String sanitizedMarkup = sanitizeMarkupWithArchive(frame, frameDocument, *result, msoListQuirksForMarkup(), [&] (const String& type) {
+        return frame->loader().client().canShowMIMETypeAsHTML(type);
     });
-    fragment = createFragmentFromMarkup(*frame.document(), sanitizedMarkup, aboutBlankURL().string(), { });
+    m_fragment = createFragmentFromMarkup(frameDocument, sanitizedMarkup, aboutBlankURL().string(), { });
 
-    if (!fragment)
-        return false;
-
-    return true;
+    return m_fragment;
 }
 
 bool WebContentMarkupReader::readWebArchive(SharedBuffer& buffer)
 {
-    if (!frame.document())
+    Ref frame = this->frame();
+    if (!frame->document())
         return false;
 
     auto result = extractMarkupAndArchive(buffer, [&] (const String& type) {
-        return frame.loader().client().canShowMIMETypeAsHTML(type);
+        return frame->loader().client().canShowMIMETypeAsHTML(type);
     });
     if (!result)
         return false;
 
     if (!shouldSanitize()) {
-        markup = result->markup;
+        m_markup = result->markup;
         return true;
     }
 
-    markup = sanitizeMarkupWithArchive(frame, *frame.document(), *result, msoListQuirksForMarkup(), [&] (const String& type) {
-        return frame.loader().client().canShowMIMETypeAsHTML(type);
+    m_markup = sanitizeMarkupWithArchive(frame, *frame->protectedDocument(), *result, msoListQuirksForMarkup(), [&] (const String& type) {
+        return frame->loader().client().canShowMIMETypeAsHTML(type);
     });
 
     return true;
@@ -577,9 +577,9 @@ static String stripMicrosoftPrefix(const String& string)
 
 bool WebContentReader::readHTML(const String& string)
 {
-    if (frame.settings().preferMIMETypeForImages() || !frame.document())
+    if (frame().settings().preferMIMETypeForImages() || !frame().document())
         return false;
-    Document& document = *frame.document();
+    Ref document = *frame().document();
 
     String stringOmittingMicrosoftPrefix = stripMicrosoftPrefix(string);
     if (stringOmittingMicrosoftPrefix.isEmpty())
@@ -601,25 +601,26 @@ bool WebContentReader::readHTML(const String& string)
 
 bool WebContentMarkupReader::readHTML(const String& string)
 {
-    if (!frame.document())
+    if (!frame().document())
         return false;
 
     String rawHTML = stripMicrosoftPrefix(string);
     if (shouldSanitize()) {
-        markup = sanitizeMarkup(rawHTML, msoListQuirksForMarkup(), WTF::Function<void (DocumentFragment&)> { [] (DocumentFragment& fragment) {
+        m_markup = sanitizeMarkup(rawHTML, msoListQuirksForMarkup(), WTF::Function<void (DocumentFragment&)> { [] (DocumentFragment& fragment) {
             removeSubresourceURLAttributes(fragment, [](auto& url) {
                 return url.protocolIsFile();
             });
         } });
     } else
-        markup = rawHTML;
+        m_markup = rawHTML;
 
-    return !markup.isEmpty();
+    return !m_markup.isEmpty();
 }
 
 bool WebContentReader::readRTFD(SharedBuffer& buffer)
 {
-    if (frame.settings().preferMIMETypeForImages() || !frame.document())
+    Ref frame = this->frame();
+    if (frame->settings().preferMIMETypeForImages() || !frame->document())
         return false;
 
     auto string = adoptNS([[NSAttributedString alloc] initWithRTFD:buffer.createNSData().get() documentAttributes:nullptr]);
@@ -633,20 +634,22 @@ bool WebContentReader::readRTFD(SharedBuffer& buffer)
 
 bool WebContentMarkupReader::readRTFD(SharedBuffer& buffer)
 {
-    if (!frame.document())
+    Ref frame = this->frame();
+    if (!frame->document())
         return false;
     auto string = adoptNS([[NSAttributedString alloc] initWithRTFD:buffer.createNSData().get() documentAttributes:nullptr]);
     auto fragment = createFragmentAndAddResources(frame, string.get());
     if (!fragment)
         return false;
 
-    markup = serializeFragment(*fragment, SerializedNodes::SubtreeIncludingNode);
+    m_markup = serializeFragment(*fragment, SerializedNodes::SubtreeIncludingNode);
     return true;
 }
 
 bool WebContentReader::readRTF(SharedBuffer& buffer)
 {
-    if (frame.settings().preferMIMETypeForImages())
+    Ref frame = this->frame();
+    if (frame->settings().preferMIMETypeForImages())
         return false;
 
     auto string = adoptNS([[NSAttributedString alloc] initWithRTF:buffer.createNSData().get() documentAttributes:nullptr]);
@@ -660,44 +663,46 @@ bool WebContentReader::readRTF(SharedBuffer& buffer)
 
 bool WebContentMarkupReader::readRTF(SharedBuffer& buffer)
 {
-    if (!frame.document())
+    Ref frame = this->frame();
+    if (!frame->document())
         return false;
     auto string = adoptNS([[NSAttributedString alloc] initWithRTF:buffer.createNSData().get() documentAttributes:nullptr]);
     auto fragment = createFragmentAndAddResources(frame, string.get());
     if (!fragment)
         return false;
-    markup = serializeFragment(*fragment, SerializedNodes::SubtreeIncludingNode);
+    m_markup = serializeFragment(*fragment, SerializedNodes::SubtreeIncludingNode);
     return true;
 }
 
 bool WebContentReader::readPlainText(const String& text)
 {
-    if (!allowPlainText)
+    if (!m_allowPlainText)
         return false;
 
     String precomposedString = [text precomposedStringWithCanonicalMapping];
-    if (auto* page = frame.page())
+    if (CheckedPtr page = frame().page())
         precomposedString = page->applyLinkDecorationFiltering(precomposedString, LinkDecorationFilteringTrigger::Paste);
 
-    addFragment(createFragmentFromText(context, precomposedString));
+    addFragment(createFragmentFromText(m_context, precomposedString));
 
-    madeFragmentFromPlainText = true;
+    m_madeFragmentFromPlainText = true;
     return true;
 }
 
 bool WebContentReader::readImage(Ref<FragmentedSharedBuffer>&& buffer, const String& type, PresentationSize preferredPresentationSize)
 {
-    ASSERT(frame.document());
-    auto& document = *frame.document();
-    if (document.quirks().shouldAvoidPastingImagesAsWebContent())
+    ASSERT(frame().document());
+    Ref frame = this->frame();
+    Ref document = *frame->document();
+    if (document->quirks().shouldAvoidPastingImagesAsWebContent())
         return false;
 
     if (shouldReplaceRichContentWithAttachments())
         addFragment(createFragmentForImageAttachment(frame, document, WTFMove(buffer), type, preferredPresentationSize));
     else
-        addFragment(createFragmentForImageAndURL(document, DOMURL::createObjectURL(document, Blob::create(&document, buffer->extractData(), type)), preferredPresentationSize));
+        addFragment(createFragmentForImageAndURL(document, DOMURL::createObjectURL(document, Blob::create(document.ptr(), buffer->extractData(), type)), preferredPresentationSize));
 
-    return fragment;
+    return m_fragment;
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -799,16 +804,17 @@ static Ref<HTMLElement> attachmentForData(LocalFrame& frame, FragmentedSharedBuf
 
 bool WebContentReader::readFilePath(const String& path, PresentationSize preferredPresentationSize, const String& contentType)
 {
-    if (path.isEmpty() || !frame.document())
+    Ref frame = this->frame();
+    if (path.isEmpty() || !frame->document())
         return false;
 
-    auto& document = *frame.document();
-    if (!fragment)
-        fragment = document.createDocumentFragment();
+    Ref document = *frame->document();
+    if (!m_fragment)
+        m_fragment = document->createDocumentFragment();
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     if (DeprecatedGlobalSettings::attachmentElementEnabled())
-        fragment->appendChild(attachmentForFilePath(frame, path, preferredPresentationSize, contentType));
+        m_fragment->appendChild(attachmentForFilePath(frame, path, preferredPresentationSize, contentType));
 #endif
 
     return true;
@@ -819,9 +825,10 @@ bool WebContentReader::readURL(const URL& url, const String& title)
     if (url.isEmpty())
         return false;
 
+    Ref frame = this->frame();
 #if PLATFORM(IOS_FAMILY)
     // FIXME: This code shouldn't be accessing selection and changing the behavior.
-    if (!frame.editor().client()->hasRichlyEditableSelection()) {
+    if (!frame->editor().client()->hasRichlyEditableSelection()) {
         if (readPlainText([(NSURL *)url absoluteString]))
             return true;
     }
@@ -831,12 +838,12 @@ bool WebContentReader::readURL(const URL& url, const String& title)
 #endif // PLATFORM(IOS_FAMILY)
 
     auto sanitizedURLString = [&] {
-        if (auto* page = frame.page())
+        if (auto* page = frame->page())
             return page->applyLinkDecorationFiltering(url, LinkDecorationFilteringTrigger::Paste);
         return url;
     }().string();
 
-    Ref document = *frame.document();
+    Ref document = *frame->document();
     auto anchor = HTMLAnchorElement::create(document.get());
     anchor->setAttributeWithoutSynchronization(HTMLNames::hrefAttr, AtomString { sanitizedURLString });
 
@@ -844,7 +851,7 @@ bool WebContentReader::readURL(const URL& url, const String& title)
     anchor->appendChild(document->createTextNode([linkText precomposedStringWithCanonicalMapping]));
 
     auto newFragment = document->createDocumentFragment();
-    if (fragment)
+    if (m_fragment)
         newFragment->appendChild(HTMLBRElement::create(document.get()));
     newFragment->appendChild(anchor);
     addFragment(WTFMove(newFragment));
@@ -859,15 +866,16 @@ bool WebContentReader::readDataBuffer(SharedBuffer& buffer, const String& type, 
     if (!shouldReplaceRichContentWithAttachments())
         return false;
 
-    RefPtr document { frame.document() };
+    Ref frame = this->frame();
+    RefPtr document { frame->document() };
     if (!document)
         return false;
 
-    if (!fragment)
-        fragment = document->createDocumentFragment();
+    if (!m_fragment)
+        m_fragment = document->createDocumentFragment();
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    fragment->appendChild(attachmentForData(frame, buffer, type, name, preferredPresentationSize));
+    protectedFragment()->appendChild(attachmentForData(frame, buffer, type, name, preferredPresentationSize));
 #else
     UNUSED_PARAM(type);
     UNUSED_PARAM(name);

--- a/Source/WebCore/editing/gtk/EditorGtk.cpp
+++ b/Source/WebCore/editing/gtk/EditorGtk.cpp
@@ -125,8 +125,8 @@ RefPtr<DocumentFragment> Editor::webContentFromPasteboard(Pasteboard& pasteboard
 {
     WebContentReader reader(*document().frame(), context, allowPlainText);
     pasteboard.read(reader);
-    chosePlainText = reader.madeFragmentFromPlainText;
-    return WTFMove(reader.fragment);
+    chosePlainText = reader.madeFragmentFromPlainText();
+    return reader.takeFragment();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/gtk/WebContentReaderGtk.cpp
+++ b/Source/WebCore/editing/gtk/WebContentReaderGtk.cpp
@@ -42,42 +42,42 @@ namespace WebCore {
 
 bool WebContentReader::readFilePath(const String& path, PresentationSize, const String&)
 {
-    if (path.isEmpty() || !frame.document())
+    if (path.isEmpty() || !frame().document())
         return false;
 
     auto markup = urlToMarkup(URL({ }, path), path);
-    addFragment(createFragmentFromMarkup(*frame.document(), markup, "file://"_s, { }));
+    addFragment(createFragmentFromMarkup(*frame().protectedDocument(), markup, "file://"_s, { }));
 
     return true;
 }
 
 bool WebContentReader::readHTML(const String& string)
 {
-    if (frame.settings().preferMIMETypeForImages() || !frame.document())
+    if (frame().settings().preferMIMETypeForImages() || !frame().document())
         return false;
 
-    addFragment(createFragmentFromMarkup(*frame.document(), string, emptyString(), { }));
+    addFragment(createFragmentFromMarkup(*frame().protectedDocument(), string, emptyString(), { }));
     return true;
 }
 
 bool WebContentReader::readPlainText(const String& text)
 {
-    if (!allowPlainText)
+    if (!m_allowPlainText)
         return false;
 
-    addFragment(createFragmentFromText(context, text));
+    addFragment(createFragmentFromText(m_context, text));
 
-    madeFragmentFromPlainText = true;
+    m_madeFragmentFromPlainText = true;
     return true;
 }
 
 bool WebContentReader::readImage(Ref<FragmentedSharedBuffer>&& buffer, const String& type, PresentationSize preferredPresentationSize)
 {
-    ASSERT(frame.document());
-    auto& document = *frame.document();
-    addFragment(createFragmentForImageAndURL(document, DOMURL::createObjectURL(document, Blob::create(&document, buffer->extractData(), type)), preferredPresentationSize));
+    ASSERT(frame()->document());
+    Ref document = *frame().document();
+    addFragment(createFragmentForImageAndURL(document, DOMURL::createObjectURL(document, Blob::create(document.ptr(), buffer->extractData(), type)), preferredPresentationSize));
 
-    return fragment;
+    return m_fragment;
 }
 
 bool WebContentReader::readURL(const URL&, const String&)
@@ -92,19 +92,19 @@ static bool shouldReplaceSubresourceURL(const URL& url)
 
 bool WebContentMarkupReader::readHTML(const String& string)
 {
-    if (!frame.document())
+    if (!frame().document())
         return false;
 
     if (shouldSanitize()) {
-        markup = sanitizeMarkup(string, MSOListQuirks::Disabled, Function<void(DocumentFragment&)> { [](DocumentFragment& fragment) {
+        m_markup = sanitizeMarkup(string, MSOListQuirks::Disabled, Function<void(DocumentFragment&)> { [](DocumentFragment& fragment) {
             removeSubresourceURLAttributes(fragment, [](const URL& url) {
                 return shouldReplaceSubresourceURL(url);
             });
         } });
     } else
-        markup = string;
+        m_markup = string;
 
-    return !markup.isEmpty();
+    return !m_markup.isEmpty();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -215,7 +215,7 @@ void Editor::pasteWithPasteboard(Pasteboard* pasteboard, OptionSet<PasteOption> 
         reader.addFragment(fragment.releaseNonNull());
     }
 
-    auto fragment = WTFMove(reader.fragment);
+    auto fragment = reader.takeFragment();
     if (!fragment) {
         bool chosePlainTextIgnored;
         fragment = webContentFromPasteboard(*pasteboard, *range, allowPlainText, chosePlainTextIgnored);

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1474,12 +1474,13 @@ bool DragController::tryToUpdateDroppedImagePlaceholders(const DragData& dragDat
     auto pasteboard = Pasteboard::create(dragData);
     pasteboard->read(reader);
 
-    if (!reader.fragment)
+    auto fragment = reader.protectedFragment();
+    if (!fragment)
         return false;
 
     Vector<Ref<HTMLImageElement>> imageElements;
-    for (auto& imageElement : descendantsOfType<HTMLImageElement>(*reader.fragment))
-        imageElements.append(imageElement);
+    for (Ref imageElement : descendantsOfType<HTMLImageElement>(*fragment))
+        imageElements.append(WTFMove(imageElement));
 
     if (imageElements.size() != m_droppedImagePlaceholders.size()) {
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -139,6 +139,7 @@ public:
     WEBCORE_EXPORT void willDetachPage();
 
     Document* document() const;
+    RefPtr<Document> protectedDocument() const;
     LocalFrameView* view() const;
 
     Editor& editor() { return document()->editor(); }
@@ -356,6 +357,11 @@ inline LocalFrameView* LocalFrame::view() const
 inline Document* LocalFrame::document() const
 {
     return m_doc.get();
+}
+
+inline RefPtr<Document> LocalFrame::protectedDocument() const
+{
+    return document();
 }
 
 inline LocalFrameView* Document::view() const

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -144,8 +144,6 @@ struct PasteboardBuffer {
 
 class PasteboardWebContentReader {
 public:
-    String contentOrigin;
-
     virtual ~PasteboardWebContentReader() = default;
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)
@@ -163,6 +161,12 @@ public:
     virtual bool readRTF(SharedBuffer&) = 0;
     virtual bool readDataBuffer(SharedBuffer&, const String& type, const AtomString& name, PresentationSize preferredPresentationSize = { }) = 0;
 #endif
+
+    const String& contentOrigin() const { return m_contentOrigin; }
+    void setContentOrigin(const String& contentOrigin) { m_contentOrigin = contentOrigin; }
+
+private:
+    String m_contentOrigin;
 };
 
 struct PasteboardPlainText {

--- a/Source/WebCore/platform/gtk/PasteboardGtk.cpp
+++ b/Source/WebCore/platform/gtk/PasteboardGtk.cpp
@@ -267,7 +267,7 @@ void Pasteboard::read(PasteboardPlainText& text, PlainTextURLReadingPolicy, std:
 
 void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolicy policy, std::optional<size_t>)
 {
-    reader.contentOrigin = readOrigin();
+    reader.setContentOrigin(readOrigin());
 
     if (m_selectionData) {
         if (m_selectionData->hasMarkup() && reader.readHTML(m_selectionData->markup()))

--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -322,7 +322,7 @@ static bool prefersAttachmentRepresentation(const PasteboardItemInfo& info)
 
 void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolicy policy, std::optional<size_t> itemIndex)
 {
-    reader.contentOrigin = readOrigin();
+    reader.setContentOrigin(readOrigin());
     if (respectsUTIFidelities()) {
         readRespectingUTIFidelities(reader, policy, itemIndex);
         return;

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -456,7 +456,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
             nonTranscodedTypes = platformTypesFromItems(*allItems);
     }
 
-    reader.contentOrigin = readOrigin();
+    reader.setContentOrigin(readOrigin());
 
     if (types.contains(WebArchivePboardType)) {
         if (auto buffer = readBufferAtPreferredItemIndex(WebArchivePboardType, itemIndex, strategy, m_pasteboardName, context())) {


### PR DESCRIPTION
#### 389241b67619b49fab63ca2d9abafb5c2a69358a
<pre>
Use more smart pointers in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=262854">https://bugs.webkit.org/show_bug.cgi?id=262854</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::getType):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::startCharacterOffsetOfParagraph):
(WebCore::AXObjectCache::endCharacterOffsetOfParagraph):
* Source/WebCore/dom/BoundaryPoint.h:
(WebCore::BoundaryPoint::protectedDocument const):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::readStringFromPasteboard const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/ShadowRoot.h:
(WebCore::Node::protectedParentOrShadowHostNode const):
* Source/WebCore/editing/CompositeEditCommand.h:
(WebCore::CompositeEditCommand::protectedComposition const):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::ReplacementFragment):
(WebCore::ReplacementFragment::removeNodePreservingChildren):
(WebCore::fragmentNeedsColorTransformed):
(WebCore::ReplaceSelectionCommand::inverseTransformColor):
(WebCore::ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline):
(WebCore::ReplaceSelectionCommand::makeInsertedContentRoundTrippableWithHTMLTreeBuilder):
(WebCore::ReplaceSelectionCommand::moveNodeOutOfAncestor):
(WebCore::ReplaceSelectionCommand::willApplyCommand):
(WebCore::ReplaceSelectionCommand::doApply):
(WebCore::ReplaceSelectionCommand::inputEventData const):
(WebCore::ReplaceSelectionCommand::ensureReplacementFragment):
* Source/WebCore/editing/ReplaceSelectionCommand.h:
(WebCore::ReplaceSelectionCommand::protectedDocumentFragment const):
* Source/WebCore/editing/SelectionGeometryGatherer.cpp:
(WebCore::SelectionGeometryGatherer::Notifier::~Notifier):
* Source/WebCore/editing/SelectionGeometryGatherer.h:
* Source/WebCore/editing/SetNodeAttributeCommand.cpp:
(WebCore::SetNodeAttributeCommand::doApply):
(WebCore::SetNodeAttributeCommand::doUnapply):
(WebCore::SetNodeAttributeCommand::getNodesInCommand):
* Source/WebCore/editing/SetNodeAttributeCommand.h:
(WebCore::SetNodeAttributeCommand::protectedElement const):
* Source/WebCore/editing/SimplifyMarkupCommand.cpp:
(WebCore::SimplifyMarkupCommand::doApply):
(WebCore::SimplifyMarkupCommand::pruneSubsequentAncestorsToRemove):
* Source/WebCore/editing/SpellChecker.cpp:
(WebCore::SpellChecker::client const):
(WebCore::SpellChecker::isAsynchronousEnabled const):
(WebCore::SpellChecker::isCheckable const):
(WebCore::SpellChecker::invokeRequest):
(WebCore::SpellChecker::didCheck):
* Source/WebCore/editing/SpellChecker.h:
(WebCore::SpellChecker::protectedDocument const):
* Source/WebCore/editing/SpellingCorrectionCommand.cpp:
(WebCore::SpellingCorrectionCommand::doApply):
(WebCore::SpellingCorrectionCommand::inputEventDataTransfer const):
* Source/WebCore/editing/SpellingCorrectionCommand.h:
(WebCore::SpellingCorrectionCommand::protectedCorrectionFragment const):
* Source/WebCore/editing/SplitElementCommand.cpp:
(WebCore::SplitElementCommand::executeApply):
(WebCore::SplitElementCommand::doApply):
(WebCore::SplitElementCommand::doUnapply):
(WebCore::SplitElementCommand::getNodesInCommand):
* Source/WebCore/editing/SplitElementCommand.h:
(WebCore::SplitElementCommand::protectedElement1 const):
(WebCore::SplitElementCommand::protectedElement2 const):
* Source/WebCore/editing/SplitTextNodeCommand.cpp:
(WebCore::SplitTextNodeCommand::doApply):
(WebCore::SplitTextNodeCommand::doUnapply):
(WebCore::SplitTextNodeCommand::doReapply):
(WebCore::SplitTextNodeCommand::insertText1AndTrimText2):
(WebCore::SplitTextNodeCommand::getNodesInCommand):
* Source/WebCore/editing/SplitTextNodeCommand.h:
(WebCore::SplitTextNodeCommand::protectedText1 const):
(WebCore::SplitTextNodeCommand::protectedText2 const):
* Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp:
(WebCore::SplitTextNodeContainingElementCommand::doApply):
* Source/WebCore/editing/TextInsertionBaseCommand.cpp:
(WebCore::dispatchBeforeTextInsertedEvent):
(WebCore::canAppendNewLineFeedToSelection):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::nextInPreOrderCrossingShadowBoundaries):
(WebCore::fullyClipsContents):
(WebCore::ignoresContainerClip):
(WebCore::setUpFullyClippedStack):
(WebCore::isClippedByFrameAncestor):
(WebCore::isRendererReplacedElement):
(WebCore::firstNode):
(WebCore::TextIterator::TextIterator):
(WebCore::TextIterator::init):
(WebCore::TextIterator::advance):
(WebCore::TextIterator::handleTextNode):
(WebCore::TextIterator::handleTextRun):
(WebCore::TextIterator::handleTextNodeFirstLetter):
(WebCore::TextIterator::handleReplacedElement):
(WebCore::shouldEmitTabBeforeNode):
(WebCore::shouldEmitNewlineForNode):
(WebCore::shouldEmitNewlinesBeforeAndAfterNode):
(WebCore::shouldEmitNewlineAfterNode):
(WebCore::shouldEmitExtraNewlineForNode):
(WebCore::maxOffsetIncludingCollapsedSpaces):
(WebCore::TextIterator::shouldRepresentNodeOffsetZero):
(WebCore::TextIterator::protectedCurrentNode const):
(WebCore::SimplifiedBackwardsTextIterator::SimplifiedBackwardsTextIterator):
(WebCore::SimplifiedBackwardsTextIterator::advance):
(WebCore::SimplifiedBackwardsTextIterator::handleTextNode):
(WebCore::SimplifiedBackwardsTextIterator::handleFirstLetter):
(WebCore::SimplifiedBackwardsTextIterator::range const):
(WebCore::CharacterIterator::range const):
(WebCore::BackwardsCharacterIterator::range const):
(WebCore::isInsideReplacedElement):
* Source/WebCore/editing/TextIterator.h:
(WebCore::TextIterator::protectedStartContainer const):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::ExclusionRuleMatcher::isExcluded):
(WebCore::TextManipulationController::startObservingParagraphs):
(WebCore::ParagraphContentIterator::currentContent):
(WebCore::ParagraphContentIterator::shouldAdvanceIteratorPastCurrentNode const):
(WebCore::isEnclosingItemBoundaryElement):
(WebCore::TextManipulationController::observeParagraphs):
(WebCore::TextManipulationController::didAddOrCreateRendererForNode):
(WebCore::TextManipulationController::scheduleObservationUpdate):
(WebCore::TextManipulationController::flushPendingItemsForCallback):
(WebCore::TextManipulationController::completeManipulation):
(WebCore::TextManipulationController::getPath):
(WebCore::TextManipulationController::updateInsertions):
(WebCore::TextManipulationController::replace):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommandLineOperation::TypingCommandLineOperation):
(WebCore::TypingCommand::insertLineBreak):
(WebCore::TypingCommand::insertParagraphSeparatorInQuotedContent):
(WebCore::TypingCommand::insertParagraphSeparator):
(WebCore::TypingCommand::lastTypingCommandIfStillOpenForTyping):
(WebCore::TypingCommand::closeTyping):
(WebCore::TypingCommand::ensureLastEditCommandHasCurrentSelectionIfOpenForMoreTyping):
(WebCore::TypingCommand::postTextStateChangeNotificationForDeletion):
(WebCore::TypingCommand::markMisspellingsAfterTyping):
(WebCore::TypingCommand::willAddTypingToOpenCommand):
(WebCore::TypingCommand::typingAddedToOpenCommand):
(WebCore::TypingCommand::insertText):
(WebCore::TypingCommand::insertTextAndNotifyAccessibility):
(WebCore::TypingCommand::insertTextRunWithoutNewlines):
(WebCore::TypingCommand::insertLineBreakAndNotifyAccessibility):
(WebCore::TypingCommand::insertParagraphSeparatorAndNotifyAccessibility):
(WebCore::TypingCommand::insertParagraphSeparatorInQuotedContentAndNotifyAccessibility):
(WebCore::TypingCommand::makeEditableRootEmpty):
(WebCore::TypingCommand::deleteKeyPressed):
(WebCore::TypingCommand::forwardDeleteKeyPressed):
(WebCore::TypingCommand::setEndingSelectionOnLastInsertCommand):
* Source/WebCore/editing/TypingCommand.h:
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::leftVisuallyDistinctCandidate const):
(WebCore::VisiblePosition::rightVisuallyDistinctCandidate const):
(WebCore::VisiblePosition::honorEditingBoundaryAtOrBefore const):
(WebCore::VisiblePosition::honorEditingBoundaryAtOrAfter const):
(WebCore::VisiblePosition::canonicalPosition):
(WebCore::VisiblePosition::characterAfter const):
(WebCore::VisiblePosition::localCaretRect const):
(WebCore::VisiblePosition::lineDirectionPointForBlockDirectionNavigation const):
(WebCore::enclosingBlockFlowElement):
(WebCore::isFirstVisiblePositionInNode):
(WebCore::isLastVisiblePositionInNode):
(WebCore::areVisiblePositionsInSameTreeScope):
(WebCore::midpoint):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::toNormalizedRange const):
(WebCore::VisibleSelection::appendTrailingWhitespace):
(WebCore::VisibleSelection::adjustPositionForEnd):
(WebCore::VisibleSelection::adjustPositionForStart):
(WebCore::isInUserAgentShadowRootOrHasEditableShadowAncestor):
(WebCore::VisibleSelection::adjustSelectionToAvoidCrossingShadowBoundaries):
(WebCore::VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries):
(WebCore::VisibleSelection::hasEditableStyle const):
(WebCore::VisibleSelection::isInPasswordField const):
(WebCore::VisibleSelection::isInAutoFilledAndViewableField const):
(WebCore::VisibleSelection::showTreeForThis const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::previousLineCandidatePosition):
(WebCore::nextLineCandidatePosition):
(WebCore::logicallyPreviousBox):
(WebCore::logicallyNextBox):
(WebCore::nextBoundary):
(WebCore::startPositionForLine):
(WebCore::endPositionForLine):
(WebCore::endOfLine):
(WebCore::previousLinePosition):
(WebCore::nextLinePosition):
(WebCore::findStartOfParagraph):
(WebCore::findEndOfParagraph):
(WebCore::endOfParagraph):
(WebCore::startOfDocument):
(WebCore::endOfDocument):
(WebCore::inSameDocument):
(WebCore::startOfEditableContent):
(WebCore::endOfEditableContent):
* Source/WebCore/editing/VisibleUnits.h:
* Source/WebCore/editing/WebContentReader.cpp:
(WebCore::WebContentReader::addFragment):
(WebCore::FrameWebContentReader::shouldSanitize const):
(WebCore::FrameWebContentReader::msoListQuirksForMarkup const):
(WebCore::WebContentReader::readFilePaths):
* Source/WebCore/editing/WebContentReader.h:
(WebCore::FrameWebContentReader::FrameWebContentReader):
(WebCore::FrameWebContentReader::frame const):
(WebCore::FrameWebContentReader::protectedFrame const):
* Source/WebCore/editing/WebCorePasteboardFileReader.cpp:
(WebCore::WebCorePasteboardFileReader::readFilename):
(WebCore::WebCorePasteboardFileReader::readBuffer):
* Source/WebCore/editing/WebCorePasteboardFileReader.h:
* Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp:
(WebCore::WrapContentsInDummySpanCommand::executeApply):
(WebCore::WrapContentsInDummySpanCommand::doApply):
(WebCore::WrapContentsInDummySpanCommand::doUnapply):
(WebCore::WrapContentsInDummySpanCommand::doReapply):
(WebCore::WrapContentsInDummySpanCommand::getNodesInCommand):
* Source/WebCore/editing/WrapContentsInDummySpanCommand.h:
(WebCore::WrapContentsInDummySpanCommand::protectedDummySpan const):
(WebCore::WrapContentsInDummySpanCommand::protectedElement const):
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::webContentFromPasteboard):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::WebContentReader::readWebArchive):
(WebCore::WebContentMarkupReader::readWebArchive):
(WebCore::WebContentReader::readHTML):
(WebCore::WebContentMarkupReader::readHTML):
(WebCore::WebContentReader::readRTFD):
(WebCore::WebContentMarkupReader::readRTFD):
(WebCore::WebContentReader::readRTF):
(WebCore::WebContentMarkupReader::readRTF):
(WebCore::WebContentReader::readPlainText):
(WebCore::WebContentReader::readImage):
* Source/WebCore/editing/gtk/EditorGtk.cpp:
(WebCore::Editor::webContentFromPasteboard):
* Source/WebCore/editing/gtk/WebContentReaderGtk.cpp:
(WebCore::WebContentReader::readFilePath):
(WebCore::WebContentReader::readHTML):
(WebCore::WebContentReader::readPlainText):
(WebCore::WebContentReader::readImage):
(WebCore::WebContentMarkupReader::readHTML):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::pasteWithPasteboard):
(WebCore::Editor::platformCopyFont): Deleted.
(WebCore::Editor::platformPasteFont): Deleted.
(WebCore::Editor::insertDictationPhrases): Deleted.
(WebCore::Editor::setDictationPhrasesAsChildOfElement): Deleted.
(WebCore::Editor::confirmMarkedText): Deleted.
(WebCore::Editor::setTextAsChildOfElement): Deleted.
(WebCore::Editor::ensureLastEditCommandHasCurrentSelectionIfOpenForMoreTyping): Deleted.
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::tryToUpdateDroppedImagePlaceholders):
* Source/WebCore/platform/Pasteboard.h:
(WebCore::PasteboardWebContentReader::contentOrigin const):
(WebCore::PasteboardWebContentReader::setContentOrigin):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::read):

Canonical link: <a href="https://commits.webkit.org/269061@main">https://commits.webkit.org/269061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ec29b9c2d2cb9d99151e63536ed09ba8ca88cf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19902 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21095 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24190 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25779 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23628 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17163 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19474 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5128 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->