### PR TITLE
Allow navigation to about scheme URLs without opaque paths

### DIFF
--- a/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document-async-delegates.html
+++ b/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document-async-delegates.html
@@ -42,7 +42,7 @@
         }
 
         onload = function () {
-            newWindow = window.open("about://webkit.org");
+            newWindow = window.open("about:webkit.org");
             handle = setInterval(checkCannotAccessDocument, 5);
 
         }

--- a/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document.html
+++ b/LayoutTests/http/tests/dom/window-open-about-webkit-org-and-access-document.html
@@ -37,7 +37,7 @@
         }
 
         onload = function () {
-            newWindow = window.open("about://webkit.org");
+            newWindow = window.open("about:webkit.org");
             handle = setInterval(checkCannotAccessDocument, 5);
 
         }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2119,7 +2119,9 @@ void DocumentLoader::startLoadingMainResource()
 
     Ref<DocumentLoader> protectedThis(*this);
 
-    if (m_request.url().protocolIsAbout() && !(m_request.url().isAboutBlank() || m_request.url().isAboutSrcDoc())) {
+    if (m_request.url().protocolIsAbout()
+        && !(m_request.url().isAboutBlank() || m_request.url().isAboutSrcDoc())
+        && m_request.url().hasOpaquePath()) {
         cancelMainResourceLoad(frameLoader()->client().cannotShowURLError(m_request));
         return;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -1943,4 +1943,10 @@ TEST(WKNavigation, NavigationToUnknownBlankURL)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:google.com"]]];
     TestWebKitAPI::Util::run(&done);
     EXPECT_TRUE(navigationFailed);
+
+    done = false;
+    navigationFailed = false;
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about://newtab/"]]];
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_FALSE(navigationFailed);
 }


### PR DESCRIPTION
#### 6eedbb94b3dea4ce23f51563eb49a4a7c5344463
<pre>
Allow navigation to about scheme URLs without opaque paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=263139">https://bugs.webkit.org/show_bug.cgi?id=263139</a>
rdar://116238322

Reviewed by Chris Dumez.

267754@main prevented navigating to URLs with the about scheme except about:blank or about:srcdoc.
However, several iOS browsers start by opening the url about://newtab/
so let&apos;s allow URLs like that to retain compatibility.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::startLoadingMainResource):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/269423@main">https://commits.webkit.org/269423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf4db6f336e4bb04f463b6b8a6848ca4b7ff3f9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21592 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/24984 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26393 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24258 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17704 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19953 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24375 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2825 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->