### PR TITLE
[Gardening]: REGRESSION(Sonoma): [ Sonoma ] 2 API tests under TestWebKitAPI.WebKit.* are constantly timing out.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
@@ -169,6 +169,7 @@ TEST(WebKit, SOCKS5)
 #if !PLATFORM(IOS_FAMILY_SIMULATOR)
 
 #if HAVE(NW_PROXY_CONFIG)
+#if USE(APPLE_INTERNAL_SDK) // FIXME: <rdar://116703485> investigate why this times out on non-internal builds.
 TEST(WebKit, HTTPSProxyAPI)
 {
     auto* createProxyConfig = nw_proxy_config_create_http_connectPtr();
@@ -294,6 +295,7 @@ TEST(WebKit, SOCKS5API)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://example.com/"]]];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
 }
+#endif // USE(APPLE_INTERNAL_SDK)
 #endif // HAVE(NW_PROXY_CONFIG)
 #endif // !PLATFORM(IOS_FAMILY_SIMULATOR)
 


### PR DESCRIPTION
#### b5f962b54b6d87c65a71e6ca7bdf9911c9892277
<pre>
[Gardening]: REGRESSION(Sonoma): [ Sonoma ] 2 API tests under TestWebKitAPI.WebKit.* are constantly timing out.
rdar://116703485
<a href="https://bugs.webkit.org/show_bug.cgi?id=262928">https://bugs.webkit.org/show_bug.cgi?id=262928</a>

Unreviewed test gardening.

Disables two API tests while the issue is investigated.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm:

Canonical link: <a href="https://commits.webkit.org/269188@main">https://commits.webkit.org/269188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1e492244e0193c529b9f3569985cdc32afe955b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23505 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21208 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24357 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25894 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23749 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17284 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19618 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5162 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23845 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2712 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->