### PR TITLE
[WebXR] Display ARKit captured image in overlay view

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ARKitSoftLink.h
+++ b/Source/WebKit/Shared/Cocoa/ARKitSoftLink.h
@@ -33,6 +33,7 @@
 SOFT_LINK_FRAMEWORK_FOR_HEADER(WebKit, ARKit)
 
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ARQuickLookPreviewItem);
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, ARSession);
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ARWorldTrackingConfiguration)
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ARKitSoftLinkAdditions.h>)

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -597,6 +597,7 @@ UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
 
 UIProcess/XR/ios/PlatformXRARKit.mm
 UIProcess/XR/ios/PlatformXRSystemIOS.mm
+UIProcess/XR/ios/WKARPresentationSession.mm
 
 WebProcess/API/Cocoa/WKWebProcess.cpp
 

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h
@@ -30,7 +30,12 @@
 
 #import "PlatformXRCoordinator.h"
 
+#import <wtf/RetainPtr.h>
+#import <wtf/Threading.h>
+#import <wtf/threads/BinarySemaphore.h>
+
 @class ARSession;
+@protocol WKARPresentationSession;
 
 namespace WebKit {
 
@@ -50,10 +55,13 @@ public:
     void submitFrame(WebPageProxy&) override;
 
 protected:
+    void createSessionIfNeeded();
     void currentSessionHasEnded();
+    void renderLoop();
 
 private:
     XRDeviceIdentifier m_deviceIdentifier = XRDeviceIdentifier::generate();
+    RetainPtr<ARSession> m_session;
 
     struct Idle {
     };
@@ -61,6 +69,9 @@ private:
         WebCore::PageIdentifier pageIdentifier;
         WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;
         PlatformXR::Device::RequestFrameCallback onFrameUpdate;
+        RetainPtr<id<WKARPresentationSession>> presentationSession;
+        RefPtr<Thread> renderThread;
+        Box<BinarySemaphore> renderSemaphore;
     };
     struct Terminating {
         WeakPtr<PlatformXRCoordinator::SessionEventClient> sessionEventClient;

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "config.h"
+#pragma once
 
-#if ((USE(SYSTEM_PREVIEW) && HAVE(ARKIT_QUICK_LOOK_PREVIEW_ITEM)) || ((PLATFORM(IOS) || PLATFORM(VISION)) && USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ARKitSoftLinkAdditions.mm>)))
+#if ENABLE(WEBXR) && USE(ARKITXR_IOS)
 
-#import <wtf/SoftLinking.h>
+NS_ASSUME_NONNULL_BEGIN
 
-SOFT_LINK_FRAMEWORK_FOR_SOURCE(WebKit, ARKit);
+@class ARSession;
 
-SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ARKit, ARQuickLookPreviewItem);
-SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ARKit, ARSession);
-SOFT_LINK_CLASS_FOR_SOURCE(WebKit, ARKit, ARWorldTrackingConfiguration);
+@interface WKARPresentationSessionDescriptor : NSObject <NSCopying>
+@property (nonatomic, nullable, weak, readwrite) UIViewController *presentingViewController;
+@end
 
-#if (PLATFORM(IOS) || PLATFORM(VISION)) && USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ARKitSoftLinkAdditions.mm>)
-#import <WebKitAdditions/ARKitSoftLinkAdditions.mm>
-#endif
+@protocol WKARPresentationSession <NSObject>
+@property (nonatomic, retain, readonly) ARSession *session;
+- (NSUInteger)startFrame;
+- (void)present;
+- (void)terminate;
+@end
 
-#endif
+id<WKARPresentationSession> createPresesentationSession(ARSession *, WKARPresentationSessionDescriptor *);
+
+NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEBXR) && USE(ARKITXR_IOS)

--- a/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
+++ b/Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#import "WKARPresentationSession.h"
+
+#if ENABLE(WEBXR) && USE(ARKITXR_IOS)
+
+#import <Metal/Metal.h>
+#import <wtf/WeakObjCPtr.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - WKARPresentationSessionDescriptor
+
+@implementation WKARPresentationSessionDescriptor {
+    WeakObjCPtr<UIViewController> _presentingViewController;
+}
+
+- (instancetype)copyWithZone:(nullable NSZone *)zone
+{
+    WKARPresentationSessionDescriptor *descriptor = [[[self class] allocWithZone:zone] init];
+    descriptor.presentingViewController = self.presentingViewController;
+
+    return descriptor;
+}
+
+- (nullable UIViewController *)presentingViewController
+{
+    return (UIViewController *) _presentingViewController;
+}
+
+- (void)setPresentingViewController:(nullable UIViewController*)presentingViewController
+{
+    _presentingViewController = presentingViewController;
+}
+
+@end
+
+@interface _WKARPresentationSession : UIViewController <WKARPresentationSession>
+- (nullable instancetype)initWithSession:(ARSession *)session descriptor:(WKARPresentationSessionDescriptor *)descriptor;
+@end
+
+#pragma mark - _WKARPresentationSession
+
+@implementation _WKARPresentationSession {
+    RetainPtr<ARSession> _session;
+    RetainPtr<WKARPresentationSessionDescriptor> _sessionDescriptor;
+
+    // View state
+    RetainPtr<UIView> _view;
+    WeakObjCPtr<CALayer> _cameraLayer;
+
+    // Camera image
+    RetainPtr<CVPixelBufferRef> _capturedImage;
+}
+
+- (nullable instancetype)initWithSession:(ARSession *)session descriptor:(WKARPresentationSessionDescriptor *)descriptor
+{
+    self = [super init];
+    if (self) {
+        _session = session;
+        _sessionDescriptor = adoptNS([descriptor copy]);
+
+        [self _enterFullscreen];
+    }
+
+    return self;
+}
+
+#pragma mark - WKARPresentationSession
+
+-(ARSession *)session {
+    return (ARSession *) _session;
+}
+
+- (NSUInteger)startFrame
+{
+    ARFrame *currentFrame = [_session currentFrame];
+    if (!currentFrame) {
+        RELEASE_LOG(XR, "%s: no frame available", __FUNCTION__);
+        return 0;
+    }
+
+    _capturedImage = currentFrame.capturedImage;
+
+    return 1;
+}
+
+- (void)present
+{
+    [CATransaction begin];
+    {
+        [_cameraLayer setContents:(id) _capturedImage.get()];
+    }
+    [CATransaction commit];
+    [CATransaction flush];
+
+    _capturedImage = nil;
+}
+
+- (void)terminate
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+}
+
+#pragma mark - UIViewController
+
+- (void)loadView
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+    RetainPtr<UIView> view = adoptNS([[UIView alloc] initWithFrame:UIScreen.mainScreen.bounds]);
+    self.view = view.get();
+}
+
+- (void)viewDidLoad
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+    [super viewDidLoad];
+
+    _cameraLayer = [self.view layer];
+    [_cameraLayer setBackgroundColor:UIColor.whiteColor.CGColor];
+    [_cameraLayer setOpaque:YES];
+}
+
+#if !PLATFORM(VISION)
+- (BOOL)preferStatusBarHidden
+{
+    return YES;
+}
+#endif
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+    [super viewWillAppear:animated];
+
+    RetainPtr<ARWorldTrackingConfiguration> configuration = adoptNS([WebKit::allocARWorldTrackingConfigurationInstance() init]);
+    [_session runWithConfiguration:configuration.get()];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+    [_session pause];
+    [super viewWillDisappear:animated];
+}
+
+#pragma mark - Private
+
+- (void)_enterFullscreen
+{
+    ASSERT(RunLoop::isMain());
+    RELEASE_LOG(XR, "%s", __FUNCTION__);
+
+    UIViewController* presentingViewController = [_sessionDescriptor presentingViewController];
+    [presentingViewController presentViewController:self animated:NO completion:^(void) {
+        RELEASE_LOG(XR, "%s: presentViewController complete", __FUNCTION__);
+    }];
+}
+
+@end
+
+id<WKARPresentationSession> createPresesentationSession(ARSession *session, WKARPresentationSessionDescriptor *descriptor)
+{
+    return [[_WKARPresentationSession alloc] initWithSession:session descriptor:descriptor];
+}
+
+NS_ASSUME_NONNULL_END
+
+#endif // ENABLE(WEBXR) && USE(ARKITXR_IOS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4644,6 +4644,8 @@
 		37FC19461850FBF2008CFA47 /* WKBrowsingContextLoadDelegatePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKBrowsingContextLoadDelegatePrivate.h; sourceTree = "<group>"; };
 		37FC194818510D6A008CFA47 /* WKNSURLAuthenticationChallenge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKNSURLAuthenticationChallenge.mm; sourceTree = "<group>"; };
 		37FC194918510D6A008CFA47 /* WKNSURLAuthenticationChallenge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKNSURLAuthenticationChallenge.h; sourceTree = "<group>"; };
+		3A5B68962AC266D400B11868 /* WKARPresentationSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKARPresentationSession.h; sourceTree = "<group>"; };
+		3A5B68972AC266D400B11868 /* WKARPresentationSession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKARPresentationSession.mm; sourceTree = "<group>"; };
 		3A7D62D229D35D9D00D57DAC /* WebSWRegistrationStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSWRegistrationStore.cpp; sourceTree = "<group>"; };
 		3A7D62D329D38DD300D57DAC /* ServiceWorkerStorageManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerStorageManager.cpp; sourceTree = "<group>"; };
 		3A7D62D429D38DD300D57DAC /* ServiceWorkerStorageManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerStorageManager.h; sourceTree = "<group>"; };
@@ -10727,6 +10729,8 @@
 				3AEE89922AA595AC00D4DF44 /* PlatformXRARKit.h */,
 				3AEE89912AA595AC00D4DF44 /* PlatformXRARKit.mm */,
 				3AEE89932AA5966A00D4DF44 /* PlatformXRSystemIOS.mm */,
+				3A5B68962AC266D400B11868 /* WKARPresentationSession.h */,
+				3A5B68972AC266D400B11868 /* WKARPresentationSession.mm */,
 			);
 			path = ios;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### f6e1ce804c6ed01924775d324fc2c745c27c4e14
<pre>
[WebXR] Display ARKit captured image in overlay view
<a href="https://bugs.webkit.org/show_bug.cgi?id=262773">https://bugs.webkit.org/show_bug.cgi?id=262773</a>
rdar://116502294

Reviewed by Dean Jackson.

Unlike other WebXR compositor systems, ARKit doesn&apos;t provide a framework for
rendering immersive AR content, just a series of captured camera images with
camera transformation, so we need to implement our own compositor.

This patch introduces WKARPresentationSession that is responsible for managing a
view and compositing the captured camera images with WebGL rendering. On
entering an immersive AR session, WKARPresentationSession creates a new
UIViewController and makes it the presenting view controller for UIKit. The
camera images, which are provided in CVPixelBuffers, are displayed by setting
them as the CALayer content of a UIView. In a following patch, the WebGL content
will be composited on top of the camera image.

Update of the captured camera image is driven off the main thread using the
setting of the animation frame callback from the page to trigger the update.

It is intended that the view should be fullscreen but currently it is rendered
as a small view to allow exiting an immersive AR session by touching outside the
view to dismiss it.

* Source/WebKit/Shared/Cocoa/ARKitSoftLink.h:
* Source/WebKit/Shared/Cocoa/ARKitSoftLink.mm:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.h:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):
(WebKit::ARKitCoordinator::endSessionIfExists):
(WebKit::ARKitCoordinator::scheduleAnimationFrame):
(WebKit::ARKitCoordinator::createSessionIfNeeded):
(WebKit::ARKitCoordinator::renderLoop):
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.h: Copied from Source/WebKit/Shared/Cocoa/ARKitSoftLink.h.
* Source/WebKit/UIProcess/XR/ios/WKARPresentationSession.mm: Added.
(-[WKARPresentationSessionDescriptor copyWithZone:]):
(-[WKARPresentationSessionDescriptor presentingViewController]):
(-[WKARPresentationSessionDescriptor setPresentingViewController:]):
(-[_WKARPresentationSession initWithSession:descriptor:]):
(-[_WKARPresentationSession session]):
(-[_WKARPresentationSession startFrame]):
(-[_WKARPresentationSession present]):
(-[_WKARPresentationSession terminate]):
(-[_WKARPresentationSession loadView]):
(-[_WKARPresentationSession viewDidLoad]):
(-[_WKARPresentationSession preferStatusBarHidden]):
(-[_WKARPresentationSession viewWillAppear:]):
(-[_WKARPresentationSession viewWillDisappear:]):
(-[_WKARPresentationSession _enterFullscreen]):
(createPresesentationSession):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Originally-landed-as: 269064@main (6371344eac3b). rdar://116502294
Canonical link: <a href="https://commits.webkit.org/269352@main">https://commits.webkit.org/269352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cfe6b75126afb43817141a101c400f7d0285b10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/22318 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/22517 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/23393 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/24218 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20656 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26779 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/22847 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/24218 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/22554 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26779 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/23393 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/25073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26779 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/23393 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/25073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26779 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/23393 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/25073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20987 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/22847 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/20445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/23393 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5313 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/24675 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/20983 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->