### PR TITLE
Re-land Make config changes to bring up iOS17, tvOS17, and watchOS10 on EWS

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -53,9 +53,9 @@
     { "name": "ews106", "platform": "mac-monterey" },
     { "name": "ews107", "platform": "mac-monterey" },
     { "name": "ews108", "platform": "*" },
-    { "name": "ews109", "platform": "ios-16" },
-    { "name": "ews110", "platform": "ios-simulator-16" },
-    { "name": "ews111", "platform": "ios-simulator-16" },
+    { "name": "ews109", "platform": "ios-17" },
+    { "name": "ews110", "platform": "ios-simulator-17" },
+    { "name": "ews111", "platform": "ios-simulator-17" },
     { "name": "ews112", "platform": "mac-monterey" },
     { "name": "ews113", "platform": "mac-monterey" },
     { "name": "ews114", "platform": "*" },
@@ -67,16 +67,16 @@
     { "name": "ews120", "platform": "mac-monterey" },
     { "name": "ews129", "platform": "mac-monterey" },
     { "name": "ews169", "platform": "mac-monterey" },
-    { "name": "ews121", "platform": "ios-simulator-16" },
-    { "name": "ews122", "platform": "ios-simulator-16" },
-    { "name": "ews123", "platform": "ios-simulator-16" },
-    { "name": "ews124", "platform": "ios-simulator-16" },
-    { "name": "ews125", "platform": "ios-simulator-16" },
-    { "name": "ews126", "platform": "ios-simulator-16" },
+    { "name": "ews121", "platform": "ios-simulator-17" },
+    { "name": "ews122", "platform": "ios-simulator-17" },
+    { "name": "ews123", "platform": "ios-simulator-17" },
+    { "name": "ews124", "platform": "ios-simulator-17" },
+    { "name": "ews125", "platform": "ios-simulator-17" },
+    { "name": "ews126", "platform": "ios-simulator-17" },
     { "name": "ews127", "platform": "mac-monterey" },
     { "name": "ews128", "platform": "mac-monterey" },
     { "name": "ews130", "platform": "*" },
-    { "name": "ews131", "platform": "ios-16" },
+    { "name": "ews131", "platform": "ios-17" },
     { "name": "ews132", "platform": "*" },
     { "name": "ews133", "platform": "*" },
     { "name": "ews134", "platform": "*" },
@@ -114,7 +114,7 @@
     { "name": "ews166", "platform": "*" },
     { "name": "ews167", "platform": "*" },
     { "name": "ews168", "platform": "*" },
-    { "name": "ews170", "platform": "tvos-simulator-16" },
+    { "name": "ews170", "platform": "tvos-simulator-17" },
     { "name": "ews171", "platform": "mac-ventura" },
     { "name": "ews172", "platform": "mac-ventura" },
     { "name": "ews173", "platform": "mac-ventura" },
@@ -128,25 +128,25 @@
     { "name": "ews181", "platform": "mac-monterey" },
     { "name": "ews182", "platform": "mac-monterey" },
     { "name": "ews183", "platform": "*" },
-    { "name": "ews184", "platform": "ios-simulator-16" },
-    { "name": "ews185", "platform": "ios-simulator-16" },
+    { "name": "ews184", "platform": "ios-simulator-17" },
+    { "name": "ews185", "platform": "ios-simulator-17" },
     { "name": "ews186", "platform": "mac-monterey" },
     { "name": "ews187", "platform": "mac-monterey" },
     { "name": "ews188", "platform": "mac-monterey" },
     { "name": "ews189", "platform": "mac-monterey" },
-    { "name": "ews190", "platform": "ios-simulator-16" },
-    { "name": "ews191", "platform": "ios-simulator-16" },
-    { "name": "ews192", "platform": "ios-simulator-16" },
-    { "name": "ews193", "platform": "ios-simulator-16" },
-    { "name": "ews194", "platform": "ios-simulator-16" },
-    { "name": "ews195", "platform": "ios-simulator-16" },
-    { "name": "ews196", "platform": "ios-simulator-16" },
-    { "name": "ews197", "platform": "ios-simulator-16" },
-    { "name": "ews198", "platform": "ios-simulator-16" },
-    { "name": "ews200", "platform": "ios-simulator-16" },
-    { "name": "ews201", "platform": "ios-simulator-16" },
-    { "name": "ews202", "platform": "ios-simulator-16" },
-    { "name": "ews203", "platform": "ios-simulator-16" },
+    { "name": "ews190", "platform": "ios-simulator-17" },
+    { "name": "ews191", "platform": "ios-simulator-17" },
+    { "name": "ews192", "platform": "ios-simulator-17" },
+    { "name": "ews193", "platform": "ios-simulator-17" },
+    { "name": "ews194", "platform": "ios-simulator-17" },
+    { "name": "ews195", "platform": "ios-simulator-17" },
+    { "name": "ews196", "platform": "ios-simulator-17" },
+    { "name": "ews197", "platform": "ios-simulator-17" },
+    { "name": "ews198", "platform": "ios-simulator-17" },
+    { "name": "ews200", "platform": "ios-simulator-17" },
+    { "name": "ews201", "platform": "ios-simulator-17" },
+    { "name": "ews202", "platform": "ios-simulator-17" },
+    { "name": "ews203", "platform": "ios-simulator-17" },
     { "name": "webkit-cq-01", "platform": "mac-monterey" },
     { "name": "webkit-cq-02", "platform": "mac-monterey" },
     { "name": "webkit-cq-03", "platform": "mac-monterey" },
@@ -179,31 +179,31 @@
       "workernames": ["igalia5-gtk-wk2-ews", "igalia6-gtk-wk2-ews", "igalia7-gtk-wk2-ews", "igalia8-gtk-wk2-ews", "igalia9-gtk-wk2-ews", "igalia10-gtk-wk2-ews", "igalia11-gtk-wk2-ews", "igalia12-gtk-wk2-ews"]
     },
     {
-      "name": "iOS-16-Build-EWS", "shortname": "ios", "icon": "buildOnly",
-      "factory": "iOSEmbeddedBuildFactory", "platform": "ios-16",
+      "name": "iOS-17-Build-EWS", "shortname": "ios", "icon": "buildOnly",
+      "factory": "iOSEmbeddedBuildFactory", "platform": "ios-17",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews152", "ews154", "ews108", "ews109", "ews130", "ews131", "ews132", "ews133"]
     },
     {
-      "name": "iOS-16-Simulator-Build-EWS", "shortname": "ios-sim", "icon": "buildOnly",
-      "factory": "iOSBuildFactory", "platform": "ios-simulator-16",
+      "name": "iOS-17-Simulator-Build-EWS", "shortname": "ios-sim", "icon": "buildOnly",
+      "factory": "iOSBuildFactory", "platform": "ios-simulator-17",
       "configuration": "release", "architectures": ["arm64"],
-      "triggers": ["api-tests-ios-sim-ews", "ios-16-sim-wk2-tests-ews", "ios-16-sim-wpt-wk2-tests-ews"],
+      "triggers": ["api-tests-ios-sim-ews", "ios-17-sim-wk2-tests-ews", "ios-17-sim-wpt-wk2-tests-ews"],
       "workernames": ["ews152", "ews154", "ews108", "ews130", "ews132", "ews133", "ews134", "ews135"]
     },
     {
-      "name": "iOS-16-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly",
-      "factory": "iOSTestsFactory", "platform": "ios-simulator-16",
+      "name": "iOS-17-Simulator-WK2-Tests-EWS", "shortname": "ios-wk2", "icon": "testOnly",
+      "factory": "iOSTestsFactory", "platform": "ios-simulator-17",
       "configuration": "release", "architectures": ["arm64"],
-      "triggered_by": ["ios-16-sim-build-ews"],
+      "triggered_by": ["ios-17-sim-build-ews"],
       "additionalArguments": ["--child-processes=6", "--exclude-tests", "imported/w3c/web-platform-tests"],
       "workernames": ["ews121", "ews122", "ews123", "ews124", "ews125", "ews126", "ews184", "ews185"]
     },
     {
-      "name": "iOS-16-Simulator-WPT-WK2-Tests-EWS", "shortname": "ios-wk2-wpt", "icon": "testOnly",
-      "factory": "iOSTestsFactory", "platform": "ios-simulator-16",
+      "name": "iOS-17-Simulator-WPT-WK2-Tests-EWS", "shortname": "ios-wk2-wpt", "icon": "testOnly",
+      "factory": "iOSTestsFactory", "platform": "ios-simulator-17",
       "configuration": "release", "architectures": ["arm64"],
-      "triggered_by": ["ios-16-sim-build-ews"],
+      "triggered_by": ["ios-17-sim-build-ews"],
       "additionalArguments": ["--child-processes=6", "imported/w3c/web-platform-tests"],
       "workernames": ["ews191", "ews192", "ews193", "ews194", "ews195", "ews196", "ews197", "ews198"]
     },
@@ -250,26 +250,26 @@
       "workernames": ["ews181", "ews182"]
     },
     {
-      "name": "watchOS-9-Build-EWS", "shortname": "watch", "icon": "buildOnly",
-      "factory": "watchOSBuildFactory", "platform": "watchos-9",
+      "name": "watchOS-10-Build-EWS", "shortname": "watch", "icon": "buildOnly",
+      "factory": "watchOSBuildFactory", "platform": "watchos-10",
       "configuration": "release", "architectures": ["arm64_32", "arm64"],
       "workernames": ["ews163", "ews164", "ews165"]
     },
     {
-      "name": "watchOS-9-Simulator-Build-EWS", "shortname": "watch-sim", "icon": "buildOnly",
-      "factory": "watchOSBuildFactory", "platform": "watchos-simulator-9",
+      "name": "watchOS-10-Simulator-Build-EWS", "shortname": "watch-sim", "icon": "buildOnly",
+      "factory": "watchOSBuildFactory", "platform": "watchos-simulator-10",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews164", "ews165", "ews166"]
     },
     {
-      "name": "tvOS-16-Build-EWS", "shortname": "tv", "icon": "buildOnly",
-      "factory": "tvOSBuildFactory", "platform": "tvos-16",
+      "name": "tvOS-17-Build-EWS", "shortname": "tv", "icon": "buildOnly",
+      "factory": "tvOSBuildFactory", "platform": "tvos-17",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews167", "ews168"]
     },
     {
-      "name": "tvOS-16-Simulator-Build-EWS", "shortname": "tv-sim", "icon": "buildOnly",
-      "factory": "tvOSBuildFactory", "platform": "tvos-simulator-16",
+      "name": "tvOS-17-Simulator-Build-EWS", "shortname": "tv-sim", "icon": "buildOnly",
+      "factory": "tvOSBuildFactory", "platform": "tvos-simulator-17",
       "configuration": "release", "architectures": ["arm64"],
       "workernames": ["ews168", "ews170"]
     },
@@ -358,7 +358,7 @@
     {
       "name": "API-Tests-iOS-Simulator-EWS", "shortname": "api-ios", "icon": "testOnly",
       "factory": "APITestsFactory", "platform": "*",
-      "triggered_by": ["ios-16-sim-build-ews"],
+      "triggered_by": ["ios-17-sim-build-ews"],
       "workernames": ["ews110", "ews111", "ews114", "ews156", "ews157", "ews158", "ews159", "ews160", "ews183"]
     },
     {
@@ -414,11 +414,11 @@
     {
       "type": "Try_Userpass", "name": "try", "port": 5555,
       "builderNames": [
-            "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-16-Build-EWS", "iOS-16-Simulator-Build-EWS",
+            "Apply-WatchList-EWS", "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-17-Build-EWS", "iOS-17-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-i386-32bits-EWS", "JSC-MIPSEL-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
             "macOS-AppleSilicon-Ventura-Debug-Build-EWS", "macOS-Monterey-Release-Build-EWS",
-            "Services-EWS", "Style-EWS", "tvOS-16-Build-EWS", "tvOS-16-Simulator-Build-EWS", "watchOS-9-Build-EWS",
-            "watchOS-9-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "WinCairo-EWS"
+            "Services-EWS", "Style-EWS", "tvOS-17-Build-EWS", "tvOS-17-Simulator-Build-EWS", "watchOS-10-Build-EWS",
+            "watchOS-10-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "WinCairo-EWS"
       ]
     },
     {
@@ -428,11 +428,11 @@
     {
       "type": "AnyBranchScheduler", "name": "pull_request",
       "builderNames": [
-            "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-16-Build-EWS", "iOS-16-Simulator-Build-EWS",
+            "Bindings-Tests-EWS", "GTK-Build-EWS", "iOS-17-Build-EWS", "iOS-17-Simulator-Build-EWS",
             "JSC-ARMv7-32bits-Build-EWS", "JSC-i386-32bits-EWS", "JSC-MIPSEL-32bits-Build-EWS", "JSC-Tests-EWS", "JSC-Tests-arm64-EWS",
             "macOS-AppleSilicon-Ventura-Debug-Build-EWS", "macOS-Monterey-Release-Build-EWS",
-            "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-16-Build-EWS", "tvOS-16-Simulator-Build-EWS", "watchOS-9-Build-EWS",
-            "watchOS-9-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "WinCairo-EWS"
+            "Services-EWS", "Style-EWS", "Style-EWS", "tvOS-17-Build-EWS", "tvOS-17-Simulator-Build-EWS", "watchOS-10-Build-EWS",
+            "watchOS-10-Simulator-Build-EWS", "WPE-Build-EWS", "WebKitPerl-Tests-EWS", "WebKitPy-Tests-EWS", "WinCairo-EWS"
       ]
     },
     {
@@ -472,16 +472,16 @@
       "builderNames": ["macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS"]
     },
     {
-      "type": "Triggerable", "name": "ios-16-sim-build-ews",
-      "builderNames": ["iOS-16-Simulator-Build-EWS"]
+      "type": "Triggerable", "name": "ios-17-sim-build-ews",
+      "builderNames": ["iOS-17-Simulator-Build-EWS"]
     },
     {
-      "type": "Triggerable", "name": "ios-16-sim-wk2-tests-ews",
-      "builderNames": ["iOS-16-Simulator-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "ios-17-sim-wk2-tests-ews",
+      "builderNames": ["iOS-17-Simulator-WK2-Tests-EWS"]
     },
     {
-      "type": "Triggerable", "name": "ios-16-sim-wpt-wk2-tests-ews",
-      "builderNames": ["iOS-16-Simulator-WPT-WK2-Tests-EWS"]
+      "type": "Triggerable", "name": "ios-17-sim-wpt-wk2-tests-ews",
+      "builderNames": ["iOS-17-Simulator-WPT-WK2-Tests-EWS"]
     },
     {
       "type": "Triggerable", "name": "api-tests-ios-sim-ews",

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -92,7 +92,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'layout-tests',
             'set-build-summary'
         ],
-        'iOS-16-Build-EWS': [
+        'iOS-17-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -107,7 +107,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'iOS-16-Simulator-Build-EWS': [
+        'iOS-17-Simulator-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -122,7 +122,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'iOS-16-Simulator-WK2-Tests-EWS': [
+        'iOS-17-Simulator-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -143,7 +143,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'iOS-16-Simulator-WPT-WK2-Tests-EWS': [
+        'iOS-17-Simulator-WPT-WK2-Tests-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -279,7 +279,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'trigger-crash-log-submission',
             'set-build-summary'
         ],
-        'watchOS-9-Build-EWS': [
+        'watchOS-10-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -294,7 +294,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'watchOS-9-Simulator-Build-EWS': [
+        'watchOS-10-Simulator-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -309,7 +309,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'tvOS-16-Build-EWS': [
+        'tvOS-17-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',
@@ -324,7 +324,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'validate-change',
             'compile-webkit'
         ],
-        'tvOS-16-Simulator-Build-EWS': [
+        'tvOS-17-Simulator-Build-EWS': [
             'configure-build',
             'validate-change',
             'configuration',


### PR DESCRIPTION
#### 2e20293b27e5a160b7bd185c648ed971fa543671
<pre>
Re-land Make config changes to bring up iOS17, tvOS17, and watchOS10 on EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=262971">https://bugs.webkit.org/show_bug.cgi?id=262971</a>
rdar://116751317

Reviewed by Ryan Haddad.

Re-land a prior revert to bring up iOS17, tvOS17, and watchOS10 on EWS.

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/269215@main">https://commits.webkit.org/269215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50eca9a38bb53750d72ad6b99939e8628ab832ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23788 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22440 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24640 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18904 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26121 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23980 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20516 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/21718 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24067 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2721 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->