### PR TITLE
[WGSL] Buffer dynamic offsets are not implemented

### DIFF
--- a/Source/WebGPU/WGSL/API.h
+++ b/Source/WebGPU/WGSL/API.h
@@ -29,8 +29,7 @@ namespace WGSL  {
 
 inline uint32_t vertexBufferIndexForBindGroup(uint32_t groupIndex, uint32_t maxIndex)
 {
-    ASSERT(groupIndex <= maxIndex);
-    return groupIndex > maxIndex ? 0 : (maxIndex - groupIndex);
+    return groupIndex > maxIndex ? groupIndex : (maxIndex - groupIndex);
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -89,7 +89,7 @@ void ComputePassEncoder::executePreDispatchCommands()
         }
     }
 
-    [m_computeCommandEncoder setBytes:&m_computeDynamicOffsets[0] length:m_computeDynamicOffsets.size() atIndex:m_device->maxBuffersForComputeStage()];
+    [m_computeCommandEncoder setBytes:&m_computeDynamicOffsets[0] length:m_computeDynamicOffsets.size() * sizeof(m_computeDynamicOffsets[0]) atIndex:m_device->maxBuffersForComputeStage()];
 
     m_bindGroupDynamicOffsets.clear();
 }

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -112,10 +112,10 @@ void RenderPassEncoder::executePreDrawCommands()
     }
 
     if (m_vertexDynamicOffsets.size())
-        [m_renderCommandEncoder setVertexBytes:&m_vertexDynamicOffsets[0] length:m_vertexDynamicOffsets.size() atIndex:m_device->maxBuffersPlusVertexBuffersForVertexStage()];
+        [m_renderCommandEncoder setVertexBytes:&m_vertexDynamicOffsets[0] length:m_vertexDynamicOffsets.size() * sizeof(m_vertexDynamicOffsets[0]) atIndex:m_device->maxBuffersPlusVertexBuffersForVertexStage()];
 
     if (m_fragmentDynamicOffsets.size())
-        [m_renderCommandEncoder setFragmentBytes:&m_fragmentDynamicOffsets[0] length:m_fragmentDynamicOffsets.size() atIndex:m_device->maxBuffersForFragmentStage()];
+        [m_renderCommandEncoder setFragmentBytes:&m_fragmentDynamicOffsets[0] length:m_fragmentDynamicOffsets.size() * sizeof(m_fragmentDynamicOffsets[0]) atIndex:m_device->maxBuffersForFragmentStage()];
 
     m_bindGroupDynamicOffsets.clear();
 }


### PR DESCRIPTION
#### 7990584a04b5ad76b25788656433ac5693c4db7c
<pre>
[WGSL] Buffer dynamic offsets are not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=262135">https://bugs.webkit.org/show_bug.cgi?id=262135</a>
rdar://116073820

Reviewed by Mike Wyrzykowski.

Add support for dynamic offsets. The implementation is rather simple, since we
materialize all the globals at the begining of each entry point, we just apply
the offset during as part of the materialization and the rest of the program
remains unchanged.

* Source/WebGPU/WGSL/API.h:
(WGSL::vertexBufferIndexForBindGroup):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::RewriteGlobalVariables::collectDynamicOffsetGlobals):
(WGSL::RewriteGlobalVariables::insertParameters):
(WGSL::RewriteGlobalVariables::insertMaterializations):
(WGSL::RewriteGlobalVariables::readVariable):
(WGSL::RewriteGlobalVariables::dynamicOffsetVariableName):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::serializeAddressSpace):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitDynamicOffset):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):

Canonical link: <a href="https://commits.webkit.org/269418@main">https://commits.webkit.org/269418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c553631fbd976aea6a964e18683b68128189c003

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22503 "Passed style check") | [💥 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/157 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20832 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23035 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25260 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24483 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/92 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/68 "Build is in progress. Recent messages:") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5362 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->