### PR TITLE
REGRESSION(iOS17): [ iOS 17 ] 5X http/tests/css/css-masking/mask- (Layout-tests) are constant ImageOnlyFailures

### DIFF
--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8183" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8183" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8183" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8183" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
 <style>
     .container {
         display: inline-block;

--- a/LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html
+++ b/LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8183" />
+<meta name="fuzzy" content="maxDifference=1-32; totalPixels=94-8248" />
 <style>
     .container {
         display: inline-block;


### PR DESCRIPTION
#### 82b3e4c30781ae0c144a65535b74128d0192c4ee
<pre>
REGRESSION(iOS17): [ iOS 17 ] 5X http/tests/css/css-masking/mask- (Layout-tests) are constant ImageOnlyFailures
rdar://116831359
<a href="https://bugs.webkit.org/show_bug.cgi?id=263041">https://bugs.webkit.org/show_bug.cgi?id=263041</a>

Unreviewed test modification.

Pixel tolerance adjustment for tests with a .01% Image Failure on iOS 17.

* LayoutTests/http/tests/css/css-masking/mask-external-svg-fragment.html:
* LayoutTests/http/tests/css/css-masking/mask-external-svg-image.html:
* LayoutTests/http/tests/css/css-masking/mask-external-svg-mask.html:
* LayoutTests/http/tests/css/css-masking/mask-inline-svg-image.html:
* LayoutTests/http/tests/css/css-masking/mask-inline-svg-mask.html:

Canonical link: <a href="https://commits.webkit.org/269280@main">https://commits.webkit.org/269280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9acf903b1e0e1785642813860c9324a809b7fdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20432 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21488 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/21974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24807 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26255 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24123 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20659 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19812 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24219 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2754 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->