### PR TITLE
[GLib] Fix build without ITP

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -567,6 +567,7 @@ void webkit_network_session_set_memory_pressure_settings(WebKitMemoryPressureSet
  */
 void webkit_network_session_get_itp_summary(WebKitNetworkSession* session, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
 {
+#if ENABLE(TRACKING_PREVENTION)
     g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
 
     auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
@@ -579,6 +580,9 @@ void webkit_network_session_get_itp_summary(WebKitNetworkSession* session, GCanc
             g_list_free_full(static_cast<GList*>(data), reinterpret_cast<GDestroyNotify>(webkit_itp_third_party_unref));
         });
     });
+#else
+    return;
+#endif
 }
 
 /**
@@ -597,10 +601,14 @@ void webkit_network_session_get_itp_summary(WebKitNetworkSession* session, GCanc
  */
 GList* webkit_network_session_get_itp_summary_finish(WebKitNetworkSession* session, GAsyncResult* result, GError** error)
 {
+#if ENABLE(TRACKING_PREVENTION)
     g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), nullptr);
     g_return_val_if_fail(g_task_is_valid(result, session), nullptr);
 
     return static_cast<GList*>(g_task_propagate_pointer(G_TASK(result), error));
+#else
+    return nullptr;
+#endif
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -1376,12 +1376,14 @@ gboolean webkit_website_data_manager_clear_finish(WebKitWebsiteDataManager* mana
  * Since: 2.30
  */
 struct _WebKitITPFirstParty {
+#if ENABLE(TRACKING_PREVENTION)
     explicit _WebKitITPFirstParty(WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty&& data)
         : domain(data.firstPartyDomain.string().utf8())
         , storageAccessGranted(data.storageAccessGranted)
         , lastUpdated(adoptGRef(g_date_time_new_from_unix_utc(data.timeLastUpdated.secondsAs<gint64>())))
     {
     }
+#endif
 
     CString domain;
     bool storageAccessGranted { false };
@@ -1419,12 +1421,14 @@ void webkit_website_data_manager_set_memory_pressure_settings(WebKitMemoryPressu
 
 G_DEFINE_BOXED_TYPE(WebKitITPFirstParty, webkit_itp_first_party, webkit_itp_first_party_ref, webkit_itp_first_party_unref)
 
+#if ENABLE(TRACKING_PREVENTION)
 static WebKitITPFirstParty* webkitITPFirstPartyCreate(WebResourceLoadStatisticsStore::ThirdPartyDataForSpecificFirstParty&& data)
 {
     auto* firstParty = static_cast<WebKitITPFirstParty*>(fastMalloc(sizeof(WebKitITPFirstParty)));
     new (firstParty) WebKitITPFirstParty(WTFMove(data));
     return firstParty;
 }
+#endif
 
 
 /**
@@ -1535,12 +1539,14 @@ GDateTime* webkit_itp_first_party_get_last_update_time(WebKitITPFirstParty* firs
  */
 
 struct _WebKitITPThirdParty {
+#if ENABLE(TRACKING_PREVENTION)
     explicit _WebKitITPThirdParty(WebResourceLoadStatisticsStore::ThirdPartyData&& data)
         : domain(data.thirdPartyDomain.string().utf8())
     {
         while (!data.underFirstParties.isEmpty())
             firstParties = g_list_prepend(firstParties, webkitITPFirstPartyCreate(data.underFirstParties.takeLast()));
     }
+#endif
 
     ~_WebKitITPThirdParty()
     {
@@ -1554,12 +1560,14 @@ struct _WebKitITPThirdParty {
 
 G_DEFINE_BOXED_TYPE(WebKitITPThirdParty, webkit_itp_third_party, webkit_itp_third_party_ref, webkit_itp_third_party_unref)
 
+#if ENABLE(TRACKING_PREVENTION)
 WebKitITPThirdParty* webkitITPThirdPartyCreate(WebResourceLoadStatisticsStore::ThirdPartyData&& data)
 {
     auto* thirdParty = static_cast<WebKitITPThirdParty*>(fastMalloc(sizeof(WebKitITPThirdParty)));
     new (thirdParty) WebKitITPThirdParty(WTFMove(data));
     return thirdParty;
 }
+#endif
 
 /**
  * webkit_itp_third_party_ref:
@@ -1656,6 +1664,7 @@ GList* webkit_itp_third_party_get_first_parties(WebKitITPThirdParty* thirdParty)
  */
 void webkit_website_data_manager_get_itp_summary(WebKitWebsiteDataManager* manager, GCancellable* cancellable, GAsyncReadyCallback callback, gpointer userData)
 {
+#if ENABLE(TRACKING_PREVENTION)
     g_return_if_fail(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager));
 
     GRefPtr<GTask> task = adoptGRef(g_task_new(manager, cancellable, callback, userData));
@@ -1667,6 +1676,9 @@ void webkit_website_data_manager_get_itp_summary(WebKitWebsiteDataManager* manag
             g_list_free_full(static_cast<GList*>(data), reinterpret_cast<GDestroyNotify>(webkit_itp_third_party_unref));
         });
     });
+#else
+    return;
+#endif
 }
 
 /**
@@ -1685,8 +1697,12 @@ void webkit_website_data_manager_get_itp_summary(WebKitWebsiteDataManager* manag
  */
 GList* webkit_website_data_manager_get_itp_summary_finish(WebKitWebsiteDataManager* manager, GAsyncResult* result, GError** error)
 {
+#if ENABLE(TRACKING_PREVENTION)
     g_return_val_if_fail(WEBKIT_IS_WEBSITE_DATA_MANAGER(manager), nullptr);
     g_return_val_if_fail(g_task_is_valid(result, manager), nullptr);
 
     return static_cast<GList*>(g_task_propagate_pointer(G_TASK(result), error));
+#else
+    return nullptr;
+#endif
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h
@@ -28,4 +28,7 @@
 WebKitWebsiteDataManager* webkitWebsiteDataManagerCreate(CString&&, CString&&);
 #endif
 WebKit::WebsiteDataStore& webkitWebsiteDataManagerGetDataStore(WebKitWebsiteDataManager*);
+
+#if ENABLE(TRACKING_PREVENTION)
 WebKitITPThirdParty* webkitITPThirdPartyCreate(WebKit::WebResourceLoadStatisticsStore::ThirdPartyData&&);
+#endif


### PR DESCRIPTION
#### 7b60261d39415401a22aa11684705778c4353c16
<pre>
[GLib] Fix build without ITP
<a href="https://bugs.webkit.org/show_bug.cgi?id=262885">https://bugs.webkit.org/show_bug.cgi?id=262885</a>

Reviewed by Michael Catanzaro.

Make the GLib API build when ITP (tracking prevention) is disabled.

* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
(webkit_network_session_get_itp_summary):
(webkit_network_session_get_itp_summary_finish):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp:
(webkit_website_data_manager_get_itp_summary):
(webkit_website_data_manager_get_itp_summary_finish):
* Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManagerPrivate.h:

Canonical link: <a href="https://commits.webkit.org/269133@main">https://commits.webkit.org/269133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f1dfceaa504e3243974038d63e3c64998855fad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23400 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19954 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21146 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24251 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18604 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25827 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23677 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17219 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19528 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5174 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23767 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->