### PR TITLE
Ensure layout on replaced elements in anonymous wrappers

### DIFF
--- a/LayoutTests/fast/replaced/replaced-element-with-percentage-height-anonymous-block-parent-expected.txt
+++ b/LayoutTests/fast/replaced/replaced-element-with-percentage-height-anonymous-block-parent-expected.txt
@@ -1,0 +1,3 @@
+
+PASS
+crbug.com/414532: Layout a percentage height replaced element when it has anonymous wrapper and an ancestor changes height.

--- a/LayoutTests/fast/replaced/replaced-element-with-percentage-height-anonymous-block-parent.html
+++ b/LayoutTests/fast/replaced/replaced-element-with-percentage-height-anonymous-block-parent.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<body style="height: 1000px; width: 1000px">
+        <div id="cb"> 
+            <div id="child" style="height: 100%"> 
+                <iframe style="width: 100%; height: 100%" data-expected-height=604></iframe> 
+                <div>crbug.com/414532: Layout a percentage height replaced element when it has anonymous wrapper and an ancestor changes height.</div>
+            </div>
+        </div>
+</div>
+</body>
+<script src="../../resources/check-layout.js"></script>
+<script>
+    function runTest() {
+        document.body.offsetTop;
+        var cb = document.getElementById('cb');
+        cb.style.height = "600px";
+        document.body.offsetTop;
+        checkLayout('iframe');
+    }
+
+    window.onload = runTest;
+</script>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3,6 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
  * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -796,7 +797,8 @@ void RenderBlock::updateBlockChildDirtyBitsBeforeLayout(bool relayoutChildren, R
 
     // FIXME: Technically percentage height objects only need a relayout if their percentage isn't going to be turned into
     // an auto value. Add a method to determine this, so that we can avoid the relayout.
-    if (relayoutChildren || (child.hasRelativeLogicalHeight() && !isRenderView()))
+    bool hasRelativeLogicalHeight = child.hasRelativeLogicalHeight() || (child.isAnonymous() && this->hasRelativeLogicalHeight());
+    if (relayoutChildren || (hasRelativeLogicalHeight && !isRenderView()))
         child.setChildNeedsLayout(MarkOnlyThis);
 
     // If relayoutChildren is set and the child has percentage padding or an embedded content box, we also need to invalidate the childs pref widths.


### PR DESCRIPTION
<pre>
Ensure layout on replaced elements in anonymous wrappers
<a href="https://bugs.webkit.org/show_bug.cgi?id=262867">https://bugs.webkit.org/show_bug.cgi?id=262867</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/10ead1fbccd4cbf4b822d9c5bd0a83885928eb03">https://chromium.googlesource.com/chromium/blink/+/10ead1fbccd4cbf4b822d9c5bd0a83885928eb03</a>

When dimensions change on an ancestor we need to layout all the way down through
the percentage descendants. This means punching through any anonymous blocks that
sit between them. If a child is anonymous and its parent has a percentage height
then we need to layout that anonymous child so we can check for any percentage
children it is managing for the DOM parent.

* Source/WebCore/rendering/RenderBlock.cpp:
(RenderBlock::updateBlockChildDirtyBitsBeforeLayout):
* LayoutTests/fast/replaced/replaced-element-with-percentage-height-anonymous-block-parent.html: Add Test Case
* LayoutTests/fast/replaced/replaced-element-with-percentage-height-anonymous-block-parent-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0d8ee3600d57b78a3dd3ec5a823520f91cec0c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19919 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21109 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24208 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25793 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23642 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17179 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19300 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->