### PR TITLE
Reduce use of Vector::uncheckedAppend() throughout the codebase

### DIFF
--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -529,6 +529,8 @@ inline RefPtr<Array> Value::asArray()
 
 } // namespace JSONImpl
 
+inline size_t containerSize(const JSONImpl::Array& array) { return array.length(); }
+
 } // namespace WTF
 
 namespace JSON {

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -999,11 +999,10 @@ void URLParser::syntaxViolation(const CodePointIterator<CharacterType>& iterator
     ASSERT(m_asciiBuffer.isEmpty());
     size_t codeUnitsToCopy = iterator.codeUnitsSince(reinterpret_cast<const CharacterType*>(m_inputBegin));
     RELEASE_ASSERT(codeUnitsToCopy <= m_inputString.length());
-    m_asciiBuffer.reserveCapacity(m_inputString.length());
-    for (size_t i = 0; i < codeUnitsToCopy; ++i) {
-        ASSERT(isASCII(m_inputString[i]));
-        m_asciiBuffer.uncheckedAppend(m_inputString[i]);
-    }
+    if (m_inputString.is8Bit())
+        m_asciiBuffer.append(m_inputString.characters8(), codeUnitsToCopy);
+    else
+        m_asciiBuffer.append(m_inputString.characters16(), codeUnitsToCopy);
 }
 
 void URLParser::failure()

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -319,16 +319,14 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
         return constant.key.utf8();
     });
 
-    Vector<WGPUConstantEntry> backingConstantEntries;
-    backingConstantEntries.reserveInitialCapacity(descriptor.compute.constants.size());
-    for (size_t i = 0; i < descriptor.compute.constants.size(); ++i) {
+    Vector<WGPUConstantEntry> backingConstantEntries(descriptor.compute.constants.size(), [&](size_t i) {
         const auto& constant = descriptor.compute.constants[i];
-        backingConstantEntries.uncheckedAppend(WGPUConstantEntry {
+        return WGPUConstantEntry {
             nullptr,
             constantNames[i].data(),
             constant.value
-        });
-    }
+        };
+    });
 
     WGPUComputePipelineDescriptor backingDescriptor {
         nullptr,
@@ -363,16 +361,14 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, bool de
         return constant.key.utf8();
     });
 
-    Vector<WGPUConstantEntry> vertexConstantEntries;
-    vertexConstantEntries.reserveInitialCapacity(descriptor.vertex.constants.size());
-    for (size_t i = 0; i < descriptor.vertex.constants.size(); ++i) {
+    Vector<WGPUConstantEntry> vertexConstantEntries(descriptor.vertex.constants.size(), [&](size_t i) {
         const auto& constant = descriptor.vertex.constants[i];
-        vertexConstantEntries.uncheckedAppend(WGPUConstantEntry {
+        return WGPUConstantEntry {
             nullptr,
             vertexConstantNames[i].data(),
-            constant.value,
-        });
-    }
+            constant.value
+        };
+    });
 
     auto backingAttributes = descriptor.vertex.buffers.map([&convertToBackingContext](const auto& buffer) -> Vector<WGPUVertexAttribute> {
         if (buffer) {
@@ -387,17 +383,15 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, bool de
             return { };
     });
 
-    Vector<WGPUVertexBufferLayout> backingBuffers;
-    backingBuffers.reserveInitialCapacity(descriptor.vertex.buffers.size());
-    for (size_t i = 0; i < descriptor.vertex.buffers.size(); ++i) {
+    Vector<WGPUVertexBufferLayout> backingBuffers(descriptor.vertex.buffers.size(), [&](size_t i) {
         const auto& buffer = descriptor.vertex.buffers[i];
-        backingBuffers.uncheckedAppend(WGPUVertexBufferLayout {
+        return WGPUVertexBufferLayout {
             buffer ? buffer->arrayStride : WGPU_COPY_STRIDE_UNDEFINED,
             buffer ? convertToBackingContext.convertToBacking(buffer->stepMode) : WGPUVertexStepMode_Vertex,
             static_cast<uint32_t>(backingAttributes[i].size()),
             backingAttributes[i].data(),
-        });
-    }
+        };
+    });
 
     WGPUDepthStencilState depthStencilState {
         nullptr,
@@ -432,15 +426,14 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, bool de
 
     Vector<WGPUConstantEntry> fragmentConstantEntries;
     if (descriptor.fragment) {
-        fragmentConstantEntries.reserveInitialCapacity(descriptor.fragment->constants.size());
-        for (size_t i = 0; i < descriptor.fragment->constants.size(); ++i) {
+        fragmentConstantEntries = Vector<WGPUConstantEntry>(descriptor.fragment->constants.size(), [&](size_t i) {
             const auto& constant = descriptor.fragment->constants[i];
-            fragmentConstantEntries.uncheckedAppend(WGPUConstantEntry {
+            return WGPUConstantEntry {
                 nullptr,
                 fragmentConstantNames[i].data(),
                 constant.value,
-            });
-        }
+            };
+        });
     }
 
     Vector<std::optional<WGPUBlendState>> blendStates;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -351,11 +351,7 @@ void GStreamerPeerConnectionBackend::dispatchPendingTrackEvents(MediaStream& med
 {
     auto events = WTFMove(m_pendingTrackEvents);
     for (auto& event : events) {
-        Vector<RefPtr<MediaStream>> pendingStreams;
-        pendingStreams.reserveInitialCapacity(1);
-        pendingStreams.uncheckedAppend(&mediaStream);
-        event.streams = WTFMove(pendingStreams);
-
+        event.streams = Vector<RefPtr<MediaStream>>({ &mediaStream });
         dispatchTrackEvent(event);
     }
 }

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -600,10 +600,8 @@ void RedirectAction::URLTransformAction::serialize(Vector<uint8_t>& vector) cons
         uncheckedAppendLengthAndString(usernameUTF8);
     if (hasPort) {
         vector.uncheckedAppend(!!*port);
-        if (*port) {
-            vector.uncheckedAppend(**port >> 0);
-            vector.uncheckedAppend(**port >> 8);
-        }
+        if (*port)
+            vector.appendList({ **port >> 0, **port >> 8 });
     }
     if (hasQuery) {
         vector.uncheckedAppend(queryTransform.index());

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -165,15 +165,15 @@ auto ContentExtensionsBackend::actionsForResourceLoad(const ResourceLoadInfo& re
     const String& urlString = resourceLoadInfo.resourceURL.string();
     ASSERT_WITH_MESSAGE(urlString.containsOnlyASCII(), "A decoded URL should only contain ASCII characters. The matching algorithm assumes the input is ASCII.");
 
-    Vector<ActionsFromContentRuleList> actionsVector;
-    actionsVector.reserveInitialCapacity(m_contentExtensions.size());
     ASSERT(!(resourceLoadInfo.getResourceFlags() & ActionConditionMask));
     const ResourceFlags flags = resourceLoadInfo.getResourceFlags() | ActionConditionMask;
-    for (auto& [identifier, contentExtension] : m_contentExtensions) {
+    Vector<ActionsFromContentRuleList> actionsVector = WTF::compactMap(m_contentExtensions, [&](auto& entry) -> std::optional<ActionsFromContentRuleList> {
+        auto& [identifier, contentExtension] = entry;
         if (ruleListFilter(identifier) == ShouldSkipRuleList::Yes)
-            continue;
-        actionsVector.uncheckedAppend(actionsFromContentRuleList(contentExtension.get(), urlString, resourceLoadInfo, flags));
-    }
+            return std::nullopt;
+        return actionsFromContentRuleList(contentExtension.get(), urlString, resourceLoadInfo, flags);
+    });
+
 #if CONTENT_EXTENSIONS_PERFORMANCE_REPORTING
     MonotonicTime addedTimeEnd = MonotonicTime::now();
     dataLogF("Time added: %f microseconds %s \n", (addedTimeEnd - addedTimeStart).microseconds(), resourceLoadInfo.resourceURL.string().utf8().data());

--- a/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
+++ b/Source/WebCore/contentextensions/DFABytecodeCompiler.cpp
@@ -288,17 +288,17 @@ DFABytecodeCompiler::JumpTable DFABytecodeCompiler::extractJumpTable(Vector<DFAB
     jumpTable.caseSensitive = ranges[lastRange].caseSensitive;
 
     unsigned size = lastRange - firstRange + 1;
-    jumpTable.destinations.reserveInitialCapacity(size);
-    for (unsigned i = firstRange; i <= lastRange; ++i) {
-        const Range& range = ranges[i];
+    jumpTable.destinations = Vector<uint32_t>(size, [&](size_t i) {
+        size_t index = firstRange + i;
+        const Range& range = ranges[index];
 
         ASSERT(range.caseSensitive == jumpTable.caseSensitive);
         ASSERT(range.min == range.max);
         ASSERT(range.min >= jumpTable.min);
         ASSERT(range.min <= jumpTable.max);
 
-        jumpTable.destinations.uncheckedAppend(range.destination);
-    }
+        return range.destination;
+    });
 
     ranges.remove(firstRange, size);
 

--- a/Source/WebCore/contentextensions/DFAMinimizer.cpp
+++ b/Source/WebCore/contentextensions/DFAMinimizer.cpp
@@ -260,10 +260,9 @@ public:
         m_flattenedTransitionsStartOffsetPerNode.resize(dfa.nodes.size());
         memset(m_flattenedTransitionsStartOffsetPerNode.data(), 0, m_flattenedTransitionsStartOffsetPerNode.size() * sizeof(unsigned));
 
-        Vector<char, 0, ContentExtensionsOverflowHandler> singularTransitionsFirsts;
-        singularTransitionsFirsts.reserveInitialCapacity(singularTransitions.m_ranges.size());
-        for (const auto& transition : singularTransitions)
-            singularTransitionsFirsts.uncheckedAppend(transition.first);
+        auto singularTransitionsFirsts = WTF::map<0, ContentExtensionsOverflowHandler>(singularTransitions, [&](auto& transition) {
+            return transition.first;
+        });
 
         for (const DFANode& node : dfa.nodes) {
             if (node.isKilled())

--- a/Source/WebCore/contentextensions/MutableRangeList.h
+++ b/Source/WebCore/contentextensions/MutableRangeList.h
@@ -44,6 +44,12 @@ public:
         uint32_t index;
         bool atEnd;
 
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = TypedMutableRange;
+        using difference_type = ptrdiff_t;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+
         const TypedMutableRange& operator*() const { return rangeList.m_ranges[index]; }
         const TypedMutableRange* operator->() const { return &rangeList.m_ranges[index]; }
 

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -96,10 +96,10 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     values.reserveInitialCapacity(exposedComputedCSSPropertyIDs.size() + inheritedCustomProperties.size() + nonInheritedCustomProperties.size());
 
     ComputedStyleExtractor extractor { m_element.ptr() };
-    for (auto propertyID : exposedComputedCSSPropertyIDs) {
+    values.appendContainerWithMapping(exposedComputedCSSPropertyIDs, [&](auto propertyID) {
         auto value = extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
-        values.uncheckedAppend(makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, document)));
-    }
+        return makeKeyValuePair(nameString(propertyID), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), propertyID, document));
+    });
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         map->forEach([&](auto& it) {

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -4328,18 +4328,16 @@ void SelectorCodeGenerator::generateElementIsNthLastChildOf(Assembler::JumpList&
 {
     generateNthLastChildParentCheckAndRelationUpdate(failureCases, fragment);
 
-    Vector<const NthChildOfSelectorInfo*> validSubsetFilters;
-    validSubsetFilters.reserveInitialCapacity(fragment.nthLastChildOfFilters.size());
-
     // The initial element must match the selector list.
     for (const NthChildOfSelectorInfo& nthLastChildOfSelectorInfo : fragment.nthLastChildOfFilters)
         generateElementMatchesSelectorList(failureCases, elementAddressRegister, nthLastChildOfSelectorInfo.selectorList);
     
-    for (const NthChildOfSelectorInfo& nthLastChildOfSelectorInfo : fragment.nthLastChildOfFilters) {
+    auto validSubsetFilters = WTF::compactMap(fragment.nthLastChildOfFilters, [](auto& nthLastChildOfSelectorInfo) -> std::optional<const NthChildOfSelectorInfo*> {
         if (nthFilterIsAlwaysSatisified(nthLastChildOfSelectorInfo.a, nthLastChildOfSelectorInfo.b))
-            continue;
-        validSubsetFilters.uncheckedAppend(&nthLastChildOfSelectorInfo);
-    }
+            return std::nullopt;
+        return &nthLastChildOfSelectorInfo;
+    });
+
     if (validSubsetFilters.isEmpty())
         return;
 

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -85,10 +85,7 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
         return;
 
     m_activeDataDetectorHighlight = nullptr;
-    m_dataDetectorContainersAndHighlights.clear();
-    m_dataDetectorContainersAndHighlights.reserveInitialCapacity(dataDetectorResultElements.size());
-
-    for (auto& element : dataDetectorResultElements) {
+    m_dataDetectorContainersAndHighlights = WTF::map(dataDetectorResultElements, [&](auto& element) {
         CGRect elementBounds = element->renderer()->absoluteBoundingBoxRect();
         elementBounds.origin = mainFrameView->windowToContents(frameView->contentsToWindow(roundedIntPoint(elementBounds.origin)));
 
@@ -98,8 +95,8 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
 #else
         auto highlight = adoptCF(PAL::softLink_DataDetectors_DDHighlightCreateWithRectsInVisibleRectWithStyleAndDirection(nullptr, &elementBounds, 1, mainFrameView->visibleContentRect(), static_cast<DDHighlightStyle>(DDHighlightStyleBubbleStandard) | static_cast<DDHighlightStyle>(DDHighlightStyleStandardIconArrow), YES, NSWritingDirectionNatural, NO, YES));
 #endif
-        m_dataDetectorContainersAndHighlights.uncheckedAppend({ element, DataDetectorHighlight::createForImageOverlay(*m_page, *this, WTFMove(highlight), *makeRangeSelectingNode(element.get())) });
-    }
+        return ContainerAndHighlight { element, DataDetectorHighlight::createForImageOverlay(*m_page, *this, WTFMove(highlight), *makeRangeSelectingNode(element.get())) };
+    });
 }
 
 bool ImageOverlayController::platformHandleMouseEvent(const PlatformMouseEvent& event)

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -124,11 +124,15 @@ public:
         ComplexTextRun(const Font&, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd, bool ltr);
         WEBCORE_EXPORT ComplexTextRun(const Vector<FloatSize>& advances, const Vector<FloatPoint>& origins, const Vector<Glyph>& glyphs, const Vector<unsigned>& stringIndices, FloatSize initialAdvance, const Font&, const UChar* characters, unsigned stringLocation, unsigned stringLength, unsigned indexBegin, unsigned indexEnd, bool ltr);
 
-        Vector<FloatSize, 64> m_baseAdvances;
+        using BaseAdvancesVector = Vector<FloatSize, 64>;
+        using GlyphVector = Vector<CGGlyph, 64>;
+        using CoreTextIndicesVector = Vector<unsigned, 64>;
+
+        BaseAdvancesVector m_baseAdvances;
         Vector<FloatPoint, 64> m_glyphOrigins;
-        Vector<CGGlyph, 64> m_glyphs;
+        GlyphVector m_glyphs;
         Vector<unsigned, 64> m_glyphEndOffsets;
-        Vector<unsigned, 64> m_coreTextIndices;
+        CoreTextIndicesVector m_coreTextIndices;
         FloatSize m_initialAdvance;
         const Font& m_font;
         const UChar* m_characters;

--- a/Source/WebCore/platform/graphics/cocoa/FontDatabase.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontDatabase.cpp
@@ -69,12 +69,9 @@ const FontDatabase::InstalledFontFamily& FontDatabase::collectionForFamily(const
         auto mandatoryAttributes = installedFontMandatoryAttributes(m_allowUserInstalledFonts);
         if (auto matches = adoptCF(CTFontDescriptorCreateMatchingFontDescriptors(fontDescriptorToMatch.get(), mandatoryAttributes.get()))) {
             auto count = CFArrayGetCount(matches.get());
-            Vector<InstalledFont> result;
-            result.reserveInitialCapacity(count);
-            for (CFIndex i = 0; i < count; ++i) {
-                InstalledFont installedFont(static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(matches.get(), i)));
-                result.uncheckedAppend(WTFMove(installedFont));
-            }
+            Vector<InstalledFont> result(count, [&](size_t i) {
+                return InstalledFont(static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(matches.get(), i)));
+            });
             return makeUnique<InstalledFontFamily>(WTFMove(result));
         }
         return makeUnique<InstalledFontFamily>();

--- a/Source/WebCore/platform/graphics/iso/ISOBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOBox.cpp
@@ -90,11 +90,7 @@ bool ISOBox::parse(DataView& view, unsigned& offset)
         if (!checkedRead<ExtendedType>(extendedTypeStruct, view, offset, BigEndian))
             return false;
 
-        Vector<uint8_t> extendedType;
-        extendedType.reserveInitialCapacity(16);
-        for (auto& character : extendedTypeStruct.value)
-            extendedType.uncheckedAppend(character);
-        m_extendedType = WTFMove(extendedType);
+        m_extendedType = Vector<uint8_t>(extendedTypeStruct.value, std::size(extendedTypeStruct.value));
     }
 
     return true;

--- a/Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm
@@ -53,9 +53,9 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
         CTRunGetStringIndices(ctRun, CFRangeMake(0, 0), coreTextIndices.data());
         coreTextIndicesPtr = coreTextIndices.data();
     }
-    m_coreTextIndices.reserveInitialCapacity(m_glyphCount);
-    for (unsigned i = 0; i < m_glyphCount; ++i)
-        m_coreTextIndices.uncheckedAppend(coreTextIndicesPtr[i]);
+    m_coreTextIndices = CoreTextIndicesVector(m_glyphCount, [&](size_t i) {
+        return coreTextIndicesPtr[i];
+    });
 
     const CGGlyph* glyphsPtr = CTRunGetGlyphsPtr(ctRun);
     Vector<CGGlyph> glyphs;
@@ -64,9 +64,9 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
         CTRunGetGlyphs(ctRun, CFRangeMake(0, 0), glyphs.data());
         glyphsPtr = glyphs.data();
     }
-    m_glyphs.reserveInitialCapacity(m_glyphCount);
-    for (unsigned i = 0; i < m_glyphCount; ++i)
-        m_glyphs.uncheckedAppend(glyphsPtr[i]);
+    m_glyphs = GlyphVector(m_glyphCount, [&](size_t i) {
+        return glyphsPtr[i];
+    });
 
     if (CTRunGetStatus(ctRun) & kCTRunStatusHasOrigins) {
         Vector<CGSize> baseAdvances(m_glyphCount);
@@ -86,9 +86,9 @@ ComplexTextController::ComplexTextRun::ComplexTextRun(CTRunRef ctRun, const Font
             CTRunGetAdvances(ctRun, CFRangeMake(0, 0), baseAdvancesVector.data());
             baseAdvances = baseAdvancesVector.data();
         }
-        m_baseAdvances.reserveInitialCapacity(m_glyphCount);
-        for (unsigned i = 0; i < m_glyphCount; ++i)
-            m_baseAdvances.uncheckedAppend(baseAdvances[i]);
+        m_baseAdvances = BaseAdvancesVector(m_glyphCount, [&](size_t i) {
+            return baseAdvances[i];
+        });
     }
 
     LOG_WITH_STREAM(TextShaping,

--- a/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm
@@ -611,13 +611,12 @@ public:
         m_globalPosition = globalPointForEvent(event);
 
         unsigned touchCount = event.touchCount;
-        m_touchPoints.reserveInitialCapacity(touchCount);
-        for (unsigned i = 0; i < touchCount; ++i) {
+        m_touchPoints = Vector<PlatformTouchPoint>(touchCount, [&](size_t i) -> PlatformTouchPoint {
             unsigned identifier = [(NSNumber *)[event.touchIdentifiers objectAtIndex:i] unsignedIntValue];
             IntPoint location = IntPoint([(NSValue *)[event.touchLocations objectAtIndex:i] pointValue]);
             PlatformTouchPoint::TouchPhaseType touchPhase = convertTouchPhase([event.touchPhases objectAtIndex:i]);
-            m_touchPoints.uncheckedAppend(PlatformTouchPointBuilder(identifier, location, touchPhase));
-        }
+            return PlatformTouchPointBuilder(identifier, location, touchPhase);
+        });
     }
     
     PlatformTouchEventBuilder(PlatformEvent::Type type, IntPoint location)
@@ -632,10 +631,7 @@ public:
         m_globalPosition = location;
         m_isPotentialTap = true;
         
-        unsigned touchCount = 1;
-        m_touchPoints.reserveInitialCapacity(touchCount);
-        for (unsigned i = 0; i < touchCount; ++i)
-            m_touchPoints.uncheckedAppend(PlatformTouchPointBuilder(1, location, touchPhaseFromPlatformEventType(type)));
+        m_touchPoints = Vector<PlatformTouchPoint>({ PlatformTouchPointBuilder(1, location, touchPhaseFromPlatformEventType(type)) });
     }
 };
 

--- a/Source/WebCore/platform/ios/WebCoreMotionManager.mm
+++ b/Source/WebCore/platform/ios/WebCoreMotionManager.mm
@@ -216,11 +216,7 @@ static const double kGravity = 9.80665;
     WebThreadRun(^{
         CMAcceleration accel = newAcceleration.acceleration;
 
-        Vector<WeakPtr<WebCore::MotionManagerClient>> motionClients;
-        motionClients.reserveInitialCapacity(m_deviceMotionClients.computeSize());
-        for (auto& client : m_deviceMotionClients)
-            motionClients.uncheckedAppend(client);
-
+        auto motionClients = copyToVector(m_deviceMotionClients);
         for (auto& client : motionClients) {
             if (client)
                 client->motionChanged(0, 0, 0, accel.x * kGravity, accel.y * kGravity, accel.z * kGravity, std::nullopt, std::nullopt, std::nullopt);
@@ -241,11 +237,7 @@ static const double kGravity = 9.80665;
 
         CMRotationRate rotationRate = newMotion.rotationRate;
 
-        Vector<WeakPtr<WebCore::MotionManagerClient>> motionClients;
-        motionClients.reserveInitialCapacity(m_deviceMotionClients.computeSize());
-        for (auto& client : m_deviceMotionClients)
-            motionClients.uncheckedAppend(client);
-        
+        auto motionClients = copyToVector(m_deviceMotionClients);
         for (auto& client : motionClients) {
             if (client)
                 client->motionChanged(userAccel.x * kGravity, userAccel.y * kGravity, userAccel.z * kGravity, totalAccel.x * kGravity, totalAccel.y * kGravity, totalAccel.z * kGravity, rad2deg(rotationRate.x), rad2deg(rotationRate.y), rad2deg(rotationRate.z));
@@ -253,10 +245,7 @@ static const double kGravity = 9.80665;
 
         CMAttitude* attitude = newMotion.attitude;
 
-        Vector<WeakPtr<WebCore::MotionManagerClient>> orientationClients;
-        orientationClients.reserveInitialCapacity(m_deviceOrientationClients.computeSize());
-        for (auto& client : m_deviceOrientationClients)
-            orientationClients.uncheckedAppend(client);
+        auto orientationClients = copyToVector(m_deviceOrientationClients);
         
         // Compose the raw motion data to an intermediate ZXY-based 3x3 rotation
         // matrix (R) where [z=attitude.yaw, x=attitude.pitch, y=attitude.roll]
@@ -329,9 +318,9 @@ static const double kGravity = 9.80665;
         double heading = (m_headingAvailable && newHeading) ? newHeading.magneticHeading : 0;
         double headingAccuracy = (m_headingAvailable && newHeading) ? newHeading.headingAccuracy : -1;
 
-        for (size_t i = 0; i < orientationClients.size(); ++i) {
-            if (orientationClients[i])
-                orientationClients[i]->orientationChanged(alpha, beta, gamma, heading, headingAccuracy);
+        for (auto& orientationClient : orientationClients) {
+            if (orientationClient)
+                orientationClient->orientationChanged(alpha, beta, gamma, heading, headingAccuracy);
         }
     });
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -452,8 +452,7 @@ static inline RTCRtpCapabilities toRTCRtpCapabilities(const webrtc::RtpCapabilit
 {
     RTCRtpCapabilities capabilities;
 
-    capabilities.codecs.reserveInitialCapacity(rtpCapabilities.codecs.size());
-    for (auto& codec : rtpCapabilities.codecs) {
+    capabilities.codecs = WTF::map(rtpCapabilities.codecs, [](auto& codec) {
         StringBuilder sdpFmtpLineBuilder;
         bool hasParameter = false;
         for (auto& parameter : codec.parameters) {
@@ -463,12 +462,13 @@ static inline RTCRtpCapabilities toRTCRtpCapabilities(const webrtc::RtpCapabilit
         String sdpFmtpLine;
         if (sdpFmtpLineBuilder.length())
             sdpFmtpLine = sdpFmtpLineBuilder.toString();
-        capabilities.codecs.uncheckedAppend(RTCRtpCodecCapability { fromStdString(codec.mime_type()), static_cast<uint32_t>(codec.clock_rate ? *codec.clock_rate : 0), toChannels(codec.num_channels), WTFMove(sdpFmtpLine) });
-    }
+        return RTCRtpCodecCapability { fromStdString(codec.mime_type()), static_cast<uint32_t>(codec.clock_rate ? *codec.clock_rate : 0), toChannels(codec.num_channels), WTFMove(sdpFmtpLine) };
 
-    capabilities.headerExtensions.reserveInitialCapacity(rtpCapabilities.header_extensions.size());
-    for (auto& header : rtpCapabilities.header_extensions)
-        capabilities.headerExtensions.uncheckedAppend(RTCRtpCapabilities::HeaderExtensionCapability { fromStdString(header.uri) });
+    });
+
+    capabilities.headerExtensions = WTF::map(rtpCapabilities.header_extensions, [](auto& header) {
+        return RTCRtpCapabilities::HeaderExtensionCapability { fromStdString(header.uri) };
+    });
 
     return capabilities;
 }

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -420,19 +420,27 @@ void RenderThemeIOS::paintCheckboxDecorations(const RenderObject& box, const Pai
                 { 11.5f / size.width, 2.5f / size.height }
             };
 
-            line.uncheckedAppend(CGPointMake(clip.x() + width * pathRatios[0].x, clip.y() + height * pathRatios[0].y));
-            line.uncheckedAppend(CGPointMake(clip.x() + width * pathRatios[1].x, clip.y() + height * pathRatios[1].y));
-            line.uncheckedAppend(CGPointMake(clip.x() + width * pathRatios[2].x, clip.y() + height * pathRatios[2].y));
+            line.appendList({
+                CGPointMake(clip.x() + width * pathRatios[0].x, clip.y() + height * pathRatios[0].y),
+                CGPointMake(clip.x() + width * pathRatios[1].x, clip.y() + height * pathRatios[1].y),
+                CGPointMake(clip.x() + width * pathRatios[2].x, clip.y() + height * pathRatios[2].y)
+            });
 
-            shadow.uncheckedAppend(shortened(line[0], line[1], lineWidth / 4.0f));
-            shadow.uncheckedAppend(line[1]);
-            shadow.uncheckedAppend(shortened(line[2], line[1], lineWidth / 4.0f));
+            shadow.appendList({
+                shortened(line[0], line[1], lineWidth / 4.0f),
+                line[1],
+                shortened(line[2], line[1], lineWidth / 4.0f)
+            });
         } else {
-            line.uncheckedAppend(CGPointMake(clip.x() + 3.5, clip.center().y()));
-            line.uncheckedAppend(CGPointMake(clip.maxX() - 3.5, clip.center().y()));
+            line.appendList({
+                CGPointMake(clip.x() + 3.5, clip.center().y()),
+                CGPointMake(clip.maxX() - 3.5, clip.center().y())
+            });
 
-            shadow.uncheckedAppend(shortened(line[0], line[1], lineWidth / 4.0f));
-            shadow.uncheckedAppend(shortened(line[1], line[0], lineWidth / 4.0f));
+            shadow.appendList({
+                shortened(line[0], line[1], lineWidth / 4.0f),
+                shortened(line[1], line[0], lineWidth / 4.0f)
+            });
         }
 
         lineWidth = std::max<float>(lineWidth, 1);

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -350,10 +350,9 @@ public:
         m_timestamp = webEvent.timestamp();
 
 #if PLATFORM(IOS_FAMILY)
-        unsigned touchCount = webEvent.touchPoints().size();
-        m_touchPoints.reserveInitialCapacity(touchCount);
-        for (unsigned i = 0; i < touchCount; ++i)
-            m_touchPoints.uncheckedAppend(WebKit2PlatformTouchPoint(webEvent.touchPoints().at(i)));
+        m_touchPoints = WTF::map(webEvent.touchPoints(), [&](auto& touchPoint) -> PlatformTouchPoint {
+            return WebKit2PlatformTouchPoint(touchPoint);
+        });
 
         m_gestureScale = webEvent.gestureScale();
         m_gestureRotation = webEvent.gestureRotation();

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -182,10 +182,10 @@ void ArgumentCoder<GRefPtr<GUnixFDList>>::encode(Encoder& encoder, const GRefPtr
 
     Vector<UnixFileDescriptor> attachments;
     unsigned length = std::max(0, g_unix_fd_list_get_length(fdList.get()));
-    if (!!length) {
-        attachments.reserveInitialCapacity(length);
-        for (unsigned i = 0; i < length; ++i)
-            attachments.uncheckedAppend(UnixFileDescriptor { g_unix_fd_list_get(fdList.get(), i, nullptr), UnixFileDescriptor::Adopt });
+    if (length) {
+        attachments = Vector<UnixFileDescriptor>(length, [&](size_t i) {
+            return UnixFileDescriptor { g_unix_fd_list_get(fdList.get(), i, nullptr), UnixFileDescriptor::Adopt };
+        });
     }
     encoder << true << WTFMove(attachments);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -548,11 +548,9 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         fetchOptions.add(WebKit::WebsiteDataFetchOption::ComputeSizes);
 
     _websiteDataStore->fetchData(WebKit::toWebsiteDataTypes(dataTypes), fetchOptions, [completionHandlerCopy = WTFMove(completionHandlerCopy)](auto websiteDataRecords) {
-        Vector<RefPtr<API::Object>> elements;
-        elements.reserveInitialCapacity(websiteDataRecords.size());
-
-        for (auto& websiteDataRecord : websiteDataRecords)
-            elements.uncheckedAppend(API::WebsiteDataRecord::create(WTFMove(websiteDataRecord)));
+        auto elements = WTF::map(websiteDataRecords, [](auto& websiteDataRecord) -> RefPtr<API::Object> {
+            return API::WebsiteDataRecord::create(WTFMove(websiteDataRecord));
+        });
 
         completionHandlerCopy(wrapper(API::Array::create(WTFMove(elements))));
     });

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp
@@ -44,10 +44,9 @@ private:
             variant = adoptGRef(g_variant_parse(nullptr, userDataString.data(), userDataString.data() + userDataString.length(), nullptr, nullptr));
         }
 
-        Vector<WebContextMenuItemData> menuItems;
-        menuItems.reserveInitialCapacity(proposedMenu.size());
-        for (auto& item : proposedMenu)
-            menuItems.uncheckedAppend(item->data());
+        auto menuItems = WTF::map(proposedMenu, [](auto& item) {
+            return item->data();
+        });
         webkitWebViewPopulateContextMenu(m_webView, menuItems, hitTestResultData, variant.get());
         contextMenuListener.useContextMenuItems({ });
     }

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -81,22 +81,20 @@ SimulatedInputKeyFrame SimulatedInputKeyFrame::keyFrameFromStateOfInputSources(c
     // The client of this class is required to intern SimulatedInputSource instances if the last state
     // from the previous command should be used as the inital state for the next command. This is the
     // case for Perform Actions and Release Actions, but not Element Click or Element Send Keys.
-    Vector<SimulatedInputKeyFrame::StateEntry> entries;
-    entries.reserveCapacity(inputSources.size());
-
-    for (const auto& inputSource : inputSources.values())
-        entries.uncheckedAppend(std::pair<SimulatedInputSource&, SimulatedInputSourceState> { inputSource.get(), inputSource->state });
+    auto& values = inputSources.values();
+    auto entries = WTF::map(values, [](auto& inputSource) {
+        return std::pair<SimulatedInputSource&, SimulatedInputSourceState> { inputSource.get(), inputSource->state };
+    });
 
     return SimulatedInputKeyFrame(WTFMove(entries));
 }
 
 SimulatedInputKeyFrame SimulatedInputKeyFrame::keyFrameToResetInputSources(const HashMap<String, Ref<SimulatedInputSource>>& inputSources)
 {
-    Vector<SimulatedInputKeyFrame::StateEntry> entries;
-    entries.reserveCapacity(inputSources.size());
-
-    for (const auto& inputSource : inputSources.values())
-        entries.uncheckedAppend(std::pair<SimulatedInputSource&, SimulatedInputSourceState> { inputSource.get(), SimulatedInputSourceState::emptyStateForSourceType(inputSource->type) });
+    auto& values = inputSources.values();
+    auto entries = WTF::map(values, [](auto& inputSource) {
+        return std::pair<SimulatedInputSource&, SimulatedInputSourceState> { inputSource.get(), SimulatedInputSourceState::emptyStateForSourceType(inputSource->type) };
+    });
 
     return SimulatedInputKeyFrame(WTFMove(entries));
 }

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -961,11 +961,9 @@ void WebAutomationSession::evaluateJavaScriptFunction(const Inspector::Protocol:
     if (frameNotFound)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(FrameNotFound);
 
-    Vector<String> argumentsVector;
-    argumentsVector.reserveCapacity(arguments->length());
-
-    for (const auto& argument : arguments.get())
-        argumentsVector.uncheckedAppend(argument->asString());
+    auto argumentsVector = WTF::map(arguments.get(), [](auto& argument) {
+        return argument->asString();
+    });
 
     uint64_t callbackID = m_nextEvaluateJavaScriptCallbackID++;
     m_evaluateJavaScriptFunctionCallbacks.set(callbackID, WTFMove(callback));

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -306,12 +306,11 @@ Ref<API::Array> WebBackForwardList::backListAsAPIArrayWithLimit(unsigned limit) 
     if (!size)
         return API::Array::create();
 
-    Vector<RefPtr<API::Object>> vector;
-    vector.reserveInitialCapacity(size);
-
     ASSERT(backListSize >= size);
-    for (unsigned i = backListSize - size; i < backListSize; ++i)
-        vector.uncheckedAppend(m_entries[i].ptr());
+    size_t startIndex = backListSize - size;
+    Vector<RefPtr<API::Object>> vector(size, [&](size_t i) -> RefPtr<API::Object> {
+        return m_entries[startIndex + i].ptr();
+    });
 
     return API::Array::create(WTFMove(vector));
 }
@@ -327,13 +326,10 @@ Ref<API::Array> WebBackForwardList::forwardListAsAPIArrayWithLimit(unsigned limi
     if (!size)
         return API::Array::create();
 
-    Vector<RefPtr<API::Object>> vector;
-    vector.reserveInitialCapacity(size);
-
-    size_t last = *m_currentIndex + size;
-    ASSERT(last < m_entries.size());
-    for (size_t i = *m_currentIndex + 1; i <= last; ++i)
-        vector.uncheckedAppend(m_entries[i].ptr());
+    size_t startIndex = *m_currentIndex + 1;
+    Vector<RefPtr<API::Object>> vector(size, [&](size_t i) -> RefPtr<API::Object> {
+        return m_entries[startIndex + i].ptr();
+    });
 
     return API::Array::create(WTFMove(vector));
 }

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -68,10 +68,9 @@ void Clipboard::formats(CompletionHandler<void(Vector<String>&&)>&& completionHa
     gsize mimeTypesCount;
     const char* const* mimeTypes = gdk_content_formats_get_mime_types(gdk_clipboard_get_formats(m_clipboard), &mimeTypesCount);
 
-    Vector<String> result;
-    result.reserveInitialCapacity(mimeTypesCount);
-    for (size_t i = 0; i < mimeTypesCount; ++i)
-        result.uncheckedAppend(String::fromUTF8(mimeTypes[i]));
+    Vector<String> result(mimeTypesCount, [&](size_t i) {
+        return String::fromUTF8(mimeTypes[i]);
+    });
     completionHandler(WTFMove(result));
 }
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -877,9 +877,9 @@ void WebAutomationSessionProxy::setFilesForInputFileUpload(WebCore::PageIdentifi
         if (auto* files = inputElement.files())
             fileObjects.appendVector(files->files());
     }
-    fileObjects.reserveCapacity(fileObjects.size() + filenames.size());
-    for (const auto& path : filenames)
-        fileObjects.uncheckedAppend(WebCore::File::create(&inputElement.document(), path));
+    fileObjects.appendContainerWithMapping(filenames, [&](auto& path) {
+        return WebCore::File::create(&inputElement.document(), path);
+    });
     inputElement.setFiles(WebCore::FileList::create(WTFMove(fileObjects)));
 
     completionHandler(std::nullopt);

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2609,10 +2609,9 @@ JSValueRef JSIPC::serializedEnumInfo(JSContextRef context, JSObjectRef thisObjec
         if (*exception)
             return JSValueMakeUndefined(context);
 
-        Vector<JSValueRef> validValuesArray;
-        validValuesArray.reserveInitialCapacity(enumeration.validValues.size());
-        for (auto& validValue : enumeration.validValues)
-            validValuesArray.uncheckedAppend(JSValueMakeNumber(context, validValue));
+        auto validValuesArray = WTF::map(enumeration.validValues, [&](auto& validValue) -> JSValueRef {
+            return JSValueMakeNumber(context, validValue);
+        });
         JSObjectRef jsValidValues = JSObjectMakeArray(context, enumeration.validValues.size(), validValuesArray.data(), exception);
         if (*exception)
             return JSValueMakeUndefined(context);

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
@@ -67,23 +67,20 @@ void UserMediaCaptureManager::validateUserMediaRequestConstraints(WebCore::Media
 void UserMediaCaptureManager::getMediaStreamDevices(bool revealIdsAndLabels, GetMediaStreamDevicesCallback&& completionHandler)
 {
     RealtimeMediaSourceCenter::singleton().getMediaStreamDevices([completionHandler = WTFMove(completionHandler), revealIdsAndLabels](auto&& devices) mutable {
-        Vector<CaptureDeviceWithCapabilities> devicesWithCapabilities;
-
-        devicesWithCapabilities.reserveInitialCapacity(devices.size());
-        for (auto& device : devices) {
+        auto devicesWithCapabilities = WTF::compactMap(devices, [&](auto& device) -> std::optional<CaptureDeviceWithCapabilities> {
             RealtimeMediaSourceCapabilities deviceCapabilities;
 
             if (device.isInputDevice()) {
                 auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
                 if (!capabilities)
-                    continue;
+                    return std::nullopt;
 
                 if (revealIdsAndLabels)
                     deviceCapabilities = *capabilities;
             }
 
-            devicesWithCapabilities.uncheckedAppend({ WTFMove(device), WTFMove(deviceCapabilities) });
-        }
+            return CaptureDeviceWithCapabilities { WTFMove(device), WTFMove(deviceCapabilities) };
+        });
 
         completionHandler(WTFMove(devicesWithCapabilities));
     });


### PR DESCRIPTION
#### e7149c4d7559e4b663d3f375be37dc5dba82c8ca
<pre>
Reduce use of Vector::uncheckedAppend() throughout the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=263002">https://bugs.webkit.org/show_bug.cgi?id=263002</a>

Reviewed by Brent Fulgham.

Reduce use of Vector::uncheckedAppend() throughout the codebase and replace
with more efficient idioms now that uncheckedAppend() has become an alias to
append().

* Source/WTF/wtf/JSONValues.h:
(WTF::containerSize):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::syntaxViolation):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::convertToBacking):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::dispatchPendingTrackEvents):
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::serialize const):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsForResourceLoad const):
* Source/WebCore/contentextensions/DFABytecodeCompiler.cpp:
(WebCore::ContentExtensions::DFABytecodeCompiler::extractJumpTable):
* Source/WebCore/contentextensions/DFAMinimizer.cpp:
* Source/WebCore/contentextensions/MutableRangeList.h:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsNthLastChildOf):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::updateDataDetectorHighlights):
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::MultiChannelResampler):
* Source/WebCore/platform/graphics/ComplexTextController.h:
* Source/WebCore/platform/graphics/cocoa/FontDatabase.cpp:
(WebCore::FontDatabase::collectionForFamily):
* Source/WebCore/platform/graphics/iso/ISOBox.cpp:
(WebCore::ISOBox::parse):
* Source/WebCore/platform/graphics/mac/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::ComplexTextRun::ComplexTextRun):
* Source/WebCore/platform/ios/PlatformEventFactoryIOS.mm:
(WebCore::PlatformTouchEventBuilder::PlatformTouchEventBuilder):
* Source/WebCore/platform/ios/WebCoreMotionManager.mm:
(-[WebCoreMotionManager sendAccelerometerData:]):
(-[WebCoreMotionManager sendMotionData:withHeading:]):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::toRTCRtpCapabilities):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintCheckboxDecorations):
(WebCore::RenderThemeIOS::adjustedPaintRect const): Deleted.
(WebCore::RenderThemeIOS::baselinePosition const): Deleted.
(WebCore::RenderThemeIOS::isControlStyled const): Deleted.
(WebCore::RenderThemeIOS::adjustMinimumIntrinsicSizeForAppearance const): Deleted.
(WebCore::RenderThemeIOS::adjustRadioStyle const): Deleted.
(WebCore::RenderThemeIOS::paintRadioDecorations): Deleted.
(WebCore::RenderThemeIOS::adjustTextFieldStyle const): Deleted.
(WebCore::RenderThemeIOS::paintTextFieldInnerShadow): Deleted.
(WebCore::RenderThemeIOS::paintTextFieldDecorations): Deleted.
(WebCore::RenderThemeIOS::adjustTextAreaStyle const): Deleted.
(WebCore::RenderThemeIOS::paintTextAreaDecorations): Deleted.
(WebCore::RenderThemeIOS::popupInternalPaddingBox const): Deleted.
(WebCore::canAdjustBorderRadiusForAppearance): Deleted.
(WebCore::RenderThemeIOS::adjustRoundBorderRadius): Deleted.
(WebCore::applyCommonButtonPaddingToStyle): Deleted.
(WebCore::adjustSelectListButtonStyle): Deleted.
(WebCore::RenderThemeMeasureTextClient::RenderThemeMeasureTextClient): Deleted.
(WebCore::adjustInputElementButtonStyle): Deleted.
(WebCore::RenderThemeIOS::adjustMenuListButtonStyle const): Deleted.
(WebCore::RenderThemeIOS::paintMenuListButtonDecorations): Deleted.
(WebCore::RenderThemeIOS::adjustSliderTrackStyle const): Deleted.
(WebCore::RenderThemeIOS::paintSliderTrack): Deleted.
(WebCore::RenderThemeIOS::adjustSliderThumbSize const): Deleted.
(WebCore::RenderThemeIOS::paintSliderThumbDecorations): Deleted.
(WebCore::RenderThemeIOS::paintProgressBar): Deleted.
(WebCore::RenderThemeIOS::sliderTickSize const): Deleted.
(WebCore::RenderThemeIOS::sliderTickOffsetFromTrackCenter const): Deleted.
(WebCore::RenderThemeIOS::adjustSearchFieldStyle const): Deleted.
(WebCore::RenderThemeIOS::paintSearchFieldDecorations): Deleted.
(WebCore::RenderThemeIOS::isSubmitStyleButton const): Deleted.
(WebCore::RenderThemeIOS::adjustButtonLikeControlStyle const): Deleted.
(WebCore::RenderThemeIOS::adjustButtonStyle const): Deleted.
(WebCore::RenderThemeIOS::paintButtonDecorations): Deleted.
(WebCore::shouldUseConvexGradient): Deleted.
(WebCore::RenderThemeIOS::paintPushButtonDecorations): Deleted.
(WebCore::RenderThemeIOS::platformActiveSelectionBackgroundColor const): Deleted.
(WebCore::RenderThemeIOS::platformInactiveSelectionBackgroundColor const): Deleted.
(WebCore::cachedFocusRingColor): Deleted.
(WebCore::cachedInsertionPointColor): Deleted.
(WebCore::RenderThemeIOS::systemFocusRingColor): Deleted.
(WebCore::RenderThemeIOS::platformFocusRingColor const): Deleted.
(WebCore::RenderThemeIOS::insertionPointColor): Deleted.
(WebCore::RenderThemeIOS::autocorrectionReplacementMarkerColor const): Deleted.
(WebCore::RenderThemeIOS::platformAnnotationHighlightColor const): Deleted.
(WebCore::RenderThemeIOS::shouldHaveSpinButton const): Deleted.
(WebCore::RenderThemeIOS::supportsFocusRing const): Deleted.
(WebCore::RenderThemeIOS::supportsBoxShadow const): Deleted.
(WebCore::cssValueSystemColorInformationList): Deleted.
(WebCore::systemColorFromCSSValueSystemColorInformation): Deleted.
(WebCore::systemColorFromCSSValueID): Deleted.
(WebCore::globalCSSValueToSystemColorMap): Deleted.
(WebCore::RenderThemeIOS::cssValueToSystemColorMap): Deleted.
(WebCore::RenderThemeIOS::setCSSValueToSystemColorMap): Deleted.
(WebCore::RenderThemeIOS::setFocusRingColor): Deleted.
(WebCore::RenderThemeIOS::setInsertionPointColor): Deleted.
(WebCore::RenderThemeIOS::systemColor const): Deleted.
(WebCore::RenderThemeIOS::pictureFrameColor): Deleted.
(WebCore::RenderThemeIOS::controlTintColor const): Deleted.
(WebCore::RenderThemeIOS::iconForAttachment): Deleted.
(WebCore::RenderThemeIOS::attachmentIntrinsicSize const): Deleted.
(WebCore::paintAttachmentIcon): Deleted.
(WebCore::paintAttachmentProgress): Deleted.
(WebCore::attachmentBorderPath): Deleted.
(WebCore::paintAttachmentBorder): Deleted.
(WebCore::RenderThemeIOS::paintAttachment): Deleted.
(WebCore::RenderThemeIOS::attachmentStyleSheet const): Deleted.
(WebCore::RenderThemeIOS::extraDefaultStyleSheet): Deleted.
(WebCore::RenderThemeIOS::paintSystemPreviewBadge): Deleted.
(WebCore::RenderThemeIOS::checkboxRadioBorderColor): Deleted.
(WebCore::RenderThemeIOS::checkboxRadioBackgroundColor): Deleted.
(WebCore::RenderThemeIOS::checkboxRadioBackgroundGradient): Deleted.
(WebCore::RenderThemeIOS::checkboxRadioIndicatorColor): Deleted.
(WebCore::RenderThemeIOS::paintCheckboxRadioInnerShadow): Deleted.
(WebCore::RenderThemeIOS::paintCheckbox): Deleted.
(WebCore::RenderThemeIOS::paintRadio): Deleted.
(WebCore::RenderThemeIOS::animationRepeatIntervalForProgressBar const): Deleted.
(WebCore::RenderThemeIOS::paintProgressBarWithFormControlRefresh): Deleted.
(WebCore::RenderThemeIOS::supportsMeter const): Deleted.
(WebCore::RenderThemeIOS::paintMeter): Deleted.
(WebCore::RenderThemeIOS::paintListButton): Deleted.
(WebCore::RenderThemeIOS::paintSliderTicks): Deleted.
(WebCore::RenderThemeIOS::paintSliderTrackWithFormControlRefresh): Deleted.
(WebCore::RenderThemeIOS::colorInputStyleSheet const): Deleted.
(WebCore::RenderThemeIOS::adjustColorWellStyle const): Deleted.
(WebCore::RenderThemeIOS::paintColorWell): Deleted.
(WebCore::RenderThemeIOS::paintColorWellDecorations): Deleted.
(WebCore::RenderThemeIOS::paintMenuListButtonDecorationsWithFormControlRefresh): Deleted.
(WebCore::RenderThemeIOS::adjustSearchFieldDecorationPartStyle const): Deleted.
(WebCore::RenderThemeIOS::paintSearchFieldDecorationPart): Deleted.
(WebCore::RenderThemeIOS::adjustSearchFieldResultsDecorationPartStyle const): Deleted.
(WebCore::RenderThemeIOS::paintSearchFieldResultsDecorationPart): Deleted.
(WebCore::RenderThemeIOS::adjustSearchFieldResultsButtonStyle const): Deleted.
(WebCore::RenderThemeIOS::paintSearchFieldResultsButton): Deleted.
* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::WebKit2PlatformTouchEvent::WebKit2PlatformTouchEvent):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt;::encode):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _fetchDataRecordsOfTypes:withOptions:completionHandler:]):
* Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp:
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
(WebKit::SimulatedInputKeyFrame::keyFrameFromStateOfInputSources):
(WebKit::SimulatedInputKeyFrame::keyFrameToResetInputSources):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::evaluateJavaScriptFunction):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::getAssertion):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backListAsAPIArrayWithLimit const):
(WebKit::WebBackForwardList::forwardListAsAPIArrayWithLimit const):
* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:
(WebKit::Clipboard::formats):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::setFilesForInputFileUpload):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPC::serializedEnumInfo):
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::getMediaStreamDevices):

Canonical link: <a href="https://commits.webkit.org/269224@main">https://commits.webkit.org/269224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfae48bf63d586fffa84f020ef0fc7ec0c23e2f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20311 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22465 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21799 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24667 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/18927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19880 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19069 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/19955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21308 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25351 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19883 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5982 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5229 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24090 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26624 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20483 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5814 "Passed tests") | 
<!--EWS-Status-Bubble-End-->