### PR TITLE
Optimizations for bit-related operations

### DIFF
--- a/Source/JavaScriptCore/assembler/ProbeStack.cpp
+++ b/Source/JavaScriptCore/assembler/ProbeStack.cpp
@@ -67,36 +67,38 @@ void Page::flushWrites()
     size_t offset = 0;
     while (dirtyBits) {
         // Find start.
-        if (dirtyBits & 1) {
-            size_t startOffset = offset;
-            // Find end.
-            do {
-                dirtyBits = dirtyBits >> 1;
-                offset += s_chunkSize;
-            } while (dirtyBits & 1);
+        auto trailingCleanBits = WTF::ctz(dirtyBits);
+        offset += s_chunkSize * trailingCleanBits;
+        dirtyBits >>= trailingCleanBits;
 
-            size_t size = offset - startOffset;
-            uint8_t* src = reinterpret_cast<uint8_t*>(&m_buffer) + startOffset;
-            uint8_t* dst = reinterpret_cast<uint8_t*>(m_baseLogicalAddress) + startOffset;
-            copyStackPage(dst, src, size);
-        }
-        dirtyBits = dirtyBits >> 1;
-        offset += s_chunkSize;
+        // Find end.
+        auto startOffset = offset;
+        auto trailingDirtyBits = WTF::ctz(~dirtyBits);
+
+        // Find size.
+        auto size = s_chunkSize * trailingDirtyBits;
+        offset += size;
+        dirtyBits >>= trailingDirtyBits;
+
+        uint8_t* src = reinterpret_cast<uint8_t*>(&m_buffer) + startOffset;
+        uint8_t* dst = reinterpret_cast<uint8_t*>(m_baseLogicalAddress) + startOffset;
+        copyStackPage(dst, src, size);
     }
     m_dirtyBits = 0;
 }
 
 void* Page::lowWatermarkFromVisitingDirtyChunks()
 {
-    uint64_t dirtyBits = m_dirtyBits;
-    size_t offset = 0;
-    while (dirtyBits) {
-        if (dirtyBits & 1)
-            return reinterpret_cast<uint8_t*>(m_baseLogicalAddress) + offset;
-        dirtyBits = dirtyBits >> 1;
-        offset += s_chunkSize;
-    }
-    return maxLowWatermark;
+    auto dirtyBits = m_dirtyBits;
+
+    // If dirtyBits is 0, we have no set bits
+    if (!dirtyBits)
+        return maxLowWatermark;
+
+    // All non-zero numbers has to have at least 1 set bit
+    auto offset = s_chunkSize * WTF::ctz(dirtyBits);
+
+    return reinterpret_cast<uint8_t*>(m_baseLogicalAddress) + offset;
 }
 
 Stack::Stack(Stack&& other)

--- a/Source/JavaScriptCore/runtime/MathCommon.cpp
+++ b/Source/JavaScriptCore/runtime/MathCommon.cpp
@@ -438,13 +438,16 @@ JSC_DEFINE_JIT_OPERATION(operationMathPow, double, (double x, double y))
         // If the exponent is a small positive int32 integer, we do a fast exponentiation
         double result = 1;
         double xd = x;
-        while (yAsInt) {
+        for (;;) {
             if (yAsInt & 1)
                 result *= xd;
-            xd *= xd;
+
             yAsInt >>= 1;
+            if (!yAsInt)
+                return result;
+
+            xd *= xd;
         }
-        return result;
     }
     return mathPowInternal(x, y);
 }

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -307,20 +307,12 @@ PacketDurationParser::PacketDurationParser(const AudioInfo& info)
             return;
         }
 
-        auto ilog = [] (uint32_t v) {
-            int ret = 0;
-            while (v) {
-                ret++;
-                v >>= 1;
-            }
-            return ret;
-        };
+        const unsigned modeBitCount = 32 - clz(m_vorbisModeInfo->mModeCount - 1);
 
-        uint32_t modeBitCount = ilog(m_vorbisModeInfo->mModeCount - 1);
-        for (uint32_t thisModeBit = 0; thisModeBit < modeBitCount; ++thisModeBit)
-            m_vorbisModeMask |= 1 << thisModeBit;
-        }
+        // Set every bit up to modeBitCount to 1.
+        m_vorbisModeMask |= (1U << modeBitCount) - 1;
         break;
+    }
 #endif
     default:
         // No need to examine the magic cookie.

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -383,8 +383,8 @@ bool BMPImageReader::processBitmasks()
         // supposed to be ignored in non-BITFIELDS cases.
         // 16 bits:    MSB <-                     xRRRRRGG GGGBBBBB -> LSB
         // 24/32 bits: MSB <- [AAAAAAAA] RRRRRRRR GGGGGGGG BBBBBBBB -> LSB
-        const int numBits = (m_infoHeader.biBitCount == 16) ? 5 : 8;
-        for (int i = 0; i <= 2; ++i)
+        const unsigned numBits = (m_infoHeader.biBitCount == 16) ? 5 : 8;
+        for (unsigned i = 0; i <= 2; ++i)
             m_bitMasks[i] = ((static_cast<uint32_t>(1) << (numBits * (3 - i))) - 1) ^ ((static_cast<uint32_t>(1) << (numBits * (2 - i))) - 1);
 
         // For Windows V4+ 32-bit RGB, don't overwrite the alpha mask from the
@@ -423,7 +423,7 @@ bool BMPImageReader::processBitmasks()
     m_needToProcessBitmasks = false;
 
     // Check masks and set shift values.
-    for (int i = 0; i < 4; ++i) {
+    for (unsigned i = 0; i < 4; ++i) {
         // Trim the mask to the allowed bit depth.  Some Windows V4+ BMPs
         // specify a bogus alpha channel in bits that don't exist in the pixel
         // data (for example, bits 25-31 in a 24-bit RGB format).
@@ -440,18 +440,18 @@ bool BMPImageReader::processBitmasks()
         }
 
         // Make sure bitmask does not overlap any other bitmasks.
-        for (int j = 0; j < i; ++j) {
+        for (unsigned j = 0; j < i; ++j) {
             if (tempMask & m_bitMasks[j])
                 return m_parent->setFailed();
         }
 
         // Count offset into pixel data.
-        for (m_bitShiftsRight[i] = 0; !(tempMask & 1); tempMask >>= 1)
-            ++m_bitShiftsRight[i];
+        unsigned rightOffset = ctz(tempMask);
+        tempMask >>= rightOffset;
 
-        // Count size of mask.
-        for (m_bitShiftsLeft[i] = 8; tempMask & 1; tempMask >>= 1)
-            --m_bitShiftsLeft[i];
+        // Count offset of mask from most significant bit
+        unsigned leftOffset = ctz(~tempMask);
+        tempMask >>= leftOffset;
 
         // Make sure bitmask is contiguous.
         if (tempMask)
@@ -459,10 +459,21 @@ bool BMPImageReader::processBitmasks()
 
         // Since RGBABuffer tops out at 8 bits per channel, adjust the shift
         // amounts to use the most significant 8 bits of the channel.
-        if (m_bitShiftsLeft[i] < 0) {
-            m_bitShiftsRight[i] -= m_bitShiftsLeft[i];
-            m_bitShiftsLeft[i] = 0;
+        if (leftOffset > 8) {
+
+            // Carry over excess shifts to rightOffset, as a negative
+            // offset to the left is a positive offset to the right.
+            rightOffset += leftOffset - 8;
+
+            // Cap leftOffset at 8
+            leftOffset = 8;
         }
+
+        m_bitShiftsRight[i] = rightOffset;
+
+        // m_bitShiftsLeft is the offset from the most significant bit,
+        // so find the mask size by subtracting the offset from 8.
+        m_bitShiftsLeft[i] = 8 - leftOffset;
     }
 
     return true;
@@ -585,14 +596,11 @@ bool BMPImageReader::processRLEData()
                 // Because processNonRLEData() expects m_decodedOffset to
                 // point to the beginning of the pixel data, bump it past
                 // the escape bytes and then reset if decoding failed.
-                m_decodedOffset += 2;
                 const ProcessingResult result = processNonRLEData(true, code);
-                if (result == Failure)
-                    return m_parent->setFailed();
-                if (result == InsufficientData) {
-                    m_decodedOffset -= 2;
-                    return false;
-                }
+                if (result != Success)
+                    return (result == Failure) ? m_parent->setFailed() : false;
+
+                m_decodedOffset += 2;
                 break;
             }
             }
@@ -621,9 +629,9 @@ bool BMPImageReader::processRLEData()
                 }
                 if ((colorIndexes[0] >= m_infoHeader.biClrUsed) || (colorIndexes[1] >= m_infoHeader.biClrUsed))
                     return m_parent->setFailed();
-                for (int which = 0; m_coord.x() < endX; ) {
+                for (unsigned which = 0; m_coord.x() < endX;) {
                     setI(colorIndexes[which]);
-                    which = !which;
+                    which ^= 1;
                 }
 
                 m_decodedOffset += 2;
@@ -704,7 +712,7 @@ BMPImageReader::ProcessingResult BMPImageReader::processNonRLEData(bool inRLE, i
                 // As an optimization, avoid setting "hasAlpha" to true for
                 // images where all alpha values are 255; opaque images are
                 // faster to draw.
-                int alpha = getAlpha(pixel);
+                unsigned alpha = getAlpha(pixel);
                 if (!m_seenNonZeroAlphaPixel && !alpha) {
                     m_seenZeroAlphaPixel = true;
                     alpha = 255;

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
@@ -321,8 +321,8 @@ private:
     // could go either direction. (If only "<< -x" were equivalent to
     // ">> x"...)
     uint32_t m_bitMasks[4];
-    int m_bitShiftsRight[4];
-    int m_bitShiftsLeft[4];
+    unsigned m_bitShiftsRight[4];
+    unsigned m_bitShiftsLeft[4];
 
     // The color palette, for paletted formats.
     Vector<RGBTriple> m_colorTable;

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
@@ -296,11 +296,11 @@ ICOImageDecoder::IconDirectoryEntry ICOImageDecoder::readDirectoryEntry()
     // this isn't quite what the bitmap info header says later, as we only use
     // this value to determine which icon entry is best.
     if (!entry.m_bitCount) {
-        int colorCount = static_cast<uint8_t>(m_data->data()[m_decodedOffset + 2]);
+        uint8_t colorCount = static_cast<uint8_t>(m_data->data()[m_decodedOffset + 2]);
         if (!colorCount)
-            colorCount = 256;  // Vague in the spec, needed by real-world icons.
-        for (--colorCount; colorCount; colorCount >>= 1)
-            ++entry.m_bitCount;
+            entry.m_bitCount = 8; // Vague in the spec, needed by real-world icons.
+        else
+            entry.m_bitCount = 8 - clz(colorCount - 1);
     }
 
     m_decodedOffset += sizeOfDirEntry;

--- a/Source/bmalloc/bmalloc/IsoPageInlines.h
+++ b/Source/bmalloc/bmalloc/IsoPageInlines.h
@@ -240,9 +240,8 @@ void IsoPage<Config>::forEachLiveObject(const LockHolder&, const Func& func)
         unsigned firstBitIndex = wordIndex * 32;
         char* cellByte = reinterpret_cast<char*>(this) + firstBitIndex * Config::objectSize;
         for (unsigned bitIndex = 0; bitIndex < 32; ++bitIndex) {
-            if (word & 1)
+            if (word & (1U << bitIndex))
                 func(static_cast<void*>(cellByte));
-            word >>= 1;
             cellByte += Config::objectSize;
         }
     }


### PR DESCRIPTION
<pre>
Optimizations for bit-related operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=262970">https://bugs.webkit.org/show_bug.cgi?id=262970</a>

Many of these bit operations can be done faster with the usage of
compiler intrinsics rather than manual looping.

I did the benchmarks, you can read them here, but the geomean is
"might be 1.0120x faster".

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/assembler/ProbeStack.cpp:
(JSC::Probe::Page::flushWrites): Use ctz to fly through continuous bits.
(JSC::Probe::Page::lowWatermarkFromVisitingDirtyChunks): Ditto.
* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp:
(WebCore::BMPImageReader::processBitmasks): Use ^= 1 to toggle "which"
variable between 0 and 1 instead of using a conditional.
(WebCore::BMPImageReader::processRLEData): Use ctz to go through bits.
(WebCore::BMPImageReader::processNonRLEData): Ditto.
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::sizeForLength): Refactored to only pass the keylength rather
than multiply by 2, which is now done in tableLengthForKeyCount.
(WebKit::nextPowerOf2): Renamed to tableLengthForKeyCount. Changed to
multiply keyCount by 2 and count the leading zeros to find next power of 2
if possible

</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9acd9f848b3e7031545b3c0de08821adb19a0417

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23192 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27648 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28603 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21695 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26427 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/24203 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/474 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31609 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3455 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6924 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2619 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31593 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2516 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6603 "Passed tests") | 
<!--EWS-Status-Bubble-End-->