### PR TITLE
WebMediaKeySystemClient in WebKitLegacy is never deallocated

### DIFF
--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h
@@ -27,9 +27,13 @@
 
 #import <WebCore/MediaKeySystemClient.h>
 
-class WebMediaKeySystemClient : public WebCore::MediaKeySystemClient {
+class WebMediaKeySystemClient final : public WebCore::MediaKeySystemClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    static WebMediaKeySystemClient& singleton();
+
+private:
+    friend NeverDestroyed<WebMediaKeySystemClient>;
     WebMediaKeySystemClient() = default;
 
     void pageDestroyed() override { }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
@@ -29,8 +29,15 @@
 
 #import <WebCore/MediaKeySystemRequest.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/NeverDestroyed.h>
 
 using namespace WebCore;
+
+WebMediaKeySystemClient& WebMediaKeySystemClient::singleton()
+{
+    static NeverDestroyed<WebMediaKeySystemClient> client;
+    return client;
+}
 
 void WebMediaKeySystemClient::requestMediaKeySystem(MediaKeySystemRequest& request)
 {

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1561,7 +1561,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     WebCore::provideNotification(_private->page, new WebNotificationClient(self));
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    WebCore::provideMediaKeySystemTo(*_private->page, *new WebMediaKeySystemClient());
+    WebCore::provideMediaKeySystemTo(*_private->page, WebMediaKeySystemClient::singleton());
 #endif
 
 #if ENABLE(REMOTE_INSPECTOR)


### PR DESCRIPTION
#### 5d76057016f8bff68ccc037253f01541b8655703
<pre>
WebMediaKeySystemClient in WebKitLegacy is never deallocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=262984">https://bugs.webkit.org/show_bug.cgi?id=262984</a>
rdar://99384041

Reviewed by Eric Carlson.

No object &quot;owns&quot; the WebMediaKeySystemClient created by WebView, so it is leaked
when the WebView itself is destroyed. Instead of creating a new WebMediaKeySystemClient
for each WebView, since the client itself just has default implementations of the
overridden client methods, just make it a singleton.

* Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h:
(): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm:
(WebMediaKeySystemClient::singleton):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):

Canonical link: <a href="https://commits.webkit.org/269441@main">https://commits.webkit.org/269441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c7a93fcbd4b4f29d34be07b83e3a44bf1ed27b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20186 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21304 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24529 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26026 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19956 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23889 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20421 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17871 "Found 1 new test failure: fast/css/tab-size.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19763 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5373 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->