### PR TITLE
_WKWebExtensionMatchPattern matchPatternWithString should fail if passed a string with a port.

### DIFF
--- a/Source/WebCore/page/UserContentURLPattern.cpp
+++ b/Source/WebCore/page/UserContentURLPattern.cpp
@@ -54,6 +54,29 @@ UserContentURLPattern::UserContentURLPattern(StringView scheme, StringView host,
         return;
     }
 
+    // No username or password is allowed in patterns.
+    if (m_host.find('@') != notFound) {
+        m_error = Error::InvalidHost;
+        return;
+    }
+
+    // No port is allowed in patterns.
+    if (m_host.startsWith('[')) {
+        auto ipv6End = m_host.find(']');
+        if (ipv6End == notFound) {
+            m_error = Error::InvalidHost;
+            return;
+        }
+
+        if (m_host.find(':', ipv6End) != notFound) {
+            m_error = Error::InvalidHost;
+            return;
+        }
+    } else if (m_host.find(':') != notFound) {
+        m_error = Error::InvalidHost;
+        return;
+    }
+
     m_path = path.toString();
     if (!m_path.startsWith("/"_s)) {
         m_error = Error::MissingPath;
@@ -142,6 +165,21 @@ UserContentURLPattern::Error UserContentURLPattern::parse(StringView pattern)
 
     // No other '*' can occur in the host after it is normalized.
     if (m_host.find('*') != notFound)
+        return Error::InvalidHost;
+
+    // No username or password is allowed in patterns.
+    if (m_host.find('@') != notFound)
+        return Error::InvalidHost;
+
+    // No port is allowed in patterns.
+    if (m_host.startsWith('[')) {
+        auto ipv6End = m_host.find(']');
+        if (ipv6End == notFound)
+            return Error::InvalidHost;
+
+        if (m_host.find(':', ipv6End) != notFound)
+            return Error::InvalidHost;
+    } else if (m_host.find(':') != notFound)
         return Error::InvalidHost;
 
     m_path = pattern.right(pattern.length() - pathStartPos).toString();


### PR DESCRIPTION
#### a15778d2d11bef82741c4291808af1f0fde0f909
<pre>
_WKWebExtensionMatchPattern matchPatternWithString should fail if passed a string with a port.
<a href="https://webkit.org/b/262976">https://webkit.org/b/262976</a>
rdar://problem/116760000

Reviewed by Brian Weinstein.

Return InvalidHost error if a pattern is passed that has a port. Ports are not valid in Chrome and
Firefox, and the UserContentURLPattern class didn&apos;t check them either. It was happily putting the
port in the host string and failing to match later.

Also return InvalidHost if the host has &quot;@&quot;, which is used for user login info.

* Source/WebCore/page/UserContentURLPattern.cpp:
(WebCore::UserContentURLPattern::UserContentURLPattern):
(WebCore::UserContentURLPattern::parse):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/269182@main">https://commits.webkit.org/269182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d9a5cdffe6b0063ffc44fcbc42aadc5267284da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21810 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/22038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23682 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22335 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24534 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/18790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26028 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23891 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19767 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/23978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2709 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->