### PR TITLE
Add <input type=checkbox switch> infrastructure

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6533,6 +6533,19 @@ SuppressesIncrementalRendering:
     WebCore:
       default: false
 
+SwitchControlEnabled:
+  type: bool
+  status: unstable
+  humanReadableName: "HTML switch control"
+  humanReadableDescription: "Enable HTML switch control"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 SyntheticEditingCommandsEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -365,6 +365,8 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         return AccessibilityRole::Button;
     if (is<HTMLInputElement>(node())) {
         HTMLInputElement& input = downcast<HTMLInputElement>(*node());
+        if (input.isSwitch())
+            return AccessibilityRole::Switch;
         if (input.isCheckbox())
             return AccessibilityRole::CheckBox;
         if (input.isRadioButton())
@@ -1118,7 +1120,7 @@ bool AccessibilityNodeObject::isFieldset() const
 AccessibilityButtonState AccessibilityNodeObject::checkboxOrRadioValue() const
 {
     if (auto* input = dynamicDowncast<HTMLInputElement>(node()); input && (input->isCheckbox() || input->isRadioButton()))
-        return input->indeterminate() ? AccessibilityButtonState::Mixed : isChecked() ? AccessibilityButtonState::On : AccessibilityButtonState::Off;
+        return input->indeterminate() && !input->isSwitch() ? AccessibilityButtonState::Mixed : isChecked() ? AccessibilityButtonState::On : AccessibilityButtonState::Off;
 
     return AccessibilityObject::checkboxOrRadioValue();
 }

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -383,6 +383,7 @@ constexpr CSSValueID toCSSValueID(StyleAppearance e)
     case StyleAppearance::SearchFieldCancelButton:
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderThumbVertical:
+    case StyleAppearance::Switch:
         ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
         return CSSValueNone;
     }

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -235,7 +235,7 @@
 /* Menu item label for automatic track selection behavior. */
 "Auto (Recommended) (text track)" = "Auto (Recommended)";
 
-/* Menu item label to toggle automatic scene dimming in fullscreen (visionOS only). */
+/* Menu item label to toggle automatic scene dimming in fullscreen (visionOS only) */
 "Auto Dimming" = "Auto Dimming";
 
 /* Automatically Resize context menu item */
@@ -598,9 +598,6 @@
 /* WebKitErrorHTTPSUpgradeRedirectLoop description */
 "HTTPS Upgrade redirect loop detected" = "HTTPS Upgrade redirect loop detected";
 
-/* WebKitErrorHTTPNavigationWithHTTPSOnly description */
-"Navigation failed because the request was for an HTTP URL with HTTPS-Only enabled" = "Navigation failed because the request was for an HTTP URL with HTTPS-Only enabled";
-
 /* Title of the Hide button for zoomed form controls. */
 "Hide" = "Hide";
 
@@ -798,6 +795,9 @@
 
 /* Media Mute context menu item */
 "Mute" = "Mute";
+
+/* WebKitErrorHTTPSOnlyHTTPURL description */
+"Navigation failed because the request was for an HTTP URL with HTTPS-Only enabled" = "Navigation failed because the request was for an HTTP URL with HTTPS-Only enabled";
 
 /* New Quick Note context menu item. */
 "New Quick Note" = "New Quick Note";
@@ -1012,7 +1012,7 @@
 /* Validation message for required radio boxes that have no selection */
 "Select one of these options" = "Select one of these options";
 
-/* Validation message for required checkboxes that have not be selected */
+/* Validation message for required checkboxes that have not been selected */
 "Select this checkbox" = "Select this checkbox";
 
 /* Selection direction context sub-menu item */
@@ -1173,6 +1173,9 @@
 
 /* File Upload alert sheet camera button string for taking only videos */
 "Take Video (file upload action sheet)" = "Take Video";
+
+/* Validation message for required switches that are not on */
+"Tap this switch" = "Tap this switch";
 
 /* Tencent Safe Browsing */
 "Tencent Safe Browsing" = "Tencent Safe Browsing";

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -52,7 +52,20 @@ bool CheckboxInputType::valueMissing(const String&) const
 
 String CheckboxInputType::valueMissingText() const
 {
+    ASSERT(element());
+    if (element()->isSwitch())
+        return validationMessageValueMissingForSwitchText();
     return validationMessageValueMissingForCheckboxText();
+}
+
+void CheckboxInputType::attributeChanged(const QualifiedName& name)
+{
+    ASSERT(element());
+    if (element()->document().settings().switchControlEnabled() && name == HTMLNames::switchAttr) {
+        if (element()->renderer())
+            element()->invalidateStyleAndRenderersForSubtree();
+    }
+    InputType::attributeChanged(name);
 }
 
 void CheckboxInputType::handleKeyupEvent(KeyboardEvent& event)
@@ -100,7 +113,7 @@ bool CheckboxInputType::matchesIndeterminatePseudoClass() const
 bool CheckboxInputType::shouldAppearIndeterminate() const
 {
     ASSERT(element());
-    return element()->indeterminate();
+    return element()->indeterminate() && !element()->isSwitch();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -51,6 +51,7 @@ private:
 
     const AtomString& formControlType() const final;
     String valueMissingText() const final;
+    void attributeChanged(const QualifiedName&) final;
     void handleKeyupEvent(KeyboardEvent&) final;
     void willDispatchClick(InputElementClickState&) final;
     void didDispatchClick(Event&, const InputElementClickState&) final;

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -401,6 +401,7 @@ step
 style
 subtitle
 summary
+switch
 tabindex
 target
 text

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1853,6 +1853,11 @@ bool HTMLInputElement::isCheckbox() const
     return m_inputType->isCheckbox();
 }
 
+bool HTMLInputElement::isSwitch() const
+{
+    return document().settings().switchControlEnabled() && isCheckbox() && hasAttributeWithoutSynchronization(switchAttr);
+}
+
 bool HTMLInputElement::isRangeControl() const
 {
     return m_inputType->isRangeControl();

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -144,6 +144,7 @@ public:
     WEBCORE_EXPORT bool isPasswordField() const;
     bool isSecureField() const { return isPasswordField() || isAutoFilledAndObscured(); }
     bool isCheckbox() const;
+    bool isSwitch() const;
     bool isRangeControl() const;
 #if ENABLE(INPUT_TYPE_COLOR)
     WEBCORE_EXPORT bool isColorControl() const;

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -56,6 +56,7 @@
     [CEReactions=NotNeeded] attribute unsigned long size;
     [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString step;
+    [EnabledBySetting=SwitchControlEnabled, CEReactions=NotNeeded, Reflect] attribute boolean switch;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString type;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString defaultValue;
     // See the discussion in https://bugs.webkit.org/show_bug.cgi?id=100085

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -1147,7 +1147,7 @@ String validationMessageValueMissingText()
 
 String validationMessageValueMissingForCheckboxText()
 {
-    return WEB_UI_STRING("Select this checkbox", "Validation message for required checkboxes that have not be selected");
+    return WEB_UI_STRING("Select this checkbox", "Validation message for required checkboxes that have not been selected");
 }
 
 String validationMessageValueMissingForFileText()
@@ -1168,6 +1168,11 @@ String validationMessageValueMissingForRadioText()
 String validationMessageValueMissingForSelectText()
 {
     return WEB_UI_STRING("Select an item in the list", "Validation message for required menu list controls that have no selection");
+}
+
+String validationMessageValueMissingForSwitchText()
+{
+    return WEB_UI_STRING("Tap this switch", "Validation message for required switches that are not on");
 }
 
 String validationMessageTypeMismatchText()

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -310,6 +310,7 @@ namespace WebCore {
     String validationMessageValueMissingForMultipleFileText();
     String validationMessageValueMissingForRadioText();
     String validationMessageValueMissingForSelectText();
+    String validationMessageValueMissingForSwitchText();
     String validationMessageTypeMismatchText();
     String validationMessageTypeMismatchForEmailText();
     String validationMessageTypeMismatchForMultipleEmailText();

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -393,6 +393,9 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
         if (input.isTextButton() || input.isUploadButton())
             return StyleAppearance::Button;
 
+        if (input.isSwitch())
+            return StyleAppearance::Switch;
+
         if (input.isCheckbox())
             return StyleAppearance::Checkbox;
 
@@ -671,6 +674,9 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderObject& renderer)
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderThumbVertical:
         return SliderThumbPart::create(appearance);
+
+    case StyleAppearance::Switch:
+        break;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/StyleAppearance.cpp
+++ b/Source/WebCore/style/StyleAppearance.cpp
@@ -139,6 +139,9 @@ TextStream& operator<<(TextStream& ts, StyleAppearance appearance)
     case StyleAppearance::SliderThumbVertical:
         ts << "sliderthumb-vertical";
         break;
+    case StyleAppearance::Switch:
+        ts << "switch";
+        break;
     }
     return ts;
 }

--- a/Source/WebCore/style/StyleAppearance.h
+++ b/Source/WebCore/style/StyleAppearance.h
@@ -77,7 +77,8 @@ enum class StyleAppearance : uint8_t {
     SearchFieldResultsButton,
     SearchFieldCancelButton,
     SliderThumbHorizontal,
-    SliderThumbVertical
+    SliderThumbVertical,
+    Switch
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, StyleAppearance);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1259,6 +1259,7 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
     case WebCore::StyleAppearance::SearchFieldCancelButton:
     case WebCore::StyleAppearance::SliderThumbHorizontal:
     case WebCore::StyleAppearance::SliderThumbVertical:
+    case WebCore::StyleAppearance::Switch:
         break;
     }
 }
@@ -1380,6 +1381,9 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::StyleAppearance::SliderThumbHorizontal:
     case WebCore::StyleAppearance::SliderThumbVertical:
         return WebCore::SliderThumbPart::create(*type);
+
+    case WebCore::StyleAppearance::Switch:
+        break;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3159,7 +3159,8 @@ enum class WebCore::StyleAppearance : uint8_t {
     SearchFieldResultsButton,
     SearchFieldCancelButton,
     SliderThumbHorizontal,
-    SliderThumbVertical
+    SliderThumbVertical,
+    Switch
 };
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4432,7 +4432,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return;
         }
 
-        UIAction *dimmingAction = [UIAction actionWithTitle:WEB_UI_STRING("Auto Dimming", "Menu item label to toggle automatic scene dimming in fullscreen") image:[UIImage _systemImageNamed:@"circle.lefthalf.dotted.inset.half.filled"] identifier:nil handler:[weakSelf] (UIAction *) {
+        UIAction *dimmingAction = [UIAction actionWithTitle:WEB_UI_STRING("Auto Dimming", "Menu item label to toggle automatic scene dimming in fullscreen (visionOS only)") image:[UIImage _systemImageNamed:@"circle.lefthalf.dotted.inset.half.filled"] identifier:nil handler:[weakSelf] (UIAction *) {
             auto strongSelf = weakSelf.get();
             if (!strongSelf)
                 return;


### PR DESCRIPTION
#### 9ea9298663a4c17a15be6c8eae83a67f8d345f9f
<pre>
Add &lt;input type=checkbox switch&gt; infrastructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=262966">https://bugs.webkit.org/show_bug.cgi?id=262966</a>
rdar://116746765

Reviewed by Aditya Keerthi.

Adds the infrastructure needed to eventually be able to support an HTML
switch control. It notably does not cover any rendering aspects (except
for not rendering a checkbox).

This feature is documented in <a href="https://github.com/whatwg/html/pull/9546.">https://github.com/whatwg/html/pull/9546.</a>

This builds on excellent prototyping work done by Lily Spiniolas.

This commit includes some fixes resulting from running
update-webkit-localizable-strings.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):
(WebCore::AccessibilityNodeObject::checkboxOrRadioValue const):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::valueMissingText const):
(WebCore::CheckboxInputType::attributeChanged):
(WebCore::CheckboxInputType::shouldAppearIndeterminate const):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::isSwitch const):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLInputElement.idl:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::validationMessageValueMissingForCheckboxText):
(WebCore::validationMessageValueMissingForSwitchText):
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):
(WebCore::RenderTheme::createControlPart const):
* Source/WebCore/style/StyleAppearance.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleAppearance.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::encode):
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView fullScreenWindowSceneDimmingAction]):

Canonical link: <a href="https://commits.webkit.org/269247@main">https://commits.webkit.org/269247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e2661c91a80393c44afa81459fd3525bccbd2ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20388 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21452 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24760 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26218 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19144 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24085 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21397 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20615 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25440 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19966 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6000 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5248 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24174 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26715 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20565 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5832 "Passed tests") | 
<!--EWS-Status-Bubble-End-->