### PR TITLE
REGRESSION: WebKit provides rectilinear selection rects for rotated text in images

### DIFF
--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -144,4 +144,33 @@ TextStream& operator<<(TextStream& ts, const EditorState& editorState)
     return ts;
 }
 
+void EditorState::clipOwnedRectExtentsToNumericLimits()
+{
+    auto sanitizePostLayoutData = [](auto& postLayoutData) {
+#if PLATFORM(MAC)
+        postLayoutData.selectionBoundingRect = postLayoutData.selectionBoundingRect.toRectWithExtentsClippedToNumericLimits();
+#else
+        UNUSED_PARAM(postLayoutData);
+#endif
+    };
+    if (hasPostLayoutData())
+        sanitizePostLayoutData(*postLayoutData);
+
+    auto sanitizeVisualData = [](auto& visualData) {
+#if PLATFORM(IOS_FAMILY)
+        visualData.selectionClipRect = visualData.selectionClipRect.toRectWithExtentsClippedToNumericLimits();
+        visualData.caretRectAtEnd = visualData.caretRectAtEnd.toRectWithExtentsClippedToNumericLimits();
+        visualData.markedTextCaretRectAtStart = visualData.markedTextCaretRectAtStart.toRectWithExtentsClippedToNumericLimits();
+        visualData.markedTextCaretRectAtEnd = visualData.markedTextCaretRectAtEnd.toRectWithExtentsClippedToNumericLimits();
+#endif
+#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
+        visualData.caretRectAtStart = visualData.caretRectAtStart.toRectWithExtentsClippedToNumericLimits();
+#else
+        UNUSED_PARAM(visualData);
+#endif
+    };
+    if (hasVisualData())
+        sanitizeVisualData(*visualData);
+}
+
 } // namespace WebKit


### PR DESCRIPTION
#### 54304685a9d46278fd8c97a05b1b9aeaeb8d5623
<pre>
REGRESSION: WebKit provides rectilinear selection rects for rotated text in images
<a href="https://bugs.webkit.org/show_bug.cgi?id=259888">https://bugs.webkit.org/show_bug.cgi?id=259888</a>
rdar://113287677

Reviewed by Wenson Hsieh.

`EditorState::clipOwnedRectExtentsToNumericLimits` was erroneously converting some selection
geometries from quads to rects.

Fix by removing these conversions. Since `FloatQuad`s have no notion of validity, there is no
need to clip them to numeric limits.

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::EditorState::clipOwnedRectExtentsToNumericLimits):

Originally-landed-as: 265870.235@safari-7616-branch (bfc6efd0dc4e). rdar://116426292
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54304685a9d46278fd8c97a05b1b9aeaeb8d5623

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21796 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22026 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22845 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23667 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20178 "Hash 54304685 for PR 18915 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26253 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22323 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/23667 "Hash 54304685 for PR 18915 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22024 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/26253 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/22845 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24519 "Hash 54304685 for PR 18915 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/26253 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/22845 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/24519 "Hash 54304685 for PR 18915 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/26253 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/22845 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/24519 "Hash 54304685 for PR 18915 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20413 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/22323 "Hash 54304685 for PR 18915 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19755 "Hash 54304685 for PR 18915 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/22845 "Hash 54304685 for PR 18915 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23966 "Hash 54304685 for PR 18915 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20350 "Hash 54304685 for PR 18915 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->