### PR TITLE
[tvOS] Set ENABLE_WEB_RTC back to 0

### DIFF
--- a/Source/WebCore/Configurations/FeatureDefines.xcconfig
+++ b/Source/WebCore/Configurations/FeatureDefines.xcconfig
@@ -41,8 +41,6 @@
 // This ENABLE_WEB_RTC configuration variable determines whether to *link* the libwebrtc library.
 // The ENABLE_WEB_RTC macro in PlatformEnableCocoa.h determines whether WebKit's WebRTC code is compiled.
 ENABLE_WEB_RTC = $(ENABLE_WEB_RTC_$(WK_PLATFORM_NAME));
-ENABLE_WEB_RTC_appletvos = ENABLE_WEB_RTC;
-ENABLE_WEB_RTC_appletvsimulator = ENABLE_WEB_RTC;
 ENABLE_WEB_RTC_iphoneos = ENABLE_WEB_RTC;
 ENABLE_WEB_RTC_iphonesimulator = ENABLE_WEB_RTC;
 ENABLE_WEB_RTC_macosx = ENABLE_WEB_RTC;

--- a/Source/WebKit/Configurations/FeatureDefines.xcconfig
+++ b/Source/WebKit/Configurations/FeatureDefines.xcconfig
@@ -41,8 +41,6 @@
 // This ENABLE_WEB_RTC configuration variable determines whether to *link* the libwebrtc library.
 // The ENABLE_WEB_RTC macro in PlatformEnableCocoa.h determines whether WebKit's WebRTC code is compiled.
 ENABLE_WEB_RTC = $(ENABLE_WEB_RTC_$(WK_PLATFORM_NAME));
-ENABLE_WEB_RTC_appletvos = ENABLE_WEB_RTC;
-ENABLE_WEB_RTC_appletvsimulator = ENABLE_WEB_RTC;
 ENABLE_WEB_RTC_iphoneos = ENABLE_WEB_RTC;
 ENABLE_WEB_RTC_iphonesimulator = ENABLE_WEB_RTC;
 ENABLE_WEB_RTC_macosx = ENABLE_WEB_RTC;


### PR DESCRIPTION
#### eb9f693b4ad6d9ad5682f59032ac536c6882f7a4
<pre>
[tvOS] Set ENABLE_WEB_RTC back to 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=262901">https://bugs.webkit.org/show_bug.cgi?id=262901</a>
rdar://116681240

Unreviewed build fix; Disable WebRTC in WebCore and WebKit until Apple production build issues can
be addressed.

* Source/WebCore/Configurations/FeatureDefines.xcconfig:
* Source/WebKit/Configurations/FeatureDefines.xcconfig:

Canonical link: <a href="https://commits.webkit.org/269082@main">https://commits.webkit.org/269082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee1f906c5416023582ac540250b8dffbdb059784

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21568 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/22620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/23432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/19983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21811 "Failed to checkout and rebase branch from PR 18848") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/25181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/23432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21795 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/25181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/22620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/25181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/22620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/24283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/25181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/22620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/22119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/19559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/22620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2666 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/20143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->