### PR TITLE
Deprecate injected bundle SPI for frame traversal

### DIFF
--- a/Source/WebKit/Shared/API/c/WKDeprecated.h
+++ b/Source/WebKit/Shared/API/c/WKDeprecated.h
@@ -27,8 +27,10 @@
 
 #ifdef _MSC_VER
 #define WK_C_API_DEPRECATED
+#define WK_C_API_DEPRECATED_WITH_MESSAGE(...)
 #define WK_C_API_DEPRECATED_WITH_REPLACEMENT(...)
 #else
 #define WK_C_API_DEPRECATED __attribute__((deprecated("No longer supported")))
+#define WK_C_API_DEPRECATED_WITH_MESSAGE(message) __attribute__((deprecated(message)))
 #define WK_C_API_DEPRECATED_WITH_REPLACEMENT(_replacement, ...) __attribute__((deprecated("use " #_replacement)))
 #endif

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.h
@@ -44,7 +44,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 @interface WKWebProcessPlugInFrame : NSObject
 
 @property (nonatomic, readonly) NSURL *URL;
-@property (nonatomic, readonly) NSArray *childFrames;
+@property (nonatomic, readonly) NSArray *childFrames WK_API_DEPRECATED("Child frames might not be in the same process", macos(10.10, WK_MAC_TBA), ios(8.0, WK_IOS_TBA));
 @property (nonatomic, readonly) BOOL containsAnyFormElements;
 @property (nonatomic, readonly) BOOL isMainFrame;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.h
@@ -39,8 +39,8 @@ extern "C" {
 WK_EXPORT WKTypeID WKBundleFrameGetTypeID();
 
 WK_EXPORT bool WKBundleFrameIsMainFrame(WKBundleFrameRef frame);
-WK_EXPORT WKBundleFrameRef WKBundleFrameGetParentFrame(WKBundleFrameRef frame);
-WK_EXPORT WKArrayRef WKBundleFrameCopyChildFrames(WKBundleFrameRef frame);
+WK_EXPORT WKBundleFrameRef WKBundleFrameGetParentFrame(WKBundleFrameRef frame) WK_C_API_DEPRECATED_WITH_MESSAGE("Parent frame might not be in the same process");
+WK_EXPORT WKArrayRef WKBundleFrameCopyChildFrames(WKBundleFrameRef frame) WK_C_API_DEPRECATED_WITH_MESSAGE("Child frames might not be in the same process");
 
 WK_EXPORT WKStringRef WKBundleFrameCopyName(WKBundleFrameRef frame);
 WK_EXPORT WKURLRef WKBundleFrameCopyURL(WKBundleFrameRef frame);

--- a/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionBasic_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionBasic_Bundle.cpp
@@ -108,7 +108,9 @@ DOMWindowExtensionBasic::DOMWindowExtensionBasic(const std::string& identifier)
 
 void DOMWindowExtensionBasic::frameLoadFinished(WKBundleFrameRef frame)
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     bool mainFrame = !WKBundleFrameGetParentFrame(frame);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     if (mainFrame)
         m_finishedOneMainFrameLoad = true;
 
@@ -197,10 +199,12 @@ void DOMWindowExtensionBasic::globalObjectIsAvailableForFrame(WKBundleFrameRef f
     bool standard;
     standard = world == WKBundleScriptWorldNormalWorld();
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (WKBundleFrameGetParentFrame(frame))
         index = standard ? 2 : 3;
     else
         index = m_finishedOneMainFrameLoad ? (standard ? 4 : 5) : (standard ? 0 : 1);
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     m_extensionToRecordMap.set(extension, index);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionNoCache_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DOMWindowExtensionNoCache_Bundle.cpp
@@ -111,7 +111,9 @@ DOMWindowExtensionNoCache::DOMWindowExtensionNoCache(const std::string& identifi
 
 void DOMWindowExtensionNoCache::frameLoadFinished(WKBundleFrameRef frame)
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     bool mainFrame = !WKBundleFrameGetParentFrame(frame);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     if (mainFrame)
         m_numberMainFrameLoads++;
 
@@ -204,7 +206,9 @@ void DOMWindowExtensionNoCache::globalObjectIsAvailableForFrame(WKBundleFrameRef
     bool standard;
     standard = world == WKBundleScriptWorldNormalWorld();
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     bool mainFrame = !WKBundleFrameGetParentFrame(frame);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     switch (m_numberMainFrameLoads) {
     case 0:
         index = mainFrame ? (standard ? 0 : 1) : (standard ? 2 : 3);

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache_Bundle.cpp
@@ -50,7 +50,9 @@ void didRemoveFrameFromHierarchyCallback(WKBundlePageRef page, WKBundleFrameRef 
 {
     didRemoveFrameFromHierarchyCount++;
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RELEASE_ASSERT(!WKBundleFrameGetParentFrame(frame));
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
     WKRetainPtr<WKStringRef> message = adoptWK(WKStringCreateWithUTF8CString("DidRemoveFrameFromHierarchy"));
     WKBundlePagePostMessage(page, message.get(), message.get());

--- a/Tools/TestWebKitAPI/Tests/WebKit/ParentFrame_Bundle.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ParentFrame_Bundle.cpp
@@ -62,7 +62,9 @@ static void didFinishLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, 
         return;
     }
     
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     bool isParentFrameCheckSuccessful = childFrame ? WKBundleFrameGetParentFrame(childFrame.get()) == frame : false;
+    ALLOW_DEPRECATED_DECLARATIONS_END
     WKBundlePostMessage(testBundle.get(), Util::toWK("DidCheckParentFrame").get(), adoptWK(WKBooleanCreate(isParentFrameCheckSuccessful)).get());
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -675,7 +675,9 @@ static void dumpFrameScrollPosition(WKBundleFrameRef frame, StringBuilder& strin
 
 static void dumpDescendantFrameScrollPositions(WKBundleFrameRef frame, StringBuilder& stringBuilder)
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto childFrames = adoptWK(WKBundleFrameCopyChildFrames(frame));
+    ALLOW_DEPRECATED_DECLARATIONS_END
     size_t size = WKArrayGetSize(childFrames.get());
     for (size_t i = 0; i < size; ++i) {
         WKBundleFrameRef subframe = static_cast<WKBundleFrameRef>(WKArrayGetItemAtIndex(childFrames.get(), i));
@@ -717,7 +719,9 @@ static void dumpFrameText(WKBundleFrameRef frame, StringBuilder& builder)
 
 static void dumpDescendantFramesText(WKBundleFrameRef frame, StringBuilder& stringBuilder)
 {
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto childFrames = adoptWK(WKBundleFrameCopyChildFrames(frame));
+    ALLOW_DEPRECATED_DECLARATIONS_END
     size_t size = WKArrayGetSize(childFrames.get());
     for (size_t i = 0; i < size; ++i) {
         WKBundleFrameRef subframe = static_cast<WKBundleFrameRef>(WKArrayGetItemAtIndex(childFrames.get(), i));


### PR DESCRIPTION
#### c2a6009aaa7d782400be353201bf78e2b883091e
<pre>
Deprecate injected bundle SPI for frame traversal
<a href="https://bugs.webkit.org/show_bug.cgi?id=263059">https://bugs.webkit.org/show_bug.cgi?id=263059</a>
rdar://116845408

Reviewed by Chris Dumez.

All use of this SPI needs to be rethought and implemented in a way that is compatible with site isolation,
where a frame may be in another process so we can&apos;t get a pointer to it.

* Source/WebKit/Shared/API/c/WKDeprecated.h:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.h:

Canonical link: <a href="https://commits.webkit.org/269312@main">https://commits.webkit.org/269312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97d9751266aebc4ba940f47d330a8341a6123266

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21489 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24808 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26256 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24124 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17593 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20013 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24220 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2771 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->