### PR TITLE
REGRESSION (266700@main): Copying a table from Mail to Numbers results in visibly broken content

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.h
+++ b/Source/WebCore/editing/cocoa/AttributedString.h
@@ -78,6 +78,9 @@ class Font;
 struct AttributedStringTextTableIDType;
 using AttributedStringTextTableID = ObjectIdentifier<AttributedStringTextTableIDType>;
 
+struct AttributedStringTextTableBlockIDType;
+using AttributedStringTextTableBlockID = ObjectIdentifier<AttributedStringTextTableBlockIDType>;
+
 struct AttributedStringTextListIDType;
 using AttributedStringTextListID = ObjectIdentifier<AttributedStringTextListIDType>;
 
@@ -88,11 +91,13 @@ struct WEBCORE_EXPORT AttributedString {
     };
 
     using TextTableID = AttributedStringTextTableID;
+    using TextTableBlockID = AttributedStringTextTableBlockID;
     using TextListID = AttributedStringTextListID;
+    using TableBlockAndTableIDPair = std::pair<TextTableBlockID, TextTableID>;
 
     struct ParagraphStyleWithTableAndListIDs {
         RetainPtr<NSParagraphStyle> style;
-        Vector<std::optional<TextTableID>> tableIDs; // Same length as `-textBlocks`.
+        Vector<std::optional<TableBlockAndTableIDPair>> tableBlockAndTableIDs; // Same length as `-textBlocks`.
         Vector<TextListID> listIDs; // Same length as `-textLists`.
     };
 

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -50,7 +50,7 @@ header: <WebCore/ResourceRequest.h>
 
 [Nested] struct WebCore::AttributedString::ParagraphStyleWithTableAndListIDs {
     RetainPtr<NSParagraphStyle> style
-    Vector<std::optional<WebCore::AttributedString::TextTableID>> tableIDs
+    Vector<std::optional<WebCore::AttributedString::TableBlockAndTableIDPair>> tableBlockAndTableIDs
     Vector<WebCore::AttributedString::TextListID> listIDs
 }
 

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -105,6 +105,7 @@ template: enum class WebKit::WCLayerTreeHostIdentifierType
 template: enum class WebKit::WebExtensionControllerIdentifierType
 template: enum class WebKit::XRDeviceIdentifierType
 template: struct WebCore::AttributedStringTextListIDType
+template: struct WebCore::AttributedStringTextTableBlockIDType
 template: struct WebCore::AttributedStringTextTableIDType
 template: struct WebCore::BackForwardItemIdentifierType
 template: struct WebCore::DictationContextType


### PR DESCRIPTION
#### 9ec7007ca6e9833edb89decb0b9293c69197c906
<pre>
REGRESSION (266700@main): Copying a table from Mail to Numbers results in visibly broken content
<a href="https://bugs.webkit.org/show_bug.cgi?id=263071">https://bugs.webkit.org/show_bug.cgi?id=263071</a>
rdar://116785572

Reviewed by Aditya Keerthi.

After the changes in 266700@main, copying tables in webpages and pasting into Numbers (which reads
RTF data from the pasteboard and converts to `NSAttributedString`) causes cells to be erroneously
merged, in the case where a cell (represented by `NSTextTableBlock`) consists of 2 or more
attributed string subranges.

This happens because, in the process of converting from `NSAttributedString` -&gt;
`WebCore::AttributedString` -&gt; `NSAttributedString` under `Editor::writeSelectionToPasteboard`, we
lose the fact that multiple paragraph styles can end up referencing not only the same `NSTextTable`
object, but the same `NSTextTableBlock` object; Pages relies on this in order to properly map text
to the correct table cell. While the changes in 266700@main preserve `NSTextTable` and `NSTextList`
identity upon serialization/deserialization of the attributed string via lists of identifiers,
there&apos;s no attempt to preserve `NSTextTableBlock` identity. This means that two pieces of text that
reference the same block:

```
&quot;foo&quot; =&gt; {
   &quot;NSParagraphStyle&quot; =&gt; {
       textBlocks =&gt; [ NSTextTableBlock(0x14233c360, table=&lt;NSTextTable 0x1423319e0&gt;, {0, 1}) ],
   }
}

&quot;bar&quot; =&gt; {
   &quot;NSParagraphStyle&quot; =&gt; {
       textBlocks =&gt; [ NSTextTableBlock(0x14233c360, table=&lt;NSTextTable 0x1423319e0&gt;, {0, 1}) ],
   }
}
```

...will reference different blocks after serialization:

```
&quot;foo&quot; =&gt; {
   &quot;NSParagraphStyle&quot; =&gt; {
       textBlocks =&gt; [ NSTextTableBlock(0x127686a00, table=&lt;NSTextTable 0x12761a060&gt;, {0, 1}) ],
   }
}

&quot;bar&quot; =&gt; {
   &quot;NSParagraphStyle&quot; =&gt; {
       textBlocks =&gt; [ NSTextTableBlock(0x127693ff0, table=&lt;NSTextTable 0x12761a060&gt;, {0, 1}) ],
   }
}
```

To fix this, we augment the existing table ID lists to include table block IDs as well, and use this
information upon deserialization to preserve text table block identity in the deserialized
attributed string.

* Source/WebCore/editing/cocoa/AttributedString.h:
* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::reconstructStyle):

Add support for plumbing a list of table block IDs along with table IDs; use this information to
ensure that two paragraph styles that pointed to the same `NSTextTableBlock` before serialization
will continue to point to the same `NSTextTableBlock` after deserialization.

(WebCore::toNSObject):
(WebCore::toNSDictionary):
(WebCore::AttributedString::documentAttributesAsNSDictionary const):
(WebCore::AttributedString::nsAttributedString const):
(WebCore::extractTableBlockAndTableIDs):
(WebCore::extractValue):
(WebCore::extractDictionary):
(WebCore::AttributedString::fromNSAttributedStringAndDocumentAttributes):
(WebCore::extractTableIDs): Deleted.
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:

Add an API test to exercise the fix.

Canonical link: <a href="https://commits.webkit.org/269265@main">https://commits.webkit.org/269265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e473cbbc0939dbbd988b1f0aba057e6d646b63d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22581 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24788 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26241 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24107 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17575 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19993 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5259 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->