### PR TITLE
Add test verifying same-site iframe access after site-isolated window.open

### DIFF
--- a/LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt
@@ -1,0 +1,13 @@
+Verifies same-origin window properties can be accessed after window.open with a frame name
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+state before window.open:
+PASS openedWindow[0].customProperty is 42
+state after window.open with a frame name:
+PASS openedWindow[0].customProperty is 43
+PASS successfullyParsed is true
+
+TEST COMPLETE
+click to run test manually in a browser

--- a/LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html
+++ b/LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+
+description("Verifies same-origin window properties can be accessed after window.open with a frame name");
+jsTestIsAsync = true;
+
+function runTest() {
+    openedWindow = window.open("http://localhost:8000/site-isolation/resources/opened-main.html");
+}
+
+function runTestIfInTestRunner() { if (window.testRunner) { runTest() } }
+
+function firstSameOriginIframeOpened() {
+    debug("state before window.open:")
+    shouldBe("openedWindow[0].customProperty", "42");
+    windowOpenedInFrame = window.open("http://127.0.0.1:8000/site-isolation/resources/opened-iframe-2.html", "openedFrameName")
+}
+function secondSameOriginIframeOpened() {
+    debug("state after window.open with a frame name:")
+    shouldBe("openedWindow[0].customProperty", "43");
+    finishJSTest();
+}
+</script>
+<body onload="runTestIfInTestRunner()">
+<button onclick="runTest()">click to run test manually in a browser</button>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/opened-iframe-2.html
+++ b/LayoutTests/http/tests/site-isolation/resources/opened-iframe-2.html
@@ -1,0 +1,4 @@
+<script>
+    window.customProperty = 43;
+    window.parent.opener.secondSameOriginIframeOpened()
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/opened-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/opened-iframe.html
@@ -1,0 +1,4 @@
+<script>
+    window.customProperty = 42;
+    window.parent.opener.firstSameOriginIframeOpened()
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/opened-main.html
+++ b/LayoutTests/http/tests/site-isolation/resources/opened-main.html
@@ -1,0 +1,1 @@
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/opened-iframe.html" name="openedFrameName"></iframe>


### PR DESCRIPTION
#### 0b042971061aab4d8826d5f23db8567abf27e2c4
<pre>
Add test verifying same-site iframe access after site-isolated window.open
<a href="https://bugs.webkit.org/show_bug.cgi?id=262925">https://bugs.webkit.org/show_bug.cgi?id=262925</a>
rdar://116700708

Reviewed by Chris Dumez.

I thought this would need to be implemented, but it turns out it already works.

* LayoutTests/http/tests/site-isolation/frame-access-after-window-open-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/frame-access-after-window-open.html: Added.
* LayoutTests/http/tests/site-isolation/resources/opened-iframe-2.html: Added.
* LayoutTests/http/tests/site-isolation/resources/opened-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/opened-main.html: Added.

Canonical link: <a href="https://commits.webkit.org/269204@main">https://commits.webkit.org/269204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa74f964f72a4cba7b987d3936984713c8ed956f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20219 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21326 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24566 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26055 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23920 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20450 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17418 "Found 1 new test failure: fast/dom/HTMLLinkElement/link-preload-load-once.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19593 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24002 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2716 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->