### PR TITLE
Add a ProcessAssertion cache

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -168,6 +168,9 @@ private:
     void numberOfPagesAllowedToRunInTheBackgroundChanged();
     void clearAssertion();
 
+    class ProcessAssertionCache;
+
+    UniqueRef<ProcessAssertionCache> m_assertionCache;
     ProcessThrottlerClient& m_process;
     ProcessID m_processID { 0 };
     RefPtr<ProcessAssertion> m_assertion;
@@ -181,7 +184,7 @@ private:
     ProcessThrottleState m_state { ProcessThrottleState::Suspended };
     PageAllowedToRunInTheBackgroundCounter m_pageAllowedToRunInTheBackgroundCounter;
     bool m_shouldDropNearSuspendedAssertionAfterDelay { false };
-    bool m_shouldTakeUIBackgroundAssertion { false };
+    const bool m_shouldTakeUIBackgroundAssertion { false };
     bool m_shouldTakeNearSuspendedAssertion { true };
     bool m_allowsActivities { true };
 };


### PR DESCRIPTION
#### f6fade6a9e367bcee8abcd66172b043ac89c915d
<pre>
Add a ProcessAssertion cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=263096">https://bugs.webkit.org/show_bug.cgi?id=263096</a>
rdar://113579564

Reviewed by Brent Fulgham.

Add a ProcessAssertion cache to avoid hammering RunningBoard when switching
quickly from one assertion type to another (e.g. background &lt;-&gt; foreground).
Taking RunningBoard assertions is expensive and this churn can result in high
CPU usage.

We have evidence this can happen for example when we&apos;re holding a background
assertion on the WebProcess but the client app keeps running JS in the view,
causing us to take a foreground assertion for each JS execution request.

We now keep previous assertions around for 3 seconds when switching from one
assertion type to another and we reuse them when possible.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::ProcessAssertionCache::add):
(WebKit::ProcessThrottler::ProcessAssertionCache::tryTake):
(WebKit::ProcessThrottler::ProcessAssertionCache::remove):
(WebKit::ProcessThrottler::ProcessAssertionCache::CachedAssertion::CachedAssertion):
(WebKit::ProcessThrottler::ProcessAssertionCache::CachedAssertion::isValid const):
(WebKit::ProcessThrottler::ProcessAssertionCache::CachedAssertion::release):
(WebKit::ProcessThrottler::ProcessAssertionCache::CachedAssertion::entryExpired):
(WebKit::ProcessThrottler::ProcessThrottler):
(WebKit::ProcessThrottler::setThrottleState):
* Source/WebKit/UIProcess/ProcessThrottler.h:

Canonical link: <a href="https://commits.webkit.org/269319@main">https://commits.webkit.org/269319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fd6dfe300ad21a09c2f62dc559110f34e973927

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20566 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22742 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24963 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19221 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26383 "Failed to checkout and rebase branch from PR 19027") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24246 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20795 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20147 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5289 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->