### PR TITLE
Stop using -[UIScrollView _setContentOffsetWithDecelerationAnimation:]

### DIFF
--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false showsScrollIndicators=false ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -14,9 +14,6 @@ body {
 if (window.testRunner)
     testRunner.waitUntilDone();
 
-//  UIKit hides the scroll indicator after 1 second.
-const ScrollIndicatorFlashHideDelay = 1000; // milliseconds
-
 let secondSquareMaxY;
 
 function done()
@@ -28,8 +25,7 @@ function done()
 function didEndScroll()
 {
     window.onscroll = null;
-    // FIXME: Disable flashing of scroll indicator or find a way know when the flash has finished.
-    window.setTimeout(done, ScrollIndicatorFlashHideDelay);
+    UIHelper.waitForZoomingOrScrollingToEnd().then(done);
 }
 
 window.onscroll = function (event) {

--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top-expected.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top-expected.html
@@ -16,7 +16,7 @@ body {
 </style>
 </head>
 <body>
-<p>Tests that pressing <key>Command</key> + <key>&#x2191;</key> scrolls to the bottom of the page. This test PASSED if you see a green square. Otherwise, it FAILED.</p>
+<p>Tests that pressing <key>Command</key> + <key>&#x2191;</key> scrolls to the top of the page. This test PASSED if you see a green square. Otherwise, it FAILED.</p>
 <div id="expected"></div>
 </body>
 </html>

--- a/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html
+++ b/LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false showsScrollIndicators=false ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -26,9 +26,6 @@ body {
 if (window.testRunner)
     testRunner.waitUntilDone();
 
-//  UIKit hides the scroll indicator after 1 second.
-const ScrollIndicatorFlashHideDelay = 1000; // milliseconds
-
 function done()
 {
     if (window.testRunner)
@@ -49,8 +46,7 @@ function swapRedGreenBackground(element)
 function didEndScroll()
 {
     window.onscroll = null;
-    // FIXME: Disable flashing of scroll indicator or find a way know when the flash has finished.
-    window.setTimeout(done, ScrollIndicatorFlashHideDelay);
+    UIHelper.waitForZoomingOrScrollingToEnd().then(done);
 }
 
 function handleScroll(event)
@@ -89,7 +85,7 @@ window.onload = function ()
 </script>
 </head>
 <body>
-<p id="description">Tests that pressing <key>Command</key> + <key>&#x2191;</key> scrolls to the bottom of the page. This test PASSED if you see a green square. Otherwise, it FAILED.</p>
+<p id="description">Tests that pressing <key>Command</key> + <key>&#x2191;</key> scrolls to the top of the page. This test PASSED if you see a green square. Otherwise, it FAILED.</p>
 <p id="manual-instructions" class="hidden">To run this test by hand, click <button onclick="runTest()">Run test</button> to first scroll to the bottom of the page. Then press <key>Command</key> + <key>&#x2191;</key>.</p>
 <div id="firstSquare" style="width: 256px; height: 256px" class="red"></div>
 <div style="height: 2000px"></div>

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -444,6 +444,8 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 @property (nonatomic) BOOL bouncesVertically;
 @property (nonatomic, setter=_setAllowsParentToBeginHorizontally:) BOOL _allowsParentToBeginHorizontally;
 @property (nonatomic, setter=_setAllowsParentToBeginVertically:) BOOL _allowsParentToBeginVertically;
+@property (nonatomic) BOOL tracksImmediatelyWhileDecelerating;
+@property (nonatomic, getter=_avoidsJumpOnInterruptedBounce, setter=_setAvoidsJumpOnInterruptedBounce:) BOOL _avoidsJumpOnInterruptedBounce;
 @end
 
 typedef NS_ENUM(NSUInteger, UIScrollPhase) {
@@ -1112,10 +1114,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 @interface UIScrollView (IPI)
 - (void)_adjustForAutomaticKeyboardInfo:(NSDictionary *)info animated:(BOOL)animated lastAdjustment:(CGFloat*)lastAdjustment;
 - (BOOL)_isScrollingToTop;
-- (void)_setContentOffsetWithDecelerationAnimation:(CGPoint)contentOffset;
-
-@property (nonatomic) BOOL tracksImmediatelyWhileDecelerating;
-@property (nonatomic, getter=_avoidsJumpOnInterruptedBounce, setter=_setAvoidsJumpOnInterruptedBounce:) BOOL _avoidsJumpOnInterruptedBounce;
 @end
 
 @interface UIPeripheralHost (IPI)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -50,6 +50,7 @@
 @property (nonatomic, readonly) CGRect _tapHighlightViewRect;
 @property (nonatomic, readonly) UIGestureRecognizer *_imageAnalysisGestureRecognizer;
 @property (nonatomic, readonly) UITapGestureRecognizer *_singleTapGestureRecognizer;
+@property (nonatomic, readonly, getter=_isKeyboardScrollingAnimationRunning) BOOL _keyboardScrollingAnimationRunning;
 
 - (void)keyboardAccessoryBarNext;
 - (void)keyboardAccessoryBarPrevious;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -436,6 +436,11 @@ static void dumpUIView(TextStream& ts, UIView *view)
     return [_contentView singleTapGestureRecognizer];
 }
 
+- (BOOL)_isKeyboardScrollingAnimationRunning
+{
+    return [_contentView isKeyboardScrollingAnimationRunning];
+}
+
 - (void)_simulateElementAction:(_WKElementActionType)actionType atLocation:(CGPoint)location
 {
     [_contentView _simulateElementAction:actionType atLocation:location];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -461,6 +461,7 @@ struct ImageAnalysisContextMenuActionData {
     WebCore::PointerID _commitPotentialTapPointerId;
 
     BOOL _keyboardDidRequestDismissal;
+    BOOL _isKeyboardScrollingAnimationRunning;
 
     BOOL _candidateViewNeedsUpdate;
     BOOL _seenHardwareKeyDownInNonEditableElement;
@@ -603,6 +604,7 @@ struct ImageAnalysisContextMenuActionData {
 @property (nonatomic, readonly) WebKit::GestureRecognizerConsistencyEnforcer& gestureRecognizerConsistencyEnforcer;
 @property (nonatomic, readonly) CGRect tapHighlightViewRect;
 @property (nonatomic, readonly) UIGestureRecognizer *imageAnalysisGestureRecognizer;
+@property (nonatomic, readonly, getter=isKeyboardScrollingAnimationRunning) BOOL keyboardScrollingAnimationRunning;
 
 #if ENABLE(DATALIST_ELEMENT)
 @property (nonatomic, strong) UIView <WKFormControl> *dataListTextSuggestionsInputView;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6723,12 +6723,19 @@ static NSString *contentTypeFromFieldName(WebCore::AutofillFieldName fieldName)
 
 - (void)keyboardScrollViewAnimatorWillScroll:(WKKeyboardScrollViewAnimator *)animator
 {
+    _isKeyboardScrollingAnimationRunning = YES;
     [self willStartZoomOrScroll];
 }
 
 - (void)keyboardScrollViewAnimatorDidFinishScrolling:(WKKeyboardScrollViewAnimator *)animator
 {
     [_webView _didFinishScrolling:self.webView.scrollView];
+    _isKeyboardScrollingAnimationRunning = NO;
+}
+
+- (BOOL)isKeyboardScrollingAnimationRunning
+{
+    return _isKeyboardScrollingAnimationRunning;
 }
 
 - (void)executeEditCommandWithCallback:(NSString *)commandName

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -189,6 +189,7 @@ const TestFeatures& TestOptions::defaults()
             { "noUseRemoteLayerTree", false },
             { "useThreadedScrolling", false },
             { "suppressInputAccessoryView", false },
+            { "showsScrollIndicators", true },
             { "enhancedWindowingEnabled", false },
         };
         features.doubleTestRunnerFeatures = {
@@ -251,6 +252,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "useRemoteLayerTree", TestHeaderKeyType::BoolTestRunner },
         { "useThreadedScrolling", TestHeaderKeyType::BoolTestRunner },
         { "suppressInputAccessoryView", TestHeaderKeyType::BoolTestRunner },
+        { "showsScrollIndicators", TestHeaderKeyType::BoolTestRunner },
         { "enhancedWindowingEnabled", TestHeaderKeyType::BoolTestRunner },
     
         { "contentInset.top", TestHeaderKeyType::DoubleTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -78,6 +78,7 @@ public:
     bool noUseRemoteLayerTree() const { return boolTestRunnerFeatureValue("noUseRemoteLayerTree"); }
     bool useThreadedScrolling() const { return boolTestRunnerFeatureValue("useThreadedScrolling"); }
     bool suppressInputAccessoryView() const { return boolTestRunnerFeatureValue("suppressInputAccessoryView"); }
+    bool showsScrollIndicators() const { return boolTestRunnerFeatureValue("showsScrollIndicators"); }
     bool enhancedWindowingEnabled() const { return boolTestRunnerFeatureValue("enhancedWindowingEnabled"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }
     double obscuredInsetTop() const { return doubleTestRunnerFeatureValue("obscuredInset.top"); }

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -385,6 +385,9 @@ IGNORE_WARNINGS_END
         || scroller.isVerticalBouncing || scroller.isHorizontalBouncing || scroller.isZoomBouncing)
         return YES;
 
+    if (self._keyboardScrollingAnimationRunning)
+        return YES;
+
     static NeverDestroyed<RetainPtr<NSSet>> animationKeyNames = [NSSet setWithArray:@[
         @"bounds.size",
         @"bounds.origin",

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -353,6 +353,8 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
         webView._dragInteractionPolicy = dragInteractionPolicy(options);
         webView.focusStartsInputSessionPolicy = focusStartsInputSessionPolicy(options);
         webView.suppressInputAccessoryView = options.suppressInputAccessoryView();
+        webView.scrollView.showsVerticalScrollIndicator = options.showsScrollIndicators();
+        webView.scrollView.showsHorizontalScrollIndicator = options.showsScrollIndicators();
 
 #if HAVE(UIFINDINTERACTION)
         webView.findInteractionEnabled = options.findInteractionEnabled();


### PR DESCRIPTION
#### 4faf2f36c97b176fa72125a0c700e58e33d6bd7a
<pre>
Stop using -[UIScrollView _setContentOffsetWithDecelerationAnimation:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=262997">https://bugs.webkit.org/show_bug.cgi?id=262997</a>
rdar://112474966

Reviewed by Tim Horton.

Refactor `WKKeyboardScrollingAnimator` to stop using `-_setContentOffsetWithDecelerationAnimation:`.
This is currently used to scroll to the start or end of the webpage using a spring animation that
loosely resembes exponential decay (i.e. the same animation that drives scrolling to the top when
tapping near the top of a `UIScrollView`).

This pulls that same `CASpringAnimation` into WebKit, and scrolls the scroll view using that
animation. Since it&apos;s not currently possible to directly drive animated scrolling in a `UIScrollView`
with a custom `CAAnimation`, we instead:

1.  Create a hidden, 0 by 0 `UIView` and add it to the view hierarchy under the scroll view.
2.  Add our spring animation to the `UIView`&apos;s layer, and use it to animate the `position` property.
    The animation starts the `position` off at the scroll view&apos;s content offset, and ends with the
    `position` at the target content offset. This allows us to...
3.  Use the existing `CADisplayLink` that drives normal smooth keyboard scrolling to synchronize
    the `position` as it animates, such that the scroll view scrolls using the same animation curve
    as it would when using `-_setContentOffsetWithDecelerationAnimation:`.

* LayoutTests/fast/scrolling/ios/key-command-scroll-to-bottom.html:
* LayoutTests/fast/scrolling/ios/key-command-scroll-to-top-expected.html:
* LayoutTests/fast/scrolling/ios/key-command-scroll-to-top.html:

Adjust a couple of layout tests to continue passing after these changes:

•   We need to suppress scroll view indicators for this test, so that they don&apos;t show up in the ref
    image. Currently, we flash scrollbars at the beginning of the scroll, such that they fade out by
    the time keyboard scrolling is complete. After this change, we&apos;ll start the fade animation only
    after scrolling finishes, which causes the scroll bar to linger around for longer than the hard-
    coded 1000 ms timeout.

•   We also need to actually wait for the keyboard scrolling animation to complete. Currently, this
    Just Works because the hard-coded 1000 ms delay that waits for the scroll indicators to fade out
    also ensures that the scrolling animation completes. Removing this timeout while suppressing
    scrollbars therefore causes the test to still fail, due to subpixel differences since the scroll
    position is rounded to 0, when the scroll view is actually &lt; 0.5 pt away from the top. Fix this
    by teaching `UIHelper.waitForZoomingOrScrollingToEnd()` about keyboard scrolling animations, via
    a new testing-only SPI hook on `WKWebView`, and then adjusting the layout tests to complete only
    after the `waitForZoomingOrScrollingToEnd()` promise resolves.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove now-unused SPI declarations. Also clean up a couple of existing SPI declarations, by moving
them to the SPI section (out of the IPI section).

* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _isKeyboardScrollingAnimationRunning]):

Add a new test-only SPI property to return whether or not a keyboard scrolling animation is running.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView keyboardScrollViewAnimatorWillScroll:]):
(-[WKContentView keyboardScrollViewAnimatorDidFinishScrolling:]):
(-[WKContentView isKeyboardScrollingAnimationRunning]):
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
(-[WKKeyboardScrollingAnimator invalidate]):
(-[WKKeyboardScrollingAnimator beginWithEvent:]):

Instead of delegating document granularity scrolling to `WKKeyboardScrollViewAnimator`, drive this
(mostly) in `WKKeyboardScrollingAnimator` using the above strategy.

(-[WKKeyboardScrollingAnimator willStartInteractiveScroll]):
(-[WKKeyboardScrollingAnimator resetViewForScrollToExtentAnimation]):
(-[WKKeyboardScrollingAnimator stopScrollingImmediately]):
(-[WKKeyboardScrollingAnimator displayLinkFired:]):

Drive the animation by setting the scroller&apos;s content offset based on the animation tracking view&apos;s
position. Note that we need a null check for the `presentationLayer` here, since the first
`CADisplayLink` tick after starting the animation sometimes fires when the `presentationLayer` is
still `nil`, which would otherwise cause us to stutter to (0, 0) before animating.

(-[WKKeyboardScrollViewAnimator willBeginScrollingToExtentWithAnimationInTrackingView:]):

Since the `WKKeyboardScrollViewAnimator` no longer drives the &quot;scroll to extent&quot; animation, rename
this method and have it simply install the tracking view in the view hierarchy, under the
`UIScrollView`.

(-[WKKeyboardScrollViewAnimator scrollWithScrollToExtentAnimationTo:]): Deleted.
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::showsScrollIndicators const):

Add a new test option to set whether or not scroll indicators should be shown during the test
(defaults to true, to match behavior of a normal `WKWebView`).

* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView isZoomingOrScrolling]):

Teach this to take animated keyboard scrolling into account by using the new
`-_isKeyboardScrollingAnimationRunning` test hook.

* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformResetStateToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/269213@main">https://commits.webkit.org/269213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dc0cf1671ca14c325807497819852305fb308bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20283 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22438 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24638 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/18903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26117 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23976 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20514 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19654 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5224 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->