### PR TITLE
[SVG] Compute stroke-bounding-box lazily

### DIFF
--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -95,6 +95,8 @@ namespace Style {
 class PseudoElementRequest;
 }
 
+enum class RepaintRectCalculation { Fast, Accurate };
+
 // Base class for all rendering tree objects.
 class RenderObject : public CachedImageClient, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(RenderObject);
@@ -506,7 +508,6 @@ public:
     // Returns the smallest rectangle enclosing all of the painted content
     // respecting clipping, masking, filters, opacity, stroke-width and markers
     // This returns approximate rectangle for SVG renderers when RepaintRectCalculation::Fast is specified.
-    enum class RepaintRectCalculation { Fast, Accurate };
     virtual FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const;
 
     // This only returns the transform="" value from the element

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -95,6 +95,7 @@ void RenderSVGContainer::layoutChildren()
 
     SVGBoundingBoxComputation boundingBoxComputation(*this);
     m_objectBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::objectBoundingBoxDecoration, &m_objectBoundingBoxValid);
+    m_strokeBoundingBox = std::nullopt;
 
     if (auto objectBoundingBoxWithoutTransformations = overridenObjectBoundingBoxWithoutTransformations())
         m_objectBoundingBoxWithoutTransformations = objectBoundingBoxWithoutTransformations.value();
@@ -103,10 +104,18 @@ void RenderSVGContainer::layoutChildren()
         m_objectBoundingBoxWithoutTransformations = boundingBoxComputation.computeDecoratedBoundingBox(objectBoundingBoxDecorationWithoutTransformations);
     }
 
-    m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
     setCurrentSVGLayoutRect(enclosingLayoutRect(m_objectBoundingBoxWithoutTransformations));
 
     containerLayout.positionChildrenRelativeToContainer();
+}
+
+FloatRect RenderSVGContainer::strokeBoundingBox() const
+{
+    if (!m_strokeBoundingBox) {
+        SVGBoundingBoxComputation boundingBoxComputation(*this);
+        m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
+    }
+    return *m_strokeBoundingBox;
 }
 
 void RenderSVGContainer::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -44,7 +44,7 @@ public:
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
-    FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
+    FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
 protected:
@@ -67,7 +67,7 @@ protected:
     bool m_didTransformToRootUpdate { false };
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
-    FloatRect m_strokeBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
 
 private:
     bool isSVGContainer() const final { return true; }

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -50,12 +50,12 @@ void RenderSVGEllipse::updateShapeFromElement()
 {
     // Before creating a new object we need to clear the cached bounding box
     // to avoid using garbage.
+    clearPath();
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
-    m_strokeBoundingBox = FloatRect();
+    m_strokeBoundingBox = std::nullopt;
     m_center = FloatPoint();
     m_radii = FloatSize();
-    clearPath();
 
     calculateRadiiAndCenter();
 
@@ -69,15 +69,15 @@ void RenderSVGEllipse::updateShapeFromElement()
         m_shapeType = ShapeType::Ellipse;
 
     if (hasNonScalingStroke()) {
-        // Fallback to RenderSVGShape if shape has a non-scaling stroke.
-        RenderSVGShape::updateShapeFromElement();
+        // Fallback to path-based approach if shape has a non-scaling stroke.
+        m_fillBoundingBox = ensurePath().boundingRect();
         return;
     }
 
     m_fillBoundingBox = FloatRect(m_center.x() - m_radii.width(), m_center.y() - m_radii.height(), 2 * m_radii.width(), 2 * m_radii.height());
     m_strokeBoundingBox = m_fillBoundingBox;
     if (style().svgStyle().hasStroke())
-        m_strokeBoundingBox.inflate(strokeWidth() / 2);
+        m_strokeBoundingBox->inflate(strokeWidth() / 2);
 }
 
 void RenderSVGEllipse::calculateRadiiAndCenter()

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -226,7 +226,7 @@ bool RenderSVGModelObject::checkIntersection(RenderElement* renderer, const Floa
     auto ctm = downcast<SVGGraphicsElement>(*svgElement).getCTM(SVGLocatable::DisallowStyleUpdate);
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return intersectsAllowingEmpty(rect, ctm.mapRect(renderer->repaintRectInLocalCoordinates(RenderObject::RepaintRectCalculation::Accurate)));
+    return intersectsAllowingEmpty(rect, ctm.mapRect(renderer->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
 }
 
 bool RenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
@@ -240,7 +240,7 @@ bool RenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRe
     auto ctm = downcast<SVGGraphicsElement>(*svgElement).getCTM(SVGLocatable::DisallowStyleUpdate);
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return rect.contains(ctm.mapRect(renderer->repaintRectInLocalCoordinates(RenderObject::RepaintRectCalculation::Accurate)));
+    return rect.contains(ctm.mapRect(renderer->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
 }
 
 LayoutSize RenderSVGModelObject::cachedSizeForOverflowClip() const

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -43,7 +43,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGPath"_s; }
 
     void updateShapeFromElement() override;
-    FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(FloatRect strokeBoundingBox) const;
+    FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const override;
 
     void strokeShape(GraphicsContext&) const override;
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -55,11 +55,12 @@ void RenderSVGRect::updateShapeFromElement()
 {
     // Before creating a new object we need to clear the cached bounding box
     // to avoid using garbage.
+    clearPath();
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
+    m_strokeBoundingBox = std::nullopt;
     m_innerStrokeRect = FloatRect();
     m_outerStrokeRect = FloatRect();
-    clearPath();
 
     SVGLengthContext lengthContext(&rectElement());
     FloatSize boundingBoxSize(lengthContext.valueForLength(style().width(), SVGLengthMode::Width), lengthContext.valueForLength(style().height(), SVGLengthMode::Height));
@@ -74,8 +75,8 @@ void RenderSVGRect::updateShapeFromElement()
         m_shapeType = ShapeType::Rectangle;
 
     if (m_shapeType != ShapeType::Rectangle || hasNonScalingStroke()) {
-        // Fall back to RenderSVGShape
-        RenderSVGShape::updateShapeFromElement();
+        // Fallback to path-based approach.
+        m_fillBoundingBox = ensurePath().boundingRect();
         return;
     }
 
@@ -99,7 +100,7 @@ void RenderSVGRect::updateShapeFromElement()
 #if USE(CG)
     // CoreGraphics can inflate the stroke by 1px when drawing a rectangle with antialiasing disabled at non-integer coordinates, we need to compensate.
     if (style().svgStyle().shapeRendering() == ShapeRendering::CrispEdges)
-        m_strokeBoundingBox.inflate(1);
+        m_strokeBoundingBox->inflate(1);
 #endif
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResource.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResource.h
@@ -43,6 +43,8 @@ enum class RenderSVGResourceMode {
     ApplyToText    = 1 << 2 // used in combination with ApplyTo{Fill|Stroke}Mode
 };
 
+enum class RepaintRectCalculation;
+
 class Color;
 class FloatRect;
 class GraphicsContext;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -70,9 +70,9 @@ void RenderSVGResourceMarker::applyViewportClip(PaintInfo& paintInfo)
         paintInfo.context().clip(m_viewport);
 }
 
-FloatRect RenderSVGResourceMarker::markerBoundaries(const AffineTransform& markerTransformation) const
+FloatRect RenderSVGResourceMarker::markerBoundaries(RepaintRectCalculation repaintRectCalculation, const AffineTransform& markerTransformation) const
 {
-    FloatRect coordinates = LegacyRenderSVGContainer::repaintRectInLocalCoordinates();
+    FloatRect coordinates = LegacyRenderSVGContainer::repaintRectInLocalCoordinates(repaintRectCalculation);
 
     // Map repaint rect into parent coordinate space, in which the marker boundaries have to be evaluated
     coordinates = localToParentTransform().mapRect(coordinates);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -41,7 +41,7 @@ public:
     void draw(PaintInfo&, const AffineTransform&);
 
     // Calculates marker boundaries, mapped to the target element's coordinate space
-    FloatRect markerBoundaries(const AffineTransform& markerTransformation) const;
+    FloatRect markerBoundaries(RepaintRectCalculation, const AffineTransform& markerTransformation) const;
 
     void applyViewportClip(PaintInfo&) override;
     void layout() override;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -178,7 +178,7 @@ void RenderSVGResourceMasker::calculateMaskContentRepaintRect()
         const RenderStyle& style = renderer->style();
         if (style.display() == DisplayType::None || style.visibility() != Visibility::Visible)
              continue;
-        m_maskContentBoundaries.unite(renderer->localToParentTransform().mapRect(renderer->repaintRectInLocalCoordinates()));
+        m_maskContentBoundaries.unite(renderer->localToParentTransform().mapRect(renderer->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
     }
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -240,11 +240,11 @@ void RenderSVGRoot::layoutChildren()
 
     SVGBoundingBoxComputation boundingBoxComputation(*this);
     m_objectBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::objectBoundingBoxDecoration);
+    m_strokeBoundingBox = std::nullopt;
 
     constexpr auto objectBoundingBoxDecorationWithoutTransformations = SVGBoundingBoxComputation::objectBoundingBoxDecoration | SVGBoundingBoxComputation::DecorationOption::IgnoreTransformations;
     m_objectBoundingBoxWithoutTransformations = boundingBoxComputation.computeDecoratedBoundingBox(objectBoundingBoxDecorationWithoutTransformations);
 
-    m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
     containerLayout.positionChildrenRelativeToContainer();
 
     if (!m_resourcesNeedingToInvalidateClients.isEmptyIgnoringNullReferences()) {
@@ -257,6 +257,15 @@ void RenderSVGRoot::layoutChildren()
         SetForScope clearLayoutSizeChanged(m_isLayoutSizeChanged, false);
         containerLayout.layoutChildren(false);
     }
+}
+
+FloatRect RenderSVGRoot::strokeBoundingBox() const
+{
+    if (!m_strokeBoundingBox) {
+        SVGBoundingBoxComputation boundingBoxComputation(*this);
+        m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
+    }
+    return *m_strokeBoundingBox;
 }
 
 bool RenderSVGRoot::shouldApplyViewportClip() const

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -66,7 +66,7 @@ public:
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
-    FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
+    FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
     LayoutRect visualOverflowRectEquivalent() const { return SVGBoundingBoxComputation::computeVisualOverflowRect(*this); }
@@ -125,7 +125,7 @@ private:
     IntSize m_containerSize;
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
-    FloatRect m_strokeBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
     WeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
 };
 

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -89,7 +89,7 @@ public:
     ShapeType shapeType() const { return m_shapeType; }
 
     FloatRect objectBoundingBox() const final { return m_fillBoundingBox; }
-    FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
+    FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
     bool needsHasSVGTransformFlags() const final;
@@ -99,9 +99,9 @@ public:
 protected:
     void element() const = delete;
 
-    void ensurePath();
+    Path& ensurePath();
 
-    virtual void updateShapeFromElement();
+    virtual void updateShapeFromElement() = 0;
     virtual bool isEmpty() const;
     virtual bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace);
     virtual bool shapeDependentFillContains(const FloatPoint&, const WindRule) const;
@@ -112,8 +112,7 @@ protected:
     AffineTransform nonScalingStrokeTransform() const;
     Path* nonScalingStrokePath(const Path*, const AffineTransform&) const;
 
-    FloatRect m_fillBoundingBox;
-    FloatRect m_strokeBoundingBox;
+    virtual FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const { return strokeBoundingBox; }
 
 private:
     // Hit-detection separated for the fill and the stroke
@@ -129,7 +128,6 @@ private:
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 
-    FloatRect calculateObjectBoundingBox() const;
     FloatRect calculateStrokeBoundingBox() const;
 
     bool setupNonScalingStrokeContext(AffineTransform&, GraphicsContextStateSaver&);
@@ -145,6 +143,9 @@ private:
 
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;
 
+protected:
+    FloatRect m_fillBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
 private:
     bool m_needsShapeUpdate { true };
 protected:

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h
@@ -44,7 +44,8 @@ public:
         IncludeOutline                      = 1 << 5, /* WebKit extension - internal    */
         IgnoreTransformations               = 1 << 6, /* WebKit extension - internal    */
         OverrideBoxWithFilterBox            = 1 << 7, /* WebKit extension - internal    */
-        OverrideBoxWithFilterBoxForChildren = 1 << 8  /* WebKit extension - internal    */
+        OverrideBoxWithFilterBoxForChildren = 1 << 8, /* WebKit extension - internal    */
+        CalculateFastRepaintRect            = 1 << 9  /* WebKit extension - internal    */
     };
 
     using DecorationOptions = OptionSet<DecorationOption>;
@@ -52,7 +53,7 @@ public:
     static constexpr DecorationOptions objectBoundingBoxDecoration = { DecorationOption::IncludeFillShape };
     static constexpr DecorationOptions strokeBoundingBoxDecoration = { DecorationOption::IncludeFillShape, DecorationOption::IncludeStrokeShape };
     static constexpr DecorationOptions filterBoundingBoxDecoration = { DecorationOption::OverrideBoxWithFilterBox, DecorationOption::OverrideBoxWithFilterBoxForChildren };
-    static constexpr DecorationOptions repaintBoundingBoxDecoration = { DecorationOption::IncludeFillShape, DecorationOption::IncludeStrokeShape, DecorationOption::IncludeMarkers, DecorationOption::IncludeClippers, DecorationOption::IncludeMaskers, DecorationOption::OverrideBoxWithFilterBox };
+    static constexpr DecorationOptions repaintBoundingBoxDecoration = { DecorationOption::IncludeFillShape, DecorationOption::IncludeStrokeShape, DecorationOption::IncludeMarkers, DecorationOption::IncludeClippers, DecorationOption::IncludeMaskers, DecorationOption::OverrideBoxWithFilterBox, DecorationOption::CalculateFastRepaintRect };
 
     FloatRect computeDecoratedBoundingBox(const DecorationOptions&, bool* boundingBoxValid = nullptr) const;
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -146,15 +146,11 @@ static inline void updateObjectBoundingBox(FloatRect& objectBoundingBox, bool& o
     objectBoundingBox.uniteEvenIfEmpty(otherBoundingBox);
 }
 
-void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& container, FloatRect& objectBoundingBox, bool& objectBoundingBoxValid, FloatRect& strokeBoundingBox, FloatRect& repaintBoundingBox)
+void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& container, FloatRect& objectBoundingBox, bool& objectBoundingBoxValid, FloatRect& repaintBoundingBox, RepaintRectCalculation repaintRectCalculation)
 {
     objectBoundingBox = FloatRect();
     objectBoundingBoxValid = false;
-    strokeBoundingBox = FloatRect();
-
-    // When computing the strokeBoundingBox, we use the repaintRects of the container's children so that the container's stroke includes
-    // the resources applied to the children (such as clips and filters). This allows filters applied to containers to correctly bound
-    // the children, and also improves inlining of SVG content, as the stroke bound is used in that situation also.
+    repaintBoundingBox = FloatRect();
     for (auto& current : childrenOfType<RenderObject>(container)) {
         if (current.isLegacySVGHiddenContainer())
             continue;
@@ -166,14 +162,36 @@ void SVGRenderSupport::computeContainerBoundingBoxes(const RenderElement& contai
         const AffineTransform& transform = current.localToParentTransform();
         if (transform.isIdentity()) {
             updateObjectBoundingBox(objectBoundingBox, objectBoundingBoxValid, &current, current.objectBoundingBox());
-            strokeBoundingBox.unite(current.repaintRectInLocalCoordinates());
+            repaintBoundingBox.unite(current.repaintRectInLocalCoordinates(repaintRectCalculation));
         } else {
             updateObjectBoundingBox(objectBoundingBox, objectBoundingBoxValid, &current, transform.mapRect(current.objectBoundingBox()));
-            strokeBoundingBox.unite(transform.mapRect(current.repaintRectInLocalCoordinates()));
+            repaintBoundingBox.unite(transform.mapRect(current.repaintRectInLocalCoordinates(repaintRectCalculation)));
         }
     }
+}
 
-    repaintBoundingBox = strokeBoundingBox;
+FloatRect SVGRenderSupport::computeContainerStrokeBoundingBox(const RenderElement& container)
+{
+    ASSERT(container.isLegacySVGRoot() || container.isLegacySVGContainer());
+    FloatRect strokeBoundingBox = FloatRect();
+    for (auto& current : childrenOfType<RenderObject>(container)) {
+        if (current.isLegacySVGHiddenContainer())
+            continue;
+
+        // Don't include elements in the union that do not render.
+        if (is<LegacyRenderSVGShape>(current) && downcast<LegacyRenderSVGShape>(current).isRenderingDisabled())
+            continue;
+
+        FloatRect childStrokeBoundingBox = current.strokeBoundingBox();
+        if (is<RenderElement>(current))
+            SVGRenderSupport::intersectRepaintRectWithResources(downcast<RenderElement>(current), childStrokeBoundingBox);
+        const AffineTransform& transform = current.localToParentTransform();
+        if (transform.isIdentity())
+            strokeBoundingBox.unite(childStrokeBoundingBox);
+        else
+            strokeBoundingBox.unite(transform.mapRect(childStrokeBoundingBox));
+    }
+    return strokeBoundingBox;
 }
 
 bool SVGRenderSupport::paintInfoIntersectsRepaintRect(const FloatRect& localRepaintRect, const AffineTransform& localTransform, const PaintInfo& paintInfo)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -61,7 +61,8 @@ public:
     // Determines whether the passed point lies in a clipping area
     static bool pointInClippingArea(const RenderElement&, const FloatPoint&);
 
-    static void computeContainerBoundingBoxes(const RenderElement& container, FloatRect& objectBoundingBox, bool& objectBoundingBoxValid, FloatRect& strokeBoundingBox, FloatRect& repaintBoundingBox);
+    static void computeContainerBoundingBoxes(const RenderElement& container, FloatRect& objectBoundingBox, bool& objectBoundingBoxValid, FloatRect& repaintBoundingBox, RepaintRectCalculation = RepaintRectCalculation::Fast);
+    static FloatRect computeContainerStrokeBoundingBox(const RenderElement& container);
     static bool paintInfoIntersectsRepaintRect(const FloatRect& localRepaintRect, const AffineTransform& localTransform, const PaintInfo&);
 
     // Important functions used by nearly all SVG renderers centralizing coordinate transformations / repaint rect calculations

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -154,8 +154,25 @@ void LegacyRenderSVGContainer::addFocusRingRects(Vector<LayoutRect>& rects, cons
 
 void LegacyRenderSVGContainer::updateCachedBoundaries()
 {
-    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_strokeBoundingBox, m_repaintBoundingBox);
+    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_repaintBoundingBox);
+    // FIXME: Once we move to the model strictly separating m_repaintBoundingBox and m_strokeBoundingBox, we will just null out m_strokeBoundingBox
+    // here, and lazily compute it in strokeBoundingBox(), which solves conflation. This will happen when we enable approximate repainting bounding box computation.
+    // https://bugs.webkit.org/show_bug.cgi?id=262409
+    //
+    // When computing the strokeBoundingBox, we use the repaintRects of the container's children so that the container's stroke includes
+    // the resources applied to the children (such as clips and filters). This allows filters applied to containers to correctly bound
+    // the children, and also improves inlining of SVG content, as the stroke bound is used in that situation also.
+    m_strokeBoundingBox = m_repaintBoundingBox;
     SVGRenderSupport::intersectRepaintRectWithResources(*this, m_repaintBoundingBox);
+}
+
+FloatRect LegacyRenderSVGContainer::strokeBoundingBox() const
+{
+    // FIXME: Once we enable approximate repainting bounding box computation, m_strokeBoundingBox becomes std::nullopt in updateCachedBoundaries and gets lazily computed.
+    // https://bugs.webkit.org/show_bug.cgi?id=262409
+    if (!m_strokeBoundingBox)
+        m_strokeBoundingBox = SVGRenderSupport::computeContainerStrokeBoundingBox(*this);
+    return *m_strokeBoundingBox;
 }
 
 bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, HitTestResult& result, const FloatPoint& pointInParent, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -51,7 +51,7 @@ protected:
     void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = 0) const final;
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
-    FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
+    FloatRect strokeBoundingBox() const final;
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return m_repaintBoundingBox; }
 
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
@@ -73,7 +73,7 @@ private:
     bool isLegacySVGContainer() const final { return true; }
 
     FloatRect m_objectBoundingBox;
-    FloatRect m_strokeBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
     FloatRect m_repaintBoundingBox;
 
     bool m_objectBoundingBoxValid { false };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -49,12 +49,12 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
 {
     // Before creating a new object we need to clear the cached bounding box
     // to avoid using garbage.
+    clearPath();
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
-    m_strokeBoundingBox = FloatRect();
+    m_strokeBoundingBox = std::nullopt;
     m_center = FloatPoint();
     m_radii = FloatSize();
-    clearPath();
 
     calculateRadiiAndCenter();
 
@@ -68,15 +68,15 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
         m_shapeType = ShapeType::Ellipse;
 
     if (hasNonScalingStroke()) {
-        // Fallback to LegacyRenderSVGShape if shape has a non-scaling stroke.
-        LegacyRenderSVGShape::updateShapeFromElement();
+        // Fallback to path-based approach if shape has a non-scaling stroke.
+        m_fillBoundingBox = ensurePath().boundingRect();
         return;
     }
 
     m_fillBoundingBox = FloatRect(m_center.x() - m_radii.width(), m_center.y() - m_radii.height(), 2 * m_radii.width(), 2 * m_radii.height());
     m_strokeBoundingBox = m_fillBoundingBox;
     if (style().svgStyle().hasStroke())
-        m_strokeBoundingBox.inflate(strokeWidth() / 2);
+        m_strokeBoundingBox->inflate(strokeWidth() / 2);
 }
 
 void LegacyRenderSVGEllipse::calculateRadiiAndCenter()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -179,7 +179,7 @@ bool LegacyRenderSVGModelObject::checkIntersection(RenderElement* renderer, cons
     ASSERT(svgElement->renderer());
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return intersectsAllowingEmpty(rect, ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinates(RenderObject::RepaintRectCalculation::Accurate)));
+    return intersectsAllowingEmpty(rect, ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
 }
 
 bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
@@ -194,7 +194,7 @@ bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const F
     ASSERT(svgElement->renderer());
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return rect.contains(ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinates(RenderObject::RepaintRectCalculation::Accurate)));
+    return rect.contains(ctm.mapRect(svgElement->renderer()->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
@@ -36,12 +36,12 @@ public:
     virtual ~LegacyRenderSVGPath();
 
     void drawMarkers(PaintInfo&) final;
+    FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const override;
 
 private:
     ASCIILiteral renderName() const override { return "RenderSVGPath"_s; }
 
     void updateShapeFromElement() override;
-    FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(FloatRect strokeBoundingBox) const;
 
     void strokeShape(GraphicsContext&) const override;
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;
@@ -54,7 +54,7 @@ private:
 
     bool shouldGenerateMarkerPositions() const;
     void processMarkerPositions();
-    FloatRect markerRect(float strokeWidth) const;
+    FloatRect markerRect(RepaintRectCalculation, float strokeWidth) const;
 
     bool isRenderingDisabled() const override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -52,11 +52,12 @@ void LegacyRenderSVGRect::updateShapeFromElement()
 {
     // Before creating a new object we need to clear the cached bounding box
     // to avoid using garbage.
+    clearPath();
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
+    m_strokeBoundingBox = std::nullopt;
     m_innerStrokeRect = FloatRect();
     m_outerStrokeRect = FloatRect();
-    clearPath();
 
     SVGLengthContext lengthContext(&rectElement());
     FloatSize boundingBoxSize(lengthContext.valueForLength(style().width(), SVGLengthMode::Width), lengthContext.valueForLength(style().height(), SVGLengthMode::Height));
@@ -71,8 +72,8 @@ void LegacyRenderSVGRect::updateShapeFromElement()
         m_shapeType = ShapeType::Rectangle;
 
     if (m_shapeType != ShapeType::Rectangle || hasNonScalingStroke()) {
-        // Fall back to LegacyRenderSVGShape
-        LegacyRenderSVGShape::updateShapeFromElement();
+        // Fallback to path-based approach.
+        m_fillBoundingBox = ensurePath().boundingRect();
         return;
     }
 
@@ -96,7 +97,7 @@ void LegacyRenderSVGRect::updateShapeFromElement()
 #if USE(CG)
     // CoreGraphics can inflate the stroke by 1px when drawing a rectangle with antialiasing disabled at non-integer coordinates, we need to compensate.
     if (style().svgStyle().shapeRendering() == ShapeRendering::CrispEdges)
-        m_strokeBoundingBox.inflate(1);
+        m_strokeBoundingBox->inflate(1);
 #endif
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -297,7 +297,7 @@ void LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect()
         const RenderStyle& style = renderer->style();
         if (style.display() == DisplayType::None || style.visibility() != Visibility::Visible)
              continue;
-        m_clipBoundaries.unite(renderer->localToParentTransform().mapRect(renderer->repaintRectInLocalCoordinates()));
+        m_clipBoundaries.unite(renderer->localToParentTransform().mapRect(renderer->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
     }
     m_clipBoundaries = clipPathElement().animatedLocalTransform().mapRect(m_clipBoundaries);
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -414,9 +414,26 @@ const RenderObject* LegacyRenderSVGRoot::pushMappingToContainer(const RenderLaye
 
 void LegacyRenderSVGRoot::updateCachedBoundaries()
 {
-    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_strokeBoundingBox, m_repaintBoundingBox);
+    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_repaintBoundingBox);
+    // FIXME: Once we move to the model strictly separating m_repaintBoundingBox and m_strokeBoundingBox, we will just null out m_strokeBoundingBox
+    // here, and lazily compute it in strokeBoundingBox(), which solves conflation. This will happen when we enable approximate repainting bounding box computation.
+    // https://bugs.webkit.org/show_bug.cgi?id=262409
+    //
+    // When computing the strokeBoundingBox, we use the repaintRects of the container's children so that the container's stroke includes
+    // the resources applied to the children (such as clips and filters). This allows filters applied to containers to correctly bound
+    // the children, and also improves inlining of SVG content, as the stroke bound is used in that situation also.
+    m_strokeBoundingBox = m_repaintBoundingBox;
     SVGRenderSupport::intersectRepaintRectWithResources(*this, m_repaintBoundingBox);
     m_repaintBoundingBox.inflate(horizontalBorderAndPaddingExtent());
+}
+
+FloatRect LegacyRenderSVGRoot::strokeBoundingBox() const
+{
+    // FIXME: Once we enable approximate repainting bounding box computation, m_strokeBoundingBox becomes std::nullopt in updateCachedBoundaries and gets lazily computed.
+    // https://bugs.webkit.org/show_bug.cgi?id=262409
+    if (!m_strokeBoundingBox)
+        m_strokeBoundingBox = SVGRenderSupport::computeContainerStrokeBoundingBox(*this);
+    return *m_strokeBoundingBox;
 }
 
 bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -86,7 +86,7 @@ private:
     const AffineTransform& localToParentTransform() const override;
 
     FloatRect objectBoundingBox() const override { return m_objectBoundingBox; }
-    FloatRect strokeBoundingBox() const override { return m_strokeBoundingBox; }
+    FloatRect strokeBoundingBox() const override;
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const override { return m_repaintBoundingBox; }
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
@@ -110,7 +110,7 @@ private:
     FloatRect m_objectBoundingBox;
     bool m_objectBoundingBoxValid { false };
     bool m_inLayout { false };
-    FloatRect m_strokeBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
     FloatRect m_repaintBoundingBox;
     mutable AffineTransform m_localToParentTransform;
     AffineTransform m_localToBorderBoxTransform;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -88,9 +88,9 @@ public:
 protected:
     void element() const = delete;
 
-    void ensurePath();
+    Path& ensurePath();
 
-    virtual void updateShapeFromElement();
+    virtual void updateShapeFromElement() = 0;
     virtual bool isEmpty() const;
     virtual bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace);
     virtual bool shapeDependentFillContains(const FloatPoint&, const WindRule) const;
@@ -101,8 +101,7 @@ protected:
     AffineTransform nonScalingStrokeTransform() const;
     Path* nonScalingStrokePath(const Path*, const AffineTransform&) const;
 
-    FloatRect m_fillBoundingBox;
-    FloatRect m_strokeBoundingBox;
+    virtual FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const { return strokeBoundingBox; }
 
 private:
     // Hit-detection separated for the fill and the stroke
@@ -124,8 +123,7 @@ private:
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) final;
 
     FloatRect objectBoundingBox() const final { return m_fillBoundingBox; }
-    FloatRect strokeBoundingBox() const final { return m_strokeBoundingBox; }
-    FloatRect calculateObjectBoundingBox() const;
+    FloatRect strokeBoundingBox() const final;
     FloatRect calculateStrokeBoundingBox() const;
     void updateRepaintBoundingBox();
 
@@ -140,6 +138,9 @@ private:
 
     virtual void drawMarkers(PaintInfo&) { }
 
+protected:
+    FloatRect m_fillBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
 private:
     FloatRect m_repaintBoundingBox;
     FloatRect m_repaintBoundingBoxExcludingShadow;


### PR DESCRIPTION
#### 131951a5efc50b06d095a49525a5653e0fb86c67
<pre>
[SVG] Compute stroke-bounding-box lazily
<a href="https://bugs.webkit.org/show_bug.cgi?id=263065">https://bugs.webkit.org/show_bug.cgi?id=263065</a>
rdar://116852041

Reviewed by Cameron McCormack.

This is one step of the patch series implementing approximate repainting rect for SVG path, derived from blink&apos;s work[1].

This patch makes strokeBoundingBox computation lazy. updateShapeFromElement&apos;s responsibility gets reduced to,

    1. It needs to compute m_fillBoundingBox, but
    2. It *can* compute m_strokeBoundingBox if it is cheap

And if m_strokeBoundingBox is not computed in updateShapeFromElement, then we lazily compute it when strokeBoundingBox() function is called.
As a result of this responsibility reduction, LegacyRenderSVGShape::updateShapeFromElement becomes just creating a path and getting boundingBox.
So, this patch makes LegacyRenderSVGShape::updateShapeFromElement as pure virtual function, and we do this path materialization in each derived class&apos;
updateShapeFromElement. This makes it explicit that nobody is directly calling LegacyRenderSVGShape::updateShapeFromElement from layout function,
and it allows us to do sequence of clearing of related fields (m_shapeType, m_strokeBoundingBox etc.) done in each updateShapeFromElement function&apos;s prologue.

We also applied this to LSBE, and it requires many threading of RepaintRectCalculation. We add CalculateFastRepaintRect to SVGBoundingBoxComputation&apos;s option,
and thread RepaintRectCalculation information.

[1]: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=435097">https://bugs.chromium.org/p/chromium/issues/detail?id=435097</a>

* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::layoutChildren):
(WebCore::RenderSVGContainer::strokeBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGContainer.h:
* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
(WebCore::RenderSVGEllipse::updateShapeFromElement):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::checkIntersection):
(WebCore::RenderSVGModelObject::checkEnclosure):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::updateShapeFromElement):
(WebCore::RenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps const):
(WebCore::RenderSVGPath::computeMarkerBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGPath.h:
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::updateShapeFromElement):
* Source/WebCore/rendering/svg/RenderSVGResource.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
(WebCore::RenderSVGResourceMarker::markerBoundaries const):
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::calculateMaskContentRepaintRect):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::layoutChildren):
(WebCore::RenderSVGRoot::strokeBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::nodeAtPoint):
(WebCore::RenderSVGShape::strokeBoundingBox const):
(WebCore::RenderSVGShape::calculateStrokeBoundingBox const):
(WebCore::RenderSVGShape::ensurePath):
(WebCore::RenderSVGShape::updateShapeFromElement): Deleted.
(WebCore::RenderSVGShape::calculateObjectBoundingBox const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGShape.h:
(WebCore::RenderSVGShape::adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps const):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleShapeOrTextOrInline const):
(WebCore::SVGBoundingBoxComputation::handleRootOrContainer const):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeContainerBoundingBoxes):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::updateCachedBoundaries):
(WebCore::LegacyRenderSVGContainer::strokeBoundingBox const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
(WebCore::LegacyRenderSVGEllipse::updateShapeFromElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::checkIntersection):
(WebCore::LegacyRenderSVGModelObject::checkEnclosure):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::updateShapeFromElement):
(WebCore::LegacyRenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps const):
(WebCore::LegacyRenderSVGPath::markerRect const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
(WebCore::LegacyRenderSVGRect::updateShapeFromElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::updateCachedBoundaries):
(WebCore::LegacyRenderSVGRoot::strokeBoundingBox const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::strokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::calculateStrokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::ensurePath):
(WebCore::LegacyRenderSVGShape::updateShapeFromElement): Deleted.
(WebCore::LegacyRenderSVGShape::calculateObjectBoundingBox const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
(WebCore::LegacyRenderSVGShape::adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps const):

Canonical link: <a href="https://commits.webkit.org/269351@main">https://commits.webkit.org/269351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d20a3918dd57a622c292d99f433f51b2399f3347

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20663 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22856 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22259 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25082 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/19309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20996 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20452 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24684 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2791 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->