### PR TITLE
Speculative fix for crash at WebCore: PAL::newTextCodec

### DIFF
--- a/Source/WebCore/PAL/pal/Logging.h
+++ b/Source/WebCore/PAL/pal/Logging.h
@@ -38,7 +38,8 @@ PAL_EXPORT void registerNotifyCallback(ASCIILiteral, Function<void()>&&);
 #endif
 
 #define PAL_LOG_CHANNELS(M) \
-    M(Media)
+    M(Media) \
+    M(TextEncoding)
 
 #undef DECLARE_LOG_CHANNEL
 #define DECLARE_LOG_CHANNEL(name) \

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -54,10 +54,15 @@ void TextCodecUTF8::registerEncodingNames(EncodingNameRegistrar registrar)
     registrar("x-unicode20utf8", "UTF-8");
 }
 
+std::unique_ptr<TextCodecUTF8> TextCodecUTF8::codec()
+{
+    return makeUnique<TextCodecUTF8>();
+}
+
 void TextCodecUTF8::registerCodecs(TextCodecRegistrar registrar)
 {
     registrar("UTF-8", [] {
-        return makeUnique<TextCodecUTF8>();
+        return codec();
     });
 }
 

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
@@ -37,6 +37,7 @@ public:
     static void registerCodecs(TextCodecRegistrar);
 
     static Vector<uint8_t> encodeUTF8(StringView);
+    static std::unique_ptr<TextCodecUTF8> codec();
 
 private:
     void stripByteOrderMark() final { m_shouldStripByteOrderMark = true; }


### PR DESCRIPTION
#### 7d0bddb8572fc3d0c0e8d76458bfd2130fb417a0
<pre>
Speculative fix for crash at WebCore: PAL::newTextCodec
<a href="https://bugs.webkit.org/show_bug.cgi?id=263084">https://bugs.webkit.org/show_bug.cgi?id=263084</a>
rdar://110454455

Reviewed by Chris Dumez.

This is a speculative fix for CrashTracer: com.apple.WebKit.WebContent at WebCore: PAL::newTextCodec.

Text encodings work with the use of 2 static maps:
- Name map, TextEncodingNameMap: maps encoding names to a canonical encoding name.
- Codec map, TextCodecMap: maps canonical encoding names to a function that creates
the desired codec. All possible canonical name has an entry in the map.

When a TextEncoding object is created, it receives a string name that
is transformed in a canonical name by atomCanonicalTextEncodingName().
A TextEncoding name can only be null, in which case it is not valid, or
a valid canonical name. Therefore, it should not be possible to create a
valid name which is not canonical.

When a canonical name is being created, we populate both Name and Codec
maps. First we try to populate them with a reduced set (buildBaseTextCodecMaps()),
if not sufficient we populate them with an extended set (extendTextCodecMaps()).

Since it is not possible to create a valid non-canonical name and that
all canonical names have an entry in the Codec maps, it should not be
possible to have no entry in the Codec map for a valid TextEncoding, i.e.
a TextEncoding with a valid name.

For that reason, the callers of newTextCodec() only assert that m_encoding,
which is a TextEncoding, isValid(). This should theoretically be enough,
but since it is crashing, it is not. The crash seems to happen because
we are trying to deref a value from the TextEncodingNameMap that is null,
that can happen if:
[1]. we hace an entry for the encoding name in the map but the value is null.
[2]. we have a valid encoding name that has no entry in the codec map.

[1] is most likely not what is happening because we would need:
1.a: Having one of the functions that populate the codec maps (registerCodecs())
registering a null value. This shouldn&apos;t be possible becuse all of these function
register lambda functions.

1.b: race-condition: This could also happen if we would get a valid entry in the map and
between this point in time and the time we access the value of such iterator,
the entry would be invalidated. That also shouldn&apos;t be possible, because
all functions that mutate/access the maps are guarded by a static lock (encodingRegistryLock).

[2] For testing this hypothesis, I&apos;ve forced WebKit to populate
the name and codec maps in the extended version, so I could verify a state
in which all possible canonical names (and its codecs) are registered.
I&apos;ve then checked that in fact there is no canonical name without an
entry in the codec map. Therefore, theoretically this should also be ruled
out.

As I haven&apos;t found a valid hypothesis for now, and also as I can&apos;t reproduce
this issue, I&apos;m trying a speculative fix, in which, we no longer just
assert that m_encoding is valid and assume that there will be a
an entry for it on the codec map. Instead, newTextCodec() will prevent a
null deref by returning a default UTF-8 codec for:
- a invalid encoding
- if there is no entry for a valid encoding in the codec map
- if there is an entry for a valid encoding in the codec map, but that
entry has a null value.

We also generate proper log that will help on further investigation.

* Source/WebCore/PAL/pal/Logging.h:
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::codec):
(PAL::TextCodecUTF8::registerCodecs):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.h:
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::newTextCodec):

Canonical link: <a href="https://commits.webkit.org/269304@main">https://commits.webkit.org/269304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c06261e1325189b45ef00a100c378ae403e2d3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22702 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24919 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20101 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24208 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17670 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20110 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5278 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->