### PR TITLE
[GTK] Simplify handling of toplevel window signals

### DIFF
--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -207,6 +207,7 @@ UIProcess/API/gtk/DropTargetGtk3.cpp @no-unify
 UIProcess/API/gtk/DropTargetGtk4.cpp @no-unify
 UIProcess/API/gtk/InputMethodFilterGtk.cpp @no-unify
 UIProcess/API/gtk/PageClientImpl.cpp @no-unify
+UIProcess/API/gtk/ToplevelWindow.cpp @no-unify
 UIProcess/API/gtk/WebKitAuthenticationDialog.cpp @no-unify
 UIProcess/API/gtk/WebKitColorChooser.cpp @no-unify
 UIProcess/API/gtk/WebKitColorChooserRequest.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ToplevelWindow.h"
+
+#include "WebKitWebViewBasePrivate.h"
+#include <wtf/HashMap.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WebKit {
+
+static HashMap<GtkWindow*, std::unique_ptr<ToplevelWindow>>& toplevelWindows()
+{
+    static NeverDestroyed<HashMap<GtkWindow*, std::unique_ptr<ToplevelWindow>>> windows;
+    return windows.get();
+}
+
+static void toplevelWindowDestroyedCallback(gpointer, GObject* window)
+{
+    toplevelWindows().remove(reinterpret_cast<GtkWindow*>(window));
+}
+
+ToplevelWindow* ToplevelWindow::forGtkWindow(GtkWindow* window)
+{
+    auto addResult = toplevelWindows().ensure(window, [window] {
+        return makeUnique<ToplevelWindow>(window);
+    });
+    if (addResult.isNewEntry)
+        g_object_weak_ref(G_OBJECT(window), toplevelWindowDestroyedCallback, nullptr);
+
+    return addResult.iterator->value.get();
+}
+
+ToplevelWindow::ToplevelWindow(GtkWindow* window)
+    : m_window(window)
+{
+}
+
+ToplevelWindow::~ToplevelWindow()
+{
+    ASSERT(m_webViews.isEmpty());
+}
+
+void ToplevelWindow::addWebView(WebKitWebViewBase* webView)
+{
+    auto addResult = m_webViews.add(webView);
+    if (addResult.isNewEntry && m_webViews.size() == 1)
+        connectSignals();
+#if !USE(GTK4)
+    if (gtk_widget_get_realized(GTK_WIDGET(m_window)))
+        gtk_widget_realize(GTK_WIDGET(webView));
+#endif
+}
+
+void ToplevelWindow::removeWebView(WebKitWebViewBase* webView)
+{
+    m_webViews.remove(webView);
+    if (m_webViews.isEmpty()) {
+        disconnectSignals();
+        g_object_weak_unref(G_OBJECT(m_window), toplevelWindowDestroyedCallback, nullptr);
+        toplevelWindows().remove(reinterpret_cast<GtkWindow*>(m_window));
+    }
+}
+
+bool ToplevelWindow::isActive() const
+{
+    return gtk_widget_get_visible(GTK_WIDGET(m_window)) && gtk_window_is_active(m_window);
+}
+
+bool ToplevelWindow::isFullscreen() const
+{
+#if USE(GTK4)
+    if (auto* surface = gtk_native_get_surface(GTK_NATIVE(m_window)))
+        return gdk_toplevel_get_state(GDK_TOPLEVEL(surface)) & GDK_TOPLEVEL_STATE_FULLSCREEN;
+#else
+    if (auto* window = gtk_widget_get_window(GTK_WIDGET(m_window)))
+        return gdk_window_get_state(window) & GDK_WINDOW_STATE_FULLSCREEN;
+#endif
+    return false;
+}
+
+GdkMonitor* ToplevelWindow::monitor() const
+{
+    auto* display = gtk_widget_get_display(GTK_WIDGET(m_window));
+#if USE(GTK4)
+    if (auto* surface = gtk_native_get_surface(GTK_NATIVE(m_window)))
+        return gdk_display_get_monitor_at_surface(display, surface);
+#else
+    if (auto* window = gtk_widget_get_window(GTK_WIDGET(m_window)))
+        return gdk_display_get_monitor_at_window(display, window);
+#endif
+    return nullptr;
+}
+
+void ToplevelWindow::connectSignals()
+{
+#if USE(GTK4)
+    g_signal_connect(m_window, "notify::is-active", G_CALLBACK(+[](GtkWindow* window, GParamSpec*, ToplevelWindow* toplevelWindow) {
+        toplevelWindow->notifyIsActive(gtk_window_is_active(window));
+    }), this);
+    if (gtk_widget_get_realized(GTK_WIDGET(m_window)))
+        connectSurfaceSignals();
+    else {
+        g_signal_connect_swapped(m_window, "realize", G_CALLBACK(+[](ToplevelWindow* toplevelWindow) {
+            toplevelWindow->connectSurfaceSignals();
+        }), this);
+    }
+    g_signal_connect_swapped(m_window, "unrealize", G_CALLBACK(+[](ToplevelWindow* toplevelWindow) {
+        toplevelWindow->disconnectSurfaceSignals();
+    }), this);
+#else
+    g_signal_connect(m_window, "focus-in-event", G_CALLBACK(+[](GtkWidget* widget, GdkEventFocus*, ToplevelWindow* toplevelWindow) -> gboolean {
+        // Spurious focus in events can occur when the window is hidden.
+        if (!gtk_widget_get_visible(widget))
+            return FALSE;
+        toplevelWindow->notifyIsActive(true);
+        return FALSE;
+    }), this);
+    g_signal_connect(m_window, "focus-out-event", G_CALLBACK(+[](GtkWidget* widget, GdkEventFocus*, ToplevelWindow* toplevelWindow) -> gboolean {
+        toplevelWindow->notifyIsActive(false);
+        return FALSE;
+    }), this);
+    g_signal_connect(m_window, "window-state-event", G_CALLBACK(+[](GtkWidget*, GdkEventWindowState* event, ToplevelWindow* toplevelWindow) -> gboolean {
+        toplevelWindow->notifyState(event->changed_mask, event->new_window_state);
+        return FALSE;
+    }), this);
+    g_signal_connect(m_window, "configure-event", G_CALLBACK(+[](GtkWidget* widget, GdkEventConfigure*, ToplevelWindow* toplevelWindow) -> gboolean {
+        if (!gtk_widget_get_realized(widget))
+            return FALSE;
+        toplevelWindow->notifyMonitorChanged(toplevelWindow->monitor());
+        return FALSE;
+    }), this);
+    if (!gtk_widget_get_realized(GTK_WIDGET(m_window))) {
+        g_signal_connect_swapped(m_window, "realize", G_CALLBACK(+[](ToplevelWindow* toplevelWindow) {
+            for (auto* webView : toplevelWindow->m_webViews)
+                gtk_widget_realize(GTK_WIDGET(webView));
+        }), this);
+    }
+#endif
+}
+
+void ToplevelWindow::disconnectSignals()
+{
+    g_signal_handlers_disconnect_by_data(m_window, this);
+#if USE(GTK4)
+    if (gtk_widget_get_realized(GTK_WIDGET(m_window)))
+        disconnectSurfaceSignals();
+#endif
+}
+
+#if USE(GTK4)
+void ToplevelWindow::connectSurfaceSignals()
+{
+    auto* surface = gtk_native_get_surface(GTK_NATIVE(m_window));
+    m_state = gdk_toplevel_get_state(GDK_TOPLEVEL(surface));
+    g_signal_connect(surface, "notify::state", G_CALLBACK(+[](GdkSurface* surface, GParamSpec*, ToplevelWindow* toplevelWindow) {
+        auto state = gdk_toplevel_get_state(GDK_TOPLEVEL(surface));
+        auto changedMask = toplevelWindow->m_state ^ state;
+        toplevelWindow->m_state = state;
+        toplevelWindow->notifyState(changedMask, state);
+    }), this);
+    notifyMonitorChanged(monitor());
+    g_signal_connect(surface, "enter-monitor", G_CALLBACK(+[](GdkSurface* surface, GdkMonitor* monitor, ToplevelWindow* toplevelWindow) {
+        toplevelWindow->notifyMonitorChanged(monitor);
+    }), this);
+    g_signal_connect(surface, "leave-monitor", G_CALLBACK(+[](GdkSurface* surface, GdkMonitor*, ToplevelWindow* toplevelWindow) {
+        toplevelWindow->notifyMonitorChanged(toplevelWindow->monitor());
+    }), this);
+}
+
+void ToplevelWindow::disconnectSurfaceSignals()
+{
+    auto* surface = gtk_native_get_surface(GTK_NATIVE(m_window));
+    g_signal_handlers_disconnect_by_data(surface, this);
+}
+#endif
+
+void ToplevelWindow::notifyIsActive(bool isActive)
+{
+    for (auto* webView : m_webViews)
+        webkitWebViewBaseToplevelWindowIsActiveChanged(webView, isActive);
+}
+
+void ToplevelWindow::notifyState(uint32_t mask, uint32_t state)
+{
+    for (auto* webView : m_webViews)
+        webkitWebViewBaseToplevelWindowStateChanged(webView, mask, state);
+}
+
+void ToplevelWindow::notifyMonitorChanged(GdkMonitor* monitor)
+{
+    for (auto* webView : m_webViews) {
+#if !USE(GTK4)
+        if (!gtk_widget_get_realized(GTK_WIDGET(webView)))
+            continue;
+#endif
+        webkitWebViewBaseToplevelWindowMonitorChanged(webView, monitor);
+    }
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h
+++ b/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/HashSet.h>
+#include <wtf/Noncopyable.h>
+
+typedef struct _WebKitWebViewBase WebKitWebViewBase;
+
+namespace WebKit {
+
+class ToplevelWindow {
+    WTF_MAKE_NONCOPYABLE(ToplevelWindow); WTF_MAKE_FAST_ALLOCATED;
+public:
+    static ToplevelWindow* forGtkWindow(GtkWindow*);
+    explicit ToplevelWindow(GtkWindow*);
+    ~ToplevelWindow();
+
+    void addWebView(WebKitWebViewBase*);
+    void removeWebView(WebKitWebViewBase*);
+
+    GtkWindow* window() const { return m_window; }
+    bool isActive() const;
+    bool isFullscreen() const;
+    GdkMonitor* monitor() const;
+
+private:
+    void connectSignals();
+    void disconnectSignals();
+#if USE(GTK4)
+    void connectSurfaceSignals();
+    void disconnectSurfaceSignals();
+#endif
+
+    void notifyIsActive(bool);
+    void notifyState(uint32_t, uint32_t);
+    void notifyMonitorChanged(GdkMonitor*);
+
+    GtkWindow* m_window { nullptr };
+    HashSet<WebKitWebViewBase*> m_webViews;
+#if USE(GTK4)
+    GdkToplevelState m_state { static_cast<GdkToplevelState>(0) };
+#endif
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -45,6 +45,7 @@
 #include "PageClientImpl.h"
 #include "PointerLockManager.h"
 #include "ScreenManager.h"
+#include "ToplevelWindow.h"
 #include "ViewGestureController.h"
 #include "WebEventFactory.h"
 #include "WebInspectorUIProxy.h"
@@ -312,21 +313,7 @@ struct _WebKitWebViewBasePrivate {
     bool isBlank;
     bool shouldNotifyFocusEvents { true };
 
-    GtkWindow* toplevelOnScreenWindow { nullptr };
-#if USE(GTK4)
-    unsigned long toplevelIsActiveID { 0 };
-    unsigned long toplevelWindowStateChangedID { 0 };
-    unsigned long toplevelWindowUnrealizedID { 0 };
-    unsigned long toplevelWindowEnterMonitorID { 0 };
-    unsigned long toplevelWindowLeaveMonitorID { 0 };
-    GdkToplevelState toplevelWindowState;
-#else
-    unsigned long toplevelFocusInEventID { 0 };
-    unsigned long toplevelFocusOutEventID { 0 };
-    unsigned long toplevelWindowStateEventID { 0 };
-    unsigned long toplevelWindowConfigureEventID { 0 };
-#endif
-    unsigned long toplevelWindowRealizedID { 0 };
+    ToplevelWindow* toplevelOnScreenWindow { nullptr };
 
     // View State.
     OptionSet<ActivityState> activityState;
@@ -409,41 +396,41 @@ static void webkitWebViewBaseScheduleUpdateActivityState(WebKitWebViewBase* webV
     priv->updateActivityStateTimer.startOneShot(0_s);
 }
 
-#if !USE(GTK4)
-static gboolean toplevelWindowFocusInEvent(GtkWidget* widget, GdkEventFocus*, WebKitWebViewBase* webViewBase)
-{
-    // Spurious focus in events can occur when the window is hidden.
-    if (!gtk_widget_get_visible(widget))
-        return FALSE;
-
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    if (priv->activityState & ActivityState::WindowIsActive)
-        return FALSE;
-
-    priv->activityState.add(ActivityState::WindowIsActive);
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::WindowIsActive);
-
-    return FALSE;
-}
-
-static gboolean toplevelWindowFocusOutEvent(GtkWidget*, GdkEventFocus*, WebKitWebViewBase* webViewBase)
+void webkitWebViewBaseToplevelWindowIsActiveChanged(WebKitWebViewBase* webViewBase, bool isActive)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    if (!(priv->activityState & ActivityState::WindowIsActive))
-        return FALSE;
-
-    priv->activityState.remove(ActivityState::WindowIsActive);
+    if (isActive) {
+        if (priv->activityState & ActivityState::WindowIsActive)
+            return;
+        priv->activityState.add(ActivityState::WindowIsActive);
+#if USE(GTK4)
+        if (priv->activityState & ActivityState::IsFocused)
+            priv->inputMethodFilter.notifyFocusedIn();
+#endif
+    } else {
+        if (!(priv->activityState & ActivityState::WindowIsActive))
+            return;
+        priv->activityState.remove(ActivityState::WindowIsActive);
+#if USE(GTK4)
+        if (priv->activityState & ActivityState::IsFocused)
+            priv->inputMethodFilter.notifyFocusedOut();
+#endif
+    }
     webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::WindowIsActive);
-
-    return FALSE;
 }
 
-static gboolean toplevelWindowStateEvent(GtkWidget*, GdkEventWindowState* event, WebKitWebViewBase* webViewBase)
+void webkitWebViewBaseToplevelWindowStateChanged(WebKitWebViewBase* webViewBase, uint32_t changedMask, uint32_t state)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
 #if ENABLE(FULLSCREEN_API)
-    if (event->changed_mask & GDK_WINDOW_STATE_FULLSCREEN) {
-        bool fullscreen = event->new_window_state & GDK_WINDOW_STATE_FULLSCREEN;
+#if USE(GTK4)
+    bool changedFullscreen = changedMask & GDK_TOPLEVEL_STATE_FULLSCREEN;
+    bool fullscreen = state & GDK_TOPLEVEL_STATE_FULLSCREEN;
+#else
+    bool changedFullscreen = changedMask & GDK_WINDOW_STATE_FULLSCREEN;
+    bool fullscreen = state & GDK_WINDOW_STATE_FULLSCREEN;
+#endif
+    if (changedFullscreen) {
         switch (priv->fullScreenState) {
         case WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen:
             if (fullscreen)
@@ -462,77 +449,72 @@ static gboolean toplevelWindowStateEvent(GtkWidget*, GdkEventWindowState* event,
         }
     }
 #endif
-    if (!(event->changed_mask & GDK_WINDOW_STATE_ICONIFIED))
-        return FALSE;
 
-    bool visible = !(event->new_window_state & GDK_WINDOW_STATE_ICONIFIED);
+#if USE(GTK4)
+    bool changedMinimized = changedMask & GDK_TOPLEVEL_STATE_MINIMIZED;
+    bool visible = !(state & GDK_TOPLEVEL_STATE_MINIMIZED);
+#else
+    bool changedMinimized = changedMask & GDK_WINDOW_STATE_ICONIFIED;
+    bool visible = !(state & GDK_WINDOW_STATE_ICONIFIED);
+#endif
+    if (!changedMinimized)
+        return;
+
     if (visible) {
         if (priv->activityState & ActivityState::IsVisible || !gtk_widget_get_mapped(GTK_WIDGET(webViewBase)))
-            return FALSE;
+            return;
         priv->activityState.add(ActivityState::IsVisible);
     } else {
         if (!(priv->activityState & ActivityState::IsVisible))
-            return FALSE;
+            return;
         priv->activityState.remove(ActivityState::IsVisible);
     }
     webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
-
-    return FALSE;
 }
 
-static gboolean toplevelWindowConfigureEvent(GtkWidget* widget, GdkEventConfigure*, WebKitWebViewBase* webViewBase)
+void webkitWebViewBaseToplevelWindowMonitorChanged(WebKitWebViewBase* webViewBase, GdkMonitor* monitor)
 {
-    if (!gtk_widget_get_realized(GTK_WIDGET(webViewBase)))
-        return FALSE;
-
-    auto* monitor = gdk_display_get_monitor_at_window(gtk_widget_get_display(widget), gtk_widget_get_window(widget));
     webkitWebViewBaseUpdateDisplayID(webViewBase, monitor);
-
-    return FALSE;
 }
 
-static void toplevelWindowRealized(WebKitWebViewBase* webViewBase)
-{
-    gtk_widget_realize(GTK_WIDGET(webViewBase));
-
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    if (priv->toplevelWindowRealizedID) {
-        g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelWindowRealizedID);
-        priv->toplevelWindowRealizedID = 0;
-    }
-}
-
-static void webkitWebViewBaseSetToplevelOnScreenWindow(WebKitWebViewBase* webViewBase, GtkWindow* window)
+static void webkitWebViewBaseSetToplevelOnScreenWindow(WebKitWebViewBase* webViewBase, ToplevelWindow* window)
 {
     WebKitWebViewBasePrivate* priv = webViewBase->priv;
     if (priv->toplevelOnScreenWindow == window)
         return;
 
-    if (priv->toplevelFocusInEventID) {
-        g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelFocusInEventID);
-        priv->toplevelFocusInEventID = 0;
-    }
-    if (priv->toplevelFocusOutEventID) {
-        g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelFocusOutEventID);
-        priv->toplevelFocusOutEventID = 0;
-    }
-    if (priv->toplevelWindowStateEventID) {
-        g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelWindowStateEventID);
-        priv->toplevelWindowStateEventID = 0;
-    }
-    if (priv->toplevelWindowRealizedID) {
-        g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelWindowRealizedID);
-        priv->toplevelWindowRealizedID = 0;
-    }
-    if (priv->toplevelWindowConfigureEventID) {
-        g_signal_handler_disconnect(priv->toplevelOnScreenWindow, priv->toplevelWindowConfigureEventID);
-        priv->toplevelWindowConfigureEventID = 0;
-    }
+    if (priv->toplevelOnScreenWindow)
+        priv->toplevelOnScreenWindow->removeWebView(webViewBase);
 
     priv->toplevelOnScreenWindow = window;
 
-    if (!priv->toplevelOnScreenWindow) {
-        OptionSet<ActivityState> flagsToUpdate;
+    OptionSet<ActivityState> flagsToUpdate;
+    if (priv->toplevelOnScreenWindow) {
+        priv->toplevelOnScreenWindow->addWebView(webViewBase);
+
+        if (!(priv->activityState & ActivityState::IsInWindow)) {
+            priv->activityState.add(ActivityState::IsInWindow);
+            flagsToUpdate.add(ActivityState::IsInWindow);
+        }
+
+#if ENABLE(DEVELOPER_MODE)
+        // Xvfb doesn't support toplevel focus, so gtk_window_is_active() always returns false. We consider
+        // toplevel window to be always active since it's the only one.
+        if (WebCore::PlatformDisplay::sharedDisplay().type() == WebCore::PlatformDisplay::Type::X11) {
+            if (!g_strcmp0(g_getenv("UNDER_XVFB"), "yes")) {
+                priv->activityState.add(ActivityState::WindowIsActive);
+                flagsToUpdate.add(ActivityState::WindowIsActive);
+            }
+        }
+#endif
+
+        if (priv->toplevelOnScreenWindow->isActive() && !(priv->activityState & ActivityState::WindowIsActive)) {
+            priv->activityState.add(ActivityState::WindowIsActive);
+            flagsToUpdate.add(ActivityState::WindowIsActive);
+        }
+
+        webkitWebViewBaseUpdateDisplayID(webViewBase, priv->toplevelOnScreenWindow->monitor());
+    } else {
         if (priv->activityState & ActivityState::IsInWindow) {
             priv->activityState.remove(ActivityState::IsInWindow);
             flagsToUpdate.add(ActivityState::IsInWindow);
@@ -541,29 +523,11 @@ static void webkitWebViewBaseSetToplevelOnScreenWindow(WebKitWebViewBase* webVie
             priv->activityState.remove(ActivityState::WindowIsActive);
             flagsToUpdate.add(ActivityState::IsInWindow);
         }
-        if (flagsToUpdate)
-            webkitWebViewBaseScheduleUpdateActivityState(webViewBase, flagsToUpdate);
-
-        return;
     }
 
-    priv->toplevelFocusInEventID =
-        g_signal_connect(priv->toplevelOnScreenWindow, "focus-in-event",
-                         G_CALLBACK(toplevelWindowFocusInEvent), webViewBase);
-    priv->toplevelFocusOutEventID =
-        g_signal_connect(priv->toplevelOnScreenWindow, "focus-out-event",
-                         G_CALLBACK(toplevelWindowFocusOutEvent), webViewBase);
-    priv->toplevelWindowStateEventID =
-        g_signal_connect(priv->toplevelOnScreenWindow, "window-state-event", G_CALLBACK(toplevelWindowStateEvent), webViewBase);
-    priv->toplevelWindowConfigureEventID =
-        g_signal_connect(priv->toplevelOnScreenWindow, "configure-event", G_CALLBACK(toplevelWindowConfigureEvent), webViewBase);
-
-    if (gtk_widget_get_realized(GTK_WIDGET(window)))
-        gtk_widget_realize(GTK_WIDGET(webViewBase));
-    else
-        priv->toplevelWindowRealizedID = g_signal_connect_swapped(window, "realize", G_CALLBACK(toplevelWindowRealized), webViewBase);
+    if (flagsToUpdate)
+        webkitWebViewBaseScheduleUpdateActivityState(webViewBase, flagsToUpdate);
 }
-#endif
 
 static void webkitWebViewBaseRealize(GtkWidget* widget)
 {
@@ -791,12 +755,13 @@ static void webkitWebViewBaseDispose(GObject* gobject)
     g_clear_pointer(&webView->priv->emojiChooser, gtk_widget_unparent);
 #else
     g_clear_pointer(&webView->priv->dialog, gtk_widget_destroy);
-    webkitWebViewBaseSetToplevelOnScreenWindow(webView, nullptr);
 #if ENABLE(ACCESSIBILITY)
     if (webView->priv->accessible)
         webkitWebViewAccessibleSetWebView(WEBKIT_WEB_VIEW_ACCESSIBLE(webView->priv->accessible.get()), nullptr);
 #endif // ENABLE(ACCESSIBILITY)
 #endif
+
+    webkitWebViewBaseSetToplevelOnScreenWindow(webView, nullptr);
 #if GTK_CHECK_VERSION(3, 24, 0)
     webkitWebViewBaseCompleteEmojiChooserRequest(webView, emptyString());
 #endif
@@ -1023,30 +988,12 @@ static void webkitWebViewBaseMap(GtkWidget* widget)
         if (!size.isEmpty())
             webkitWebViewBaseSetSize(webViewBase, size);
     }
-    OptionSet<ActivityState> flagsToUpdate;
-    if (!(priv->activityState & ActivityState::IsVisible))
-        flagsToUpdate.add(ActivityState::IsVisible);
-    if (priv->toplevelOnScreenWindow) {
-        if (!(priv->activityState & ActivityState::IsInWindow))
-            flagsToUpdate.add(ActivityState::IsInWindow);
 
-#if ENABLE(DEVELOPER_MODE)
-        // Xvfb doesn't support toplevel focus, so gtk_window_is_active() always returns false. We consider
-        // toplevel window to be always active since it's the only one.
-        if (WebCore::PlatformDisplay::sharedDisplay().type() == WebCore::PlatformDisplay::Type::X11) {
-            if (!g_strcmp0(g_getenv("UNDER_XVFB"), "yes"))
-                flagsToUpdate.add(ActivityState::WindowIsActive);
-        }
-#endif
-
-        if (gtk_window_is_active(GTK_WINDOW(priv->toplevelOnScreenWindow)) && !(priv->activityState & ActivityState::WindowIsActive))
-            flagsToUpdate.add(ActivityState::WindowIsActive);
-    }
-    if (!flagsToUpdate)
+    if (priv->activityState & ActivityState::IsVisible)
         return;
 
-    priv->activityState.add(flagsToUpdate);
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, flagsToUpdate);
+    priv->activityState.add(ActivityState::IsVisible);
+    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
 }
 
 static void webkitWebViewBaseUnmap(GtkWidget* widget)
@@ -1977,177 +1924,24 @@ static AtkObject* webkitWebViewBaseGetAccessible(GtkWidget* widget)
 #endif
 
 #if USE(GTK4)
-static void toplevelWindowIsActiveChanged(GtkWindow* window, GParamSpec*, WebKitWebViewBase* webViewBase)
-{
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    if (gtk_window_is_active(window)) {
-        if (priv->activityState & ActivityState::WindowIsActive)
-            return;
-        priv->activityState.add(ActivityState::WindowIsActive);
-        if (priv->activityState & ActivityState::IsFocused)
-            priv->inputMethodFilter.notifyFocusedIn();
-    } else {
-        if (!(priv->activityState & ActivityState::WindowIsActive))
-            return;
-        priv->activityState.remove(ActivityState::WindowIsActive);
-        if (priv->activityState & ActivityState::IsFocused)
-            priv->inputMethodFilter.notifyFocusedOut();
-    }
-
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::WindowIsActive);
-}
-
-static void toplevelWindowStateChanged(GdkSurface* surface, GParamSpec*, WebKitWebViewBase* webViewBase)
-{
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    auto state = gdk_toplevel_get_state(GDK_TOPLEVEL(surface));
-    auto changedMask = priv->toplevelWindowState ^ state;
-    priv->toplevelWindowState = state;
-#if ENABLE(FULLSCREEN_API)
-    if (changedMask & GDK_TOPLEVEL_STATE_FULLSCREEN) {
-        bool fullscreen = state & GDK_TOPLEVEL_STATE_FULLSCREEN;
-        switch (priv->fullScreenState) {
-        case WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen:
-            if (fullscreen)
-                webkitWebViewBaseDidEnterFullScreen(webViewBase);
-            break;
-        case WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen:
-            if (!fullscreen)
-                webkitWebViewBaseDidExitFullScreen(webViewBase);
-            break;
-        case WebFullScreenManagerProxy::FullscreenState::InFullscreen:
-            if (!fullscreen && webkitWebViewBaseIsFullScreen(webViewBase))
-                webkitWebViewBaseRequestExitFullScreen(webViewBase);
-            break;
-        case WebFullScreenManagerProxy::FullscreenState::NotInFullscreen:
-            break;
-        }
-    }
-#endif
-    if (!(changedMask & GDK_TOPLEVEL_STATE_MINIMIZED))
-        return;
-
-    bool visible = !(state & GDK_TOPLEVEL_STATE_MINIMIZED);
-    if (visible) {
-        if (priv->activityState & ActivityState::IsVisible || !gtk_widget_get_mapped(GTK_WIDGET(webViewBase)))
-            return;
-        priv->activityState.add(ActivityState::IsVisible);
-    } else {
-        if (!(priv->activityState & ActivityState::IsVisible))
-            return;
-        priv->activityState.remove(ActivityState::IsVisible);
-    }
-    webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
-}
-
-static void toplevelWindowMonitorsChanged(GdkSurface* surface, GdkMonitor*, WebKitWebViewBase* webViewBase)
-{
-    auto* priv = webViewBase->priv;
-    auto* monitor = gdk_display_get_monitor_at_surface(gtk_widget_get_display(GTK_WIDGET(priv->toplevelOnScreenWindow)), surface);
-    webkitWebViewBaseUpdateDisplayID(webViewBase, monitor);
-}
-
-static void toplevelWindowRealized(WebKitWebViewBase* webViewBase)
-{
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    g_clear_signal_handler(&priv->toplevelWindowRealizedID, priv->toplevelOnScreenWindow);
-    auto* surface = gtk_native_get_surface(GTK_NATIVE(priv->toplevelOnScreenWindow));
-    priv->toplevelWindowState = gdk_toplevel_get_state(GDK_TOPLEVEL(surface));
-    priv->toplevelWindowStateChangedID =
-        g_signal_connect(surface, "notify::state", G_CALLBACK(toplevelWindowStateChanged), webViewBase);
-    auto* monitor = gdk_display_get_monitor_at_surface(gtk_widget_get_display(GTK_WIDGET(priv->toplevelOnScreenWindow)), surface);
-    webkitWebViewBaseUpdateDisplayID(webViewBase, monitor);
-    priv->toplevelWindowEnterMonitorID =
-        g_signal_connect(surface, "enter-monitor", G_CALLBACK(toplevelWindowMonitorsChanged), webViewBase);
-    priv->toplevelWindowLeaveMonitorID =
-        g_signal_connect(surface, "leave-monitor", G_CALLBACK(toplevelWindowMonitorsChanged), webViewBase);
-}
-
-static void toplevelWindowUnrealized(WebKitWebViewBase* webViewBase)
-{
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    g_clear_signal_handler(&priv->toplevelWindowUnrealizedID, priv->toplevelOnScreenWindow);
-    auto* surface = gtk_native_get_surface(GTK_NATIVE(priv->toplevelOnScreenWindow));
-    g_clear_signal_handler(&priv->toplevelWindowStateChangedID, surface);
-    g_clear_signal_handler(&priv->toplevelWindowEnterMonitorID, surface);
-    g_clear_signal_handler(&priv->toplevelWindowLeaveMonitorID, surface);
-}
-
 static void webkitWebViewBaseRoot(GtkWidget* widget)
 {
     GTK_WIDGET_CLASS(webkit_web_view_base_parent_class)->root(widget);
 
-    WebKitWebViewBase* webViewBase = WEBKIT_WEB_VIEW_BASE(widget);
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    priv->toplevelOnScreenWindow = GTK_WINDOW(gtk_widget_get_root(widget));
-
-    OptionSet<ActivityState> flagsToUpdate;
-    if (!(priv->activityState & ActivityState::IsInWindow)) {
-        priv->activityState.add(ActivityState::IsInWindow);
-        flagsToUpdate.add(ActivityState::IsInWindow);
-    }
-    if (gtk_widget_get_visible(GTK_WIDGET(priv->toplevelOnScreenWindow)) && gtk_window_is_active(priv->toplevelOnScreenWindow)) {
-        priv->activityState.add(ActivityState::WindowIsActive);
-        flagsToUpdate.add(ActivityState::IsInWindow);
-    }
-    if (flagsToUpdate)
-        webkitWebViewBaseScheduleUpdateActivityState(webViewBase, flagsToUpdate);
-
-    priv->toplevelIsActiveID =
-        g_signal_connect(priv->toplevelOnScreenWindow, "notify::is-active", G_CALLBACK(toplevelWindowIsActiveChanged), widget);
-    if (gtk_widget_get_realized(GTK_WIDGET(priv->toplevelOnScreenWindow))) {
-        auto* surface = gtk_native_get_surface(GTK_NATIVE(priv->toplevelOnScreenWindow));
-        priv->toplevelWindowState = gdk_toplevel_get_state(GDK_TOPLEVEL(surface));
-        priv->toplevelWindowStateChangedID =
-            g_signal_connect(surface, "notify::state", G_CALLBACK(toplevelWindowStateChanged), widget);
-        auto* monitor = gdk_display_get_monitor_at_surface(gtk_widget_get_display(GTK_WIDGET(priv->toplevelOnScreenWindow)), surface);
-        webkitWebViewBaseUpdateDisplayID(webViewBase, monitor);
-        priv->toplevelWindowEnterMonitorID =
-            g_signal_connect(surface, "enter-monitor", G_CALLBACK(toplevelWindowMonitorsChanged), webViewBase);
-        priv->toplevelWindowLeaveMonitorID =
-            g_signal_connect(surface, "leave-monitor", G_CALLBACK(toplevelWindowMonitorsChanged), webViewBase);
-    } else {
-        priv->toplevelWindowRealizedID =
-            g_signal_connect_swapped(priv->toplevelOnScreenWindow, "realize", G_CALLBACK(toplevelWindowRealized), widget);
-    }
-    priv->toplevelWindowUnrealizedID =
-        g_signal_connect_swapped(priv->toplevelOnScreenWindow, "unrealize", G_CALLBACK(toplevelWindowUnrealized), widget);
+    webkitWebViewBaseSetToplevelOnScreenWindow(WEBKIT_WEB_VIEW_BASE(widget), ToplevelWindow::forGtkWindow(GTK_WINDOW(gtk_widget_get_root(widget))));
 }
 
 static void webkitWebViewBaseUnroot(GtkWidget* widget)
 {
     GTK_WIDGET_CLASS(webkit_web_view_base_parent_class)->unroot(widget);
 
-    WebKitWebViewBase* webViewBase = WEBKIT_WEB_VIEW_BASE(widget);
-    WebKitWebViewBasePrivate* priv = webViewBase->priv;
-    g_clear_signal_handler(&priv->toplevelIsActiveID, priv->toplevelOnScreenWindow);
-    g_clear_signal_handler(&priv->toplevelWindowRealizedID, priv->toplevelOnScreenWindow);
-    g_clear_signal_handler(&priv->toplevelWindowUnrealizedID, priv->toplevelOnScreenWindow);
-    if (gtk_widget_get_realized(GTK_WIDGET(priv->toplevelOnScreenWindow))) {
-        auto* surface = gtk_native_get_surface(GTK_NATIVE(priv->toplevelOnScreenWindow));
-        g_clear_signal_handler(&priv->toplevelWindowStateChangedID, surface);
-        g_clear_signal_handler(&priv->toplevelWindowEnterMonitorID, surface);
-        g_clear_signal_handler(&priv->toplevelWindowLeaveMonitorID, surface);
-    }
-    priv->toplevelOnScreenWindow = nullptr;
-
-    OptionSet<ActivityState> flagsToUpdate;
-    if (priv->activityState & ActivityState::IsInWindow) {
-        priv->activityState.remove(ActivityState::IsInWindow);
-        flagsToUpdate.add(ActivityState::IsInWindow);
-    }
-    if (priv->activityState & ActivityState::WindowIsActive) {
-        priv->activityState.remove(ActivityState::WindowIsActive);
-        flagsToUpdate.add(ActivityState::IsInWindow);
-    }
-    if (flagsToUpdate)
-        webkitWebViewBaseScheduleUpdateActivityState(webViewBase, flagsToUpdate);
+    webkitWebViewBaseSetToplevelOnScreenWindow(WEBKIT_WEB_VIEW_BASE(widget), nullptr);
 }
 #else
 static void webkitWebViewBaseHierarchyChanged(GtkWidget* widget, GtkWidget* oldToplevel)
 {
     WebKitWebViewBasePrivate* priv = WEBKIT_WEB_VIEW_BASE(widget)->priv;
-    if (widgetIsOnscreenToplevelWindow(oldToplevel) && GTK_WINDOW(oldToplevel) == priv->toplevelOnScreenWindow) {
+    if (widgetIsOnscreenToplevelWindow(oldToplevel) && priv->toplevelOnScreenWindow && GTK_WINDOW(oldToplevel) == priv->toplevelOnScreenWindow->window()) {
         webkitWebViewBaseSetToplevelOnScreenWindow(WEBKIT_WEB_VIEW_BASE(widget), nullptr);
         return;
     }
@@ -2155,7 +1949,7 @@ static void webkitWebViewBaseHierarchyChanged(GtkWidget* widget, GtkWidget* oldT
     if (!oldToplevel) {
         GtkWidget* toplevel = gtk_widget_get_toplevel(widget);
         if (widgetIsOnscreenToplevelWindow(toplevel))
-            webkitWebViewBaseSetToplevelOnScreenWindow(WEBKIT_WEB_VIEW_BASE(widget), GTK_WINDOW(toplevel));
+            webkitWebViewBaseSetToplevelOnScreenWindow(WEBKIT_WEB_VIEW_BASE(widget), ToplevelWindow::forGtkWindow(GTK_WINDOW(toplevel)));
     }
 }
 #endif
@@ -2729,17 +2523,7 @@ void webkitWebViewBasePropagateWheelEvent(WebKitWebViewBase* webkitWebViewBase, 
 static bool webkitWebViewBaseToplevelOnScreenWindowIsFullScreen(WebKitWebViewBase* webkitWebViewBase)
 {
     WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
-    if (!priv->toplevelOnScreenWindow)
-        return false;
-
-#if USE(GTK4)
-    if (auto* surface = gtk_native_get_surface(GTK_NATIVE(priv->toplevelOnScreenWindow)))
-        return gdk_toplevel_get_state(GDK_TOPLEVEL(surface)) & GDK_TOPLEVEL_STATE_FULLSCREEN;
-#else
-    if (auto* window = gtk_widget_get_window(GTK_WIDGET(priv->toplevelOnScreenWindow)))
-        return gdk_window_get_state(window) & GDK_WINDOW_STATE_FULLSCREEN;
-#endif
-    return false;
+    return priv->toplevelOnScreenWindow && priv->toplevelOnScreenWindow->isFullscreen();
 }
 
 void webkitWebViewBaseWillEnterFullScreen(WebKitWebViewBase* webkitWebViewBase)
@@ -2765,7 +2549,7 @@ void webkitWebViewBaseEnterFullScreen(WebKitWebViewBase* webkitWebViewBase)
     priv->windowWasAlreadyInFullScreen = false;
 
     if (priv->toplevelOnScreenWindow)
-        gtk_window_fullscreen(priv->toplevelOnScreenWindow);
+        gtk_window_fullscreen(priv->toplevelOnScreenWindow->window());
 }
 
 static void webkitWebViewBaseDidEnterFullScreen(WebKitWebViewBase* webkitWebViewBase)
@@ -2798,7 +2582,7 @@ void webkitWebViewBaseExitFullScreen(WebKitWebViewBase* webkitWebViewBase)
     }
 
     if (priv->toplevelOnScreenWindow)
-        gtk_window_unfullscreen(priv->toplevelOnScreenWindow);
+        gtk_window_unfullscreen(priv->toplevelOnScreenWindow->window());
 }
 
 static void webkitWebViewBaseDidExitFullScreen(WebKitWebViewBase* webkitWebViewBase)
@@ -3077,7 +2861,7 @@ RefPtr<WebKit::ViewSnapshot> webkitWebViewBaseTakeViewSnapshot(WebKitWebViewBase
     return ViewSnapshot::create(WTFMove(surface));
 #else
     WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
-    auto* renderer = gtk_native_get_renderer(GTK_NATIVE(priv->toplevelOnScreenWindow));
+    auto* renderer = gtk_native_get_renderer(GTK_NATIVE(priv->toplevelOnScreenWindow->window()));
 
     GRefPtr<GtkSnapshot> snapshot = adoptGRef(gtk_snapshot_new());
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -133,3 +133,7 @@ void webkitWebViewBaseSynthesizeWheelEvent(WebKitWebViewBase*, const GdkEvent*, 
 void webkitWebViewBaseMakeBlank(WebKitWebViewBase*, bool);
 void webkitWebViewBasePageGrabbedTouch(WebKitWebViewBase*);
 void webkitWebViewBaseSetShouldNotifyFocusEvents(WebKitWebViewBase*, bool);
+
+void webkitWebViewBaseToplevelWindowIsActiveChanged(WebKitWebViewBase*, bool);
+void webkitWebViewBaseToplevelWindowStateChanged(WebKitWebViewBase*, uint32_t, uint32_t);
+void webkitWebViewBaseToplevelWindowMonitorChanged(WebKitWebViewBase*, GdkMonitor*);


### PR DESCRIPTION
#### c4614fd4f2f2fff205c92dcabd1879feca1b728e
<pre>
[GTK] Simplify handling of toplevel window signals
<a href="https://bugs.webkit.org/show_bug.cgi?id=262944">https://bugs.webkit.org/show_bug.cgi?id=262944</a>

Reviewed by Alejandro G. Castro.

We currently track the state of the toplevel window from every web view,
connecting to the same signals to be notified when something changes. We
could add a toplevel window wrapper instead to track its state and
notify all the web views when there&apos;s any change.

* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp: Added.
(WebKit::toplevelWindows):
(WebKit::toplevelWindowDestroyedCallback):
(WebKit::ToplevelWindow::forGtkWindow):
(WebKit::ToplevelWindow::ToplevelWindow):
(WebKit::ToplevelWindow::~ToplevelWindow):
(WebKit::ToplevelWindow::addWebView):
(WebKit::ToplevelWindow::removeWebView):
(WebKit::ToplevelWindow::isActive const):
(WebKit::ToplevelWindow::isFullscreen const):
(WebKit::ToplevelWindow::connectSignals):
(WebKit::ToplevelWindow::disconnectSignals):
(WebKit::ToplevelWindow::connectSurfaceSignals):
(WebKit::ToplevelWindow::disconnectSurfaceSignals):
(WebKit::ToplevelWindow::notifyIsActive):
(WebKit::ToplevelWindow::notifyState):
(WebKit::ToplevelWindow::notifyMonitorChanged):
* Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h: Added.
(WebKit::ToplevelWindow::window const):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseToplevelWindowIsActiveChanged):
(webkitWebViewBaseToplevelWindowStateChanged):
(webkitWebViewBaseToplevelWindowMonitorChanged):
(webkitWebViewBaseSetToplevelOnScreenWindow):
(webkitWebViewBaseDispose):
(webkitWebViewBaseMap):
(webkitWebViewBaseRoot):
(webkitWebViewBaseUnroot):
(webkitWebViewBaseHierarchyChanged):
(webkitWebViewBaseToplevelOnScreenWindowIsFullScreen):
(webkitWebViewBaseEnterFullScreen):
(webkitWebViewBaseExitFullScreen):
(webkitWebViewBaseTakeViewSnapshot):
(toplevelWindowFocusInEvent): Deleted.
(toplevelWindowFocusOutEvent): Deleted.
(toplevelWindowStateEvent): Deleted.
(toplevelWindowConfigureEvent): Deleted.
(toplevelWindowRealized): Deleted.
(toplevelWindowIsActiveChanged): Deleted.
(toplevelWindowStateChanged): Deleted.
(toplevelWindowMonitorsChanged): Deleted.
(toplevelWindowUnrealized): Deleted.
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:

Canonical link: <a href="https://commits.webkit.org/269136@main">https://commits.webkit.org/269136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bda25b69e265aa84112de698c90f66d90021398a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21709 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23575 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20099 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22241 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21937 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24429 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/25952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/19873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23811 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20352 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23905 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2687 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->