### PR TITLE
Add canvas noise injection test

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5451,6 +5451,9 @@ webkit.org/b/255287 fast/block/lineboxcontain/inline-box-vertical.html [ Failure
 # This is marked as passing on WK2.
 fast/canvas/large-getImageData.html [ Skip ]
 
+# This should fail, but it flakey-passes, so skipping now.
+fast/canvas/canvas-noise-injection.html [ Skip ]
+
 webkit.org/b/237108 http/tests/websocket/tests/hybi/extensions.html [ Failure ]
 webkit.org/b/237108 http/tests/websocket/tests/hybi/deflate-frame-parameter.html [ Failure ] # <rdar://33630526>
 webkit.org/b/237108 http/tests/websocket/tests/hybi/handshake-ok-with-legacy-sec-websocket-response-headers.html [ Pass Failure ]

--- a/LayoutTests/fast/canvas/canvas-noise-injection-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-noise-injection-expected.txt
@@ -1,0 +1,37 @@
+Test that noise injection is controlled by the salt, and that noise is not applied for bitmaps.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Initial canvas should not have pending dirty rects
+PASS drawImage should not require noise injection
+PASS Initial canvas should not have pending dirty rects
+PASS putImageData should not require noise injection
+PASS fillText should not require noise injection when noise injection is not enabled
+PASS getImageData should not apply noise when noise injection is not enabled
+PASS putImageData should not require noise injection
+PASS fillRect should not require noise injection when noise injection is not enabled
+PASS fillText should not require noise injection when noise injection is not enabled
+PASS getImageData should not apply noise when noise injection is not enabled
+PASS putImageData should not require noise injection
+PASS fillRect should not require noise injection when noise injection is not enabled
+Enabling canvas noise injection
+PASS Initial canvas should not have pending dirty rects
+FAIL drawImage should not require noise injection
+PASS Initial canvas should not have pending dirty rects
+PASS putImageData should not require noise injection
+FAIL data: url after putImageData should be equal
+PASS fillText should require noise injection
+PASS getImageData should apply all required noise
+PASS putImageData should not require noise injection
+PASS fillRect should require noise injection
+PASS data: url after fillRect should not be equal
+PASS fillText should require noise injection
+PASS getImageData should apply all required noise
+PASS putImageData should not require noise injection
+PASS fillRect should require noise injection
+PASS data: url after fillRect should not be equal
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/canvas-noise-injection.html
+++ b/LayoutTests/fast/canvas/canvas-noise-injection.html
@@ -1,0 +1,144 @@
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<img src="resources/background.png" id="img">
+<script>
+    let dataURLComparisonArray = [];
+
+    description("Test that noise injection is controlled by the salt, and that noise is not applied for bitmaps.");
+    function hasPendingCanvasNoiseInjection(canvas) {
+        return internals.doesCanvasHavePendingCanvasNoiseInjection(canvas);
+    }
+
+    function setCanvasNoiseInjection(canvas) {
+        const salt = 5;
+        internals.setCanvasNoiseInjectionSalt(canvas, salt);
+    }
+
+    function expectFalse(result, msg) {
+        expectTrue(!result, msg);
+    }
+
+    function setOrCompareDataUrl(index, url, shouldExpectTrue, msg) {
+        if (dataURLComparisonArray[index] === undefined)
+            dataURLComparisonArray[index] = url;
+        else if (shouldExpectTrue)
+            expectTrue(dataURLComparisonArray[index] === url, msg);
+        else
+            expectFalse(dataURLComparisonArray[index] === url, msg);
+    }
+
+    function runTest(noiseInjectionEnabled) {
+        let dataURLComparisonIndex = 0;
+        let dataURLMsg;
+        let img = document.getElementById("img");
+        let canvas = document.createElement("canvas");
+        if (noiseInjectionEnabled)
+            setCanvasNoiseInjection(canvas);
+
+        document.body.appendChild(canvas);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "Initial canvas should not have pending dirty rects");
+        let ctx = canvas.getContext("2d");
+        ctx.drawImage(img, 0, 0);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage should not require noise injection");
+        let imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+
+        document.body.removeChild(canvas);
+
+        canvas = document.createElement("canvas");
+        document.body.appendChild(canvas);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "Initial canvas should not have pending dirty rects");
+        ctx = canvas.getContext("2d");
+        ctx.putImageData(imageData, 0, 0);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "putImageData should not require noise injection");
+        setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), true, "data: url after putImageData should be equal");
+
+        document.body.removeChild(canvas);
+
+        canvas = document.createElement("canvas");
+        if (noiseInjectionEnabled)
+            setCanvasNoiseInjection(canvas);
+
+        document.body.appendChild(canvas);
+        ctx = canvas.getContext("2d");
+        ctx.setFillColor("blue", .9);
+        ctx.fillText("This is text", 10, 10);
+        if (noiseInjectionEnabled)
+            expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillText should require noise injection");
+        else
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "fillText should not require noise injection when noise injection is not enabled");
+
+        imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        if (noiseInjectionEnabled)
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "getImageData should apply all required noise");
+        else
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "getImageData should not apply noise when noise injection is not enabled");
+        ctx.putImageData(imageData, 0, 0);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "putImageData should not require noise injection");
+
+        ctx.fillRect(50, 50, 100, 100);
+        if (noiseInjectionEnabled) {
+            expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillRect should require noise injection");
+            //shouldBeEqualToString(canvas.toDataURL(), modifiedImageCanvasWithNoiseDataURL);
+            dataURLMsg = "data: url after fillRect should not be equal";
+        } else {
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "fillRect should not require noise injection when noise injection is not enabled");
+            //shouldBeEqualToString(canvas.toDataURL(), modifiedImageCanvasDataURL);
+            dataURLMsg = "data: url after fillRect should be equal";
+        }
+        setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), !noiseInjectionEnabled, dataURLMsg);
+
+        document.body.removeChild(canvas);
+
+        canvas = document.createElement("canvas");
+        if (noiseInjectionEnabled)
+            setCanvasNoiseInjection(canvas);
+
+        document.body.appendChild(canvas);
+        ctx = canvas.getContext("2d");
+        ctx.setFillColor("blue", .9);
+        ctx.fillText("This is text", 10, 10);
+        if (noiseInjectionEnabled)
+            expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillText should require noise injection");
+        else
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "fillText should not require noise injection when noise injection is not enabled");
+
+        imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        if (noiseInjectionEnabled)
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "getImageData should apply all required noise");
+        else
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "getImageData should not apply noise when noise injection is not enabled");
+        ctx.putImageData(imageData, 0, 0);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "putImageData should not require noise injection");
+
+        ctx.fillRect(50, 50, 100, 100);
+        if (noiseInjectionEnabled) {
+            expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillRect should require noise injection");
+            //shouldBeEqualToString(canvas.toDataURL(), fillRectCanvasWithNoiseDataURL);
+            dataURLMsg = "data: url after fillRect should not be equal";
+        } else {
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "fillRect should not require noise injection when noise injection is not enabled");
+            //shouldBeEqualToString(canvas.toDataURL(), fillRectCanvasDataURL);
+            dataURLMsg = "data: url after fillRect should be equal";
+        }
+        setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), !noiseInjectionEnabled, dataURLMsg);
+
+        document.body.removeChild(canvas);
+    }
+
+    if (window.internals) {
+        let noiseInjectionEnabled = false;
+        runTest(noiseInjectionEnabled);
+
+        debug("Enabling canvas noise injection");
+        noiseInjectionEnabled = true;
+        runTest(noiseInjectionEnabled);
+    } else
+        document.body.innerHTML = "window.internals is required for this test";
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -133,6 +133,9 @@ public:
 
     void resetGraphicsContextState() const;
 
+    void setNoiseInjectionSalt(NoiseInjectionHashSalt salt) { m_canvasNoiseHashSalt = salt; }
+    bool havePendingCanvasNoiseInjection() const { return m_canvasNoiseInjection.haveDirtyRects(); }
+
 protected:
     explicit CanvasBase(IntSize, const std::optional<NoiseInjectionHashSalt>&);
 

--- a/Source/WebCore/html/CanvasNoiseInjection.h
+++ b/Source/WebCore/html/CanvasNoiseInjection.h
@@ -40,6 +40,7 @@ public:
     void postProcessDirtyCanvasBuffer(ImageBuffer*, NoiseInjectionHashSalt);
     bool postProcessPixelBufferResults(PixelBuffer&, NoiseInjectionHashSalt) const;
     void updateDirtyRect(const IntRect&);
+    bool haveDirtyRects() const { return !m_postProcessDirtyRect.isEmpty(); }
 
 private:
     IntRect m_postProcessDirtyRect;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3794,6 +3794,16 @@ void Internals::setMockVideoPresentationModeEnabled(bool enabled)
 }
 #endif
 
+void Internals::setCanvasNoiseInjectionSalt(HTMLCanvasElement& element, unsigned long long salt)
+{
+    return element.setNoiseInjectionSalt(salt);
+}
+
+bool Internals::doesCanvasHavePendingCanvasNoiseInjection(HTMLCanvasElement& element) const
+{
+    return element.havePendingCanvasNoiseInjection();
+}
+
 void Internals::setApplicationCacheOriginQuota(unsigned long long quota)
 {
     Document* document = contextDocument();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -617,6 +617,9 @@ public:
     void setMockVideoPresentationModeEnabled(bool);
 #endif
 
+    void setCanvasNoiseInjectionSalt(HTMLCanvasElement&, unsigned long long salt);
+    bool doesCanvasHavePendingCanvasNoiseInjection(HTMLCanvasElement&) const;
+
     WEBCORE_TESTSUPPORT_EXPORT void setApplicationCacheOriginQuota(unsigned long long);
 
     void registerURLSchemeAsBypassingContentSecurityPolicy(const String& scheme);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -739,6 +739,9 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined startTrackingLayerFlushes();
     unsigned long layerFlushCount();
 
+    undefined setCanvasNoiseInjectionSalt(HTMLCanvasElement element, unsigned long long salt);
+    boolean doesCanvasHavePendingCanvasNoiseInjection(HTMLCanvasElement element);
+
     // Query if a timer is currently throttled, to debug timer throttling.
     boolean isTimerThrottled(long timerHandle);
 


### PR DESCRIPTION
#### 38294bd0b5d959b1c43be0caee0460d5cd3721a5
<pre>
Add canvas noise injection test
<a href="https://bugs.webkit.org/show_bug.cgi?id=263094">https://bugs.webkit.org/show_bug.cgi?id=263094</a>
rdar://116886810

Reviewed by Simon Fraser.

Noise injection should only be applied when the feature is enabled (i.e., when
a salt value is set), and it should not be applied when the canvas only
contains bitmap data (e.g., drawImage, putImageData).

This test fail the latter expectation, and that will be fixed in a follow-up
patch.

This patch exposes some internal state via Internals.

* LayoutTests/TestExpectations:
* LayoutTests/fast/canvas/canvas-noise-injection-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-noise-injection.html: Added.
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::setNoiseInjectionSalt):
(WebCore::CanvasBase::havePendingCanvasNoiseInjection const):
* Source/WebCore/html/CanvasNoiseInjection.h:
(WebCore::CanvasNoiseInjection::haveDirtyRects const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setCanvasNoiseInjectionSalt):
(WebCore::Internals::doesCanvasHavePendingCanvasNoiseInjection const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/269541@main">https://commits.webkit.org/269541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8267367157d9aa2095736661bab2334d892ae04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21944 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25451 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26795 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18094 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20364 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5450 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->