### PR TITLE
[PGO] Warn when PGO data appears to be an LFS stub

### DIFF
--- a/Source/JavaScriptCore/Scripts/copy-profiling-data.sh
+++ b/Source/JavaScriptCore/Scripts/copy-profiling-data.sh
@@ -1,14 +1,21 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # Decompresses and copies PGO profiles from WebKitAdditions to a derived folder.
 
 if [ "${CLANG_USE_OPTIMIZATION_PROFILE}" = YES ]; then
-    compression_tool -v -decode -i "${SCRIPT_INPUT_FILE_0}" -o "${SCRIPT_OUTPUT_FILE_0}" && exit
-    if [ "${CONFIGURATION}" = Production ]; then
-        echo "error: ${SCRIPT_INPUT_FILE_0} failed to extract"
-        exit 1
+    eval $(stat -s "${SCRIPT_INPUT_FILE_0}")
+    if [ ${st_size} -lt 1024 ]; then
+        if [ "${CONFIGURATION}" = Production ]; then
+            echo "error: ${SCRIPT_INPUT_FILE_0} is <1KB, is it a Git LFS stub?"\
+                "Ensure this file was checked out on a machine with git-lfs installed."
+            exit 1
+        else
+            echo "warning: ${SCRIPT_INPUT_FILE_0} is <1KB, is it a Git LFS stub?"\
+                "To build with production optimizations, ensure this file was checked out on a machine with git-lfs installed."\
+                "Falling back to stub profile data."
+            cp -vf "${SCRIPT_INPUT_FILE_1}" "${SCRIPT_OUTPUT_FILE_0}"
+        fi
     else
-        echo "warning: ${SCRIPT_INPUT_FILE_0} failed to extract, falling back to stub profile data"
-        cp -vf "${SCRIPT_INPUT_FILE_1}" "${SCRIPT_OUTPUT_FILE_0}"
+        compression_tool -v -decode -i "${SCRIPT_INPUT_FILE_0}" -o "${SCRIPT_OUTPUT_FILE_0}"
     fi
 fi


### PR DESCRIPTION
#### bcd2edf42d7fc9b709017808388bbb0424234880
<pre>
[PGO] Warn when PGO data appears to be an LFS stub
<a href="https://bugs.webkit.org/show_bug.cgi?id=263087">https://bugs.webkit.org/show_bug.cgi?id=263087</a>
rdar://113034512

Reviewed by Alexey Proskuryakov.

Check input PGO data&apos;s size; if it&apos;s &lt; 1KB, assume it&apos;s invalid, and
likely an LFS stub indicating that the checkout is not set up to
download LFS objects. Print an diagnostic message accordingly.

Previously, we allowed decompression to fail in Debug/Release builds, so
that engineers who don&apos;t have LFS set up can build. Now that we check
for this case explicitly, require compression_tool to succeed.

* Source/JavaScriptCore/Scripts/copy-profiling-data.sh:

Canonical link: <a href="https://commits.webkit.org/269282@main">https://commits.webkit.org/269282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d5556b3354bdbdf574c66dab506913b10339474

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20469 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22637 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22021 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24854 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19107 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26294 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19221 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20124 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24153 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21482 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20695 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25527 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20049 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6017 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5265 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24257 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26803 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20643 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5849 "Passed tests") | 
<!--EWS-Status-Bubble-End-->