### PR TITLE
[JSC] REGRESSION(269099@main) Fix the regression caused by HeapLocation with an extra state

### DIFF
--- a/JSTests/stress/getbyoffset-cse-consistency-2.js
+++ b/JSTests/stress/getbyoffset-cse-consistency-2.js
@@ -1,0 +1,45 @@
+
+let a = {"x": 3};
+a.y1 = 3.3;
+
+let b = {};
+let res = 42;
+b.__defineGetter__("y2", function () {
+    res = 43;
+    return {};
+});
+b.x = 1.1;
+
+let c = {};
+c.slot_1 = 1.1;
+
+function func(flag, arg0, arg1) {
+    let tmp = b;
+    if (flag) {
+        tmp = a;
+    }
+    if (arg1 > 100) {
+        return;
+    }
+    for (let i = 0; i < 2; i++) {
+        if (flag) {
+            var x = tmp.x;
+        } else {
+            var x = tmp.x;
+        }
+        arg0.y = 3.3;
+    }
+    "" + x;
+    c.slot_1 = x;
+}
+
+for (let i = 0; i < 0x100000; i++) {
+    func(i % 2, {}, i);
+}
+
+b.x
+func(0, {}, 1);
+c.slot_1
+
+if (res == 43)
+    throw "BAD!";

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -252,7 +252,8 @@ inline KillStatus killStatusForDoesKill(bool doesKill)
 
 enum class PlanStage {
     Initial,
-    AfterFixup
+    AfterFixup,
+    LICMAndLater
 };
 
 // If possible, this will acquire a lock to make sure that if multiple threads

--- a/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
@@ -63,6 +63,9 @@ public:
     
     bool run()
     {
+        ASSERT(m_graph.m_planStage <= PlanStage::LICMAndLater);
+        m_graph.m_planStage = PlanStage::LICMAndLater;
+
         DFG_ASSERT(m_graph, nullptr, m_graph.m_form == SSA);
         
         m_graph.ensureSSADominators();


### PR DESCRIPTION
#### dcfc255035aed5598df75a58f90a3e1dfeb415fa
<pre>
[JSC] REGRESSION(269099@main) Fix the regression caused by HeapLocation with an extra state
<a href="https://bugs.webkit.org/show_bug.cgi?id=262979">https://bugs.webkit.org/show_bug.cgi?id=262979</a>
rdar://116764992

Reviewed by Yusuke Suzuki.

Previously, we landed a patch (269099@main) to introduce a new HeapLocation
constructor with an extra state, which might disable certain optimizations in
DFG and FTL and cause regressions. This patch fixes the issue by enabling
the new HeapLocation construction only after LICM phase.

* Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
(JSC::DFG::performGlobalCSE):
(JSC::DFG::performGlobalCSESlow):
* Source/JavaScriptCore/dfg/DFGCSEPhase.h:
* Source/JavaScriptCore/dfg/DFGClobberSet.cpp:
(JSC::DFG::addReads):
(JSC::DFG::addWrites):
(JSC::DFG::addReadsAndWrites):
(JSC::DFG::readsOverlap):
(JSC::DFG::writesOverlap):
* Source/JavaScriptCore/dfg/DFGClobberize.cpp:
(JSC::DFG::doesWrites):
(JSC::DFG::accessesOverlap):
(JSC::DFG::writesOverlap):
(JSC::DFG::clobbersHeap):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp:
(JSC::DFG::clobbersExitState):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h:
(JSC::DFG::preciseLocalClobberize):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileCurrentBlock):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileBlock):
(JSC::FTL::DFG::LowerDFGToB3::compileNode):

Canonical link: <a href="https://commits.webkit.org/269295@main">https://commits.webkit.org/269295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dcbc0443e1e00eb8c0080dc8d71cef12d4391b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23777 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20275 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21379 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24629 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26119 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19042 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24004 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17476 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25314 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19851 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5976 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5273 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24057 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26586 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20451 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5808 "Passed tests") | 
<!--EWS-Status-Bubble-End-->