### PR TITLE
[WebGPU] A RenderBundle with several calls to setPipeline may not be built correctly

### DIFF
--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -41,6 +41,8 @@ struct WGPURenderBundleImpl {
 @property (nonatomic) MTLRenderStages renderStages;
 @end
 
+@class RenderBundleICBWithResources;
+
 namespace WebGPU {
 
 class Device;
@@ -50,9 +52,9 @@ class RenderBundle : public WGPURenderBundleImpl, public RefCounted<RenderBundle
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using ResourcesContainer = NSMapTable<id<MTLResource>, ResourceUsageAndRenderStage*>;
-    static Ref<RenderBundle> create(id<MTLIndirectCommandBuffer> indirectCommandBuffer, ResourcesContainer* resources, id<MTLRenderPipelineState> renderPipelineState, id<MTLDepthStencilState> depthStencilState, MTLCullMode cullMode, MTLWinding frontFace, MTLDepthClipMode clipMode, Device& device)
+    static Ref<RenderBundle> create(NSArray<RenderBundleICBWithResources*> *resources, Device& device)
     {
-        return adoptRef(*new RenderBundle(indirectCommandBuffer, WTFMove(resources), renderPipelineState, depthStencilState, cullMode, frontFace, clipMode, device));
+        return adoptRef(*new RenderBundle(resources, device));
     }
     static Ref<RenderBundle> createInvalid(Device& device)
     {
@@ -63,31 +65,17 @@ public:
 
     void setLabel(String&&);
 
-    bool isValid() const { return m_indirectCommandBuffer; }
-
-    id<MTLIndirectCommandBuffer> indirectCommandBuffer() const { return m_indirectCommandBuffer; }
+    bool isValid() const { return m_renderBundlesResources != nil; }
 
     Device& device() const { return m_device; }
-    const Vector<BindableResources>& resources() const { return m_resources; }
-    id<MTLRenderPipelineState> currentPipelineState() const;
-    id<MTLDepthStencilState> depthStencilState() const;
-    MTLCullMode cullMode() const;
-    MTLWinding frontFace() const;
-    MTLDepthClipMode depthClipMode() const;
+    NSArray<RenderBundleICBWithResources*> *renderBundlesResources() const { return m_renderBundlesResources; }
 
 private:
-    RenderBundle(id<MTLIndirectCommandBuffer>, ResourcesContainer*, id<MTLRenderPipelineState>, id<MTLDepthStencilState>, MTLCullMode, MTLWinding, MTLDepthClipMode, Device&);
+    RenderBundle(NSArray<RenderBundleICBWithResources*> *, Device&);
     RenderBundle(Device&);
 
-    const id<MTLIndirectCommandBuffer> m_indirectCommandBuffer { nil };
-
     const Ref<Device> m_device;
-    Vector<BindableResources> m_resources;
-    id<MTLRenderPipelineState> m_currentPipelineState { nil };
-    id<MTLDepthStencilState> m_depthStencilState { nil };
-    MTLCullMode m_cullMode { MTLCullModeNone };
-    MTLWinding m_frontFace { MTLWindingClockwise };
-    MTLDepthClipMode m_depthClipMode { MTLDepthClipModeClip };
+    NSArray<RenderBundleICBWithResources*> *m_renderBundlesResources;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -68,6 +68,7 @@ public:
     MTLWinding frontFace() const { return m_frontFace; }
     MTLCullMode cullMode() const { return m_cullMode; }
     MTLDepthClipMode depthClipMode() const { return m_clipMode; }
+    MTLDepthStencilDescriptor *depthStencilDescriptor() const { return m_depthStencilDescriptor; }
 
     Device& device() const { return m_device; }
     PipelineLayout& pipelineLayout() const;


### PR DESCRIPTION
#### 17f80e19eb23c6d2878e2dacbb67a5f3cf4a42f0
<pre>
[WebGPU] A RenderBundle with several calls to setPipeline may not be built correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=263099">https://bugs.webkit.org/show_bug.cgi?id=263099</a>
&lt;radar://116893300&gt;

Reviewed by Dan Glastonbury.

In WebGPU, the render pipeline state also constains depth stencil state,
cull mode, front facing, etc, but this is not possible to set on the ICB
commands.

So if a render bundle is encoding with varying state which can not be
encoded into the ICB, then we need to create several ICBs.

* Source/WebGPU/WebGPU/RenderBundle.h:
(WebGPU::RenderBundle::create):
(WebGPU::RenderBundle::isValid const):
(WebGPU::RenderBundle:: const):
(WebGPU::RenderBundle::indirectCommandBuffer const): Deleted.
(WebGPU::RenderBundle::resources const): Deleted.
(): Deleted.
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::RenderBundle):
(WebGPU::RenderBundle::setLabel):
(WebGPU::RenderBundle::currentPipelineState const): Deleted.
(WebGPU::RenderBundle::depthStencilState const): Deleted.
(WebGPU::RenderBundle::cullMode const): Deleted.
(WebGPU::RenderBundle::frontFace const): Deleted.
(WebGPU::RenderBundle::depthClipMode const): Deleted.
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(-[RenderBundleICBWithResources initWithICB:pipelineState:depthStencilState:cullMode:frontFace:depthClipMode:]):
(-[RenderBundleICBWithResources resources]):
(WebGPU::makeRenderBundleICBWithResources):
(WebGPU::Device::createRenderBundleEncoder):
(WebGPU::RenderBundleEncoder::RenderBundleEncoder):
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::draw):
(WebGPU::RenderBundleEncoder::drawIndexed):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::endCurrentICB):
(WebGPU::RenderBundleEncoder::finish):
(WebGPU::RenderBundleEncoder::setBindGroup):
(WebGPU::RenderBundleEncoder::setIndexBuffer):
(WebGPU::icbNeedsToBeSplit):
(WebGPU::RenderBundleEncoder::setPipeline):
(WebGPU::RenderBundleEncoder::setVertexBuffer):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):
* Source/WebGPU/WebGPU/RenderPipeline.h:
(WebGPU::RenderPipeline::depthStencilDescriptor const):

Canonical link: <a href="https://commits.webkit.org/269826@main">https://commits.webkit.org/269826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c27849938782ab9eba9e023bd03e0891618fd6db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24483 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21578 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23913 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26125 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/843 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27270 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18575 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/787 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5663 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->