### PR TITLE
AX: rename CheckBox to Checkbox

### DIFF
--- a/LayoutTests/platform/ios/accessibility/aria-checked-mixed-value-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/aria-checked-mixed-value-expected.txt
@@ -13,11 +13,11 @@ Role: MenuItemCheckbox
 Mixed: true
 
 <div id="element4" role="checkbox"></div>
-Role: CheckBox
+Role: Checkbox
 Mixed: false
 
 <div id="element5" role="checkbox" aria-checked="mixed"></div>
-Role: CheckBox
+Role: Checkbox
 Mixed: true
 
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -130,7 +130,7 @@ enum class AccessibilityRole {
     Canvas,
     Caption,
     Cell,
-    CheckBox,
+    Checkbox,
     Code,
     ColorWell,
     Column,
@@ -310,8 +310,8 @@ ALWAYS_INLINE String accessibilityRoleToString(AccessibilityRole role)
         return "Caption"_s;
     case AccessibilityRole::Cell:
         return "Cell"_s;
-    case AccessibilityRole::CheckBox:
-        return "CheckBox"_s;
+    case AccessibilityRole::Checkbox:
+        return "Checkbox"_s;
     case AccessibilityRole::Code:
         return "Code"_s;
     case AccessibilityRole::ColorWell:
@@ -615,7 +615,7 @@ enum class AccessibilitySearchKey {
     Blockquote,
     BoldFont,
     Button,
-    CheckBox,
+    Checkbox,
     Control,
     DifferentType,
     FontChange,
@@ -851,7 +851,7 @@ public:
     virtual bool isSecureField() const = 0;
     virtual bool isNativeTextControl() const = 0;
     bool isWebArea() const { return roleValue() == AccessibilityRole::WebArea; }
-    bool isCheckbox() const { return roleValue() == AccessibilityRole::CheckBox; }
+    bool isCheckbox() const { return roleValue() == AccessibilityRole::Checkbox; }
     bool isRadioButton() const { return roleValue() == AccessibilityRole::RadioButton; }
     bool isListBox() const { return roleValue() == AccessibilityRole::ListBox; }
     virtual bool isListBoxOption() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -262,8 +262,8 @@ TextStream& operator<<(TextStream& stream, AccessibilitySearchKey searchKey)
     case AccessibilitySearchKey::Button:
         stream << "Button";
         break;
-    case AccessibilitySearchKey::CheckBox:
-        stream << "CheckBox";
+    case AccessibilitySearchKey::Checkbox:
+        stream << "Checkbox";
         break;
     case AccessibilitySearchKey::Control:
         stream << "Control";

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -368,7 +368,7 @@ AccessibilityRole AccessibilityNodeObject::determineAccessibilityRoleFromNode(Tr
         if (input.isSwitch())
             return AccessibilityRole::Switch;
         if (input.isCheckbox())
-            return AccessibilityRole::CheckBox;
+            return AccessibilityRole::Checkbox;
         if (input.isRadioButton())
             return AccessibilityRole::RadioButton;
         if (input.isTextButton())
@@ -592,7 +592,7 @@ bool AccessibilityNodeObject::canHaveChildren() const
     switch (roleValue()) {
     case AccessibilityRole::Button:
     case AccessibilityRole::PopUpButton:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::RadioButton:
     case AccessibilityRole::Tab:
     case AccessibilityRole::ToggleButton:
@@ -824,7 +824,7 @@ bool AccessibilityNodeObject::isChecked() const
     bool validRole = false;
     switch (ariaRoleAttribute()) {
     case AccessibilityRole::RadioButton:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::MenuItem:
     case AccessibilityRole::MenuItemCheckbox:
     case AccessibilityRole::MenuItemRadio:
@@ -931,7 +931,7 @@ bool AccessibilityNodeObject::supportsRequiredAttribute() const
         return isFileUploadButton();
     case AccessibilityRole::Cell:
     case AccessibilityRole::ColumnHeader:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::ComboBox:
     case AccessibilityRole::Grid:
     case AccessibilityRole::GridCell:
@@ -1921,7 +1921,7 @@ void AccessibilityNodeObject::visibleText(Vector<AccessibilityText>& textOrder) 
         FALLTHROUGH;
     case AccessibilityRole::Button:
     case AccessibilityRole::ToggleButton:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::ListBoxOption:
     // MacOS does not expect native <li> elements to expose label information, it only expects leaf node elements to do that.
 #if !PLATFORM(COCOA)
@@ -2379,7 +2379,7 @@ String AccessibilityNodeObject::title() const
 
     switch (roleValue()) {
     case AccessibilityRole::Button:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::ListBoxOption:
     case AccessibilityRole::ListItem:
     case AccessibilityRole::MenuButton:

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1088,7 +1088,7 @@ bool AccessibilityObject::hasAttributesRequiredForInclusion() const
 bool AccessibilityObject::isARIAInput(AccessibilityRole ariaRole)
 {
     switch (ariaRole) {
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::RadioButton:
     case AccessibilityRole::SearchField:
     case AccessibilityRole::Switch:
@@ -1908,7 +1908,7 @@ bool AccessibilityObject::supportsReadOnly() const
 {
     AccessibilityRole role = roleValue();
 
-    return role == AccessibilityRole::CheckBox
+    return role == AccessibilityRole::Checkbox
         || role == AccessibilityRole::ColumnHeader
         || role == AccessibilityRole::ComboBox
         || role == AccessibilityRole::Grid
@@ -2275,8 +2275,8 @@ String AccessibilityObject::localizedActionVerb() const
     static NeverDestroyed<const String> buttonAction(AXButtonActionVerb());
     static NeverDestroyed<const String> textFieldAction(AXTextFieldActionVerb());
     static NeverDestroyed<const String> radioButtonAction(AXRadioButtonActionVerb());
-    static NeverDestroyed<const String> checkedCheckBoxAction(AXCheckedCheckBoxActionVerb());
-    static NeverDestroyed<const String> uncheckedCheckBoxAction(AXUncheckedCheckBoxActionVerb());
+    static NeverDestroyed<const String> checkedCheckboxAction(AXCheckedCheckboxActionVerb());
+    static NeverDestroyed<const String> uncheckedCheckboxAction(AXUncheckedCheckboxActionVerb());
     static NeverDestroyed<const String> linkAction(AXLinkActionVerb());
     static NeverDestroyed<const String> menuListAction(AXMenuListActionVerb());
     static NeverDestroyed<const String> menuListPopupAction(AXMenuListPopupActionVerb());
@@ -2291,9 +2291,9 @@ String AccessibilityObject::localizedActionVerb() const
         return textFieldAction;
     case AccessibilityRole::RadioButton:
         return radioButtonAction;
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::Switch:
-        return isChecked() ? checkedCheckBoxAction : uncheckedCheckBoxAction;
+        return isChecked() ? checkedCheckboxAction : uncheckedCheckboxAction;
     case AccessibilityRole::Link:
     case AccessibilityRole::WebCoreLink:
         return linkAction;
@@ -2324,7 +2324,7 @@ String AccessibilityObject::actionVerb() const
         return "activate"_s;
     case AccessibilityRole::RadioButton:
         return "select"_s;
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::Switch:
         return isChecked() ? "uncheck"_s : "check"_s;
     case AccessibilityRole::Link:
@@ -2595,7 +2595,7 @@ static void initializeRoleMap()
         { "button"_s, AccessibilityRole::Button },
         { "caption"_s, AccessibilityRole::Caption },
         { "code"_s, AccessibilityRole::Code },
-        { "checkbox"_s, AccessibilityRole::CheckBox },
+        { "checkbox"_s, AccessibilityRole::Checkbox },
         { "complementary"_s, AccessibilityRole::LandmarkComplementary },
         { "contentinfo"_s, AccessibilityRole::LandmarkContentInfo },
         { "deletion"_s, AccessibilityRole::Deletion },
@@ -3388,7 +3388,7 @@ bool AccessibilityObject::supportsExpanded() const
     case AccessibilityRole::Details:
         return true;
     case AccessibilityRole::Button:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::ColumnHeader:
     case AccessibilityRole::ComboBox:
     case AccessibilityRole::DisclosureTriangle:
@@ -3450,7 +3450,7 @@ bool AccessibilityObject::isExpanded() const
 bool AccessibilityObject::supportsChecked() const
 {
     switch (roleValue()) {
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::MenuItemCheckbox:
     case AccessibilityRole::MenuItemRadio:
     case AccessibilityRole::RadioButton:
@@ -4416,7 +4416,7 @@ static bool isAccessibilityObjectSearchMatchAtIndex(RefPtr<AXCoreObject> axObjec
         return axObject->hasBoldFont();
     case AccessibilitySearchKey::Button:
         return axObject->isButton();
-    case AccessibilitySearchKey::CheckBox:
+    case AccessibilitySearchKey::Checkbox:
         return axObject->isCheckbox();
     case AccessibilitySearchKey::Control:
         return axObject->isControl();

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -599,7 +599,7 @@ static constexpr std::pair<AccessibilityRole, RoleNameEntry> roleNames[] = {
     { AccessibilityRole::Canvas, { "canvas", N_("canvas") } },
     { AccessibilityRole::Caption, { "caption", N_("caption") } },
     { AccessibilityRole::Cell, { "table cell", N_("table cell") } },
-    { AccessibilityRole::CheckBox, { "check box", N_("check box") } },
+    { AccessibilityRole::Checkbox, { "check box", N_("check box") } },
     { AccessibilityRole::ColorWell, { "push button", N_("push button") } },
     { AccessibilityRole::ColumnHeader, { "column header", N_("column header") } },
     { AccessibilityRole::ComboBox, { "combo box", N_("combo box") } },

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -174,7 +174,7 @@ static Atspi::Role atspiRole(AccessibilityRole role)
         return Atspi::Role::ToggleButton;
     case AccessibilityRole::RadioButton:
         return Atspi::Role::RadioButton;
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
         return Atspi::Role::CheckBox;
     case AccessibilityRole::Slider:
         return Atspi::Role::Slider;

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -322,7 +322,7 @@ static AccessibilityObjectWrapper* AccessibilityUnignoredAncestor(AccessibilityO
     // Elements that can be returned when performing fuzzy hit testing.
     switch (role) {
     case AccessibilityRole::Button:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::ColorWell:
     case AccessibilityRole::ComboBox:
     case AccessibilityRole::DisclosureTriangle:
@@ -871,7 +871,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
         traits |= [self _axRadioButtonTrait] | [self _axToggleTrait];
         break;
     case AccessibilityRole::ToggleButton:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::Switch:
         traits |= ([self _axButtonTrait] | [self _axToggleTrait]);
         break;
@@ -945,7 +945,7 @@ static AccessibilityObjectWrapper *ancestorWithRole(const AXCoreObject& descenda
     case AccessibilityRole::Button:
     case AccessibilityRole::ToggleButton:
     case AccessibilityRole::PopUpButton:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::ColorWell:
     case AccessibilityRole::RadioButton:
     case AccessibilityRole::Slider:

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -764,7 +764,7 @@ PlatformRoleMap createPlatformRoleMap()
         { AccessibilityRole::Unknown, NSAccessibilityUnknownRole },
         { AccessibilityRole::Button, NSAccessibilityButtonRole },
         { AccessibilityRole::RadioButton, NSAccessibilityRadioButtonRole },
-        { AccessibilityRole::CheckBox, NSAccessibilityCheckBoxRole },
+        { AccessibilityRole::Checkbox, NSAccessibilityCheckBoxRole },
         { AccessibilityRole::Slider, NSAccessibilitySliderRole },
         { AccessibilityRole::TabGroup, NSAccessibilityTabGroupRole },
         { AccessibilityRole::TextField, NSAccessibilityTextFieldRole },

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -827,7 +827,7 @@ static AccessibilitySearchKeyMap* createAccessibilitySearchKeyMap()
         { NSAccessibilityBlockquoteSearchKey, AccessibilitySearchKey::Blockquote },
         { NSAccessibilityBoldFontSearchKey, AccessibilitySearchKey::BoldFont },
         { NSAccessibilityButtonSearchKey, AccessibilitySearchKey::Button },
-        { NSAccessibilityCheckBoxSearchKey, AccessibilitySearchKey::CheckBox },
+        { NSAccessibilityCheckBoxSearchKey, AccessibilitySearchKey::Checkbox },
         { NSAccessibilityControlSearchKey, AccessibilitySearchKey::Control },
         { NSAccessibilityDifferentTypeSearchKey, AccessibilitySearchKey::DifferentType },
         { NSAccessibilityFontChangeSearchKey, AccessibilitySearchKey::FontChange },

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -93,7 +93,7 @@ static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element
 {
     switch (AccessibilityObject::ariaRoleToWebCoreRole(element.attributeWithoutSynchronization(HTMLNames::roleAttr))) {
     case AccessibilityRole::Button:
-    case AccessibilityRole::CheckBox:
+    case AccessibilityRole::Checkbox:
     case AccessibilityRole::DisclosureTriangle:
     case AccessibilityRole::ImageMapLink:
     case AccessibilityRole::Link:

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -815,12 +815,12 @@ String AXTextFieldActionVerb()
     return WEB_UI_STRING("activate", "Verb stating the action that will occur when a text field is selected, as used by accessibility");
 }
 
-String AXCheckedCheckBoxActionVerb()
+String AXCheckedCheckboxActionVerb()
 {
     return WEB_UI_STRING("uncheck", "Verb stating the action that will occur when a checked checkbox is clicked, as used by accessibility");
 }
 
-String AXUncheckedCheckBoxActionVerb()
+String AXUncheckedCheckboxActionVerb()
 {
     return WEB_UI_STRING("check", "Verb stating the action that will occur when an unchecked checkbox is clicked, as used by accessibility");
 }

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -231,8 +231,8 @@ namespace WebCore {
     String AXButtonActionVerb();
     String AXRadioButtonActionVerb();
     String AXTextFieldActionVerb();
-    String AXCheckedCheckBoxActionVerb();
-    String AXUncheckedCheckBoxActionVerb();
+    String AXCheckedCheckboxActionVerb();
+    String AXUncheckedCheckboxActionVerb();
     String AXMenuListActionVerb();
     String AXMenuListPopupActionVerb();
     String AXLinkActionVerb();

--- a/Source/WebCore/platform/gtk/po/it.po
+++ b/Source/WebCore/platform/gtk/po/it.po
@@ -542,12 +542,12 @@ msgstr "seleziona"
 msgid "activate"
 msgstr "attiva"
 
-# String AXCheckedCheckBoxActionVerb()
+# String AXCheckedCheckboxActionVerb()
 #: ../LocalizedStrings.cpp:600
 msgid "uncheck"
 msgstr "togli spunta"
 
-# String AXUncheckedCheckBoxActionVerb()
+# String AXUncheckedCheckboxActionVerb()
 #: ../LocalizedStrings.cpp:605
 msgid "check"
 msgstr "metti spunta"


### PR DESCRIPTION
#### d20a93e4da306814db4ef08ea5363a4567acfd21
<pre>
AX: rename CheckBox to Checkbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=263063">https://bugs.webkit.org/show_bug.cgi?id=263063</a>
rdar://116850242

Reviewed by Tyler Wilcock.

Rename those instances of CheckBox that are fully in scope of WebKit to
Checkbox and leave the others, such as NSAccessibilityCheckBoxRole,
alone.

* LayoutTests/platform/ios/accessibility/aria-checked-mixed-value-expected.txt:
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::accessibilityRoleToString):
(WebCore::AXCoreObject::isCheckbox const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::determineAccessibilityRoleFromNode const):
(WebCore::AccessibilityNodeObject::canHaveChildren const):
(WebCore::AccessibilityNodeObject::isChecked const):
(WebCore::AccessibilityNodeObject::supportsRequiredAttribute const):
(WebCore::AccessibilityNodeObject::visibleText const):
(WebCore::AccessibilityNodeObject::title const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isARIAInput):
(WebCore::AccessibilityObject::supportsReadOnly const):
(WebCore::AccessibilityObject::localizedActionVerb const):
(WebCore::AccessibilityObject::actionVerb const):
(WebCore::initializeRoleMap):
(WebCore::AccessibilityObject::supportsExpanded const):
(WebCore::AccessibilityObject::supportsChecked const):
(WebCore::Accessibility::isAccessibilityObjectSearchMatchAtIndex):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::atspiRole):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityCanFuzzyHitTest]):
(-[WebAccessibilityObjectWrapper accessibilityTraits]):
(-[WebAccessibilityObjectWrapper determineIsAccessibilityElement]):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::Accessibility::createPlatformRoleMap):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(createAccessibilitySearchKeyMap):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowAccessibilityRoleAsPointerCursorReplacement):
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::AXCheckedCheckboxActionVerb):
(WebCore::AXUncheckedCheckboxActionVerb):
(WebCore::AXCheckedCheckBoxActionVerb): Deleted.
(WebCore::AXUncheckedCheckBoxActionVerb): Deleted.
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/gtk/po/it.po:

Canonical link: <a href="https://commits.webkit.org/269259@main">https://commits.webkit.org/269259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a4850f032168728ada728ec2a4081de7033f154

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21457 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24765 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26222 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19148 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24089 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17556 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25445 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19775 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6001 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5255 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24179 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26720 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20570 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5833 "Passed tests") | 
<!--EWS-Status-Bubble-End-->