### PR TITLE
[ iOS ] 2X css3/filters/ (layout-tests) are constant ImageOnlyFailures

### DIFF
--- a/LayoutTests/css3/filters/effect-blur-expected.html
+++ b/LayoutTests/css3/filters/effect-blur-expected.html
@@ -2,18 +2,25 @@
 <html>
 <head>
     <link rel="stylesheet" href="resources/filter-helpers.css">
-    <script src="resources/filter-helpers.js"></script>
 </head>
 <body>
-    <script>
-        const filters = [
-            'blur(0px)',
-            'blur(2px)',
-            'blur(3px)',
-            'blur(10px)',
-        ];
-
-        buildSVGFilteredBoxes(filters);
-    </script>
+    <img src="resources/reference.png" style="filter: url('#filter-1');">
+    <img src="resources/reference.png" style="filter: url('#filter-2');">
+    <img src="resources/reference.png" style="filter: url('#filter-3');">
+    <img src="resources/reference.png" style="filter: url('#filter-4');">
+    <svg>
+        <filter id="filter-1">
+            <feGaussianBlur stdDeviation="0"/>
+        </filter>
+        <filter id="filter-2">
+            <feGaussianBlur stdDeviation="2"/>
+        </filter>
+        <filter id="filter-3">
+            <feGaussianBlur stdDeviation="3"/>
+        </filter>
+        <filter id="filter-4" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur stdDeviation="10"/>
+        </filter>
+    </svg>
 </body>
 </html>

--- a/LayoutTests/css3/filters/effect-blur.html
+++ b/LayoutTests/css3/filters/effect-blur.html
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-15059">
+    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-5000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
-    <script src="resources/filter-helpers.js"></script>
     <script>
     if (window.internals) {
         // Force software rendering mode.
@@ -12,15 +11,9 @@
     </script>
 </head>
 <body>
-    <script>
-        const filters = [
-            'blur(0)',
-            'blur(2px)',
-            'blur(3px)',
-            'blur(10px)',
-        ];
-
-        buildCSSFilteredBoxes(filters);
-    </script>
+    <img src="resources/reference.png" style="filter: blur(0)">
+    <img src="resources/reference.png" style="filter: blur(2px)">
+    <img src="resources/reference.png" style="filter: blur(3px)">
+    <img src="resources/reference.png" style="filter: blur(10px)"> 
 </body>
 </html>

--- a/LayoutTests/css3/filters/effect-invert.html
+++ b/LayoutTests/css3/filters/effect-invert.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-8900" />
+    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-10000" />
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4350,8 +4350,6 @@ webkit.org/b/229934 webgl/1.0.x/conformance/extensions/webgl-depth-texture.html 
 webkit.org/b/254398 webgl/2.0.y/conformance/extensions/webgl-compressed-texture-astc.html [ Failure ]
 
 # webkit.org/b/255177 Batch mark expectations for newly failing tests introduced with iOS 16.4 update
-css3/filters/effect-blur.html [ ImageOnlyFailure ]
-css3/filters/effect-invert.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-text-multi-line.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-4.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-backgrounds/background-repeat-space-5.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### ba7c6f0ab457d10c4345ae776cec68fa81ca75ec
<pre>
[ iOS ] 2X css3/filters/ (layout-tests) are constant ImageOnlyFailures
<a href="https://bugs.webkit.org/show_bug.cgi?id=255180">https://bugs.webkit.org/show_bug.cgi?id=255180</a>
rdar://107774552

Reviewed by Said Abou-Hallawa.

effect-invert.html needed a bit more pixel tolerance.

effect-blur.html needed the same fix that Said did in 269152@main: we need to
increase the filter effect region to avoid clipping, so can&apos;t use the JS
helper.

* LayoutTests/css3/filters/effect-blur-expected.html:
* LayoutTests/css3/filters/effect-blur.html:
* LayoutTests/css3/filters/effect-invert.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269305@main">https://commits.webkit.org/269305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd9c36c65ae86a4dd94c61812dfc58ec553c71e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20483 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21516 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24868 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26306 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24165 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17627 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19857 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5279 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->