### PR TITLE
REGRESSION(268342@main): Web process crashes when loading a cross-origin WebM resource

### DIFF
--- a/LayoutTests/http/tests/media/cross-origin-webm-video-expected.txt
+++ b/LayoutTests/http/tests/media/cross-origin-webm-video-expected.txt
@@ -1,0 +1,6 @@
+
+PASS if no crash occurs.
+
+EVENT(canplay)
+END OF TEST
+

--- a/LayoutTests/http/tests/media/cross-origin-webm-video.html
+++ b/LayoutTests/http/tests/media/cross-origin-webm-video.html
@@ -1,0 +1,17 @@
+<script src=../../media-resources/video-test.js></script>
+<video id="video" playsinline muted></video>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onload = async () => {
+    findMediaElement();
+
+    video.src = "http://localhost:8000/media/resources/serve_video.py.webm?type=video/webm&name=../media-source/webm/test.webm";
+    await waitFor(video, "canplay");
+    endTest();
+};
+</script>
+<p>PASS if no crash occurs.</p>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1001,6 +1001,7 @@ platform/mac/media/media-source/media-source-change-source.html [ Skip ]
 media/now-playing-status-without-media.html [ Skip ]
 
 # WebM not supported in WK1 on macOS.
+http/tests/media/cross-origin-webm-video.html [ Skip ]
 http/tests/media/video-webm-stall.html
 media/W3C/video/canPlayType/canPlayType_codecs_order_1.html [ Failure ]
 media/W3C/video/canPlayType/canPlayType_supported_but_no_codecs_parameter_1.html [ Failure ]

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -167,7 +167,6 @@ void MediaPlayerPrivateWebM::load(const String& url)
 
     ResourceRequest request(url);
     request.setAllowCookies(true);
-    request.setFirstPartyForCookies(URL(url));
 
     auto loader = player->createResourceLoader();
     m_resourceClient = WebMResourceClient::create(*this, *loader, WTFMove(request));


### PR DESCRIPTION
#### a971ac1032e7e561aa2388217733d3d117617a98
<pre>
REGRESSION(268342@main): Web process crashes when loading a cross-origin WebM resource
<a href="https://bugs.webkit.org/show_bug.cgi?id=263144">https://bugs.webkit.org/show_bug.cgi?id=263144</a>
rdar://116894594

Reviewed by Pascoe.

WebM video requests currently always set the first party for cookies to its own URL, so our
allowsFirstPartyForCookies message check will fail when loading a cross origin video. The resource
loader will end up setting the correct first party for cookies if one is not already set, so let’s
just not set one here.

* LayoutTests/http/tests/media/cross-origin-webm-video-expected.txt: Added.
* LayoutTests/http/tests/media/cross-origin-webm-video.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::load):

Canonical link: <a href="https://commits.webkit.org/269345@main">https://commits.webkit.org/269345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d7249fd84166f3f6f7e76059328653a1e52493d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24156 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20597 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21606 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25010 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26413 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24277 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17720 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19978 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24398 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2788 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->