### PR TITLE
[UnifiedPDF] Fix layer hierarchy for plugins that are hosted via GraphicsLayers

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-in-embed-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-embed-expected.txt
@@ -1,0 +1,30 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 300.00 300.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 300.00 300.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border-expected.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        .cover {
+            position: absolute;
+            background-color: gray;
+            left: 0px;
+            top: 0px;
+            width: 302px;
+            height: 302px;
+        }
+        
+        .cover1 {
+            width: 220px;
+        }
+        
+        .cover2 {
+            top: 82px;
+            height: 220px;
+        }
+    </style>
+</head>
+<body>
+    <div class="cover cover1"></div>
+    <div class="cover cover2"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        embed {
+            width: 300px;
+            height: 300px;
+            border: 2px solid gray;
+            box-sizing: border-box;
+            border-radius: 0 100%;
+        }
+        
+        .cover {
+            position: absolute;
+            background-color: gray;
+            left: 0px;
+            top: 0px;
+            width: 302px;
+            height: 302px;
+        }
+        
+        .cover1 {
+            width: 220px;
+        }
+        
+        .cover2 {
+            top: 82px;
+            height: 220px;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+            testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <embed src="../../../fast/images/resources/green_rectangle.pdf">
+    <div class="cover cover1"></div>
+    <div class="cover cover2"></div>
+</body>
+</html>

--- a/LayoutTests/compositing/plugins/pdf/pdf-in-embed.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-embed.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+    <style>
+        embed {
+            width: 300px;
+            height: 300px;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            testRunner.dumpAsText();
+        }
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+            
+            const layers = document.getElementById('layers');
+            layers.textContent = internals.layerTreeAsText(document);
+            
+            testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <embed src="../../../fast/images/resources/green_rectangle.pdf">
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2,6 +2,7 @@
 # Platform-specific directories. Skipped globally, then re-enabled here.
 #//////////////////////////////////////////////////////////////////////////////////////////
 
+[ Sonoma+ ] compositing/plugins/pdf [ Pass ]
 compositing/shared-backing/overflow-scroll [ Pass ]
 compositing/scrolling/async-overflow-scrolling [ Pass ]
 compositing/layer-creation/clipping-scope [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -20,7 +20,6 @@ fast/images/mac [ Pass ]
 [ Debug ] displaylists [ Pass ]
 
 # Disable plug-in tests on Apple Silicon
-[ arm64 ] compositing/plugins [ Skip ]
 [ arm64 ] http/tests/plugins [ Skip ]
 [ arm64 ] imported/blink/plugins [ Skip ]
 [ arm64 ] platform/mac-wk2/plugins [ Skip ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -324,7 +324,6 @@ fast/replaced/applet-disabled-positioned.html
 fast/replaced/applet-rendering-java-disabled.html
 
 # WebKitTestRunner needs testRunner.displayInvalidatedRegion
-compositing/plugins/invalidate_rect.html
 plugins/windowless_plugin_paint_test.html
 
 # eventSender.clearKillRing() is unimplemented

--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -51,6 +51,8 @@ public:
     virtual PlatformLayer* platformLayer() const { return nullptr; }
     virtual GraphicsLayer* graphicsLayer() const { return nullptr; }
 
+    virtual void layerHostingStrategyDidChange() { }
+
 #if PLATFORM(IOS_FAMILY)
     virtual bool willProvidePluginLayer() const { return false; }
     virtual void attachPluginLayer() { }

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -99,16 +99,11 @@ void RenderEmbeddedObject::willBeDestroyed()
     RenderWidget::willBeDestroyed();
 }
 
-bool RenderEmbeddedObject::requiresLayer() const
+bool RenderEmbeddedObject::requiresAcceleratedCompositing() const
 {
-    if (RenderWidget::requiresLayer())
+    if (RenderWidget::requiresAcceleratedCompositing())
         return true;
-    
-    return allowsAcceleratedCompositing();
-}
 
-bool RenderEmbeddedObject::allowsAcceleratedCompositing() const
-{
     auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
     if (!pluginViewBase)
         return false;

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -55,7 +55,7 @@ public:
 
     void handleUnavailablePluginIndicatorEvent(Event*);
 
-    bool allowsAcceleratedCompositing() const;
+    bool requiresAcceleratedCompositing() const override;
 
     LayoutRect unavailablePluginIndicatorBounds(const LayoutPoint& accumulatedOffset) const;
 
@@ -73,8 +73,6 @@ private:
     ASCIILiteral renderName() const final { return "RenderEmbeddedObject"_s; }
 
     bool showsUnavailablePluginIndicator() const { return isPluginUnavailable() && m_isUnavailablePluginIndicatorState != UnavailablePluginIndicatorState::Hidden; }
-
-    bool requiresLayer() const final;
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1781,7 +1781,7 @@ bool RenderLayer::updateLayerPosition(OptionSet<UpdateLayerPositionsFlag>* flags
             flags->add(ContainingClippingLayerChangedSize);
 
         // Trigger RenderLayerCompositor::requiresCompositingForFrame() which depends on the contentBoxRect size.
-        if (compositor().isCompositedSubframeRenderer(renderer()))
+        if (compositor().hasCompositedWidgetContents(renderer()))
             setNeedsPostLayoutCompositingUpdate();
     }
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -294,10 +294,12 @@ public:
     // to know if there is non-affine content, e.g. for drawing into an image.
     bool has3DContent() const;
     
-    static bool isCompositedSubframeRenderer(const RenderObject&);
+    static bool hasCompositedWidgetContents(const RenderObject&);
+    static bool isCompositedPlugin(const RenderObject&);
+
     static RenderLayerCompositor* frameContentsCompositor(RenderWidget&);
-    // Return true if the layers changed.
-    bool parentFrameContentLayers(RenderWidget&);
+    // Returns true the widget contents layer was parented.
+    bool attachWidgetContentLayers(RenderWidget&);
 
     // Update the geometry of the layers used for clipping and scrolling in frames.
     void frameViewDidChangeLocation(const IntPoint& contentsOffset);

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -446,7 +446,7 @@ bool RenderWidget::requiresLayer() const
 bool RenderWidget::requiresAcceleratedCompositing() const
 {
     // If this is a renderer with a contentDocument and that document needs a layer, then we need a layer.
-    if (Document* contentDocument = frameOwnerElement().contentDocument()) {
+    if (auto* contentDocument = frameOwnerElement().contentDocument()) {
         if (RenderView* view = contentDocument->renderView())
             return view->usesCompositing();
     }

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -78,7 +78,7 @@ public:
     ChildWidgetState updateWidgetPosition() WARN_UNUSED_RETURN;
     WEBCORE_EXPORT IntRect windowClipRect() const;
 
-    bool requiresAcceleratedCompositing() const;
+    virtual bool requiresAcceleratedCompositing() const;
 
     RemoteFrame* remoteFrame() const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -87,6 +87,9 @@ void UnifiedPDFPlugin::installPDFDocument()
 
     m_documentLayout.updateLayout(size());
     updateLayerHierarchy();
+
+    if (m_view)
+        m_view->layerHostingStrategyDidChange();
 }
 
 RefPtr<GraphicsLayer> UnifiedPDFPlugin::createGraphicsLayer(const String& name, GraphicsLayer::Type layerType)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -287,11 +287,15 @@ void PluginView::manualLoadDidFinishLoading()
     }
 
     m_plugin->streamDidFinishLoading();
+}
 
-    if (layerHostingStrategy() != PluginLayerHostingStrategy::None) {
-        // This ensures that we update RenderLayers and compositing when the result of RenderEmbeddedObject::requiresLayer() changes.
-        Ref { m_pluginElement }->invalidateStyleAndLayerComposition();
-    }
+void PluginView::layerHostingStrategyDidChange()
+{
+    if (!m_isInitialized)
+        return;
+
+    // This ensures that we update RenderLayers and compositing when the result of RenderEmbeddedObject::requiresLayer() changes.
+    Ref { m_pluginElement }->invalidateStyleAndLayerComposition();
 }
 
 void PluginView::manualLoadDidFail()

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -72,6 +72,8 @@ public:
     id accessibilityObject() const final;
     id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const final;
 
+    void layerHostingStrategyDidChange() final;
+
     WebCore::HTMLPlugInElement& pluginElement() const { return m_pluginElement; }
     const URL& mainResourceURL() const { return m_mainResourceURL; }
 
@@ -111,6 +113,7 @@ private:
 
     void viewGeometryDidChange();
     void viewVisibilityDidChange();
+
     WebCore::IntRect clipRectInWindowCoordinates() const;
     void focusPluginElement();
     
@@ -125,6 +128,7 @@ private:
 
     // WebCore::PluginViewBase
     WebCore::PluginLayerHostingStrategy layerHostingStrategy() const final;
+
     PlatformLayer* platformLayer() const final;
     WebCore::GraphicsLayer* graphicsLayer() const final;
 


### PR DESCRIPTION
#### 6f0db138bd4a80615be9a5f0801c862f1ec227f4
<pre>
[UnifiedPDF] Fix layer hierarchy for plugins that are hosted via GraphicsLayers
<a href="https://bugs.webkit.org/show_bug.cgi?id=262856">https://bugs.webkit.org/show_bug.cgi?id=262856</a>
rdar://problem/116635683

Reviewed by Richard Robinson.

269029@main added the ability for a plugin to expose a GraphicsLayer, which gets parented
in the RenderEmbeddedObject&apos;s primary layer. However, this didn&apos;t work correctly in some
configurations, for example when the plugin has rounded borders.

Fix by sharing code with iframe layer hosting; both plugins and iframes are RenderWidgets
with composited contents, so their layer configurations are the same.

To do this, merge RenderWidget::requiresAcceleratedCompositing() and
RenderEmbeddedObject::requiresAcceleratedCompositing() which had the same role, and refactor
some RenderLayerCompositor code to be shared between plugins and iframes.

We now ensure that layer hookup occurs at the right time by having UnifiedPDFPlugin::installPDFDocument()
call layerHostingStrategyDidChange(), which triggers the invalidateStyleAndLayerComposition() call
in PluginView.

Add compositing/plugins/pdf for tests, and enable them on mac-wk2 on Sonoma and later only.

* LayoutTests/compositing/plugins/pdf/pdf-in-embed-expected.txt: Added.
* LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border-expected.html: Added.
* LayoutTests/compositing/plugins/pdf/pdf-in-embed-rounded-border.html: Added.
* LayoutTests/compositing/plugins/pdf/pdf-in-embed.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:
* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::layerHostingStrategyDidChange):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::requiresLayer const):
(WebCore::RenderEmbeddedObject::requiresAcceleratedCompositing const):
(WebCore::RenderEmbeddedObject::allowsAcceleratedCompositing const): Deleted.
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPosition):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::layerWillBeDestroyed):
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::layerForContents const):
(WebCore::isCompositedPlugin):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBackingAndHierarchy):
(WebCore::RenderLayerCompositor::attachWidgetContentLayers):
(WebCore::RenderLayerCompositor::hasCompositedWidgetContents):
(WebCore::RenderLayerCompositor::isCompositedPlugin):
(WebCore::RenderLayerCompositor::requiresCompositingForPlugin const):
(WebCore::RenderLayerCompositor::parentFrameContentLayers): Deleted.
(WebCore::RenderLayerCompositor::isCompositedSubframeRenderer): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::requiresAcceleratedCompositing const):
* Source/WebCore/rendering/RenderWidget.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::manualLoadDidFinishLoading):
(WebKit::PluginView::layerHostingStrategyDidChange):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/269063@main">https://commits.webkit.org/269063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12815f18afcb4b5fc9bab6553b8e918271599bda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23373 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19927 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22056 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24217 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25801 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23650 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20182 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17189 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19313 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5130 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->