### PR TITLE
REGRESSION(iOS17): [ iOS17 wk2 ] fast/dom/collection-iterators.html is a constant failure.

### DIFF
--- a/LayoutTests/fast/dom/collection-iterators.html
+++ b/LayoutTests/fast/dom/collection-iterators.html
@@ -56,8 +56,10 @@ checkHasIterator("HTMLOptionsCollection", document.createElement("select").optio
 checkHasIterator("HTMLSelectElement", document.createElement("select"));
 checkHasIterator("MediaList", document.getElementsByTagName("style")[0].sheet.media);
 checkHasIterator("NamedNodeMap", document.body.attributes);
-if ('SourceBufferList' in window)
+if ('MediaSource' in window)
     checkHasIterator("SourceBufferList", (new MediaSource()).sourceBuffers);
+else if ('ManagedMediaSource' in window)
+    checkHasIterator("SourceBufferList", (new ManagedMediaSource()).sourceBuffers);
 checkHasIterator("StyleSheetList", document.styleSheets);
 checkHasIterator("TextTrackCueList", document.createElement("video").addTextTrack("subtitles").cues);
 checkHasIterator("TextTrackList", media.textTracks);

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2494,7 +2494,6 @@ webkit.org/b/261957 media/audio-play-with-video-element-interrupted.html [ Pass 
 css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html [ Skip ]
 
 webkit.org/b/263048 accessibility/ios-simulator/input-type-time.html [ Failure ]
-webkit.org/b/263050 fast/dom/collection-iterators.html [ Failure ]
 webkit.org/b/263052 fast/events/ios/keydown-keyup-keypress-keys-in-non-editable-using-chinese-keyboard.html [ Failure ]
 
 # re-baseline candidates, will file new bugs if not approved

--- a/LayoutTests/platform/ios/fast/dom/collection-iterators-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/collection-iterators-expected.txt
@@ -138,6 +138,15 @@ PASS 'keys' in obj is false
 PASS 'forEach' in obj is false
 PASS 'values' in obj is false
 
+* SourceBufferList
+PASS obj.__proto__ is SourceBufferList.prototype
+PASS Symbol.iterator in obj is true
+PASS for..of did not throw an exception
+PASS 'entries' in obj is false
+PASS 'keys' in obj is false
+PASS 'forEach' in obj is false
+PASS 'values' in obj is false
+
 * StyleSheetList
 PASS obj.__proto__ is StyleSheetList.prototype
 PASS Symbol.iterator in obj is true


### PR DESCRIPTION
#### 6cd43ab65889ec5dd3f309bdf3a12f9a1e791a5e
<pre>
REGRESSION(iOS17): [ iOS17 wk2 ] fast/dom/collection-iterators.html is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263050">https://bugs.webkit.org/show_bug.cgi?id=263050</a>
rdar://116838330

Reviewed by Jer Noble.

SourceBufferList is exposed on iOS 17 iPhone Simulator but not MediaSource, which
was causing the test to fail. Update the test to use ManagedMediaSource to get a
SourceBufferList instead of MediaSource, if MediaSource is unavailable.

* LayoutTests/fast/dom/collection-iterators.html:
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269268@main">https://commits.webkit.org/269268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e4c38188f3e2d7d2e6685aa0797c15822c0cbca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20420 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22588 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24795 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26247 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24116 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20648 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20000 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19802 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24207 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2742 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->