### PR TITLE
Add script to count instances of handwritten serialization code in Source

### DIFF
--- a/Tools/Scripts/count-handwritten-decoders
+++ b/Tools/Scripts/count-handwritten-decoders
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# This script scans Source for certain types of handwritten serialization logic and provides a count
+#
+
+cd "$(dirname "$0")/../../Source/"
+
+enumtraits=$(grep -ri "struct EnumTraits<" | wc -l | xargs);
+optionals=$(grep -riE "> decode\((Decoder|IPC::Decoder)" . | grep -v "Scripts/webkit/tests" | grep -v generate-serializers.py | grep -v "WTF/wtf/ArgumentCoder.h" | grep -vi gtk | grep -vi glib | wc -l | xargs);
+bools=$(grep -riE "bool decode\((Decoder|IPC::Decoder)" . | grep -v "Scripts/webkit/tests" | grep -v generate-serializers.py | grep -v "WTF/wtf/ArgumentCoder.h" | grep -vi gtk | grep -vi glib | wc -l | xargs);
+
+echo "EnumTraits remaining: $enumtraits"
+echo "Decoders that return std::optional<>: $optionals"
+echo "Legacy decoders that return bool: $bools"
+sum=$(($optionals+$bools))
+echo "Total decoders remaining: $sum"


### PR DESCRIPTION
#### ededc2ad69321b5b8b6e28b047e5f64d77732361
<pre>
Add script to count instances of handwritten serialization code in Source
<a href="https://bugs.webkit.org/show_bug.cgi?id=263057">https://bugs.webkit.org/show_bug.cgi?id=263057</a>
rdar://116844772

Reviewed by Tim Horton.

* Tools/Scripts/count-handwritten-decoders: Added.

Canonical link: <a href="https://commits.webkit.org/269240@main">https://commits.webkit.org/269240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/920f1a44d63d66e9c935ec7dcf80fbe69f1adcee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22508 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24714 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19919 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/19999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24048 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20574 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19927 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5240 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24132 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->