### PR TITLE
[GStreamer][DMABuf] Allow negotiation with decoders without drm-format

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -49,15 +49,12 @@ GST_DEBUG_CATEGORY_STATIC(webkit_dmabuf_video_sink_debug);
 
 #define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV21, Y444, Y41B, Y42B, VUYA, P010_10LE, P010_10BE, P016_LE, P016BE }"
 
-#define GST_WEBKIT_DMABUF_SINK_DRM_FORMAT_LIST "{ (string) P010:0x0100000000000002, (string) NV12:0x0100000000000002, (string) P010, (string) NV12 }"
-
 static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
     GST_STATIC_CAPS(
 #if GST_CHECK_VERSION(1, 23, 0)
-        GST_VIDEO_DMA_DRM_CAPS_MAKE ", drm-format = " GST_WEBKIT_DMABUF_SINK_DRM_FORMAT_LIST
-#else
-        GST_VIDEO_CAPS_MAKE(GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST)
+        GST_VIDEO_DMA_DRM_CAPS_MAKE ";"
 #endif
+        GST_VIDEO_CAPS_MAKE(GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST)
         ));
 
 // TODO: this is a list of remaining YUV formats we want to support, but don't currently work (due to improper handling in TextureMapper):
@@ -104,14 +101,13 @@ static void webKitDMABufVideoSinkConstructed(GObject* object)
     // MediaPlayerPrivateGStreamer). The format list corresponds to the formats we are able to then handle in the graphics pipeline.
     // In case of dmabuf data, that dmabuf is handled most optimally and just relayed to the graphics pipeline.
     // In case of raw data, dmabuf objects are produced on the spot and filled with that data, and then pushed to the graphics pipeline.
+
+    static GstStaticCaps s_dmabufCaps = GST_STATIC_CAPS(
 #if GST_CHECK_VERSION(1, 23, 0)
-#define DMABUF_CAPS GST_VIDEO_DMA_DRM_CAPS_MAKE ", drm-format = " GST_WEBKIT_DMABUF_SINK_DRM_FORMAT_LIST
-#else
-#define DMABUF_CAPS GST_VIDEO_CAPS_MAKE_WITH_FEATURES(GST_CAPS_FEATURE_MEMORY_DMABUF, GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST)
+        GST_VIDEO_DMA_DRM_CAPS_MAKE ";"
 #endif
-    static GstStaticCaps s_dmabufCaps = GST_STATIC_CAPS(DMABUF_CAPS);
+        GST_VIDEO_CAPS_MAKE_WITH_FEATURES(GST_CAPS_FEATURE_MEMORY_DMABUF, GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST));
     static GstStaticCaps s_fallbackCaps = GST_STATIC_CAPS(GST_VIDEO_CAPS_MAKE(GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST));
-#undef DMABUF_CAPS
 
     GRefPtr<GstCaps> caps = adoptGRef(gst_caps_new_empty());
     {


### PR DESCRIPTION
#### fcf3a66b27a8ee289b8366b7fa13689d2acf6394
<pre>
[GStreamer][DMABuf] Allow negotiation with decoders without drm-format
<a href="https://bugs.webkit.org/show_bug.cgi?id=263079">https://bugs.webkit.org/show_bug.cgi?id=263079</a>

Reviewed by Xabier Rodriguez-Calvar.

The TextureMapper is capable to generating DMABufs and guess related format fourcc when the decoder
hasn&apos;t explicitely supplied those infos in the caps, so there is no reason for our sink to restrict
its caps to a specific set of DRM formats.

This should allow decoders not yet ported to the new DRM caps format to still be used in combination
with our DMABuf sink.

* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkConstructed):

Canonical link: <a href="https://commits.webkit.org/269356@main">https://commits.webkit.org/269356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88878a8bda582a8e5e5de9d1e6ef8095cd640064

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20418 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21479 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24793 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26245 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24111 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17577 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/19998 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5315 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->