### PR TITLE
[mac-wk1] LayoutTest userscripts/window-onerror-for-isolated-world-3.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1552,8 +1552,6 @@ imported/w3c/web-platform-tests/navigation-timing/nav2_test_attributes_values.ht
 
 webkit.org/b/244676 [ Debug ] imported/w3c/web-platform-tests/navigation-timing/dom_interactive_media_document.html [ Pass Crash ]
 
-webkit.org/b/160101 userscripts/window-onerror-for-isolated-world-3.html [ Pass Failure ]
-
 # rdar://problem/27723718
 imported/blink/compositing/child-transform-with-anchor-point.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/userscripts/window-onerror-for-isolated-world-3-expected.txt
+++ b/LayoutTests/userscripts/window-onerror-for-isolated-world-3-expected.txt
@@ -4,8 +4,8 @@ Test that window.onerror and "error" event listeners from main world are invoked
 User Script
 Main world window.onerror: SerializableError from (user script) at :5:59 SerializableError from (user script)
 Main world error event listener: SerializableError from (user script) at :5:59 SerializableError from (user script)
-Main world window.onerror: [object Window] at undefined:0:0 null
-Main world error event listener: [object Window] at undefined:0:0 null
+Main world window.onerror: [object Window] at :11:27 null
+Main world error event listener: [object Window] at :11:27 null
 
 Main World
 Main world window.onerror: SerializableError from (main world) at window-onerror-for-isolated-world-3.html:49:59 SerializableError from (main world)

--- a/LayoutTests/userscripts/window-onerror-for-isolated-world-3.html
+++ b/LayoutTests/userscripts/window-onerror-for-isolated-world-3.html
@@ -67,12 +67,11 @@ testRunner.addUserScript("(" + triggerExceptions + ")('user script')", false, tr
 setTimeout(function() {
     header("Main World");
     triggerExceptions("main world");
-}, 100);
-
-setTimeout(function() {
+    setTimeout(function() {
     header("Isolated World");
     testRunner.evaluateScriptInIsolatedWorld(0, "(" + triggerExceptions + ")('isolated script')");
-}, 200);
+    }, 100);
+}, 100);
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### 036e5c39e5e104a06acc2952b74a2d3041554388
<pre>
[mac-wk1] LayoutTest userscripts/window-onerror-for-isolated-world-3.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=160101">https://bugs.webkit.org/show_bug.cgi?id=160101</a>
rdar://115472137

Reviewed by Ryosuke Niwa.

Nest the setTimeout() calls to guarantee the ordering of the subtests and address
the flakiness.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/userscripts/window-onerror-for-isolated-world-3-expected.txt:
* LayoutTests/userscripts/window-onerror-for-isolated-world-3.html:

Canonical link: <a href="https://commits.webkit.org/269158@main">https://commits.webkit.org/269158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a3220061ac4f0e90dc0ae7bf3f76554826778d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21723 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20113 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22255 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21951 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24443 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25964 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17345 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19488 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5188 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->