### PR TITLE
[ews] Add Sonoma mapping to PrintConfiguration step

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5453,6 +5453,7 @@ class PrintConfiguration(steps.ShellSequence):
             return 'Unknown'
 
         build_to_name_mapping = {
+            '14': 'Sonoma',
             '13': 'Ventura',
             '12': 'Monterey',
             '11': 'Big Sur'


### PR DESCRIPTION
#### c7e5572ce6af10c7b76b443717eab3d007e2b1ed
<pre>
[ews] Add Sonoma mapping to PrintConfiguration step
<a href="https://bugs.webkit.org/show_bug.cgi?id=263134">https://bugs.webkit.org/show_bug.cgi?id=263134</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-build/steps.py:
(PrintConfiguration.convert_build_to_os_name): Add Sonoma to our version / name map.

Canonical link: <a href="https://commits.webkit.org/269315@main">https://commits.webkit.org/269315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7abd79b102d75171ecda8ef6cc1fb8a5d3adde71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22220 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/22424 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/23292 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/24117 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/22468 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26683 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/22748 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/24117 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/22453 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26683 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/23292 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24970 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26683 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/23292 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/24970 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26683 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/23292 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24970 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/22748 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22022 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20153 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/23292 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/24364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2772 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/20749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->