### PR TITLE
Enabled Blob partitioning

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -802,9 +802,9 @@ BlobRegistryTopOriginPartitioningEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 BlockIOKitInWebContentSandbox:
   type: bool


### PR DESCRIPTION
#### 9155875fd91cae6f79c9a82e2fefa09581ebfa3a
<pre>
Enabled Blob partitioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=263018">https://bugs.webkit.org/show_bug.cgi?id=263018</a>
rdar://116813727

Reviewed by Sihui Liu.

In a previous patch I moved the blob partitioning feature flag from preview to
stable status, but I didn&apos;t change its default value. This patch enables the
feature in WebKit/WebCore. WebKitLegacy has only a shim support for blob
registry partitioning, so this feature remains disabled by default in that
layer.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/269264@main">https://commits.webkit.org/269264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7535606fa42ffbb4dd9ebb13e397c3661fdd1063

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20267 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21370 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24618 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26104 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19037 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23962 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21263 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20499 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17474 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom/HTMLLinkElement-disabled-005.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25306 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19845 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5257 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24049 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26577 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20443 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5804 "Passed tests") | 
<!--EWS-Status-Bubble-End-->