### PR TITLE
Retry generating RTCNetwork serialization

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/socket_address.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/socket_address.h
@@ -50,6 +50,16 @@ class RTC_EXPORT SocketAddress {
   // Creates a copy of the given address.
   SocketAddress(const SocketAddress& addr);
 
+  // Construct after deserialization.
+#ifdef WEBRTC_WEBKIT_BUILD
+  SocketAddress(std::string&& hostname, IPAddress ip, uint16_t port, int scope_id, bool literal)
+    : hostname_(std::move(hostname))
+    , ip_(ip)
+    , port_(port)
+    , scope_id_(scope_id)
+    , literal_(literal) { }
+#endif
+
   // Resets to the nil address.
   void Clear();
 
@@ -107,6 +117,11 @@ class RTC_EXPORT SocketAddress {
   // a field for them.
   int scope_id() const { return scope_id_; }
   void SetScopeID(int id) { scope_id_ = id; }
+
+  // Expose literal_ for serialization.
+#ifdef WEBRTC_WEBKIT_BUILD
+  bool literal() const { return literal_; }
+#endif
 
   // Returns the 'host' portion of the address (hostname or IP) in a form
   // suitable for use in a URI. If both IP and hostname are present, hostname

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -395,6 +395,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/Pasteboard.serialization.in
     Shared/PlatformPopupMenuData.serialization.in
     Shared/PolicyDecision.serialization.in
+    Shared/RTCNetwork.serialization.in
     Shared/RemoteWorkerInitializationData.serialization.in
     Shared/RemoteWorkerType.serialization.in
     Shared/ResourceLoadInfo.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -235,6 +235,7 @@ $(PROJECT_DIR)/Shared/PlatformPopupMenuData.serialization.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
 $(PROJECT_DIR)/Shared/PolicyDecision.serialization.in
 $(PROJECT_DIR)/Shared/PushMessageForTesting.serialization.in
+$(PROJECT_DIR)/Shared/RTCNetwork.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
 $(PROJECT_DIR)/Shared/RemoteWorkerInitializationData.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -543,6 +543,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/PlatformPopupMenuData.serialization.in \
 	Shared/PolicyDecision.serialization.in \
 	Shared/PushMessageForTesting.serialization.in \
+	Shared/RTCNetwork.serialization.in \
 	Shared/RemoteWorkerInitializationData.serialization.in \
 	Shared/RemoteWorkerType.serialization.in \
 	Shared/ResourceLoadInfo.serialization.in \

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -110,10 +110,12 @@ void NetworkManagerWrapper::onNetworksChanged()
 {
     RELEASE_LOG(WebRTC, "NetworkManagerWrapper::onNetworksChanged");
 
-    RTCNetwork::IPAddress ipv4;
-    m_manager->GetDefaultLocalAddress(AF_INET, &ipv4.value);
-    RTCNetwork::IPAddress ipv6;
-    m_manager->GetDefaultLocalAddress(AF_INET6, &ipv6.value);
+    rtc::IPAddress ipv4RTC;
+    m_manager->GetDefaultLocalAddress(AF_INET, &ipv4RTC);
+    RTCNetwork::IPAddress ipv4(ipv4RTC);
+    rtc::IPAddress ipv6RTC;
+    m_manager->GetDefaultLocalAddress(AF_INET6, &ipv6RTC);
+    RTCNetwork::IPAddress ipv6(ipv6RTC);
 
     auto networks = m_manager->GetNetworks();
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -167,13 +167,13 @@ void NetworkRTCProvider::createUDPSocket(LibWebRTCSocketIdentifier identifier, c
 
 #if PLATFORM(COCOA)
     if (m_platformUDPSocketsEnabled) {
-        auto socket = makeUnique<NetworkRTCUDPSocketCocoa>(identifier, *this, address.value, m_ipcConnection.copyRef(), String(attributedBundleIdentifierFromPageIdentifier(pageIdentifier)), isFirstParty, isRelayDisabled, WTFMove(domain));
+        auto socket = makeUnique<NetworkRTCUDPSocketCocoa>(identifier, *this, address.rtcAddress(), m_ipcConnection.copyRef(), String(attributedBundleIdentifierFromPageIdentifier(pageIdentifier)), isFirstParty, isRelayDisabled, WTFMove(domain));
         addSocket(identifier, WTFMove(socket));
         return;
     }
 #endif
 
-    std::unique_ptr<rtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateUdpSocket(address.value, minPort, maxPort));
+    std::unique_ptr<rtc::AsyncPacketSocket> socket(m_packetSocketFactory->CreateUdpSocket(address.rtcAddress(), minPort, maxPort));
     createSocket(identifier, WTFMove(socket), Socket::Type::UDP, m_ipcConnection.copyRef());
 }
 
@@ -190,7 +190,7 @@ void NetworkRTCProvider::createClientTCPSocket(LibWebRTCSocketIdentifier identif
 
 #if PLATFORM(COCOA)
     if (m_platformTCPSocketsEnabled) {
-        auto socket = NetworkRTCTCPSocketCocoa::createClientTCPSocket(identifier, *this, remoteAddress.value, options, attributedBundleIdentifierFromPageIdentifier(pageIdentifier), isFirstParty, isRelayDisabled, domain, m_ipcConnection.copyRef());
+        auto socket = NetworkRTCTCPSocketCocoa::createClientTCPSocket(identifier, *this, remoteAddress.rtcAddress(), options, attributedBundleIdentifierFromPageIdentifier(pageIdentifier), isFirstParty, isRelayDisabled, domain, m_ipcConnection.copyRef());
         if (socket)
             addSocket(identifier, WTFMove(socket));
         else
@@ -208,7 +208,7 @@ void NetworkRTCProvider::createClientTCPSocket(LibWebRTCSocketIdentifier identif
             signalSocketIsClosed(identifier);
             return;
         }
-        callOnRTCNetworkThread([this, identifier, localAddress = RTCNetwork::isolatedCopy(localAddress.value), remoteAddress = RTCNetwork::isolatedCopy(remoteAddress.value), proxyInfo = proxyInfoFromSession(remoteAddress, *session), userAgent = WTFMove(userAgent).isolatedCopy(), options]() mutable {
+        callOnRTCNetworkThread([this, identifier, localAddress = RTCNetwork::isolatedCopy(localAddress.rtcAddress()), remoteAddress = RTCNetwork::isolatedCopy(remoteAddress.rtcAddress()), proxyInfo = proxyInfoFromSession(remoteAddress, *session), userAgent = WTFMove(userAgent).isolatedCopy(), options]() mutable {
 
             rtc::PacketSocketTcpOptions tcpOptions;
             tcpOptions.opts = options;
@@ -233,7 +233,7 @@ void NetworkRTCProvider::sendToSocket(LibWebRTCSocketIdentifier identifier, cons
     auto iterator = m_sockets.find(identifier);
     if (iterator == m_sockets.end())
         return;
-    iterator->second->sendTo(data.data(), data.size(), address.value, options.options);
+    iterator->second->sendTo(data.data(), data.size(), address.rtcAddress(), options.options);
 }
 
 void NetworkRTCProvider::closeSocket(LibWebRTCSocketIdentifier identifier)

--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -28,14 +28,11 @@
 
 #if USE(LIBWEBRTC)
 
-#include "DataReference.h"
-#include "WebCoreArgumentCoders.h"
-
 namespace WebKit {
 
 RTCNetwork::RTCNetwork(const rtc::Network& network)
-    : name(network.name())
-    , description(network.description())
+    : name(network.name().data(), network.name().length())
+    , description(network.description().data(), network.description().length())
     , prefix { network.prefix() }
     , prefixLength(network.prefix_length())
     , type(network.type())
@@ -44,68 +41,38 @@ RTCNetwork::RTCNetwork(const rtc::Network& network)
     , active(network.active())
     , ignored(network.ignored())
     , scopeID(network.scope_id())
-    , ips(network.GetIPs())
-{
-}
+    , ips(WTF::map(network.GetIPs(), [] (const rtc::InterfaceAddress& address) {
+        return RTCNetwork::InterfaceAddress(address);
+    })) { }
+
+RTCNetwork::RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<char>&& key, size_t length, Vector<InterfaceAddress>&& ips)
+    : name(WTFMove(name))
+    , description(WTFMove(description))
+    , prefix(prefix)
+    , prefixLength(prefixLength)
+    , type(type)
+    , id(id)
+    , preference(preference)
+    , active(active)
+    , ignored(ignored)
+    , scopeID(scopeID)
+    , key(WTFMove(key))
+    , length(length)
+    , ips(WTFMove(ips)) { }
 
 rtc::Network RTCNetwork::value() const
 {
-    rtc::Network network(name.data(), description.data(), prefix.value, prefixLength, rtc::AdapterType(type));
+    rtc::Network network(name.data(), description.data(), prefix.rtcAddress(), prefixLength, rtc::AdapterType(type));
     network.set_id(id);
     network.set_preference(preference);
     network.set_active(active);
     network.set_ignored(ignored);
     network.set_scope_id(scopeID);
-    network.SetIPs(ips, true);
+    auto rtcInterfaceAddresses = WTF::map(ips, [] (const RTCNetwork::InterfaceAddress& address) {
+        return address.rtcAddress();
+    });
+    network.SetIPs(std::vector<rtc::InterfaceAddress>(rtcInterfaceAddresses.begin(), rtcInterfaceAddresses.end()), true);
     return network;
-}
-
-auto RTCNetwork::IPAddress::decode(IPC::Decoder& decoder) -> std::optional<IPAddress>
-{
-    IPAddress result;
-    int family;
-    if (!decoder.decode(family))
-        return std::nullopt;
-
-    ASSERT(family == AF_INET || family == AF_INET6 || family == AF_UNSPEC);
-
-    if (family == AF_UNSPEC)
-        return result;
-
-    IPC::DataReference data;
-    if (!decoder.decode(data))
-        return std::nullopt;
-
-    if (family == AF_INET) {
-        if (data.size() != sizeof(in_addr))
-            return std::nullopt;
-        result.value = rtc::IPAddress(*reinterpret_cast<const in_addr*>(data.data()));
-        return result;
-    }
-
-    if (data.size() != sizeof(in6_addr))
-        return std::nullopt;
-    result.value = rtc::IPAddress(*reinterpret_cast<const in6_addr*>(data.data()));
-    return result;
-}
-
-void RTCNetwork::IPAddress::encode(IPC::Encoder& encoder) const
-{
-    auto family = value.family();
-    ASSERT(family == AF_INET || family == AF_INET6 || family == AF_UNSPEC);
-    encoder << family;
-
-    if (family == AF_UNSPEC)
-        return;
-
-    if (family == AF_INET) {
-        auto address = value.ipv4_address();
-        encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(&address), sizeof(address));
-        return;
-    }
-
-    auto address = value.ipv6_address();
-    encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(&address), sizeof(address));
 }
 
 rtc::SocketAddress RTCNetwork::isolatedCopy(const rtc::SocketAddress& value)
@@ -119,119 +86,74 @@ rtc::SocketAddress RTCNetwork::isolatedCopy(const rtc::SocketAddress& value)
     return rtc::SocketAddress(copy);
 }
 
-auto RTCNetwork::SocketAddress::decode(IPC::Decoder& decoder) -> std::optional<SocketAddress>
+namespace RTC::Network {
+
+IPAddress::IPAddress(const rtc::IPAddress& input)
 {
-    SocketAddress result;
-    uint16_t port;
-    if (!decoder.decode(port))
-        return std::nullopt;
-    int scopeId;
-    if (!decoder.decode(scopeId))
-        return std::nullopt;
-    result.value.SetPort(port);
-    result.value.SetScopeID(scopeId);
-
-    IPC::DataReference hostname;
-    if (!decoder.decode(hostname))
-        return std::nullopt;
-    result.value.SetIP(std::string(reinterpret_cast<const char*>(hostname.data()), hostname.size()));
-
-    bool isUnresolved;
-    if (!decoder.decode(isUnresolved))
-        return std::nullopt;
-    if (isUnresolved)
-        return result;
-
-    std::optional<IPAddress> ipAddress;
-    decoder >> ipAddress;
-    if (!ipAddress)
-        return std::nullopt;
-    result.value.SetResolvedIP(ipAddress->value);
-    return result;
-}
-
-void RTCNetwork::SocketAddress::encode(IPC::Encoder& encoder) const
-{
-    encoder << value.port();
-    encoder << value.scope_id();
-
-    auto hostname = value.hostname();
-    encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(hostname.data()), hostname.length());
-
-    if (value.IsUnresolvedIP()) {
-        encoder << true;
+    switch (input.family()) {
+    case AF_INET6: {
+        in6_addr addr = input.ipv6_address();
+        std::array<uint32_t, 4> array;
+        static_assert(sizeof(array) == sizeof(addr));
+        memcpy(array.data(), &addr, sizeof(array));
+        value = array;
         return;
     }
-    encoder << false;
-    encoder << RTCNetwork::IPAddress(value.ipaddr());
+    case AF_INET:
+        value = input.ipv4_address().s_addr;
+        return;
+    case AF_UNSPEC:
+        value = UnspecifiedFamily { };
+        return;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
 }
 
-std::optional<RTCNetwork> RTCNetwork::decode(IPC::Decoder& decoder)
+rtc::IPAddress IPAddress::rtcAddress() const
 {
-    RTCNetwork result;
-    IPC::DataReference name, description;
-    if (!decoder.decode(name))
-        return std::nullopt;
-    result.name = std::string(reinterpret_cast<const char*>(name.data()), name.size());
-    if (!decoder.decode(description))
-        return std::nullopt;
-    result.description = std::string(reinterpret_cast<const char*>(description.data()), description.size());
-    std::optional<IPAddress> prefix;
-    decoder >> prefix;
-    if (!prefix)
-        return std::nullopt;
-    result.prefix = WTFMove(*prefix);
-    if (!decoder.decode(result.prefixLength))
-        return std::nullopt;
-    if (!decoder.decode(result.type))
-        return std::nullopt;
-    if (!decoder.decode(result.id))
-        return std::nullopt;
-    if (!decoder.decode(result.preference))
-        return std::nullopt;
-    if (!decoder.decode(result.active))
-        return std::nullopt;
-    if (!decoder.decode(result.ignored))
-        return std::nullopt;
-    if (!decoder.decode(result.scopeID))
-        return std::nullopt;
-
-    uint64_t length;
-    if (!decoder.decode(length))
-        return std::nullopt;
-    result.ips.reserve(length);
-    for (size_t index = 0; index < length; ++index) {
-        std::optional<IPAddress> address;
-        decoder >> address;
-        if (!address)
-            return std::nullopt;
-        int flags;
-        if (!decoder.decode(flags))
-            return std::nullopt;
-        result.ips.push_back({ address->value, flags });
-    }
-    return result;
+    return WTF::switchOn(value, [](UnspecifiedFamily) {
+        return rtc::IPAddress();
+    }, [] (uint32_t ipv4) {
+        in_addr addressv4;
+        addressv4.s_addr = ipv4;
+        return rtc::IPAddress(addressv4);
+    }, [] (std::array<uint32_t, 4> ipv6) {
+        in6_addr result;
+        static_assert(sizeof(ipv6) == sizeof(result));
+        memcpy(&result, ipv6.data(), sizeof(ipv6));
+        return rtc::IPAddress(result);
+    });
 }
 
-void RTCNetwork::encode(IPC::Encoder& encoder) const
+SocketAddress::SocketAddress(const rtc::SocketAddress& address)
+    : hostname(address.hostname().data(), address.hostname().length())
+    , ip(address.ipaddr())
+    , port(address.port())
+    , scopeID(address.scope_id())
+    , literal(address.literal()) { }
+
+SocketAddress::SocketAddress(Vector<char>&& hostname, IPAddress ip, uint16_t port, int scopeID, bool literal)
+    : hostname(WTFMove(hostname))
+    , ip(ip)
+    , port(port)
+    , scopeID(scopeID)
+    , literal(literal) { }
+
+rtc::SocketAddress SocketAddress::rtcAddress() const
 {
-    encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(name.data()), name.length());
-    encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(description.data()), description.length());
-    encoder << prefix;
-    encoder << prefixLength;
-    encoder << type;
+    return rtc::SocketAddress(std::string(hostname.data(), hostname.size()), ip.rtcAddress(), port, scopeID, literal);
+}
 
-    encoder << id;
-    encoder << preference;
-    encoder << active;
-    encoder << ignored;
-    encoder << scopeID;
+InterfaceAddress::InterfaceAddress(const rtc::InterfaceAddress& address)
+    : address(address)
+    , ipv6Flags(address.ipv6_flags()) { }
 
-    encoder << (uint64_t)ips.size();
-    for (auto& ip : ips) {
-        encoder << IPAddress { ip };
-        encoder << ip.ipv6_flags();
-    }
+rtc::InterfaceAddress InterfaceAddress::rtcAddress() const
+{
+    return rtc::InterfaceAddress(address.rtcAddress(), ipv6Flags);
+}
+
 }
 
 }

--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -30,6 +30,7 @@
 #include <WebCore/LibWebRTCMacros.h>
 #include <optional>
 #include <wtf/Forward.h>
+#include <wtf/Vector.h>
 
 ALLOW_COMMA_BEGIN
 
@@ -38,48 +39,66 @@ ALLOW_COMMA_BEGIN
 
 ALLOW_COMMA_END
 
-namespace IPC {
-class Decoder;
-class Encoder;
-}
-
 namespace WebKit {
 
+namespace RTC::Network {
+
+struct IPAddress {
+    struct UnspecifiedFamily {
+        constexpr bool operator==(const UnspecifiedFamily&) const { return true; }
+    };
+
+    IPAddress() = default;
+    explicit IPAddress(const rtc::IPAddress&);
+    explicit IPAddress(std::variant<UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value)
+        : value(value) { }
+
+    bool operator==(const IPAddress&) const = default;
+
+    rtc::IPAddress rtcAddress() const;
+
+    std::variant<UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value;
+};
+
+struct InterfaceAddress {
+    explicit InterfaceAddress(const rtc::InterfaceAddress&);
+    explicit InterfaceAddress(IPAddress address, int ipv6Flags)
+        : address(address), ipv6Flags(ipv6Flags) { }
+
+    rtc::InterfaceAddress rtcAddress() const;
+
+    IPAddress address;
+    int ipv6Flags;
+};
+
+struct SocketAddress {
+    explicit SocketAddress(const rtc::SocketAddress&);
+    explicit SocketAddress(Vector<char>&&, IPAddress, uint16_t, int, bool);
+
+    rtc::SocketAddress rtcAddress() const;
+
+    Vector<char> hostname;
+    IPAddress ip;
+    uint16_t port;
+    int scopeID;
+    bool literal;
+};
+
+}
+
 struct RTCNetwork {
-    RTCNetwork() = default;
+    using SocketAddress = RTC::Network::SocketAddress;
+    using IPAddress = RTC::Network::IPAddress;
+    using InterfaceAddress = RTC::Network::InterfaceAddress;
+
     explicit RTCNetwork(const rtc::Network&);
+    RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<char>&& key, size_t length, Vector<InterfaceAddress>&& ips);
 
     rtc::Network value() const;
-
-    void encode(IPC::Encoder&) const;
-    static std::optional<RTCNetwork> decode(IPC::Decoder&);
-
-    struct IPAddress {
-        IPAddress() = default;
-        explicit IPAddress(const rtc::IPAddress& address)
-            : value(address) { }
-
-        void encode(IPC::Encoder&) const;
-        static std::optional<IPAddress> decode(IPC::Decoder&);
-
-        rtc::IPAddress value;
-    };
-
     static rtc::SocketAddress isolatedCopy(const rtc::SocketAddress&);
 
-    struct SocketAddress {
-        SocketAddress() = default;
-        explicit SocketAddress(const rtc::SocketAddress& address)
-            : value(address) { }
-
-        void encode(IPC::Encoder&) const;
-        static std::optional<SocketAddress> decode(IPC::Decoder&);
-
-        rtc::SocketAddress value;
-    };
-
-    std::string name;
-    std::string description;
+    Vector<char> name;
+    Vector<char> description;
     IPAddress prefix;
     int prefixLength;
     int type;
@@ -88,9 +107,9 @@ struct RTCNetwork {
     bool active;
     bool ignored;
     int scopeID;
-    std::string key;
+    Vector<char> key;
     size_t length;
-    std::vector<rtc::InterfaceAddress> ips;
+    Vector<InterfaceAddress> ips;
 };
 
 }

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -1,0 +1,61 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(LIBWEBRTC)
+
+[CustomHeader] struct WebKit::RTC::Network::IPAddress {
+    std::variant<WebKit::RTC::Network::IPAddress::UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value;
+};
+
+[Nested] struct WebKit::RTC::Network::IPAddress::UnspecifiedFamily {
+};
+
+[CustomHeader] struct WebKit::RTC::Network::InterfaceAddress {
+    WebKit::RTC::Network::IPAddress address;
+    int ipv6Flags;
+};
+
+[CustomHeader] struct WebKit::RTC::Network::SocketAddress {
+    Vector<char> hostname;
+    WebKit::RTC::Network::IPAddress ip;
+    uint16_t port;
+    int scopeID;
+    bool literal;
+};
+
+struct WebKit::RTCNetwork {
+    Vector<char> name;
+    Vector<char> description;
+    WebKit::RTC::Network::IPAddress prefix;
+    int prefixLength;
+    int type;
+    uint16_t id;
+    int preference;
+    bool active;
+    bool ignored;
+    int scopeID;
+    Vector<char> key;
+    size_t length;
+    Vector<WebKit::RTC::Network::InterfaceAddress> ips;
+};
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5743,6 +5743,7 @@
 		5CD4F01C28B6ADDB00F9ECEA /* generate-serializers.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = "generate-serializers.py"; sourceTree = "<group>"; };
 		5CD748B523C8EB190092A999 /* WebURLSchemeHandlerIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebURLSchemeHandlerIdentifier.h; sourceTree = "<group>"; };
 		5CD748B523C8EB190092A9B5 /* NetworkResourceLoadIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkResourceLoadIdentifier.h; sourceTree = "<group>"; };
+		5CDFAD9C2ACFA9480040A8D8 /* RTCNetwork.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RTCNetwork.serialization.in; sourceTree = "<group>"; };
 		5CE0C366229F2D3D003695F0 /* APIContextMenuElementInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIContextMenuElementInfo.cpp; sourceTree = "<group>"; };
 		5CE0C367229F2D3E003695F0 /* APIContextMenuElementInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContextMenuElementInfo.h; sourceTree = "<group>"; };
 		5CE0C368229F2D4A003695F0 /* WKContextMenuElementInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKContextMenuElementInfo.mm; sourceTree = "<group>"; };
@@ -8366,6 +8367,7 @@
 				5C00993B2417FB7E00D53C25 /* ResourceLoadStatisticsParameters.h */,
 				410482CB1DDD2FB500F006D0 /* RTCNetwork.cpp */,
 				410482CC1DDD2FB500F006D0 /* RTCNetwork.h */,
+				5CDFAD9C2ACFA9480040A8D8 /* RTCNetwork.serialization.in */,
 				41B28B091F83AD3E00FB52AC /* RTCPacketOptions.cpp */,
 				41B28B081F83AD3E00FB52AC /* RTCPacketOptions.h */,
 				41B8D85628C9B8D100E5FA37 /* RTCWebKitEncodedFrameInfo.h */,

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -113,14 +113,14 @@ void LibWebRTCNetwork::signalAddressReady(WebCore::LibWebRTCSocketIdentifier ide
 {
     ASSERT(!WTF::isMainRunLoop());
     if (auto* socket = m_socketFactory.socket(identifier))
-        socket->signalAddressReady(address.value);
+        socket->signalAddressReady(address.rtcAddress());
 }
 
 void LibWebRTCNetwork::signalReadPacket(WebCore::LibWebRTCSocketIdentifier identifier, const IPC::DataReference& data, const RTCNetwork::IPAddress& address, uint16_t port, int64_t timestamp)
 {
     ASSERT(!WTF::isMainRunLoop());
     if (auto* socket = m_socketFactory.socket(identifier))
-        socket->signalReadPacket(data.data(), data.size(), rtc::SocketAddress(address.value, port), timestamp);
+        socket->signalReadPacket(data.data(), data.size(), rtc::SocketAddress(address.rtcAddress(), port), timestamp);
 }
 
 void LibWebRTCNetwork::signalSentPacket(WebCore::LibWebRTCSocketIdentifier identifier, int rtcPacketID, int64_t sendTimeMs)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -142,7 +142,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         filteredNetworks = networks;
     else {
         for (auto& network : networks) {
-            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.value == ip || ipv6.value == ip; }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.c_str()))))
+            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4 == ip.address || ipv6 == ip.address; }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.data()))))
                 filteredNetworks.append(network);
         }
     }
@@ -153,7 +153,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
             networkList[index] = std::make_unique<rtc::Network>(networks[index].value());
 
         bool hasChanged;
-        set_default_local_addresses(ipv4.value, ipv6.value);
+        set_default_local_addresses(ipv4.rtcAddress(), ipv6.rtcAddress());
         MergeNetworkList(WTFMove(networkList), &hasChanged);
         if (hasChanged || forceSignaling)
             SignalNetworksChanged();

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
@@ -47,7 +47,7 @@ void WebRTCResolver::setResolvedAddress(const Vector<RTCNetwork::IPAddress>& add
     auto& factory = m_socketFactory;
 
     auto rtcAddresses = addresses.map([](auto& address) {
-        return address.value;
+        return address.rtcAddress();
     });
     WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([&factory, identifier, rtcAddresses = WTFMove(rtcAddresses)]() {
         auto* resolver = factory.resolver(identifier);


### PR DESCRIPTION
#### 1a1ce78e0071b437acc015e4a13f645e068a20ba
<pre>
Retry generating RTCNetwork serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=263060">https://bugs.webkit.org/show_bug.cgi?id=263060</a>
rdar://116847094

Reviewed by Youenn Fablet.

A few days ago I tried this, but the SocketAddress transformation wasn&apos;t lossless so
it was quickly reverted.  This redoes it, but with a very straightforward SocketAddress struct.

* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/socket_address.h:
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkManagerWrapper::onNetworksChanged):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::createUDPSocket):
(WebKit::NetworkRTCProvider::createClientTCPSocket):
(WebKit::NetworkRTCProvider::sendToSocket):
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::RTCNetwork):
(WebKit::ips):
(WebKit::RTCNetwork::value const):
(WebKit::RTC::Network::IPAddress::IPAddress):
(WebKit::RTC::Network::IPAddress::rtcAddress const):
(WebKit::RTC::Network::SocketAddress::SocketAddress):
(WebKit::RTC::Network::SocketAddress::rtcAddress const):
(WebKit::RTC::Network::InterfaceAddress::InterfaceAddress):
(WebKit::RTC::Network::InterfaceAddress::rtcAddress const):
(WebKit::RTCNetwork::IPAddress::decode): Deleted.
(WebKit::RTCNetwork::IPAddress::encode const): Deleted.
(WebKit::RTCNetwork::SocketAddress::decode): Deleted.
(WebKit::RTCNetwork::SocketAddress::encode const): Deleted.
(WebKit::RTCNetwork::decode): Deleted.
(WebKit::RTCNetwork::encode const): Deleted.
* Source/WebKit/Shared/RTCNetwork.h:
(WebKit::RTC::Network::IPAddress::UnspecifiedFamily::operator== const):
(WebKit::RTC::Network::IPAddress::IPAddress):
(WebKit::RTC::Network::InterfaceAddress::InterfaceAddress):
(WebKit::RTCNetwork::IPAddress::IPAddress): Deleted.
(WebKit::RTCNetwork::SocketAddress::SocketAddress): Deleted.
* Source/WebKit/Shared/RTCNetwork.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::LibWebRTCNetwork::signalAddressReady):
(WebKit::LibWebRTCNetwork::signalReadPacket):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp:
(WebKit::WebRTCResolver::setResolvedAddress):

Canonical link: <a href="https://commits.webkit.org/269302@main">https://commits.webkit.org/269302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6c060962d70f67b119c921724907293e3877ee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20429 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24804 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26252 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17590 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24216 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2769 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->