### PR TITLE
Use of many shadow trees with unique style triggers significant CPU usage and a rise in process size

### DIFF
--- a/Source/WebCore/dom/InlineStyleSheetOwner.cpp
+++ b/Source/WebCore/dom/InlineStyleSheetOwner.cpp
@@ -213,7 +213,7 @@ void InlineStyleSheetOwner::createSheet(Element& element, const String& text)
         inlineStyleSheetCache().add(*cacheKey, &m_sheet->contents());
 
         // Prevent pathological growth.
-        const size_t maximumInlineStyleSheetCacheSize = 50;
+        static constexpr auto maximumInlineStyleSheetCacheSize = 256;
         if (inlineStyleSheetCache().size() > maximumInlineStyleSheetCacheSize) {
             auto toRemove = inlineStyleSheetCache().random();
             toRemove->value->removedFromMemoryCache();

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -142,7 +142,12 @@ void Scope::createOrFindSharedShadowTreeResolver()
     if (!result.isNewEntry) {
         m_resolver = result.iterator->value.ptr();
         m_resolver->setSharedBetweenShadowTrees();
+        return;
     }
+
+    static constexpr auto maximimumSharedResolverCount = 256;
+    if (documentScope().m_sharedShadowTreeResolvers.size() > maximimumSharedResolverCount)
+        documentScope().m_sharedShadowTreeResolvers.remove(documentScope().m_sharedShadowTreeResolvers.random());
 }
 
 void Scope::unshareShadowTreeResolverBeforeMutation()


### PR DESCRIPTION
#### b3c5d420be05ac62170f8fd5550773eb54fb6c6f
<pre>
Use of many shadow trees with unique style triggers significant CPU usage and a rise in process size
<a href="https://bugs.webkit.org/show_bug.cgi?id=260925">https://bugs.webkit.org/show_bug.cgi?id=260925</a>
rdar://114731415

Reviewed by Alan Baradlay.

Style resolver sharing cache in Style::Scope has unlimited size and the test case keeps adding more items
there. Low memory handler clears the cache causing memory use to eventually drop.

* Source/WebCore/dom/InlineStyleSheetOwner.cpp:
(WebCore::InlineStyleSheetOwner::createSheet):

Increase the size of the inline stylesheet sharing cache  (50 -&gt; 256 items). Content that uses many unique
shadow tree style (like this test) could overrun this smallish cache easily rendering it ineffective.

Style resolver sharing in Style::Scope depends on inline stylesheet getting shared so this also made
that cache work poorly.

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createOrFindSharedShadowTreeResolver):

Add a limit to the resolver sharing cache size.

Canonical link: <a href="https://commits.webkit.org/269142@main">https://commits.webkit.org/269142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbb033fc3574924a08ab3b82988d7d0a1e949ecb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21707 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21948 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22239 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21935 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24427 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25949 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23808 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17331 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19678 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5179 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->