### PR TITLE
Fix missing invalidation when scrollbar is destroyed

### DIFF
--- a/LayoutTests/fast/repaint/destroy-scrollbar-expected.txt
+++ b/LayoutTests/fast/repaint/destroy-scrollbar-expected.txt
@@ -1,0 +1,9 @@
+Tests invalidation when a scrollbar is destroyed. Passes if there is no scrollbar.
+ (repaint rects
+  (rect 0 100 100 200)
+  (rect 0 100 100 100)
+  (rect 185 100 15 200)
+  (rect 0 100 200 200)
+  (rect 0 100 200 200)
+)
+

--- a/LayoutTests/fast/repaint/destroy-scrollbar.html
+++ b/LayoutTests/fast/repaint/destroy-scrollbar.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="resources/text-based-repaint.js"></script>
+<script>
+function repaintTest() {
+  document.getElementById('content').style.height = '100px';
+}
+onload = runRepaintTest;
+</script>
+Tests invalidation when a scrollbar is destroyed. Passes if there is no scrollbar.
+<div style="position: absolute; top: 100px; left: 0; width: 200px; height: 200px; overflow: auto">
+  <div id="content" style="width: 100px; height: 400px"></div>
+</div>

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2019 Adobe. All rights reserved.
- * Copyright (C) 2014 Google. All rights reserved.
+ * Copyright (C) 2014-2015 Google. All rights reserved.
  * Copyright (C) 2020 Igalia S.L.
  *
  * Portions are Copyright (C) 1998 Netscape Communications Corporation.
@@ -916,6 +916,9 @@ void RenderLayerScrollableArea::setHasHorizontalScrollbar(bool hasScrollbar)
         ScrollableArea::setHorizontalScrollElasticity(elasticity);
 #endif
     } else {
+        if (!layerForHorizontalScrollbar())
+            m_hBar->invalidate();
+        // Otherwise we will remove the layer and just need recompositing.
         destroyScrollbar(ScrollbarOrientation::Horizontal);
 #if HAVE(RUBBER_BANDING)
         ScrollableArea::setHorizontalScrollElasticity(ScrollElasticity::None);
@@ -942,6 +945,9 @@ void RenderLayerScrollableArea::setHasVerticalScrollbar(bool hasScrollbar)
         ScrollableArea::setVerticalScrollElasticity(elasticity);
 #endif
     } else {
+        if (!layerForVerticalScrollbar())
+            m_vBar->invalidate();
+        // Otherwise we will remove the layer and just need recompositing.
         destroyScrollbar(ScrollbarOrientation::Vertical);
 #if HAVE(RUBBER_BANDING)
         ScrollableArea::setVerticalScrollElasticity(ScrollElasticity::None);


### PR DESCRIPTION
<pre>
Fix missing invalidation when scrollbar is destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=249869">https://bugs.webkit.org/show_bug.cgi?id=249869</a>
rdar://problem/103790698

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/f3a2b99c3c2ee5d435c09ceedcd4a1f213c3baf7">https://chromium.googlesource.com/chromium/blink/+/f3a2b99c3c2ee5d435c09ceedcd4a1f213c3baf7</a>

This patch adds 'invalidation' prior to scrollbar being destroyed after being marked as damaged.
Prior to this PR, while running test, we don't get repaintRects but post patch, we do.

* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(RenderLayerScrollableArea::setHasHorizontalScrollbar):
(RenderLayerScrollableArea::setHasVerticalScrollbar):
* LayoutTests/fast/repaint/destroy-scrollbar.html: Add Test Case
* LayoutTests/fast/repaint/destroy-scrollbar-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20f12a457626db93deb114f2274e9ba21ce434ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21478 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24791 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26284 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24109 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17576 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19804 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->