### PR TITLE
[Cocoa] CRASH in RemoteMediaPlayerProxy::updateVideoFullscreenInlineImage

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -30,6 +30,7 @@
 #include "MediaPlayerPrivateAVFoundation.h"
 #include "VideoFrameMetadata.h"
 #include <CoreMedia/CMTime.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/Observer.h>
 #include <wtf/RobinHoodHashMap.h>
@@ -260,8 +261,8 @@ private:
     void destroyImageGenerator();
     RetainPtr<CGImageRef> createImageForTimeInRect(float, const FloatRect&);
 
-    enum class UpdateType { UpdateSynchronously, UpdateAsynchronously };
-    void updateLastImage(UpdateType type = UpdateType::UpdateAsynchronously);
+    using UpdateCompletion = CompletionHandler<void()>;
+    void updateLastImage(UpdateCompletion&&);
 
     void createVideoOutput();
     void destroyVideoOutput();
@@ -271,7 +272,9 @@ private:
     RefPtr<VideoFrame> videoFrameForCurrentTime() final;
     RefPtr<NativeImage> nativeImageForCurrentTime() final;
     DestinationColorSpace colorSpace() final;
-    void waitForVideoOutputMediaDataWillChange();
+
+    enum class UpdateResult { Succeeded, Failed, TimedOut, ObjectDestroyed };
+    UpdateResult waitForVideoOutputMediaDataWillChange();
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     void keyAdded() final;


### PR DESCRIPTION
#### 3e536cdd2b1fe184627a33fb98024070f0fa2a83
<pre>
[Cocoa] CRASH in RemoteMediaPlayerProxy::updateVideoFullscreenInlineImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=258898">https://bugs.webkit.org/show_bug.cgi?id=258898</a>
rdar://107296485

Reviewed by Eric Carlson.

A command to destroy the MediaPlayer may be received while MediaPlayerPrivateAVFoundationObjC
is spinning the RunLoop in waitForVideoOutputMediaDataWillChange(). Detect this by instantiating
a WeakPtr in waitForVideoOutputMediaDataWillChange() and bailing early with an error code if the
WeakPtr has been invalidated while spinning the RunLoop.

Modify updateLastImage() to take a CompletionHandler, which will only fire if
waitForVideoOutputMediaDataWillChange() returns a non-exceptional result. If that method
detects that the WeakPtr was invalidated, the completion handler will not be called
(which will trigger an ASSERT in debug builds).

Update all the callers of updateLastImage() to do their subsequent work in the completion handler
they pass to updateLastImage().

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateVideoFullscreenInlineImage):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateLastImage):
(WebCore::MediaPlayerPrivateAVFoundationObjC::paintWithVideoOutput):
(WebCore::MediaPlayerPrivateAVFoundationObjC::nativeImageForCurrentTime):
(WebCore::MediaPlayerPrivateAVFoundationObjC::colorSpace):
(WebCore::MediaPlayerPrivateAVFoundationObjC::waitForVideoOutputMediaDataWillChange):

Originally-landed-as: 265870.11@safari-7616-branch (1fb95912042f). rdar://116424357
Canonical link: <a href="https://commits.webkit.org/269212@main">https://commits.webkit.org/269212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e4f98116109192c120e0233b6ab65f64b42596

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21792 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21303 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24514 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26017 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23879 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20411 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17383 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-removed.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19751 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23964 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2719 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->