### PR TITLE
[Site Isolation] Fix mouse event coordinates with scrolled frames

### DIFF
--- a/LayoutTests/http/tests/site-isolation/mouse-events/resources/message-mouse-down-coordinates.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/resources/message-mouse-down-coordinates.html
@@ -1,0 +1,5 @@
+<script>
+addEventListener("mousedown", (event) => {
+    window.parent.postMessage(event.pageX + "," + event.pageY, "*");
+});
+</script>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/resources/scroll-and-message-mouse-down-coordinates.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/resources/scroll-and-message-mouse-down-coordinates.html
@@ -1,0 +1,27 @@
+<style>
+#content {
+    width: 800px;
+    height: 800px;
+    overflow: auto;
+}
+</style>
+<div id="content">
+<script>
+addEventListener("mousedown", (event) => {
+    window.parent.postMessage(event.pageX + "," + event.pageY, "*");
+});
+
+addEventListener("load", (event) => {
+    window.scrollTo(50, 50);
+
+    function checkScrollPosition() {
+        if (window.scrollX === 50 && window.scrollY === 50)
+            window.parent.postMessage("scrolled", "*");
+        else
+            requestAnimationFrame(checkScrollPosition);
+    }
+
+    requestAnimationFrame(checkScrollPosition);
+});
+</script>
+</div>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS Correct mouse coordinates
+

--- a/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe.html
@@ -1,0 +1,24 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+addEventListener("message", (event) => {
+    if (event.data == "scrolled") {
+        eventSender.mouseMoveTo(100, 100);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+        return;
+    }
+
+    if (event.data == "140,95")
+        testPassed("Correct mouse coordinates");
+    else
+        testFailed("Unexpected mouse coordinates: " + event.data);
+    testRunner.notifyDone();
+});
+</script>
+<iframe src="http://localhost:8000/site-isolation/mouse-events/resources/scroll-and-message-mouse-down-coordinates.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-mainframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-mainframe-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS Correct mouse coordinates
+

--- a/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-mainframe.html
+++ b/LayoutTests/http/tests/site-isolation/mouse-events/scrolled-mainframe.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+addEventListener("message", (event) => {
+    if (event.data == "140,140")
+        testPassed("Correct mouse coordinates");
+    else
+        testFailed("Unexpected mouse coordinates: " + event.data);
+    testRunner.notifyDone();
+});
+
+function onLoad() {
+    window.scrollTo(50, 50);
+    
+    function checkScrollPosition() {
+        if (window.scrollX === 50 && window.scrollY === 95) {
+            eventSender.mouseMoveTo(100, 100);
+            eventSender.mouseDown();
+            eventSender.mouseUp();
+        } else
+            requestAnimationFrame(checkScrollPosition);
+    }
+
+    requestAnimationFrame(checkScrollPosition);
+}
+</script>
+<iframe onload="onLoad()" width="1500" height="1500" src="http://localhost:8000/site-isolation/mouse-events/resources/message-mouse-down-coordinates.html"></iframe>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4596,6 +4596,7 @@ imported/w3c/web-platform-tests/css/css-lists/list-style-image-gradients-dynamic
 imported/w3c/web-platform-tests/css/css-lists/list-style-image-gradients.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-disc.html [ Skip ]
 
+http/tests/site-isolation/mouse-events/ [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/basic-iframe.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/selection-focus.html [ Skip ]
 

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -85,6 +85,7 @@ class PlatformGestureEvent;
 class PlatformKeyboardEvent;
 class PlatformTouchEvent;
 class PlatformWheelEvent;
+class RemoteFrame;
 class RenderBox;
 class RenderElement;
 class RenderLayer;
@@ -99,6 +100,7 @@ class WheelEvent;
 class Widget;
 
 struct DragState;
+struct RemoteMouseEventData;
 
 enum class WheelEventProcessingSteps : uint8_t;
 enum class WheelScrollGestureState : uint8_t;
@@ -557,6 +559,8 @@ private:
 
     bool canMouseDownStartSelect(const MouseEventWithHitTestResults&);
     bool mouseDownMayStartSelect() const;
+
+    std::optional<RemoteMouseEventData> mouseEventDataForRemoteFrame(const RemoteFrame*, const IntPoint&);
     
     LocalFrame& m_frame;
     RefPtr<Node> m_mousePressNode;


### PR DESCRIPTION
#### 20e46bea66daf37a1032bb1aa02dca3fdc656c84
<pre>
[Site Isolation] Fix mouse event coordinates with scrolled frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=262905">https://bugs.webkit.org/show_bug.cgi?id=262905</a>
rdar://116690742

Reviewed by Alex Christensen.

Currently, mouse events passed to site-isolated frames will be offset if the target frame or target
frame’s ancestors are scrolled. We should convert to/from root view coordinates so that the scroll
position for each frame is considered.

Also change the parameter back on `documentPointForWindowPoint()` since that function should only be
used for local frames.

* LayoutTests/http/tests/site-isolation/mouse-events/resources/message-mouse-down-coordinates.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/resources/scroll-and-message-mouse-down-coordinates.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/scrolled-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/scrolled-mainframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/mouse-events/scrolled-mainframe.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::documentPointForWindowPoint):
(WebCore::EventHandler::mouseEventDataForRemoteFrame):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
* Source/WebCore/page/EventHandler.h:

Canonical link: <a href="https://commits.webkit.org/269143@main">https://commits.webkit.org/269143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d68de82b9c037ffbf2882d2bfc443dddbca3fc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21663 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23526 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21904 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21221 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21890 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24380 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25908 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23767 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17298 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19427 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5169 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23861 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2690 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->