### PR TITLE
REGRESSION (260813@main): Jamf Assessment app crashes on launch

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -302,8 +302,6 @@ static void logProcessPoolState(const WebProcessPool& pool)
 #if ENABLE(WEBCONTENT_CRASH_TESTING)
 void WebProcessPool::initializeShouldCrashWhenCreatingWebProcess()
 {
-    ASSERT(!s_didGlobalStaticInitialization);
-
     // Do the check on a background queue to avoid an app launch time regression. Note that this means we're racing with the
     // construction of the first WebProcess. However, the race is OK, we just want to make sure a WebProcess will crash in
     // the future, it doesn't have to be the very first one.
@@ -321,11 +319,11 @@ void WebProcessPool::initializeShouldCrashWhenCreatingWebProcess()
 }
 #endif
 
-void WebProcessPool::platformInitialize()
+void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization needsGlobalStaticInitialization)
 {
     registerNotificationObservers();
 
-    if (s_didGlobalStaticInitialization)
+    if (needsGlobalStaticInitialization == NeedsGlobalStaticInitialization::No)
         return;
 
     registerUserDefaults();

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -532,7 +532,8 @@ public:
     bool operator==(const WebProcessPool& other) const { return (this == &other); }
 
 private:
-    void platformInitialize();
+    enum class NeedsGlobalStaticInitialization : bool { No, Yes };
+    void platformInitialize(NeedsGlobalStaticInitialization);
 
     void platformInitializeWebProcess(const WebProcessProxy&, WebProcessCreationParameters&);
     void platformInvalidateContext();
@@ -819,7 +820,6 @@ private:
     bool m_delaysWebProcessLaunchDefaultValue { globalDelaysWebProcessLaunchDefaultValue() };
 
     static bool s_useSeparateServiceWorkerProcess;
-    static bool s_didGlobalStaticInitialization;
 
 #if ENABLE(TRACKING_PREVENTION)
     HashSet<WebCore::RegistrableDomain> m_domainsWithUserInteraction;

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -63,7 +63,7 @@
 
 namespace WebKit {
 
-void WebProcessPool::platformInitialize()
+void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 {
     m_alwaysUsesComplexTextCodePath = true;
 

--- a/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp
@@ -59,7 +59,7 @@ static void initializeRemoteInspectorServer(StringView address)
 }
 #endif
 
-void WebProcessPool::platformInitialize()
+void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization)
 {
 #if ENABLE(REMOTE_INSPECTOR)
     if (const char* address = getenv("WEBKIT_INSPECTOR_SERVER"))

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -146,6 +146,7 @@ Tests/WebKitCocoa/IndexedDBSuspendImminently.html
 Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
 Tests/WebKitCocoa/IndexedDBTempFileSize.mm
 Tests/WebKitCocoa/IndexedDBUserDelete.mm
+Tests/WebKitCocoa/InitializeWebViewWhenChangingUserDefaults.mm
 Tests/WebKitCocoa/InjectedBundleNodeHandleIsSelectElement.mm
 Tests/WebKitCocoa/InjectedBundleNodeHandleIsTextField.mm
 Tests/WebKitCocoa/InsertTextAlternatives.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3596,6 +3596,7 @@
 		F4D5E4E71F0C5D27008C1A49 /* dragstart-clear-selection.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "dragstart-clear-selection.html"; sourceTree = "<group>"; };
 		F4D65DA71F5E46C0009D8C27 /* selected-text-image-link-and-editable.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "selected-text-image-link-and-editable.html"; sourceTree = "<group>"; };
 		F4D9818E2196B911008230FC /* editable-nested-lists.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "editable-nested-lists.html"; sourceTree = "<group>"; };
+		F4DD79E12AD4BDCB000C6821 /* InitializeWebViewWhenChangingUserDefaults.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InitializeWebViewWhenChangingUserDefaults.mm; sourceTree = "<group>"; };
 		F4DEF6EC1E9B4D950048EF61 /* image-in-link-and-input.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "image-in-link-and-input.html"; sourceTree = "<group>"; };
 		F4E0A28E211E5D5B00AF7C7F /* DragAndDropTestsMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DragAndDropTestsMac.mm; sourceTree = "<group>"; };
 		F4E0A295211FC5A300AF7C7F /* selected-text-and-textarea.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "selected-text-and-textarea.html"; sourceTree = "<group>"; };
@@ -4047,6 +4048,7 @@
 				CA2879DA226E6986001026F5 /* IndexedDBSuspendImminently.mm */,
 				CA5B94D62191005B0059FE38 /* IndexedDBTempFileSize.mm */,
 				CA97B3922193663B0045DF6F /* IndexedDBUserDelete.mm */,
+				F4DD79E12AD4BDCB000C6821 /* InitializeWebViewWhenChangingUserDefaults.mm */,
 				F460F659261117E70064F2B6 /* InjectedBundleHitTestPlugIn.mm */,
 				F460F65A2611183F0064F2B6 /* InjectedBundleHitTestProtocol.h */,
 				0E404A8A2166DDF8008271BA /* InjectedBundleNodeHandleIsSelectElement.mm */,


### PR DESCRIPTION
#### bf341c88387aafbac42d78a7e9f1b9ee929aaede
<pre>
REGRESSION (260813@main): Jamf Assessment app crashes on launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=262931">https://bugs.webkit.org/show_bug.cgi?id=262931</a>
rdar://115072267

Reviewed by Chris Dumez.

After the changes in 260813@main, `registerUserDefaults` (called from `platformInitialize`) is no
longer robust against reentrancy. This causes infinite recursion in the Jamf Assessment app, which
listens to `NSUserDefaultsDidChangeNotification` and initializes a `WKWebView` instance in response
to the notification.

We can fix this while preserving the fact that there&apos;s a single &quot;global static initialization&quot; flag
in WebKit2, by simply setting the flag upon reading it in the constructor of `WebProcessPool`,
rather than at the very end of the `WebProcessPool` constructor.

Test: WebKit2.NoCrashWhenInitializeWebViewWhenChangingUserDefaults

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::initializeShouldCrashWhenCreatingWebProcess):

Also remove a debug assertion that&apos;s no longer needed, since `ENABLE(WEBCONTENT_CRASH_TESTING)` is
no longer relevant.

(WebKit::WebProcessPool::platformInitialize):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
* Source/WebKit/UIProcess/WebProcessPool.h:

Additionally use an enum class to represent this boolean flag (since it&apos;s now passed as an argument
to a function), and also negate it to represent whether or not we need static global initialization,
since it&apos;s no longer only set after completing static global initialization in `WebProcessPool`.

* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitialize):
* Source/WebKit/UIProcess/playstation/WebProcessPoolPlayStation.cpp:
(WebKit::WebProcessPool::platformInitialize):
* Source/WebKit/UIProcess/win/WebProcessPoolWin.cpp:
(WebKit::WebProcessPool::platformInitialize):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/InitializeWebViewWhenChangingUserDefaults.mm: Copied from Source/WebKit/UIProcess/playstation/WebProcessPoolPlayStation.cpp.

Add an API test to exercise the infinite recursion.

(-[UserDefaultChangeObserver init]):
(-[UserDefaultChangeObserver defaultsChanged:]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/269145@main">https://commits.webkit.org/269145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7732698c5a4fe7ee266edb7a73fac5ae3a7c50bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21660 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21901 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21219 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21887 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24377 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25905 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23764 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17296 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19632 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5181 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->