### PR TITLE
Stop using -[UIScrollView _horizontalVelocity] and -[UIScrollView _verticalVelocity]

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -432,8 +432,6 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 
 @interface UIScrollView ()
 - (void)_stopScrollingAndZoomingAnimations;
-- (double)_horizontalVelocity;
-- (double)_verticalVelocity;
 - (void)_flashScrollIndicatorsForAxes:(UIAxis)axes persistingPreviousFlashes:(BOOL)persisting;
 @property (nonatomic, getter=isZoomEnabled) BOOL zoomEnabled;
 @property (nonatomic, readonly, getter=_isAnimatingZoom) BOOL isAnimatingZoom;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -503,6 +503,7 @@ UIProcess/ios/WKTouchActionGestureRecognizer.mm
 UIProcess/ios/WKTouchEventsGestureRecognizer.mm
 UIProcess/ios/WKTextSelectionRect.mm
 UIProcess/ios/WKUSDPreviewView.mm
+UIProcess/ios/WKVelocityTrackingScrollView.mm
 UIProcess/ios/WKVideoView.mm
 UIProcess/ios/WKWebEvent.mm
 UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -213,11 +213,6 @@ struct PerWebProcessState {
 #if PLATFORM(MAC)
     std::unique_ptr<WebKit::WebViewImpl> _impl;
     RetainPtr<WKTextFinderClient> _textFinderClient;
-
-    // Only used with UI-side compositing.
-    RetainPtr<WKScrollView> _scrollView;
-    RetainPtr<WKContentView> _contentView;
-
 #if HAVE(NSWINDOW_SNAPSHOT_READINESS_HANDLER)
     BlockPtr<void()> _windowSnapshotReadinessHandler;
 #endif

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -198,6 +198,7 @@ enum class TapHandlingResult : uint8_t;
 @property (nonatomic, readonly) BOOL _isWindowResizingEnabled;
 #endif
 
+@property (nonatomic, readonly) WKVelocityTrackingScrollView *_scrollViewInternal;
 @property (nonatomic, readonly) CGRect _contentRectForUserInteraction;
 
 @end

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2042,6 +2042,9 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
+    if (scrollView == _scrollView)
+        [_scrollView updateInteractiveScrollVelocity];
+
     if (![self usesStandardContentView] && [_customContentView respondsToSelector:@selector(web_scrollViewDidScroll:)])
         [_customContentView web_scrollViewDidScroll:(UIScrollView *)scrollView];
 
@@ -2363,6 +2366,11 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     obscuredInsets.bottom = std::max(_obscuredInsets.bottom, _inputViewBoundsInWindow.size.height);
     CGRect unobscuredRect = UIEdgeInsetsInsetRect(self.bounds, obscuredInsets);
     return [self convertRect:unobscuredRect toView:self._currentContentView];
+}
+
+- (WKVelocityTrackingScrollView *)_scrollViewInternal
+{
+    return _scrollView.get();
 }
 
 // Ideally UIScrollView would expose this for us: <rdar://problem/21394567>.

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -909,7 +909,7 @@ static WKDragSessionContext *ensureLocalDragSessionContext(id <UIDragSession> se
         [self.superview addSubview:_interactionViewsContainerView.get()];
     }
 
-    _keyboardScrollingAnimator = adoptNS([[WKKeyboardScrollViewAnimator alloc] initWithScrollView:self.webView.scrollView]);
+    _keyboardScrollingAnimator = adoptNS([[WKKeyboardScrollViewAnimator alloc] initWithScrollView:self.webView._scrollViewInternal]);
     [_keyboardScrollingAnimator setDelegate:self];
 
     [self.layer addObserver:self forKeyPath:@"transform" options:NSKeyValueObservingOptionInitial context:WKContentViewKVOTransformContext];

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.h
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.h
@@ -32,14 +32,15 @@ class FloatPoint;
 }
 
 
-@class UIScrollView;
+@class WKVelocityTrackingScrollView;
 @class WebEvent;
+
 @protocol WKKeyboardScrollViewAnimatorDelegate;
 
 @interface WKKeyboardScrollViewAnimator : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithScrollView:(UIScrollView *)scrollView;
+- (instancetype)initWithScrollView:(WKVelocityTrackingScrollView *)scrollView;
 
 - (void)invalidate;
 

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -192,7 +192,7 @@
     if (!(self = [super initWithFrame:frame webView:webView]))
         return nil;
 
-    _keyboardScrollingAnimator = adoptNS([[WKKeyboardScrollViewAnimator alloc] initWithScrollView:webView.scrollView]);
+    _keyboardScrollingAnimator = adoptNS([[WKKeyboardScrollViewAnimator alloc] initWithScrollView:webView._scrollViewInternal]);
     _webView = webView;
 
     [self updateBackgroundColor];

--- a/Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,35 +23,17 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #if PLATFORM(IOS_FAMILY)
 
-#import "UIKitSPI.h"
-#import "WKVelocityTrackingScrollView.h"
+#import <UIKit/UIKit.h>
 
-@class WKWebView;
+@interface WKVelocityTrackingScrollView : UIScrollView
 
-@interface WKScrollView : WKVelocityTrackingScrollView
+- (void)updateInteractiveScrollVelocity;
 
-@property (nonatomic, assign) WKWebView <UIScrollViewDelegate> *internalDelegate;
-
-- (void)_setBackgroundColorInternal:(UIColor *)backgroundColor;
-- (void)_setIndicatorStyleInternal:(UIScrollViewIndicatorStyle)indicatorStyle;
-- (void)_setContentSizePreservingContentOffsetDuringRubberband:(CGSize)contentSize;
-- (void)_setScrollEnabledInternal:(BOOL)enabled;
-- (void)_setZoomEnabledInternal:(BOOL)enabled;
-- (void)_setBouncesInternal:(BOOL)horizontal vertical:(BOOL)vertical;
-- (BOOL)_setContentScrollInsetInternal:(UIEdgeInsets)insets;
-- (void)_setDecelerationRateInternal:(UIScrollViewDecelerationRate)rate;
-
-// FIXME: Likely we can remove this special case for watchOS and tvOS.
-#if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-@property (nonatomic, assign, readonly) BOOL _contentInsetAdjustmentBehaviorWasExternallyOverridden;
-- (void)_setContentInsetAdjustmentBehaviorInternal:(UIScrollViewContentInsetAdjustmentBehavior)insetAdjustmentBehavior;
-#endif
-
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-- (bool)_updateOverlayRegions:(const Vector<CGRect> &)overlayRegions;
-#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+@property (nonatomic, readonly) CGSize interactiveScrollVelocityInPointsPerSecond;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.mm
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKVelocityTrackingScrollView.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import <wtf/ApproximateTime.h>
+#import <wtf/FixedVector.h>
+
+template <size_t windowSize>
+struct ScrollingDeltaWindow {
+public:
+    static constexpr auto maxDeltaDuration = 100_ms;
+
+    void update(CGPoint contentOffset)
+    {
+        auto currentTime = ApproximateTime::now();
+        auto deltaDuration = currentTime - m_lastTimestamp;
+        if (deltaDuration > maxDeltaDuration)
+            reset();
+        else {
+            m_deltas[m_lastIndex] = {
+                CGSizeMake(contentOffset.x - m_lastOffset.x, contentOffset.y - m_lastOffset.y),
+                deltaDuration
+            };
+            m_lastIndex = ++m_lastIndex % windowSize;
+        }
+        m_lastTimestamp = currentTime;
+        m_lastOffset = contentOffset;
+    }
+
+    void reset()
+    {
+        for (auto& delta : m_deltas)
+            delta = { CGSizeZero, 0_ms };
+    }
+
+    CGSize averageVelocity() const
+    {
+        if (ApproximateTime::now() - m_lastTimestamp > maxDeltaDuration)
+            return CGSizeZero;
+
+        auto cumulativeDelta = CGSizeZero;
+        CGFloat numberOfDeltas = 0;
+        for (auto [delta, duration] : m_deltas) {
+            if (!duration)
+                continue;
+
+            cumulativeDelta.width += delta.width / duration.seconds();
+            cumulativeDelta.height += delta.height / duration.seconds();
+            numberOfDeltas += 1;
+        }
+
+        if (!numberOfDeltas)
+            return CGSizeZero;
+
+        cumulativeDelta.width /= numberOfDeltas;
+        cumulativeDelta.height /= numberOfDeltas;
+        return cumulativeDelta;
+    }
+
+private:
+    std::array<std::pair<CGSize, Seconds>, windowSize> m_deltas;
+    size_t m_lastIndex { 0 };
+    ApproximateTime m_lastTimestamp;
+    CGPoint m_lastOffset { CGPointZero };
+};
+
+@implementation WKVelocityTrackingScrollView {
+    ScrollingDeltaWindow<3> _scrollingDeltaWindow;
+}
+
+- (void)updateInteractiveScrollVelocity
+{
+    if (!self.tracking && !self.decelerating)
+        return;
+
+    _scrollingDeltaWindow.update(self.contentOffset);
+}
+
+- (CGSize)interactiveScrollVelocityInPointsPerSecond
+{
+    return _scrollingDeltaWindow.averageVelocity();
+}
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7511,6 +7511,8 @@
 		F4DBC0BC276AA6A70001D169 /* _WKModalContainerInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKModalContainerInfo.h; sourceTree = "<group>"; };
 		F4DBC0BD276AA6A70001D169 /* _WKModalContainerInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKModalContainerInfo.mm; sourceTree = "<group>"; };
 		F4DBC0C0276AA6CA0001D169 /* _WKModalContainerInfoInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKModalContainerInfoInternal.h; sourceTree = "<group>"; };
+		F4DD79EE2AD59BA6000C6821 /* WKVelocityTrackingScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKVelocityTrackingScrollView.h; path = ios/WKVelocityTrackingScrollView.h; sourceTree = "<group>"; };
+		F4DD79EF2AD59BA6000C6821 /* WKVelocityTrackingScrollView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKVelocityTrackingScrollView.mm; path = ios/WKVelocityTrackingScrollView.mm; sourceTree = "<group>"; };
 		F4E2B44A268FDE1A00327ABC /* TapHandlingResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TapHandlingResult.h; path = ios/TapHandlingResult.h; sourceTree = "<group>"; };
 		F4E47BB527B5AE5B00813B38 /* CocoaImage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CocoaImage.mm; sourceTree = "<group>"; };
 		F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKTouchEventsGestureRecognizerTypes.h; path = ios/WKTouchEventsGestureRecognizerTypes.h; sourceTree = "<group>"; };
@@ -10073,6 +10075,8 @@
 				F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */,
 				316B8B622054B55800BD4A62 /* WKUSDPreviewView.h */,
 				316B8B612054B55800BD4A62 /* WKUSDPreviewView.mm */,
+				F4DD79EE2AD59BA6000C6821 /* WKVelocityTrackingScrollView.h */,
+				F4DD79EF2AD59BA6000C6821 /* WKVelocityTrackingScrollView.mm */,
 				CDB96AD32AB379C9007A90D3 /* WKVideoView.h */,
 				CDB96AD42AB379CA007A90D3 /* WKVideoView.mm */,
 				2D1E8221216FFF5000A15265 /* WKWebEvent.h */,


### PR DESCRIPTION
#### 5d0fdb0896b24f0f31078bac5b067fc6ae0d9ac1
<pre>
Stop using -[UIScrollView _horizontalVelocity] and -[UIScrollView _verticalVelocity]
<a href="https://bugs.webkit.org/show_bug.cgi?id=262964">https://bugs.webkit.org/show_bug.cgi?id=262964</a>

Reviewed by Tim Horton.

Stop using these two SPI properties on `UIScrollView`. Instead, track horizontal and vertical
velocities on `WKScrollView` by storing a moving window of the last 3 recent scrolling deltas, and
using the average of this to estimate horizontal and vertical scrolling velocities.

This velocity tracking functionality is contained within a new `WKVelocityTrackingScrollView` class,
which `WKScrollView` now subclasses; this will make it easier to eventually bring smooth keyboard
scrolling to overflow/iframe `WKChildScrollView`s, which can be refactored to extend from
`WKVelocityTrackingScrollView` and integrate with their own keyboard scrolling animators.

See below for more details.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove now-unused SPI declarations on `UIScrollView`.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Add an internal iOS property on `WKWebView` to return a `WKVelocityTrackingScrollView` (as opposed
to a `UIScrollView`, which is what the API `-scrollView` property returns to clients).

Drive-by fix: also remove a couple of unused ivars.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollViewDidScroll:]):

Call into `WKScrollView` to update the velocity tracking window if needed.

(-[WKWebView _scrollViewInternal]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.h:
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
(-[WKKeyboardScrollViewAnimator initWithScrollView:]):
(-[WKKeyboardScrollViewAnimator distanceForIncrement:inDirection:]):
(-[WKKeyboardScrollViewAnimator scrollToContentOffset:animated:]):
(-[WKKeyboardScrollViewAnimator scrollWithScrollToExtentAnimationTo:]):
(-[WKKeyboardScrollViewAnimator contentOffset]):
(-[WKKeyboardScrollViewAnimator boundedContentOffset:]):
(-[WKKeyboardScrollViewAnimator interactiveScrollVelocity]):

Use the new `-interactiveScrollVelocityInPointsPerSecond` property instead of scroll view SPI.

(-[WKKeyboardScrollViewAnimator scrollableDirectionsFromOffset:]):
(-[WKKeyboardScrollViewAnimator rubberbandableDirections]):

Drive-by refactoring: change `WKScrollView` to a `__weak` reference, to eliminate the need for
`getAutoreleased()`.

* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView web_initWithFrame:webView:mimeType:]):
* Source/WebKit/UIProcess/ios/WKScrollView.h:

Make this subclass `WKVelocityTrackingScrollView`, for scrolling velocity tracking functionality.

* Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.h: Copied from Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.h.
* Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.mm: Added.
(ScrollingDeltaWindow::update):
(ScrollingDeltaWindow::reset):
(ScrollingDeltaWindow::averageVelocity const):
(-[WKVelocityTrackingScrollView updateInteractiveScrollVelocity]):
(-[WKVelocityTrackingScrollView interactiveScrollVelocityInPointsPerSecond]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/269177@main">https://commits.webkit.org/269177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d20fbe52b79e3acdb126f3ae83e234226bc7f219

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21736 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/21992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20124 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21267 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24457 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18748 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25974 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23833 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17351 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19704 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5198 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->