### PR TITLE
[WGSL] Fix argument buffer generation when using explicit layouts

### DIFF
--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -116,8 +116,10 @@ void NameManglerVisitor::run()
         String originalName = function.name();
         introduceVariable(function.name(), MangledName::Function);
         auto it = m_result.entryPoints.find(originalName);
-        if (it != m_result.entryPoints.end())
+        if (it != m_result.entryPoints.end()) {
+            it->value.originalName = originalName;
             it->value.mangledName = function.name();
+        }
         visit(function);
     }
 }

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -210,6 +210,7 @@ struct SpecializationConstant {
 
 struct EntryPointInformation {
     // FIXME: This can probably be factored better.
+    String originalName;
     String mangledName;
     std::optional<PipelineLayout> defaultLayout; // If the input PipelineLayout is nullopt, the compiler computes a layout and returns it. https://gpuweb.github.io/gpuweb/#default-pipeline-layout
     HashMap<std::pair<size_t, size_t>, size_t> bufferLengthLocations; // Metal buffer identity -> offset within helper buffer where its size needs to lie

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -45,7 +45,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
     RELEASE_ASSERT(ast);
 
     std::optional<WGSL::PipelineLayout> wgslPipelineLayout { std::nullopt };
-    if (pipelineLayout)
+    if (pipelineLayout && pipelineLayout->numberOfBindGroupLayouts())
         wgslPipelineLayout = ShaderModule::convertPipelineLayout(*pipelineLayout);
 
     auto prepareResult = WGSL::prepare(*ast, entryPoint, wgslPipelineLayout);

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -365,7 +365,7 @@ WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& p
         for (auto& entry : bindGroupLayout.entries()) {
             WGSL::BindGroupLayoutEntry wgslEntry;
             wgslEntry.binding = entry.value.binding;
-            wgslEntry.visibility.fromRaw(entry.value.visibility);
+            wgslEntry.visibility = wgslEntry.visibility.fromRaw(entry.value.visibility);
             wgslEntry.bindingMember = convertBindingLayout(entry.value.bindingLayout);
             wgslEntry.vertexArgumentBufferIndex = entry.value.argumentBufferIndices[WebGPU::ShaderStage::Vertex];
             wgslEntry.vertexArgumentBufferSizeIndex = entry.value.bufferSizeArgumentBufferIndices[WebGPU::ShaderStage::Vertex];


### PR DESCRIPTION
#### baa3a7fc959adc64f4cf77ee5319a3266461d54a
<pre>
[WGSL] Fix argument buffer generation when using explicit layouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=262956">https://bugs.webkit.org/show_bug.cgi?id=262956</a>
rdar://116739149

Reviewed by Dan Glastonbury and Mike Wyrzykowski.

Originally, the global rewriter was written with only auto layouts in mind, so it
always generated a new layout instead of consulting the user-provided layout when
there is one. The biggest change required was in `insertStructs`, where we either
use the information we discovered about which globals are used to create the
argument buffer structs, or the new path, where we use the user-provided bind group
layouts to generate the same structs.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::RewriteGlobalVariables):
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::RewriteGlobalVariables::determineUsedGlobals):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::createArgumentBufferEntry):
(WGSL::RewriteGlobalVariables::finalizeArgumentBufferStruct):
(WGSL::RewriteGlobalVariables::insertParameters):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::run):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::convertPipelineLayout):

Canonical link: <a href="https://commits.webkit.org/269392@main">https://commits.webkit.org/269392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6583eb4075589254922d3d3196d7c514c57716c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20380 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21447 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24750 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19005 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26209 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24076 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17544 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19958 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5339 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->