### PR TITLE
Style::commitRelations should update elementUpdate.chage accordingly.

### DIFF
--- a/LayoutTests/fast/selectors/first-and-last-child-style-invalidation-expected.html
+++ b/LayoutTests/fast/selectors/first-and-last-child-style-invalidation-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        span:first-child span,
+        span:last-child span {
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div>
+        <span><span>A</span></span>
+        <span><span>B</span></span>
+        <span><span>C</span></span>
+        <span><span>D</span></span>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/selectors/first-and-last-child-style-invalidation.html
+++ b/LayoutTests/fast/selectors/first-and-last-child-style-invalidation.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        span:first-child span,
+        span:last-child span {
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div id="test-case">
+        <span id="first"><span>A</span></span>
+        <span><span>B</span></span>
+        <span><span>C</span></span>
+        <span id="last"><span>D</span></span>
+    </div>
+    <script>
+        window.addEventListener("load", function() {
+            if (window.testRunner) {
+                testRunner.waitUntilDone();
+            }
+
+            var firstChild = document.getElementById("first");
+            firstChild.remove();
+            var lastChild = document.getElementById("last");
+            lastChild.remove();
+
+            setTimeout(function() {
+                var testCase = document.getElementById("test-case");
+                testCase.prepend(firstChild);
+                testCase.append(lastChild);
+
+                if (window.testRunner) {
+                    testRunner.notifyDone();
+                }
+            }, 0)
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/style/StyleRelations.cpp
+++ b/Source/WebCore/style/StyleRelations.cpp
@@ -123,21 +123,41 @@ void commitRelations(std::unique_ptr<Relations> relations, Update& update)
             element.setChildrenAffectedByLastChildRules();
             break;
         case Relation::FirstChild:
-            if (auto* style = update.elementStyle(element))
+            if (auto* style = update.elementStyle(element)) {
+                if (!style->firstChildState()) {
+                    if (auto* elementUpdate = update.elementUpdate(element))
+                        elementUpdate->change = std::max(elementUpdate->change, Change::NonInherited);
+                }
                 style->setFirstChildState();
+            }
             break;
         case Relation::LastChild:
-            if (auto* style = update.elementStyle(element))
+            if (auto* style = update.elementStyle(element)) {
+                if (!style->lastChildState()) {
+                    if (auto* elementUpdate = update.elementUpdate(element))
+                        elementUpdate->change = std::max(elementUpdate->change, Change::NonInherited);
+                }
                 style->setLastChildState();
+            }
             break;
         case Relation::NthChildIndex:
-            if (auto* style = update.elementStyle(element))
+            if (auto* style = update.elementStyle(element)) {
+                if (!style->unique()) {
+                    if (auto* elementUpdate = update.elementUpdate(element))
+                        elementUpdate->change = std::max(elementUpdate->change, Change::NonInherited);
+                }
                 style->setUnique();
+            }
             element.setChildIndex(relation.value);
             break;
         case Relation::Unique:
-            if (auto* style = update.elementStyle(element))
+            if (auto* style = update.elementStyle(element)) {
+                if (!style->unique()) {
+                    if (auto* elementUpdate = update.elementUpdate(element))
+                        elementUpdate->change = std::max(elementUpdate->change, Change::NonInherited);
+                }
                 style->setUnique();
+            }
             break;
         }
     }


### PR DESCRIPTION
#### ae2d16f63487a63d924c93a5de13622c330c8a33
<pre>
Style::commitRelations should update elementUpdate.chage accordingly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=262968">https://bugs.webkit.org/show_bug.cgi?id=262968</a>

Reviewed by NOBODY (OOPS!).

Style::commitRelations should update elementUpdate.chage for the Style::Update object.
Otherwise, elements with selectors such as &quot;:first-child&quot; and &quot;:last-child&quot; may not
invalidate their styles properly.

* LayoutTests/fast/selectors/first-and-last-child-style-invalidation-expected.html: Added.
* LayoutTests/fast/selectors/first-and-last-child-style-invalidation.html: Added.
* Source/WebCore/style/StyleRelations.cpp:
(WebCore::Style::commitRelations):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a6d05967fd931200e3bd7fb83c2fa9bb0961d88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20610 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21620 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25023 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26427 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24289 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17733 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/19989 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->