### PR TITLE
Update fallback-url-to-local.html and its expected result.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/fallback-url-to-local-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/fallback-url-to-local-expected.txt
@@ -1,4 +1,4 @@
 0123456789
 
-FAIL We should use the local font to render the page when the primary remote font is loading assert_false: expected false got true
+PASS We should use the local font to render the page when the primary remote font is loading
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/fallback-url-to-local.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/fallback-url-to-local.html
@@ -9,7 +9,7 @@
 <style>
 @font-face {
   font-family: remote-font;
-  src: url(/fonts/Revalia.woff?pipe=trickle(d1)) format(woff);
+  src: url("/fonts/Revalia.woff?pipe=trickle(d1)") format(woff);
 }
 
 @font-face {


### PR DESCRIPTION
#### d0c48f7ae3442165f9b92239cf5b4fbee3c255da
<pre>
Update fallback-url-to-local.html and its expected result.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263064">https://bugs.webkit.org/show_bug.cgi?id=263064</a>

Reviewed by Tim Nguyen.

A WPT test, fallback-url-to-local.html, had a bug, and it has been fixed since [1].
This change re-imports the test and updates the expected result accordingly.

[1] <a href="https://github.com/web-platform-tests/wpt/pull/42368">https://github.com/web-platform-tests/wpt/pull/42368</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/fallback-url-to-local-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/fallback-url-to-local.html:

Canonical link: <a href="https://commits.webkit.org/269263@main">https://commits.webkit.org/269263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac860c59f5a5b499d12e45a15eb2ce7be3406df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21444 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24742 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26204 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24071 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17541 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5258 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->