### PR TITLE
Regression(267014@main) Flaky crash under WebKit::GPUConnectionToWebProcess::didReceiveMessage()

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -272,7 +272,6 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
     , m_presentingApplicationAuditToken(WTFMove(parameters.presentingApplicationAuditToken))
 #endif
     , m_isLockdownModeEnabled(parameters.isLockdownModeEnabled)
-    , m_allowTestOnlyIPC(parameters.allowTestOnlyIPC)
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
     , m_routingArbitrator(LocalAudioSessionRoutingArbitrator::create(*this))
 #endif

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -135,8 +135,6 @@ public:
     bool isWebGPUEnabled() const { return m_preferences.isWebGPUEnabled; }
     bool isWebGLEnabled() const { return m_preferences.isWebGLEnabled; }
 
-    void updatePreferences(const GPUProcessPreferencesForWebProcess& preferences) { m_preferences = preferences; }
-
     using WebCore::NowPlayingManager::Client::weakPtrFactory;
     using WebCore::NowPlayingManager::Client::WeakValueType;
     using WebCore::NowPlayingManager::Client::WeakPtrImplType;
@@ -154,7 +152,7 @@ public:
     PAL::SessionID sessionID() const { return m_sessionID; }
 
     bool isLockdownModeEnabled() const { return m_isLockdownModeEnabled; }
-    bool allowTestOnlyIPC() const { return m_allowTestOnlyIPC; }
+    bool allowTestOnlyIPC() const { return m_preferences.allowTestOnlyIPC; }
 
     Logger& logger();
 
@@ -407,7 +405,6 @@ private:
     RefPtr<RemoteRemoteCommandListenerProxy> m_remoteRemoteCommandListener;
     bool m_isActiveNowPlayingProcess { false };
     const bool m_isLockdownModeEnabled { false };
-    const bool m_allowTestOnlyIPC { false };
 #if ENABLE(MEDIA_SOURCE)
     bool m_mockMediaSourceEnabled { false };
 #endif
@@ -418,7 +415,9 @@ private:
 #if ENABLE(IPC_TESTING_API)
     IPCTester m_ipcTester;
 #endif
-    GPUProcessPreferencesForWebProcess m_preferences;
+    // GPU preferences don't change for a given WebProcess. Pages that use different GPUProcessPreferences
+    // cannot be in the same WebProcess.
+    const GPUProcessPreferencesForWebProcess m_preferences;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -118,12 +118,6 @@ void GPUProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& de
     didReceiveGPUProcessMessage(connection, decoder);
 }
 
-void GPUProcess::updatePreferencesForWebProcess(WebCore::ProcessIdentifier processIdentifier, const GPUProcessPreferencesForWebProcess& preferences)
-{
-    if (auto* connection = m_webProcessConnections.get(processIdentifier))
-        connection->updatePreferences(preferences);
-}
-
 void GPUProcess::createGPUConnectionToWebProcess(WebCore::ProcessIdentifier identifier, PAL::SessionID sessionID, IPC::Connection::Handle&& connectionHandle, GPUProcessConnectionParameters&& parameters, CompletionHandler<void()>&& completionHandler)
 {
     RELEASE_LOG(Process, "%p - GPUProcess::createGPUConnectionToWebProcess: processIdentifier=%" PRIu64, this, identifier.toUInt64());

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -151,7 +151,6 @@ private:
     void platformInitializeGPUProcess(GPUProcessCreationParameters&);
     void updateGPUProcessPreferences(GPUProcessPreferences&&);
     void createGPUConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&, CompletionHandler<void()>&&);
-    void updatePreferencesForWebProcess(WebCore::ProcessIdentifier, const GPUProcessPreferencesForWebProcess&);
     void addSession(PAL::SessionID, GPUProcessSessionParameters&&);
     void removeSession(PAL::SessionID);
     void updateSandboxAccess(const Vector<SandboxExtension::Handle>&);

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -26,7 +26,6 @@ messages -> GPUProcess LegacyReceiver {
     InitializeGPUProcess(struct WebKit::GPUProcessCreationParameters processCreationParameters)
 
     CreateGPUConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::Connection::Handle connectionHandle, struct WebKit::GPUProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply
-    UpdatePreferencesForWebProcess(WebCore::ProcessIdentifier processIdentifier, struct WebKit::GPUProcessPreferencesForWebProcess preferences)
     UpdateGPUProcessPreferences(struct WebKit::GPUProcessPreferences preferences)
     UpdateSandboxAccess(Vector<WebKit::SandboxExtension::Handle> extensions);
 

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.h
@@ -41,7 +41,6 @@ struct GPUProcessConnectionParameters {
 #if ENABLE(IPC_TESTING_API)
     bool ignoreInvalidMessageForTesting { false };
 #endif
-    bool allowTestOnlyIPC { false };
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> presentingApplicationAuditToken;
 #endif

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
@@ -29,7 +29,6 @@
 #if ENABLE(IPC_TESTING_API)
     bool ignoreInvalidMessageForTesting;
 #endif
-    bool allowTestOnlyIPC;
 #if HAVE(AUDIT_TOKEN)
     std::optional<audit_token_t> presentingApplicationAuditToken;
 #endif

--- a/Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.h
+++ b/Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.h
@@ -33,6 +33,7 @@ struct GPUProcessPreferencesForWebProcess {
     bool isWebGLEnabled { false };
     bool isWebGPUEnabled { false };
     bool isDOMRenderingEnabled { false };
+    bool allowTestOnlyIPC { false };
 
     friend bool operator==(const GPUProcessPreferencesForWebProcess&, const GPUProcessPreferencesForWebProcess&) = default;
 };

--- a/Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.serialization.in
@@ -26,6 +26,7 @@ struct WebKit::GPUProcessPreferencesForWebProcess {
     bool isWebGLEnabled;
     bool isWebGPUEnabled;
     bool isDOMRenderingEnabled;
+    bool allowTestOnlyIPC;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -245,4 +245,19 @@ void PageConfiguration::setApplicationManifest(ApplicationManifest* applicationM
 }
 #endif
 
+#if ENABLE(GPU_PROCESS)
+WebKit::GPUProcessPreferencesForWebProcess PageConfiguration::preferencesForGPUProcess() const
+{
+    RefPtr preferences = m_data.preferences;
+    RELEASE_ASSERT(preferences);
+
+    return {
+        preferences->webGLEnabled(),
+        preferences->webGPUEnabled(),
+        preferences->useGPUProcessForDOMRenderingEnabled(),
+        allowTestOnlyIPC()
+    };
+}
+#endif
+
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -50,6 +50,8 @@ class WebProcessPool;
 class WebUserContentControllerProxy;
 class WebsiteDataStore;
 
+struct GPUProcessPreferencesForWebProcess;
+
 #if ENABLE(WK_WEB_EXTENSIONS)
 class WebExtensionController;
 #endif
@@ -222,6 +224,10 @@ public:
 
     void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_data.contentSecurityPolicyModeForExtension = mode; }
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_data.contentSecurityPolicyModeForExtension; }
+
+#if ENABLE(GPU_PROCESS)
+    WebKit::GPUProcessPreferencesForWebProcess preferencesForGPUProcess() const;
+#endif
 
 private:
     struct Data {

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -448,11 +448,6 @@ std::optional<bool> GPUProcessProxy::s_hasVP9HardwareDecoder;
 std::optional<bool> GPUProcessProxy::s_hasVP9ExtensionSupport;
 #endif
 
-void GPUProcessProxy::updatePreferencesForWebProcess(WebProcessProxy& webProcessProxy, const GPUProcessPreferencesForWebProcess& preferences)
-{
-    send(Messages::GPUProcess::UpdatePreferencesForWebProcess(webProcessProxy.coreProcessIdentifier(), preferences), 0);
-}
-
 void GPUProcessProxy::createGPUProcessConnection(WebProcessProxy& webProcessProxy, IPC::Connection::Handle&& connectionIdentifier, GPUProcessConnectionParameters&& parameters)
 {
 #if ENABLE(VP9)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -77,7 +77,6 @@ public:
     ~GPUProcessProxy();
 
     void createGPUProcessConnection(WebProcessProxy&, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
-    void updatePreferencesForWebProcess(WebProcessProxy&, const GPUProcessPreferencesForWebProcess&);
 
     ProcessThrottler& throttler() final { return m_throttler; }
     void updateProcessAssertion();

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -67,6 +67,8 @@ public:
     static Ref<RemotePageProxy> create(WebPageProxy& page, WebProcessProxy& process, const WebCore::RegistrableDomain& domain, WebPageProxyMessageReceiverRegistration* registrationToTransfer = nullptr) { return adoptRef(*new RemotePageProxy(page, process, domain, registrationToTransfer)); }
     ~RemotePageProxy();
 
+    WebPageProxy* page() const { return m_page.get(); }
+
     template<typename M> void send(M&&);
     template<typename M, typename C> void sendWithAsyncReply(M&&, C&&);
     template<typename M, typename C> void sendWithAsyncReply(M&&, C&&, const ObjectIdentifierGenericBase&);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SuspendedPageProxy.h"
 
+#include "APIPageConfiguration.h"
 #include "DrawingAreaProxy.h"
 #include "HandleMessage.h"
 #include "Logging.h"
@@ -52,12 +53,19 @@ static WeakHashSet<SuspendedPageProxy>& allSuspendedPages()
     return map;
 }
 
-RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode)
+RefPtr<WebProcessProxy> SuspendedPageProxy::findReusableSuspendedPageProcess(WebProcessPool& processPool, const RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, const API::PageConfiguration& pageConfiguration)
 {
     for (auto& suspendedPage : allSuspendedPages()) {
         Ref process = suspendedPage.process();
-        if (&process->processPool() == &processPool && process->registrableDomain() == registrableDomain && process->websiteDataStore() == &dataStore && process->crossOriginMode() != CrossOriginMode::Isolated && process->lockdownMode() == lockdownMode && !process->wasTerminated())
+        if (&process->processPool() == &processPool
+            && process->registrableDomain() == registrableDomain
+            && process->websiteDataStore() == &dataStore
+            && process->crossOriginMode() != CrossOriginMode::Isolated
+            && process->lockdownMode() == lockdownMode
+            && !process->wasTerminated()
+            && process->hasSameGPUProcessPreferencesAs(pageConfiguration)) {
             return process;
+        }
     }
     return nullptr;
 }

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -60,7 +60,7 @@ public:
     SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, ShouldDelayClosingUntilFirstLayerFlush);
     ~SuspendedPageProxy();
 
-    static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode);
+    static RefPtr<WebProcessProxy> findReusableSuspendedPageProcess(WebProcessPool&, const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode, const API::PageConfiguration&);
 
     WebPageProxy& page() const { return m_page.get(); }
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1026,6 +1026,16 @@ void WebPageProxy::handleSynchronousMessage(IPC::Connection& connection, const S
     });
 }
 
+bool WebPageProxy::hasSameGPUProcessPreferencesAs(const API::PageConfiguration& configuration) const
+{
+#if ENABLE(GPU_PROCESS)
+    return preferencesForGPUProcess() == configuration.preferencesForGPUProcess();
+#else
+    UNUSED_PARAM(configuration);
+    return true;
+#endif
+}
+
 void WebPageProxy::launchProcess(const RegistrableDomain& registrableDomain, ProcessLaunchReason reason)
 {
     ASSERT(!m_isClosed);
@@ -1043,11 +1053,11 @@ void WebPageProxy::launchProcess(const RegistrableDomain& registrableDomain, Pro
     auto& processPool = m_process->processPool();
 
     auto* relatedPage = m_configuration->relatedPage();
-    if (relatedPage && !relatedPage->isClosed() && reason == ProcessLaunchReason::InitialProcess) {
+    if (relatedPage && !relatedPage->isClosed() && reason == ProcessLaunchReason::InitialProcess && hasSameGPUProcessPreferencesAs(*relatedPage)) {
         m_process = relatedPage->ensureRunningProcess();
         WEBPAGEPROXY_RELEASE_LOG(Loading, "launchProcess: Using process (process=%p, PID=%i) from related page", m_process.ptr(), m_process->processID());
     } else
-        m_process = processPool.processForRegistrableDomain(m_websiteDataStore.get(), registrableDomain, shouldEnableLockdownMode() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled);
+        m_process = processPool.processForRegistrableDomain(m_websiteDataStore.get(), registrableDomain, shouldEnableLockdownMode() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled, configuration());
 
     m_hasRunningProcess = true;
     m_shouldReloadDueToCrashWhenVisible = false;
@@ -6296,6 +6306,13 @@ void WebPageProxy::didChangeMainDocument(FrameIdentifier frameID)
     m_speechRecognitionPermissionManager = nullptr;
 }
 
+#if ENABLE(GPU_PROCESS)
+GPUProcessPreferencesForWebProcess WebPageProxy::preferencesForGPUProcess() const
+{
+    return configuration().preferencesForGPUProcess();
+}
+#endif
+
 void WebPageProxy::viewIsBecomingVisible()
 {
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "viewIsBecomingVisible:");
@@ -6841,7 +6858,7 @@ void WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation(uint64_t navig
     if (browsingContextGroupSwitchDecision == BrowsingContextGroupSwitchDecision::NewIsolatedGroup)
         processForNavigation = m_process->processPool().createNewWebProcess(&websiteDataStore(), m_process->lockdownMode(), WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Isolated);
     else
-        processForNavigation = m_process->processPool().processForRegistrableDomain(websiteDataStore(), responseDomain, m_process->lockdownMode());
+        processForNavigation = m_process->processPool().processForRegistrableDomain(websiteDataStore(), responseDomain, m_process->lockdownMode(), configuration());
 
     auto processIdentifier = processForNavigation->coreProcessIdentifier();
     auto preventProcessShutdownScope = processForNavigation->shutdownPreventingScope();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -420,6 +420,7 @@ struct FocusedElementInformation;
 struct FrameInfoData;
 struct FrameTreeCreationParameters;
 struct FrameTreeNodeData;
+struct GPUProcessPreferencesForWebProcess;
 struct GeolocationIdentifierType;
 struct InputMethodState;
 struct InsertTextOptions;
@@ -537,6 +538,13 @@ public:
 
     bool isLockdownModeExplicitlySet() const { return m_isLockdownModeExplicitlySet; }
     bool shouldEnableLockdownMode() const;
+
+#if ENABLE(GPU_PROCESS)
+    GPUProcessPreferencesForWebProcess preferencesForGPUProcess() const;
+#endif
+
+    bool hasSameGPUProcessPreferencesAs(const API::PageConfiguration&) const;
+    bool hasSameGPUProcessPreferencesAs(const WebPageProxy& page) const { return hasSameGPUProcessPreferencesAs(page.configuration()); }
 
     void processIsNoLongerAssociatedWithPage(WebProcessProxy&);
 

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebProcessCache.h"
 
+#include "APIPageConfiguration.h"
 #include "LegacyGlobalSettings.h"
 #include "Logging.h"
 #include "WebProcessPool.h"
@@ -146,7 +147,7 @@ bool WebProcessCache::addProcess(std::unique_ptr<CachedProcess>&& cachedProcess)
     return true;
 }
 
-RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode)
+RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::RegistrableDomain& registrableDomain, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, const API::PageConfiguration& pageConfiguration)
 {
     auto it = m_processesPerRegistrableDomain.find(registrableDomain);
     if (it == m_processesPerRegistrableDomain.end())
@@ -156,6 +157,9 @@ RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::RegistrableD
         return nullptr;
 
     if (it->value->process().lockdownMode() != lockdownMode)
+        return nullptr;
+
+    if (!it->value->process().hasSameGPUProcessPreferencesAs(pageConfiguration))
         return nullptr;
 
     auto process = it->value->takeProcess();

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -44,7 +44,7 @@ public:
     explicit WebProcessCache(WebProcessPool&);
 
     bool addProcessIfPossible(Ref<WebProcessProxy>&&);
-    RefPtr<WebProcessProxy> takeProcess(const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode);
+    RefPtr<WebProcessProxy> takeProcess(const WebCore::RegistrableDomain&, WebsiteDataStore&, WebProcessProxy::LockdownMode, const API::PageConfiguration&);
 
     void updateCapacity(WebProcessPool&);
     unsigned capacity() const { return m_capacity; }

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -312,7 +312,7 @@ public:
 
     void reportWebContentCPUTime(Seconds cpuTime, uint64_t activityState);
 
-    Ref<WebProcessProxy> processForRegistrableDomain(WebsiteDataStore&, const WebCore::RegistrableDomain&, WebProcessProxy::LockdownMode); // Will return an existing one if limit is met or due to caching.
+    Ref<WebProcessProxy> processForRegistrableDomain(WebsiteDataStore&, const WebCore::RegistrableDomain&, WebProcessProxy::LockdownMode, const API::PageConfiguration&); // Will return an existing one if limit is met or due to caching.
 
     void prewarmProcess();
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -436,6 +436,28 @@ void WebProcessProxy::updateRegistrationWithDataStore()
     }
 }
 
+void WebProcessProxy::initializePreferencesForGPUProcess(const WebPageProxy& page)
+{
+#if ENABLE(GPU_PROCESS)
+    if (!m_preferencesForGPUProcess)
+        m_preferencesForGPUProcess = page.preferencesForGPUProcess();
+    else
+        ASSERT(*m_preferencesForGPUProcess == page.preferencesForGPUProcess());
+#else
+    UNUSED_PARAM(page);
+#endif
+}
+
+bool WebProcessProxy::hasSameGPUProcessPreferencesAs(const API::PageConfiguration& pageConfiguration) const
+{
+#if ENABLE(GPU_PROCESS)
+    return !m_preferencesForGPUProcess || *m_preferencesForGPUProcess == pageConfiguration.preferencesForGPUProcess();
+#else
+    UNUSED_PARAM(pageConfiguration);
+    return true;
+#endif
+}
+
 void WebProcessProxy::addProvisionalPageProxy(ProvisionalPageProxy& provisionalPage)
 {
     WEBPROCESSPROXY_RELEASE_LOG(Loading, "addProvisionalPageProxy: provisionalPage=%p, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, &provisionalPage, provisionalPage.page().identifier().toUInt64(), provisionalPage.webPageID().toUInt64());
@@ -444,6 +466,7 @@ void WebProcessProxy::addProvisionalPageProxy(ProvisionalPageProxy& provisionalP
     ASSERT(!m_provisionalPages.contains(provisionalPage));
     markProcessAsRecentlyUsed();
     m_provisionalPages.add(provisionalPage);
+    initializePreferencesForGPUProcess(provisionalPage.page());
     updateRegistrationWithDataStore();
 }
 
@@ -468,6 +491,7 @@ void WebProcessProxy::addRemotePageProxy(RemotePageProxy& remotePage)
     ASSERT(!m_remotePages.contains(remotePage));
     m_remotePages.add(remotePage);
     markProcessAsRecentlyUsed();
+    initializePreferencesForGPUProcess(*remotePage.page());
 }
 
 void WebProcessProxy::removeRemotePageProxy(RemotePageProxy& remotePage)
@@ -777,6 +801,8 @@ void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataS
         m_processPool->pageBeginUsingWebsiteDataStore(webPage, webPage.websiteDataStore());
     }
 
+    initializePreferencesForGPUProcess(webPage);
+
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
     if (webPage.preferences().backgroundWebContentRunningBoardThrottlingEnabled())
         setRunningBoardThrottlingEnabled();
@@ -791,7 +817,6 @@ void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataS
     updateRegistrationWithDataStore();
     updateBackgroundResponsivenessTimer();
     updateBlobRegistryPartitioningState();
-    updatePreferencesForGPUProcess();
 
     // If this was previously a standalone worker process with no pages we need to call didChangeThrottleState()
     // to update our process assertions on the network process since standalone worker processes do not hold
@@ -830,7 +855,6 @@ void WebProcessProxy::removeWebPage(WebPageProxy& webPage, EndsUsingDataStore en
     updateAudibleMediaAssertions();
     updateMediaStreamingActivity();
     updateBackgroundResponsivenessTimer();
-    updatePreferencesForGPUProcess();
     updateBlobRegistryPartitioningState();
 
     maybeShutDown();
@@ -1014,11 +1038,13 @@ void WebProcessProxy::getNetworkProcessConnection(CompletionHandler<void(Network
 }
 
 #if ENABLE(GPU_PROCESS)
+
 void WebProcessProxy::createGPUProcessConnection(IPC::Connection::Handle&& connectionIdentifier, WebKit::GPUProcessConnectionParameters&& parameters)
 {
-    if (!m_preferencesForGPUProcess)
-        m_preferencesForGPUProcess = computePreferencesForGPUProcess();
-    parameters.preferences = *m_preferencesForGPUProcess;
+    auto& gpuPreferences = preferencesForGPUProcess();
+    ASSERT(gpuPreferences);
+    if (gpuPreferences)
+        parameters.preferences = *gpuPreferences;
 
     m_processPool->createGPUProcessConnection(*this, WTFMove(connectionIdentifier), WTFMove(parameters));
 }
@@ -1991,32 +2017,6 @@ void WebProcessProxy::updateBlobRegistryPartitioningState() const
     auto* dataStore = websiteDataStore();
     if (auto* networkProcess = dataStore ? dataStore->networkProcessIfExists() : nullptr)
         networkProcess->setBlobRegistryTopOriginPartitioningEnabled(sessionID(),  dataStore->isBlobRegistryPartitioningEnabled());
-}
-
-#if ENABLE(GPU_PROCESS)
-GPUProcessPreferencesForWebProcess WebProcessProxy::computePreferencesForGPUProcess() const
-{
-    GPUProcessPreferencesForWebProcess preferences;
-    for (auto& page : pages()) {
-        preferences.isWebGPUEnabled |= page->preferences().webGPUEnabled();
-        preferences.isWebGLEnabled |= page->preferences().webGLEnabled();
-        preferences.isDOMRenderingEnabled |= page->preferences().useGPUProcessForDOMRenderingEnabled();
-    }
-    return preferences;
-}
-#endif
-
-void WebProcessProxy::updatePreferencesForGPUProcess()
-{
-#if ENABLE(GPU_PROCESS)
-    if (auto* process = processPool().gpuProcess()) {
-        auto newPreferences = computePreferencesForGPUProcess();
-        if (m_preferencesForGPUProcess != newPreferences) {
-            m_preferencesForGPUProcess = newPreferences;
-            process->updatePreferencesForWebProcess(*this, newPreferences);
-        }
-    }
-#endif
 }
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -174,6 +174,10 @@ public:
     WebProcessPool* processPoolIfExists() const;
     WebProcessPool& processPool() const;
 
+#if ENABLE(GPU_PROCESS)
+    const std::optional<GPUProcessPreferencesForWebProcess>& preferencesForGPUProcess() const { return m_preferencesForGPUProcess; }
+#endif
+
     bool isMatchingRegistrableDomain(const WebCore::RegistrableDomain& domain) const { return m_registrableDomain ? *m_registrableDomain == domain : false; }
     WebCore::RegistrableDomain registrableDomain() const { return valueOrDefault(m_registrableDomain); }
     const std::optional<WebCore::RegistrableDomain>& optionalRegistrableDomain() const { return m_registrableDomain; }
@@ -391,6 +395,8 @@ public:
     void sendAudioComponentRegistrations();
 #endif
 
+    bool hasSameGPUProcessPreferencesAs(const API::PageConfiguration&) const;
+
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
     void enableRemoteInspectorIfNeeded();
 #endif
@@ -532,6 +538,8 @@ private:
     static WebPageProxyMap& globalPageMap();
     static Vector<RefPtr<WebPageProxy>> globalPages();
 
+    void initializePreferencesForGPUProcess(const WebPageProxy&);
+
     void reportProcessDisassociatedWithPageIfNecessary(WebPageProxyIdentifier);
     bool isAssociatedWithPage(WebPageProxyIdentifier) const;
 
@@ -564,11 +572,6 @@ private:
     void updateBackgroundResponsivenessTimer();
 
     void updateBlobRegistryPartitioningState() const;
-
-#if ENABLE(GPU_PROCESS)
-    GPUProcessPreferencesForWebProcess computePreferencesForGPUProcess() const;
-#endif
-    void updatePreferencesForGPUProcess();
 
     void processDidTerminateOrFailedToLaunch(ProcessTerminationReason);
 
@@ -771,7 +774,7 @@ private:
 #endif
     mutable String m_environmentIdentifier;
 #if ENABLE(GPU_PROCESS)
-    std::optional<GPUProcessPreferencesForWebProcess> m_preferencesForGPUProcess;
+    mutable std::optional<GPUProcessPreferencesForWebProcess> m_preferencesForGPUProcess;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -118,6 +118,7 @@ RefPtr<GPUProcessConnection> GPUProcessConnection::create(IPC::Connection& paren
     if (!connectionIdentifiers)
         return nullptr;
 
+    RELEASE_ASSERT_WITH_MESSAGE(WebProcess::singleton().hasWebPages(), "GPUProcess preferences come from the pages");
     parentConnection.send(Messages::WebProcessProxy::CreateGPUProcessConnection(WTFMove(connectionIdentifiers->client), getGPUProcessConnectionParameters()), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 
     auto instance = adoptRef(*new GPUProcessConnection(WTFMove(connectionIdentifiers->server)));

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -200,6 +200,7 @@ public:
     void createWebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
     void removeWebPage(WebCore::PageIdentifier);
     WebPage* focusedWebPage() const;
+    bool hasWebPages() const { return !m_pageMap.isEmpty(); }
 
     InjectedBundle* injectedBundle() const { return m_injectedBundle.get(); }
     


### PR DESCRIPTION
#### e4fcb9c6b04bedb7d92df0b301198c9ab601562b
<pre>
Regression(267014@main) Flaky crash under WebKit::GPUConnectionToWebProcess::didReceiveMessage()
<a href="https://bugs.webkit.org/show_bug.cgi?id=262981">https://bugs.webkit.org/show_bug.cgi?id=262981</a>
rdar://114245301

Reviewed by Simon Fraser.

In 267014@main, we added support for [EnabledIf=Setting] in our IPC messages.in files and
started using it for a few IPC messages. Since then we&apos;ve had flaky crashes on the bots
inside GPUConnectionToWebProcess::didReceiveMessage() because these IPC messages are
sometimes not handled.

The issue is that the checks were racy. The GPUProcess would for example receive the
CreateRemoteGPU IPC and check the `isWebGPUEnabled()` setting. If the setting is disabled,
it would refuse to handle the IPC message and we would crash in debug.

The reason this is racy is that the tests keep enabling / disabling these settings. These
settings are propagated via asynchronous IPC from the UIProcess to the GPUProcess. However,
the IPCs that check for those settings in the GPUProcess are coming from the WebProcess,
not the UIProcess. As a result, it is possible for this to happen:
1. A page gets created with WebGPU enabled
2. The UIProcess sends an async IPC to the GPUProcess to let it know WebGPU is now enabled
3. The WebProcess starts using WebGPU and sends a WebGPU-related IPC to the GPUProcess
4. The GPUProcess receives the WebGPU-related IPC from the WebProcess
5. The GPUProcess receives the IPC from the UIProcess to let it know WebGPU is now enabled

Note that the IPC from the UIProcess (step 5) can get received too late, since there is
no synchronization. The same issue occurs if a page goes away and a setting gets turned
off as a result.

To address the issue, this patch makes it so that the GPUProcessPreferencesForWebProcess
no longer change for a particular WebProcess. This means that if a new page gets created
with different GPUProcess preferences, it will now use a separate WebProcess. Because the
GPUProcess preferences for a particular WebProcess no longer change, there is no race
anymore. When the WebProcess requests a connection to the GPUProcess, it goes via the
UIProcess (synchronously), which sends an IPC to the GPUProcess to create the connection.
The GPUProcessPreferencesForWebProcess are passed with this IPC so that the GPUProcess has
those preferences before receiving any other IPC from the WebProcess.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::allowTestOnlyIPC const):
(WebKit::GPUConnectionToWebProcess::updatePreferences): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updatePreferencesForWebProcess): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/Shared/GPUProcessConnectionParameters.h:
* Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in:
* Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.h:
* Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::preferencesForGPUProcess const):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::updatePreferencesForWebProcess): Deleted.
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.h:
(WebKit::RemotePageProxy::page const):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::findReusableSuspendedPageProcess):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::hasSameGPUProcessPreferencesAs const):
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::preferencesForGPUProcess const):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::takeProcess):
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createGPUProcessConnection):
(WebKit::WebProcessPool::processForRegistrableDomain):
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::initializePreferencesForGPUProcess):
(WebKit::WebProcessProxy::addProvisionalPageProxy):
(WebKit::WebProcessProxy::addRemotePageProxy):
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::removeWebPage):
(WebKit::WebProcessProxy::createGPUProcessConnection):
(WebKit::WebProcessProxy::computePreferencesForGPUProcess const): Deleted.
(WebKit::WebProcessProxy::updatePreferencesForGPUProcess): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::preferencesForGPUProcess const):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::create):
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::hasWebPages const):

Canonical link: <a href="https://commits.webkit.org/269209@main">https://commits.webkit.org/269209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b10c69afeff2b419576c94702f92e94387e8bf61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20270 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24623 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18889 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26109 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23967 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20502 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19848 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5220 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->