### PR TITLE
Allow run-jsc-stress-tests shell runner can be paused when running

### DIFF
--- a/Tools/Scripts/jsc-stress-test-helpers/shell-runner.sh
+++ b/Tools/Scripts/jsc-stress-test-helpers/shell-runner.sh
@@ -37,6 +37,7 @@ indexFile=".index"
 testList=".all_tests.txt"
 tempFile=".temp.txt"
 lockDir=".lock_dir"
+pauseFile=".pause"
 
 trap "kill -9 0" INT HUP TERM
 
@@ -49,7 +50,17 @@ else
 fi
 
 lock_test_list() {
-    until mkdir ${lockDir} 2> /dev/null; do sleep 0; done
+    
+    until mkdir ${lockDir} 2> /dev/null
+    do
+        if [ -e ${pauseFile} ]
+        then
+            echo 'Running paused...'
+            sleep 600
+        else
+            sleep 0
+        fi
+    done
 }
 
 unlock_test_list() {
@@ -67,6 +78,12 @@ do
         lock_test_list
         while [ -s ${testList} ]
         do
+            if [ -e ${pauseFile} ]
+            then
+                echo 'Running paused...'
+                sleep 600
+                continue
+            fi
             index=`cat ${indexFile}`
             index=$((index + 1))
             echo "${index}" > ${indexFile}


### PR DESCRIPTION
#### eec858ecd19fcaa0517ad063622481cdfe54577a
<pre>
Allow run-jsc-stress-tests shell runner can be paused when running
<a href="https://bugs.webkit.org/show_bug.cgi?id=263142">https://bugs.webkit.org/show_bug.cgi?id=263142</a>
<a href="https://rdar.apple.com/116938793">rdar://116938793</a>

Reviewed by Alexey Proskuryakov.

Pausing the running of the test is needed when JSC test is running on embedded devices, specially, those devices will need some time to get charged. JSC test can drain the battery to 0 quickly.

* Tools/Scripts/jsc-stress-test-helpers/shell-runner.sh:

Canonical link: <a href="https://commits.webkit.org/270606@main">https://commits.webkit.org/270606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fcb2a3d31c74a1aa8e3238269b00bbb5c55d539

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23633 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23734 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28492 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29258 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/22467 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27129 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1189 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/32477 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4353 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/7058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6227 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->