### PR TITLE
Constraints on the max width/height cause blurry getDisplayMedia video on Safari 17

### DIFF
--- a/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints4-expected.txt
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints4-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Underlying change of resolution should update how the constraints are used
+

--- a/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints4.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-max-constraints4.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>getDisplayMedia track support of max constraints</title>
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+        <script src="resources/getDisplayMedia-utils.js"></script>
+    </head>
+    <body>
+        <video id=video autoplay playsinline></video>
+        <script>
+promise_test(async (test) => {
+    const stream = await callGetDisplayMedia({ video: { height: { max: 2000 }, width : { max : 3000 } } });
+    video.srcObject = stream;
+    await video.play();
+
+    const videoFrame1 = await new Promise((resolve, reject) => video.requestVideoFrameCallback(() => {
+        resolve(new VideoFrame(video));
+        setTimeout(() => reject("videoFrame1 timeout"), 5000);
+    }));
+
+    assert_equals(videoFrame1.codedWidth, 1920);
+    assert_equals(videoFrame1.codedHeight, 1080);
+    videoFrame1.close();
+
+    const promise = new Promise((resolve, reject) => {
+        stream.getVideoTracks()[0].onconfigurationchange = resolve;
+        setTimeout(() => reject("configuration change timeout"), 5000);
+    });
+    if (window.testRunner)
+        testRunner.triggerMockCaptureConfigurationChange(false, true);
+    await promise;
+
+    let videoFrame2;
+    let counter = 0;
+    while (counter++ < 100) {
+        if (videoFrame2)
+            videoFrame2.close();
+        videoFrame2 = await new Promise((resolve, reject) => video.requestVideoFrameCallback(() => {
+            resolve(new VideoFrame(video));
+            setTimeout(() => reject("videoFrame2 timeout"), 5000);
+        }));
+        if (videoFrame2.codedWidth > 2000)
+            break;
+    }
+    assert_less_than(counter, 100);
+    assert_equals(videoFrame2.codedWidth, 3000);
+    assert_equals(videoFrame2.codedHeight, 1687);
+    videoFrame2.close();
+}, "Underlying change of resolution should update how the constraints are used");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html
@@ -21,7 +21,7 @@
 
         assert_equals(track.label, "Mock audio device 1");
 
-        testRunner.triggerMockMicrophoneConfigurationChange();
+        testRunner.triggerMockCaptureConfigurationChange(true, false);
 
         await new Promise((resolve, reject) => {
             track.onconfigurationchange = resolve;

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1839,6 +1839,8 @@ webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure 
 
 webkit.org/b/261099 webrtc/video-lowercase-media-subtype.html [ Skip ]
 
+fast/mediastream/getDisplayMedia-max-constraints4.html [ Skip ]
+
 # DataChannel GstWebRTC implementation incomplete, missing stats support.
 webkit.org/b/235885 webrtc/datachannel/datachannel-stats.html [ Skip ]
 webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [ Skip ]

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -275,7 +275,7 @@ void DisplayCaptureSourceCocoa::emitFrame()
     if (imageSize.isEmpty())
         return;
 
-    if (intrinsicSize() != imageSize) {
+    if (intrinsicSize() != imageSize || size() != imageSize) {
         setIntrinsicSize(imageSize);
         setSize(imageSize);
     }

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -451,7 +451,12 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
     }
 
     m_currentFrame = WTFMove(sampleBuffer);
-    m_intrinsicSize = IntSize(PAL::CMVideoFormatDescriptionGetPresentationDimensions(PAL::CMSampleBufferGetFormatDescription(m_currentFrame.get()), true, true));
+
+    auto intrinsicSize = IntSize(PAL::CMVideoFormatDescriptionGetPresentationDimensions(PAL::CMSampleBufferGetFormatDescription(m_currentFrame.get()), true, true));
+    if (!m_intrinsicSize || *m_intrinsicSize != intrinsicSize) {
+        m_intrinsicSize = intrinsicSize;
+        configurationChanged();
+    }
 }
 
 dispatch_queue_t ScreenCaptureKitCaptureSource::captureQueue()

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h
@@ -50,7 +50,7 @@ public:
     WEBCORE_EXPORT static void resetDevices();
     WEBCORE_EXPORT static void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
 
-    WEBCORE_EXPORT void triggerMockMicrophoneConfigurationChange();
+    WEBCORE_EXPORT void triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay);
 
     void setMockAudioCaptureEnabled(bool isEnabled) { m_isMockAudioCaptureEnabled = isEnabled; }
     void setMockVideoCaptureEnabled(bool isEnabled) { m_isMockVideoCaptureEnabled = isEnabled; }

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -465,9 +465,9 @@ void GPUProcess::setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool
     MockRealtimeMediaSourceCenter::setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
 }
 
-void GPUProcess::triggerMockMicrophoneConfigurationChange()
+void GPUProcess::triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay)
 {
-    MockRealtimeMediaSourceCenter::singleton().triggerMockMicrophoneConfigurationChange();
+    MockRealtimeMediaSourceCenter::singleton().triggerMockCaptureConfigurationChange(forMicrophone, forDisplay);
 }
 #endif // ENABLE(MEDIA_STREAM)
 

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -170,7 +170,7 @@ private:
     void setMockMediaDeviceIsEphemeral(const String&, bool);
     void resetMockMediaDevices();
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
-    void triggerMockMicrophoneConfigurationChange();
+    void triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay);
 #endif
 #if HAVE(SCREEN_CAPTURE_KIT)
     void promptForGetDisplayMedia(WebCore::DisplayCapturePromptType, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -46,7 +46,7 @@ messages -> GPUProcess LegacyReceiver {
     SetMockMediaDeviceIsEphemeral(String persistentId, bool isEphemeral)
     ResetMockMediaDevices()
     SetMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted)
-    TriggerMockMicrophoneConfigurationChange()
+    TriggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay)
 #endif
 #if HAVE(SC_CONTENT_SHARING_PICKER)
     SetUseSCContentSharingPicker(bool use)

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3196,13 +3196,18 @@ void WKPageSetMockCaptureDevicesInterrupted(WKPageRef pageRef, bool isCameraInte
 #endif
 }
 
-void WKPageTriggerMockMicrophoneConfigurationChange(WKPageRef pageRef)
+void WKPageTriggerMockCaptureConfigurationChange(WKPageRef pageRef, bool forMicrophone, bool forDisplay)
 {
     CRASH_IF_SUSPENDED;
-#if ENABLE(MEDIA_STREAM) && ENABLE(GPU_PROCESS)
+#if ENABLE(MEDIA_STREAM)
+    MockRealtimeMediaSourceCenter::singleton().triggerMockCaptureConfigurationChange(forMicrophone, forDisplay);
+
+#if ENABLE(GPU_PROCESS)
     auto& gpuProcess = toImpl(pageRef)->process().processPool().ensureGPUProcess();
-    gpuProcess.triggerMockMicrophoneConfigurationChange();
-#endif
+    gpuProcess.triggerMockCaptureConfigurationChange(forMicrophone, forDisplay);
+#endif // ENABLE(GPU_PROCESS)
+
+#endif // ENABLE(MEDIA_STREAM)
 }
 
 void WKPageLoadedSubresourceDomains(WKPageRef pageRef, WKPageLoadedSubresourceDomainsFunction callback, void* callbackContext)

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -202,7 +202,7 @@ WK_EXPORT void WKPageSetPrivateClickMeasurementAppBundleIDForTesting(WKPageRef p
 WK_EXPORT void WKPageSetMockCameraOrientation(WKPageRef page, uint64_t orientation);
 WK_EXPORT bool WKPageIsMockRealtimeMediaSourceCenterEnabled(WKPageRef page);
 WK_EXPORT void WKPageSetMockCaptureDevicesInterrupted(WKPageRef page, bool isCameraInterrupted, bool isMicrophoneInterrupted);
-WK_EXPORT void WKPageTriggerMockMicrophoneConfigurationChange(WKPageRef page);
+WK_EXPORT void WKPageTriggerMockCaptureConfigurationChange(WKPageRef page, bool forMicrophone, bool forDisplay);
 
 typedef void (*WKPageLoadedSubresourceDomainsFunction)(WKArrayRef domains, void* functionContext);
 WK_EXPORT void WKPageLoadedSubresourceDomains(WKPageRef page, WKPageLoadedSubresourceDomainsFunction callback, void* callbackContext);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -413,9 +413,9 @@ void GPUProcessProxy::setMockCaptureDevicesInterrupted(bool isCameraInterrupted,
     send(Messages::GPUProcess::SetMockCaptureDevicesInterrupted { isCameraInterrupted, isMicrophoneInterrupted }, 0);
 }
 
-void GPUProcessProxy::triggerMockMicrophoneConfigurationChange()
+void GPUProcessProxy::triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay)
 {
-    send(Messages::GPUProcess::TriggerMockMicrophoneConfigurationChange { }, 0);
+    send(Messages::GPUProcess::TriggerMockCaptureConfigurationChange { forMicrophone, forDisplay }, 0);
 }
 #endif // ENABLE(MEDIA_STREAM)
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -93,7 +93,7 @@ public:
     void setMockMediaDeviceIsEphemeral(const String&, bool);
     void resetMockMediaDevices();
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
-    void triggerMockMicrophoneConfigurationChange();
+    void triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay);
     void updateSandboxAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture);
 #endif
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -415,7 +415,7 @@ interface TestRunner {
     undefined setMockCameraOrientation(unsigned long orientation);
     boolean isMockRealtimeMediaSourceCenterEnabled();
     undefined setMockCaptureDevicesInterrupted(boolean isCameraInterrupted, boolean isMicrophoneInterrupted);
-    undefined triggerMockMicrophoneConfigurationChange();
+    undefined triggerMockCaptureConfigurationChange(boolean forMicrophone, boolean forDisplay);
 
     boolean hasAppBoundSession();
     undefined clearAppBoundSession();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1980,9 +1980,12 @@ void TestRunner::setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool
     }));
 }
 
-void TestRunner::triggerMockMicrophoneConfigurationChange()
+void TestRunner::triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay)
 {
-    postSynchronousMessage("TriggerMockMicrophoneConfigurationChange");
+    postSynchronousMessage("TriggerMockCaptureConfigurationChange", createWKDictionary({
+        { "microphone", adoptWK(WKBooleanCreate(forMicrophone)) },
+        { "display", adoptWK(WKBooleanCreate(forDisplay)) },
+    }));
 }
 
 #if ENABLE(GAMEPAD)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -538,7 +538,7 @@ public:
     void setMockCameraOrientation(unsigned);
     bool isMockRealtimeMediaSourceCenterEnabled();
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
-    void triggerMockMicrophoneConfigurationChange();
+    void triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay);
 
     bool hasAppBoundSession();
     void clearAppBoundSession();

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -4029,9 +4029,9 @@ void TestController::setMockCaptureDevicesInterrupted(bool isCameraInterrupted, 
     WKPageSetMockCaptureDevicesInterrupted(m_mainWebView->page(), isCameraInterrupted, isMicrophoneInterrupted);
 }
 
-void TestController::triggerMockMicrophoneConfigurationChange()
+void TestController::triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay)
 {
-    WKPageTriggerMockMicrophoneConfigurationChange(m_mainWebView->page());
+    WKPageTriggerMockCaptureConfigurationChange(m_mainWebView->page(), forMicrophone, forDisplay);
 }
 
 struct InAppBrowserPrivacyCallbackContext {

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -333,7 +333,7 @@ public:
     void setMockCameraOrientation(uint64_t);
     bool isMockRealtimeMediaSourceCenterEnabled() const;
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
-    void triggerMockMicrophoneConfigurationChange();
+    void triggerMockCaptureConfigurationChange(bool forMicrophone, bool forDisplay);
     bool hasAppBoundSession();
 
     void injectUserScript(WKStringRef);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1063,8 +1063,11 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
     
-    if (WKStringIsEqualToUTF8CString(messageName, "TriggerMockMicrophoneConfigurationChange")) {
-        TestController::singleton().triggerMockMicrophoneConfigurationChange();
+    if (WKStringIsEqualToUTF8CString(messageName, "TriggerMockCaptureConfigurationChange")) {
+        auto messageBodyDictionary = dictionaryValue(messageBody);
+        bool forMicrophone = booleanValue(messageBodyDictionary, "microphone");
+        bool forDisplay = booleanValue(messageBodyDictionary, "display");
+        TestController::singleton().triggerMockCaptureConfigurationChange(forMicrophone, forDisplay);
         return nullptr;
     }
 


### PR DESCRIPTION
#### 2a1363e51a7cb864069914e8c28bfc1aae1e6d06
<pre>
Constraints on the max width/height cause blurry getDisplayMedia video on Safari 17
<a href="https://bugs.webkit.org/show_bug.cgi?id=263015">https://bugs.webkit.org/show_bug.cgi?id=263015</a>
rdar://116810370

Reviewed by Eric Carlson.

We were applying constraints at the time of starting the capture.
For getDisplayMedia, we do not know yet the size of window/screen, so we start with 640x480.
Later on, the size may increase, but we were not recomputing the constraints and our resizer was sticking to the old values.

Whenever there is a change of size, we are now calling configuration change.
Within UserMediaCaptureManagerProxy, in case of getDisplayMedia, we will reapply constraints.
This will trigger recomputation of the resizer based on any max constraint.

We add a test that is emulating the change of screen being captured.
We update an existing testRunner API for that purpose.

* LayoutTests/fast/mediastream/getDisplayMedia-max-constraints4-expected.txt: Added.
* LayoutTests/fast/mediastream/getDisplayMedia-max-constraints4.html: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::emitFrame):
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockDisplayCapturer::triggerMockCaptureConfigurationChange):
(WebCore::MockRealtimeDisplaySourceFactory::latestCapturer):
(WebCore::MockRealtimeMediaSourceCenter::triggerMockCaptureConfigurationChange):
(WebCore::MockRealtimeMediaSourceCenter::triggerMockMicrophoneConfigurationChange): Deleted.
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.h:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::triggerMockCaptureConfigurationChange):
(WebKit::GPUProcess::triggerMockMicrophoneConfigurationChange): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageTriggerMockCaptureConfigurationChange):
(WKPageTriggerMockMicrophoneConfigurationChange): Deleted.
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::updateVideoConstraints):
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::applyConstraints):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::triggerMockCaptureConfigurationChange):
(WebKit::GPUProcessProxy::triggerMockMicrophoneConfigurationChange): Deleted.
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::triggerMockCaptureConfigurationChange):
(WTR::TestRunner::triggerMockMicrophoneConfigurationChange): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::triggerMockCaptureConfigurationChange):
(WTR::TestController::triggerMockMicrophoneConfigurationChange): Deleted.
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/269406@main">https://commits.webkit.org/269406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ed88cce4f4d33e3e449a0ed33629fe6381df6d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24384 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21792 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22719 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/95 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25236 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/71 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26610 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24466 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/72 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/54 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5352 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/85 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/82 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->