### PR TITLE
Use CVBufferGetAttachment or IOSurfaceGetYCbCrMatrix instead of hard coding the YCbCr matrix

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -34,6 +34,18 @@
 #import "TextureView.h"
 #import <wtf/EnumeratedArray.h>
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <CoreVideo/CVPixelBufferPrivate.h>
+#else
+
+#if HAVE(COREVIDEO_COMPRESSED_PIXEL_FORMAT_TYPES)
+enum {
+    kCVPixelFormatType_AGX_420YpCbCr8BiPlanarVideoRange = '&8v0',
+    kCVPixelFormatType_AGX_420YpCbCr8BiPlanarFullRange = '&8f0',
+};
+#endif
+#endif
+
 namespace WebGPU {
 
 static bool bufferIsPresent(const WGPUBindGroupEntry& entry)
@@ -67,16 +79,114 @@ template <typename T>
 using ShaderStageArray = EnumeratedArray<ShaderStage, T, ShaderStage::Compute>;
 
 #if HAVE(COREVIDEO_METAL_SUPPORT)
+
+enum class TransferFunctionCV {
+    kITU_R_709_2,
+    kITU_R_601_4,
+    kITU_R_2020,
+};
+
+enum class PixelRange {
+    Video,
+    Full
+};
+
+static PixelRange pixelRangeFromPixelFormat(OSType pixelFormat)
+{
+    switch (pixelFormat) {
+    case kCVPixelFormatType_4444AYpCbCr8:
+    case kCVPixelFormatType_4444AYpCbCr16:
+    case kCVPixelFormatType_422YpCbCr_4A_8BiPlanar:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange:
+#if HAVE(COREVIDEO_COMPRESSED_PIXEL_FORMAT_TYPES)
+    case kCVPixelFormatType_AGX_420YpCbCr8BiPlanarVideoRange:
+#endif
+        return PixelRange::Video;
+    case kCVPixelFormatType_420YpCbCr8PlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr8FullRange:
+    case kCVPixelFormatType_ARGB2101010LEPacked:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_422YpCbCr10BiPlanarFullRange:
+    case kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+#if HAVE(COREVIDEO_COMPRESSED_PIXEL_FORMAT_TYPES)
+    case kCVPixelFormatType_AGX_420YpCbCr8BiPlanarFullRange:
+#endif
+        return PixelRange::Full;
+    default:
+        return PixelRange::Video;
+    }
+}
+
+static TransferFunctionCV transferFunctionFromString(RetainPtr<CFStringRef> string)
+{
+    CFStringRef cfString = string.get();
+    if (!string || CFEqual(cfString, kCVImageBufferYCbCrMatrix_ITU_R_709_2))
+        return TransferFunctionCV::kITU_R_709_2;
+    if (CFEqual(cfString, kCVImageBufferYCbCrMatrix_ITU_R_601_4))
+        return TransferFunctionCV::kITU_R_601_4;
+    if (CFEqual(cfString, kCVImageBufferYCbCrMatrix_ITU_R_2020))
+        return TransferFunctionCV::kITU_R_2020;
+
+    ASSERT_NOT_REACHED("Unexpected transfer function format");
+    return TransferFunctionCV::kITU_R_709_2;
+}
+
 static simd::float4x3 colorSpaceConversionMatrixForPixelBuffer(CVPixelBufferRef pixelBuffer)
 {
     auto format = CVPixelBufferGetPixelFormatType(pixelBuffer);
-    UNUSED_PARAM(format);
+    auto range = pixelRangeFromPixelFormat(format);
+    auto transferFunction = transferFunctionFromString(adoptCF((CFStringRef)CVBufferCopyAttachment(pixelBuffer, kCVImageBufferYCbCrMatrixKey, nil)));
 
-    // FIXME: Implement other formats after https://bugs.webkit.org/show_bug.cgi?id=256724 is implemented
-    return simd::float4x3(simd::make_float3(+1.16895f, +1.16895f, +1.16895f),
-        simd::make_float3(-0.00012f, -0.21399f, +2.12073f),
-        simd::make_float3(+1.79968f, -0.53503f, +0.00012f),
-        simd::make_float3(-0.97284f, 0.30145f, -1.13348f));
+    switch (transferFunction) {
+    case TransferFunctionCV::kITU_R_709_2: {
+        switch (range) {
+        case PixelRange::Full:
+            return simd::float4x3(simd::make_float3(+1.00000f, +1.00000f, +1.00000f),
+                simd::make_float3(-0.00012f, -0.18726f, +1.85559f),
+                simd::make_float3(+1.57471f, -0.46814f, +0.00012f),
+                simd::make_float3(-0.78729f, +0.32770f, -0.92786f));
+        case PixelRange::Video:
+            return simd::float4x3(simd::make_float3(+1.16895f, +1.16895f, +1.16895f),
+                simd::make_float3(-0.00012f, -0.21399f, +2.12073f),
+                simd::make_float3(+1.79968f, -0.53503f, +0.00012f),
+                simd::make_float3(-0.97284f, +0.30145f, -1.13348f));
+        }
+    }
+
+    case TransferFunctionCV::kITU_R_601_4: {
+        switch (range) {
+        case PixelRange::Full:
+            return simd::float4x3(simd::make_float3(+1.00000f, +1.00000f, +1.00000f),
+                simd::make_float3(-0.00100f, -0.34375f, +1.77221f),
+                simd::make_float3(+1.40173f, -0.71411f, +0.00100f),
+                simd::make_float3(-0.70038f, +0.51672f, -0.88660f));
+
+        case PixelRange::Video:
+            return simd::float4x3(simd::make_float3(+1.16895f, +1.16895f, +1.16895f),
+                simd::make_float3(-0.00110f, -0.39282f, +2.02527f),
+                simd::make_float3(+1.60193f, -0.81616f, +0.00110f),
+                simd::make_float3(-0.87347f, +0.53143f, -1.08624f));
+        }
+    }
+
+    case TransferFunctionCV::kITU_R_2020: {
+        switch (range) {
+        case PixelRange::Full:
+            return simd::float4x3(simd::make_float3(+1.00000f, +1.00000f, +1.00000f),
+                simd::make_float3(+0.00000f, -0.16455f, +1.88135f),
+                simd::make_float3(+1.47461f, -0.57129f, -0.00012f),
+                simd::make_float3(-0.73730f, +0.36792f, -0.94061f));
+        case PixelRange::Video:
+            return simd::float4x3(simd::make_float3(+1.16895f, +1.16895f, +1.16895f),
+                simd::make_float3(+0.00000f, -0.18799f, +2.15015f),
+                simd::make_float3(+1.68530f, -0.65295f, +0.00012f),
+                simd::make_float3(-0.91571f, +0.34741f, -1.14807f));
+        }
+    } }
 }
 
 static MTLPixelFormat metalPixelFormat(CVPixelBufferRef pixelBuffer, size_t plane)


### PR DESCRIPTION
#### de69fde68bd5ee275c25c52a160b3fc803366368
<pre>
Use CVBufferGetAttachment or IOSurfaceGetYCbCrMatrix instead of hard coding the YCbCr matrix
<a href="https://bugs.webkit.org/show_bug.cgi?id=258938">https://bugs.webkit.org/show_bug.cgi?id=258938</a>
&lt;radar://111858329&gt;

Reviewed by Dan Glastonbury.

Support other video and full formats than 709 video.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::pixelRangeFromPixelFormat):
(WebGPU::transferFunctionFromString):
(WebGPU::colorSpaceConversionMatrixForPixelBuffer):

Canonical link: <a href="https://commits.webkit.org/269470@main">https://commits.webkit.org/269470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e36d891f10817961f0d8bb83384748b71d33810

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/23996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20461 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21502 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24846 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19102 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26287 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24145 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17614 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20041 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5395 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24249 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->