### PR TITLE
Ensure resources from blob URL are correctly saved to disk

### DIFF
--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -567,7 +567,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
             if (auto subframeArchive = create(*childFrame->document(), WTFMove(frameFilter), mainFrameFileName)) {
                 auto subframeMainResource = subframeArchive->mainResource();
                 auto subframeMainResourceURL = subframeMainResource ? subframeMainResource->url() : URL { };
-                if (!subframeMainResourceURL.isNull()) {
+                if (!subframeMainResourceURL.isEmpty()) {
                     if (subframeMainResourceURL.isAboutSrcDoc() || subframeMainResourceURL.isAboutBlank())
                         uniqueSubresources.add(childFrame->frameID().toString(), subframeMainResource->fileName());
                     else
@@ -634,6 +634,10 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
         auto* document = frame.document();
         if (!document)
             return nullptr;
+
+        if (responseURL.isEmpty())
+            return nullptr;
+
         auto fileNameWithExtension = frame.isMainFrame() ? mainFrameFileName : makeString(subresourcesDirectoryName, "/frame_", frame.frameID().toString());
         auto extension = MIMETypeRegistry::preferredExtensionForMIMEType(mainResource->mimeType());
         if (!fileNameWithExtension.endsWith(extension))


### PR DESCRIPTION
#### 40496031556f61808a583fe254d60fb9380580ab
<pre>
Ensure resources from blob URL are correctly saved to disk
<a href="https://bugs.webkit.org/show_bug.cgi?id=262904">https://bugs.webkit.org/show_bug.cgi?id=262904</a>
rdar://116690714

Reviewed by Ryosuke Niwa.

This patch fixes an issue that an empty html file is created when iframe&apos;s src attribute is a blob url, by skipping
empty url when generating file names. Also, this patch adds regression test for saving resources from blob URL.

API Test: WebArchive.SaveResourcesBlobURL

* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/269129@main">https://commits.webkit.org/269129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3880f2c74463eea40b887662f6cee04e032a0e79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21578 "6 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/19989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21176 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24292 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25857 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23708 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17252 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19565 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5171 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->