### PR TITLE
B3 should use isTuple rather than `== Tuple`

### DIFF
--- a/JSTests/wasm/stress/multi-tuple.js
+++ b/JSTests/wasm/stress/multi-tuple.js
@@ -1,0 +1,40 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+const N = 1000
+
+let wat = `
+(module
+  (type (;0;) (func (result i32 i64)))
+  (type (;1;) (func))
+  (type (;2;) (func (result i32 i32)))
+  (import "m" "fn0" (func (;0;) (type 2)))
+  (func (;1;) (type 0) (result i32 i64)
+    i32.const 0
+    i64.const 0
+  )
+  (func (;2;) (type 1)
+    call 1
+    call 0
+    return
+  )
+  (export "fn1" (func 2))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {
+        m: {
+            fn0() {
+                return [0, 0];
+            }
+        }
+    });
+    const { fn1 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(fn1(), undefined);
+    }
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3Type.h
+++ b/Source/JavaScriptCore/b3/B3Type.h
@@ -59,7 +59,9 @@ public:
     constexpr Type(const Type&) = default;
     constexpr Type(TypeKind kind)
         : m_kind(kind)
-    { }
+    {
+        ASSERT(kind != Tuple);
+    }
 
     ~Type() = default;
 

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -727,7 +727,7 @@ public:
                 break;
             case Extract: {
                 VALIDATE(value->numChildren() == 1, ("At ", *value));
-                VALIDATE(value->child(0)->type() == Tuple, ("At ", *value));
+                VALIDATE(value->child(0)->type().isTuple(), ("At ", *value));
                 VALIDATE(value->type().isNumeric(), ("At ", *value));
                 break;
             }

--- a/Source/JavaScriptCore/b3/air/AirCustom.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCustom.cpp
@@ -75,7 +75,7 @@ bool CCallCustom::isValidForm(Inst& inst)
     size_t resultCount = cCallResultCount(code, value);
     size_t expectedArgCount = resultCount + 1; // first Arg is always CCallSpecial.
     for (Value* child : value->children()) {
-        ASSERT(child->type() != Tuple);
+        ASSERT(!child->type().isTuple());
         expectedArgCount += cCallArgumentRegisterCount(child);
     }
 


### PR DESCRIPTION
#### b0bf5bc7500a53126e9c9fb1f9ee1d978db07c7c
<pre>
B3 should use isTuple rather than `== Tuple`
<a href="https://bugs.webkit.org/show_bug.cgi?id=261467">https://bugs.webkit.org/show_bug.cgi?id=261467</a>
rdar://115283700

Reviewed by Yusuke Suzuki.

Recently we switched to using the default operator== for many JSC classes (<a href="https://commits.webkit.org/267645@main).">https://commits.webkit.org/267645@main).</a>
This however revealed a subtle inconsistency where we would allow Tuple TypeKinds to be compared to Types but
didn&apos;t check the tuple index. Now that we use the default operator== we started checking the tuple index, which
causes assertion failures in validation.

To fix this validation should use `isTuple()` rather than `== Tuple`. Also, to prevent others from making the
same mistake, we now `ASSERT` the implicit `Type` constructor isn&apos;t receiving a `Tuple`.

* JSTests/wasm/stress/multi-tuple.js: Added.
(type.1.call.1.call.0.return.export.string_appeared_here.func.2.async test):
* Source/JavaScriptCore/b3/B3Type.h:
(JSC::B3::Type::Type):
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/air/AirCustom.cpp:
(JSC::B3::Air::CCallCustom::isValidForm):

Canonical link: <a href="https://commits.webkit.org/269216@main">https://commits.webkit.org/269216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f370b13cad309666e9da8a19516726a920e7e5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23789 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20286 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22441 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/18998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24641 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19852 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26123 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19052 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23982 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21282 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20517 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25326 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19862 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5979 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5228 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24068 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26598 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20462 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5811 "Passed tests") | 
<!--EWS-Status-Bubble-End-->