### PR TITLE
[css-grid] enums in grid code should be enum classes

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1064,7 +1064,7 @@ static void addValuesForNamedGridLinesAtIndex(OrderedNamedLinesCollector& collec
 
 static Ref<CSSValueList> valueForGridTrackSizeList(GridTrackSizingDirection direction, const RenderStyle& style)
 {
-    auto& autoTrackSizes = direction == ForColumns ? style.gridAutoColumns() : style.gridAutoRows();
+    auto& autoTrackSizes = direction == GridTrackSizingDirection::ForColumns ? style.gridAutoColumns() : style.gridAutoRows();
 
     CSSValueListBuilder list;
     for (auto& trackSize : autoTrackSizes)
@@ -1096,10 +1096,10 @@ static void populateSubgridLineNameList(CSSValueListBuilder& list, OrderedNamedL
 
 static Ref<CSSValue> valueForGridTrackList(GridTrackSizingDirection direction, RenderObject* renderer, const RenderStyle& style)
 {
-    bool isRowAxis = direction == ForColumns;
+    bool isRowAxis = direction == GridTrackSizingDirection::ForColumns;
     bool isRenderGrid = is<RenderGrid>(renderer);
     bool isSubgrid = isRowAxis ? style.gridSubgridColumns() : style.gridSubgridRows();
-    bool isMasonry = (direction == ForRows) ? style.gridMasonryRows() : style.gridMasonryColumns();
+    bool isMasonry = (direction == GridTrackSizingDirection::ForRows) ? style.gridMasonryRows() : style.gridMasonryColumns();
     auto& trackSizes = isRowAxis ? style.gridColumnTrackSizes() : style.gridRowTrackSizes();
     auto& autoRepeatTrackSizes = isRowAxis ? style.gridAutoRepeatColumns() : style.gridAutoRepeatRows();
 
@@ -3372,14 +3372,14 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     // depending on the size of the explicit grid or the number of implicit tracks added to the grid. See
     // http://lists.w3.org/Archives/Public/www-style/2013Nov/0014.html
     case CSSPropertyGridAutoColumns:
-        return valueForGridTrackSizeList(ForColumns, style);
+        return valueForGridTrackSizeList(GridTrackSizingDirection::ForColumns, style);
     case CSSPropertyGridAutoRows:
-        return valueForGridTrackSizeList(ForRows, style);
+        return valueForGridTrackSizeList(GridTrackSizingDirection::ForRows, style);
 
     case CSSPropertyGridTemplateColumns:
-        return valueForGridTrackList(ForColumns, renderer, style);
+        return valueForGridTrackList(GridTrackSizingDirection::ForColumns, renderer, style);
     case CSSPropertyGridTemplateRows:
-        return valueForGridTrackList(ForRows, renderer, style);
+        return valueForGridTrackList(GridTrackSizingDirection::ForRows, renderer, style);
 
     case CSSPropertyGridColumnStart:
         return valueForGridPosition(style.gridItemColumnStart());

--- a/Source/WebCore/rendering/Grid.cpp
+++ b/Source/WebCore/rendering/Grid.cpp
@@ -38,7 +38,7 @@ Grid::Grid(RenderGrid& grid)
 
 unsigned Grid::numTracks(GridTrackSizingDirection direction) const
 {
-    if (direction == ForRows)
+    if (direction == GridTrackSizingDirection::ForRows)
         return m_grid.size();
     return m_grid.size() ? m_grid[0].size() : 0;
 }
@@ -47,8 +47,8 @@ void Grid::ensureGridSize(unsigned maximumRowSize, unsigned maximumColumnSize)
 {
     ASSERT(static_cast<int>(maximumRowSize) < GridPosition::max() * 2);
     ASSERT(static_cast<int>(maximumColumnSize) < GridPosition::max() * 2);
-    const size_t oldColumnSize = numTracks(ForColumns);
-    const size_t oldRowSize = numTracks(ForRows);
+    const size_t oldColumnSize = numTracks(GridTrackSizingDirection::ForColumns);
+    const size_t oldRowSize = numTracks(GridTrackSizingDirection::ForRows);
     if (maximumRowSize > oldRowSize) {
         m_grid.grow(maximumRowSize);
     }
@@ -106,7 +106,7 @@ void Grid::setExplicitGridStart(unsigned rowStart, unsigned columnStart)
 
 unsigned Grid::explicitGridStart(GridTrackSizingDirection direction) const
 {
-    return direction == ForRows ? m_explicitRowStart : m_explicitColumnStart;
+    return direction == GridTrackSizingDirection::ForRows ? m_explicitRowStart : m_explicitColumnStart;
 }
 
 void Grid::setClampingForSubgrid(unsigned maxRows, unsigned maxColumns)
@@ -140,15 +140,15 @@ void Grid::setGridItemArea(const RenderBox& item, GridArea area)
 
 void Grid::setAutoRepeatTracks(unsigned autoRepeatRows, unsigned autoRepeatColumns)
 {
-    ASSERT(static_cast<unsigned>(GridPosition::max()) >= numTracks(ForRows) + autoRepeatRows);
-    ASSERT(static_cast<unsigned>(GridPosition::max()) >= numTracks(ForColumns) + autoRepeatColumns);
+    ASSERT(static_cast<unsigned>(GridPosition::max()) >= numTracks(GridTrackSizingDirection::ForRows) + autoRepeatRows);
+    ASSERT(static_cast<unsigned>(GridPosition::max()) >= numTracks(GridTrackSizingDirection::ForColumns) + autoRepeatColumns);
     m_autoRepeatRows = autoRepeatRows;
     m_autoRepeatColumns =  autoRepeatColumns;
 }
 
 unsigned Grid::autoRepeatTracks(GridTrackSizingDirection direction) const
 {
-    return direction == ForRows ? m_autoRepeatRows : m_autoRepeatColumns;
+    return direction == GridTrackSizingDirection::ForRows ? m_autoRepeatRows : m_autoRepeatColumns;
 }
 
 void Grid::setAutoRepeatEmptyColumns(std::unique_ptr<OrderedTrackIndexSet> autoRepeatEmptyColumns)
@@ -165,7 +165,7 @@ void Grid::setAutoRepeatEmptyRows(std::unique_ptr<OrderedTrackIndexSet> autoRepe
 
 bool Grid::hasAutoRepeatEmptyTracks(GridTrackSizingDirection direction) const
 {
-    return direction == ForColumns ? !!m_autoRepeatEmptyColumns : !!m_autoRepeatEmptyRows;
+    return direction == GridTrackSizingDirection::ForColumns ? !!m_autoRepeatEmptyColumns : !!m_autoRepeatEmptyRows;
 }
 
 bool Grid::isEmptyAutoRepeatTrack(GridTrackSizingDirection direction, unsigned line) const
@@ -177,13 +177,13 @@ bool Grid::isEmptyAutoRepeatTrack(GridTrackSizingDirection direction, unsigned l
 OrderedTrackIndexSet* Grid::autoRepeatEmptyTracks(GridTrackSizingDirection direction) const
 {
     ASSERT(hasAutoRepeatEmptyTracks(direction));
-    return direction == ForColumns ? m_autoRepeatEmptyColumns.get() : m_autoRepeatEmptyRows.get();
+    return direction == GridTrackSizingDirection::ForColumns ? m_autoRepeatEmptyColumns.get() : m_autoRepeatEmptyRows.get();
 }
 
 GridSpan Grid::gridItemSpan(const RenderBox& gridItem, GridTrackSizingDirection direction) const
 {
     GridArea area = gridItemArea(gridItem);
-    return direction == ForColumns ? area.columns : area.rows;
+    return direction == GridTrackSizingDirection::ForColumns ? area.columns : area.rows;
 }
 
 GridSpan Grid::gridItemSpanIgnoringCollapsedTracks(const RenderBox& gridItem, GridTrackSizingDirection direction) const
@@ -233,28 +233,28 @@ void Grid::setNeedsItemsPlacement(bool needsItemsPlacement)
 GridIterator::GridIterator(const Grid& grid, GridTrackSizingDirection direction, unsigned fixedTrackIndex, unsigned varyingTrackIndex)
     : m_grid(grid)
     , m_direction(direction)
-    , m_rowIndex((direction == ForColumns) ? varyingTrackIndex : fixedTrackIndex)
-    , m_columnIndex((direction == ForColumns) ? fixedTrackIndex : varyingTrackIndex)
+    , m_rowIndex((direction == GridTrackSizingDirection::ForColumns) ? varyingTrackIndex : fixedTrackIndex)
+    , m_columnIndex((direction == GridTrackSizingDirection::ForColumns) ? fixedTrackIndex : varyingTrackIndex)
     , m_childIndex(0)
 {
     if (m_grid.maxRows()) {
-        ASSERT(m_grid.numTracks(ForRows));
-        ASSERT(m_rowIndex < m_grid.numTracks(ForRows));
+        ASSERT(m_grid.numTracks(GridTrackSizingDirection::ForRows));
+        ASSERT(m_rowIndex < m_grid.numTracks(GridTrackSizingDirection::ForRows));
     }
     if (m_grid.maxColumns()) {
-        ASSERT(m_grid.numTracks(ForColumns));
-        ASSERT(m_columnIndex < m_grid.numTracks(ForColumns));
+        ASSERT(m_grid.numTracks(GridTrackSizingDirection::ForColumns));
+        ASSERT(m_columnIndex < m_grid.numTracks(GridTrackSizingDirection::ForColumns));
     }
 }
 
 RenderBox* GridIterator::nextGridItem()
 {
     if (m_grid.maxRows())
-        ASSERT(m_grid.numTracks(ForRows));
+        ASSERT(m_grid.numTracks(GridTrackSizingDirection::ForRows));
     if (m_grid.maxColumns())
-        ASSERT(m_grid.numTracks(ForColumns));
-    unsigned& varyingTrackIndex = (m_direction == ForColumns) ? m_rowIndex : m_columnIndex;
-    const unsigned endOfVaryingTrackIndex = (m_direction == ForColumns) ? m_grid.numTracks(ForRows) : m_grid.numTracks(ForColumns);
+        ASSERT(m_grid.numTracks(GridTrackSizingDirection::ForColumns));
+    unsigned& varyingTrackIndex = (m_direction == GridTrackSizingDirection::ForColumns) ? m_rowIndex : m_columnIndex;
+    const unsigned endOfVaryingTrackIndex = (m_direction == GridTrackSizingDirection::ForColumns) ? m_grid.numTracks(GridTrackSizingDirection::ForRows) : m_grid.numTracks(GridTrackSizingDirection::ForColumns);
     for (; varyingTrackIndex < endOfVaryingTrackIndex; ++varyingTrackIndex) {
         const auto& children = m_grid.cell(m_rowIndex, m_columnIndex);
         if (m_childIndex < children.size())
@@ -268,12 +268,12 @@ RenderBox* GridIterator::nextGridItem()
 bool GridIterator::isEmptyAreaEnough(unsigned rowSpan, unsigned columnSpan) const
 {
     if (m_grid.maxRows())
-        ASSERT(m_grid.numTracks(ForRows));
+        ASSERT(m_grid.numTracks(GridTrackSizingDirection::ForRows));
     if (m_grid.maxColumns())
-        ASSERT(m_grid.numTracks(ForColumns));
+        ASSERT(m_grid.numTracks(GridTrackSizingDirection::ForColumns));
     // Ignore cells outside current grid as we will grow it later if needed.
-    unsigned maxRows = std::min<unsigned>(m_rowIndex + rowSpan, m_grid.numTracks(ForRows));
-    unsigned maxColumns = std::min<unsigned>(m_columnIndex + columnSpan, m_grid.numTracks(ForColumns));
+    unsigned maxRows = std::min<unsigned>(m_rowIndex + rowSpan, m_grid.numTracks(GridTrackSizingDirection::ForRows));
+    unsigned maxColumns = std::min<unsigned>(m_columnIndex + columnSpan, m_grid.numTracks(GridTrackSizingDirection::ForColumns));
 
     // This adds a O(N^2) behavior that shouldn't be a big deal as we expect spanning areas to be small.
     for (unsigned row = m_rowIndex; row < maxRows; ++row) {
@@ -290,20 +290,20 @@ bool GridIterator::isEmptyAreaEnough(unsigned rowSpan, unsigned columnSpan) cons
 std::optional<GridArea> GridIterator::nextEmptyGridArea(unsigned fixedTrackSpan, unsigned varyingTrackSpan)
 {
     if (m_grid.maxRows())
-        ASSERT(m_grid.numTracks(ForRows));
+        ASSERT(m_grid.numTracks(GridTrackSizingDirection::ForRows));
     if (m_grid.maxColumns())
-        ASSERT(m_grid.numTracks(ForColumns));
+        ASSERT(m_grid.numTracks(GridTrackSizingDirection::ForColumns));
     ASSERT(fixedTrackSpan >= 1);
     ASSERT(varyingTrackSpan >= 1);
 
     if (!m_grid.hasGridItems())
         return { };
 
-    unsigned rowSpan = (m_direction == ForColumns) ? varyingTrackSpan : fixedTrackSpan;
-    unsigned columnSpan = (m_direction == ForColumns) ? fixedTrackSpan : varyingTrackSpan;
+    unsigned rowSpan = (m_direction == GridTrackSizingDirection::ForColumns) ? varyingTrackSpan : fixedTrackSpan;
+    unsigned columnSpan = (m_direction == GridTrackSizingDirection::ForColumns) ? fixedTrackSpan : varyingTrackSpan;
 
-    unsigned& varyingTrackIndex = (m_direction == ForColumns) ? m_rowIndex : m_columnIndex;
-    const unsigned endOfVaryingTrackIndex = (m_direction == ForColumns) ? m_grid.numTracks(ForRows) : m_grid.numTracks(ForColumns);
+    unsigned& varyingTrackIndex = (m_direction == GridTrackSizingDirection::ForColumns) ? m_rowIndex : m_columnIndex;
+    const unsigned endOfVaryingTrackIndex = (m_direction == GridTrackSizingDirection::ForColumns) ? m_grid.numTracks(GridTrackSizingDirection::ForRows) : m_grid.numTracks(GridTrackSizingDirection::ForColumns);
     for (; varyingTrackIndex < endOfVaryingTrackIndex; ++varyingTrackIndex) {
         if (isEmptyAreaEnough(rowSpan, columnSpan)) {
             auto result = GridArea { GridSpan::translatedDefiniteGridSpan(m_rowIndex, m_rowIndex + rowSpan), GridSpan::translatedDefiniteGridSpan(m_columnIndex, m_columnIndex + columnSpan) };
@@ -322,7 +322,7 @@ GridIterator GridIterator::createForSubgrid(const RenderGrid& subgrid, const Gri
 
     // Translate the current row/column indices into the coordinate
     // space of the subgrid.
-    unsigned fixedIndex = (outer.direction() == ForColumns) ? outer.m_columnIndex : outer.m_rowIndex;
+    unsigned fixedIndex = (outer.direction() == GridTrackSizingDirection::ForColumns) ? outer.m_columnIndex : outer.m_rowIndex;
     fixedIndex -= fixedSpan.startLine();
 
     GridTrackSizingDirection innerDirection = GridLayoutFunctions::flowAwareDirectionForChild(*downcast<RenderGrid>(subgrid.parent()), subgrid, outer.direction());

--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -117,7 +117,7 @@ bool GridBaselineAlignment::isDescentBaselineForChild(const RenderBox& child, Gr
 
 bool GridBaselineAlignment::isHorizontalBaselineAxis(GridAxis axis) const
 {
-    return axis == GridRowAxis ? isHorizontalWritingMode(m_blockFlow) : !isHorizontalWritingMode(m_blockFlow);
+    return axis == GridAxis::GridRowAxis ? isHorizontalWritingMode(m_blockFlow) : !isHorizontalWritingMode(m_blockFlow);
 }
 
 bool GridBaselineAlignment::isOrthogonalChildForBaseline(const RenderBox& child) const
@@ -127,13 +127,13 @@ bool GridBaselineAlignment::isOrthogonalChildForBaseline(const RenderBox& child)
 
 bool GridBaselineAlignment::isParallelToBaselineAxisForChild(const RenderBox& child, GridAxis axis) const
 {
-    return axis == GridColumnAxis ? !isOrthogonalChildForBaseline(child) : isOrthogonalChildForBaseline(child);
+    return axis == GridAxis::GridColumnAxis ? !isOrthogonalChildForBaseline(child) : isOrthogonalChildForBaseline(child);
 }
 
 const BaselineGroup& GridBaselineAlignment::baselineGroupForChild(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis baselineAxis) const
 {
     ASSERT(isBaselinePosition(preference));
-    bool isRowAxisContext = baselineAxis == GridColumnAxis;
+    bool isRowAxisContext = baselineAxis == GridAxis::GridColumnAxis;
     auto& baselineAlignmentStateMap = isRowAxisContext ? m_rowAxisBaselineAlignmentStates : m_colAxisBaselineAlignmentStates;
     auto* baselineAlignmentState = baselineAlignmentStateMap.get(sharedContext);
     ASSERT(baselineAlignmentState);
@@ -150,7 +150,7 @@ void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preferen
     LayoutUnit ascent = logicalAscentForChild(child, baselineAxis, preference);
     // Looking up for a shared alignment context perpendicular to the
     // baseline axis.
-    bool isRowAxisContext = baselineAxis == GridColumnAxis;
+    bool isRowAxisContext = baselineAxis == GridAxis::GridColumnAxis;
     auto& baselineAlignmentStateMap = isRowAxisContext ? m_rowAxisBaselineAlignmentStates : m_colAxisBaselineAlignmentStates;
     // Looking for a compatible baseline-sharing group.
     if (auto* baselineAlignmentStateSearch = baselineAlignmentStateMap.get(sharedContext))
@@ -170,7 +170,7 @@ LayoutUnit GridBaselineAlignment::baselineOffsetForChild(ItemPosition preference
 
 void GridBaselineAlignment::clear(GridAxis baselineAxis)
 {
-    if (baselineAxis == GridColumnAxis)
+    if (baselineAxis == GridAxis::GridColumnAxis)
         m_rowAxisBaselineAlignmentStates.clear();
     else
         m_colAxisBaselineAlignmentStates.clear();

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -39,18 +39,18 @@ namespace GridLayoutFunctions {
 
 static inline bool marginStartIsAuto(const RenderBox& child, GridTrackSizingDirection direction)
 {
-    return direction == ForColumns ? child.style().marginStart().isAuto() : child.style().marginBefore().isAuto();
+    return direction == GridTrackSizingDirection::ForColumns ? child.style().marginStart().isAuto() : child.style().marginBefore().isAuto();
 }
 
 static inline bool marginEndIsAuto(const RenderBox& child, GridTrackSizingDirection direction)
 {
-    return direction == ForColumns ? child.style().marginEnd().isAuto() : child.style().marginAfter().isAuto();
+    return direction == GridTrackSizingDirection::ForColumns ? child.style().marginEnd().isAuto() : child.style().marginAfter().isAuto();
 }
 
 static bool childHasMargin(const RenderBox& child, GridTrackSizingDirection direction)
 {
     // Length::IsZero returns true for 'auto' margins, which is aligned with the purpose of this function.
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         return !child.style().marginStart().isZero() || !child.style().marginEnd().isZero();
     return !child.style().marginBefore().isZero() || !child.style().marginAfter().isZero();
 }
@@ -63,7 +63,7 @@ LayoutUnit computeMarginLogicalSizeForChild(const RenderGrid& grid, GridTrackSiz
 
     LayoutUnit marginStart;
     LayoutUnit marginEnd;
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         child.computeInlineDirectionMargins(grid, child.containingBlockLogicalWidthForContentInFragment(nullptr), { }, child.logicalWidth(), marginStart, marginEnd);
     else
         child.computeBlockDirectionMargins(grid, marginStart, marginEnd);
@@ -72,7 +72,7 @@ LayoutUnit computeMarginLogicalSizeForChild(const RenderGrid& grid, GridTrackSiz
 
 static bool hasRelativeOrIntrinsicSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
 {
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         return child.hasRelativeLogicalWidth() || child.style().logicalWidth().isIntrinsicOrAuto();
     return child.hasRelativeLogicalHeight() || child.style().logicalHeight().isIntrinsicOrAuto();
 }
@@ -90,12 +90,12 @@ static LayoutUnit extraMarginForSubgrid(const RenderGrid& parent, unsigned start
     RenderGrid& grandParent = downcast<RenderGrid>(*parent.parent());
     LayoutUnit mbp;
     if (!startLine)
-        mbp += (direction == ForColumns) ? parent.marginAndBorderAndPaddingStart() : parent.marginAndBorderAndPaddingBefore();
+        mbp += (direction == GridTrackSizingDirection::ForColumns) ? parent.marginAndBorderAndPaddingStart() : parent.marginAndBorderAndPaddingBefore();
     else
         mbp += (parent.gridGap(direction, availableSpace) - grandParent.gridGap(direction)) / 2;
 
     if (endLine == numTracks)
-        mbp += (direction == ForColumns) ? parent.marginAndBorderAndPaddingEnd() : parent.marginAndBorderAndPaddingAfter();
+        mbp += (direction == GridTrackSizingDirection::ForColumns) ? parent.marginAndBorderAndPaddingEnd() : parent.marginAndBorderAndPaddingAfter();
     else
         mbp += (parent.gridGap(direction, availableSpace) - grandParent.gridGap(direction)) / 2;
 
@@ -132,7 +132,7 @@ LayoutUnit marginLogicalSizeForChild(const RenderGrid& grid, GridTrackSizingDire
         margin = computeMarginLogicalSizeForChild(grid, direction, child);
     else {
         GridTrackSizingDirection flowAwareDirection = flowAwareDirectionForChild(grid, child, direction);
-        bool isRowAxis = flowAwareDirection == ForColumns;
+        bool isRowAxis = flowAwareDirection == GridTrackSizingDirection::ForColumns;
         LayoutUnit marginStart = marginStartIsAuto(child, flowAwareDirection) ? 0_lu : isRowAxis ? child.marginStart() : child.marginBefore();
         LayoutUnit marginEnd = marginEndIsAuto(child, flowAwareDirection) ? 0_lu : isRowAxis ? child.marginEnd() : child.marginAfter();
         margin = marginStart + marginEnd;
@@ -163,27 +163,27 @@ bool isAspectRatioBlockSizeDependentChild(const RenderBox& child)
 
 GridTrackSizingDirection flowAwareDirectionForChild(const RenderGrid& grid, const RenderBox& child, GridTrackSizingDirection direction)
 {
-    return !isOrthogonalChild(grid, child) ? direction : (direction == ForColumns ? ForRows : ForColumns);
+    return !isOrthogonalChild(grid, child) ? direction : (direction == GridTrackSizingDirection::ForColumns ? GridTrackSizingDirection::ForRows : GridTrackSizingDirection::ForColumns);
 }
 
 GridTrackSizingDirection flowAwareDirectionForParent(const RenderGrid& grid, const RenderElement& parent, GridTrackSizingDirection direction)
 {
-    return isOrthogonalParent(grid, parent) ? (direction == ForColumns ? ForRows : ForColumns) : direction;
+    return isOrthogonalParent(grid, parent) ? (direction == GridTrackSizingDirection::ForColumns ? GridTrackSizingDirection::ForRows : GridTrackSizingDirection::ForColumns) : direction;
 }
 
 bool hasOverridingContainingBlockContentSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
 {
-    return direction == ForColumns ? child.hasOverridingContainingBlockContentLogicalWidth() : child.hasOverridingContainingBlockContentLogicalHeight();
+    return direction == GridTrackSizingDirection::ForColumns ? child.hasOverridingContainingBlockContentLogicalWidth() : child.hasOverridingContainingBlockContentLogicalHeight();
 }
 
 std::optional<LayoutUnit> overridingContainingBlockContentSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
 {
-    return direction == ForColumns ? child.overridingContainingBlockContentLogicalWidth() : child.overridingContainingBlockContentLogicalHeight();
+    return direction == GridTrackSizingDirection::ForColumns ? child.overridingContainingBlockContentLogicalWidth() : child.overridingContainingBlockContentLogicalHeight();
 }
 
 bool isFlippedDirection(const RenderGrid& grid, GridTrackSizingDirection direction)
 {
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         return !grid.style().isLeftToRightDirection();
     return grid.style().isFlippedBlocksWritingMode();
 }

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -35,7 +35,7 @@ class RenderBox;
 class RenderElement;
 class RenderGrid;
 
-enum GridAxis {
+enum class GridAxis : uint8_t {
     GridRowAxis = 1 << 0,
     GridColumnAxis = 1 << 1
 };

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -55,8 +55,8 @@ void GridMasonryLayout::performMasonryPlacement(unsigned gridAxisTracks, GridTra
 {
     initializeMasonry(gridAxisTracks, masonryAxisDirection);
 
-    m_renderGrid.populateGridPositionsForDirection(ForColumns);
-    m_renderGrid.populateGridPositionsForDirection(ForRows);
+    m_renderGrid.populateGridPositionsForDirection(GridTrackSizingDirection::ForColumns);
+    m_renderGrid.populateGridPositionsForDirection(GridTrackSizingDirection::ForRows);
 
     // 2.4 Masonry Layout Algorithm
     addItemsToFirstTrack();
@@ -100,7 +100,7 @@ void GridMasonryLayout::collectMasonryItems()
 
 void GridMasonryLayout::allocateCapacityForMasonryVectors()
 {
-    auto gridCapacity = m_renderGrid.currentGrid().numTracks(ForRows) * m_renderGrid.currentGrid().numTracks(ForColumns);
+    auto gridCapacity = m_renderGrid.currentGrid().numTracks(GridTrackSizingDirection::ForRows) * m_renderGrid.currentGrid().numTracks(GridTrackSizingDirection::ForColumns);
     if (m_renderGrid.style().masonryAutoFlow().placementOrder == MasonryAutoFlowPlacementOrder::DefiniteFirst) {
         m_itemsWithDefiniteGridAxisPosition.reserveCapacity(gridCapacity / m_masonryDefiniteItemsQuarterCapacity);
         m_itemsWithIndefiniteGridAxisPosition.reserveCapacity(gridCapacity / m_masonryIndefiniteItemsHalfCapacity);
@@ -179,10 +179,10 @@ void GridMasonryLayout::placeItemsWithIndefiniteGridAxisPosition()
 
 void GridMasonryLayout::setItemGridAxisContainingBlockToGridArea(RenderBox& child)
 {
-    if (gridAxisDirection() == ForColumns)
-        child.setOverridingContainingBlockContentLogicalWidth(m_renderGrid.m_trackSizingAlgorithm.gridAreaBreadthForChild(child, ForColumns));
+    if (gridAxisDirection() == GridTrackSizingDirection::ForColumns)
+        child.setOverridingContainingBlockContentLogicalWidth(m_renderGrid.m_trackSizingAlgorithm.gridAreaBreadthForChild(child, GridTrackSizingDirection::ForColumns));
     else
-        child.setOverridingContainingBlockContentLogicalHeight(m_renderGrid.m_trackSizingAlgorithm.gridAreaBreadthForChild(child, ForRows));
+        child.setOverridingContainingBlockContentLogicalHeight(m_renderGrid.m_trackSizingAlgorithm.gridAreaBreadthForChild(child, GridTrackSizingDirection::ForRows));
     
     // FIXME(249230): Try to cache masonry layout sizes
     child.setChildNeedsLayout(MarkOnlyThis);
@@ -200,7 +200,7 @@ void GridMasonryLayout::insertIntoGridAndLayoutItem(RenderBox& child, const Grid
 LayoutUnit GridMasonryLayout::masonryAxisMarginBoxForItem(const RenderBox& child)
 {
     LayoutUnit marginBoxSize;
-    if (m_masonryAxisDirection == ForRows) {
+    if (m_masonryAxisDirection == GridTrackSizingDirection::ForRows) {
         if (GridLayoutFunctions::isOrthogonalChild(m_renderGrid, child))
             marginBoxSize = child.isHorizontalWritingMode() ? child.width() + child.horizontalMarginExtent() : child.height() + child.verticalMarginExtent();
         else
@@ -285,7 +285,7 @@ inline GridTrackSizingDirection GridMasonryLayout::gridAxisDirection() const
 {
     // The masonry axis and grid axis can never be the same. 
     // They are always perpendicular to each other.
-    return m_masonryAxisDirection == ForRows ? ForColumns : ForRows;
+    return m_masonryAxisDirection == GridTrackSizingDirection::ForRows ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
 }
 
 bool GridMasonryLayout::hasDefiniteGridAxisPosition(const RenderBox& child, GridTrackSizingDirection gridAxisDirection) const 
@@ -296,12 +296,12 @@ bool GridMasonryLayout::hasDefiniteGridAxisPosition(const RenderBox& child, Grid
 
 GridSpan GridMasonryLayout::gridAxisSpanFromArea(const GridArea& gridArea) const
 {
-    return gridAxisDirection() == ForRows ? gridArea.rows : gridArea.columns;
+    return gridAxisDirection() == GridTrackSizingDirection::ForRows ? gridArea.rows : gridArea.columns;
 }
 
 GridArea GridMasonryLayout::masonryGridAreaFromGridAxisSpan(const GridSpan& gridAxisSpan) const
 {
-    return m_masonryAxisDirection == ForRows ? GridArea { m_masonryAxisSpan, gridAxisSpan } : GridArea { gridAxisSpan, m_masonryAxisSpan };
+    return m_masonryAxisDirection == GridTrackSizingDirection::ForRows ? GridArea { m_masonryAxisSpan, gridAxisSpan } : GridArea { gridAxisSpan, m_masonryAxisSpan };
 }
 
 bool GridMasonryLayout::hasEnoughSpaceAtPosition(unsigned startingPosition, unsigned spanLength) const

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -70,7 +70,7 @@ private:
     bool hasDefiniteGridAxisPosition(const RenderBox& child, GridTrackSizingDirection masonryDirection) const;
     static bool itemGridAreaStartsAtFirstLine(const GridArea& area, GridTrackSizingDirection masonryDirection)
     {
-        return !(masonryDirection == ForRows ? area.rows.startLine() : area.columns.startLine());
+        return !(masonryDirection == GridTrackSizingDirection::ForRows ? area.rows.startLine() : area.columns.startLine());
     }
     GridArea masonryGridAreaFromGridAxisSpan(const GridSpan&) const;
     GridSpan gridAxisSpanFromArea(const GridArea&) const;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -116,24 +116,24 @@ void GridTrack::ensureGrowthLimitIsBiggerThanBaseSize()
 
 static GridAxis gridAxisForDirection(GridTrackSizingDirection direction)
 {
-    return direction == ForColumns ? GridRowAxis : GridColumnAxis;
+    return direction == GridTrackSizingDirection::ForColumns ? GridAxis::GridRowAxis : GridAxis::GridColumnAxis;
 }
 
 static GridTrackSizingDirection gridDirectionForAxis(GridAxis axis)
 {
-    return axis == GridRowAxis ? ForColumns : ForRows;
+    return axis == GridAxis::GridRowAxis ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
 }
 
 static bool hasRelativeMarginOrPaddingForChild(const RenderBox& child, GridTrackSizingDirection direction)
 {
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         return child.style().marginStart().isPercentOrCalculated() || child.style().marginEnd().isPercentOrCalculated() || child.style().paddingStart().isPercentOrCalculated() || child.style().paddingEnd().isPercentOrCalculated();
     return child.style().marginBefore().isPercentOrCalculated() || child.style().marginAfter().isPercentOrCalculated() || child.style().paddingBefore().isPercentOrCalculated() || child.style().paddingAfter().isPercentOrCalculated();
 }
 
 static bool hasRelativeOrIntrinsicSizeForChild(const RenderBox& child, GridTrackSizingDirection direction)
 {
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         return child.hasRelativeLogicalWidth() || child.style().logicalWidth().isIntrinsicOrAuto();
     return child.hasRelativeLogicalHeight() || child.style().logicalHeight().isIntrinsicOrAuto();
 }
@@ -150,7 +150,7 @@ static void setOverridingContainingBlockContentSizeForChild(const RenderGrid& gr
     // writing mode of the CB and the grid for which we're doing sizing don't match, swap
     // the directions.
     direction = GridLayoutFunctions::flowAwareDirectionForChild(grid, *child.containingBlock(), direction);
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         child.setOverridingContainingBlockContentLogicalWidth(size);
     else
         child.setOverridingContainingBlockContentLogicalHeight(size);
@@ -160,7 +160,7 @@ static void setOverridingContainingBlockContentSizeForChild(const RenderGrid& gr
 
 void GridTrackSizingAlgorithm::setFreeSpace(GridTrackSizingDirection direction, std::optional<LayoutUnit> freeSpace)
 {
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         m_freeSpaceColumns = freeSpace;
     else
         m_freeSpaceRows = freeSpace;
@@ -174,7 +174,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::availableSpace() const
 
 void GridTrackSizingAlgorithm::setAvailableSpace(GridTrackSizingDirection direction, std::optional<LayoutUnit> availableSpace)
 {
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         m_availableSpaceColumns = availableSpace;
     else
         m_availableSpaceRows = availableSpace;
@@ -182,7 +182,7 @@ void GridTrackSizingAlgorithm::setAvailableSpace(GridTrackSizingDirection direct
 
 const GridTrackSize& GridTrackSizingAlgorithm::rawGridTrackSize(GridTrackSizingDirection direction, unsigned translatedIndex) const
 {
-    bool isRowAxis = direction == ForColumns;
+    bool isRowAxis = direction == GridTrackSizingDirection::ForColumns;
     auto& renderStyle = m_renderGrid->style();
     auto& trackStyles = isRowAxis ? renderStyle.gridColumnTrackSizes() : renderStyle.gridRowTrackSizes();
     auto& autoRepeatTrackStyles = isRowAxis ? renderStyle.gridAutoRepeatColumns() : renderStyle.gridAutoRepeatRows();
@@ -321,7 +321,7 @@ struct GridItemsSpanGroupRange {
     Vector<GridItemWithSpan>::iterator rangeEnd;
 };
 
-enum TrackSizeRestriction {
+enum class TrackSizeRestriction : uint8_t {
     AllowInfinity,
     ForbidInfinity,
 };
@@ -329,15 +329,15 @@ enum TrackSizeRestriction {
 LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhase(TrackSizeComputationPhase phase, RenderBox& gridItem) const
 {
     switch (phase) {
-    case ResolveIntrinsicMinimums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
         return m_strategy->minSizeForChild(gridItem);
-    case ResolveContentBasedMinimums:
-    case ResolveIntrinsicMaximums:
+    case TrackSizeComputationPhase::ResolveContentBasedMinimums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
         return m_strategy->minContentForChild(gridItem);
-    case ResolveMaxContentMinimums:
-    case ResolveMaxContentMaximums:
+    case TrackSizeComputationPhase::ResolveMaxContentMinimums:
+    case TrackSizeComputationPhase::ResolveMaxContentMaximums:
         return m_strategy->maxContentForChild(gridItem);
-    case MaximizeTracks:
+    case TrackSizeComputationPhase::MaximizeTracks:
         ASSERT_NOT_REACHED();
         return 0;
     }
@@ -349,17 +349,17 @@ LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhase(TrackS
 static bool shouldProcessTrackForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const GridTrackSize& trackSize)
 {
     switch (phase) {
-    case ResolveIntrinsicMinimums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
         return trackSize.hasIntrinsicMinTrackBreadth();
-    case ResolveContentBasedMinimums:
+    case TrackSizeComputationPhase::ResolveContentBasedMinimums:
         return trackSize.hasMinOrMaxContentMinTrackBreadth();
-    case ResolveMaxContentMinimums:
+    case TrackSizeComputationPhase::ResolveMaxContentMinimums:
         return trackSize.hasMaxContentMinTrackBreadth();
-    case ResolveIntrinsicMaximums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
         return trackSize.hasIntrinsicMaxTrackBreadth();
-    case ResolveMaxContentMaximums:
+    case TrackSizeComputationPhase::ResolveMaxContentMaximums:
         return trackSize.hasMaxContentOrAutoMaxTrackBreadth();
-    case MaximizeTracks:
+    case TrackSizeComputationPhase::MaximizeTracks:
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -371,14 +371,14 @@ static bool shouldProcessTrackForTrackSizeComputationPhase(TrackSizeComputationP
 static LayoutUnit trackSizeForTrackSizeComputationPhase(TrackSizeComputationPhase phase, GridTrack& track, TrackSizeRestriction restriction)
 {
     switch (phase) {
-    case ResolveIntrinsicMinimums:
-    case ResolveContentBasedMinimums:
-    case ResolveMaxContentMinimums:
-    case MaximizeTracks:
+    case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
+    case TrackSizeComputationPhase::ResolveContentBasedMinimums:
+    case TrackSizeComputationPhase::ResolveMaxContentMinimums:
+    case TrackSizeComputationPhase::MaximizeTracks:
         return track.baseSize();
-    case ResolveIntrinsicMaximums:
-    case ResolveMaxContentMaximums:
-        return restriction == AllowInfinity ? track.growthLimit() : track.growthLimitIfNotInfinite();
+    case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
+    case TrackSizeComputationPhase::ResolveMaxContentMaximums:
+        return restriction == TrackSizeRestriction::AllowInfinity ? track.growthLimit() : track.growthLimitIfNotInfinite();
     }
 
     ASSERT_NOT_REACHED();
@@ -388,16 +388,16 @@ static LayoutUnit trackSizeForTrackSizeComputationPhase(TrackSizeComputationPhas
 static void updateTrackSizeForTrackSizeComputationPhase(TrackSizeComputationPhase phase, GridTrack& track)
 {
     switch (phase) {
-    case ResolveIntrinsicMinimums:
-    case ResolveContentBasedMinimums:
-    case ResolveMaxContentMinimums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
+    case TrackSizeComputationPhase::ResolveContentBasedMinimums:
+    case TrackSizeComputationPhase::ResolveMaxContentMinimums:
         track.setBaseSize(track.plannedSize());
         return;
-    case ResolveIntrinsicMaximums:
-    case ResolveMaxContentMaximums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
+    case TrackSizeComputationPhase::ResolveMaxContentMaximums:
         track.setGrowthLimit(track.plannedSize());
         return;
-    case MaximizeTracks:
+    case TrackSizeComputationPhase::MaximizeTracks:
         ASSERT_NOT_REACHED();
         return;
     }
@@ -408,15 +408,15 @@ static void updateTrackSizeForTrackSizeComputationPhase(TrackSizeComputationPhas
 static bool trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const GridTrackSize& trackSize)
 {
     switch (phase) {
-    case ResolveIntrinsicMinimums:
-    case ResolveContentBasedMinimums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
+    case TrackSizeComputationPhase::ResolveContentBasedMinimums:
         return trackSize.hasAutoOrMinContentMinTrackBreadthAndIntrinsicMaxTrackBreadth();
-    case ResolveMaxContentMinimums:
+    case TrackSizeComputationPhase::ResolveMaxContentMinimums:
         return trackSize.hasMaxContentMinTrackBreadthAndMaxContentMaxTrackBreadth();
-    case ResolveIntrinsicMaximums:
-    case ResolveMaxContentMaximums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
+    case TrackSizeComputationPhase::ResolveMaxContentMaximums:
         return true;
-    case MaximizeTracks:
+    case TrackSizeComputationPhase::MaximizeTracks:
         ASSERT_NOT_REACHED();
         return false;
     }
@@ -428,19 +428,19 @@ static bool trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase(TrackS
 static void markAsInfinitelyGrowableForTrackSizeComputationPhase(TrackSizeComputationPhase phase, GridTrack& track)
 {
     switch (phase) {
-    case ResolveIntrinsicMinimums:
-    case ResolveContentBasedMinimums:
-    case ResolveMaxContentMinimums:
+    case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
+    case TrackSizeComputationPhase::ResolveContentBasedMinimums:
+    case TrackSizeComputationPhase::ResolveMaxContentMinimums:
         return;
-    case ResolveIntrinsicMaximums:
-        if (trackSizeForTrackSizeComputationPhase(phase, track, AllowInfinity) == infinity  && track.plannedSize() != infinity)
+    case TrackSizeComputationPhase::ResolveIntrinsicMaximums:
+        if (trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::AllowInfinity) == infinity  && track.plannedSize() != infinity)
             track.setInfinitelyGrowable(true);
         return;
-    case ResolveMaxContentMaximums:
+    case TrackSizeComputationPhase::ResolveMaxContentMaximums:
         if (track.infinitelyGrowable())
             track.setInfinitelyGrowable(false);
         return;
-    case MaximizeTracks:
+    case TrackSizeComputationPhase::MaximizeTracks:
         ASSERT_NOT_REACHED();
         return;
     }
@@ -454,7 +454,7 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems(const Gri
     Vector<GridTrack>& allTracks = tracks(m_direction);
     for (const auto& trackIndex : m_contentSizedTracksIndex) {
         GridTrack& track = allTracks[trackIndex];
-        track.setPlannedSize(trackSizeForTrackSizeComputationPhase(phase, track, AllowInfinity));
+        track.setPlannedSize(trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::AllowInfinity));
     }
 
     Vector<WeakPtr<GridTrack>> growBeyondGrowthLimitsTracks;
@@ -470,7 +470,7 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems(const Gri
         for (auto trackPosition : itemSpan) {
             GridTrack& track = allTracks[trackPosition];
             const auto& trackSize = track.cachedTrackSize();
-            spanningTracksSize += trackSizeForTrackSizeComputationPhase(phase, track, ForbidInfinity);
+            spanningTracksSize += trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::ForbidInfinity);
             if (variant == TrackSizeComputationVariant::CrossingFlexibleTracks && !trackSize.maxTrackBreadth().isFlex())
                 continue;
             if (!shouldProcessTrackForTrackSizeComputationPhase(phase, trackSize))
@@ -503,11 +503,11 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems(const Gri
 template <TrackSizeComputationVariant variant>
 void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems(const GridItemsSpanGroupRange& gridItemsWithSpan)
 {
-    increaseSizesToAccommodateSpanningItems<variant, ResolveIntrinsicMinimums>(gridItemsWithSpan);
-    increaseSizesToAccommodateSpanningItems<variant, ResolveContentBasedMinimums>(gridItemsWithSpan);
-    increaseSizesToAccommodateSpanningItems<variant, ResolveMaxContentMinimums>(gridItemsWithSpan);
-    increaseSizesToAccommodateSpanningItems<variant, ResolveIntrinsicMaximums>(gridItemsWithSpan);
-    increaseSizesToAccommodateSpanningItems<variant, ResolveMaxContentMaximums>(gridItemsWithSpan);
+    increaseSizesToAccommodateSpanningItems<variant, TrackSizeComputationPhase::ResolveIntrinsicMinimums>(gridItemsWithSpan);
+    increaseSizesToAccommodateSpanningItems<variant, TrackSizeComputationPhase::ResolveContentBasedMinimums>(gridItemsWithSpan);
+    increaseSizesToAccommodateSpanningItems<variant, TrackSizeComputationPhase::ResolveMaxContentMinimums>(gridItemsWithSpan);
+    increaseSizesToAccommodateSpanningItems<variant, TrackSizeComputationPhase::ResolveIntrinsicMaximums>(gridItemsWithSpan);
+    increaseSizesToAccommodateSpanningItems<variant, TrackSizeComputationPhase::ResolveMaxContentMaximums>(gridItemsWithSpan);
 }
 
 template <TrackSizeComputationVariant variant>
@@ -539,7 +539,7 @@ static bool sortByGridTrackGrowthPotential(const WeakPtr<GridTrack>& track1, con
 
 static void clampGrowthShareIfNeeded(TrackSizeComputationPhase phase, const GridTrack& track, LayoutUnit& growthShare)
 {
-    if (phase != ResolveMaxContentMaximums || !track.growthLimitCap())
+    if (phase != TrackSizeComputationPhase::ResolveMaxContentMaximums || !track.growthLimitCap())
         return;
 
     LayoutUnit distanceToCap = track.growthLimitCap().value() - track.tempSize();
@@ -553,7 +553,7 @@ template <TrackSizeComputationPhase phase, SpaceDistributionLimit limit>
 static void distributeItemIncurredIncreaseToTrack(GridTrack& track, LayoutUnit& freeSpace, double shareFraction)
 {
     LayoutUnit freeSpaceShare(freeSpace / shareFraction);
-    LayoutUnit growthShare = limit == SpaceDistributionLimit::BeyondGrowthLimit || track.infiniteGrowthPotential() ? freeSpaceShare : std::min(freeSpaceShare, track.growthLimit() - trackSizeForTrackSizeComputationPhase(phase, track, ForbidInfinity));
+    LayoutUnit growthShare = limit == SpaceDistributionLimit::BeyondGrowthLimit || track.infiniteGrowthPotential() ? freeSpaceShare : std::min(freeSpaceShare, track.growthLimit() - trackSizeForTrackSizeComputationPhase(phase, track, TrackSizeRestriction::ForbidInfinity));
     clampGrowthShareIfNeeded(phase, track, growthShare);
     ASSERT_WITH_MESSAGE(growthShare >= 0, "We must never shrink any grid track or else we can't guarantee we abide by our min-sizing function.");
     track.growTempSize(growthShare);
@@ -599,7 +599,7 @@ void GridTrackSizingAlgorithm::distributeSpaceToTracks(Vector<WeakPtr<GridTrack>
     ASSERT(freeSpace >= 0);
 
     for (auto& track : tracks)
-        track->setTempSize(trackSizeForTrackSizeComputationPhase(phase, *track, ForbidInfinity));
+        track->setTempSize(trackSizeForTrackSizeComputationPhase(phase, *track, TrackSizeRestriction::ForbidInfinity));
 
     if (freeSpace > 0)
         distributeItemIncurredIncreases<variant, phase, SpaceDistributionLimit::UpToGrowthLimit>(tracks, freeSpace);
@@ -631,7 +631,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForC
 
     gridAreaSize += m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSize);
 
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*m_renderGrid, child, ForColumns);
+    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*m_renderGrid, child, GridTrackSizingDirection::ForColumns);
     if (gridAreaIsIndefinite)
         return direction == childInlineDirection ? std::make_optional(std::max(child.maxPreferredLogicalWidth(), gridAreaSize)) : std::nullopt;
     return gridAreaSize;
@@ -643,16 +643,16 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForChild(cons
         return m_renderGrid->contentLogicalWidth();
 
     bool addContentAlignmentOffset =
-        direction == ForColumns && (m_sizingState == RowSizingFirstIteration || m_sizingState == RowSizingExtraIterationForSizeContainment);
+        direction == GridTrackSizingDirection::ForColumns && (m_sizingState == SizingState::RowSizingFirstIteration || m_sizingState == SizingState::RowSizingExtraIterationForSizeContainment);
     // To determine the column track's size based on an orthogonal grid item we need it's logical
     // height, which may depend on the row track's size. It's possible that the row tracks sizing
     // logic has not been performed yet, so we will need to do an estimation.
-    if (direction == ForRows && (m_sizingState == ColumnSizingFirstIteration || m_sizingState == ColumnSizingSecondIteration) && !m_renderGrid->areMasonryColumns()) {
+    if (direction == GridTrackSizingDirection::ForRows && (m_sizingState == SizingState::ColumnSizingFirstIteration || m_sizingState == SizingState::ColumnSizingSecondIteration) && !m_renderGrid->areMasonryColumns()) {
         ASSERT(GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child));
         // FIXME (jfernandez) Content Alignment should account for this heuristic.
         // https://github.com/w3c/csswg-drafts/issues/2697
-        if (m_sizingState == ColumnSizingFirstIteration)
-            return estimatedGridAreaBreadthForChild(child, ForRows);
+        if (m_sizingState == SizingState::ColumnSizingFirstIteration)
+            return estimatedGridAreaBreadthForChild(child, GridTrackSizingDirection::ForRows);
         addContentAlignmentOffset = true;
     }
 
@@ -803,7 +803,7 @@ double GridTrackSizingAlgorithm::findFrUnitSize(const GridSpan& tracksSpan, Layo
 
 void GridTrackSizingAlgorithm::computeGridContainerIntrinsicSizes()
 {
-    if (m_direction == ForColumns && m_strategy->isComputingSizeOrInlineSizeContainment()) {
+    if (m_direction == GridTrackSizingDirection::ForColumns && m_strategy->isComputingSizeOrInlineSizeContainment()) {
         if (auto size = m_renderGrid->explicitIntrinsicInnerLogicalSize(m_direction)) {
             m_minContentSize = size.value();
             m_maxContentSize = size.value();
@@ -827,10 +827,10 @@ void GridTrackSizingAlgorithm::computeGridContainerIntrinsicSizes()
 // GridTrackSizingAlgorithmStrategy.
 LayoutUnit GridTrackSizingAlgorithmStrategy::logicalHeightForChild(RenderBox& child) const
 {
-    GridTrackSizingDirection childBlockDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, ForRows);
+    GridTrackSizingDirection childBlockDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForRows);
     // If |child| has a relative logical height, we shouldn't let it override its intrinsic height, which is
     // what we are interested in here. Thus we need to set the block-axis override size to nullopt (no possible resolution).
-    if (shouldClearOverridingContainingBlockContentSizeForChild(child, ForRows)) {
+    if (shouldClearOverridingContainingBlockContentSizeForChild(child, GridTrackSizingDirection::ForRows)) {
         setOverridingContainingBlockContentSizeForChild(*renderGrid(), child, childBlockDirection, std::nullopt);
         child.setNeedsLayout(MarkOnlyThis);
     }
@@ -845,7 +845,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::logicalHeightForChild(RenderBox& ch
 
 LayoutUnit GridTrackSizingAlgorithmStrategy::minContentForChild(RenderBox& child) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, ForColumns);
+    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
     if (direction() == childInlineDirection) {
         if (isComputingInlineSizeContainment())
             return { };
@@ -870,7 +870,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContentForChild(RenderBox& child
 
 LayoutUnit GridTrackSizingAlgorithmStrategy::maxContentForChild(RenderBox& child) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, ForColumns);
+    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
     if (direction() == childInlineDirection) {
         if (isComputingInlineSizeContainment())
             return { };
@@ -888,7 +888,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::maxContentForChild(RenderBox& child
 
 LayoutUnit GridTrackSizingAlgorithmStrategy::minSizeForChild(RenderBox& child) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, ForColumns);
+    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
     bool isRowAxis = direction() == childInlineDirection;
     if (isRowAxis && isComputingInlineSizeContainment())
         return { };
@@ -932,12 +932,12 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minSizeForChild(RenderBox& child) c
 
 bool GridTrackSizingAlgorithm::canParticipateInBaselineAlignment(const RenderBox& child, GridAxis baselineAxis) const
 {
-    ASSERT(baselineAxis == GridColumnAxis ? m_columnBaselineItemsMap.contains(&child) : m_rowBaselineItemsMap.contains(&child));
+    ASSERT(baselineAxis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap.contains(&child) : m_rowBaselineItemsMap.contains(&child));
 
     // Baseline cyclic dependencies only happen with synthesized
     // baselines. These cases include orthogonal or empty grid items
     // and replaced elements.
-    bool isParallelToBaselineAxis = baselineAxis == GridColumnAxis ? !GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child) : GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child);
+    bool isParallelToBaselineAxis = baselineAxis == GridAxis::GridColumnAxis ? !GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child) : GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child);
     if (isParallelToBaselineAxis && child.firstLineBaseline())
         return true;
 
@@ -958,7 +958,7 @@ bool GridTrackSizingAlgorithm::canParticipateInBaselineAlignment(const RenderBox
 
 bool GridTrackSizingAlgorithm::participateInBaselineAlignment(const RenderBox& child, GridAxis baselineAxis) const
 {
-    return baselineAxis == GridColumnAxis ? m_columnBaselineItemsMap.get(&child) : m_rowBaselineItemsMap.get(&child);
+    return baselineAxis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap.get(&child) : m_rowBaselineItemsMap.get(&child);
 }
 
 void GridTrackSizingAlgorithm::updateBaselineAlignmentContext(const RenderBox& child, GridAxis baselineAxis)
@@ -1000,9 +1000,9 @@ void GridTrackSizingAlgorithm::cacheBaselineAlignedItem(const RenderBox& item, G
     ASSERT(downcast<RenderGrid>(item.parent())->isBaselineAlignmentForChild(item, axis));
 
     if (GridLayoutFunctions::isOrthogonalParent(*m_renderGrid, *item.parent()))
-        axis = axis == GridColumnAxis ? GridRowAxis : GridColumnAxis;
+        axis = axis == GridAxis::GridColumnAxis ? GridAxis::GridRowAxis : GridAxis::GridColumnAxis;
 
-    if (axis == GridColumnAxis)
+    if (axis == GridAxis::GridColumnAxis)
         m_columnBaselineItemsMap.add(&item, true);
     else
         m_rowBaselineItemsMap.add(&item, true);
@@ -1010,7 +1010,7 @@ void GridTrackSizingAlgorithm::cacheBaselineAlignedItem(const RenderBox& item, G
 
 void GridTrackSizingAlgorithm::copyBaselineItemsCache(const GridTrackSizingAlgorithm& source, GridAxis axis)
 {
-    if (axis == GridColumnAxis)
+    if (axis == GridAxis::GridColumnAxis)
         m_columnBaselineItemsMap = source.m_columnBaselineItemsMap;
     else
         m_rowBaselineItemsMap = source.m_rowBaselineItemsMap;
@@ -1059,13 +1059,13 @@ bool GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSiz
 
 LayoutUnit GridTrackSizingAlgorithmStrategy::minLogicalSizeForChild(RenderBox& child, const Length& childMinSize, std::optional<LayoutUnit> availableSize) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, ForColumns);
+    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
     bool isRowAxis = direction() == childInlineDirection;
     if (isRowAxis)
         return isComputingInlineSizeContainment() ? 0_lu : child.computeLogicalWidthInFragmentUsing(MinSize, childMinSize, availableSize.value_or(0), *renderGrid(), nullptr) + GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), childInlineDirection, child);
     bool overrideSizeHasChanged = updateOverridingContainingBlockContentSizeForChild(child, childInlineDirection, availableSize);
     layoutGridItemForMinSizeComputation(child, overrideSizeHasChanged);
-    GridTrackSizingDirection childBlockDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, ForRows);
+    GridTrackSizingDirection childBlockDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForRows);
     return child.computeLogicalHeightUsing(MinSize, childMinSize, std::nullopt).value_or(0) + GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), childBlockDirection, child);
 }
 
@@ -1088,7 +1088,7 @@ private:
 
 void IndefiniteSizeStrategy::layoutGridItemForMinSizeComputation(RenderBox& child, bool overrideSizeHasChanged) const
 {
-    if (overrideSizeHasChanged && direction() != ForColumns)
+    if (overrideSizeHasChanged && direction() != GridTrackSizingDirection::ForColumns)
         child.setNeedsLayout(MarkOnlyThis);
     child.layoutIfNeeded();
 }
@@ -1156,7 +1156,7 @@ double IndefiniteSizeStrategy::findUsedFlexFraction(Vector<unsigned>& flexibleSi
 
 bool IndefiniteSizeStrategy::recomputeUsedFlexFractionIfNeeded(double& flexFraction, LayoutUnit& totalGrowth) const
 {
-    if (direction() == ForColumns)
+    if (direction() == GridTrackSizingDirection::ForColumns)
         return false;
 
     const RenderGrid* renderGrid = this->renderGrid();
@@ -1174,9 +1174,9 @@ bool IndefiniteSizeStrategy::recomputeUsedFlexFractionIfNeeded(double& flexFract
 
     LayoutUnit freeSpace = checkMaxSize ? maxSize.value() : -1_lu;
     const Grid& grid = m_algorithm.grid();
-    freeSpace = std::max(freeSpace, minSize.value_or(0_lu)) - renderGrid->guttersSize(ForRows, 0, grid.numTracks(ForRows), availableSpace());
+    freeSpace = std::max(freeSpace, minSize.value_or(0_lu)) - renderGrid->guttersSize(GridTrackSizingDirection::ForRows, 0, grid.numTracks(GridTrackSizingDirection::ForRows), availableSpace());
 
-    size_t numberOfTracks = m_algorithm.tracks(ForRows).size();
+    size_t numberOfTracks = m_algorithm.tracks(GridTrackSizingDirection::ForRows).size();
     flexFraction = findFrUnitSize(GridSpan::translatedDefiniteGridSpan(0, numberOfTracks), freeSpace);
     return true;
 }
@@ -1202,7 +1202,7 @@ private:
 LayoutUnit IndefiniteSizeStrategy::freeSpaceForStretchAutoTracksStep() const
 {
     ASSERT(!m_algorithm.freeSpace(direction()));
-    if (direction() == ForColumns)
+    if (direction() == GridTrackSizingDirection::ForColumns)
         return 0_lu;
 
     auto minSize = renderGrid()->computeContentLogicalHeight(MinSize, renderGrid()->style().logicalMinHeight(), std::nullopt);
@@ -1213,7 +1213,7 @@ LayoutUnit IndefiniteSizeStrategy::freeSpaceForStretchAutoTracksStep() const
 
 LayoutUnit DefiniteSizeStrategy::minLogicalSizeForChild(RenderBox& child, const Length& childMinSize, std::optional<LayoutUnit> availableSize) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, ForColumns);
+    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
     GridTrackSizingDirection flowAwareDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, direction());
     if (hasRelativeMarginOrPaddingForChild(child, flowAwareDirection) || (direction() != childInlineDirection && hasRelativeOrIntrinsicSizeForChild(child, flowAwareDirection))) {
         auto indefiniteSize = direction() == childInlineDirection ? std::make_optional(0_lu) : std::nullopt;
@@ -1260,8 +1260,8 @@ LayoutUnit DefiniteSizeStrategy::freeSpaceForStretchAutoTracksStep() const
 
 LayoutUnit DefiniteSizeStrategy::minContentForChild(RenderBox& child) const
 {
-    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, ForColumns);
-    if (direction() == childInlineDirection && child.needsLayout() && shouldClearOverridingContainingBlockContentSizeForChild(child, ForColumns))
+    GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*renderGrid(), child, GridTrackSizingDirection::ForColumns);
+    if (direction() == childInlineDirection && child.needsLayout() && shouldClearOverridingContainingBlockContentSizeForChild(child, GridTrackSizingDirection::ForColumns))
         setOverridingContainingBlockContentSizeForChild(*renderGrid(), child, childInlineDirection, LayoutUnit());
     return GridTrackSizingAlgorithmStrategy::minContentForChild(child);
 }
@@ -1284,7 +1284,7 @@ void GridTrackSizingAlgorithm::initializeTrackSizes()
     ASSERT(!m_hasFlexibleMaxTrackBreadth);
 
     Vector<GridTrack>& allTracks = tracks(m_direction);
-    const bool indefiniteHeight = m_direction == ForRows && !m_renderGrid->hasDefiniteLogicalHeight();
+    const bool indefiniteHeight = m_direction == GridTrackSizingDirection::ForRows && !m_renderGrid->hasDefiniteLogicalHeight();
     LayoutUnit maxSize = std::max(0_lu, availableSpace().value_or(0_lu));
     // 1. Initialize per Grid track variables.
     for (unsigned i = 0; i < allTracks.size(); ++i) {
@@ -1319,7 +1319,7 @@ void GridTrackSizingAlgorithm::initializeTrackSizes()
 
 static LayoutUnit marginAndBorderAndPaddingForEdge(const RenderGrid& grid, GridTrackSizingDirection direction, bool startEdge)
 {
-    if (direction == ForColumns)
+    if (direction == GridTrackSizingDirection::ForColumns)
         return startEdge ? grid.marginAndBorderAndPaddingStart() : grid.marginAndBorderAndPaddingEnd();
     return startEdge ? grid.marginAndBorderAndPaddingBefore() : grid.marginAndBorderAndPaddingAfter();
 }
@@ -1365,7 +1365,7 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track
             // m_direction shall always be the gridAxisDirection.
             ASSERT(!isDirectionInMasonryDirection());
             auto gridAxisDirection = m_direction;
-            auto masonryAxisDirection = m_renderGrid->areMasonryRows() ? ForRows : ForColumns;
+            auto masonryAxisDirection = m_renderGrid->areMasonryRows() ? GridTrackSizingDirection::ForRows : GridTrackSizingDirection::ForColumns;
             auto span = GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, gridAxisDirection);
 
             // Items placed at the first implicit line in the masonry axis.
@@ -1500,36 +1500,36 @@ void GridTrackSizingAlgorithm::stretchAutoTracks()
 void GridTrackSizingAlgorithm::advanceNextState()
 {
     switch (m_sizingState) {
-    case ColumnSizingFirstIteration:
-        m_sizingState = RowSizingFirstIteration;
+    case SizingState::ColumnSizingFirstIteration:
+        m_sizingState = SizingState::RowSizingFirstIteration;
         return;
-    case RowSizingFirstIteration:
-        m_sizingState = m_strategy->isComputingSizeContainment() ? RowSizingExtraIterationForSizeContainment : ColumnSizingSecondIteration;
+    case SizingState::RowSizingFirstIteration:
+        m_sizingState = m_strategy->isComputingSizeContainment() ? SizingState::RowSizingExtraIterationForSizeContainment : SizingState::ColumnSizingSecondIteration;
         return;
-    case RowSizingExtraIterationForSizeContainment:
-        m_sizingState = ColumnSizingSecondIteration;
+    case SizingState::RowSizingExtraIterationForSizeContainment:
+        m_sizingState = SizingState::ColumnSizingSecondIteration;
         return;
-    case ColumnSizingSecondIteration:
-        m_sizingState = RowSizingSecondIteration;
+    case SizingState::ColumnSizingSecondIteration:
+        m_sizingState = SizingState::RowSizingSecondIteration;
         return;
-    case RowSizingSecondIteration:
-        m_sizingState = ColumnSizingFirstIteration;
+    case SizingState::RowSizingSecondIteration:
+        m_sizingState = SizingState::ColumnSizingFirstIteration;
         return;
     }
     ASSERT_NOT_REACHED();
-    m_sizingState = ColumnSizingFirstIteration;
+    m_sizingState = SizingState::ColumnSizingFirstIteration;
 }
 
 bool GridTrackSizingAlgorithm::isValidTransition() const
 {
     switch (m_sizingState) {
-    case ColumnSizingFirstIteration:
-    case ColumnSizingSecondIteration:
-        return m_direction == ForColumns;
-    case RowSizingFirstIteration:
-    case RowSizingExtraIterationForSizeContainment:
-    case RowSizingSecondIteration:
-        return m_direction == ForRows;
+    case SizingState::ColumnSizingFirstIteration:
+    case SizingState::ColumnSizingSecondIteration:
+        return m_direction == GridTrackSizingDirection::ForColumns;
+    case SizingState::RowSizingFirstIteration:
+    case SizingState::RowSizingExtraIterationForSizeContainment:
+    case SizingState::RowSizingSecondIteration:
+        return m_direction == GridTrackSizingDirection::ForRows;
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -1545,10 +1545,10 @@ void GridTrackSizingAlgorithm::setup(GridTrackSizingDirection direction, unsigne
 
     m_sizingOperation = sizingOperation;
     switch (m_sizingOperation) {
-    case IntrinsicSizeComputation:
+    case SizingOperation::IntrinsicSizeComputation:
         m_strategy = makeUnique<IndefiniteSizeStrategy>(*this);
         break;
-    case TrackSizing:
+    case SizingOperation::TrackSizing:
         m_strategy = makeUnique<DefiniteSizeStrategy>(*this);
         break;
     }
@@ -1576,7 +1576,7 @@ void GridTrackSizingAlgorithm::computeBaselineAlignmentContext()
     GridAxis axis = gridAxisForDirection(m_direction);
     m_baselineAlignment.clear(axis);
     m_baselineAlignment.setBlockFlow(m_renderGrid->style().writingMode());
-    BaselineItemsCache& baselineItemsCache = axis == GridColumnAxis ? m_columnBaselineItemsMap : m_rowBaselineItemsMap;
+    BaselineItemsCache& baselineItemsCache = axis == GridAxis::GridColumnAxis ? m_columnBaselineItemsMap : m_rowBaselineItemsMap;
     BaselineItemsCache tmpBaselineItemsCache = baselineItemsCache;
     for (auto* child : tmpBaselineItemsCache.keys()) {
         // FIXME (jfernandez): We may have to get rid of the baseline participation
@@ -1630,9 +1630,9 @@ bool GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid()
     if (GridLayoutFunctions::isSubgridReversedDirection(*outer, direction, *m_renderGrid))
         allTracks.reverse();
 
-    LayoutUnit startMBP = (m_direction == ForColumns) ? m_renderGrid->marginAndBorderAndPaddingStart() : m_renderGrid->marginAndBorderAndPaddingBefore();
+    LayoutUnit startMBP = (m_direction == GridTrackSizingDirection::ForColumns) ? m_renderGrid->marginAndBorderAndPaddingStart() : m_renderGrid->marginAndBorderAndPaddingBefore();
     removeSubgridMarginBorderPaddingFromTracks(allTracks, startMBP, true);
-    LayoutUnit endMBP = (m_direction == ForColumns) ? m_renderGrid->marginAndBorderAndPaddingEnd() : m_renderGrid->marginAndBorderAndPaddingAfter();
+    LayoutUnit endMBP = (m_direction == GridTrackSizingDirection::ForColumns) ? m_renderGrid->marginAndBorderAndPaddingEnd() : m_renderGrid->marginAndBorderAndPaddingAfter();
     removeSubgridMarginBorderPaddingFromTracks(allTracks, endMBP, false);
 
     LayoutUnit gapDifference = (m_renderGrid->gridGap(m_direction, availableSpace(m_direction)) - outer->gridGap(direction)) / 2;
@@ -1678,7 +1678,7 @@ void GridTrackSizingAlgorithm::run()
     }
 
     // Step 3.
-    m_strategy->maximizeTracks(tracks(m_direction), m_direction == ForColumns ? m_freeSpaceColumns : m_freeSpaceRows);
+    m_strategy->maximizeTracks(tracks(m_direction), m_direction == GridTrackSizingDirection::ForColumns ? m_freeSpaceColumns : m_freeSpaceRows);
     if (m_strategy->isComputingSizeOrInlineSizeContainment() && !m_renderGrid->explicitIntrinsicInnerLogicalSize(m_direction))
         return;
 
@@ -1692,14 +1692,14 @@ void GridTrackSizingAlgorithm::run()
 void GridTrackSizingAlgorithm::reset()
 {
     ASSERT(wasSetup());
-    m_sizingState = ColumnSizingFirstIteration;
+    m_sizingState = SizingState::ColumnSizingFirstIteration;
     m_columns.shrink(0);
     m_rows.shrink(0);
     m_contentSizedTracksIndex.shrink(0);
     m_flexibleSizedTracksIndex.shrink(0);
     m_autoSizedTracksForStretchIndex.shrink(0);
-    setAvailableSpace(ForRows, std::nullopt);
-    setAvailableSpace(ForColumns, std::nullopt);
+    setAvailableSpace(GridTrackSizingDirection::ForRows, std::nullopt);
+    setAvailableSpace(GridTrackSizingDirection::ForColumns, std::nullopt);
     m_hasPercentSizedRowsIndefiniteHeight = false;
     m_hasFlexibleMaxTrackBreadth = false;
 }

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -34,14 +34,14 @@ namespace WebCore {
 
 static const int infinity = -1;
 
-enum SizingOperation { TrackSizing, IntrinsicSizeComputation };
+enum class SizingOperation : uint8_t { TrackSizing, IntrinsicSizeComputation };
 
 enum class TrackSizeComputationVariant : uint8_t {
     NotCrossingFlexibleTracks,
     CrossingFlexibleTracks,
 };
 
-enum TrackSizeComputationPhase {
+enum class TrackSizeComputationPhase : uint8_t {
     ResolveIntrinsicMinimums,
     ResolveContentBasedMinimums,
     ResolveMaxContentMinimums,
@@ -110,7 +110,7 @@ public:
     GridTrackSizingAlgorithm(const RenderGrid* renderGrid, Grid& grid)
         : m_grid(grid)
         , m_renderGrid(renderGrid)
-        , m_sizingState(ColumnSizingFirstIteration)
+        , m_sizingState(SizingState::ColumnSizingFirstIteration)
     {
     }
 
@@ -137,13 +137,13 @@ public:
     void copyBaselineItemsCache(const GridTrackSizingAlgorithm&, GridAxis);
     void clearBaselineItemsCache();
 
-    Vector<GridTrack>& tracks(GridTrackSizingDirection direction) { return direction == ForColumns ? m_columns : m_rows; }
-    const Vector<GridTrack>& tracks(GridTrackSizingDirection direction) const { return direction == ForColumns ? m_columns : m_rows; }
+    Vector<GridTrack>& tracks(GridTrackSizingDirection direction) { return direction == GridTrackSizingDirection::ForColumns ? m_columns : m_rows; }
+    const Vector<GridTrack>& tracks(GridTrackSizingDirection direction) const { return direction == GridTrackSizingDirection::ForColumns ? m_columns : m_rows; }
 
-    std::optional<LayoutUnit> freeSpace(GridTrackSizingDirection direction) const { return direction == ForColumns ? m_freeSpaceColumns : m_freeSpaceRows; }
+    std::optional<LayoutUnit> freeSpace(GridTrackSizingDirection direction) const { return direction == GridTrackSizingDirection::ForColumns ? m_freeSpaceColumns : m_freeSpaceRows; }
     void setFreeSpace(GridTrackSizingDirection, std::optional<LayoutUnit>);
 
-    std::optional<LayoutUnit> availableSpace(GridTrackSizingDirection direction) const { return direction == ForColumns ? m_availableSpaceColumns : m_availableSpaceRows; }
+    std::optional<LayoutUnit> availableSpace(GridTrackSizingDirection direction) const { return direction == GridTrackSizingDirection::ForColumns ? m_availableSpaceColumns : m_availableSpaceRows; }
     void setAvailableSpace(GridTrackSizingDirection, std::optional<LayoutUnit>);
 
     LayoutUnit computeTrackBasedSize() const;
@@ -242,7 +242,7 @@ private:
     LayoutUnit m_minContentSize;
     LayoutUnit m_maxContentSize;
 
-    enum SizingState {
+    enum class SizingState : uint8_t {
         ColumnSizingFirstIteration,
         RowSizingFirstIteration,
         RowSizingExtraIterationForSizeContainment,
@@ -301,7 +301,7 @@ protected:
     LayoutUnit computeTrackBasedSize() const { return m_algorithm.computeTrackBasedSize(); }
     GridTrackSizingDirection direction() const { return m_algorithm.m_direction; }
     double findFrUnitSize(const GridSpan& tracksSpan, LayoutUnit leftOverSpace) const { return m_algorithm.findFrUnitSize(tracksSpan, leftOverSpace); }
-    void distributeSpaceToTracks(Vector<WeakPtr<GridTrack>>& tracks, LayoutUnit& availableLogicalSpace) const { m_algorithm.distributeSpaceToTracks<TrackSizeComputationVariant::NotCrossingFlexibleTracks, MaximizeTracks>(tracks, nullptr, availableLogicalSpace); }
+    void distributeSpaceToTracks(Vector<WeakPtr<GridTrack>>& tracks, LayoutUnit& availableLogicalSpace) const { m_algorithm.distributeSpaceToTracks<TrackSizeComputationVariant::NotCrossingFlexibleTracks, TrackSizeComputationPhase::MaximizeTracks>(tracks, nullptr, availableLogicalSpace); }
     const RenderGrid* renderGrid() const { return m_algorithm.m_renderGrid; }
     std::optional<LayoutUnit> availableSpace() const { return m_algorithm.availableSpace(); }
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2912,11 +2912,11 @@ bool RenderBox::hasStretchedLogicalHeight() const
         return false;
     }
     if (containingBlock->isHorizontalWritingMode() != isHorizontalWritingMode()) {
-        if (is<RenderGrid>(this) && downcast<RenderGrid>(this)->isSubgridInParentDirection(ForColumns))
+        if (is<RenderGrid>(this) && downcast<RenderGrid>(this)->isSubgridInParentDirection(GridTrackSizingDirection::ForColumns))
             return true;
         return style.resolvedJustifySelf(&containingBlock->style(), containingBlock->selfAlignmentNormalBehavior(this)).position() == ItemPosition::Stretch;
     }
-    if (is<RenderGrid>(this) && downcast<RenderGrid>(this)->isSubgridInParentDirection(ForRows))
+    if (is<RenderGrid>(this) && downcast<RenderGrid>(this)->isSubgridInParentDirection(GridTrackSizingDirection::ForRows))
         return true;
     return style.resolvedAlignSelf(&containingBlock->style(), containingBlock->selfAlignmentNormalBehavior(this)).position() == ItemPosition::Stretch;
 }
@@ -2935,11 +2935,11 @@ bool RenderBox::hasStretchedLogicalWidth(StretchingMode stretchingMode) const
     }
     auto normalItemPosition = stretchingMode == StretchingMode::Any ? containingBlock->selfAlignmentNormalBehavior(this) : ItemPosition::Normal;
     if (containingBlock->isHorizontalWritingMode() != isHorizontalWritingMode()) {
-        if (is<RenderGrid>(this) && downcast<RenderGrid>(this)->isSubgridInParentDirection(ForRows))
+        if (is<RenderGrid>(this) && downcast<RenderGrid>(this)->isSubgridInParentDirection(GridTrackSizingDirection::ForRows))
             return true;
         return style.resolvedAlignSelf(&containingBlock->style(), normalItemPosition).position() == ItemPosition::Stretch;
     }
-    if (is<RenderGrid>(this) && downcast<RenderGrid>(this)->isSubgridInParentDirection(ForColumns))
+    if (is<RenderGrid>(this) && downcast<RenderGrid>(this)->isSubgridInParentDirection(GridTrackSizingDirection::ForColumns))
         return true;
     return style.resolvedJustifySelf(&containingBlock->style(), normalItemPosition).position() == ItemPosition::Stretch;
 }

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -47,7 +47,7 @@ public:
     LayoutUnit distributionOffset;
 };
 
-enum GridAxisPosition {GridAxisStart, GridAxisEnd, GridAxisCenter};
+enum class GridAxisPosition : uint8_t { GridAxisStart, GridAxisEnd, GridAxisCenter };
 
 class RenderGrid final : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderGrid);
@@ -98,11 +98,11 @@ public:
     bool isSubgrid(GridTrackSizingDirection) const;
     bool isSubgridRows() const
     {
-        return isSubgrid(ForRows);
+        return isSubgrid(GridTrackSizingDirection::ForRows);
     }
     bool isSubgridColumns() const
     {
-        return isSubgrid(ForColumns);
+        return isSubgrid(GridTrackSizingDirection::ForColumns);
     }
     bool isSubgridInParentDirection(GridTrackSizingDirection parentDirection) const;
 
@@ -173,7 +173,7 @@ private:
 
     static bool itemGridAreaIsWithinImplicitGrid(const GridArea& area, unsigned gridAxisLinesCount, GridTrackSizingDirection gridAxisDirection)
     {
-        auto itemSpan = gridAxisDirection == ForColumns ? area.columns : area.rows;
+        auto itemSpan = gridAxisDirection == GridTrackSizingDirection::ForColumns ? area.columns : area.rows;
         return itemSpan.startLine() <  gridAxisLinesCount && itemSpan.endLine() < gridAxisLinesCount;
     }
 

--- a/Source/WebCore/rendering/style/GridPosition.cpp
+++ b/Source/WebCore/rendering/style/GridPosition.cpp
@@ -40,14 +40,14 @@ static const int kGridMaxPosition = 1000000;
 
 void GridPosition::setExplicitPosition(int position, const String& namedGridLine)
 {
-    m_type = ExplicitPosition;
+    m_type = GridPositionType::ExplicitPosition;
     setIntegerPosition(position);
     m_namedGridLine = namedGridLine;
 }
 
 void GridPosition::setAutoPosition()
 {
-    m_type = AutoPosition;
+    m_type = GridPositionType::AutoPosition;
     m_integerPosition = 0;
 }
 
@@ -56,32 +56,32 @@ void GridPosition::setAutoPosition()
 // some precision here. It shouldn't be an issue in practice though.
 void GridPosition::setSpanPosition(int position, const String& namedGridLine)
 {
-    m_type = SpanPosition;
+    m_type = GridPositionType::SpanPosition;
     setIntegerPosition(position);
     m_namedGridLine = namedGridLine;
 }
 
 void GridPosition::setNamedGridArea(const String& namedGridArea)
 {
-    m_type = NamedGridAreaPosition;
+    m_type = GridPositionType::NamedGridAreaPosition;
     m_namedGridLine = namedGridArea;
 }
 
 int GridPosition::integerPosition() const
 {
-    ASSERT(type() == ExplicitPosition);
+    ASSERT(type() == GridPositionType::ExplicitPosition);
     return m_integerPosition;
 }
 
 String GridPosition::namedGridLine() const
 {
-    ASSERT(type() == ExplicitPosition || type() == SpanPosition || type() == NamedGridAreaPosition);
+    ASSERT(type() == GridPositionType::ExplicitPosition || type() == GridPositionType::SpanPosition || type() == GridPositionType::NamedGridAreaPosition);
     return m_namedGridLine;
 }
 
 int GridPosition::spanPosition() const
 {
-    ASSERT(type() == SpanPosition);
+    ASSERT(type() == GridPositionType::SpanPosition);
     return m_integerPosition;
 }
 
@@ -103,13 +103,13 @@ void GridPosition::setMaxPositionForTesting(unsigned maxPosition)
 TextStream& operator<<(TextStream& ts, const GridPosition& o)
 {
     switch (o.type()) {
-    case AutoPosition:
+    case GridPositionType::AutoPosition:
         return ts << "auto";
-    case ExplicitPosition:
+    case GridPositionType::ExplicitPosition:
         return ts << o.namedGridLine() << " " << o.integerPosition();
-    case SpanPosition:
+    case GridPositionType::SpanPosition:
         return ts << "span" << " " << o.namedGridLine() << " " << o.integerPosition();
-    case NamedGridAreaPosition:
+    case GridPositionType::NamedGridAreaPosition:
         return ts << o.namedGridLine();
     }
     return ts;

--- a/Source/WebCore/rendering/style/GridPosition.h
+++ b/Source/WebCore/rendering/style/GridPosition.h
@@ -35,14 +35,14 @@
 
 namespace WebCore {
 
-enum GridPositionType {
+enum class GridPositionType : uint8_t {
     AutoPosition,
     ExplicitPosition, // [ <integer> || <string> ]
     SpanPosition, // span && [ <integer> || <string> ]
     NamedGridAreaPosition // <ident>
 };
 
-enum GridPositionSide {
+enum class GridPositionSide : uint8_t {
     ColumnStartSide,
     ColumnEndSide,
     RowStartSide,
@@ -51,18 +51,12 @@ enum GridPositionSide {
 
 class GridPosition {
 public:
-    GridPosition()
-        : m_type(AutoPosition)
-        , m_integerPosition(0)
-    {
-    }
-
     bool isPositive() const { return integerPosition() > 0; }
 
     GridPositionType type() const { return m_type; }
-    bool isAuto() const { return m_type == AutoPosition; }
-    bool isSpan() const { return m_type == SpanPosition; }
-    bool isNamedGridArea() const { return m_type == NamedGridAreaPosition; }
+    bool isAuto() const { return m_type == GridPositionType::AutoPosition; }
+    bool isSpan() const { return m_type == GridPositionType::SpanPosition; }
+    bool isNamedGridArea() const { return m_type == GridPositionType::NamedGridAreaPosition; }
 
     WEBCORE_EXPORT void setExplicitPosition(int position, const String& namedGridLine);
     void setAutoPosition();
@@ -89,8 +83,8 @@ private:
 
     void setIntegerPosition(int integerPosition) { m_integerPosition = clampTo(integerPosition, min(), max()); }
 
-    GridPositionType m_type;
-    int m_integerPosition;
+    GridPositionType m_type { GridPositionType::AutoPosition };
+    int m_integerPosition { 0 };
     String m_namedGridLine;
 };
 

--- a/Source/WebCore/rendering/style/GridPositionsResolver.cpp
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.cpp
@@ -42,17 +42,17 @@ namespace WebCore {
 
 static inline bool isColumnSide(GridPositionSide side)
 {
-    return side == ColumnStartSide || side == ColumnEndSide;
+    return side == GridPositionSide::ColumnStartSide || side == GridPositionSide::ColumnEndSide;
 }
 
 static inline bool isStartSide(GridPositionSide side)
 {
-    return side == ColumnStartSide || side == RowStartSide;
+    return side == GridPositionSide::ColumnStartSide || side == GridPositionSide::RowStartSide;
 }
 
 static inline GridTrackSizingDirection directionFromSide(GridPositionSide side)
 {
-    return side == ColumnStartSide || side == ColumnEndSide ? ForColumns : ForRows;
+    return side == GridPositionSide::ColumnStartSide || side == GridPositionSide::ColumnEndSide ? GridTrackSizingDirection::ForColumns : GridTrackSizingDirection::ForRows;
 }
 
 static const String implicitNamedGridLineForSide(const String& lineName, GridPositionSide side)
@@ -68,10 +68,10 @@ static unsigned explicitGridSizeForSide(const RenderGrid& gridContainer, GridPos
 static inline GridPositionSide transposedSide(GridPositionSide side)
 {
     switch (side) {
-    case ColumnStartSide: return RowStartSide;
-    case ColumnEndSide: return RowEndSide;
-    case RowStartSide: return ColumnStartSide;
-    default: return ColumnEndSide;
+    case GridPositionSide::ColumnStartSide: return GridPositionSide::RowStartSide;
+    case GridPositionSide::ColumnEndSide: return GridPositionSide::RowEndSide;
+    case GridPositionSide::RowStartSide: return GridPositionSide::ColumnStartSide;
+    default: return GridPositionSide::ColumnEndSide;
     }
 }
 
@@ -94,7 +94,7 @@ NamedLineCollectionBase::NamedLineCollectionBase(const RenderGrid& initialGrid, 
     auto direction = directionFromSide(side);
     const auto* grid = &initialGrid;
     const auto* gridContainerStyle = &grid->style();
-    bool isRowAxis = direction == ForColumns;
+    bool isRowAxis = direction == GridTrackSizingDirection::ForColumns;
 
     m_lastLine = explicitGridSizeForSide(*grid, side);
 
@@ -234,7 +234,7 @@ NamedLineCollection::NamedLineCollection(const RenderGrid& initialGrid, const St
     auto direction = directionFromSide(currentSide);
     bool initialFlipped = GridLayoutFunctions::isFlippedDirection(initialGrid, direction);
     const RenderGrid* grid = &initialGrid;
-    bool isRowAxis = direction == ForColumns;
+    bool isRowAxis = direction == GridTrackSizingDirection::ForColumns;
 
     // If we're a subgrid, we want to inherit the line names from any ancestor grids.
     while (isRowAxis ? grid->isSubgridColumns() : grid->isSubgridRows()) {
@@ -360,7 +360,7 @@ static bool isIndefiniteSpan(GridPosition& initialPosition, GridPosition& finalP
 
 static void adjustGridPositionsFromStyle(const RenderBox& gridItem, GridTrackSizingDirection direction, GridPosition& initialPosition, GridPosition& finalPosition)
 {
-    bool isForColumns = direction == ForColumns;
+    bool isForColumns = direction == GridTrackSizingDirection::ForColumns;
     initialPosition = isForColumns ? gridItem.style().gridItemColumnStart() : gridItem.style().gridItemRowStart();
     finalPosition = isForColumns ? gridItem.style().gridItemColumnEnd() : gridItem.style().gridItemRowEnd();
 
@@ -393,20 +393,20 @@ unsigned GridPositionsResolver::explicitGridColumnCount(const RenderGrid& gridCo
 {
     if (gridContainer.isSubgridColumns()) {
         const RenderGrid& parent = *downcast<RenderGrid>(gridContainer.parent());
-        GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForChild(parent, gridContainer, ForColumns);
+        GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForChild(parent, gridContainer, GridTrackSizingDirection::ForColumns);
         return parent.gridSpanForChild(gridContainer, direction).integerSpan();
     }
-    return std::min<unsigned>(std::max(gridContainer.style().gridColumnTrackSizes().size() + gridContainer.autoRepeatCountForDirection(ForColumns), gridContainer.style().namedGridAreaColumnCount()), GridPosition::max());
+    return std::min<unsigned>(std::max(gridContainer.style().gridColumnTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForColumns), gridContainer.style().namedGridAreaColumnCount()), GridPosition::max());
 }
 
 unsigned GridPositionsResolver::explicitGridRowCount(const RenderGrid& gridContainer)
 {
     if (gridContainer.isSubgridRows()) {
         const RenderGrid& parent = *downcast<RenderGrid>(gridContainer.parent());
-        GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForChild(parent, gridContainer, ForRows);
+        GridTrackSizingDirection direction = GridLayoutFunctions::flowAwareDirectionForChild(parent, gridContainer, GridTrackSizingDirection::ForRows);
         return parent.gridSpanForChild(gridContainer, direction).integerSpan();
     }
-    return std::min<unsigned>(std::max(gridContainer.style().gridRowTrackSizes().size() + gridContainer.autoRepeatCountForDirection(ForRows), gridContainer.style().namedGridAreaRowCount()), GridPosition::max());
+    return std::min<unsigned>(std::max(gridContainer.style().gridRowTrackSizes().size() + gridContainer.autoRepeatCountForDirection(GridTrackSizingDirection::ForRows), gridContainer.style().namedGridAreaRowCount()), GridPosition::max());
 }
 
 static unsigned lookAheadForNamedGridLine(int start, unsigned numberOfLines, NamedLineCollection& linesCollection)
@@ -463,7 +463,7 @@ static int resolveNamedGridLinePositionFromStyle(const RenderGrid& gridContainer
 static GridSpan definiteGridSpanWithNamedLineSpanAgainstOpposite(int oppositeLine, const GridPosition& position, GridPositionSide side, NamedLineCollection& linesCollection)
 {
     int start, end;
-    if (side == RowStartSide || side == ColumnStartSide) {
+    if (side == GridPositionSide::RowStartSide || side == GridPositionSide::ColumnStartSide) {
         start = lookBackForNamedGridLine(oppositeLine - 1, position.spanPosition(), linesCollection);
         end = oppositeLine;
     } else {
@@ -512,12 +512,12 @@ static GridSpan resolveGridPositionAgainstOppositePosition(const RenderGrid& gri
 
 GridPositionSide GridPositionsResolver::initialPositionSide(GridTrackSizingDirection direction)
 {
-    return direction == ForColumns ? ColumnStartSide : RowStartSide;
+    return direction == GridTrackSizingDirection::ForColumns ? GridPositionSide::ColumnStartSide : GridPositionSide::RowStartSide;
 }
 
 GridPositionSide GridPositionsResolver::finalPositionSide(GridTrackSizingDirection direction)
 {
-    return direction == ForColumns ? ColumnEndSide : RowEndSide;
+    return direction == GridTrackSizingDirection::ForColumns ? GridPositionSide::ColumnEndSide : GridPositionSide::RowEndSide;
 }
 
 unsigned GridPositionsResolver::spanSizeForAutoPlacedItem(const RenderBox& gridItem, GridTrackSizingDirection direction)
@@ -541,7 +541,7 @@ unsigned GridPositionsResolver::spanSizeForAutoPlacedItem(const RenderBox& gridI
 static int resolveGridPositionFromStyle(const RenderGrid& gridContainer, const GridPosition& position, GridPositionSide side)
 {
     switch (position.type()) {
-    case ExplicitPosition: {
+    case GridPositionType::ExplicitPosition: {
         ASSERT(position.integerPosition());
 
         if (!position.namedGridLine().isNull())
@@ -556,7 +556,7 @@ static int resolveGridPositionFromStyle(const RenderGrid& gridContainer, const G
 
         return endOfTrack - resolvedPosition;
     }
-    case NamedGridAreaPosition:
+    case GridPositionType::NamedGridAreaPosition:
     {
         // First attempt to match the grid area's edge to a named grid area: if there is a named line with the name
         // ''<custom-ident>-start (for grid-*-start) / <custom-ident>-end'' (for grid-*-end), contributes the first such
@@ -577,8 +577,8 @@ static int resolveGridPositionFromStyle(const RenderGrid& gridContainer, const G
         // If none of the above works specs mandate to assume that all the lines in the implicit grid have this name.
         return explicitGridSizeForSide(gridContainer, side) + 1;
     }
-    case AutoPosition:
-    case SpanPosition:
+    case GridPositionType::AutoPosition:
+    case GridPositionType::SpanPosition:
         // 'auto' and span depend on the opposite position for resolution (e.g. grid-row: auto / 1 or grid-column: span 3 / "myHeader").
         ASSERT_NOT_REACHED();
         return 0;

--- a/Source/WebCore/rendering/style/GridPositionsResolver.h
+++ b/Source/WebCore/rendering/style/GridPositionsResolver.h
@@ -39,7 +39,7 @@ class RenderBox;
 class RenderGrid;
 class RenderStyle;
 
-enum GridTrackSizingDirection {
+enum class GridTrackSizingDirection : uint8_t {
     ForColumns,
     ForRows
 };

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1289,7 +1289,7 @@ inline bool BuilderConverter::createGridPosition(const CSSValue& value, GridPosi
 inline void BuilderConverter::createImplicitNamedGridLinesFromGridArea(const NamedGridAreaMap& namedGridAreas, NamedGridLinesMap& namedGridLines, GridTrackSizingDirection direction)
 {
     for (auto& area : namedGridAreas.map) {
-        GridSpan areaSpan = direction == ForRows ? area.value.rows : area.value.columns;
+        GridSpan areaSpan = direction == GridTrackSizingDirection::ForRows ? area.value.rows : area.value.columns;
         {
             auto& startVector = namedGridLines.map.add(area.key + "-start"_s, Vector<unsigned>()).iterator->value;
             startVector.append(areaSpan.startLine());

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1847,8 +1847,8 @@ inline void BuilderCustom::applyValueGridTemplateAreas(BuilderState& builderStat
 
     NamedGridLinesMap implicitNamedGridColumnLines;
     NamedGridLinesMap implicitNamedGridRowLines;
-    BuilderConverter::createImplicitNamedGridLinesFromGridArea(newNamedGridAreas, implicitNamedGridColumnLines, ForColumns);
-    BuilderConverter::createImplicitNamedGridLinesFromGridArea(newNamedGridAreas, implicitNamedGridRowLines, ForRows);
+    BuilderConverter::createImplicitNamedGridLinesFromGridArea(newNamedGridAreas, implicitNamedGridColumnLines, GridTrackSizingDirection::ForColumns);
+    BuilderConverter::createImplicitNamedGridLinesFromGridArea(newNamedGridAreas, implicitNamedGridRowLines, GridTrackSizingDirection::ForRows);
     builderState.style().setImplicitNamedGridColumnLines(implicitNamedGridColumnLines);
     builderState.style().setImplicitNamedGridRowLines(implicitNamedGridRowLines);
 


### PR DESCRIPTION
#### 0d2e95a2786bc89afe987be509593e5edbeece34
<pre>
[css-grid] enums in grid code should be enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=262975">https://bugs.webkit.org/show_bug.cgi?id=262975</a>
rdar://problem/116755214

Reviewed by Simon Fraser.

The follwing are enums in grid code that should be enum classes.

cacheBaselineAlignedChildren uses bitwise operators with GridAxis so
a couple of static_casts were needed there.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForGridTrackSizeList):
(WebCore::valueForGridTrackList):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/rendering/Grid.cpp:
(WebCore::Grid::numTracks const):
(WebCore::Grid::ensureGridSize):
(WebCore::Grid::explicitGridStart const):
(WebCore::Grid::setAutoRepeatTracks):
(WebCore::Grid::autoRepeatTracks const):
(WebCore::Grid::hasAutoRepeatEmptyTracks const):
(WebCore::Grid::autoRepeatEmptyTracks const):
(WebCore::Grid::gridItemSpan const):
(WebCore::GridIterator::GridIterator):
(WebCore::GridIterator::nextGridItem):
(WebCore::GridIterator::isEmptyAreaEnough const):
(WebCore::GridIterator::nextEmptyGridArea):
(WebCore::GridIterator::createForSubgrid):
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::isHorizontalBaselineAxis const):
(WebCore::GridBaselineAlignment::isParallelToBaselineAxisForChild const):
(WebCore::GridBaselineAlignment::baselineGroupForChild const):
(WebCore::GridBaselineAlignment::updateBaselineAlignmentContext):
(WebCore::GridBaselineAlignment::clear):
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::marginStartIsAuto):
(WebCore::GridLayoutFunctions::marginEndIsAuto):
(WebCore::GridLayoutFunctions::childHasMargin):
(WebCore::GridLayoutFunctions::computeMarginLogicalSizeForChild):
(WebCore::GridLayoutFunctions::hasRelativeOrIntrinsicSizeForChild):
(WebCore::GridLayoutFunctions::extraMarginForSubgrid):
(WebCore::GridLayoutFunctions::marginLogicalSizeForChild):
(WebCore::GridLayoutFunctions::flowAwareDirectionForChild):
(WebCore::GridLayoutFunctions::flowAwareDirectionForParent):
(WebCore::GridLayoutFunctions::hasOverridingContainingBlockContentSizeForChild):
(WebCore::GridLayoutFunctions::overridingContainingBlockContentSizeForChild):
(WebCore::GridLayoutFunctions::isFlippedDirection):
* Source/WebCore/rendering/GridLayoutFunctions.h:
(): Deleted.
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::performMasonryPlacement):
(WebCore::GridMasonryLayout::allocateCapacityForMasonryVectors):
(WebCore::GridMasonryLayout::setItemGridAxisContainingBlockToGridArea):
(WebCore::GridMasonryLayout::masonryAxisMarginBoxForItem):
(WebCore::GridMasonryLayout::gridAxisDirection const):
(WebCore::GridMasonryLayout::gridAxisSpanFromArea const):
(WebCore::GridMasonryLayout::masonryGridAreaFromGridAxisSpan const):
* Source/WebCore/rendering/GridMasonryLayout.h:
(WebCore::GridMasonryLayout::itemGridAreaStartsAtFirstLine):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::gridAxisForDirection):
(WebCore::gridDirectionForAxis):
(WebCore::hasRelativeMarginOrPaddingForChild):
(WebCore::hasRelativeOrIntrinsicSizeForChild):
(WebCore::setOverridingContainingBlockContentSizeForChild):
(WebCore::GridTrackSizingAlgorithm::setFreeSpace):
(WebCore::GridTrackSizingAlgorithm::setAvailableSpace):
(WebCore::GridTrackSizingAlgorithm::rawGridTrackSize const):
(WebCore::GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhase const):
(WebCore::shouldProcessTrackForTrackSizeComputationPhase):
(WebCore::trackSizeForTrackSizeComputationPhase):
(WebCore::updateTrackSizeForTrackSizeComputationPhase):
(WebCore::trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase):
(WebCore::markAsInfinitelyGrowableForTrackSizeComputationPhase):
(WebCore::GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems):
(WebCore::clampGrowthShareIfNeeded):
(WebCore::distributeItemIncurredIncreaseToTrack):
(WebCore::GridTrackSizingAlgorithm::distributeSpaceToTracks const):
(WebCore::GridTrackSizingAlgorithm::estimatedGridAreaBreadthForChild const):
(WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForChild const):
(WebCore::GridTrackSizingAlgorithm::computeGridContainerIntrinsicSizes):
(WebCore::GridTrackSizingAlgorithmStrategy::logicalHeightForChild const):
(WebCore::GridTrackSizingAlgorithmStrategy::minContentForChild const):
(WebCore::GridTrackSizingAlgorithmStrategy::maxContentForChild const):
(WebCore::GridTrackSizingAlgorithmStrategy::minSizeForChild const):
(WebCore::GridTrackSizingAlgorithm::canParticipateInBaselineAlignment const):
(WebCore::GridTrackSizingAlgorithm::participateInBaselineAlignment const):
(WebCore::GridTrackSizingAlgorithm::cacheBaselineAlignedItem):
(WebCore::GridTrackSizingAlgorithm::copyBaselineItemsCache):
(WebCore::GridTrackSizingAlgorithmStrategy::minLogicalSizeForChild const):
(WebCore::IndefiniteSizeStrategy::layoutGridItemForMinSizeComputation const):
(WebCore::IndefiniteSizeStrategy::recomputeUsedFlexFractionIfNeeded const):
(WebCore::IndefiniteSizeStrategy::freeSpaceForStretchAutoTracksStep const):
(WebCore::DefiniteSizeStrategy::minLogicalSizeForChild const):
(WebCore::DefiniteSizeStrategy::minContentForChild const):
(WebCore::GridTrackSizingAlgorithm::initializeTrackSizes):
(WebCore::marginAndBorderAndPaddingForEdge):
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):
(WebCore::GridTrackSizingAlgorithm::advanceNextState):
(WebCore::GridTrackSizingAlgorithm::isValidTransition const):
(WebCore::GridTrackSizingAlgorithm::setup):
(WebCore::GridTrackSizingAlgorithm::computeBaselineAlignmentContext):
(WebCore::GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid):
(WebCore::GridTrackSizingAlgorithm::run):
(WebCore::GridTrackSizingAlgorithm::reset):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
(WebCore::GridTrackSizingAlgorithmStrategy::distributeSpaceToTracks const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hasStretchedLogicalHeight const):
(WebCore::RenderBox::hasStretchedLogicalWidth const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::selfAlignmentForChild const):
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::availableSpaceForGutters const):
(WebCore::RenderGrid::computeTrackSizesForDefiniteSize):
(WebCore::RenderGrid::repeatTracksSizingIfNeeded):
(WebCore::cacheBaselineAlignedChildren):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):
(WebCore::RenderGrid::gridGap const):
(WebCore::RenderGrid::gridItemOffset const):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
(WebCore::RenderGrid::computeTrackSizesForIndefiniteSize const):
(WebCore::RenderGrid::shouldCheckExplicitIntrinsicInnerLogicalSize const):
(WebCore::RenderGrid::explicitIntrinsicInnerLogicalSize const):
(WebCore::RenderGrid::computeAutoRepeatTracksCount const):
(WebCore::RenderGrid::computeEmptyTracksForAutoRepeat const):
(WebCore::RenderGrid::clampAutoRepeatTracks const):
(WebCore::RenderGrid::isMasonry const):
(WebCore::RenderGrid::placeItemsOnGrid):
(WebCore::RenderGrid::performGridItemsPreLayout const):
(WebCore::RenderGrid::populateExplicitGridAndOrderIterator):
(WebCore::RenderGrid::createEmptyGridAreaAtSpecifiedPositionsOutsideGrid const):
(WebCore::RenderGrid::placeSpecifiedMajorAxisItemsOnGrid):
(WebCore::RenderGrid::placeAutoMajorAxisItemOnGrid):
(WebCore::RenderGrid::autoPlacementMajorAxisDirection const):
(WebCore::RenderGrid::autoPlacementMinorAxisDirection const):
(WebCore::RenderGrid::trackSizesForComputedStyle const):
(WebCore::overrideSizeChanged):
(WebCore::RenderGrid::updateGridAreaLogicalSize const):
(WebCore::RenderGrid::updateGridAreaForAspectRatioItems):
(WebCore::RenderGrid::layoutGridItems):
(WebCore::RenderGrid::layoutMasonryItems):
(WebCore::RenderGrid::hasStaticPositionForChild const):
(WebCore::RenderGrid::layoutPositionedObject):
(WebCore::RenderGrid::gridAreaBreadthForChildIncludingAlignmentOffsets const):
(WebCore::RenderGrid::populateGridPositionsForDirection):
(WebCore::RenderGrid::alignSelfForChild const):
(WebCore::RenderGrid::justifySelfForChild const):
(WebCore::RenderGrid::applyStretchAlignmentToChildIfNeeded):
(WebCore::RenderGrid::applySubgridStretchAlignmentToChildIfNeeded):
(WebCore::RenderGrid::isChildEligibleForMarginTrim const):
(WebCore::RenderGrid::isBaselineAlignmentForChild const):
(WebCore::RenderGrid::getBaselineChild const):
(WebCore::RenderGrid::columnAxisBaselineOffsetForChild const):
(WebCore::RenderGrid::rowAxisBaselineOffsetForChild const):
(WebCore::RenderGrid::columnAxisPositionForChild const):
(WebCore::RenderGrid::rowAxisPositionForChild const):
(WebCore::RenderGrid::columnAxisOffsetForChild const):
(WebCore::RenderGrid::rowAxisOffsetForChild const):
(WebCore::RenderGrid::isSubgrid const):
(WebCore::RenderGrid::gridAreaBreadthForOutOfFlowChild):
(WebCore::RenderGrid::logicalOffsetForOutOfFlowChild const):
(WebCore::RenderGrid::gridAreaPositionForOutOfFlowChild const):
(WebCore::RenderGrid::gridAreaPositionForInFlowChild const):
(WebCore::RenderGrid::contentAlignment const):
(WebCore::RenderGrid::computeContentPositionAndDistributionOffset):
(WebCore::RenderGrid::setLogicalPositionForChild const):
(WebCore::RenderGrid::setLogicalOffsetForChild const):
(WebCore::RenderGrid::logicalOffsetForChild const):
(WebCore::RenderGrid::numTracks const):
(WebCore::RenderGrid::computeGridPositionsForOutOfFlowChild const):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/style/GridPosition.cpp:
(WebCore::GridPosition::setExplicitPosition):
(WebCore::GridPosition::setAutoPosition):
(WebCore::GridPosition::setSpanPosition):
(WebCore::GridPosition::setNamedGridArea):
(WebCore::GridPosition::integerPosition const):
(WebCore::GridPosition::namedGridLine const):
(WebCore::GridPosition::spanPosition const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/GridPosition.h:
(WebCore::GridPosition::GridPosition):
(WebCore::GridPosition::isAuto const):
(WebCore::GridPosition::isSpan const):
(WebCore::GridPosition::isNamedGridArea const):
(): Deleted.
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::isColumnSide):
(WebCore::isStartSide):
(WebCore::directionFromSide):
(WebCore::transposedSide):
(WebCore::NamedLineCollectionBase::NamedLineCollectionBase):
(WebCore::NamedLineCollection::NamedLineCollection):
(WebCore::adjustGridPositionsFromStyle):
(WebCore::GridPositionsResolver::explicitGridColumnCount):
(WebCore::GridPositionsResolver::explicitGridRowCount):
(WebCore::definiteGridSpanWithNamedLineSpanAgainstOpposite):
(WebCore::GridPositionsResolver::initialPositionSide):
(WebCore::GridPositionsResolver::finalPositionSide):
(WebCore::resolveGridPositionFromStyle):
* Source/WebCore/rendering/style/GridPositionsResolver.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::createImplicitNamedGridLinesFromGridArea):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueGridTemplateAreas):

Canonical link: <a href="https://commits.webkit.org/269184@main">https://commits.webkit.org/269184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51356fe7e190f4b63425e720cb103c3845746af5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21287 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24500 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26009 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23871 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17378 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19740 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5202 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->