### PR TITLE
Regression (268779@main) A lot of Safari Reader tests are failing

### DIFF
--- a/Source/WebCore/loader/archive/ArchiveResource.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResource.cpp
@@ -49,8 +49,11 @@ RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&&
     if (!data)
         return nullptr;
     if (response.isNull()) {
-        unsigned dataSize = data->size();
-        return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, ResourceResponse(url, mimeType, dataSize, textEncoding), fileName));
+        ResourceResponse syntheticResponse(url, mimeType, data->size(), textEncoding);
+        // Provide a valid HTTP status code for http URLs since we have logic in WebCore that validates it.
+        if (url.protocolIsInHTTPFamily())
+            syntheticResponse.setHTTPStatusCode(200);
+        return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, WTFMove(syntheticResponse), fileName));
     }
     return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, response, fileName));
 }


### PR DESCRIPTION
#### 405e0bba3951bc10d4b026ab04a4788c997f3c8c
<pre>
Regression (268779@main) A lot of Safari Reader tests are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=262927">https://bugs.webkit.org/show_bug.cgi?id=262927</a>
rdar://116606281

Reviewed by Alex Christensen.

In the Web archives used by Safari&apos;s reader tests, the resource response is
missing, causing ArchiveResource::create() to generate a synthetic response.
I am not sure why the response is missing from Safari&apos;s web archives, as it
seems to be present in web archives I generate locally (maybe an older
format?).

In any case, the synthetic response didn&apos;t have an HTTP status code set,
even when the URL is a HTTP/HTTPS one. This would trip the logic added in
268779@main to validate the HTTP status code of CSS style sheets since the
status code is 0 instead of being in the 200-299 range.

To address the issue, I am updating ArchiveResource::create() to set a status
code of 200 on the synthetic network response if the URL is in the HTTP
family.

* Source/WebCore/loader/archive/ArchiveResource.cpp:
(WebCore::ArchiveResource::create):

Canonical link: <a href="https://commits.webkit.org/269140@main">https://commits.webkit.org/269140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73bbe45f29952a3265ac1a3bd9a4798a451885b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21630 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23491 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/25429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21215 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24342 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25887 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23741 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17277 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19606 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5177 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->