### PR TITLE
REGRESSION (iOS 17): mediaDevices.enumerateDevices() breaks audio

### DIFF
--- a/LayoutTests/fast/mediastream/enumerateDevices-active-auxiliary-unit-expected.txt
+++ b/LayoutTests/fast/mediastream/enumerateDevices-active-auxiliary-unit-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Validate auxiliary unit activation
+

--- a/LayoutTests/fast/mediastream/enumerateDevices-active-auxiliary-unit.html
+++ b/LayoutTests/fast/mediastream/enumerateDevices-active-auxiliary-unit.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+promise_test(async (test) => {
+    if (!window.testRunner)
+        return;
+
+    assert_false(testRunner.isEnumeratingAudioUnitActive, "test1");
+
+    await navigator.mediaDevices.enumerateDevices();
+    assert_false(testRunner.isEnumeratingAudioUnitActive, "test2");
+
+    await navigator.mediaDevices.getUserMedia({ video:true });
+    assert_false(testRunner.isEnumeratingAudioUnitActive, "test3");
+
+    await navigator.mediaDevices.getUserMedia({ audio:true });
+    assert_true(testRunner.isEnumeratingAudioUnitActive, "test4");
+}, "Validate auxiliary unit activation");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1800,6 +1800,9 @@ webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Ti
 # This ends up calling WKPageTriggerMockMicrophoneConfigurationChange which is specific to GPUProcess.
 fast/mediastream/mediastreamtrack-configurationchange.html [ Skip ]
 
+# No auxiliary unit in glib.
+fast/mediastream/enumerateDevices-active-auxiliary-unit.html [ Skip ]
+
 fast/mediastream/video-rotation2.html [ Failure Pass Timeout ]
 
 # Missing/broken pageIsFocused notification.

--- a/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h
@@ -44,7 +44,7 @@ class CaptureDevice;
 class AVAudioSessionCaptureDeviceManager final : public CaptureDeviceManager {
     friend class NeverDestroyed<AVAudioSessionCaptureDeviceManager>;
 public:
-    static AVAudioSessionCaptureDeviceManager& singleton();
+    WEBCORE_EXPORT static AVAudioSessionCaptureDeviceManager& singleton();
 
     const Vector<CaptureDevice>& captureDevices() final;
     void computeCaptureDevices(CompletionHandler<void()>&&) final;
@@ -61,6 +61,8 @@ public:
     void setPreferredAudioSessionDeviceUID(const String&);
     String preferredAudioSessionDeviceUID() const { return m_preferredAudioDeviceUID; }
     void configurePreferredAudioCaptureDevice();
+
+    bool isActive() const { return m_audioSessionState == AudioSessionState::Active; }
 
 private:
     AVAudioSessionCaptureDeviceManager();

--- a/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h
+++ b/Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h
@@ -35,18 +35,19 @@ OBJC_CLASS WebCoreAudioCaptureSourceIOSListener;
 
 namespace WebCore {
 
-class CoreAudioCaptureSourceFactoryIOS final : public CoreAudioCaptureSourceFactory  {
+class CoreAudioCaptureSourceFactoryIOS : public CoreAudioCaptureSourceFactory  {
 public:
     CoreAudioCaptureSourceFactoryIOS();
     ~CoreAudioCaptureSourceFactoryIOS();
 
 private:
-    CaptureSourceOrError createAudioCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier) final;
+    CaptureSourceOrError createAudioCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier) override;
     void addExtensiveObserver(ExtensiveObserver&) final;
     void removeExtensiveObserver(ExtensiveObserver&) final;
 
     RetainPtr<WebCoreAudioCaptureSourceIOSListener> m_listener;
     WeakHashSet<ExtensiveObserver> m_observers;
+    bool m_hasForcedDeviceQuery { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -152,8 +152,8 @@ private:
 
     // AudioCaptureFactory
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice&, MediaDeviceHashSalts&&, const MediaConstraints*, PageIdentifier) override;
-    CaptureDeviceManager& audioCaptureDeviceManager() final;
-    const Vector<CaptureDevice>& speakerDevices() const final;
+    CaptureDeviceManager& audioCaptureDeviceManager() override;
+    const Vector<CaptureDevice>& speakerDevices() const override;
 
     void beginInterruption();
     void endInterruption();

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -48,6 +48,10 @@
 #include "MockRealtimeVideoSourceMac.h"
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+#include "CoreAudioCaptureSourceIOS.h"
+#endif
+
 #if USE(GSTREAMER)
 #include "MockDisplayCaptureSourceGStreamer.h"
 #include "MockRealtimeVideoSourceGStreamer.h"
@@ -221,7 +225,13 @@ private:
     DisplayCaptureManager& displayCaptureDeviceManager() final { return MockRealtimeMediaSourceCenter::singleton().displayCaptureDeviceManager(); }
 };
 
-class MockRealtimeAudioSourceFactory final : public AudioCaptureFactory {
+class MockRealtimeAudioSourceFactory final
+#if PLATFORM(IOS_FAMILY)
+    : public CoreAudioCaptureSourceFactoryIOS
+#else
+    : public AudioCaptureFactory
+#endif
+{
 public:
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, PageIdentifier pageIdentifier) final
     {

--- a/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.cpp
@@ -33,6 +33,10 @@
 #include "WKMutableArray.h"
 #include "WKString.h"
 
+#if PLATFORM(IOS_FAMILY) && ENABLE(MEDIA_STREAM)
+#include <WebCore/AVAudioSessionCaptureDeviceManager.h>
+#endif
+
 using namespace WebKit;
 
 WKTypeID WKUserMediaPermissionCheckGetTypeID()
@@ -45,3 +49,11 @@ void WKUserMediaPermissionCheckSetUserMediaAccessInfo(WKUserMediaPermissionCheck
     toImpl(userMediaPermissionRequestRef)->setUserMediaAccessInfo(allowed);
 }
 
+bool WKUserMediaIsEnumeratingAudioUnitActive()
+{
+#if PLATFORM(IOS_FAMILY) && ENABLE(MEDIA_STREAM)
+    return WebCore::AVAudioSessionCaptureDeviceManager::singleton().isActive();
+#else
+    return false;
+#endif
+}

--- a/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.h
+++ b/Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.h
@@ -36,6 +36,7 @@ extern "C" {
 WK_EXPORT WKTypeID WKUserMediaPermissionCheckGetTypeID();
 
 WK_EXPORT void WKUserMediaPermissionCheckSetUserMediaAccessInfo(WKUserMediaPermissionCheckRef, WKStringRef, bool);
+WK_EXPORT bool WKUserMediaIsEnumeratingAudioUnitActive();
 
 #ifdef __cplusplus
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -247,6 +247,7 @@ interface TestRunner {
     unsigned long userMediaPermissionRequestCountForOrigin(DOMString origin, DOMString parentOrigin);
     undefined resetUserMediaPermissionRequestCountForOrigin(DOMString origin, DOMString parentOrigin);
     readonly attribute boolean isDoingMediaCapture;
+    readonly attribute boolean isEnumeratingAudioUnitActive;
 
     // Audio testing.
     [PassContext] undefined setAudioResult(object data);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1021,6 +1021,11 @@ bool TestRunner::isDoingMediaCapture() const
     return postSynchronousPageMessageReturningBoolean("IsDoingMediaCapture");
 }
 
+bool TestRunner::isEnumeratingAudioUnitActive() const
+{
+    return postSynchronousPageMessageReturningBoolean("IsEnumeratingAudioUnitActive");
+}
+
 void TestRunner::setUserMediaPersistentPermissionForOrigin(bool permission, JSStringRef origin, JSStringRef parentOrigin)
 {
     InjectedBundle::singleton().setUserMediaPersistentPermissionForOrigin(permission, toWK(origin).get(), toWK(parentOrigin).get());

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -346,6 +346,7 @@ public:
     unsigned userMediaPermissionRequestCountForOrigin(JSStringRef origin, JSStringRef parentOrigin) const;
     void resetUserMediaPermissionRequestCountForOrigin(JSStringRef origin, JSStringRef parentOrigin);
     bool isDoingMediaCapture() const;
+    bool isEnumeratingAudioUnitActive() const;
 
     void setPageVisibility(JSStringRef state);
     void resetPageVisibility();

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3514,6 +3514,10 @@ bool TestController::isDoingMediaCapture() const
     return false;
 }
 
+bool TestController::isEnumeratingAudioUnitActive() const
+{
+    return false;
+}
 #endif
 
 struct ResourceStatisticsCallbackContext {

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -364,6 +364,7 @@ public:
     void abortModal();
 
     bool isDoingMediaCapture() const;
+    bool isEnumeratingAudioUnitActive() const;
 
     String dumpPrivateClickMeasurement();
     void clearPrivateClickMeasurement();

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1132,7 +1132,10 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
 
     if (WKStringIsEqualToUTF8CString(messageName, "IsDoingMediaCapture"))
         return adoptWK(WKBooleanCreate(TestController::singleton().isDoingMediaCapture()));
-    
+
+    if (WKStringIsEqualToUTF8CString(messageName, "IsEnumeratingAudioUnitActive"))
+        return adoptWK(WKBooleanCreate(TestController::singleton().isEnumeratingAudioUnitActive()));
+
     if (WKStringIsEqualToUTF8CString(messageName, "ClearStatisticsDataForDomain")) {
         TestController::singleton().clearStatisticsDataForDomain(stringValue(messageBody));
         return nullptr;

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -45,6 +45,7 @@
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKStringCF.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
+#import <WebKit/WKUserMediaPermissionCheck.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -580,7 +581,16 @@ void TestController::setAllowedMenuActions(const Vector<String>& actions)
 
 bool TestController::isDoingMediaCapture() const
 {
-    return m_mainWebView->platformView()._mediaCaptureState != _WKMediaCaptureStateDeprecatedNone;
+    return m_mainWebView->platformView().microphoneCaptureState != WKMediaCaptureStateNone || m_mainWebView->platformView().cameraCaptureState != WKMediaCaptureStateNone;
+}
+
+bool TestController::isEnumeratingAudioUnitActive() const
+{
+#if PLATFORM(IOS_FAMILY) && ENABLE(MEDIA_STREAM)
+    return WKUserMediaIsEnumeratingAudioUnitActive();
+#else
+    return m_mainWebView->platformView().microphoneCaptureState == WKMediaCaptureStateActive;
+#endif
 }
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 1bf29719b1040f73b6b1175cabb3e89534e4134a
<pre>
REGRESSION (iOS 17): mediaDevices.enumerateDevices() breaks audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=262569">https://bugs.webkit.org/show_bug.cgi?id=262569</a>
rdar://116433066

Reviewed by Eric Carlson.

The auxiliary unit allows to enumerate all audio devices.
But, when enabled with PlayAndRecord, it might have an impact on rendered audio.

To prevent this effect, we are now limiting when this unit is made active.
In particular, when only camera capture happens, we are still exposing all capabilities
but we are limiting the unit to be active for a single run loop during which happens the microphone enumeration.

We add a WTR testRunner API to validate this is working as expected on iOS.
To make it work with mocks, we make MockAudioCaptureSourceFactory derive from CoreAudioCaptureSourceFactoryIOS on iOS.

* LayoutTests/fast/mediastream/enumerateDevices-active-auxiliary-unit-expected.txt: Added.
* LayoutTests/fast/mediastream/enumerateDevices-active-auxiliary-unit.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/mediastream/ios/AVAudioSessionCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.h:
* Source/WebCore/platform/mediastream/ios/CoreAudioCaptureSourceIOS.mm:
(WebCore::CoreAudioCaptureSourceFactoryIOS::removeExtensiveObserver):
(WebCore::CoreAudioCaptureSourceFactoryIOS::createAudioCaptureSource):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
* Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.cpp:
(WKUserMediaIsEnumeratingAudioUnitActive):
* Source/WebKit/UIProcess/API/C/WKUserMediaPermissionCheck.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::isEnumeratingAudioUnitActive const):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::isEnumeratingAudioUnitActive const):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::isDoingMediaCapture const):
(WTR::TestController::isEnumeratingAudioUnitActive const):

Canonical link: <a href="https://commits.webkit.org/269196@main">https://commits.webkit.org/269196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c2f9719092b9f7b24164b44dec98e8ec893db98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21333 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24579 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26069 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23931 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20459 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19607 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5216 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->