### PR TITLE
[webkitbugspy] Use session for bugzilla requests

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.13.2',
+    version='0.13.3',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 13, 2)
+version = Version(0, 13, 3)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
@@ -128,9 +128,10 @@ class Tracker(object):
             return cls._trackers[0]
         return None
 
-    def __init__(self, users=None, redact=None, hide_title=None, redact_exemption=None):
+    def __init__(self, users=None, redact=None, hide_title=None, redact_exemption=None, timeout=None):
         self.users = users or User.Mapping()
         self.hide_title = False if hide_title is None else hide_title
+        self.timeout = None
 
         for name, rvalue in (('redact', redact), ('redact_exemption', redact_exemption)):
             if rvalue is None:

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.6.17',
+    version='6.6.18',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 6, 17)
+version = Version(6, 6, 18)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -257,13 +257,13 @@ class TestLand(testing.PathTestCase):
 
     def test_canonicalize_with_bugzilla(self):
         with OutputCapture(level=logging.INFO) as captured, repository(self.path, has_oops=False, issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA)), \
-                mocks.local.Svn(), MockTerminal.input('n'), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]), bmocks.Bugzilla(
+                mocks.local.Svn(), MockTerminal.input('n'), bmocks.Bugzilla(
                     self.BUGZILLA.split('://')[-1],
                     issues=bmocks.ISSUES,
                     environment=Environment(
                         BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
                         BUGS_EXAMPLE_COM_PASSWORD='password',
-                )):
+                )), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
 
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
@@ -314,14 +314,13 @@ class TestLand(testing.PathTestCase):
     def test_svn_with_bugzilla(self):
         with MockTime, OutputCapture(level=logging.INFO) as captured, \
                 repository(self.path, has_oops=False, git_svn=True, issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA)), \
-                mocks.local.Svn(), MockTerminal.input('n'), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]), \
-                bmocks.Bugzilla(
+                mocks.local.Svn(), MockTerminal.input('n'), bmocks.Bugzilla(
                     self.BUGZILLA.split('://')[-1],
                     issues=bmocks.ISSUES,
                     environment=Environment(
                         BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
                         BUGS_EXAMPLE_COM_PASSWORD='password',
-                )):
+                )), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
 
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
@@ -529,7 +528,6 @@ class TestLandGitHub(testing.PathTestCase):
         )
 
     def test_merge_queue_linked_bug(self):
-        self.maxDiff = None
         with OutputCapture(level=logging.INFO) as captured, MockTerminal.input('y', 'n'), self.webserver(
             approved=True, labels={'merge-queue': dict(color='3AE653', description="Send PR to merge-queue")},
             environment=Environment(
@@ -541,13 +539,13 @@ class TestLandGitHub(testing.PathTestCase):
             issue_url='{}/show_bug.cgi?id=1'.format(self.BUGZILLA),
             remote='https://{}'.format(remote.remote),
             remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]), bmocks.Bugzilla(
+        ), bmocks.Bugzilla(
             self.BUGZILLA.split('://')[-1],
             issues=bmocks.ISSUES,
             environment=Environment(
             BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
             BUGS_EXAMPLE_COM_PASSWORD='password',
-        )):
+        )), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
             self.assertEqual(0, program.main(
                 args=('land', '-v'),
                 path=self.path,


### PR DESCRIPTION
#### be79c2ae75d406ec81b8f295b4286e8fce4c95e0
<pre>
[webkitbugspy] Use session for bugzilla requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=263133">https://bugs.webkit.org/show_bug.cgi?id=263133</a>
rdar://116933160

Rubber-stamped by Aakash Jain.

Use requests.Session for requests to bugzilla and pass timeout
to request calls.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.__init__): Set a default timeout of 30 seconds.
(Tracker.user): Use session, pass timeout value.
(Tracker.credentials.validater): Ditto.
(Tracker.populate): Ditto.
(Tracker.set): Ditto.
(Tracker.add_comment): Ditto.
(Tracker.projects): Ditto.
(Tracker.cc_radar): Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py:
(Tracker.__init__): Add timeout (none by default).
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
(TestLand.test_canonicalize_with_bugzilla): Construct Bugzilla tracker after
instantiating Bugzilla mock.
(TestLand.test_svn_with_bugzilla): Ditto.

Canonical link: <a href="https://commits.webkit.org/269368@main">https://commits.webkit.org/269368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c0489c486a47d6ef4e39adbc37a2e469f6d9cb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22384 "5 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/2 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22638 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/2 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22917 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22623 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/2 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19430 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25143 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/22567 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/2 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20285 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26539 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/2 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20521 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24393 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/3 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22180 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/3 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/4 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2798 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/4 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->