### PR TITLE
[ews] email about bot being in bad state should include more information

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3197,16 +3197,21 @@ class CompileWebKitWithoutChange(CompileWebKit):
 
     def send_email_for_unexpected_build_failure(self):
         try:
+            pr_number = self.getProperty('github.number')
+            sha = self.getProperty('github.head.sha', '')[:HASH_LENGTH_TO_DISPLAY]
+            owners = self.getProperty('owners', [])
+            author = owners[0] if owners else '?'
             builder_name = self.getProperty('buildername', '')
             worker_name = self.getProperty('workername', '')
-            build_url = '{}#/builders/{}/builds/{}'.format(self.master.config.buildbotURL, self.build._builderid, self.build.number)
-            email_subject = '{} might be in bad state, unable to build WebKit'.format(worker_name)
-            email_text = '{} might be in bad state. It is unable to build WebKit.'.format(worker_name)
-            email_text += ' Same patch was built successfuly on builder queue previously.\n\nBuild: {}\n\nBuilder: {}'.format(build_url, builder_name)
-            reference = 'build-failure-{}'.format(worker_name)
-            send_email_to_bot_watchers(email_subject, email_text, builder_name, reference)
+            build_url = f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}'
+            email_subject = f'{worker_name} might be in bad state, unable to build WebKit'
+            email_text = f'{worker_name} might be in bad state. It is unable to build WebKit.'
+            email_text += f' Same code was built successfuly on builder queue previously.'
+            email_text += f'\n\nBuild: {build_url}\n\nBuilder: {builder_name}'
+            email_text += f'\n\nPR: {pr_number}, Hash: {sha}, By: {author}\n'
+            send_email_to_bot_watchers(email_subject, email_text, builder_name, f'build-failure-{worker_name}')
         except Exception as e:
-            print('Error in sending email for unexpected build failure: {}'.format(e))
+            print(f'Error in sending email for unexpected build failure: {e}')
 
 
 class AnalyzeCompileWebKitResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin):


### PR DESCRIPTION
#### cc544c9c4912b9b7ddd16aaa185379d805631473
<pre>
[ews] email about bot being in bad state should include more information
<a href="https://bugs.webkit.org/show_bug.cgi?id=263137">https://bugs.webkit.org/show_bug.cgi?id=263137</a>

Reviewed by Jonathan Bedard.

This would help in quickly triaging if multiple failures are happening on same PR.
Similar to 264173@main.

* Tools/CISupport/ews-build/steps.py:
(CompileWebKitWithoutChange.send_email_for_unexpected_build_failure):

Canonical link: <a href="https://commits.webkit.org/269316@main">https://commits.webkit.org/269316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d82702973ca2c030e86e5594845995ed5c01c39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22225 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/22428 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/23296 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/24121 "Build was cancelled. Recent messages:Failed to print configuration") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/22472 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/26687 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/22752 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/24121 "Build was cancelled. Recent messages:Failed to print configuration") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22458 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/26687 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/23296 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24975 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/26687 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/23296 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/24975 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/26687 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/23296 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/24975 "Build was cancelled. Recent messages:Failed to print configuration") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/22752 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22026 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20157 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/23296 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24368 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2773 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/20752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->