### PR TITLE
Optimize Vector::appendRange() when input iterators are random access iterators

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp
@@ -153,7 +153,6 @@ private:
             m_workset->remove(liveIndexAtHead);
         ASSERT(!m_workset->isEmpty());
 
-        liveAtHead.reserveCapacity(liveAtHead.size() + m_workset->size());
         liveAtHead.appendRange(m_workset->begin(), m_workset->end());
 
         bool changedPredecessor = false;

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -323,7 +323,6 @@ protected:
                 if (m_workset.isEmpty())
                     continue;
 
-                liveAtHead.reserveCapacity(liveAtHead.size() + m_workset.size());
                 liveAtHead.appendRange(m_workset.begin(), m_workset.end());
                 
                 m_workset.sort();

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -61,7 +61,6 @@ static std::optional<cbor::CBORValue> coseKeyForAttestationObject(Ref<ArrayBuffe
 
     const size_t cosePublicKeyLength = authData.size() - cosePublicKeyOffset;
     Vector<uint8_t> cosePublicKey;
-    cosePublicKey.reserveInitialCapacity(cosePublicKeyLength);
     auto beginIt = authData.begin() + cosePublicKeyOffset;
     cosePublicKey.appendRange(beginIt, beginIt + cosePublicKeyLength);
 

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -105,7 +105,6 @@ static Vector<uint8_t> getCredentialId(const Vector<uint8_t>& authenticatorData)
     if (authenticatorData.size() < credentialIdLengthOffset + credentialIdLengthLength + credentialIdLength)
         return { };
     Vector<uint8_t> credentialId;
-    credentialId.reserveInitialCapacity(credentialIdLength);
     auto beginIt = authenticatorData.begin() + credentialIdLengthOffset + credentialIdLengthLength;
     credentialId.appendRange(beginIt, beginIt + credentialIdLength);
     return credentialId;


### PR DESCRIPTION
#### d9dcd1c0fc110f76be60bfb7b60a72535791adda
<pre>
Optimize Vector::appendRange() when input iterators are random access iterators
<a href="https://bugs.webkit.org/show_bug.cgi?id=262889">https://bugs.webkit.org/show_bug.cgi?id=262889</a>

Reviewed by Yusuke Suzuki.

Optimize Vector::appendRange() when input iterators are random access iterators.
When such iterators are provided, we can compute the new size in constant time
and thus reserve capacity + unsafeAppendWithoutCapacityCheck().

* Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp:
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::compute):
* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::appendRange):
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
(WebCore::coseKeyForAttestationObject):
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::getCredentialId):

Canonical link: <a href="https://commits.webkit.org/269115@main">https://commits.webkit.org/269115@main</a>
</pre>
