### PR TITLE
WebAssembly SIMD results in incorrect float values and non working bitwise operations

### DIFF
--- a/JSTests/wasm/stress/omg-simd-simple.js
+++ b/JSTests/wasm/stress/omg-simd-simple.js
@@ -1,0 +1,33 @@
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+async function test() {
+    let wat = `(module
+      (func $bad (export "bad") (result i64)
+        (local $l41 v128)
+        (local.set $l41
+        (v128.const i32x4 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF))
+
+          (if (result i64)
+            (i32.eqz
+              (v128.any_true
+                (local.get $l41)))
+            (then (i64.const 1))
+            (else
+              (i64x2.extract_lane 1
+                  (v128.const i32x4 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF))
+            )
+          )
+      )
+)
+`
+    const instance = await instantiate(wat, { }, { simd: true, log: false })
+    const { bad } = instance.exports
+
+    for (let i = 0; i < 100000; ++i) {
+      assert.eq(bad(), -1n)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/omg-simd-stress.js
+++ b/JSTests/wasm/stress/omg-simd-stress.js
@@ -1,0 +1,109 @@
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+async function test() {
+    let fnBase = read("omg-simd-stress.wat")
+    let wat = `(module
+      (memory $imports.mem (import "imports" "mem") 1 1)
+
+      (func $probe_begin (import "imports" "probe_begin") (param i32))
+      (func $probe_end (import "imports" "probe_end") (param i32))
+      (func $probe (import "imports" "probe") (param i64))
+      (func $probe32 (import "imports" "probe") (param i32))
+
+      (func $bad (export "bad")
+    ` + fnBase + `
+      (func $good (export "good")
+    ` + fnBase + ")"
+
+    let memory = new WebAssembly.Memory({ initial: 1, maximum: 1 })
+
+    let probe_log = []
+    let y = 0
+    let enableLogging = false
+
+    const instance = await instantiate(wat, {
+        imports: {
+            mem: memory,
+            probe_begin: function(x) {
+              if (!enableLogging)
+                return
+              probe_log.push({event: "probe_begin", id: x})
+              ++y
+            },
+            probe_end: function(x) {
+              if (!enableLogging)
+                return
+              probe_log.push({event: "probe_end", id: x})
+              ++y
+            },
+            probe: function(x) {
+              if (!enableLogging)
+                return
+              let id = 0
+              let idOffset = 0
+              let depth = 0
+              let offset = 0
+              for (let l of probe_log) {
+                if (l.event == "probe_begin") {
+                  ++depth
+                  if (depth > 1) {
+                    console.log("Probe depth > 1 at: ", l)
+                    breakpoint10
+                  }
+                  id = l.id
+                  idOffset = offset
+                } else if (l.event == "probe_end") {
+                  --depth
+                  if (depth < 0) {
+                    console.log("Probe depth < 0 at: ", l)
+                    breakpoint11
+                  }
+                  id = -9007199254740991
+                  idOffset = -9007199254740991
+                }
+
+                offset++
+              }
+
+              probe_log.push({event: "probe", id, val: x, offset: -idOffset + probe_log.length - 1})
+            }
+          }
+    }, { simd: true, log: false })
+    const { bad, good } = instance.exports
+
+    for (let i = 0; i < 100000; ++i) {
+      bad()
+    }
+
+    enableLogging = true
+
+    for (let i = 0; i < 10; ++i) {
+      probe_log = []
+      good()
+      let goodLog = probe_log
+      probe_log = []
+      bad()
+      let badLog = probe_log
+
+      for (let i = 0; i < goodLog.length && i < badLog.length; ++i) {
+        if (goodLog[i].event != badLog[i].event || goodLog[i].id != badLog[i].id || (goodLog[i].event == "probe" && goodLog[i].val != badLog[i].val)) {
+          print("Different at: ", i, "Bad: ", badLog[i], " Good:", goodLog[i])
+
+          for (let j = 0; j < badLog.length; ++j) {
+            let str = (key, value) => {
+                return typeof value === 'bigint'
+                    ? value.toString()
+                    : value // return everything else unchanged
+            }
+            print(JSON.stringify(badLog[i], str), JSON.stringify(goodLog[i], str))
+          }
+
+          $vm.abort()
+        }
+      }
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/omg-simd-stress.wat
+++ b/JSTests/wasm/stress/omg-simd-stress.wat
@@ -1,0 +1,33 @@
+    (local $i i32) (local $l24 v128) (local $l41 v128) 
+    (local.set $i
+      (i32.const 2))
+    (local.set $l41
+      (v128.const i32x4 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF))
+
+    (block $B0
+      (loop $L1
+
+        (block $B2
+          (call $probe_begin (i32.const -1))
+          (call $probe (i64x2.extract_lane 0 (local.get $l41)))
+          (call $probe (i64x2.extract_lane 1 (local.get $l41)))
+          (call $probe (i64x2.extract_lane 0 (local.get $l24)))
+          (call $probe (i64x2.extract_lane 1 (local.get $l24)))
+          (call $probe_end (i32.const -1))
+
+          (br_if $B2
+            (i32.eqz
+              (v128.any_true
+                (local.get $l41))))
+          (local.set $l24
+            (v128.not
+              (local.get $l41)))
+         )
+
+        (br_if $B0
+          (i32.eqz
+            (local.tee $i
+              (i32.sub
+                (local.get $i)
+                (i32.const 1)))))
+        (br $L1))))

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -299,9 +299,10 @@ void lowerMacros(Code& code)
                 auto* origin = inst.origin;
 
                 Tmp tmp = code.newTmp(GP);
+                Tmp vtmp = code.newTmp(FP);
 
-                insertionSet.insert(instIndex, VectorUnsignedMax, origin, Arg::simdInfo({ SIMDLane::i32x4, SIMDSignMode::None }), vec, vec);
-                insertionSet.insert(instIndex, MoveFloatTo32, origin, vec, tmp);
+                insertionSet.insert(instIndex, VectorUnsignedMax, origin, Arg::simdInfo({ SIMDLane::i32x4, SIMDSignMode::None }), vec, vtmp);
+                insertionSet.insert(instIndex, MoveFloatTo32, origin, vtmp, tmp);
                 insertionSet.insert(instIndex, Compare32, origin, Arg::relCond(MacroAssembler::NotEqual), tmp, Arg::imm(0), dst);
 
                 inst = Inst();


### PR DESCRIPTION
#### f9a3a2147af0a89a67c74b9da7a291387c6cb39c
<pre>
WebAssembly SIMD results in incorrect float values and non working bitwise operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=258302">https://bugs.webkit.org/show_bug.cgi?id=258302</a>
rdar://111050621

Reviewed by Alexey Shvayka.

We accidentally clobber our input, causing some random SIMD bugs.

This was pretty difficult to isolate, even though the bug is so obvious.
The included (larger) test case actually serves as a pretty general way
to debug a differential jit-tier bug.

* JSTests/wasm/stress/omg-simd-simple.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* JSTests/wasm/stress/omg-simd-stress.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* JSTests/wasm/stress/omg-simd-stress.wat: Added.
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):

Canonical link: <a href="https://commits.webkit.org/269080@main">https://commits.webkit.org/269080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d71ea33a0e000a71f883a8f76f6da311099f0349

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19934 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21129 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24229 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25811 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/18718 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23661 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/20892 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17198 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/24918 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19507 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5894 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5145 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23747 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26185 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20094 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5723 "Passed tests") | 
<!--EWS-Status-Bubble-End-->