### PR TITLE
return a createCommaSeparated() in CSSPropertyBackgroundBlendMode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/compositing/parsing/background-blend-mode-computed-multiple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/compositing/parsing/background-blend-mode-computed-multiple-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL Property background-blend-mode value 'normal' assert_equals: expected "normal" but got "normal normal normal"
-FAIL Property background-blend-mode value 'multiply' assert_equals: expected "multiply" but got "multiply multiply multiply"
-FAIL Property background-blend-mode value 'normal, luminosity' assert_equals: expected "normal, luminosity" but got "normal luminosity normal"
-FAIL Property background-blend-mode value 'screen, overlay' assert_equals: expected "screen, overlay" but got "screen overlay screen"
-FAIL Property background-blend-mode value 'color, saturation' assert_equals: expected "color, saturation" but got "color saturation color"
-FAIL Property background-blend-mode value 'normal, luminosity, color' assert_equals: expected "normal, luminosity, color" but got "normal luminosity color"
-FAIL Property background-blend-mode value 'screen, overlay, screen' assert_equals: expected "screen, overlay, screen" but got "screen overlay screen"
+FAIL Property background-blend-mode value 'normal' assert_equals: expected "normal" but got "normal, normal, normal"
+FAIL Property background-blend-mode value 'multiply' assert_equals: expected "multiply" but got "multiply, multiply, multiply"
+FAIL Property background-blend-mode value 'normal, luminosity' assert_equals: expected "normal, luminosity" but got "normal, luminosity, normal"
+FAIL Property background-blend-mode value 'screen, overlay' assert_equals: expected "screen, overlay" but got "screen, overlay, screen"
+FAIL Property background-blend-mode value 'color, saturation' assert_equals: expected "color, saturation" but got "color, saturation, color"
+PASS Property background-blend-mode value 'normal, luminosity, color'
+PASS Property background-blend-mode value 'screen, overlay, screen'
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4105,7 +4105,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         CSSValueListBuilder list;
         for (auto* currLayer = &layers; currLayer; currLayer = currLayer->next())
             list.append(createConvertingToCSSValueID(currLayer->blendMode()));
-        return CSSValueList::createSpaceSeparated(WTFMove(list));
+        return CSSValueList::createCommaSeparated(WTFMove(list));
     }
     case CSSPropertyBackground:
         return getBackgroundShorthandValue();


### PR DESCRIPTION
#### c7bdf39661727360505861e0b39b38b22701923e
<pre>
return a createCommaSeparated() in CSSPropertyBackgroundBlendMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=263051">https://bugs.webkit.org/show_bug.cgi?id=263051</a>
rdar://116838342

Reviewed by Simon Fraser.

A very simple fix to align with the spec. Currently WebKit returns
a space separated list, when it should return a comma separated list.
see <a href="https://drafts.fxtf.org/compositing-1/#background-blend-mode">https://drafts.fxtf.org/compositing-1/#background-blend-mode</a>

Computed value: as specified

For having a full pass on the current tests,
it will be necessary to solve a wider bug
about coordinating list properties
See <a href="https://bugs.webkit.org/show_bug.cgi?id=263104">https://bugs.webkit.org/show_bug.cgi?id=263104</a>

* LayoutTests/imported/w3c/web-platform-tests/css/compositing/parsing/background-blend-mode-computed-multiple-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):

Canonical link: <a href="https://commits.webkit.org/269325@main">https://commits.webkit.org/269325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/331325d8a27fc7e64be572d951df68ef21f18d39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21558 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24922 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26350 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24211 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17672 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20113 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5292 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->