### PR TITLE
keyFramesDecoded > 0 while framesDecoded == 0

### DIFF
--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -84,6 +84,13 @@ public:
     struct Decoder {
         WTF_MAKE_FAST_ALLOCATED;
     public:
+        struct EncodedFrame {
+            int64_t timeStamp { 0 };
+            Vector<uint8_t> data;
+            uint16_t width { 0 };
+            uint16_t height { 0 };
+        };
+
         VideoDecoderIdentifier identifier;
         VideoCodecType type;
         String codec;
@@ -92,6 +99,7 @@ public:
         Lock decodedImageCallbackLock;
         bool hasError { false };
         RefPtr<IPC::Connection> connection;
+        Vector<EncodedFrame> pendingFrames;
         Deque<Function<void()>> flushCallbacks WTF_GUARDED_BY_LOCK(flushCallbacksLock);
         Lock flushCallbacksLock;
     };


### PR DESCRIPTION
#### 248020847da1d5e6b9130d04b3ff4353efa29d2c
<pre>
keyFramesDecoded &gt; 0 while framesDecoded == 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=262972">https://bugs.webkit.org/show_bug.cgi?id=262972</a>
rdar://116810102

Reviewed by Eric Carlson.

When creating a remote decoder, there is a small amount of time where the decoder does not have a connection.
We were previously returning an error, which would instruct libwebrtc backend to request a key frame.
Some services only provide SPS/PPS in the first frame and not the succeesive key frames.
When dropping the first frame with a missing connection, we would not be able to recover.

To prevent this, we store the frames to decode in a vector if the decoder does not have a connection.
When setting the connection, we then send all frames to the GPU process.

Manually tested.

* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::sendFrameToDecode):
(WebKit::LibWebRTCCodecs::decodeFrame):
(WebKit::LibWebRTCCodecs::setDecoderConnection):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:

Canonical link: <a href="https://commits.webkit.org/269258@main">https://commits.webkit.org/269258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39362e9e017daae7f2970b9ffd6f167502c1a7ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21454 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24762 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19021 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26219 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24086 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17553 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19968 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5253 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->