### PR TITLE
[check-for-duplicated-platform-test-results] Only remove expectations

### DIFF
--- a/Tools/Scripts/check-for-duplicated-platform-test-results
+++ b/Tools/Scripts/check-for-duplicated-platform-test-results
@@ -36,11 +36,6 @@ webkit_finder = webkit_finder.WebKitFinder(host.filesystem)
 layout_tests_directory = webkit_finder.layout_tests_dir()
 platform_directory = os.path.join(layout_tests_directory, 'platform')
 
-IGNORED_FILE_NAMES = {
-    'TestExpectations',
-    '.DS_Store'
-}
-
 txt_types = (".webarchive", ".txt")
 
 
@@ -111,7 +106,7 @@ def find_duplicates_in_path(baseline_search_path):
         _log.debug(' comparing files in {0} and {1}'.format(remove_layout_test_path_prefix(remaining_paths[0]), remove_layout_test_path_prefix(remaining_paths[1])))
         for root, dirs, files in os.walk(remaining_paths[0]):
             for file_name in files:
-                if file_name in IGNORED_FILE_NAMES:
+                if '-expected' not in file_name:
                     continue
 
                 platform_test_result = os.path.join(root, file_name)


### PR DESCRIPTION
#### fc7d2c4aac4603e25118645973a2546d67b244ba
<pre>
[check-for-duplicated-platform-test-results] Only remove expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=262887">https://bugs.webkit.org/show_bug.cgi?id=262887</a>
rdar://problem/116676951

Reviewed by Jonathan Bedard.

Previously we removed all duplicated files, but only expectations are
fully resolved along the inheritance path: deleting tests or non-test
support files is dangerous because we can break relative URLs.

* Tools/Scripts/check-for-duplicated-platform-test-results:
(find_duplicates_in_path.find_duplicates):

Canonical link: <a href="https://commits.webkit.org/269113@main">https://commits.webkit.org/269113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f483be42bfbade2e64f678b8e68ea5972d41838b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19957 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22090 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21149 "Found 1 new test failure: media/media-source/media-source-abort-resets-parser.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24254 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25830 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23680 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20213 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17221 "Found 1 new test failure: media/video-remove-insert-repaints.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23770 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2679 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->