### PR TITLE
Try again to fix the tvOS 17 Public SDK build after 269030@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm
@@ -33,9 +33,6 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
-// We can enable the test for old iOS versions after <rdar://problem/63572534> is fixed.
-#if ENABLE(VIDEO_PRESENTATION_MODE) && (PLATFORM(MAC) || (PLATFORM(IOS_FAMILY) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 140000))
-
 static void loadPictureInPicture(RetainPtr<TestWKWebView> webView)
 {
     [webView synchronouslyLoadHTMLString:@"<video src=video-with-audio.mp4 webkit-playsinline playsinline loop></video>"];
@@ -59,6 +56,9 @@ static void loadPictureInPicture(RetainPtr<TestWKWebView> webView)
         TestWebKitAPI::Util::runFor(0.5_s);
     } while (true);
 }
+
+// We can enable the test for old iOS versions after <rdar://problem/63572534> is fixed.
+#if ENABLE(VIDEO_PRESENTATION_MODE) && (PLATFORM(MAC) || (PLATFORM(IOS_FAMILY) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 140000))
 
 // FIXME: Re-enable this test for Big Sur once webkit.org/b/245241 is resolved
 #if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 141000)

--- a/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
+++ b/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
@@ -11,7 +11,6 @@ $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-class.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-runtime.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/history.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/readline.h
-$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AVKit.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioToolbox.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioUnit.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/CFNetwork.framework

--- a/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders.xcfilelist
+++ b/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders.xcfilelist
@@ -11,7 +11,6 @@ $(SDK_DIR_macosx)/usr/include/objc/objc-class.h
 $(SDK_DIR_macosx)/usr/include/objc/objc-runtime.h
 $(SDK_DIR_macosx)/usr/include/readline/history.h
 $(SDK_DIR_macosx)/usr/include/readline/readline.h
-$(SDK_DIR_iphoneos)/System/Library/Frameworks/AVKit.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioToolbox.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioUnit.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/CFNetwork.framework

--- a/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
+++ b/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
@@ -11,7 +11,6 @@ $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-class.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-runtime.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/history.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/readline.h
-$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AVKit.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioToolbox.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioUnit.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/CFNetwork.framework

--- a/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders.xcfilelist
+++ b/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders.xcfilelist
@@ -11,7 +11,6 @@ $(SDK_DIR_macosx)/usr/include/objc/objc-class.h
 $(SDK_DIR_macosx)/usr/include/objc/objc-runtime.h
 $(SDK_DIR_macosx)/usr/include/readline/history.h
 $(SDK_DIR_macosx)/usr/include/readline/readline.h
-$(SDK_DIR_iphoneos)/System/Library/Frameworks/AVKit.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioToolbox.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioUnit.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/CFNetwork.framework


### PR DESCRIPTION
#### a13dd1bd8d0627029a95cc2d23cde4f1798dacb3
<pre>
Try again to fix the tvOS 17 Public SDK build after 269030@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=263155">https://bugs.webkit.org/show_bug.cgi?id=263155</a>
rdar://116948702

Unreviewed build fix. Removed AVKit from tvOS 17&apos;s SDKAdditions and fixed a compiler error in an API test.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm:
* WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist:
* WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders.xcfilelist:
* WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist:
* WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders.xcfilelist:

Canonical link: <a href="https://commits.webkit.org/269337@main">https://commits.webkit.org/269337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9121764549017b5cf099d8b8f23145a9f84aab11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22262 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22788 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22495 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/22202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25013 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/19251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/20834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/20191 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/24401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2783 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/20781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->