### PR TITLE
iOS 17.1 beta 2: ManagedMediaSource video playback stops when changing timestampOffset

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-resume-after-stall-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-resume-after-stall-expected.txt
@@ -1,0 +1,21 @@
+
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.muted = true)
+RUN(video.playsInline = true)
+RUN(video.disableRemotePlayback = true)
+RUN(video.autoplay = true)
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(2)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(3)))
+EVENT(update)
+EXPECTED (video.currentTime >= '3.5') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-resume-after-stall.html
+++ b/LayoutTests/media/media-source/media-managedmse-resume-after-stall.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mediasource-resume-after-stall</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        await loaderPromise(loader);
+
+        source = new ManagedMediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        run('video.muted = true');
+        run('video.playsInline = true');
+        run('video.disableRemotePlayback = true');
+        run('video.autoplay = true');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
+        await waitFor(sourceBuffer, 'update');
+
+        await sleepFor(2000);
+        sourceBuffer.timestampOffset = -0.5;
+
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(2))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(3))');
+        await waitFor(sourceBuffer, 'update');
+
+        await testExpectedEventually("video.currentTime", 3.5, ">=");
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/platform/ios-16/TestExpectations
+++ b/LayoutTests/platform/ios-16/TestExpectations
@@ -20,6 +20,7 @@ accessibility/ios-simulator/inline-prediction-attributed-string.html [ Skip ]
 
 # Only supported with iOS 17 and later.
 media/media-webm-opus-variable-length.html [ Failure ]
+media/media-source/media-managedmse-resume-after-stall.html [ Skip ]
 
 # webkit.org/b/262663 (REGRESSION(iOS17/Sonoma): 8 WebCryptoAPI tests are constantly crashing.)
 imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_X25519.https.any.html [ Pass ]

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -57,7 +57,7 @@ webkit.org/b/194234 media/modern-media-controls/media-documents/background-color
 
 webkit.org/b/165311 platform/ipad/media/modern-media-controls/pip-support/pip-support-tap.html [ Skip ]
 
-# webkit.org/b/237689 These tests are constantly failing on iPad 
+# webkit.org/b/237689 These tests are constantly failing on iPad
 webkit.org/b/237689 svg/filters/big-height-filter.svg [ Failure ]
 webkit.org/b/237689 svg/filters/big-sized-off-viewport-filter.svg [ Failure ]
 webkit.org/b/237689 svg/filters/big-width-filter.svg [ Failure ]
@@ -95,6 +95,7 @@ media/remove-video-element-in-pip-from-document.html [ Pass ]
 
 media/media-source/media-managedmse-airplay.html [ Fail ] # This test must fail on all platform but iPhone.
 http/tests/media/media-source/mediasource-rvfc.html [ Pass ]
+media/media-source/media-managedmse-resume-after-stall.html [ Pass ]
 
 webkit.org/b/228622 [ Debug ] accessibility/ios-simulator/scroll-in-overflow-div.html [ Crash ]
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -334,11 +334,11 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     MediaTime m_mediaTimeDuration { MediaTime::invalidTime() };
     MediaTime m_lastSeekTime;
     FloatSize m_naturalSize;
-    double m_rate;
-    bool m_playing;
-    bool m_synchronizerSeeking;
+    double m_rate { 1 };
+    bool m_playing { false };
+    bool m_synchronizerSeeking { false };
     SeekState m_seekState { SeekCompleted };
-    mutable bool m_loadingProgressed;
+    mutable bool m_loadingProgressed { false };
 #if !HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
     bool m_hasBeenAskedToPaintGL { false };
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -144,10 +144,6 @@ MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(Media
     , m_seekTimer(*this, &MediaPlayerPrivateMediaSourceAVFObjC::seekInternal)
     , m_networkState(MediaPlayer::NetworkState::Empty)
     , m_readyState(MediaPlayer::ReadyState::HaveNothing)
-    , m_rate(1)
-    , m_playing(0)
-    , m_synchronizerSeeking(false)
-    , m_loadingProgressed(false)
     , m_logger(player->mediaPlayerLogger())
     , m_logIdentifier(player->mediaPlayerLogIdentifier())
     , m_videoLayerManager(makeUnique<VideoLayerManagerObjC>(m_logger, m_logIdentifier))
@@ -1138,7 +1134,6 @@ void MediaPlayerPrivateMediaSourceAVFObjC::durationChanged()
 void MediaPlayerPrivateMediaSourceAVFObjC::effectiveRateChanged()
 {
     ALWAYS_LOG(LOGIDENTIFIER, effectiveRate());
-    m_playing = effectiveRate() != 0;
     if (auto player = m_player.get())
         player->rateChanged();
 }


### PR DESCRIPTION
#### 3acdede1a2e206a002bf8436467c51296fe223e7
<pre>
iOS 17.1 beta 2: ManagedMediaSource video playback stops when changing timestampOffset
<a href="https://bugs.webkit.org/show_bug.cgi?id=262886">https://bugs.webkit.org/show_bug.cgi?id=262886</a>
rdar://116707511

Reviewed by Eric Carlson.

We set MediaPlayerPrivateMediaSourceAVFObjC::m_playing to false if the video
playback stalled for whatever reason: a condition detected when the effective
playback rate became 0 and a notification was sent.
However, once we finished seeking or once a decoded data is available again
we would resume playback only if m_playback is true.
We need to resume playback if we used to play the video (that is play() was called
and the video wasn&apos;t explictly paused).

The change effectively revert changes made in 266665@main and 266675@main.

Adding test to catch future regressions.

* LayoutTests/media/media-source/media-managedmse-resume-after-stall-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-resume-after-stall.html: Added.
* LayoutTests/platform/ios-16/TestExpectations:
* LayoutTests/platform/ipad/TestExpectations:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::playInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::pauseInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldBePlaying const):

Canonical link: <a href="https://commits.webkit.org/269290@main">https://commits.webkit.org/269290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e3dbe0f41e01b4982d657be52ecf07e66f60f05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20476 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22644 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24861 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26300 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24159 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20702 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5267 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->