### PR TITLE
[AutoInstall] Allow wheels by default

### DIFF
--- a/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
@@ -33,36 +33,42 @@ AutoInstall.install(Package('future', Version(0, 18, 2)))
 AutoInstall.install(Package('jinja2', Version(2, 11, 3), pypi_name='Jinja2'))
 AutoInstall.install(Package('pbr', Version(5, 9, 0)))
 AutoInstall.install(Package('lz4', Version(4, 3, 2)))
-AutoInstall.install(Package('PyJWT', Version(1, 7, 1), pypi_name='PyJWT', aliases=['jwt']))
+AutoInstall.install(Package('jwt', Version(1, 7, 1), pypi_name='PyJWT'))
 AutoInstall.install(Package('pyyaml', Version(5, 3, 1), pypi_name='PyYAML'))
 
 AutoInstall.install('markupsafe')
 
 if sys.version_info >= (3, 0):
-    AutoInstall.install(Package('autobahn', Version(20, 7, 1)))
+    # autobahn has wheel=False because of https://bugs.webkit.org/show_bug.cgi?id=263392
+    AutoInstall.install(Package('autobahn', Version(20, 7, 1), wheel=False))
     AutoInstall.install(Package('automat', Version(20, 2, 0), pypi_name='Automat'))
     AutoInstall.install(Package('decorator', Version(5, 1, 1)))
-    AutoInstall.install(Package('PyHamcrest', Version(2, 0, 3)))
+    AutoInstall.install(Package('hamcrest', Version(2, 0, 3), pypi_name='PyHamcrest'))
     AutoInstall.install(Package('sqlalchemy', Version(1, 3, 20), pypi_name='SQLAlchemy'))
     AutoInstall.install(Package('sqlalchemy-migrate', Version(0, 13, 0)))
     AutoInstall.install(Package('sqlparse', Version(0, 4, 2)))
     AutoInstall.install(Package('txaio', Version(20, 4, 1)))
-    AutoInstall.install(Package('Tempita', Version(0, 5, 2)))
+    AutoInstall.install(Package('tempita', Version(0, 5, 2), pypi_name='Tempita'))
 
-    AutoInstall.install(Package('buildbot', Version(2, 10, 5)))
+    # buildbot has wheel=False because we rely on items in buildbot.test that only
+    # became public API and started being included in wheels from 3.5.0.
+    AutoInstall.install(Package('buildbot', Version(2, 10, 5), wheel=False))
     AutoInstall.install(Package('buildbot-worker', Version(2, 10, 5)))
 
     from buildbot import statistics
 else:
-    AutoInstall.install(Package('autobahn', Version(17, 8, 1)))
+    # autobahn has wheel=False because of https://bugs.webkit.org/show_bug.cgi?id=263392
+    AutoInstall.install(Package('autobahn', Version(17, 8, 1), wheel=False))
     AutoInstall.install(Package('automat', Version(0, 6, 0), pypi_name='Automat'))
     AutoInstall.install(Package('decorator', Version(3, 4, 0)))
     AutoInstall.install(Package('sqlalchemy-migrate', Version(0, 11, 0)))
     AutoInstall.install(Package('sqlparse', Version(0, 2, 3)))
     AutoInstall.install(Package('txaio', Version(2, 8, 1)))
-    AutoInstall.install(Package('Tempita', Version(0, 4, 0)))
+    AutoInstall.install(Package('tempita', Version(0, 4, 0), pypi_name='Tempita'))
 
-    AutoInstall.install(Package('buildbot', Version(1, 1, 1)))
+    # buildbot has wheel=False because we rely on items in buildbot.test that only
+    # became public API and started being included in wheels from 3.5.0.
+    AutoInstall.install(Package('buildbot', Version(1, 1, 1), wheel=False))
     AutoInstall.install(Package('buildbot-worker', Version(1, 1, 1)))
 
 sys.modules[__name__] = __import__('buildbot')

--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -33,10 +33,10 @@ if sys.version_info >= (3, 0):
 
     if sys.version_info >= (3, 11):
         AutoInstall.install(Package('twisted', Version(23, 8, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
-        AutoInstall.install(Package('pyOpenSSL', Version(23, 2, 0)))
+        AutoInstall.install(Package('OpenSSL', Version(23, 2, 0), pypi_name='pyOpenSSL'))
     else:
         AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
-        AutoInstall.install(Package('pyOpenSSL', Version(20, 0, 0)))
+        AutoInstall.install(Package('OpenSSL', Version(20, 0, 0), pypi_name='pyOpenSSL'))
 
     # There are no prebuilt binaries for arm-32 of 'bcrypt' and building it requires cargo/rust
     # Since this dep is not really needed for the current arm-32 bots we skip it instead of
@@ -52,7 +52,7 @@ else:
     AutoInstall.install(Package('incremental', Version(17, 5, 0), pypi_name='incremental'))
     AutoInstall.install(Package('twisted', Version(17, 5, 0), pypi_name='Twisted', implicit_deps=['pyparsing']))
 
-    AutoInstall.install(Package('pyOpenSSL', Version(17, 2, 0)))
+    AutoInstall.install(Package('OpenSSL', Version(17, 2, 0), pypi_name='pyOpenSSL'))
     AutoInstall.install(Package('pycparser', Version(2, 18)))
 
 sys.modules[__name__] = __import__('twisted')


### PR DESCRIPTION
#### dba0adf164394251846b0da1769c06de85097666
<pre>
[AutoInstall] Allow wheels by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=263119">https://bugs.webkit.org/show_bug.cgi?id=263119</a>

Reviewed by Jonathan Bedard.

This allows packages to be installed by wheels by default; if wheel=True
is passed then only wheels will be accepted, if wheel=False is passed
then wheels will never be accepted.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py:
(Package.__init__):
(Package.archives):
(AutoInstall):
(AutoInstall.enabled):
(AutoInstall.temporarily_disable):
* Tools/Scripts/webkitpy/autoinstalled/buildbot.py:
* Tools/Scripts/webkitpy/autoinstalled/twisted.py:

Canonical link: <a href="https://commits.webkit.org/269817@main">https://commits.webkit.org/269817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a2701e864931452c1bacf2acb5a193fa53052e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22389 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26400 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23828 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27642 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18776 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/23438 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1052 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5658 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->