### PR TITLE
WebContent.Development service missing RunningBoard assertion entitlement

### DIFF
--- a/Source/WebKit/Scripts/update-info-plist-for-runningboard.sh
+++ b/Source/WebKit/Scripts/update-info-plist-for-runningboard.sh
@@ -2,7 +2,7 @@ VERSION_MAJOR=`echo $MACOSX_DEPLOYMENT_TARGET | cut -d"." -f1`
 VERSION_MINOR=`echo $MACOSX_DEPLOYMENT_TARGET | cut -d"." -f2`
 
 # We only use RunningBoard on macOS >= 13.3
-if [[ "${USE_INTERNAL_SDK}" == "YES"  &&  "${WK_PLATFORM_NAME}" == macosx ]] && (([[ $VERSION_MAJOR -eq 13 ]] && [[ $VERSION_MINOR -ge 3 ]]) || [[ $VERSION_MAJOR -ge 14 ]])
+if [[ "${USE_INTERNAL_SDK}" == YES && "${WK_PLATFORM_NAME}" == macosx && "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]] && (([[ $VERSION_MAJOR -eq 13 ]] && [[ $VERSION_MINOR -ge 3 ]]) || [[ $VERSION_MAJOR -ge 14 ]])
 then
     /usr/libexec/PlistBuddy -c "Add :LSDoNotSetTaskPolicyAutomatically bool YES" "${SCRIPT_INPUT_FILE_0}"
     /usr/libexec/PlistBuddy -c "Add :XPCService:_AdditionalProperties:RunningBoard:Managed bool YES" "${SCRIPT_INPUT_FILE_0}"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -16084,7 +16084,6 @@
 				A1EF36BF2581F73B0090B02A /* Copy Plug-ins */,
 				7AFCBD5520B8917D00F55C9C /* Process WebContent entitlements */,
 				6577FFBD2769C70F0011AEC8 /* Create Symlink to Alt Root Path */,
-				3AB34B6328D4F08E009DAAB6 /* Update Info.plist for RunningBoard management */,
 			);
 			buildRules = (
 			);
@@ -16739,25 +16738,6 @@
 			shellScript = "if [ \"${ACTION}\" = \"installhdrs\" ] || [ \"${ACTION}\" = \"installapi\" ]; then\n    exit 0;\nfi\n\nif [ -f ../../Tools/Scripts/check-for-inappropriate-objc-class-names ]; then\n    ../../Tools/Scripts/check-for-inappropriate-objc-class-names WK _WK || exit $?\nfi\n";
 		};
 		3AB34B6228D4F01C009DAAB6 /* Update Info.plist for RunningBoard management */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
-			);
-			name = "Update Info.plist for RunningBoard management";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "Scripts/update-info-plist-for-runningboard.sh\n";
-		};
-		3AB34B6328D4F08E009DAAB6 /* Update Info.plist for RunningBoard management */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (


### PR DESCRIPTION
#### f8192d525e8b9f281a672cb3bf49b2889ce088a0
<pre>
WebContent.Development service missing RunningBoard assertion entitlement
<a href="https://bugs.webkit.org/show_bug.cgi?id=263078">https://bugs.webkit.org/show_bug.cgi?id=263078</a>
rdar://116866896

Reviewed by Chris Dumez.

The Development XPC service doesn&apos;t use restricted entitlements, so that
it can be debugged when it&apos;s part of the system. This means it cannot
take RunningBoard assertions, so it should be opted out of RunningBoard
entirely to avoid being suspended/deprioritized.

* Source/WebKit/Scripts/update-info-plist-for-runningboard.sh: During
  debug builds, when the _normal_ WebContent service has restricted
  entitlements disabled, make the script a no-op.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Delete the
  WebContent.Development target&apos;s script phase that invokes
  update-info-plist-for-runningboard.sh.

Canonical link: <a href="https://commits.webkit.org/269328@main">https://commits.webkit.org/269328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e11d46d86aced036dc31b0880cc42ccec0bfbe8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20494 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21522 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24880 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/22316 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19130 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26314 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24173 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17635 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20074 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5300 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->