### PR TITLE
Ignore calc() values on colgroup elements

### DIFF
--- a/LayoutTests/fast/table/calculated-width-on-col-within-colgroup-expected.txt
+++ b/LayoutTests/fast/table/calculated-width-on-col-within-colgroup-expected.txt
@@ -1,0 +1,2 @@
+PASS
+crbug.com/446936: Use a used value of Auto on col elements that have a calc value. This is permitted by the spec and avoids ASSERTs.

--- a/LayoutTests/fast/table/calculated-width-on-col-within-colgroup.html
+++ b/LayoutTests/fast/table/calculated-width-on-col-within-colgroup.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+    col {
+        width: calc(-10in - 10%);
+    }
+</style>
+<script src="../../resources/check-layout.js"></script>
+<table>
+    <colgroup width="200">
+        <col data-expected-width=200>
+        <col data-expected-width=200>
+    </colgroup>
+    <tr>
+        <td data-expected-width=200></td>
+        <td data-expected-width=200></td>
+    </tr>
+</table>
+<script>
+    checkLayout('table')
+</script>
+<p> crbug.com/446936: Use a used value of Auto on col elements that have a calc value. This is permitted by the spec and avoids ASSERTs.</p>

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2002 Lars Knoll (knoll@kde.org)
  *           (C) 2002 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003, 2006, 2008, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -159,7 +160,8 @@ void AutoTableLayout::fullRecalc()
             groupLogicalWidth = column->style().logicalWidth();
         else {
             Length colLogicalWidth = column->style().logicalWidth();
-            if (colLogicalWidth.isAuto())
+            // FIXME: calc() on tables should be handled consistently with other lengths.
+            if (colLogicalWidth.isCalculated() || colLogicalWidth.isAuto())
                 colLogicalWidth = groupLogicalWidth;
             if ((colLogicalWidth.isFixed() || colLogicalWidth.isPercentOrCalculated()) && colLogicalWidth.isZero())
                 colLogicalWidth = Length();


### PR DESCRIPTION
#### a47442a35d9c773236814d0f5868a81db79cc8dc
<pre>
Ignore calc() values on colgroup elements

<a href="https://bugs.webkit.org/show_bug.cgi?id=253841">https://bugs.webkit.org/show_bug.cgi?id=253841</a>
rdar://problem/106692191

Reviewed by Alan Baradlay.

This patch aligns WebKit to Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=193912

This patch add condition to ignore calc() values on &apos;colgroup&apos; elements to align with
web-spec.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(AutoTableLayout::fullRecalc): Add &apos;isCalculated&apos; condition
* LayoutTests/fast/table/calculated-width-on-col-within-colgroup.html: Add Test Case
* LayoutTests/fast/table/calculated-width-on-col-within-colgroup-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/269200@main">https://commits.webkit.org/269200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94071c851e6ebb009e2a0321abae62c8a2899e3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/21994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21277 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/21981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24474 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/25987 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17366 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19510 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5218 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->