### PR TITLE
[WebGPU] Texture::createView is non-functional for 2D texture arrays

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -51,26 +51,15 @@ Ref<TextureView> TextureImpl::createView(const std::optional<TextureViewDescript
     CString label = descriptor ? descriptor->label.utf8() : CString("");
 
     WGPUTextureViewDescriptor backingDescriptor {
-        nullptr,
-        label.data(),
-        descriptor && descriptor->format ? m_convertToBackingContext->convertToBacking(*descriptor->format) : m_convertToBackingContext->convertToBacking(m_format),
-        ([&]() -> WGPUTextureViewDimension {
-            if (descriptor && descriptor->dimension)
-                return m_convertToBackingContext->convertToBacking(*descriptor->dimension);
-            switch (m_dimension) {
-            case TextureDimension::_1d:
-                return WGPUTextureViewDimension_1D;
-            case TextureDimension::_2d:
-                return WGPUTextureViewDimension_2D;
-            case TextureDimension::_3d:
-                return WGPUTextureViewDimension_2D;
-            }
-        })(),
-        descriptor ? descriptor->baseMipLevel : 0,
-        descriptor && descriptor->mipLevelCount ? *descriptor->mipLevelCount : static_cast<uint32_t>(WGPU_MIP_LEVEL_COUNT_UNDEFINED),
-        descriptor ? descriptor->baseArrayLayer : 0,
-        descriptor && descriptor->arrayLayerCount ? *descriptor->arrayLayerCount : static_cast<uint32_t>(WGPU_ARRAY_LAYER_COUNT_UNDEFINED),
-        descriptor ? m_convertToBackingContext->convertToBacking(descriptor->aspect) : WGPUTextureAspect_All,
+        .nextInChain = nullptr,
+        .label = label.data(),
+        .format = descriptor && descriptor->format ? m_convertToBackingContext->convertToBacking(*descriptor->format) : m_convertToBackingContext->convertToBacking(m_format),
+        .dimension = descriptor && descriptor->dimension ? m_convertToBackingContext->convertToBacking(*descriptor->dimension) : WGPUTextureViewDimension_Undefined,
+        .baseMipLevel = descriptor ? descriptor->baseMipLevel : 0,
+        .mipLevelCount = descriptor && descriptor->mipLevelCount ? *descriptor->mipLevelCount : static_cast<uint32_t>(WGPU_MIP_LEVEL_COUNT_UNDEFINED),
+        .baseArrayLayer = descriptor ? descriptor->baseArrayLayer : 0,
+        .arrayLayerCount = descriptor && descriptor->arrayLayerCount ? *descriptor->arrayLayerCount : static_cast<uint32_t>(WGPU_ARRAY_LAYER_COUNT_UNDEFINED),
+        .aspect = descriptor ? m_convertToBackingContext->convertToBacking(descriptor->aspect) : WGPUTextureAspect_All,
     };
 
     return TextureViewImpl::create(adoptWebGPU(wgpuTextureCreateView(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2097,19 +2097,33 @@ std::optional<WGPUTextureViewDescriptor> Texture::resolveTextureViewDescriptorDe
     }
 
     if (resolved.dimension == WGPUTextureViewDimension_Undefined) {
-        switch (m_dimension) {
-        case WGPUTextureDimension_1D:
+        switch (m_texture.textureType) {
+        case MTLTextureType1D:
             resolved.dimension = WGPUTextureViewDimension_1D;
             break;
-        case WGPUTextureDimension_2D:
+        case MTLTextureType1DArray:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        case MTLTextureType2D:
+        case MTLTextureType2DMultisample:
             resolved.dimension = WGPUTextureViewDimension_2D;
             break;
-        case WGPUTextureDimension_3D:
+        case MTLTextureType2DArray:
+        case MTLTextureType2DMultisampleArray:
+            resolved.dimension = WGPUTextureViewDimension_2DArray;
+            break;
+        case MTLTextureTypeCube:
+            resolved.dimension = WGPUTextureViewDimension_Cube;
+            break;
+        case MTLTextureTypeCubeArray:
+            resolved.dimension = WGPUTextureViewDimension_CubeArray;
+            break;
+        case MTLTextureType3D:
             resolved.dimension = WGPUTextureViewDimension_3D;
             break;
-        case WGPUTextureDimension_Force32:
+        case MTLTextureTypeTextureBuffer:
             ASSERT_NOT_REACHED();
-            return resolved;
+            break;
         }
     }
 


### PR DESCRIPTION
#### ac2b499faf9411f0e08225ccb158497126cc6526
<pre>
[WebGPU] Texture::createView is non-functional for 2D texture arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=262937">https://bugs.webkit.org/show_bug.cgi?id=262937</a>&gt;
&lt;radar://116716108&gt;

Reviewed by Dan Glastonbury and Tadeu Zagallo.

Texture::createView did not work for anything other than 1D, 2D, or 3D textures
unless the dimension was passed.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp:
(WebCore::WebGPU::TextureImpl::createView):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::resolveTextureViewDescriptorDefaults const):

Canonical link: <a href="https://commits.webkit.org/269135@main">https://commits.webkit.org/269135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f51a5d2ebf6f484da82cc213311019a5ceff28d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21674 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23537 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20066 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21915 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22204 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21229 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21901 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24391 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25914 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23773 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17308 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19646 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5175 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->