### PR TITLE
[css-grid] Update test expectations for css-grid/subgrid/orthogonal-writing-mode-005.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1604,7 +1604,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/subgrid/masonry-c
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-columns-item-placement-auto-flow-next-001.html [ Skip ]
 
 # Subgrid failures
-imported/w3c/web-platform-tests/css/css-grid/subgrid/orthogonal-writing-mode-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-no-items-on-edges-002.html [ ImageOnlyFailure ]
 
 # Timeout

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/orthogonal-writing-mode-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/orthogonal-writing-mode-005-expected.html
@@ -250,37 +250,37 @@
   <!-- Named grid areas -->
   <div class="grid"><div class="subgrid areas-1a"><div class="subgrid">
     <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:2"></div>
+    <div style="grid-row:1 / -1"></div>
+    <div style="grid-row:1 / -1"></div>
+    <div style="grid-row:-1"></div>
   </div></div></div>
 
   <div class="grid"><div class="subgrid areas-1b"><div class="subgrid">
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
     <div style="grid-row:2"></div>
+    <div style="grid-row:2 / -1"></div>
+    <div style="grid-row:2 / -1"></div>
+    <div style="grid-row:-1"></div>
   </div></div></div>
 
   <div class="grid"><div class="subgrid areas-1c"><div class="subgrid">
     <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:2"></div>
+    <div style="grid-row:1/-2"></div>
+    <div style="grid-row:1/-2"></div>
+    <div style="grid-row:-2"></div>
   </div></div></div>
 
   <div class="grid"><div class="subgrid areas-1d"><div class="subgrid">
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:2"></div>
+    <div style="grid-row:3"></div>
+    <div style="grid-row:3 / -1"></div>
+    <div style="grid-row:3 / -1"></div>
+    <div style="grid-row:-1"></div>
   </div></div></div>
 
   <div class="grid"><div class="subgrid areas-1e"><div class="subgrid">
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:2"></div>
+    <div style="grid-row:3"></div>
+    <div style="grid-row:3"></div>
+    <div style="grid-row:3"></div>
+    <div style="grid-row:-1"></div>
   </div></div></div>
   </body>
   </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/orthogonal-writing-mode-005-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/orthogonal-writing-mode-005-ref.html
@@ -250,37 +250,37 @@
   <!-- Named grid areas -->
   <div class="grid"><div class="subgrid areas-1a"><div class="subgrid">
     <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:2"></div>
+    <div style="grid-row:1 / -1"></div>
+    <div style="grid-row:1 / -1"></div>
+    <div style="grid-row:-1"></div>
   </div></div></div>
 
   <div class="grid"><div class="subgrid areas-1b"><div class="subgrid">
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
     <div style="grid-row:2"></div>
+    <div style="grid-row:2 / -1"></div>
+    <div style="grid-row:2 / -1"></div>
+    <div style="grid-row:-1"></div>
   </div></div></div>
 
   <div class="grid"><div class="subgrid areas-1c"><div class="subgrid">
     <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:2"></div>
+    <div style="grid-row:1/-2"></div>
+    <div style="grid-row:1/-2"></div>
+    <div style="grid-row:-2"></div>
   </div></div></div>
 
   <div class="grid"><div class="subgrid areas-1d"><div class="subgrid">
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:2"></div>
+    <div style="grid-row:3"></div>
+    <div style="grid-row:3 / -1"></div>
+    <div style="grid-row:3 / -1"></div>
+    <div style="grid-row:-1"></div>
   </div></div></div>
 
   <div class="grid"><div class="subgrid areas-1e"><div class="subgrid">
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:1"></div>
-    <div style="grid-row:2"></div>
+    <div style="grid-row:3"></div>
+    <div style="grid-row:3"></div>
+    <div style="grid-row:3"></div>
+    <div style="grid-row:-1"></div>
   </div></div></div>
   </body>
   </html>


### PR DESCRIPTION
#### 6126b9b5fa7170ed88e8561b0a6afb74befe5a40
<pre>
[css-grid] Update test expectations for css-grid/subgrid/orthogonal-writing-mode-005.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262912">https://bugs.webkit.org/show_bug.cgi?id=262912</a>
rdar://116685783

Reviewed by Tim Nguyen.

There was a CSSWG discussion regarding some of the subtests within
this test: <a href="https://github.com/w3c/csswg-drafts/issues/9418">https://github.com/w3c/csswg-drafts/issues/9418</a>

Based off of the discussion, the subtests should be updated to reflect
the current WebKit rendering.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/orthogonal-writing-mode-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/orthogonal-writing-mode-005-ref.html:

Canonical link: <a href="https://commits.webkit.org/269141@main">https://commits.webkit.org/269141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2a488320d08d4eaab2575fee1183692635ce645

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21677 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20069 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21231 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21904 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24394 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25918 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23777 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17311 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19649 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5178 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23875 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->