### PR TITLE
REGRESSION(265561@main): [ Monterey+ x86_64 ] imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp9 is a constant failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-utils.js
@@ -37,8 +37,8 @@ function fourColorsFrame(ctx, width, height, text) {
 // later. This is an analog of the most basic bar code.
 function putBlackDots(ctx, width, height, count) {
   ctx.fillStyle = 'black';
-  const dot_size = 10;
-  const step = dot_size * 3;
+  const dot_size = 20;
+  const step = dot_size * 2;
 
   for (let i = 1; i <= count; i++) {
     let x = i * step;
@@ -55,8 +55,8 @@ function validateBlackDots(frame, count) {
   let cnv = new OffscreenCanvas(width, height);
   var ctx = cnv.getContext('2d');
   ctx.drawImage(frame, 0, 0);
-  const dot_size = 10;
-  const step = dot_size * 3;
+  const dot_size = 20;
+  const step = dot_size * 2;
 
   for (let i = 1; i <= count; i++) {
     let x = i * step + dot_size / 2;
@@ -69,7 +69,7 @@ function validateBlackDots(frame, count) {
       y = y -1;
 
     let rgba = ctx.getImageData(x, y, 2, 2).data;
-    const tolerance = 40;
+    const tolerance = 60;
     if ((rgba[0] > tolerance || rgba[1] > tolerance || rgba[2] > tolerance)
       && (rgba[4] > tolerance || rgba[5] > tolerance || rgba[6] > tolerance)
       && (rgba[8] > tolerance || rgba[9] > tolerance || rgba[10] > tolerance)

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1789,9 +1789,6 @@ webkit.org/b/259403 [ x86_64 ] fast/canvas/webgl/texImage2D-video-flipY-false.ht
 
 webkit.org/b/259464 [ Monterey+ ] fast/events/wheel/redispatched-wheel-event.html [ Pass Failure ]
 
-webkit.org/b/259497 [ x86_64 ] imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 [ Failure ]
-webkit.org/b/259496 [ x86_64 ] imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp9 [ Failure ]
-
 webkit.org/b/259183 fast/attachment/mac/wide-attachment-image-controls-basic.html [ Pass Failure ]
 
 webkit.org/b/259708 fast/mediastream/video-rotation-gpu-process-crash.html [ Pass Crash Failure Timeout ]

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -110,7 +110,8 @@ static VideoDecoder::Config createVideoDecoderConfig(const WebCodecsVideoDecoder
     return {
         description,
         config.codedWidth.value_or(0),
-        config.codedHeight.value_or(0)
+        config.codedHeight.value_or(0),
+        config.hardwareAcceleration == HardwareAcceleration::PreferSoftware
     };
 }
 

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -45,6 +45,7 @@ public:
         std::span<const uint8_t> description;
         uint64_t width { 0 };
         uint64_t height { 0 };
+        bool prefersSoftware { false };
     };
 
     struct EncodedFrame {


### PR DESCRIPTION
#### 8af9ce4f8d0ac588f11c663dd6f0516d20b17569
<pre>
REGRESSION(265561@main): [ Monterey+ x86_64 ] imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker.html?vp9 is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=259496">https://bugs.webkit.org/show_bug.cgi?id=259496</a>
rdar://112858534

Reviewed by Eric Carlson.

The size of the black dots is not always big enough to prevent the encoed black to be closer to neightbored colors.
To improve the stability of the black dot detection, we increase the size of the black dots.
We increase the tolerance from 40 to 60 to further improve stability.

Also, VP9 HW decoder does not handle well SVC in x86_64 platforms.
When web page asks for SW VP9 decoder, use SW VP9 for these platforms to allow correct use of SVC VP9.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-utils.js:
(putBlackDots):
(validateBlackDots):
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::createVideoDecoderConfig):
* Source/WebCore/platform/VideoDecoder.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::shouldUseLocalDecoder):
(WebKit::RemoteVideoCodecFactory::createDecoder):

Canonical link: <a href="https://commits.webkit.org/269569@main">https://commits.webkit.org/269569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b47f8dcac829c39db343f623638d8a4420c6b7c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23200 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2145 "Hash b47f8dca for PR 19044 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23176 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/2145 "Hash b47f8dca for PR 19044 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25703 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/2145 "Hash b47f8dca for PR 19044 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20777 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/2145 "Hash b47f8dca for PR 19044 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21039 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/471 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/384 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5478 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->