### PR TITLE
REGRESSION (266070@main): iOS Notes: selection and cursor color is gray in color and not yellow

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -603,7 +603,6 @@ typedef enum {
 - (void)insertSubview:(UIView *)view above:(UIView *)sibling;
 - (void)_didRemoveSubview:(UIView *)subview;
 - (CGSize)convertSize:(CGSize)size toView:(UIView *)view;
-- (UIColor *)_inheritedInteractionTintColor;
 - (NSString *)recursiveDescription;
 @end
 

--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -97,6 +97,8 @@ TextStream& operator<<(TextStream& ts, const EditorState& editorState)
             ts.dumpProperty("insideFixedPosition", editorState.postLayoutData->insideFixedPosition);
         if (editorState.postLayoutData->caretColor.isValid())
             ts.dumpProperty("caretColor", editorState.postLayoutData->caretColor);
+        if (editorState.postLayoutData->hasCaretColorAuto)
+            ts.dumpProperty("hasCaretColorAuto", editorState.postLayoutData->hasCaretColorAuto);
 #endif
 #if PLATFORM(MAC)
         if (editorState.postLayoutData->selectionBoundingRect != IntRect())

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -111,6 +111,7 @@ struct EditorState {
         bool insideFixedPosition { false };
         bool hasPlainText { false };
         WebCore::Color caretColor; // FIXME: Maybe this should be on VisualData?
+        bool hasCaretColorAuto { false };
         bool atStartOfSentence { false };
         bool selectionStartIsAtParagraphBoundary { false };
         bool selectionEndIsAtParagraphBoundary { false };

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -88,6 +88,7 @@ struct WebKit::EditorState {
     bool insideFixedPosition;
     bool hasPlainText;
     WebCore::Color caretColor;
+    bool hasCaretColorAuto;
     bool atStartOfSentence;
     bool selectionStartIsAtParagraphBoundary;
     bool selectionEndIsAtParagraphBoundary;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -419,6 +419,8 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 {
     [super didMoveToWindow];
 
+    _cachedHasCustomTintColor = std::nullopt;
+
     if (self.window)
         [self setUpInteraction];
     else

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -484,6 +484,7 @@ struct ImageAnalysisContextMenuActionData {
     NSInteger _dropAnimationCount;
 
     BOOL _hasSetUpInteractions;
+    std::optional<BOOL> _cachedHasCustomTintColor;
     NSUInteger _ignoreSelectionCommandFadeCount;
     NSUInteger _activeTextInteractionCount;
     NSInteger _suppressNonEditableSingleTapTextInteractionCount;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -404,7 +404,9 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
             // rather than the focused element. This causes caret colors in editable children to be
             // ignored in favor of the editing host's caret color. See: <https://webkit.org/b/229809>.
             if (RefPtr editableRoot = selection.rootEditableElement(); editableRoot && editableRoot->renderer()) {
-                postLayoutData.caretColor = CaretBase::computeCaretColor(editableRoot->renderer()->style(), editableRoot.get());
+                auto& style = editableRoot->renderer()->style();
+                postLayoutData.caretColor = CaretBase::computeCaretColor(style, editableRoot.get());
+                postLayoutData.hasCaretColorAuto = style.hasAutoCaretColor();
                 postLayoutData.hasGrammarDocumentMarkers = editableRoot->document().markers().hasMarkers(makeRangeSelectingNodeContents(*editableRoot), DocumentMarker::Grammar);
             }
         }


### PR DESCRIPTION
#### 33d14a68bc4a80441096c71d70160a56bc21a760
<pre>
REGRESSION (266070@main): iOS Notes: selection and cursor color is gray in color and not yellow
<a href="https://bugs.webkit.org/show_bug.cgi?id=263123">https://bugs.webkit.org/show_bug.cgi?id=263123</a>
rdar://116748932

Reviewed by Aditya Keerthi and Richard Robinson.

After the changes in &lt;<a href="https://commits.webkit.org/266070@main">https://commits.webkit.org/266070@main</a>&gt;, the caret color from the page (i.e.
derived from either the CSS `caret-color` property or an explicitly-set `color` property) now
overrides any `tintColor` specified by the WebKit client (either directly on the view, or a global
application tint color). This means that in HTML Notes, which sets a CSS `color` attribute on the
body that&apos;s different from their app&apos;s yellow tint color, the selection is now gray (matching the
text color) instead of yellow.

To mitigate this and keep native apps with custom tint colors working with respect to CSS caret
colors without bringing back the double-caret observed on GitHub in <a href="https://webkit.org/b/259166">https://webkit.org/b/259166</a>, we
adjust our logic for determining the effective interaction tint color:

1.  If the page author&apos;s CSS specifies an explicit (non-auto) `caret-color`, use that.
2.  Otherwise, if the embedding app specifies a non-default tint color, use that.
3.  Otherwise, if the page author&apos;s CSS indirectly specifies a `caret-color` through an explicitly-
    set CSS `color` property, use that.
4.  Finally, fall back to the embedding app&apos;s tint color.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Remove now-unused SPI.

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::operator&lt;&lt;):
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:

Add a flag to indicate whether `caret-color: auto;` is used.

* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView didMoveToWindow]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
(-[WKContentView cleanUpInteraction]):
(-[WKContentView _hasCustomTintColor]):

Add a helper method to compute whether or not the content view has a custom (non-default) tint
color. We deduce this by creating a new, unparented `UIView`, asking for its `tintColor`, and
comparing that against the content view&apos;s current tint color.

(-[WKContentView _cascadeInteractionTintColor]):

Implement the new fallback logic described above.

Drive-by fix: we can also replace usage of the `-_inheritedInteractionTintColor` SPI property with
just `-tintColor` instead. In UIKit, `-_inheritedInteractionTintColor` is implemented as another SPI
property, `-interactionTintColor`, which in turn simply wraps the API property `-tintColor`.

(-[WKContentView tintColorDidChange]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemColors.mm:
(-[UIColor expectRed:green:blue:alpha:]):

Augment an existing API test to exercise these new scenarios.

Canonical link: <a href="https://commits.webkit.org/269314@main">https://commits.webkit.org/269314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a25fe67299020e0f6a575fb6eb9f558dea856dc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23263 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24087 "Failed to checkout and rebase branch from PR 19054") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22719 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/24087 "Failed to checkout and rebase branch from PR 19054") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24938 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19198 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_avc (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26365 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20207 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24225 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20776 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20127 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5285 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->