### PR TITLE
[iOS] Smooth keyboard scrolling animates in the wrong direction when pressing ↓ after scrolling up

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -333,8 +333,24 @@ static NSString * const scrollToExtentWithAnimationKey = @"ScrollToExtentAnimati
 
     [self startDisplayLinkIfNeeded];
 
+    auto initialVelocity = WebCore::FloatSize([_scrollable interactiveScrollVelocity]);
+    switch (scroll->direction) {
+    case WebCore::ScrollDirection::ScrollUp:
+        initialVelocity.setHeight(std::min<CGFloat>(0, initialVelocity.height()));
+        break;
+    case WebCore::ScrollDirection::ScrollDown:
+        initialVelocity.setHeight(std::max<CGFloat>(0, initialVelocity.height()));
+        break;
+    case WebCore::ScrollDirection::ScrollLeft:
+        initialVelocity.setWidth(std::min<CGFloat>(0, initialVelocity.width()));
+        break;
+    case WebCore::ScrollDirection::ScrollRight:
+        initialVelocity.setWidth(std::max<CGFloat>(0, initialVelocity.width()));
+        break;
+    }
+
     _currentPosition = WebCore::FloatPoint([_scrollable contentOffset]);
-    _velocity += WebCore::FloatSize([_scrollable interactiveScrollVelocity]);
+    _velocity += initialVelocity;
     _idealPositionForMinimumTravel = _currentPosition + _currentScroll->offset;
 
     return YES;


### PR DESCRIPTION
#### 9dcecd144778336ce80abbf264cc67d2e2b0b20b
<pre>
[iOS] Smooth keyboard scrolling animates in the wrong direction when pressing ↓ after scrolling up
<a href="https://bugs.webkit.org/show_bug.cgi?id=263028">https://bugs.webkit.org/show_bug.cgi?id=263028</a>
rdar://116823122

Reviewed by Tim Horton and Richard Robinson.

The logic to compound existing interactive scrolling velocity (i.e. when panning or decelerating
after a pan gesture) on top of the current keyboard scrolling velocity in `-beginWithEvent:` is
intended to make it so that the user can naturally transition between scrolling normally and the
scroll view and using arrow keys to trigger keyboard scrolling, without the scrolling velocity being
reset to 0 upon pressing an arrow key.

However, this can lead to some pretty unintuitive behaviors when the user flings the scroll view in
one direction, but presses an arrow key in the opposite direction to scroll the web view; this
causes the scroll view to accelerate in the opposite direction as the arrow key, before snapping
back to the starting position (or, in the case where we&apos;re rubber-banding against the scroll
extents, we can end up in a state where we&apos;re permanently stuck rubber-banding, until the user
touches the scroll view).

To fix this, we simply limit this velocity compounding to only the case where interactive scrolling
is in the same direction as keyboard scrolling. This means that in the scenario described above,
we&apos;ll now interrupt momentum scrolling immediately, and begin scrolling in the direction of the
arrow key.

* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
(-[WKKeyboardScrollingAnimator beginWithEvent:]):

Canonical link: <a href="https://commits.webkit.org/269219@main">https://commits.webkit.org/269219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/334a4293478a4142edd1769be324d47354738f0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/22979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22446 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21774 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24646 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18909 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26127 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/23986 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20522 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19867 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5227 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->