### PR TITLE
Make GPUProcessPreferences use generated serialization

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -345,6 +345,7 @@ set(WebKit_MESSAGES_IN_FILES
 
 set(WebKit_SERIALIZATION_IN_FILES
     GPUProcess/GPUProcessCreationParameters.serialization.in
+    GPUProcess/GPUProcessPreferences.serialization.in
     GPUProcess/GPUProcessSessionParameters.serialization.in
 
     GPUProcess/graphics/PathSegment.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -34,6 +34,7 @@ $(PROJECT_DIR)/DerivedSources.make
 $(PROJECT_DIR)/GPUProcess/GPUConnectionToWebProcess.messages.in
 $(PROJECT_DIR)/GPUProcess/GPUProcess.messages.in
 $(PROJECT_DIR)/GPUProcess/GPUProcessCreationParameters.serialization.in
+$(PROJECT_DIR)/GPUProcess/GPUProcessPreferences.serialization.in
 $(PROJECT_DIR)/GPUProcess/GPUProcessSessionParameters.serialization.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -470,6 +470,7 @@ $(WEB_PREFERENCES_PATTERNS) : $(WTF_BUILD_SCRIPTS_DIR)/GeneratePreferences.rb $(
 
 SERIALIZATION_DESCRIPTION_FILES = \
 	GPUProcess/GPUProcessCreationParameters.serialization.in \
+	GPUProcess/GPUProcessPreferences.serialization.in \
 	GPUProcess/GPUProcessSessionParameters.serialization.in \
 	GPUProcess/graphics/PathSegment.serialization.in \
 	GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in \

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
@@ -44,6 +44,19 @@ GPUProcessPreferences::GPUProcessPreferences(const WebPreferences& webPreference
     copyEnabledWebPreferences(webPreferences);
 }
 
+GPUProcessPreferences::GPUProcessPreferences(std::optional<bool> opusDecoderEnabled, std::optional<bool> vorbisDecoderEnabled, std::optional<bool> webMFormatReaderEnabled,
+    std::optional<bool> webMParserEnabled, std::optional<bool> mediaSourceInlinePaintingEnabled, std::optional<bool> sampleBufferContentKeySessionSupportEnabled,
+    std::optional<bool> alternateWebMPlayerEnabled, std::optional<bool> useSCContentSharingPicker)
+    : opusDecoderEnabled(opusDecoderEnabled)
+    , vorbisDecoderEnabled(vorbisDecoderEnabled)
+    , webMFormatReaderEnabled(webMFormatReaderEnabled)
+    , webMParserEnabled(webMParserEnabled)
+    , mediaSourceInlinePaintingEnabled(mediaSourceInlinePaintingEnabled)
+    , sampleBufferContentKeySessionSupportEnabled(sampleBufferContentKeySessionSupportEnabled)
+    , alternateWebMPlayerEnabled(alternateWebMPlayerEnabled)
+    , useSCContentSharingPicker(useSCContentSharingPicker)
+{ }
+
 void GPUProcessPreferences::copyEnabledWebPreferences(const WebPreferences& webPreferences)
 {
 #if ENABLE(OPUS)
@@ -80,86 +93,6 @@ void GPUProcessPreferences::copyEnabledWebPreferences(const WebPreferences& webP
     if (webPreferences.alternateWebMPlayerEnabled())
         alternateWebMPlayerEnabled = true;
 #endif
-}
-
-void GPUProcessPreferences::encode(IPC::Encoder& encoder) const
-{
-#if ENABLE(OPUS)
-    encoder << opusDecoderEnabled;
-#endif
-    
-#if ENABLE(VORBIS)
-    encoder << vorbisDecoderEnabled;
-#endif
-    
-#if ENABLE(WEBM_FORMAT_READER)
-    encoder << webMFormatReaderEnabled;
-#endif
-    
-#if ENABLE(MEDIA_SOURCE) && ENABLE(VP9)
-    encoder << webMParserEnabled;
-#endif
-    
-#if ENABLE(MEDIA_SOURCE) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)
-    encoder << mediaSourceInlinePaintingEnabled;
-#endif
-    
-#if HAVE(AVCONTENTKEYSPECIFIER)
-    encoder << sampleBufferContentKeySessionSupportEnabled;
-#endif
-    
-#if ENABLE(ALTERNATE_WEBM_PLAYER)
-    encoder << alternateWebMPlayerEnabled;
-#endif
-    
-#if ENABLE(SC_CONTENT_SHARING_PICKER)
-    encoder << useSCContentSharingPicker;
-#endif
-}
-
-bool GPUProcessPreferences::decode(IPC::Decoder& decoder, GPUProcessPreferences& result)
-{
-#if ENABLE(OPUS)
-    if (!decoder.decode(result.opusDecoderEnabled))
-        return false;
-#endif
-    
-#if ENABLE(VORBIS)
-    if (!decoder.decode(result.vorbisDecoderEnabled))
-        return false;
-#endif
-    
-#if ENABLE(WEBM_FORMAT_READER)
-    if (!decoder.decode(result.webMFormatReaderEnabled))
-        return false;
-#endif
-    
-#if ENABLE(MEDIA_SOURCE) && ENABLE(VP9)
-    if (!decoder.decode(result.webMParserEnabled))
-        return false;
-#endif
-    
-#if ENABLE(MEDIA_SOURCE) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)
-    if (!decoder.decode(result.mediaSourceInlinePaintingEnabled))
-        return false;
-#endif
-    
-#if HAVE(AVCONTENTKEYSPECIFIER)
-    if (!decoder.decode(result.sampleBufferContentKeySessionSupportEnabled))
-        return false;
-#endif
-    
-#if ENABLE(ALTERNATE_WEBM_PLAYER)
-    if (!decoder.decode(result.alternateWebMPlayerEnabled))
-        return false;
-#endif
-    
-#if ENABLE(SC_CONTENT_SHARING_PICKER)
-    if (!decoder.decode(result.useSCContentSharingPicker))
-        return false;
-#endif
-
-    return true;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.h
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.h
@@ -41,8 +41,11 @@ class WebPreferences;
 struct GPUProcessPreferences {
     GPUProcessPreferences();
     GPUProcessPreferences(const WebPreferences&);
+    GPUProcessPreferences(std::optional<bool> opusDecoderEnabled, std::optional<bool> vorbisDecoderEnabled, std::optional<bool> webMFormatReaderEnabled,
+        std::optional<bool> webMParserEnabled, std::optional<bool> mediaSourceInlinePaintingEnabled, std::optional<bool> sampleBufferContentKeySessionSupportEnabled,
+        std::optional<bool> alternateWebMPlayerEnabled, std::optional<bool> useSCContentSharingPicker);
     void copyEnabledWebPreferences(const WebPreferences&);
-    
+
 #if ENABLE(OPUS)
     std::optional<bool> opusDecoderEnabled;
 #endif
@@ -74,9 +77,6 @@ struct GPUProcessPreferences {
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     std::optional<bool> useSCContentSharingPicker;
 #endif
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, GPUProcessPreferences&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
@@ -1,0 +1,59 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+struct WebKit::GPUProcessPreferences {
+#if ENABLE(OPUS)
+    std::optional<bool> opusDecoderEnabled;
+#endif
+
+#if ENABLE(VORBIS)
+    std::optional<bool> vorbisDecoderEnabled;
+#endif
+
+#if ENABLE(WEBM_FORMAT_READER)
+    std::optional<bool> webMFormatReaderEnabled;
+#endif
+
+#if ENABLE(MEDIA_SOURCE) && ENABLE(VP9)
+    std::optional<bool> webMParserEnabled;
+#endif
+
+#if ENABLE(MEDIA_SOURCE) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)
+    std::optional<bool> mediaSourceInlinePaintingEnabled;
+#endif
+
+#if HAVE(AVCONTENTKEYSPECIFIER)
+    std::optional<bool> sampleBufferContentKeySessionSupportEnabled;
+#endif
+
+#if ENABLE(ALTERNATE_WEBM_PLAYER)
+    std::optional<bool> alternateWebMPlayerEnabled;
+#endif
+
+#if HAVE(SC_CONTENT_SHARING_PICKER)
+    std::optional<bool> useSCContentSharingPicker;
+#endif
+};
+
+#endif


### PR DESCRIPTION
#### 1d0d641497e10e7e571bbb27807b37f52fe08bd2
<pre>
Make GPUProcessPreferences use generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=262900">https://bugs.webkit.org/show_bug.cgi?id=262900</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUProcessPreferences.cpp:
(WebKit::GPUProcessPreferences::GPUProcessPreferences):
(WebKit::GPUProcessPreferences::encode const): Deleted.
(WebKit::GPUProcessPreferences::decode): Deleted.
* Source/WebKit/GPUProcess/GPUProcessPreferences.h:
* Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d0d641497e10e7e571bbb27807b37f52fe08bd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21569 "9 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21892 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22621 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23433 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19984 "Hash 1d0d6414 for PR 18849 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25182 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22120 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21174 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21796 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/25182 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/22621 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24284 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/25182 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/22621 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25849 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/25182 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/22621 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23699 "Passed tests") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20240 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/22120 "Hash 1d0d6414 for PR 18849 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19560 "Hash 1d0d6414 for PR 18849 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/22621 "Hash 1d0d6414 for PR 18849 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23796 "Hash 1d0d6414 for PR 18849 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20144 "Hash 1d0d6414 for PR 18849 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->