### PR TITLE
Remove PassKitUI/PKPaymentSetupController.h header check for PASSKIT_MODULARIZATION SPI declaration

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -145,11 +145,10 @@ WTF_EXTERN_C_END
 #endif
 
 #if HAVE(PASSKIT_MODULARIZATION)
-// FIXME: remove this after <rdar://88985220>
-#if __has_include(<PassKitUI/PKPaymentSetupController.h>)
-#import <PassKitUI/PKPaymentSetupController.h>
+#if PLATFORM(MAC)
+#import <PassKitMacHelper/PKPaymentSetupController.h>
 #else
-#import <PassKit/PKPaymentSetupController.h>
+#import <PassKitUI/PKPaymentSetupController.h>
 #endif
 #if PLATFORM(MAC)
 #if HAVE(PASSKIT_MAC_HELPER_TEMP)


### PR DESCRIPTION
#### 662835773f8867460a69f7d89367c2f407e767fe
<pre>
Remove PassKitUI/PKPaymentSetupController.h header check for PASSKIT_MODULARIZATION SPI declaration
<a href="https://bugs.webkit.org/show_bug.cgi?id=262860">https://bugs.webkit.org/show_bug.cgi?id=262860</a>
rdar://116640545

Reviewed by Wenson Hsieh.

Following rdar://88985220, all PassKit .m files are now in PassKitUI and
PassKitMacHelper, which means that the header check is now unnecessary.
Lets follow the spirit of PASSKIT_MODULARIZATION and stop pulling in
PKPaymentSetupController.h from &lt;PassKit/&gt;.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:

Canonical link: <a href="https://commits.webkit.org/269078@main">https://commits.webkit.org/269078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dc81386b285e59519a743125f49cef00eb65bf4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23374 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21124 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24225 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18560 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19498 "Found 1 new test failure: http/tests/websocket/tests/hybi/url-parsing.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25807 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23657 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17195 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19504 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5144 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->