### PR TITLE
[ Sonoma arm64 ] css3/filters/effect-blur-hw.html is a consistent failure

### DIFF
--- a/LayoutTests/css3/filters/effect-blur-hw-expected.html
+++ b/LayoutTests/css3/filters/effect-blur-hw-expected.html
@@ -2,18 +2,25 @@
 <html>
 <head>
     <link rel="stylesheet" href="resources/filter-helpers.css">
-    <script src="resources/filter-helpers.js"></script>
 </head>
 <body>
-    <script>
-        const filters = [
-            'blur(0px)',
-            'blur(2px)',
-            'blur(3px)',
-            'blur(10px)',
-        ];
-
-        buildSVGFilteredBoxes(filters);
-    </script>
+    <img src="resources/reference.png" style="filter: url('#filter-1');">
+    <img src="resources/reference.png" style="filter: url('#filter-2');">
+    <img src="resources/reference.png" style="filter: url('#filter-3');">
+    <img src="resources/reference.png" style="filter: url('#filter-4');">
+    <svg>
+        <filter id="filter-1">
+            <feGaussianBlur stdDeviation="0"/>
+        </filter>
+        <filter id="filter-2">
+            <feGaussianBlur stdDeviation="2"/>
+        </filter>
+        <filter id="filter-3">
+            <feGaussianBlur stdDeviation="3"/>
+        </filter>
+        <filter id="filter-4" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur stdDeviation="10"/>
+        </filter>
+    </svg>
 </body>
 </html>

--- a/LayoutTests/css3/filters/effect-blur-hw.html
+++ b/LayoutTests/css3/filters/effect-blur-hw.html
@@ -8,18 +8,11 @@
             will-change: transform;
         }
     </style>
-    <script src="resources/filter-helpers.js"></script>
 </head>
 <body>
-    <script>
-        const filters = [
-            'blur(0)',
-            'blur(2px)',
-            'blur(3px)',
-            'blur(10px)',
-        ];
-
-        buildCSSFilteredBoxes(filters);
-    </script>
+    <img src="resources/reference.png" style="filter: blur(0)">
+    <img src="resources/reference.png" style="filter: blur(2px)">
+    <img src="resources/reference.png" style="filter: blur(3px)">
+    <img src="resources/reference.png" style="filter: blur(10px)"> 
 </body>
 </html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2885,6 +2885,4 @@ webkit.org/b/261306 imported/w3c/web-platform-tests/content-security-policy/repo
 
 webkit.org/b/262732 [ Sonoma+ ] fast/css/text-overflow-input.html [ Failure ]
 
-webkit.org/b/262750 [ Sonoma+ arm64 ] css3/filters/effect-blur-hw.html [ ImageOnlyFailure ]
-
 webkit.org/b/262915 [ Sonoma+ ] compositing/plugins/pdf/pdf-in-embed-rounded-border.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 485231878ea3b1e5ea55508bfc47fd099815edfc
<pre>
[ Sonoma arm64 ] css3/filters/effect-blur-hw.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=262750">https://bugs.webkit.org/show_bug.cgi?id=262750</a>
rdar://116551869

Reviewed by Simon Fraser.

The last image is clipped in the expected page. Its filter has a GaussianBlur
effect (std = 10). The height of the target element is 90 pixels and the filter
element has outsets of 10% of the target element. So the top and bottom outset
are both equal to 9 pixels. This outset is not enough for this filter. So the
fix is to increase the dimension of the filter by 20% instead.

* LayoutTests/css3/filters/effect-blur-hw-expected.html:
* LayoutTests/css3/filters/effect-blur-hw.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269152@main">https://commits.webkit.org/269152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9edd5093372f85f0e0fffe8c12b5a94ae1cfd50c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21650 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20043 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21210 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24365 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25897 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23753 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17286 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19418 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5187 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->