### PR TITLE
Unable to scroll results.webkit.org results using the scrollbars

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hit-test-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hit-test-expected.txt
@@ -1,0 +1,16 @@
+sticky
+Test hit-testing the overlay scrollbar with a composited element inside the scroller
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial state
+enabled
+Hovering horizontal scrollbar should show expanded scrollbar
+PASS Scrollbar is enabled and expanded
+Attempting to drag the scrollbar
+PASS Scrolled by dragging the scrollbar
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hit-test.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hit-test.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .scroller {
+	        overflow-x: auto;
+	        overflow-y: hidden;
+	        width: 500px;
+	        height: 200px;
+	        border: 1px solid black;
+			will-change: z-index;
+			resize: both;
+        }
+	    .wide {
+	        position: relative;
+	        width: 400%;
+	        border: 1px solid green;
+	    }
+        .sticky {
+	        position: sticky;
+	        top: 10px;
+	        left: 10px;
+	        width: 350px;
+	        height: 200px;
+	        background-color: rgba(0, 0, 0, 0.2);
+        }
+    </style>
+    <script src="../../../../resources/js-test-pre.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        if (window.internals)
+            internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            description('Test hit-testing the overlay scrollbar with a composited element inside the scroller');
+            if (!window.internals) {
+                finishJSTest();                
+                return;
+            }
+
+            const scroller = document.querySelector('.scroller');
+            const scrollerBounds = scroller.getBoundingClientRect();
+            const x = scrollerBounds.left + 90;
+            const y = scrollerBounds.bottom - 5;
+
+            debug('Initial state');
+            var scrollbarState = await UIHelper.horizontalScrollbarState(scroller);
+            debug(scrollbarState);
+
+            debug('Hovering horizontal scrollbar should show expanded scrollbar');
+            await UIHelper.mouseWheelScrollAt(x, y, -1, 0, -2, 0); // Horizontal scroll gesture.
+            await UIHelper.waitForConditionAsync(async () => {
+                let state = await UIHelper.horizontalScrollbarState(scroller);
+                let enabled = state.indexOf('enabled') != -1;
+                let expanded = state.indexOf('expanded') != -1;
+                if (enabled && expanded)
+                    testPassed('Scrollbar is enabled and expanded');
+                return expanded;
+            });
+
+			// Flush out scroll events from gesture
+            await UIHelper.renderingUpdate();
+
+            scroller.addEventListener("scroll", async () => {
+                testPassed('Scrolled by dragging the scrollbar');
+            	finishJSTest();
+            });
+			
+			// Now try and click and drag the scrollbar
+            debug('Attempting to drag the scrollbar');
+            eventSender.mouseMoveTo(x, y);
+            eventSender.mouseDown();
+            eventSender.mouseMoveTo(x + 20, y);
+            eventSender.mouseUp();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="wide">
+            <div class="composited sticky">
+                sticky
+            </div>
+        </div>
+    </div>
+    <div id="console"></div>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3945,7 +3945,7 @@ bool RenderLayer::hitTest(const HitTestRequest& request, const HitTestLocation& 
 
     auto insideLayer = hitTestLayer(this, nullptr, request, result, hitTestArea, hitTestLocation, false);
     if (!insideLayer.layer) {
-        // We didn't hit any layer. If we are the root layer and the mouse is -- or just was -- down, 
+        // We didn't hit any layer. If we are the root layer and the mouse is -- or just was -- down,
         // return ourselves. We do this so mouse events continue getting delivered after a drag has 
         // exited the WebView, and so hit testing over a scrollbar hits the content document.
         if (!request.isChildFrameHitTest() && (request.active() || request.release()) && isRenderViewLayer()) {
@@ -4221,12 +4221,15 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     {
         HitTestResult tempResult(result.hitTestLocation());
         hitLayer = hitTestList(normalFlowLayers(), rootLayer, request, tempResult, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+
         if (request.resultIsElementList())
             result.append(tempResult, request);
+
         if (hitLayer.layer) {
             if (!depthSortDescendants || !using3DTransformsInterop || hitLayer.zOffset > candidateLayer.zOffset) {
                 if (!request.resultIsElementList())
                     result = tempResult;
+
                 candidateLayer = hitLayer;
             }
 
@@ -4248,6 +4251,7 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     auto isHitCandidate = [&]() {
         if (using3DTransformsInterop)
             return !depthSortDescendants || selfZOffset > candidateLayer.zOffset;
+
         return isHitCandidateLegacy(this, false, zOffsetForContentsPtr, unflattenedTransformState.get());
     };
 
@@ -4262,8 +4266,10 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
                 result.append(tempResult, request);
             else
                 result = tempResult;
+
             if (!depthSortDescendants)
                 return { this, selfZOffset };
+
             // Foreground can depth-sort with descendant layers, so keep this as a candidate.
             candidateLayer = { this, selfZOffset };
         } else if (insideFragmentForegroundRect && request.resultIsElementList())
@@ -4274,12 +4280,15 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     {
         HitTestResult tempResult(result.hitTestLocation());
         hitLayer = hitTestList(negativeZOrderLayers(), rootLayer, request, tempResult, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+
         if (request.resultIsElementList())
             result.append(tempResult, request);
+
         if (hitLayer.layer) {
             if (!depthSortDescendants || !using3DTransformsInterop || hitLayer.zOffset > candidateLayer.zOffset) {
                 if (!request.resultIsElementList())
                     result = tempResult;
+
                 candidateLayer = hitLayer;
             }
 
@@ -4295,15 +4304,18 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     if (isSelfPaintingLayer()) {
         HitTestResult tempResult(result.hitTestLocation());
         bool insideFragmentBackgroundRect = false;
-            if (hitTestContentsForFragments(layerFragments, request, tempResult, hitTestLocation, HitTestSelf, insideFragmentBackgroundRect)  && isHitCandidate()) {
+        if (hitTestContentsForFragments(layerFragments, request, tempResult, hitTestLocation, HitTestSelf, insideFragmentBackgroundRect) && isHitCandidate()) {
             if (request.resultIsElementList())
                 result.append(tempResult, request);
             else
                 result = tempResult;
+
             if (!depthSortDescendants)
                 return { this, selfZOffset };
+
             candidateLayer = { this, selfZOffset };
         }
+
         if (insideFragmentBackgroundRect && request.resultIsElementList())
             result.append(tempResult, request);
     }
@@ -4318,7 +4330,7 @@ bool RenderLayer::hitTestContentsForFragments(const LayerFragments& layerFragmen
         return false;
 
     for (int i = layerFragments.size() - 1; i >= 0; --i) {
-        const LayerFragment& fragment = layerFragments.at(i);
+        const auto& fragment = layerFragments.at(i);
         if ((hitTestFilter == HitTestSelf && !fragment.backgroundRect.intersects(hitTestLocation))
             || (hitTestFilter == HitTestDescendants && !fragment.foregroundRect.intersects(hitTestLocation)))
             continue;
@@ -4569,8 +4581,7 @@ void RenderLayer::calculateClipRects(const ClipRectsContext& clipRectsContext, C
             clipRects = *parentLayer->clipRects(clipRectsContext);
         else {
             ClipRectsContext parentContext(clipRectsContext);
-            parentContext.options.remove(ClipRectsOption::IncludeOverlayScrollbarSize); // FIXME: Why?
-            
+
             if ((parentContext.clipRectsType != TemporaryClipRects && parentContext.clipRectsType != AbsoluteClipRects) && clipCrossesPaintingBoundary())
                 parentContext.clipRectsType = TemporaryClipRects;
 


### PR DESCRIPTION
#### db2f6b2a047a9f2f493bd20a6f0faff640fd3f8e
<pre>
Unable to scroll results.webkit.org results using the scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=237308">https://bugs.webkit.org/show_bug.cgi?id=237308</a>
rdar://89598421

Reviewed by Dan Glastonbury and Richard Robinson.

If an overflow:scroll contained a composited, positioned descendant, then trying to click and drag an
overlay scrollbar that overlapped that descendant would fail to work. This affected results.webkit.org,
where the canvas elements caused the bug.

This happened because when the hit-testing code tested whether the composited layer contained the
point, it would use a backgroundClipRect that was not shrunk for the scrollbar. There was already
a &quot;FIXME&quot; comment on a line of code that explicitly removed the `IncludeOverlayScrollbarSize` option,
and removing this line fixes the bug. The code dates from when composited overflow scrolling was
first implemented (112856@main). `IncludeOverlayScrollbarSize` is only ever specified when requesting
clip rects for hit-testing, so it seems reasonable to assume the code was wrong.

Do other whitespace cleanup in the hit-testing code, including fixing a line with bad indentation.

* LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hit-test-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-hit-test.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTest):
(WebCore::RenderLayer::hitTestLayer):
(WebCore::RenderLayer::hitTestContentsForFragments const):
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/269255@main">https://commits.webkit.org/269255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b94f9a52809b7a103cfe1352f2c952398fd0efe1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/21990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21433 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24724 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/18979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26186 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24052 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17532 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19731 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5251 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24141 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->