### PR TITLE
Try again to fix the tvOS 17 Public SDK build after 269030@main

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm
@@ -33,8 +33,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
-// We can enable the test for old iOS versions after <rdar://problem/63572534> is fixed.
-#if ENABLE(VIDEO_PRESENTATION_MODE) && (PLATFORM(MAC) || (PLATFORM(IOS_FAMILY) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 140000))
+#if ENABLE(FULLSCREEN_API) || ENABLE(VIDEO_PRESENTATION_MODE)
 
 static void loadPictureInPicture(RetainPtr<TestWKWebView> webView)
 {
@@ -59,6 +58,10 @@ static void loadPictureInPicture(RetainPtr<TestWKWebView> webView)
         TestWebKitAPI::Util::runFor(0.5_s);
     } while (true);
 }
+
+#endif // ENABLE(FULLSCREEN_API) || ENABLE(VIDEO_PRESENTATION_MODE)
+
+#if ENABLE(VIDEO_PRESENTATION_MODE)
 
 // FIXME: Re-enable this test for Big Sur once webkit.org/b/245241 is resolved
 #if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 141000)
@@ -123,7 +126,7 @@ TEST(WKWebViewCloseAllMediaPresentationsInternal, PictureInPicture)
     EXPECT_TRUE([webView _allMediaPresentationsClosed]);
 }
 
-#endif
+#endif // ENABLE(VIDEO_PRESENTATION_MODE)
 
 #if ENABLE(FULLSCREEN_API)
 
@@ -248,4 +251,4 @@ TEST(WKWebViewCloseAllMediaPresentations, RemovedCloseAllMediaPresentationAPIs)
     EXPECT_FALSE(exception);
 }
 
-#endif
+#endif // ENABLE(FULLSCREEN_API)

--- a/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
+++ b/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
@@ -11,7 +11,6 @@ $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-class.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-runtime.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/history.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/readline.h
-$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AVKit.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioToolbox.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioUnit.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/CFNetwork.framework

--- a/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders.xcfilelist
+++ b/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders.xcfilelist
@@ -11,7 +11,6 @@ $(SDK_DIR_macosx)/usr/include/objc/objc-class.h
 $(SDK_DIR_macosx)/usr/include/objc/objc-runtime.h
 $(SDK_DIR_macosx)/usr/include/readline/history.h
 $(SDK_DIR_macosx)/usr/include/readline/readline.h
-$(SDK_DIR_iphoneos)/System/Library/Frameworks/AVKit.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioToolbox.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioUnit.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/CFNetwork.framework

--- a/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
+++ b/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist
@@ -11,7 +11,6 @@ $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-class.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/objc/objc-runtime.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/history.h
 $(WK_DERIVED_SDK_HEADERS_DIR)/usr/include/readline/readline.h
-$(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AVKit.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioToolbox.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/AudioUnit.framework
 $(WK_DERIVED_SDK_HEADERS_DIR)/System/Library/Frameworks/CFNetwork.framework

--- a/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders.xcfilelist
+++ b/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders.xcfilelist
@@ -11,7 +11,6 @@ $(SDK_DIR_macosx)/usr/include/objc/objc-class.h
 $(SDK_DIR_macosx)/usr/include/objc/objc-runtime.h
 $(SDK_DIR_macosx)/usr/include/readline/history.h
 $(SDK_DIR_macosx)/usr/include/readline/readline.h
-$(SDK_DIR_iphoneos)/System/Library/Frameworks/AVKit.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioToolbox.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/AudioUnit.framework
 $(SDK_DIR_iphoneos)/System/Library/Frameworks/CFNetwork.framework


### PR DESCRIPTION
#### 59e0009a3d737397314615b9148d6e3bea3ec6a5
<pre>
Try again to fix the tvOS 17 Public SDK build after 269030@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=263155">https://bugs.webkit.org/show_bug.cgi?id=263155</a>
rdar://116948702

Unreviewed build fix. Removed AVKit from tvOS 17&apos;s SDKAdditions and fixed a compiler error in an API test.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm:
* WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist:
* WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SymlinkedHeaders.xcfilelist:
* WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders-output.xcfilelist:
* WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SymlinkedHeaders.xcfilelist:

Canonical link: <a href="https://commits.webkit.org/269343@main">https://commits.webkit.org/269343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7703604498a67beb82aaf307f4ad13bb4997b0cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20613 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22802 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25027 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20184 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24294 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17737 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20403 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24630 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2786 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->