### PR TITLE
Don't apply canvas noise on drawImage/putImageData rects

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5499,9 +5499,6 @@ webkit.org/b/245080 fast/text/whitespace/nowrap-clear-float.html [ Failure ]
 webkit.org/b/255255 fast/text/text-underline-vertical-first-line-decoration.html [ ImageOnlyFailure ]
 webkit.org/b/255287 fast/block/lineboxcontain/inline-box-vertical.html [ Failure ]
 
-# This is marked as passing on WK2.
-fast/canvas/large-getImageData.html [ Skip ]
-
 # This should fail, but it flakey-passes, so skipping now.
 fast/canvas/canvas-noise-injection.html [ Skip ]
 

--- a/LayoutTests/fast/canvas/canvas-noise-injection-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-noise-injection-expected.txt
@@ -11,22 +11,26 @@ PASS fillText should not require noise injection when noise injection is not ena
 PASS getImageData should not apply noise when noise injection is not enabled
 PASS putImageData should not require noise injection
 PASS fillRect should not require noise injection when noise injection is not enabled
+PASS drawImage that covers entire canvas should not require noise injection
 PASS fillText should not require noise injection when noise injection is not enabled
+PASS drawImage after fillText should not require noise injection when noise injection is not enabled
 PASS getImageData should not apply noise when noise injection is not enabled
 PASS putImageData should not require noise injection
 PASS fillRect should not require noise injection when noise injection is not enabled
 Enabling canvas noise injection
 PASS Initial canvas should not have pending dirty rects
-FAIL drawImage should not require noise injection
+PASS drawImage should not require noise injection
 PASS Initial canvas should not have pending dirty rects
 PASS putImageData should not require noise injection
-FAIL data: url after putImageData should be equal
+PASS data: url after putImageData should be equal
 PASS fillText should require noise injection
 PASS getImageData should apply all required noise
 PASS putImageData should not require noise injection
 PASS fillRect should require noise injection
 PASS data: url after fillRect should not be equal
+PASS drawImage that covers entire canvas should not require noise injection
 PASS fillText should require noise injection
+PASS drawImage after fillText require noise injection
 PASS getImageData should apply all required noise
 PASS putImageData should not require noise injection
 PASS fillRect should require noise injection

--- a/LayoutTests/fast/canvas/canvas-noise-injection.html
+++ b/LayoutTests/fast/canvas/canvas-noise-injection.html
@@ -81,14 +81,26 @@
         ctx.fillRect(50, 50, 100, 100);
         if (noiseInjectionEnabled) {
             expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillRect should require noise injection");
-            //shouldBeEqualToString(canvas.toDataURL(), modifiedImageCanvasWithNoiseDataURL);
             dataURLMsg = "data: url after fillRect should not be equal";
         } else {
             expectFalse(hasPendingCanvasNoiseInjection(canvas), "fillRect should not require noise injection when noise injection is not enabled");
-            //shouldBeEqualToString(canvas.toDataURL(), modifiedImageCanvasDataURL);
             dataURLMsg = "data: url after fillRect should be equal";
         }
         setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), !noiseInjectionEnabled, dataURLMsg);
+
+        document.body.removeChild(canvas);
+
+        canvas = document.createElement("canvas");
+        canvas.width = img.width;
+        canvas.height = img.height;
+        if (noiseInjectionEnabled)
+            setCanvasNoiseInjection(canvas);
+        document.body.appendChild(canvas);
+        ctx = canvas.getContext("2d");
+
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(img, 0, 0);
+        expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage that covers entire canvas should not require noise injection");
 
         document.body.removeChild(canvas);
 
@@ -105,6 +117,12 @@
         else
             expectFalse(hasPendingCanvasNoiseInjection(canvas), "fillText should not require noise injection when noise injection is not enabled");
 
+        ctx.drawImage(img, 0, 0);
+        if (noiseInjectionEnabled)
+            expectTrue(hasPendingCanvasNoiseInjection(canvas), "drawImage after fillText require noise injection");
+        else
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage after fillText should not require noise injection when noise injection is not enabled");
+
         imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
         if (noiseInjectionEnabled)
             expectFalse(hasPendingCanvasNoiseInjection(canvas), "getImageData should apply all required noise");
@@ -116,11 +134,9 @@
         ctx.fillRect(50, 50, 100, 100);
         if (noiseInjectionEnabled) {
             expectTrue(hasPendingCanvasNoiseInjection(canvas), "fillRect should require noise injection");
-            //shouldBeEqualToString(canvas.toDataURL(), fillRectCanvasWithNoiseDataURL);
             dataURLMsg = "data: url after fillRect should not be equal";
         } else {
             expectFalse(hasPendingCanvasNoiseInjection(canvas), "fillRect should not require noise injection when noise injection is not enabled");
-            //shouldBeEqualToString(canvas.toDataURL(), fillRectCanvasDataURL);
             dataURLMsg = "data: url after fillRect should be equal";
         }
         setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), !noiseInjectionEnabled, dataURLMsg);

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -185,11 +185,14 @@ void CanvasBase::notifyObserversCanvasChanged(const std::optional<FloatRect>& re
 void CanvasBase::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
     // FIXME: We should exclude rects with ShouldApplyPostProcessingToDirtyRect::No
-    if (shouldInjectNoiseBeforeReadback() && shouldApplyPostProcessingToDirtyRect == ShouldApplyPostProcessingToDirtyRect::Yes) {
-        if (rect)
-            m_canvasNoiseInjection.updateDirtyRect(intersection(enclosingIntRect(*rect), { { }, size() }));
-        else
-            m_canvasNoiseInjection.updateDirtyRect({ { }, size() });
+    if (shouldInjectNoiseBeforeReadback()) {
+        if (shouldApplyPostProcessingToDirtyRect == ShouldApplyPostProcessingToDirtyRect::Yes) {
+            if (rect)
+                m_canvasNoiseInjection.updateDirtyRect(intersection(enclosingIntRect(*rect), { { }, size() }));
+            else
+                m_canvasNoiseInjection.updateDirtyRect({ { }, size() });
+        } else if (!rect)
+            m_canvasNoiseInjection.clearDirtyRect();
     }
 }
 

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -38,6 +38,11 @@ void CanvasNoiseInjection::updateDirtyRect(const IntRect& rect)
     m_postProcessDirtyRect.unite(rect);
 }
 
+void CanvasNoiseInjection::clearDirtyRect()
+{
+    m_postProcessDirtyRect = { };
+}
+
 static inline bool isIndexInBounds(int size, int index)
 {
     ASSERT(index <= size);

--- a/Source/WebCore/html/CanvasNoiseInjection.h
+++ b/Source/WebCore/html/CanvasNoiseInjection.h
@@ -40,6 +40,7 @@ public:
     void postProcessDirtyCanvasBuffer(ImageBuffer*, NoiseInjectionHashSalt);
     bool postProcessPixelBufferResults(PixelBuffer&, NoiseInjectionHashSalt) const;
     void updateDirtyRect(const IntRect&);
+    void clearDirtyRect();
     bool haveDirtyRects() const { return !m_postProcessDirtyRect.isEmpty(); }
 
 private:

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1258,7 +1258,7 @@ void CanvasRenderingContext2DBase::clearRect(double x, double y, double width, d
     context->clearRect(rect);
     if (saved)
         context->restore();
-    didDraw(rect);
+    didDraw(rect, defaultDidDrawOptionsWithoutPostProcessing());
 }
 
 void CanvasRenderingContext2DBase::fillRect(double x, double y, double width, double height)
@@ -1599,6 +1599,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(WebCodecsVideoFrame& f
 
     auto normalizedDstRect = normalizeRect(dstRect);
     bool repaintEntireCanvas = rectContainsCanvas(normalizedDstRect);
+    // FIXME: Can we avoid post-processing in any cases?
     didDraw(repaintEntireCanvas, normalizedDstRect);
 
     return { };
@@ -1641,6 +1642,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
         return { };
 
     auto observer = image->imageObserver();
+    auto shouldPostProcess { true };
 
     if (image->drawsSVGImage()) {
         image->setImageObserver(nullptr);
@@ -1655,6 +1657,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
                 return { };
         }
         downcast<BitmapImage>(*image).updateFromSettings(document.settings());
+        shouldPostProcess = false;
     }
 
     ImagePaintingOptions options = { op, blendMode, orientation };
@@ -1673,7 +1676,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
     } else
         c->drawImage(*image, normalizedDstRect, normalizedSrcRect, options);
 
-    didDraw(repaintEntireCanvas, normalizedDstRect);
+    didDraw(repaintEntireCanvas, normalizedDstRect, shouldPostProcess ? defaultDidDrawOptions() : defaultDidDrawOptionsWithoutPostProcessing());
 
     if (image->drawsSVGImage())
         image->setImageObserver(WTFMove(observer));
@@ -1739,7 +1742,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     } else
         c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
 
-    didDraw(repaintEntireCanvas, normalizedDstRect);
+    didDraw(repaintEntireCanvas, normalizedDstRect, defaultDidDrawOptionsWithoutPostProcessing());
 
     return { };
 }
@@ -1780,7 +1783,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLVideoElement& vide
         if (auto image = video.nativeImageForCurrentTime()) {
             c->drawNativeImage(*image, FloatSize(video.videoWidth(), video.videoHeight()), normalizedDstRect, normalizedSrcRect);
 
-            didDraw(repaintEntireCanvas, normalizedDstRect);
+            didDraw(repaintEntireCanvas, normalizedDstRect, defaultDidDrawOptionsWithoutPostProcessing());
 
             return { };
         }
@@ -1795,7 +1798,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLVideoElement& vide
     video.paintCurrentFrameInContext(*c, FloatRect(FloatPoint(), size(video)));
     stateSaver.restore();
 
-    didDraw(repaintEntireCanvas, normalizedDstRect);
+    didDraw(repaintEntireCanvas, normalizedDstRect, defaultDidDrawOptionsWithoutPostProcessing());
 
     return { };
 }
@@ -1843,7 +1846,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(ImageBitmap& imageBitm
     } else
         c->drawImageBuffer(*buffer, dstRect, srcRect, { state().globalComposite, state().globalBlend });
 
-    didDraw(repaintEntireCanvas, dstRect);
+    didDraw(repaintEntireCanvas, dstRect, defaultDidDrawOptionsWithoutPostProcessing());
 
     return { };
 }
@@ -2184,9 +2187,9 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(C
     return Exception { TypeError };
 }
 
-void CanvasRenderingContext2DBase::didDrawEntireCanvas()
+void CanvasRenderingContext2DBase::didDrawEntireCanvas(OptionSet<DidDrawOption> options)
 {
-    didDraw(backingStoreBounds(), { DidDrawOption::ApplyClip, DidDrawOption::ApplyPostProcessing });
+    didDraw(backingStoreBounds(), options);
 }
 
 void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, OptionSet<DidDrawOption> options)
@@ -2197,8 +2200,10 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
     if (!drawingContext())
         return;
 
+    auto shouldApplyPostProcessing = options.contains(DidDrawOption::ApplyPostProcessing) ? ShouldApplyPostProcessingToDirtyRect::Yes : ShouldApplyPostProcessingToDirtyRect::No;
+
     if (!rect) {
-        canvasBase().didDraw(std::nullopt);
+        canvasBase().didDraw(std::nullopt, shouldApplyPostProcessing);
         return;
     }
 
@@ -2221,31 +2226,33 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
     }
 
     // FIXME: This does not apply the clip because we have no way of reading the clip out of the GraphicsContext.
-
     if (m_dirtyRect.contains(dirtyRect))
-        canvasBase().didDraw(std::nullopt);
+        canvasBase().didDraw(std::nullopt, shouldApplyPostProcessing);
     else {
         m_dirtyRect.unite(dirtyRect);
-        canvasBase().didDraw(m_dirtyRect, options.contains(DidDrawOption::ApplyPostProcessing) ? ShouldApplyPostProcessingToDirtyRect::Yes : ShouldApplyPostProcessingToDirtyRect::No);
+        canvasBase().didDraw(m_dirtyRect, shouldApplyPostProcessing);
     }
 }
 
-void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, const FloatRect& rect)
+void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, const FloatRect& rect, OptionSet<DidDrawOption> options)
 {
     return didDraw(entireCanvas, [&] {
         return rect;
-    });
+    }, options);
 }
 
 template<typename RectProvider>
-void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, RectProvider rectProvider)
+void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, RectProvider rectProvider, OptionSet<DidDrawOption> options)
 {
     if (isEntireBackingStoreDirty())
-        didDraw(std::nullopt);
-    else if (entireCanvas)
-        didDrawEntireCanvas();
-    else
-        didDraw(rectProvider());
+        didDraw(std::nullopt, options);
+    else if (entireCanvas) {
+        OptionSet<DidDrawOption> didDrawEntireCanvasOptions { DidDrawOption::ApplyClip };
+        if (options.contains(DidDrawOption::ApplyPostProcessing))
+            didDrawEntireCanvasOptions.add(DidDrawOption::ApplyPostProcessing);
+        didDrawEntireCanvas(didDrawEntireCanvasOptions);
+    } else
+        didDraw(rectProvider(), options);
 }
 
 void CanvasRenderingContext2DBase::clearAccumulatedDirtyRect()

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -345,10 +345,30 @@ private:
         ApplyPostProcessing = 1 << 3,
         PreserveCachedImageData = 1 << 4,
     };
-    void didDraw(std::optional<FloatRect>, OptionSet<DidDrawOption> = { DidDrawOption::ApplyTransform, DidDrawOption::ApplyShadow, DidDrawOption::ApplyClip, DidDrawOption::ApplyPostProcessing });
-    void didDrawEntireCanvas();
-    void didDraw(bool entireCanvas, const FloatRect&);
-    template<typename RectProvider> void didDraw(bool entireCanvas, RectProvider);
+
+    static constexpr OptionSet<DidDrawOption> defaultDidDrawOptions()
+    {
+        return {
+            DidDrawOption::ApplyTransform,
+            DidDrawOption::ApplyShadow,
+            DidDrawOption::ApplyClip,
+            DidDrawOption::ApplyPostProcessing,
+        };
+    }
+
+    static constexpr OptionSet<DidDrawOption> defaultDidDrawOptionsWithoutPostProcessing()
+    {
+        return {
+            DidDrawOption::ApplyTransform,
+            DidDrawOption::ApplyShadow,
+            DidDrawOption::ApplyClip,
+        };
+    }
+
+    void didDraw(std::optional<FloatRect>, OptionSet<DidDrawOption> = defaultDidDrawOptions());
+    void didDrawEntireCanvas(OptionSet<DidDrawOption> options = defaultDidDrawOptions());
+    void didDraw(bool entireCanvas, const FloatRect&, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
+    template<typename RectProvider> void didDraw(bool entireCanvas, RectProvider, OptionSet<DidDrawOption> options = defaultDidDrawOptions());
 
     bool is2dBase() const final { return true; }
     bool needsPreparationForDisplay() const final;


### PR DESCRIPTION
#### 86b51a59cf534cac68af4f8e4304e6134f8f45bf
<pre>
Don&apos;t apply canvas noise on drawImage/putImageData rects
<a href="https://bugs.webkit.org/show_bug.cgi?id=263129">https://bugs.webkit.org/show_bug.cgi?id=263129</a>
<a href="https://rdar.apple.com/115313154">rdar://115313154</a>

Reviewed by Simon Fraser.

When noise injection is enabled, the backing pixelbuffer of Canvas2D has noise
applied as an anti-fingerprinting protection. That operation is expensive and
the protection is not needed in situations where we are given an explicit
ImageData or specific types of Images because those data don&apos;t reveal any
identifying information about the machine when extracted via getImageData() or
toDataURL().

This patch abstracts the default DidDrawOptions into a static function that
includes DidDrawOption::ApplyPostProcessing, and a companion function that
doesn&apos;t include ApplyPostProcessing. These are static class functions because
they should both be updated if the default DidDrawOption OptionSet changes in
the future, and defining them separately seems error prone.

As described above, the noise injection post-processing is not applied after
certain drawImage operations where the image is a bitmap, and post-processing
is conditionally applied when the entire canvas is dirty.

* LayoutTests/TestExpectations:
* LayoutTests/fast/canvas/canvas-noise-injection-expected.txt:
* LayoutTests/fast/canvas/canvas-noise-injection.html:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::didDraw):
* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::CanvasNoiseInjection::clearDirtyRect):
* Source/WebCore/html/CanvasNoiseInjection.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::clearRect):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::didDrawEntireCanvas):
(WebCore::CanvasRenderingContext2DBase::didDraw):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::defaultDidDrawOptions):
(WebCore::CanvasRenderingContext2DBase::defaultDidDrawOptionsWithoutPostProcessing):
(WebCore::CanvasRenderingContext2DBase::didDraw): Deleted.

Canonical link: <a href="https://commits.webkit.org/270207@main">https://commits.webkit.org/270207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/502f947714493d06d7cbfb77504c55cd11302a5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22961 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27259 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22128 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28329 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/144 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5952 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->