### PR TITLE
Element::dispatchMouseEvent should return whether an event is prevented default

### DIFF
--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -621,8 +621,10 @@ public:
     IntPoint savedLayerScrollPosition() const;
     void setSavedLayerScrollPosition(const IntPoint&);
 
-    // FIXME: <https://webkit.org/b/263034> Indicate isEventDefaultPrevented through the return value instead of as an out-param.
-    bool dispatchMouseEvent(const PlatformMouseEvent& platformEvent, const AtomString& eventType, int clickCount = 0, Element* relatedTarget = nullptr, IsSyntheticClick = IsSyntheticClick::No, bool* isEventDefaultPrevented = nullptr);
+    enum class EventIsDefaultPrevented : bool { No, Yes };
+    enum class EventIsDispatched : bool { No, Yes };
+    using DispatchMouseEventResult = std::pair<EventIsDispatched, EventIsDefaultPrevented>;
+    DispatchMouseEventResult dispatchMouseEvent(const PlatformMouseEvent& platformEvent, const AtomString& eventType, int clickCount = 0, Element* relatedTarget = nullptr, IsSyntheticClick = IsSyntheticClick::No);
     bool dispatchWheelEvent(const PlatformWheelEvent&, OptionSet<EventHandling>&, EventIsCancelable = EventIsCancelable::Yes);
     bool dispatchKeyEvent(const PlatformKeyboardEvent&);
     bool dispatchSimulatedClick(Event* underlyingEvent, SimulatedClickMouseEventOptions = SendNoEvents, SimulatedClickVisualOptions = ShowPressedLook);

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2891,11 +2891,10 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
     bool isMouseDownEvent = eventType == eventNames().mousedownEvent;
 
     if (auto elementUnderMouse = m_elementUnderMouse) {
-        bool isEventDefaultPrevented = false;
-        bool dispatchedMouseEvent = elementUnderMouse->dispatchMouseEvent(platformMouseEvent, eventType, clickCount, nullptr, IsSyntheticClick::No, &isEventDefaultPrevented);
-        auto dragCaptureInabilityReason = isEventDefaultPrevented && isMouseDownEvent ? CapturesDragging::InabilityReason::MousePressIsCancelled : CapturesDragging::InabilityReason::Unknown;
+        auto [eventIsDispatched, eventIsDefaultPrevented] = elementUnderMouse->dispatchMouseEvent(platformMouseEvent, eventType, clickCount, nullptr, IsSyntheticClick::No);
+        auto dragCaptureInabilityReason = eventIsDefaultPrevented == Element::EventIsDefaultPrevented::Yes && isMouseDownEvent ? CapturesDragging::InabilityReason::MousePressIsCancelled : CapturesDragging::InabilityReason::Unknown;
         m_capturesDragging = dragCaptureInabilityReason;
-        if (!dispatchedMouseEvent)
+        if (eventIsDispatched == Element::EventIsDispatched::No)
             return false;
     }
 


### PR DESCRIPTION
#### b5ebe19c24912a985953aa16786df965a9d7d12c
<pre>
Element::dispatchMouseEvent should return whether an event is prevented default
<a href="https://bugs.webkit.org/show_bug.cgi?id=263034">https://bugs.webkit.org/show_bug.cgi?id=263034</a>
rdar://116859739

Reviewed by Wenson Hsieh.

As part of the changes in 269246@main, Element::dispatchMouseEvent
received an extra out param to indicate whether a mouse event was
defaultPrevented.

This patch refactors dispatchMouseEvent to instead return a pair of
flags representing whether the event was dispatched and whether the
event was defaultPrevented. The former flag was already represented by
the original `bool` return type, while the latter flag was represented
through the out param.

I believe calling into dispatchMouseEvent, and receiving the
preventDefaulted information, is much more ergonomic following this
patch.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchMouseEvent):
* Source/WebCore/dom/Element.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchMouseEvent):

Canonical link: <a href="https://commits.webkit.org/269266@main">https://commits.webkit.org/269266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1225c013c2054bb3c75c9b560f646a8ff6bb39c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21466 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24771 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26231 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17562 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19977 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5260 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->