### PR TITLE
[GTK][WPE] Enable `StackTraceTest.StackTraceWorks` and `StackTraceTest.CaptureStackTraceLimitAndSkip` in Release build

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/StackTraceTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StackTraceTest.cpp
@@ -31,7 +31,7 @@
 #include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/unicode/CharacterNames.h>
 
-#if ((PLATFORM(GTK) || PLATFORM(WPE)) && defined(NDEBUG)) || (PLATFORM(WIN) && !defined(NDEBUG))
+#if PLATFORM(WIN) && !defined(NDEBUG)
 #define MAYBE(name) DISABLED_##name
 #else
 #define MAYBE(name) name


### PR DESCRIPTION
#### 0b220647e234b5ed7f0d0aa99710ffdf5ba18932
<pre>
[GTK][WPE] Enable `StackTraceTest.StackTraceWorks` and `StackTraceTest.CaptureStackTraceLimitAndSkip` in Release build
<a href="https://bugs.webkit.org/show_bug.cgi?id=262947">https://bugs.webkit.org/show_bug.cgi?id=262947</a>

Reviewed by Philippe Normand.

Since we&apos;re now using `libbacktrace` to symbolize the stack trace,
these tests should pass in Release build too.

* Tools/TestWebKitAPI/Tests/WTF/StackTraceTest.cpp:

Canonical link: <a href="https://commits.webkit.org/269306@main">https://commits.webkit.org/269306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31306e2e3e363d2386b0a1196454539d785fbd2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/21963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23556 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21240 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24410 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25934 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23793 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17320 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19664 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5280 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->