### PR TITLE
AX: align AccessibilityRole::Switch with ::Checkbox

### DIFF
--- a/LayoutTests/accessibility/aria-required-expected.txt
+++ b/LayoutTests/accessibility/aria-required-expected.txt
@@ -3,7 +3,7 @@ This tests that aria-required is a usable attribute.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-Elements to test: 36
+Elements to test: 39
 
 PASS textfield isRequired is false
 PASS textfield_required isRequired is true
@@ -41,6 +41,9 @@ PASS spinbutton isRequired is false
 PASS tree_ariarequiredtrue isRequired is true
 PASS tree_ariarequiredfalse isRequired is false
 PASS tree isRequired is false
+PASS switch_ariarequiredtrue isRequired is true
+PASS switch_ariarequiredfalse isRequired is false
+PASS switch isRequired is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/aria-required.html
+++ b/LayoutTests/accessibility/aria-required.html
@@ -65,6 +65,10 @@
   <div tabindex="0" aria-required="false" role="tree" id="tree_ariarequiredfalse" data-expectedrequired="false">text</div>
   <div tabindex="0" role="tree" id="tree" data-expectedrequired="false">text</div>
 
+  <div tabindex="0" aria-required="true" role="switch" id="switch_ariarequiredtrue" data-expectedrequired="true">text</div>
+  <div tabindex="0" aria-required="false" role="switch" id="switch_ariarequiredfalse" data-expectedrequired="false">text</div>
+  <div tabindex="0" role="switch" id="switch" data-expectedrequired="false">text</div>
+
 </div>
 
 <p id="description"></p>

--- a/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
+++ b/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
@@ -4,10 +4,10 @@ Checking Web Inspector protocol for the Accessibility Node Inspector.
     exists: true
     label:
     role:
-    childNodeIds.length: 92
+    childNodeIds.length: 93
 
 
-Total elements to be tested: 122.
+Total elements to be tested: 123.
 
 <div onclick="void(0);">click</div>
     exists: true
@@ -777,6 +777,14 @@ Total elements to be tested: 122.
     parentNodeId: exists
     readonly: true
     required: false
+
+<div role="switch" aria-required="true">Required switch.</div>
+    exists: true
+    label: Required switch.
+    role: switch
+    checked: false
+    parentNodeId: exists
+    required: true
 
 <input readonly="" value="readonly">
     exists: true

--- a/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode.html
+++ b/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode.html
@@ -57,6 +57,8 @@
 <input class="ex" aria-invalid="foo" value="fake value will eval to true">
 <input class="ex" readonly value="readonly">
 
+<div class="ex" role="switch" aria-required="true">Required switch.</div>
+
 <div class="ex" role="textbox" tabindex="0" aria-readonly="true">readonly</div>
 <input class="ex" disabled value="disabled">
 <div class="ex" role="textbox" tabindex="0" aria-disabled="true">disabled</div>

--- a/LayoutTests/interaction-region/aria-roles-expected.txt
+++ b/LayoutTests/interaction-region/aria-roles-expected.txt
@@ -3,6 +3,7 @@ This works like a link
 Menu option 1
 Menu option 2
 Menu option 3
+This works like a switch.
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -25,6 +26,8 @@ Menu option 3
         (interaction (40,76) width=760 height=20)
         (borderRadius 8.00),
         (interaction (40,96) width=760 height=20)
+        (borderRadius 8.00),
+        (interaction (0,132) width=800 height=20)
         (borderRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/aria-roles.html
+++ b/LayoutTests/interaction-region/aria-roles.html
@@ -11,6 +11,7 @@
     <li role="menuitem">Menu option 2</li>
     <li role="option">Menu option 3</li>
 </ul>
+<div role="switch">This works like a switch.</div>
 <pre id="results"></pre>
 <script>
 document.body.addEventListener("click", function(e) {

--- a/LayoutTests/platform/gtk/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
+++ b/LayoutTests/platform/gtk/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
@@ -4,10 +4,10 @@ Checking Web Inspector protocol for the Accessibility Node Inspector.
     exists: true
     label:
     role:
-    childNodeIds.length: 92
+    childNodeIds.length: 93
 
 
-Total elements to be tested: 122.
+Total elements to be tested: 123.
 
 <div onclick="void(0);">click</div>
     exists: true
@@ -713,6 +713,14 @@ Total elements to be tested: 122.
     parentNodeId: exists
     readonly: true
     required: false
+
+<div role="switch" aria-required="true">Required switch.</div>
+    exists: true
+    label: Required switch.
+    role: switch
+    checked: false
+    parentNodeId: exists
+    required: true
 
 <input readonly="" value="readonly">
     exists: true

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -943,6 +943,7 @@ bool AccessibilityNodeObject::supportsRequiredAttribute() const
     case AccessibilityRole::RowHeader:
     case AccessibilityRole::Slider:
     case AccessibilityRole::SpinButton:
+    case AccessibilityRole::Switch:
     case AccessibilityRole::TableHeaderContainer:
     case AccessibilityRole::TextArea:
     case AccessibilityRole::TextField:

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -105,6 +105,7 @@ static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element
     case AccessibilityRole::MenuItemRadio:
     case AccessibilityRole::PopUpButton:
     case AccessibilityRole::RadioButton:
+    case AccessibilityRole::Switch:
     case AccessibilityRole::ToggleButton:
         return true;
     default:


### PR DESCRIPTION
#### 5ce55c698227f6ac484867f0b741cb9b8c73f4c7
<pre>
AX: align AccessibilityRole::Switch with ::Checkbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=263008">https://bugs.webkit.org/show_bug.cgi?id=263008</a>
rdar://116805287

Reviewed by Tyler Wilcock.

A switch should essentially be a checkbox except that it doesn&apos;t
support the intermediate/mixed state.

As such, this makes the following changes:

- We make switch support the required attribute.
- We make interaction regions support switches.

* LayoutTests/accessibility/aria-required-expected.txt:
* LayoutTests/accessibility/aria-required.html:
* LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt:
* LayoutTests/inspector/dom/getAccessibilityPropertiesForNode.html:
* LayoutTests/interaction-region/aria-roles-expected.txt:
* LayoutTests/interaction-region/aria-roles.html:
* LayoutTests/platform/gtk/inspector/dom/getAccessibilityPropertiesForNode-expected.txt:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::supportsRequiredAttribute const):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowAccessibilityRoleAsPointerCursorReplacement):

Canonical link: <a href="https://commits.webkit.org/269311@main">https://commits.webkit.org/269311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/179d3741eb299467a90512401e04ca73d7573133

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24937 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26364 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24224 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19919 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5284 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->