### PR TITLE
WebKit MediaRecorderPrivate should not be refcounted

### DIFF
--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -49,16 +49,11 @@ namespace WebKit {
 
 class MediaRecorderPrivate final
     : public WebCore::MediaRecorderPrivate
-    , public GPUProcessConnection::Client
-    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate> {
+    , public CanMakeWeakPtr<MediaRecorderPrivate> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     MediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivate();
-
-    void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate>::ref(); }
-    void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate>::deref(); }
-    ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaRecorderPrivate>::controlBlock(); }
 
 private:
     // WebCore::MediaRecorderPrivate
@@ -71,8 +66,35 @@ private:
     void pauseRecording(CompletionHandler<void()>&&) final;
     void resumeRecording(CompletionHandler<void()>&&) final;
 
-    // GPUProcessConnection::Client
-    void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
+    void gpuProcessConnectionDidClose();
+
+    class GPUProcessDidCloseObserver final
+        : public GPUProcessConnection::Client
+        , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GPUProcessDidCloseObserver> {
+    public:
+        static Ref<GPUProcessDidCloseObserver> create(MediaRecorderPrivate& recorder) { return adoptRef(*new GPUProcessDidCloseObserver(recorder)); }
+
+        // GPUProcessConnection::Client
+        void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GPUProcessDidCloseObserver>::ref(); }
+        void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GPUProcessDidCloseObserver>::deref(); }
+        ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GPUProcessDidCloseObserver>::controlBlock(); }
+
+    private:
+        explicit GPUProcessDidCloseObserver(MediaRecorderPrivate& recorder)
+            : m_recorder(recorder)
+        {
+        }
+
+        void gpuProcessConnectionDidClose(GPUProcessConnection&) final
+        {
+            callOnMainRunLoop([recorder = m_recorder] {
+                if (recorder)
+                    recorder->gpuProcessConnectionDidClose();
+            });
+        }
+
+        WeakPtr<MediaRecorderPrivate> m_recorder;
+    };
 
     MediaRecorderIdentifier m_identifier;
     Ref<WebCore::MediaStreamPrivate> m_stream;
@@ -87,6 +109,7 @@ private:
     bool m_isStopped { false };
     std::optional<WebCore::IntSize> m_blackFrameSize;
 
+    Ref<GPUProcessDidCloseObserver> m_gpuProcessDidCloseObserver;
     SharedVideoFrameWriter m_sharedVideoFrameWriter;
 };
 


### PR DESCRIPTION
#### 5ac998d7f35a3ab87cf5d3f551d79214b62fdee6
<pre>
WebKit MediaRecorderPrivate should not be refcounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=262945">https://bugs.webkit.org/show_bug.cgi?id=262945</a>
rdar://problem/116726041

Reviewed by Alex Christensen and Chris Dumez.

Given MediaRecorderPrivate is stored as a std::unique_ptr, it is best to not ref/deref.
Instead MediaRecorderPrivate stores a ref counted object that is observing GPUProcess connection closure.

* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::MediaRecorderPrivate):
(WebKit::MediaRecorderPrivate::startRecording):
(WebKit::MediaRecorderPrivate::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:

Canonical link: <a href="https://commits.webkit.org/269195@main">https://commits.webkit.org/269195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feae42ec375c5d8ea938d02b2cde4f15f758d42e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23548 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20077 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21236 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24402 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18728 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25927 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23787 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17315 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19657 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5215 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->