### PR TITLE
[testharnessreport.js] Only pay attention to the top-level completion handler

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6163,6 +6163,7 @@ imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/004.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-global-scope.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/navigate-cross-origin-iframe-to-same-url-with-fragment-fire-load-event.html [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function-parent-then-fragment.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/unloading-documents/004.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/008.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/combination_history_004.html [ Skip ]

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/basic-upgrade-cors.https-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/basic-upgrade-cors.https-expected.txt
@@ -2,3 +2,6 @@ CONSOLE MESSAGE: PASS: Successfully retrieved image data.
 This test opens a window that loads an insecure image. We should upgrade this request and thereby avoid triggering a mixed content callback.
 
 
+
+PASS Verify that images have correct cross-origin behavior.
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/basic-upgrade-cors.https.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/basic-upgrade-cors.https.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
+<head>
+<script src="/js-test-resources/testharness.js"></script>
+<script src="/js-test-resources/testharnessreport.js"></script>
 <body>
-<script>
-if (window.testRunner) {
-    testRunner.waitUntilDone();
-    testRunner.dumpAsText();
-}
-</script>
 <p>This test opens a window that loads an insecure image.  We should upgrade
 this request and thereby avoid triggering a mixed content callback.</p>
 <iframe src="https://127.0.0.1:8443/security/contentSecurityPolicy/upgrade-insecure-requests/resources/basic-upgrade-cors.https.html"></iframe>
+<script>
+fetch_tests_from_window(window.frames[0]);
+</script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Partitioned cookies accessible on the top-level site they are created in via HTTP assert_equals: Expected __Host-pccookistore to be available on the top-level site it was created in expected true but got false
-FAIL Partitioned cookies accessible on the top-level site they are created in via DOM assert_equals: Expected __Host-pccookistore to be available on the top-level site it was created in expected true but got false
-FAIL Partitioned cookies accessible on the top-level site they are created in via CookieStore assert_equals: Expected __Host-pccookistore to be available on the top-level site it was created in expected true but got false
+FAIL Partitioned cookies accessible on the top-level site they are created in via HTTP assert_equals: Expected __Host-pccookiestore to be available on the top-level site it was created in expected true but got false
+FAIL Partitioned cookies accessible on the top-level site they are created in via DOM assert_equals: Expected __Host-pccookiestore to be available on the top-level site it was created in expected true but got false
+FAIL Partitioned cookies accessible on the top-level site they are created in via CookieStore assert_equals: Expected __Host-pccookiestore to be available on the top-level site it was created in expected true but got false
 PASS Cross-site window opened correctly
 FAIL Partitioned cookies are not accessible on a different top-level site via HTTP assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true
 FAIL Partitioned cookies are not accessible on a different top-level site via DOM assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function-parent-then-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function-parent-then-fragment-expected.txt
@@ -1,1 +1,9 @@
 
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT
+  Set location from a parent, then do a fragment navigation from within the
+  frame.
+ Test timed out
+

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -874,8 +874,6 @@ webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.an
 webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker.html [ Pass Failure ]
 webkit.org/b/253533 imported/w3c/web-platform-tests/xhr/status.h2.window.html [ Pass Failure ]
 
-webkit.org/b/259409 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Pass Failure ]
-
 webkit.org/b/259482 fast/media/managed-media-source-open-crash.html [ Pass Failure ]
 
 webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]

--- a/LayoutTests/resources/testharnessreport.js
+++ b/LayoutTests/resources/testharnessreport.js
@@ -10,6 +10,8 @@
  * parameters they are called with see testharness.js
  */
 
+(function(){
+
 // Setup for WebKit JavaScript tests
 if (self.testRunner) {
     testRunner.dumpAsText();
@@ -57,10 +59,20 @@ if (self.testRunner) {
     */
     setup({"output": false, "explicit_timeout": true});
 
+    // window.opener is a configurable property, so store it before we run anything.
+    const orig_opener = window.opener;
+
     /*  Using a callback function, test results will be added to the page in a
     *   manner that allows dumpAsText to produce readable test results
     */
     add_completion_callback(function (tests, harness_status) {
+        // Only pay attention to results at the top-level window.
+        // Ideally testharness.js would allow us to only attach a completion handler in this case:
+        // https://github.com/web-platform-tests/rfcs/pull/168
+        if (window !== window.top || (orig_opener !== null && orig_opener !== window)) {
+            return;
+        }
+
         var resultStr = "\n";
 
         // Sanitizes the given text for display in test results.
@@ -140,3 +152,5 @@ if (self.testRunner) {
         }, 0);
     });
 }
+
+})();


### PR DESCRIPTION
#### 5273909547b13c75ce88e806b773737baa363c9d
<pre>
[testharnessreport.js] Only pay attention to the top-level completion handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=259409">https://bugs.webkit.org/show_bug.cgi?id=259409</a>
rdar://problem/112683033

Reviewed by Jonathan Bedard.

Previously, we were considering the test as having to run to completion
when any testharness.js completion handler first ran (which was
sometimes that of the frame within the opened window; the nondeterminism
here just adds flakiness to the already bad behaviour).

Instead, only output anything for the top-level completion handler, as
all results should be passed up to it. Note wptrunner with the WebDriver
or Marionette executors only ever pays attention to the top-level
completion handler (as they only pay attention to the top-level frame &amp;
window), thus they don&apos;t have any flakiness like this.

Ideally testharness.js would have an API we could use for this; I&apos;ve
filed an RFC at <a href="https://github.com/web-platform-tests/rfcs/pull/168">https://github.com/web-platform-tests/rfcs/pull/168</a> for
this, but there&apos;s no reason not to do the simple fix ourselves, as at
least for now this is a strict progression. (It would stop being a
strict progression if at some point testharness.js started allowing
fetch_tests_from_window() with a window with noopener.)

It seems likely we have other tests that are marked as flaky because of
it, but alas there&apos;s no easy way to find what tests will have been fixed
by this.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/basic-upgrade-cors.https-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/basic-upgrade-cors.https.html:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function-parent-then-fragment-expected.txt:
* LayoutTests/platform/wk2/TestExpectations:
* LayoutTests/resources/testharnessreport.js:

Canonical link: <a href="https://commits.webkit.org/269483@main">https://commits.webkit.org/269483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45dd7a805c8e870165c3cde8e623d3c4755ccc75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20851 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21836 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22762 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25281 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26656 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24499 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17965 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/81 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20209 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5403 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->