### PR TITLE
Web Inspector: remove incorrect WebGPU support after 268693@main

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -23,7 +23,7 @@
         {
             "id": "ContextType",
             "type": "string",
-            "enum": ["canvas-2d", "offscreen-canvas-2d", "bitmaprenderer", "webgl", "webgl2", "webgpu"],
+            "enum": ["canvas-2d", "offscreen-canvas-2d", "bitmaprenderer", "webgl", "webgl2"],
             "description": "The type of rendering context backing the canvas element."
         },
         {

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -39,7 +39,6 @@
 #include "Document.h"
 #include "Element.h"
 #include "FloatPoint.h"
-#include "GPUCanvasContext.h"
 #include "Gradient.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
@@ -893,8 +892,6 @@ Ref<Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(bool capture
         if (is<WebGL2RenderingContext>(m_context))
             return Protocol::Canvas::ContextType::WebGL2;
 #endif
-        if (is<GPUCanvasContext>(m_context))
-            return Protocol::Canvas::ContextType::WebGPU;
 
         ASSERT_NOT_REACHED();
         return Protocol::Canvas::ContextType::Canvas2D;

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -147,10 +147,17 @@ void InspectorCanvasAgent::internalEnable()
     {
         Locker locker { CanvasRenderingContext::instancesLock() };
         for (auto* context : CanvasRenderingContext::instances()) {
+            if (!is<CanvasRenderingContext2D>(context)
+                && !is<ImageBitmapRenderingContext>(context)
 #if ENABLE(OFFSCREEN_CANVAS)
-            if (is<PlaceholderRenderingContext>(context))
-                continue;
+                && !is<OffscreenCanvasRenderingContext2D>(context)
 #endif
+#if ENABLE(WEBGL)
+                && !is<WebGLRenderingContext>(context)
+                && !is<WebGL2RenderingContext>(context)
+#endif
+            )
+                continue;
 
             if (matchesCurrentContext(context->canvasBase().scriptExecutionContext()))
                 bindCanvas(*context, false);


### PR DESCRIPTION
#### a19a3bb3454c094054797db8c0279eedab4c2135
<pre>
Web Inspector: remove incorrect WebGPU support after 268693@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=263135">https://bugs.webkit.org/show_bug.cgi?id=263135</a>

Reviewed by Mike Wyrzykowski.

Web Inspector does not currently support WebGPU (not counting compatibility support for older macOS/iOS).

Furthermore, previous WebGPU instrumentation focused on the `GPUDevice` rather than the `GPUCanvasContext` since a single `GPUDevice` could be used for multiple `GPUCanvasContext`.

There was already logic to ensure that only supported `&lt;canvas&gt;` were instrumented when created *after* Web Inspector was opened (though technically that logic was more &quot;we only insert `InspectorInstrumentation` in the places we know we can support&quot;), but the path for if it was created *before* Web Inspector is opened didn&apos;t have the same safeguards.

* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::buildObjectForCanvas):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::internalEnable):

Canonical link: <a href="https://commits.webkit.org/269322@main">https://commits.webkit.org/269322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7c4225a14d83a0264b7710e65a066703ba3f092

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24120 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22751 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24974 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/19224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26389 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/19325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24253 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21595 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20803 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25641 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20156 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5288 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24367 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26915 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20751 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5865 "Passed tests") | 
<!--EWS-Status-Bubble-End-->