### PR TITLE
4x imported/mozilla/svg/text/* (layout-tests) are flaky image failures

### DIFF
--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -400,7 +400,6 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
     RELEASE_ASSERT(viewSize.width);
     RELEASE_ASSERT(viewSize.height);
 
-    // FIXME: Do we still require this workaround?
 #if !HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     UIView *selectionView = [platformView().contentView valueForKeyPath:@"interactionAssistant.selectionView"];
     UIView *startGrabberView = [selectionView valueForKeyPath:@"rangeView.startGrabber"];
@@ -420,6 +419,9 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
         [endGrabberView setHidden:YES];
         viewsToUnhide.uncheckedAppend(endGrabberView);
     }
+#else
+    UITextSelectionDisplayInteraction *interaction = [platformView().contentView valueForKeyPath:@"interactionAssistant._selectionViewManager"];
+    interaction.activated = NO;
 #endif
 
     __block bool isDone = false;
@@ -444,6 +446,8 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
 #if !HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     for (auto view : viewsToUnhide)
         [view setHidden:NO];
+#else
+    interaction.activated = YES;
 #endif
 
     return result;


### PR DESCRIPTION
#### 486a57246e8e9c6ef4d2b7f3d10036d84d9060dc
<pre>
4x imported/mozilla/svg/text/* (layout-tests) are flaky image failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=262916">https://bugs.webkit.org/show_bug.cgi?id=262916</a>
rdar://114780887

Reviewed by Wenson Hsieh.

This is the effectively the same problem as <a href="https://bugs.webkit.org/show_bug.cgi?id=199196">https://bugs.webkit.org/show_bug.cgi?id=199196</a>,
but this time in the `UI_TEXT_SELECTION_DISPLAY_INTERACTION` code path.

Fix by applying a similar workaround that fixed the aforementioned bug; this time, by temporarily
deactivating the text selection interaction which also hides all of its views, including the
highlight and handle views.

* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(WTR::PlatformWebView::windowSnapshotImage):

Canonical link: <a href="https://commits.webkit.org/269138@main">https://commits.webkit.org/269138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/148ece11ce8183a1e2467896a6a61b2c96456118

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21622 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23483 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21864 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21198 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24335 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25886 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23740 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17276 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19599 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5176 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->