### PR TITLE
Unable to enter fullscreen in Counterstrike (http://game.play-cs.com) in Safari 16.3

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -257,7 +257,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     // Painting is normally suspended when the WKView is removed from the window, but this is
     // unnecessary in the full-screen animation case, and can cause bugs; see
     // https://bugs.webkit.org/show_bug.cgi?id=88940 and https://bugs.webkit.org/show_bug.cgi?id=88374
-    // We will resume the normal behavior in _startEnterFullScreenAnimationWithDuration:
+    // We will resume the normal behavior in -finishedEnterFullScreenAnimation:
     _page->setSuppressVisibilityUpdates(true);
 
     // Swap the webView placeholder into place.
@@ -310,7 +310,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [window makeKeyAndOrderFront:self];
     [window setCollectionBehavior:behavior];
 
-    _page->setSuppressVisibilityUpdates(false);
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [[self window] setAutodisplay:YES];
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -333,6 +332,7 @@ static const float minVideoWidth = 468; // Keep in sync with `--controls-bar-wid
 
         [self _manager]->didEnterFullScreen();
         [self _manager]->setAnimatingFullScreen(false);
+        _page->setSuppressVisibilityUpdates(false);
 
         [_backgroundView.get().layer removeAllAnimations];
         [[_clipView layer] removeAllAnimations];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.html
@@ -8,6 +8,9 @@
         document.addEventListener('webkitfullscreenchange', function(event) {
             window.webkit.messageHandlers.fullscreenChangeHandler.postMessage('fullscreenchange');
         });
+        document.addEventListener('visibilitychange', function(event) {
+            window.webkit.messageHandlers.fullscreenChangeHandler.postMessage('visibilitychange');
+        });
         document.addEventListener('mousedown', function(event) {
             // Toggle fullscreen
             var target = document.getElementById('target');


### PR DESCRIPTION
#### 7e8c765bf94d37bbbf56c279c81b63957cb88fff
<pre>
Unable to enter fullscreen in Counterstrike (<a href="http://game.play-cs.com)">http://game.play-cs.com)</a> in Safari 16.3
<a href="https://bugs.webkit.org/show_bug.cgi?id=251648">https://bugs.webkit.org/show_bug.cgi?id=251648</a>
rdar://104984915

Reviewed by Jer Noble.

When entering fullscreen, WKFullScreenWindowController calls
WebPageProxy::setSuppressVisibilityUpdates to suppress visibility updates while the web view moves to
the new fullscreen window, since updating visibility is unnecessary when transitioning to fullscreen
and can even cause bugs (see the comment in -[WKFullScreenWindowController enterFullScreen:]). It
ends suppression in -beganEnterFullScreenWithInitialFrame:finalFrame: and schedules an activity
state update, but this occurs at a time when AppKit considers the fullscreen window to be occluded.
As a result a `visibilitychange` event is dispatched where `document.visibilityState == &apos;hidden&apos;`,
and play-cs.com responds to this event by exiting fullscreen. The upshot is that the user cannot
stay in fullscreen as the page exits this mode as soon as the user enters it.

Resolved this by extending the period where visibility updates are suppressed to when
-finishedEnterFullScreenAnimation: is called. At this point AppKit no longer considers the
fullscreen window to be occluded, so WebPageProxy detects no change in activity state and does not
dispatch any `visibilitychange` events. This matches the behavior of Firefox and Chrome on macOS,
which also do not dispatch `visiblitychange` events when entering fullscreen.

Added an API test.

* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenDelegate.mm:
(-[FullscreenDelegateMessageHandler userContentController:didReceiveScriptMessage:]):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/269150@main">https://commits.webkit.org/269150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68913302042452f926354f0f770418c80b7f8b3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21717 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21958 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21945 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24437 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25959 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23818 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19688 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5184 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23913 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->