### PR TITLE
[WebXR] ARKitCoordinator enter/exit state management

### DIFF
--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -49,8 +49,25 @@ public:
     void scheduleAnimationFrame(WebPageProxy&, PlatformXR::Device::RequestFrameCallback&&) override;
     void submitFrame(WebPageProxy&) override;
 
+protected:
+    void currentSessionHasEnded();
+
 private:
     XRDeviceIdentifier m_deviceIdentifier = XRDeviceIdentifier::generate();
+
+    struct Idle {
+    };
+    struct Active {
+        WebCore::PageIdentifier pageIdentifier;
+        WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
+        PlatformXR::Device::RequestFrameCallback onFrameUpdate;
+    };
+    struct Terminating {
+        WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
+    };
+
+    using State = std::variant<Idle, Active, Terminating>;
+    State m_state;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### cebf8bf46cd6279bb3b6a1bcb1cd4483c95131a1
<pre>
[WebXR] ARKitCoordinator enter/exit state management
<a href="https://bugs.webkit.org/show_bug.cgi?id=262760">https://bugs.webkit.org/show_bug.cgi?id=262760</a>
rdar://116502232

Unreviewed relanding rolled-out dependency.

Implement basic state management for ARKitCoordinator to provide enough support
for immersive-ar-session.html to support starting and exiting an immersive AR
session and handle messages from the page.

* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):
(WebKit::ARKitCoordinator::endSessionIfExists):
(WebKit::ARKitCoordinator::scheduleAnimationFrame):
(WebKit::ARKitCoordinator::submitFrame):
(WebKit::ARKitCoordinator::currentSessionHasEnded):
(WebKit::ARKitCoordinator::didCompleteSessionSetup):

Canonical link: <a href="https://commits.webkit.org/269239@main">https://commits.webkit.org/269239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b45597c440190cbfe26b309e78bed790717d3b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20352 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22509 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21854 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24715 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/18974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/19997 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24049 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20575 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19928 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24133 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2734 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->