### PR TITLE
Generate serialization for WebCore::Color

### DIFF
--- a/Source/WebCore/platform/graphics/Color.cpp
+++ b/Source/WebCore/platform/graphics/Color.cpp
@@ -49,6 +49,56 @@ Color::Color(Color&& other)
     *this = WTFMove(other);
 }
 
+Color::Color(std::optional<Color::ColorDataForIPC>&& colorData)
+{
+    if (colorData) {
+        OptionSet<FlagsIncludingPrivate> flags;
+        if (colorData->isSemantic)
+            flags.add(FlagsIncludingPrivate::Semantic);
+        if (colorData->usesFunctionSerialization)
+            flags.add(FlagsIncludingPrivate::UseColorFunctionSerialization);
+
+        WTF::switchOn(colorData->data,
+            [&] (const PackedColor::RGBA& d) { setColor(asSRGBA(d), flags); },
+            [&] (const ColorDataForIPC::OutOfLineColorData& d) {
+                setOutOfLineComponents(OutOfLineComponents::create({ d.c1, d.c2, d.c3, d.alpha }), d.colorSpace, flags);
+            }
+        );
+    }
+}
+
+std::optional<Color::ColorDataForIPC> Color::data() const
+{
+    if (!isValid())
+        return std::nullopt;
+
+    if (isOutOfLine()) {
+        auto& outOfLineComponents = asOutOfLine();
+        auto [c1, c2, c3, alpha] = outOfLineComponents.unresolvedComponents();
+
+        Color::ColorDataForIPC::OutOfLineColorData oolcd = {
+            .colorSpace = colorSpace(),
+            .c1 = c1,
+            .c2 = c2,
+            .c3 = c3,
+            .alpha = alpha
+        };
+
+        return { {
+            .isSemantic = flags().contains(FlagsIncludingPrivate::Semantic),
+            .usesFunctionSerialization = flags().contains(FlagsIncludingPrivate::UseColorFunctionSerialization),
+            .data = oolcd
+        } };
+
+    } else {
+        return { {
+            .isSemantic = flags().contains(FlagsIncludingPrivate::Semantic),
+            .usesFunctionSerialization = flags().contains(FlagsIncludingPrivate::UseColorFunctionSerialization),
+            .data = asPackedInline()
+        } };
+    };
+};
+
 Color& Color::operator=(const Color& other)
 {
     if (*this == other)

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -61,11 +61,25 @@ public:
         UseColorFunctionSerialization   = 1 << 1,
     };
 
+    struct ColorDataForIPC {
+        struct OutOfLineColorData {
+            ColorSpace colorSpace;
+            float c1;
+            float c2;
+            float c3;
+            float alpha;
+        };
+        bool isSemantic;
+        bool usesFunctionSerialization;
+        std::variant<PackedColor::RGBA, OutOfLineColorData> data;
+    };
+
     Color() = default;
 
     Color(SRGBA<uint8_t>, OptionSet<Flags> = { });
     Color(std::optional<SRGBA<uint8_t>>, OptionSet<Flags> = { });
-    
+    WEBCORE_EXPORT Color(std::optional<ColorDataForIPC>&&);
+
     template<typename ColorType, typename std::enable_if_t<IsColorTypeWithComponentType<ColorType, float>>* = nullptr>
     Color(const ColorType&, OptionSet<Flags> = { });
     
@@ -89,6 +103,7 @@ public:
     bool usesColorFunctionSerialization() const;
 
     ColorSpace colorSpace() const;
+    WEBCORE_EXPORT std::optional<ColorDataForIPC> data() const;
 
     bool isOpaque() const { return isOutOfLine() ? asOutOfLine().resolvedAlpha() == 1.0 : asInline().resolved().alpha == 255; }
     bool isVisible() const { return isOutOfLine() ? asOutOfLine().resolvedAlpha() > 0.0 : asInline().resolved().alpha > 0; }
@@ -162,9 +177,6 @@ public:
     friend bool equalIgnoringSemanticColor(const Color& a, const Color& b);
     friend bool outOfLineComponentsEqual(const Color&, const Color&);
     friend bool outOfLineComponentsEqualIgnoringSemanticColor(const Color&, const Color&);
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<Color> decode(Decoder&);
 
     // Returns the underlying color converted to pre-resolved 8-bit sRGBA, useful for debugging purposes.
     struct DebugRGBA {
@@ -537,89 +549,6 @@ inline void Color::setOutOfLineComponents(Ref<OutOfLineComponents>&& color, Colo
     flags.add({ FlagsIncludingPrivate::Valid, FlagsIncludingPrivate::OutOfLine });
     m_colorAndFlags = encodedOutOfLineComponents(WTFMove(color)) | encodedColorSpace(colorSpace) | encodedFlags(flags);
     ASSERT(isOutOfLine());
-}
-
-template<class Encoder> void Color::encode(Encoder& encoder) const
-{
-    if (!isValid()) {
-        encoder << false;
-        return;
-    }
-    encoder << true;
-
-    encoder << flags().contains(FlagsIncludingPrivate::Semantic);
-    encoder << flags().contains(FlagsIncludingPrivate::UseColorFunctionSerialization);
-    
-    if (isOutOfLine()) {
-        encoder << true;
-        encoder << colorSpace();
-
-        auto& outOfLineComponents = asOutOfLine();
-        auto [c1, c2, c3, alpha] = outOfLineComponents.unresolvedComponents();
-        encoder << c1;
-        encoder << c2;
-        encoder << c3;
-        encoder << alpha;
-        return;
-    }
-    encoder << false;
-
-    encoder << asPackedInline().value;
-}
-
-template<class Decoder> std::optional<Color> Color::decode(Decoder& decoder)
-{
-    bool isValid;
-    if (!decoder.decode(isValid))
-        return std::nullopt;
-
-    if (!isValid)
-        return Color { };
-
-    OptionSet<Flags> flags;
-
-    bool isSemantic;
-    if (!decoder.decode(isSemantic))
-        return std::nullopt;
-
-    if (isSemantic)
-        flags.add(Flags::Semantic);
-
-    bool usesColorFunctionSerialization;
-    if (!decoder.decode(usesColorFunctionSerialization))
-        return std::nullopt;
-
-    if (usesColorFunctionSerialization)
-        flags.add(Flags::UseColorFunctionSerialization);
-
-    bool isOutOfLine;
-    if (!decoder.decode(isOutOfLine))
-        return std::nullopt;
-
-    if (isOutOfLine) {
-        ColorSpace colorSpace;
-        if (!decoder.decode(colorSpace))
-            return std::nullopt;
-        float c1;
-        if (!decoder.decode(c1))
-            return std::nullopt;
-        float c2;
-        if (!decoder.decode(c2))
-            return std::nullopt;
-        float c3;
-        if (!decoder.decode(c3))
-            return std::nullopt;
-        float alpha;
-        if (!decoder.decode(alpha))
-            return std::nullopt;
-        return Color { OutOfLineComponents::create({ c1, c2, c3, alpha }), colorSpace, flags };
-    }
-
-    uint32_t value;
-    if (!decoder.decode(value))
-        return std::nullopt;
-
-    return Color { asSRGBA(PackedColor::RGBA { value }), flags };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ColorSpace.h
+++ b/Source/WebCore/platform/graphics/ColorSpace.h
@@ -135,33 +135,3 @@ template<typename T, typename Functor> constexpr decltype(auto) callWithColorTyp
 
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::ColorSpace> {
-    using values = EnumValues<
-        WebCore::ColorSpace,
-        WebCore::ColorSpace::A98RGB,
-        WebCore::ColorSpace::DisplayP3,
-        WebCore::ColorSpace::ExtendedA98RGB,
-        WebCore::ColorSpace::ExtendedDisplayP3,
-        WebCore::ColorSpace::ExtendedLinearSRGB,
-        WebCore::ColorSpace::ExtendedProPhotoRGB,
-        WebCore::ColorSpace::ExtendedRec2020,
-        WebCore::ColorSpace::ExtendedSRGB,
-        WebCore::ColorSpace::HSL,
-        WebCore::ColorSpace::HWB,
-        WebCore::ColorSpace::LCH,
-        WebCore::ColorSpace::Lab,
-        WebCore::ColorSpace::LinearSRGB,
-        WebCore::ColorSpace::OKLCH,
-        WebCore::ColorSpace::OKLab,
-        WebCore::ColorSpace::ProPhotoRGB,
-        WebCore::ColorSpace::Rec2020,
-        WebCore::ColorSpace::SRGB,
-        WebCore::ColorSpace::XYZ_D50,
-        WebCore::ColorSpace::XYZ_D65
-    >;
-};
-
-}

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2028,6 +2028,53 @@ class WebCore::BlobPart {
     std::variant<Vector<uint8_t>, URL> m_dataOrURL;
 };
 
+enum class WebCore::ColorSpace : uint8_t {
+    A98RGB,
+    DisplayP3,
+    ExtendedA98RGB,
+    ExtendedDisplayP3,
+    ExtendedLinearSRGB,
+    ExtendedProPhotoRGB,
+    ExtendedRec2020,
+    ExtendedSRGB,
+    HSL,
+    HWB,
+    LCH,
+    Lab,
+    LinearSRGB,
+    OKLCH,
+    OKLab,
+    ProPhotoRGB,
+    Rec2020,
+    SRGB,
+    XYZ_D50,
+    XYZ_D65,
+}
+
+header: <WebCore/ColorTypes.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::PackedColor::RGBA {
+    uint32_t value;
+}
+
+header: <WebCore/Color.h>
+[Nested, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Color::ColorDataForIPC::OutOfLineColorData {
+    WebCore::ColorSpace colorSpace;
+    float c1;
+    float c2;
+    float c3;
+    float alpha;
+}
+
+[Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Color::ColorDataForIPC {
+    bool isSemantic;
+    bool usesFunctionSerialization;
+    std::variant<WebCore::PackedColor::RGBA, WebCore::Color::ColorDataForIPC::OutOfLineColorData> data;
+}
+
+[AdditionalEncoder=StreamConnectionEncoder] class WebCore::Color {
+    std::optional<WebCore::Color::ColorDataForIPC> data();
+}
+
 struct WebCore::MediaCapabilitiesInfo {
     bool supported;
     bool smooth;


### PR DESCRIPTION
#### 71513d364e3d4cb1f32a6f8fcf8b387ce57e8ac2
<pre>
Generate serialization for WebCore::Color
<a href="https://bugs.webkit.org/show_bug.cgi?id=263089">https://bugs.webkit.org/show_bug.cgi?id=263089</a>
rdar://116882741

Reviewed by Ryosuke Niwa and Alex Christensen.

* Source/WebCore/platform/graphics/Color.cpp:
(WebCore::Color::Color):
(WebCore::Color::data const):
* Source/WebCore/platform/graphics/Color.h:
(WebCore::Color::encode const): Deleted.
(WebCore::Color::decode): Deleted.
* Source/WebCore/platform/graphics/ColorSpace.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/269336@main">https://commits.webkit.org/269336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe166e320fbec01be3dae009b69ee933fa90ca2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21600 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24999 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26404 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24268 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17714 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24387 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2782 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->