### PR TITLE
getBoundingClientRect return a wrong rect on a range that ends at the beginning of an element

### DIFF
--- a/LayoutTests/fast/dom/Range/getBoundingClientRect-on-range-ending-at-beginning-of-element-expected.html
+++ b/LayoutTests/fast/dom/Range/getBoundingClientRect-on-range-ending-at-beginning-of-element-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.rect { position: absolute; background: green; }
+.bounding-rect { position: absolute; border: solid 1px #00f; }
+</style>
+<script>
+
+onload = () => {
+    const startContainer = document.getElementById('s1').firstChild;
+    const endContainer = document.getElementById('s2');
+
+    const range = document.createRange();
+    range.setStart(startContainer, startContainer.textContent.length);
+    range.setEnd(endContainer.firstChild, 0)
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+
+    const rectRoot = document.getElementById('rectRoot');
+    const rects = Array.from(range.getClientRects());
+    const boundingRect = range.getBoundingClientRect();
+
+    rectRoot.innerHTML = rects.map(rect => 
+    `<div class="rect" style="left: ${rect.left}px; top: ${rect.top}px; width: ${rect.width}px; height: ${rect.height}px"></div>`
+    ).join('') + `<div class="bounding-rect" style="left: ${boundingRect.left}px; top: ${boundingRect.top}px; width: ${boundingRect.width}px; height: ${boundingRect.height}px"></div>`;
+}
+
+</script>
+</head>
+<body>
+<p>
+<span id="s1">ABCD</span><span style="color: orange">EFGHIJKL</span><span id="s2">MNOPQRSTUVWXYZ</span>
+</p>
+<div id="rectRoot"></div>
+</body>
+</html>

--- a/LayoutTests/fast/dom/Range/getBoundingClientRect-on-range-ending-at-beginning-of-element.html
+++ b/LayoutTests/fast/dom/Range/getBoundingClientRect-on-range-ending-at-beginning-of-element.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.rect { position: absolute; background: green; }
+.bounding-rect { position: absolute; border: solid 1px #00f; }
+</style>
+<script>
+
+onload = () => {
+    const startContainer = document.getElementById('s1').firstChild;
+    const endContainer = document.getElementById('s2');
+
+    const range = document.createRange();
+    range.setStart(startContainer, startContainer.textContent.length);
+    range.setEnd(endContainer, 0)
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+
+    const rectRoot = document.getElementById('rectRoot');
+    const rects = Array.from(range.getClientRects());
+    const boundingRect = range.getBoundingClientRect();
+
+    rectRoot.innerHTML = rects.map(rect => 
+    `<div class="rect" style="left: ${rect.left}px; top: ${rect.top}px; width: ${rect.width}px; height: ${rect.height}px"></div>`
+    ).join('') + `<div class="bounding-rect" style="left: ${boundingRect.left}px; top: ${boundingRect.top}px; width: ${boundingRect.width}px; height: ${boundingRect.height}px"></div>`;
+}
+
+</script>
+</head>
+<body>
+<p>
+<span id="s1">ABCD</span><span style="color: orange">EFGHIJKL</span><span id="s2">MNOPQRSTUVWXYZ</span>
+</p>
+<div id="rectRoot"></div>
+</body>
+</html>

--- a/LayoutTests/fast/dom/Range/getClientRects-expected.txt
+++ b/LayoutTests/fast/dom/Range/getClientRects-expected.txt
@@ -235,11 +235,7 @@ PASS rects[1].top.toFixed(2) is "2615.00"
 PASS rects[1].width.toFixed(2) is "181.75"
 PASS rects[1].height.toFixed(2) is "18.00"
 Test 12
-PASS rects.length is 1
-PASS rects[0].left.toFixed(2) is "8.00"
-PASS rects[0].top.toFixed(2) is "2840.00"
-PASS rects[0].width.toFixed(2) is "400.00"
-PASS rects[0].height.toFixed(2) is "160.00"
+PASS rects.length is 0
 Test 13
 PASS rects.length is 4
 PASS rects[0].left.toFixed(2) is "8.00"

--- a/LayoutTests/fast/dom/Range/getClientRects.html
+++ b/LayoutTests/fast/dom/Range/getClientRects.html
@@ -442,11 +442,7 @@
     range12.setEndBefore(document.getElementById('test12').firstChild);
     show(range12);
     rects = range12.getClientRects();
-    shouldBe("rects.length", "1");
-    shouldBeEqualToString("rects[0].left.toFixed(2)", "8.00");
-    shouldBeEqualToString("rects[0].top.toFixed(2)", "2840.00");
-    shouldBeEqualToString("rects[0].width.toFixed(2)", "400.00");
-    shouldBeEqualToString("rects[0].height.toFixed(2)", "160.00");
+    shouldBe("rects.length", "0");
 
     // Test 13
     debug("Test 13");

--- a/LayoutTests/platform/ios/ios/fast/coordinates/range-client-rects-expected.txt
+++ b/LayoutTests/platform/ios/ios/fast/coordinates/range-client-rects-expected.txt
@@ -13,3 +13,4 @@ PASS successfullyParsed is true
 
 TEST COMPLETE
 
+

--- a/LayoutTests/platform/ios/ios/fast/coordinates/range-client-rects.html
+++ b/LayoutTests/platform/ios/ios/fast/coordinates/range-client-rects.html
@@ -11,6 +11,7 @@
 <div id="console"></div>
 <!-- Filler to allow scrolling -->
 <div style="width:1500px;height:1500px;"></div>
+<div><br></div>
 <script>
 description("This tests Range.getBoundingClientRects and getClientRects positions when unscaled, scaled, and panned.");
 

--- a/Source/WebCore/dom/ElementAncestorIteratorInlines.h
+++ b/Source/WebCore/dom/ElementAncestorIteratorInlines.h
@@ -76,6 +76,22 @@ inline ElementAncestorRange<const ElementType> lineageOfType(const Element& firs
 }
 
 template <typename ElementType>
+inline ElementAncestorRange<ElementType> lineageOfType(Node& first)
+{
+    if (is<ElementType>(first))
+        return ElementAncestorRange<ElementType>(&downcast<ElementType>(first));
+    return ancestorsOfType<ElementType>(first);
+}
+
+template <typename ElementType>
+inline ElementAncestorRange<const ElementType> lineageOfType(const Node& first)
+{
+    if (is<ElementType>(first))
+        return ElementAncestorRange<const ElementType>(&downcast<ElementType>(first));
+    return ancestorsOfType<ElementType>(first);
+}
+
+template <typename ElementType>
 inline ElementAncestorRange<ElementType> ancestorsOfType(Node& descendant)
 {
     return ElementAncestorRange<ElementType>(findElementAncestorOfType<ElementType>(descendant));

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2261,12 +2261,10 @@ Vector<IntRect> RenderObject::absoluteTextRects(const SimpleRange& range, Option
     });
 }
 
-static RefPtr<Node> nodeBefore(const BoundaryPoint& point)
+static RefPtr<Node> nodeAfter(const BoundaryPoint& point)
 {
-    if (point.offset) {
-        if (auto node = point.container->traverseToChildAt(point.offset - 1))
-            return node;
-    }
+    if (auto node = point.container->traverseToChildAt(point.offset + 1))
+        return node;
     return point.container.ptr();
 }
 
@@ -2288,8 +2286,8 @@ static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, Coordinate
 
     // Don't include elements at the end of the range that are only partially selected.
     // FIXME: What about the start of the range? The asymmetry here does not make sense. Seems likely this logic is not quite right in other respects, too.
-    if (auto lastNode = nodeBefore(range.end)) {
-        for (auto& ancestor : ancestorsOfType<Element>(*lastNode))
+    if (auto lastNode = nodeAfter(range.end)) {
+        for (auto& ancestor : lineageOfType<Element>(*lastNode))
             selectedElementsSet.remove(&ancestor);
     }
 


### PR DESCRIPTION
#### fc487e690086d5553a6a00540924142ab8d409ae
<pre>
getBoundingClientRect return a wrong rect on a range that ends at the beginning of an element
<a href="https://bugs.webkit.org/show_bug.cgi?id=263040">https://bugs.webkit.org/show_bug.cgi?id=263040</a>
&lt;rdar://112543805&gt;

Reviewed by Alan Baradlay.

The bug was caused by a logic error in borderAndTextRects to avoid including partially selected elements.
We need to exclude any element after, not before, the range&apos;s end and its ancestors.

* LayoutTests/fast/dom/Range/getBoundingClientRect-on-range-ending-at-beginning-of-element-expected.html: Added.
* LayoutTests/fast/dom/Range/getBoundingClientRect-on-range-ending-at-beginning-of-element.html: Added.
* LayoutTests/fast/dom/Range/getClientRects-expected.txt: Rebaselined as the expectation has changed to not to
include the rect for unselected text per this bug fix.
* LayoutTests/fast/dom/Range/getClientRects.html:
* LayoutTests/platform/ios/ios/fast/coordinates/range-client-rects-expected.txt: Rebaselined.
* LayoutTests/platform/ios/ios/fast/coordinates/range-client-rects.html: Add a blank line with br to force
the selection to be extended beneath the 1500px by 1500px square.
* Source/WebCore/dom/ElementAncestorIteratorInlines.h:
(WebCore::lineageOfType):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::nodeAfter):
(WebCore::borderAndTextRects):
(WebCore::nodeBefore): Deleted.

Canonical link: <a href="https://commits.webkit.org/269271@main">https://commits.webkit.org/269271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e172195787397760809b73232815442696dafd9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21432 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24722 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26184 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24050 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17531 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19736 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24139 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2745 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->