### PR TITLE
[GTK] Mark the view as not visible when left the last monitor

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h
+++ b/Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h
@@ -47,7 +47,9 @@ public:
     GtkWindow* window() const { return m_window; }
     bool isActive() const;
     bool isFullscreen() const;
+    bool isMinimized() const;
     GdkMonitor* monitor() const;
+    bool isInMonitor() const;
 
 private:
     void connectSignals();
@@ -65,6 +67,7 @@ private:
     HashSet<WebKitWebViewBase*> m_webViews;
 #if USE(GTK4)
     GdkToplevelState m_state { static_cast<GdkToplevelState>(0) };
+    HashSet<GdkMonitor*> m_monitors;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -461,7 +461,7 @@ void webkitWebViewBaseToplevelWindowStateChanged(WebKitWebViewBase* webViewBase,
         return;
 
     if (visible) {
-        if (priv->activityState & ActivityState::IsVisible || !gtk_widget_get_mapped(GTK_WIDGET(webViewBase)))
+        if (priv->activityState & ActivityState::IsVisible || !gtk_widget_get_mapped(GTK_WIDGET(webViewBase)) || !priv->toplevelOnScreenWindow->isInMonitor())
             return;
         priv->activityState.add(ActivityState::IsVisible);
     } else {
@@ -474,6 +474,18 @@ void webkitWebViewBaseToplevelWindowStateChanged(WebKitWebViewBase* webViewBase,
 
 void webkitWebViewBaseToplevelWindowMonitorChanged(WebKitWebViewBase* webViewBase, GdkMonitor* monitor)
 {
+    WebKitWebViewBasePrivate* priv = webViewBase->priv;
+    if (priv->toplevelOnScreenWindow->isInMonitor()) {
+        if (!(priv->activityState & ActivityState::IsVisible) && gtk_widget_get_mapped(GTK_WIDGET(webViewBase)) && !priv->toplevelOnScreenWindow->isMinimized()) {
+            priv->activityState.add(ActivityState::IsVisible);
+            webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
+        }
+    } else {
+        if (priv->activityState & ActivityState::IsVisible) {
+            priv->activityState.remove(ActivityState::IsVisible);
+            webkitWebViewBaseScheduleUpdateActivityState(webViewBase, ActivityState::IsVisible);
+        }
+    }
     webkitWebViewBaseUpdateDisplayID(webViewBase, monitor);
 }
 


### PR DESCRIPTION
#### 1a71158338c4da55858134e1957cf0d78088265d
<pre>
[GTK] Mark the view as not visible when left the last monitor
<a href="https://bugs.webkit.org/show_bug.cgi?id=262954">https://bugs.webkit.org/show_bug.cgi?id=262954</a>

Reviewed by Michael Catanzaro.

In GTK4 under wayland we receive the leave-monitor signal when the
window is minimized, or hidden in other ways like moving to a different
workspace. In those cases, we can mark the view as not visible to avoid
doing rendering updates.

* Source/WebKit/UIProcess/API/gtk/ToplevelWindow.cpp:
(WebKit::ToplevelWindow::isMinimized const):
(WebKit::ToplevelWindow::isInMonitor const):
(WebKit::ToplevelWindow::connectSurfaceSignals):
* Source/WebKit/UIProcess/API/gtk/ToplevelWindow.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseToplevelWindowStateChanged):
(webkitWebViewBaseToplevelWindowMonitorChanged):

Canonical link: <a href="https://commits.webkit.org/269137@main">https://commits.webkit.org/269137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42343e39221780956650ca4a933fedf8b7b53479

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21710 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20100 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22242 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21938 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/18808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24430 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25953 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23812 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20353 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19681 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23906 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2688 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->