### PR TITLE
jsc_fuz/wktr: RELEASE_ASSERT(to <= inlineTextItem.end()); in WebCore::Layout::TextUtil::width(...) (TextUtil.cpp:96).

### DIFF
--- a/LayoutTests/fast/text/crash-grapheme-cluster-spanning-adjacent-textitems-expected.txt
+++ b/LayoutTests/fast/text/crash-grapheme-cluster-spanning-adjacent-textitems-expected.txt
@@ -1,0 +1,2 @@
+؀🀀
+This test used for grapheme cluster spanning adjucent inline text-items.PASS if no crash or ASSERT.

--- a/LayoutTests/fast/text/crash-grapheme-cluster-spanning-adjacent-textitems.html
+++ b/LayoutTests/fast/text/crash-grapheme-cluster-spanning-adjacent-textitems.html
@@ -1,0 +1,6 @@
+<div style="float: left; line-break: anywhere">&#1536;&#126976;</div>
+<p>This test used for grapheme cluster spanning adjucent inline text-items.PASS if no crash or ASSERT.</p>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp
@@ -134,7 +134,11 @@ InlineLayoutUnit IntrinsicWidthHandler::simplifiedMinimumWidth() const
                 auto characterIndex = inlineTextItem.start() + index;
                 auto characterLength = TextUtil::firstUserPerceivedCharacterLength(inlineTextItem.inlineTextBox(), characterIndex, contentLength - index);
                 ASSERT(characterLength);
-                maximumWidth = std::max(maximumWidth, TextUtil::width(inlineTextItem, fontCascade, characterIndex, characterIndex + characterLength, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::No));
+                if (characterIndex + characterLength > inlineTextItem.end()) {
+                    // grapheme clusters could span across multiple adjacent inline text items.
+                    maximumWidth = std::max(maximumWidth, TextUtil::width(inlineTextItem.inlineTextBox(), fontCascade, characterIndex, characterIndex + characterLength, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::No));
+                } else
+                    maximumWidth = std::max(maximumWidth, TextUtil::width(inlineTextItem, fontCascade, characterIndex, characterIndex + characterLength, { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::No));
                 index += characterLength;
             }
             continue;


### PR DESCRIPTION
#### c36c902179515a61aa57a9c0fe9db65521f8ee30
<pre>
jsc_fuz/wktr: RELEASE_ASSERT(to &lt;= inlineTextItem.end()); in WebCore::Layout::TextUtil::width(...) (TextUtil.cpp:96).
<a href="https://bugs.webkit.org/show_bug.cgi?id=262799">https://bugs.webkit.org/show_bug.cgi?id=262799</a>
rdar://115842183.

Reviewed by Alan Baradlay.

Modified IntrinsicWidthHandler::simplifiedMinimumWidth() API to calculate width for grapheme-clusters spanning adjacent inline textitems.

Test : fast/text/crash-grapheme-cluster-spanning-adjacent-textitems.html.

* Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp : Changing API to consider grapheme-clusters spanning adjacent inline textitems.
* LayoutTests/fast/text/crash-grapheme-cluster-spanning-adjacent-textitems.html : Added test case.
* LayoutTests/fast/text/crash-grapheme-cluster-spanning-adjacent-textitems-expected.html : Added test expected file.

Canonical link: <a href="https://commits.webkit.org/269276@main">https://commits.webkit.org/269276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf566eec6f2390abe981044e24a606a4126e774

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21399 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24676 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26147 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24011 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20539 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17499 "Found 1 new test failure: js/for-in-to-text.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19692 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5263 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->