### PR TITLE
Fix build failures when importing WebKit, when `-DOS_OBJECT_USE_OBJC=0` is set

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
@@ -117,7 +117,11 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
  @discussion Changing the proxy configurations might interupt current networking operations in any WKWebView that use this WKWebsiteDataStore,
  so it is encouraged to finish setting the proxy configurations before starting any page loads.
 */
+#if defined(OS_OBJECT_USE_OBJC) && OS_OBJECT_USE_OBJC
 @property (nullable, nonatomic, copy) NSArray<nw_proxy_config_t> *proxyConfigurations NS_REFINED_FOR_SWIFT API_AVAILABLE(macos(14.0), ios(17.0));
+#else
+@property (nullable, nonatomic, copy) NSArray *proxyConfigurations NS_REFINED_FOR_SWIFT API_AVAILABLE(macos(14.0), ios(17.0));
+#endif
 #endif
 
 @end


### PR DESCRIPTION
#### 722fe4fc50a4935023c450c325f8db75bdcc24a7
<pre>
Fix build failures when importing WebKit, when `-DOS_OBJECT_USE_OBJC=0` is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=263156">https://bugs.webkit.org/show_bug.cgi?id=263156</a>
rdar://114438852

Reviewed by Richard Robinson.

Before iOS 17 / macOS Sonoma, it was possible to pull in WebKit headers (directly, or through Swift
modules) when compiling without ObjC-backed OS objects, by specifying `-DOS_OBJECT_USE_OBJC=0` as a
build setting. Some popular libraries and plugins such as the `flutter_inappwebview` plugin (see
also: &lt;<a href="https://github.com/pichillilorenzo/flutter_inappwebview/issues/1735">https://github.com/pichillilorenzo/flutter_inappwebview/issues/1735</a>&gt;) use this.

However, after we introduced the following public API in iOS 17:

```
@property (nullable, nonatomic, copy) NSArray&lt;nw_proxy_config_t&gt; *proxyConfigurations;
```

...this became impossible, since `nw_proxy_config_t` would be type-defined to an opaque struct
pointer in `Network.framework`, which is invalid as a type template argument in an `NSArray`. To fix
this, we adopt the same technique used in `Network/NSURLSession+Network.h` and simply expose a
generically-typed `NSArray` in the case where `OS_OBJECT_USE_OBJC` is off.

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h:

Canonical link: <a href="https://commits.webkit.org/269371@main">https://commits.webkit.org/269371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51785e57aed53e720606b746fb9ad7d70dcf0a64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24177 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20617 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21628 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25031 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19266 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26435 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24297 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17741 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20407 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5330 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->