### PR TITLE
Update WTF Unexpected to follow final C++23 specs

### DIFF
--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -186,9 +186,7 @@ inline namespace fundamentals_v3 {
 #include <wtf/StdLibExtras.h>
 #include <wtf/Unexpected.h>
 
-namespace std {
-namespace experimental {
-inline namespace fundamentals_v3 {
+namespace WTF::detail_from_clang_libstdcpp {
 
 struct unexpected_t {
     unexpected_t() = default;
@@ -441,10 +439,10 @@ public:
     constexpr expected(value_type&& e) : base(__expected_detail::value_tag, std::forward<value_type>(e)) { }
     template<class... Args> constexpr explicit expected(std::in_place_t, Args&&... args) : base(__expected_detail::value_tag, value_type(std::forward<Args>(args)...)) { }
     // template<class U, class... Args> constexpr explicit expected(in_place_t, std::initializer_list<U>, Args&&...);
-    constexpr expected(const unexpected_type& u) : base(__expected_detail::error_tag, u.value()) { }
-    constexpr expected(unexpected_type&& u) : base(__expected_detail::error_tag, std::forward<unexpected_type>(u).value()) { }
-    template<class Err> constexpr expected(const unexpected<Err>& u) : base(__expected_detail::error_tag, u.value()) { }
-    template<class Err> constexpr expected(unexpected<Err>&& u) : base(__expected_detail::error_tag, std::forward<Err>(u.value())) { }
+    constexpr expected(const unexpected_type& u) : base(__expected_detail::error_tag, u.error()) { }
+    constexpr expected(unexpected_type&& u) : base(__expected_detail::error_tag, std::forward<unexpected_type>(u).error()) { }
+    template<class Err> constexpr expected(const unexpected<Err>& u) : base(__expected_detail::error_tag, u.error()) { }
+    template<class Err> constexpr expected(unexpected<Err>&& u) : base(__expected_detail::error_tag, std::forward<Err>(u.error())) { }
     template<class... Args> constexpr explicit expected(unexpected_t, Args&&... args) : base(__expected_detail::error_tag, error_type(std::forward<Args>(args)...)) { }
     // template<class U, class... Args> constexpr explicit expected(unexpected_t, std::initializer_list<U>, Args&&...);
 
@@ -522,9 +520,9 @@ public:
     expected(const expected&) = default;
     expected(expected&&) = default;
     // constexpr explicit expected(in_place_t);
-    constexpr expected(unexpected_type const& u) : base(__expected_detail::error_tag, u.value()) { }
-    constexpr expected(unexpected_type&& u) : base(__expected_detail::error_tag, std::forward<unexpected_type>(u).value()) { }
-    template<class Err> constexpr expected(unexpected<Err> const& u) : base(__expected_detail::error_tag, u.value()) { }
+    constexpr expected(unexpected_type const& u) : base(__expected_detail::error_tag, u.error()) { }
+    constexpr expected(unexpected_type&& u) : base(__expected_detail::error_tag, std::forward<unexpected_type>(u).error()) { }
+    template<class Err> constexpr expected(unexpected<Err> const& u) : base(__expected_detail::error_tag, u.error()) { }
 
     ~expected() = default;
 
@@ -565,12 +563,12 @@ template<class E> constexpr bool operator==(const expected<void, E>& x, const ex
 template<class T, class E> constexpr bool operator==(const expected<T, E>& x, const T& y) { return x ? *x == y : false; }
 template<class T, class E> constexpr bool operator==(const T& x, const expected<T, E>& y) { return y ? x == *y : false; }
 
-template<class T, class E> constexpr bool operator==(const expected<T, E>& x, const unexpected<E>& y) { return x ? false : x.error() == y.value(); }
-template<class T, class E> constexpr bool operator==(const unexpected<E>& x, const expected<T, E>& y) { return y ? false : x.value() == y.error(); }
+template<class T, class E> constexpr bool operator==(const expected<T, E>& x, const unexpected<E>& y) { return x ? false : x.error() == y.error(); }
+template<class T, class E> constexpr bool operator==(const unexpected<E>& x, const expected<T, E>& y) { return y ? false : x.error() == y.error(); }
 
 template<typename T, typename E> void swap(expected<T, E>& x, expected<T, E>& y) { x.swap(y); }
 
-}}} // namespace std::experimental::fundamentals_v3
+} // namespace WTF::detail_from_clang_libstdcpp
 
-__EXPECTED_INLINE_VARIABLE constexpr auto& unexpect = std::experimental::unexpect;
-template<class T, class E> using Expected = std::experimental::expected<T, E>;
+__EXPECTED_INLINE_VARIABLE constexpr auto& unexpect = WTF::detail_from_clang_libstdcpp::unexpect;
+template<class T, class E> using Expected = WTF::detail_from_clang_libstdcpp::expected<T, E>;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -129,12 +129,10 @@ using GenericNonExclusivePromise = NativePromise<void, void, 1>;
 template<typename T> class NativePromiseRequest;
 }
 
-namespace std {
-namespace experimental {
-inline namespace fundamentals_v3 {
+namespace WTF::detail_from_clang_libstdcpp {
 template<class, class> class expected;
 template<class> class unexpected;
-}}} // namespace std::experimental::fundamentals_v3
+} // namespace WTF::detail_from_clang_libstdcpp
 
 using WTF::ASCIILiteral;
 using WTF::AbstractLocker;
@@ -190,8 +188,8 @@ using WTF::Vector;
 using WTF::WeakPtr;
 using WTF::WeakRef;
 
-template<class T, class E> using Expected = std::experimental::expected<T, E>;
-template<class E> using Unexpected = std::experimental::unexpected<E>;
+template<class T, class E> using Expected = WTF::detail_from_clang_libstdcpp::expected<T, E>;
+template<class E> using Unexpected = WTF::detail_from_clang_libstdcpp::unexpected<E>;
 
 // Sometimes an inline method simply forwards to another one and does nothing else. If it were
 // just a forward declaration of that method then you would only need a forward declaration of

--- a/Tools/TestWebKitAPI/Tests/WTF/Expected.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Expected.cpp
@@ -76,19 +76,19 @@ TEST(WTF_Expected, Unexpected)
 {
     {
         auto u = Unexpected<int>(42);
-        EXPECT_EQ(u.value(), 42);
+        EXPECT_EQ(u.error(), 42);
         constexpr auto c = makeUnexpected(42);
-        EXPECT_EQ(c.value(), 42);
+        EXPECT_EQ(c.error(), 42);
         EXPECT_EQ(u, c);
         EXPECT_FALSE(u != c);
     }
     {
         auto c = makeUnexpected(oops);
-        EXPECT_EQ(c.value(), oops);
+        EXPECT_EQ(c.error(), oops);
     }
     {
         auto s = makeUnexpected(std::string(oops));
-        EXPECT_EQ(s.value(), oops);
+        EXPECT_EQ(s.error(), oops);
     }
     {
         constexpr auto s0 = makeUnexpected(oops);


### PR DESCRIPTION
#### 987f5f2769ffafe037243957c3ed55651ebe7038
<pre>
Update WTF Unexpected to follow final C++23 specs
<a href="https://bugs.webkit.org/show_bug.cgi?id=263054">https://bugs.webkit.org/show_bug.cgi?id=263054</a>
<a href="https://rdar.apple.com/problem/116841632">rdar://problem/116841632</a>

Reviewed by NOBODY (OOPS!).

The previous implementation was based on an early proposal from 2017.
Since std::unexpected was finalized in C++23 and WebKit is limited to
C++20, we still need to use a local copy. This patch brings it up to
the final C++23 specs as shipped in Xcode SDKs.

The main API differences are that the contents are now accessed through
`error()` (instead of `value()`), and there are extra validity checks.

Also moved the local experimental `expected` implementation out of
`namespace std` to reduce UB risk.

* Source/WTF/wtf/Expected.h:
(WTF::detail_from_clang_libstdcpp::expected::expected):
(WTF::detail_from_clang_libstdcpp::operator==):
(std::experimental::fundamentals_v3::bad_expected_access&lt;void&gt;::bad_expected_access): Deleted.
(std::experimental::fundamentals_v3::bad_expected_access::bad_expected_access): Deleted.
(std::experimental::fundamentals_v3::bad_expected_access::error): Deleted.
(std::experimental::fundamentals_v3::bad_expected_access::error const): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::__expected_terminate): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::destroy): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::std::is_trivially_destructible&lt;T&gt;::value): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::constexpr_base::constexpr_base): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::base::base): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::base::~base): Deleted.
(std::experimental::fundamentals_v3::expected::expected): Deleted.
(std::experimental::fundamentals_v3::expected::operator=): Deleted.
(std::experimental::fundamentals_v3::expected::swap): Deleted.
(std::experimental::fundamentals_v3::expected::operator-&gt; const): Deleted.
(std::experimental::fundamentals_v3::expected::operator-&gt;): Deleted.
(std::experimental::fundamentals_v3::expected::operator* const): Deleted.
(std::experimental::fundamentals_v3::expected::operator*): Deleted.
(std::experimental::fundamentals_v3::expected::operator bool const): Deleted.
(std::experimental::fundamentals_v3::expected::has_value const): Deleted.
(std::experimental::fundamentals_v3::expected::value const): Deleted.
(std::experimental::fundamentals_v3::expected::value): Deleted.
(std::experimental::fundamentals_v3::expected::error const): Deleted.
(std::experimental::fundamentals_v3::expected::error): Deleted.
(std::experimental::fundamentals_v3::expected::value_or const): Deleted.
(std::experimental::fundamentals_v3::expected::value_or): Deleted.
(std::experimental::fundamentals_v3::operator==): Deleted.
(std::experimental::fundamentals_v3::swap): Deleted.
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/Unexpected.h:
(WTF::detail_from_clang_libstdcpp::unexpected::unexpected):
(WTF::detail_from_clang_libstdcpp::unexpected::error const):
(WTF::detail_from_clang_libstdcpp::unexpected::error):
(WTF::detail_from_clang_libstdcpp::unexpected::swap):
(WTF::detail_from_clang_libstdcpp::unexpected::operator==):
(std::experimental::fundamentals_v3::unexpected::unexpected): Deleted.
(std::experimental::fundamentals_v3::unexpected::value const): Deleted.
(std::experimental::fundamentals_v3::unexpected::value): Deleted.
(std::experimental::fundamentals_v3::operator==): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/Expected.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/987f5f2769ffafe037243957c3ed55651ebe7038

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35269 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/14205 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/37398 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38024 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31828 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36432 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/16587 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/11267 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/38024 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35816 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/16587 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/37398 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38024 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/16587 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/37398 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39270 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/29958 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/16587 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/37398 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39270 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/35173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/10721 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/11267 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39270 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12488 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/37398 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41811 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11245 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8692 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11545 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->