### PR TITLE
Stop using -_canScrollWithoutBouncing(X|Y) and -_adjustedContentOffsetForContentOffset: on UIScrollView

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1112,10 +1112,7 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @interface UIScrollView (IPI)
 - (void)_adjustForAutomaticKeyboardInfo:(NSDictionary *)info animated:(BOOL)animated lastAdjustment:(CGFloat*)lastAdjustment;
 - (BOOL)_isScrollingToTop;
-- (BOOL)_canScrollWithoutBouncingX;
-- (BOOL)_canScrollWithoutBouncingY;
 - (void)_setContentOffsetWithDecelerationAnimation:(CGPoint)contentOffset;
-- (CGPoint)_adjustedContentOffsetForContentOffset:(CGPoint)contentOffset;
 
 @property (nonatomic) BOOL tracksImmediatelyWhileDecelerating;
 @property (nonatomic, getter=_avoidsJumpOnInterruptedBounce, setter=_setAvoidsJumpOnInterruptedBounce:) BOOL _avoidsJumpOnInterruptedBounce;

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -33,6 +33,12 @@
 @interface UIScrollView (WebKitInternal)
 @property (readonly, nonatomic) BOOL _wk_isInterruptingDeceleration;
 @property (readonly, nonatomic) BOOL _wk_isScrolledBeyondExtents;
+@property (readonly, nonatomic) BOOL _wk_canScrollHorizontallyWithoutBouncing;
+@property (readonly, nonatomic) BOOL _wk_canScrollVerticallyWithoutBouncing;
+@property (readonly, nonatomic) CGFloat _wk_contentWidthIncludingInsets;
+@property (readonly, nonatomic) CGFloat _wk_contentHeightIncludingInsets;
+
+- (CGPoint)_wk_clampToScrollExtents:(CGPoint)contentOffset;
 @end
 
 @interface UIView (WebKitInternal)

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -30,6 +30,7 @@
 
 #import "AccessibilitySupportSPI.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "WKVelocityTrackingScrollView.h"
 #import <QuartzCore/CADisplayLink.h>
 #import <WebCore/FloatPoint.h>
@@ -611,10 +612,7 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 
 - (CGPoint)boundedContentOffset:(CGPoint)offset
 {
-    if (!_scrollView)
-        return CGPointZero;
-
-    return [_scrollView _adjustedContentOffsetForContentOffset:offset];
+    return [_scrollView _wk_clampToScrollExtents:offset];
 }
 
 - (CGSize)interactiveScrollVelocity
@@ -652,9 +650,9 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 
     WebCore::RectEdges<bool> edges;
 
-    edges.setTop(_scrollView._canScrollWithoutBouncingY);
+    edges.setTop(_scrollView._wk_canScrollVerticallyWithoutBouncing);
     edges.setBottom(edges.top());
-    edges.setLeft(_scrollView._canScrollWithoutBouncingX);
+    edges.setLeft(_scrollView._wk_canScrollHorizontallyWithoutBouncing);
     edges.setRight(edges.left());
 
     return edges;

--- a/Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.mm
@@ -29,7 +29,6 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import <wtf/ApproximateTime.h>
-#import <wtf/FixedVector.h>
 
 template <size_t windowSize>
 struct ScrollingDeltaWindow {


### PR DESCRIPTION
#### a609e0dfd7633783fb3ec2342d1ce0db20f0c637
<pre>
Stop using -_canScrollWithoutBouncing(X|Y) and -_adjustedContentOffsetForContentOffset: on UIScrollView
<a href="https://bugs.webkit.org/show_bug.cgi?id=262973">https://bugs.webkit.org/show_bug.cgi?id=262973</a>

Reviewed by Richard Robinson.

Remove uses of these three SPI methods and properties on `UIScrollView`, which are currently just
used for smooth keyboard scrolling on iOS:

```
-_canScrollWithoutBouncingX
-_canScrollWithoutBouncingY
-_adjustedContentOffsetForContentOffset:
```

Instead, we use a combination `-adjustedContentInset`, `-contentSize` and `-bounds` to both compute
the scroll extents and total content dimensions of the content scroll view, and to adjust a given
content offset to fit within the extents.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove the now-unnecessary SPI declarations.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIScrollView _wk_contentWidthIncludingInsets]):
(-[UIScrollView _wk_contentHeightIncludingInsets]):
(-[UIScrollView _wk_isScrolledBeyondExtents]):
(-[UIScrollView _wk_clampToScrollExtents:]):
(-[UIScrollView _wk_canScrollHorizontallyWithoutBouncing]):
(-[UIScrollView _wk_canScrollVerticallyWithoutBouncing]):
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
(-[WKKeyboardScrollViewAnimator boundedContentOffset:]):
(-[WKKeyboardScrollViewAnimator rubberbandableDirections]):
* Source/WebKit/UIProcess/ios/WKVelocityTrackingScrollView.mm:

Drive-by fix: remove an unnecessary header import for `FixedVector.h`.
Canonical link: <a href="https://commits.webkit.org/269186@main">https://commits.webkit.org/269186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ec23786dc9232ffb0cf411efbe2e7f80f4d4e91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20191 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22336 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24535 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18794 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26029 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/19959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23892 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20426 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17395 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19768 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5205 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/23979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->