### PR TITLE
Long delay when switching audio input in Google Meet

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -58,11 +58,11 @@ namespace WebCore {
 const UInt32 outputBus = 0;
 const UInt32 inputBus = 1;
 
-class CoreAudioSharedInternalUnit :  public CoreAudioSharedUnit::InternalUnit {
+class CoreAudioSharedInternalUnit final :  public CoreAudioSharedUnit::InternalUnit {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Expected<UniqueRef<InternalUnit>, OSStatus> create(bool shouldUseVPIO);
-    explicit CoreAudioSharedInternalUnit(AudioUnit);
+    CoreAudioSharedInternalUnit(AudioUnit, bool shouldUseVPIO);
     ~CoreAudioSharedInternalUnit() final;
 
 private:
@@ -75,12 +75,22 @@ private:
     OSStatus render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32, UInt32, AudioBufferList*) final;
     OSStatus defaultInputDevice(uint32_t*) final;
     OSStatus defaultOutputDevice(uint32_t*) final;
+    void storeVPIOUnitIfNeeded() final;
 
     AudioUnit m_ioUnit { nullptr };
+    bool m_shouldUseVPIO { false };
 };
 
 Expected<UniqueRef<CoreAudioSharedUnit::InternalUnit>, OSStatus> CoreAudioSharedInternalUnit::create(bool shouldUseVPIO)
 {
+    if (shouldUseVPIO) {
+        if (auto ioUnit = CoreAudioSharedUnit::unit().takeStoredVPIOUnit()) {
+            RELEASE_LOG(WebRTC, "Creating a CoreAudioSharedInternalUnit wilth a stored VPIO unit");
+            UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<CoreAudioSharedInternalUnit>(ioUnit, shouldUseVPIO);
+            return result;
+        }
+    }
+
     OSType unitSubType = kAudioUnitSubType_VoiceProcessingIO;
     if (!shouldUseVPIO) {
 #if PLATFORM(MAC)
@@ -117,18 +127,26 @@ Expected<UniqueRef<CoreAudioSharedUnit::InternalUnit>, OSStatus> CoreAudioShared
 
     RELEASE_LOG(WebRTC, "Successfully created a CoreAudioSharedInternalUnit");
 
-    UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<CoreAudioSharedInternalUnit>(ioUnit);
+    UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<CoreAudioSharedInternalUnit>(ioUnit, shouldUseVPIO);
     return result;
 }
 
-CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit(AudioUnit ioUnit)
+CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit(AudioUnit ioUnit, bool shouldUseVPIO)
     : m_ioUnit(ioUnit)
+    , m_shouldUseVPIO(shouldUseVPIO)
 {
 }
 
 CoreAudioSharedInternalUnit::~CoreAudioSharedInternalUnit()
 {
-    PAL::AudioComponentInstanceDispose(m_ioUnit);
+    if (!CoreAudioSharedUnit::unit().iStoredVPIOUnit(m_ioUnit))
+        PAL::AudioComponentInstanceDispose(m_ioUnit);
+}
+
+void CoreAudioSharedInternalUnit::storeVPIOUnitIfNeeded()
+{
+    if (m_shouldUseVPIO)
+        CoreAudioSharedUnit::unit().setStoredVPIOUnit(m_ioUnit);
 }
 
 OSStatus CoreAudioSharedInternalUnit::initialize()
@@ -218,6 +236,13 @@ CoreAudioSharedUnit::CoreAudioSharedUnit()
 
 CoreAudioSharedUnit::~CoreAudioSharedUnit()
 {
+    ASSERT(!m_storedVPIOUnit);
+}
+
+void CoreAudioSharedUnit::setStoredVPIOUnit(AudioUnit unit)
+{
+    ASSERT(!m_storedVPIOUnit);
+    m_storedVPIOUnit = unit;
 }
 
 void CoreAudioSharedUnit::resetSampleRate()
@@ -546,6 +571,16 @@ OSStatus CoreAudioSharedUnit::reconfigureAudioUnit()
             return err;
         }
     }
+
+#if PLATFORM(MAC)
+    m_ioUnit->storeVPIOUnitIfNeeded();
+    auto scopeVPIOUnit = makeScopeExit([this] {
+        if (auto unit = takeStoredVPIOUnit()) {
+            RELEASE_LOG_INFO(WebRTC, "CoreAudioSharedUnit::reconfigureAudioUnit disposing VPIO unit");
+            PAL::AudioComponentInstanceDispose(unit);
+        }
+    });
+#endif
 
     cleanupAudioUnit();
     if (auto err = setupAudioUnit())


### PR DESCRIPTION
#### 7ca419834e5cf349386849b51920d2b81d9ecb86
<pre>
Long delay when switching audio input in Google Meet
<a href="https://bugs.webkit.org/show_bug.cgi?id=248183">https://bugs.webkit.org/show_bug.cgi?id=248183</a>
rdar://102724364

Reviewed by Eric Carlson.

Creating a kAudioUnitSubType_VoiceProcessingIO is expensive as it may block the thread for 2 seconds.
To limit this overhead, we reuse the VPIO unit in case of reconfiguration, if any is being used.
Testing on Google Meet locally, this improves device switching both in terms of UI (which does not freeze)
and in terms of delay of audio switching.
We only reuse VPIO unit on macOS for now.

* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedInternalUnit::create):
(WebCore::CoreAudioSharedInternalUnit::CoreAudioSharedInternalUnit):
(WebCore::CoreAudioSharedInternalUnit::~CoreAudioSharedInternalUnit):
(WebCore::CoreAudioSharedInternalUnit::storeVPIOUnitIfNeeded):
(WebCore::CoreAudioSharedUnit::~CoreAudioSharedUnit):
(WebCore::CoreAudioSharedUnit::setStoredVPIOUnit):
(WebCore::CoreAudioSharedUnit::reconfigureAudioUnit):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:

Canonical link: <a href="https://commits.webkit.org/269242@main">https://commits.webkit.org/269242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba9634bbc5fa4cb46bd332d258480af3cddae68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20246 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21348 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24596 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18853 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26082 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23945 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20475 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19822 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5243 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->