### PR TITLE
Adopt more smart pointers in dom/

### DIFF
--- a/Source/WebCore/dom/AbortController.cpp
+++ b/Source/WebCore/dom/AbortController.cpp
@@ -58,12 +58,17 @@ void AbortController::abort(JSDOMGlobalObject& globalObject, JSC::JSValue reason
     if (reason.isUndefined())
         reason = toJS(&globalObject, &globalObject, DOMException::create(AbortError));
 
-    m_signal->signalAbort(reason);
+    protectedSignal()->signalAbort(reason);
 }
 
 WebCoreOpaqueRoot AbortController::opaqueRoot()
 {
     return root(&signal());
+}
+
+Ref<AbortSignal> AbortController::protectedSignal() const
+{
+    return m_signal;
 }
 
 }

--- a/Source/WebCore/dom/AbortController.h
+++ b/Source/WebCore/dom/AbortController.h
@@ -47,6 +47,7 @@ public:
     ~AbortController();
 
     AbortSignal& signal();
+    Ref<AbortSignal> protectedSignal() const;
     void abort(JSDOMGlobalObject&, JSC::JSValue reason);
 
     WebCoreOpaqueRoot opaqueRoot();

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -106,7 +106,7 @@ AbortSignal::~AbortSignal() = default;
 void AbortSignal::addSourceSignal(AbortSignal& signal)
 {
     if (signal.isDependent()) {
-        for (auto& sourceSignal : signal.sourceSignals())
+        for (Ref sourceSignal : signal.sourceSignals())
             addSourceSignal(sourceSignal);
         return;
     }
@@ -145,8 +145,8 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     // 5. Fire an event named abort at signal.
     dispatchEvent(Event::create(eventNames().abortEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
-    for (auto& dependentSignal : std::exchange(m_dependentSignals, { }))
-        Ref { dependentSignal }->signalAbort(reason);
+    for (Ref dependentSignal : std::exchange(m_dependentSignals, { }))
+        dependentSignal->signalAbort(reason);
 }
 
 // https://dom.spec.whatwg.org/#abortsignal-follow
@@ -163,8 +163,8 @@ void AbortSignal::signalFollow(AbortSignal& signal)
     ASSERT(!m_followingSignal);
     m_followingSignal = signal;
     signal.addAlgorithm([weakThis = WeakPtr<AbortSignal, WeakPtrImplWithEventTargetData> { this }](JSC::JSValue reason) {
-        if (weakThis)
-            weakThis->signalAbort(reason);
+        if (RefPtr signal = weakThis.get())
+            signal->signalAbort(reason);
     });
 }
 

--- a/Source/WebCore/dom/ActiveDOMCallback.cpp
+++ b/Source/WebCore/dom/ActiveDOMCallback.cpp
@@ -44,19 +44,19 @@ ActiveDOMCallback::~ActiveDOMCallback() = default;
 
 bool ActiveDOMCallback::canInvokeCallback() const
 {
-    ScriptExecutionContext* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     return context && !context->activeDOMObjectsAreSuspended() && !context->activeDOMObjectsAreStopped();
 }
 
 bool ActiveDOMCallback::activeDOMObjectsAreSuspended() const
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     return context && context->activeDOMObjectsAreSuspended();
 }
 
 bool ActiveDOMCallback::activeDOMObjectAreStopped() const
 {
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     return !context || context->activeDOMObjectsAreStopped();
 }
 

--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -76,6 +76,8 @@ ActiveDOMObject::~ActiveDOMObject()
     // ContextDestructionObserver::contextDestroyed() (which we implement /
     // inherit). Hence, we should ensure that this is not 0 before use it
     // here.
+
+    // Unable to ref the context as it may have started destruction.
     auto* context = scriptExecutionContext();
     if (!context)
         return;
@@ -91,6 +93,7 @@ void ActiveDOMObject::suspendIfNeeded()
     ASSERT(!m_suspendIfNeededWasCalled);
     m_suspendIfNeededWasCalled = true;
 #endif
+    // Unable to ref the context as it may have started destruction.
     if (auto* context = scriptExecutionContext())
         context->suspendActiveDOMObjectIfNeeded(*this);
 }
@@ -168,7 +171,7 @@ private:
 void ActiveDOMObject::queueTaskToDispatchEventInternal(EventTarget& target, TaskSource source, Ref<Event>&& event)
 {
     ASSERT(!event->target() || &target == event->target());
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
     auto& eventLoopTaskGroup = context->eventLoop();
@@ -181,7 +184,7 @@ void ActiveDOMObject::queueTaskToDispatchEventInternal(EventTarget& target, Task
 void ActiveDOMObject::queueCancellableTaskToDispatchEventInternal(EventTarget& target, TaskSource source, TaskCancellationGroup& cancellationGroup, Ref<Event>&& event)
 {
     ASSERT(!event->target() || &target == event->target());
-    auto* context = scriptExecutionContext();
+    RefPtr context = scriptExecutionContext();
     if (!context)
         return;
     auto& eventLoopTaskGroup = context->eventLoop();

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -72,6 +72,7 @@ Attr::~Attr()
     ASSERT_WITH_SECURITY_IMPLICATION(!isInShadowTree());
     ASSERT_WITH_SECURITY_IMPLICATION(treeScope().rootNode().isDocumentNode());
 
+    // Unable to protect the document here as it may have started destruction.
     willBeDeletedFrom(document());
 }
 
@@ -118,9 +119,10 @@ CSSStyleDeclaration* Attr::style()
     RefPtr styledElement = dynamicDowncast<StyledElement>(m_element.get());
     if (!styledElement)
         return nullptr;
-    m_style = MutableStyleProperties::create();
-    styledElement->collectPresentationalHintsForAttribute(qualifiedName(), value(), *m_style);
-    return &m_style->ensureCSSStyleDeclaration();
+    Ref style = MutableStyleProperties::create();
+    m_style = style.copyRef();
+    styledElement->collectPresentationalHintsForAttribute(qualifiedName(), value(), style);
+    return &style->ensureCSSStyleDeclaration();
 }
 
 AtomString Attr::value() const
@@ -136,6 +138,7 @@ void Attr::detachFromElementWithValue(const AtomString& value)
     ASSERT(m_standaloneValue.isNull());
     m_standaloneValue = value;
     m_element = nullptr;
+    // Unable to ref the document here because it may have started destruction.
     setTreeScopeRecursively(document());
 }
 

--- a/Source/WebCore/dom/BoundaryPoint.cpp
+++ b/Source/WebCore/dom/BoundaryPoint.cpp
@@ -36,18 +36,18 @@ template std::partial_ordering treeOrder<ComposedTree>(const BoundaryPoint&, con
 
 std::optional<BoundaryPoint> makeBoundaryPointBeforeNode(Node& node)
 {
-    auto parent = node.parentNode();
+    RefPtr parent = node.parentNode();
     if (!parent)
         return std::nullopt;
-    return BoundaryPoint { *parent, node.computeNodeIndex() };
+    return BoundaryPoint { parent.releaseNonNull(), node.computeNodeIndex() };
 }
 
 std::optional<BoundaryPoint> makeBoundaryPointAfterNode(Node& node)
 {
-    auto parent = node.parentNode();
+    RefPtr parent = node.parentNode();
     if (!parent)
         return std::nullopt;
-    return BoundaryPoint { *parent, node.computeNodeIndex() + 1 };
+    return BoundaryPoint { parent.releaseNonNull(), node.computeNodeIndex() + 1 };
 }
 
 static bool isOffsetBeforeChild(ContainerNode& container, unsigned offset, Node& child)
@@ -70,18 +70,18 @@ template<TreeType treeType> std::partial_ordering treeOrder(const BoundaryPoint&
     if (a.container.ptr() == b.container.ptr())
         return a.offset <=> b.offset;
 
-    for (auto ancestor = b.container.ptr(); ancestor; ) {
-        auto nextAncestor = parent<treeType>(*ancestor);
+    for (RefPtr ancestor = b.container.copyRef(); ancestor; ) {
+        RefPtr nextAncestor = parent<treeType>(*ancestor);
         if (nextAncestor == a.container.ptr())
             return isOffsetBeforeChild(*nextAncestor, a.offset, *ancestor) ? std::strong_ordering::less : std::strong_ordering::greater;
-        ancestor = nextAncestor;
+        ancestor = WTFMove(nextAncestor);
     }
 
-    for (auto ancestor = a.container.ptr(); ancestor; ) {
-        auto nextAncestor = parent<treeType>(*ancestor);
+    for (RefPtr ancestor = a.container.copyRef(); ancestor; ) {
+        RefPtr nextAncestor = parent<treeType>(*ancestor);
         if (nextAncestor == b.container.ptr())
             return isOffsetBeforeChild(*nextAncestor, b.offset, *ancestor) ? std::strong_ordering::greater : std::strong_ordering::less;
-        ancestor = nextAncestor;
+        ancestor = WTFMove(nextAncestor);
     }
 
     return treeOrder<treeType>(a.container, b.container);

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -84,6 +84,8 @@ private:
     void stop() final { close(); }
 
     class MainThreadBridge;
+    Ref<MainThreadBridge> protectedMainThreadBridge() const;
+
     Ref<MainThreadBridge> m_mainThreadBridge;
     bool m_isClosed { false };
     bool m_hasRelevantEventListener { false };

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -56,7 +56,7 @@ Ref<Node> CDATASection::cloneNodeInternal(Document& targetDocument, CloningOpera
 
 Ref<Text> CDATASection::virtualCreate(String&& data)
 {
-    return create(document(), WTFMove(data));
+    return create(protectedDocument(), WTFMove(data));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -44,14 +44,15 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(CharacterData);
 
 CharacterData::~CharacterData()
 {
+    // Unable to ref the document as it may have started destruction.
     willBeDeletedFrom(document());
 }
 
 static bool canUseSetDataOptimization(const CharacterData& node)
 {
-    auto& document = node.document();
-    return !document.hasListenerType(Document::ListenerType::DOMCharacterDataModified) && !document.hasMutationObserversOfType(MutationObserverOptionType::CharacterData)
-        && !document.hasListenerType(Document::ListenerType::DOMSubtreeModified) && !is<HTMLStyleElement>(node.parentNode());
+    Ref document = node.document();
+    return !document->hasListenerType(Document::ListenerType::DOMCharacterDataModified) && !document->hasMutationObserversOfType(MutationObserverOptionType::CharacterData)
+        && !document->hasListenerType(Document::ListenerType::DOMSubtreeModified) && !is<HTMLStyleElement>(node.parentNode());
 }
 
 void CharacterData::setData(const String& data)
@@ -60,8 +61,9 @@ void CharacterData::setData(const String& data)
     unsigned oldLength = length();
 
     if (m_data == nonNullData && canUseSetDataOptimization(*this)) {
-        document().textRemoved(*this, 0, oldLength);
-        if (auto* frame = document().frame())
+        Ref document = this->document();
+        document->textRemoved(*this, 0, oldLength);
+        if (RefPtr frame = document->frame())
             frame->selection().textWasReplaced(*this, 0, oldLength, oldLength);
         return;
     }
@@ -83,8 +85,8 @@ static ContainerNode::ChildChange makeChildChange(CharacterData& characterData, 
     return {
         ContainerNode::ChildChange::Type::TextChanged,
         nullptr,
-        ElementTraversal::previousSibling(characterData),
-        ElementTraversal::nextSibling(characterData),
+        RefPtr { ElementTraversal::previousSibling(characterData) }.get(),
+        RefPtr { ElementTraversal::nextSibling(characterData) }.get(),
         source,
         ContainerNode::ChildChange::AffectsElements::No
     };
@@ -94,7 +96,7 @@ void CharacterData::parserAppendData(StringView string)
 {
     auto childChange = makeChildChange(*this, ContainerNode::ChildChange::Source::Parser);
     std::optional<Style::ChildChangeInvalidation> styleInvalidation;
-    if (auto* parent = parentNode())
+    if (RefPtr parent = parentNode())
         styleInvalidation.emplace(*parent, childChange);
 
     String oldData = m_data;
@@ -171,16 +173,17 @@ void CharacterData::setDataAndUpdate(const String& newData, unsigned offsetOfRep
     String oldData = WTFMove(m_data);
     {
         std::optional<Style::ChildChangeInvalidation> styleInvalidation;
-        if (auto* parent = parentNode())
+        if (RefPtr parent = parentNode())
             styleInvalidation.emplace(*parent, childChange);
 
         m_data = newData;
     }
 
+    Ref document = this->document();
     if (oldLength && shouldUpdateLiveRanges != UpdateLiveRanges::No)
-        document().textRemoved(*this, offsetOfReplacedData, oldLength);
+        document->textRemoved(*this, offsetOfReplacedData, oldLength);
     if (newLength && shouldUpdateLiveRanges != UpdateLiveRanges::No)
-        document().textInserted(*this, offsetOfReplacedData, newLength);
+        document->textInserted(*this, offsetOfReplacedData, newLength);
 
     ASSERT(!renderer() || is<Text>(*this));
     if (auto text = dynamicDowncast<Text>(*this))
@@ -188,7 +191,7 @@ void CharacterData::setDataAndUpdate(const String& newData, unsigned offsetOfRep
     else if (auto processingIntruction = dynamicDowncast<ProcessingInstruction>(*this))
         processingIntruction->checkStyleSheet();
 
-    if (auto* frame = document().frame())
+    if (RefPtr frame = document->frame())
         frame->selection().textWasReplaced(*this, offsetOfReplacedData, oldLength, newLength);
 
     notifyParentAfterChange(childChange);
@@ -200,10 +203,11 @@ void CharacterData::notifyParentAfterChange(const ContainerNode::ChildChange& ch
 {
     document().incDOMTreeVersion();
 
-    if (!parentNode())
+    RefPtr parentNode = this->parentNode();
+    if (!parentNode)
         return;
 
-    parentNode()->childrenChanged(childChange);
+    parentNode->childrenChanged(childChange);
 }
 
 void CharacterData::dispatchModifiedEvent(const String& oldData)
@@ -217,7 +221,7 @@ void CharacterData::dispatchModifiedEvent(const String& oldData)
         dispatchSubtreeModifiedEvent();
     }
 
-    InspectorInstrumentation::characterDataModified(document(), *this);
+    InspectorInstrumentation::characterDataModified(protectedDocument(), *this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ChildListMutationScope.cpp
+++ b/Source/WebCore/dom/ChildListMutationScope.cpp
@@ -83,7 +83,7 @@ void ChildListMutationAccumulator::childAdded(Node& childRef)
 {
     ASSERT(hasObservers());
 
-    Ref<Node> child(childRef);
+    Ref child(childRef);
 
     if (!isAddedNodeInOrder(child))
         enqueueMutationRecord();
@@ -106,7 +106,7 @@ void ChildListMutationAccumulator::willRemoveChild(Node& childRef)
 {
     ASSERT(hasObservers());
 
-    Ref<Node> child(childRef);
+    Ref child(childRef);
 
     if (!m_addedNodes.isEmpty() || !isRemovedNodeInOrder(child))
         enqueueMutationRecord();
@@ -126,10 +126,15 @@ void ChildListMutationAccumulator::enqueueMutationRecord()
     ASSERT(hasObservers());
     ASSERT(!isEmpty());
 
-    auto record = MutationRecord::createChildList(m_target, StaticNodeList::create(WTFMove(m_addedNodes)), StaticNodeList::create(WTFMove(m_removedNodes)), WTFMove(m_previousSibling), WTFMove(m_nextSibling));
+    auto record = MutationRecord::createChildList(protectedTarget(), StaticNodeList::create(WTFMove(m_addedNodes)), StaticNodeList::create(WTFMove(m_removedNodes)), WTFMove(m_previousSibling), WTFMove(m_nextSibling));
     m_observers->enqueueMutationRecord(WTFMove(record));
     m_lastAdded = nullptr;
     ASSERT(isEmpty());
+}
+
+Ref<ContainerNode> ChildListMutationAccumulator::protectedTarget() const
+{
+    return m_target;
 }
 
 bool ChildListMutationAccumulator::isEmpty()

--- a/Source/WebCore/dom/ChildListMutationScope.h
+++ b/Source/WebCore/dom/ChildListMutationScope.h
@@ -60,6 +60,8 @@ private:
     bool isAddedNodeInOrder(Node&);
     bool isRemovedNodeInOrder(Node&);
 
+    Ref<ContainerNode> protectedTarget() const;
+
     Ref<ContainerNode> m_target;
 
     Vector<Ref<Node>> m_removedNodes;

--- a/Source/WebCore/dom/ChildNodeList.cpp
+++ b/Source/WebCore/dom/ChildNodeList.cpp
@@ -45,7 +45,7 @@ ChildNodeList::ChildNodeList(ContainerNode& parent)
 
 ChildNodeList::~ChildNodeList()
 {
-    m_parent.get().nodeLists()->removeChildNodeList(this);
+    Ref { m_parent }->nodeLists()->removeChildNodeList(this);
 }
 
 unsigned ChildNodeList::length() const

--- a/Source/WebCore/dom/ClassCollection.cpp
+++ b/Source/WebCore/dom/ClassCollection.cpp
@@ -46,7 +46,7 @@ Ref<ClassCollection> ClassCollection::create(ContainerNode& rootNode, Collection
 
 ClassCollection::~ClassCollection()
 {
-    ownerNode().nodeLists()->removeCachedCollection(this, m_originalClassNames);
+    protectedOwnerNode()->nodeLists()->removeCachedCollection(this, m_originalClassNames);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ConstantPropertyMap.cpp
+++ b/Source/WebCore/dom/ConstantPropertyMap.cpp
@@ -125,9 +125,15 @@ static Ref<CSSVariableData> variableDataForPositiveDuration(Seconds durationInSe
     return CSSVariableData::create(tokenRange);
 }
 
+Ref<Document> ConstantPropertyMap::protectedDocument() const
+{
+    return m_document.get();
+}
+
 void ConstantPropertyMap::updateConstantsForSafeAreaInsets()
 {
-    FloatBoxExtent unobscuredSafeAreaInsets = m_document.page() ? m_document.page()->unobscuredSafeAreaInsets() : FloatBoxExtent();
+    CheckedPtr page = m_document->page();
+    FloatBoxExtent unobscuredSafeAreaInsets = page ? page->unobscuredSafeAreaInsets() : FloatBoxExtent();
     setValueForProperty(ConstantProperty::SafeAreaInsetTop, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.top()));
     setValueForProperty(ConstantProperty::SafeAreaInsetRight, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.right()));
     setValueForProperty(ConstantProperty::SafeAreaInsetBottom, variableDataForPositivePixelLength(unobscuredSafeAreaInsets.bottom()));
@@ -137,31 +143,32 @@ void ConstantPropertyMap::updateConstantsForSafeAreaInsets()
 void ConstantPropertyMap::didChangeSafeAreaInsets()
 {
     updateConstantsForSafeAreaInsets();
-    m_document.invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+    protectedDocument()->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
 void ConstantPropertyMap::updateConstantsForFullscreen()
 {
-    FloatBoxExtent fullscreenInsets = m_document.page() ? m_document.page()->fullscreenInsets() : FloatBoxExtent();
+    CheckedPtr page = m_document->page();
+    FloatBoxExtent fullscreenInsets = page ? page->fullscreenInsets() : FloatBoxExtent();
     setValueForProperty(ConstantProperty::FullscreenInsetTop, variableDataForPositivePixelLength(fullscreenInsets.top()));
     setValueForProperty(ConstantProperty::FullscreenInsetRight, variableDataForPositivePixelLength(fullscreenInsets.right()));
     setValueForProperty(ConstantProperty::FullscreenInsetBottom, variableDataForPositivePixelLength(fullscreenInsets.bottom()));
     setValueForProperty(ConstantProperty::FullscreenInsetLeft, variableDataForPositivePixelLength(fullscreenInsets.left()));
 
-    Seconds fullscreenAutoHideDuration = m_document.page() ? m_document.page()->fullscreenAutoHideDuration() : 0_s;
+    Seconds fullscreenAutoHideDuration = page ? page->fullscreenAutoHideDuration() : 0_s;
     setValueForProperty(ConstantProperty::FullscreenAutoHideDuration, variableDataForPositiveDuration(fullscreenAutoHideDuration));
 }
 
 void ConstantPropertyMap::didChangeFullscreenInsets()
 {
     updateConstantsForFullscreen();
-    m_document.invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+    protectedDocument()->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
 void ConstantPropertyMap::setFullscreenAutoHideDuration(Seconds duration)
 {
     setValueForProperty(ConstantProperty::FullscreenAutoHideDuration, variableDataForPositiveDuration(duration));
-    m_document.invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+    protectedDocument()->invalidateMatchedPropertiesCacheAndForceStyleRecalc();
 }
 
 }

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
@@ -71,9 +72,11 @@ private:
     void updateConstantsForSafeAreaInsets();
     void updateConstantsForFullscreen();
 
+    Ref<Document> protectedDocument() const;
+
     std::optional<Values> m_values;
 
-    Document& m_document;
+    CheckedRef<Document> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -139,6 +139,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
         if (UNLIKELY(isShadowRoot() || isInShadowTree()))
             containingShadowRoot()->willRemoveAllChildren(*this);
 
+        // Unable to ref the document here because it may have started destruction.
         document().nodeChildrenWillBeRemoved(*this);
 
         while (RefPtr child = m_firstChild) {
@@ -184,16 +185,17 @@ static ContainerNode::ChildChange makeChildChangeForRemoval(Node& childToRemove,
 
 ALWAYS_INLINE bool ContainerNode::removeNodeWithScriptAssertion(Node& childToRemove, ChildChange::Source source)
 {
-    Ref<Node> protectedChildToRemove(childToRemove);
+    Ref protectedChildToRemove { childToRemove };
     ASSERT_WITH_SECURITY_IMPLICATION(childToRemove.parentNode() == this);
     {
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         ChildListMutationScope(*this).willRemoveChild(childToRemove);
     }
 
+    Ref document = this->document();
     if (source == ChildChange::Source::API) {
         childToRemove.notifyMutationObserversNodeWillDetach();
-        if (!document().shouldNotFireMutationEvents()) {
+        if (!document->shouldNotFireMutationEvents()) {
             RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(childToRemove));
             dispatchChildRemovalEvents(protectedChildToRemove);
         }
@@ -224,13 +226,13 @@ ALWAYS_INLINE bool ContainerNode::removeNodeWithScriptAssertion(Node& childToRem
         if (UNLIKELY(isShadowRoot() || isInShadowTree()))
             containingShadowRoot()->resolveSlotsBeforeNodeInsertionOrRemoval();
 
-        document().nodeWillBeRemoved(childToRemove);
+        document->nodeWillBeRemoved(childToRemove);
 
         ASSERT_WITH_SECURITY_IMPLICATION(childToRemove.parentNode() == this);
         ASSERT(!childToRemove.isDocumentFragment());
 
-        RefPtr<Node> previousSibling = childToRemove.previousSibling();
-        RefPtr<Node> nextSibling = childToRemove.nextSibling();
+        RefPtr previousSibling = childToRemove.previousSibling();
+        RefPtr nextSibling = childToRemove.nextSibling();
 
         removeBetween(previousSibling.get(), nextSibling.get(), childToRemove);
         subtreeObservability = notifyChildNodeRemoved(*this, childToRemove);
@@ -239,7 +241,7 @@ ALWAYS_INLINE bool ContainerNode::removeNodeWithScriptAssertion(Node& childToRem
     if (source == ChildChange::Source::API && subtreeObservability == RemovedSubtreeObservability::MaybeObservableByRefPtr)
         willCreatePossiblyOrphanedTreeByRemoval(childToRemove);
 
-    ASSERT_WITH_SECURITY_IMPLICATION(!document().selection().selection().isOrphan());
+    ASSERT_WITH_SECURITY_IMPLICATION(!document->selection().selection().isOrphan());
 
     // FIXME: Move childrenChanged into ScriptDisallowedScope block.
     childrenChanged(childChange);
@@ -338,7 +340,7 @@ ExceptionOr<void> ContainerNode::removeSelfOrChildNodesForInsertion(Node& child,
 void ContainerNode::removeDetachedChildren()
 {
     if (connectedSubframeCount()) {
-        for (Node* child = firstChild(); child; child = child->nextSibling())
+        for (RefPtr child = firstChild(); child; child = child->nextSibling())
             child->updateAncestorConnectedSubframeCountForRemoval();
     }
     // FIXME: We should be able to ASSERT(!attached()) here: https://bugs.webkit.org/show_bug.cgi?id=107801
@@ -390,7 +392,7 @@ static inline bool isChildTypeAllowed(ContainerNode& newParent, Node& child)
     if (!child.isDocumentFragment())
         return newParent.childTypeAllowed(child.nodeType());
 
-    for (Node* node = child.firstChild(); node; node = node->nextSibling()) {
+    for (RefPtr node = child.firstChild(); node; node = node->nextSibling()) {
         if (!newParent.childTypeAllowed(node->nodeType()))
             return false;
     }
@@ -536,19 +538,19 @@ void ContainerNode::insertBeforeCommon(Node& nextChild, Node& newChild)
     ASSERT(!newChild.previousSibling());
     ASSERT(!newChild.isShadowRoot());
 
-    Node* prev = nextChild.previousSibling();
-    ASSERT(m_lastChild != prev);
+    RefPtr previousSibling = nextChild.previousSibling();
+    ASSERT(m_lastChild != previousSibling);
     nextChild.setPreviousSibling(&newChild);
-    if (prev) {
+    if (previousSibling) {
         ASSERT(m_firstChild != &nextChild);
-        ASSERT(prev->nextSibling() == &nextChild);
-        prev->setNextSibling(&newChild);
+        ASSERT(previousSibling->nextSibling() == &nextChild);
+        previousSibling->setNextSibling(&newChild);
     } else {
         ASSERT(m_firstChild == &nextChild);
         m_firstChild = &newChild;
     }
     newChild.setParentNode(this);
-    newChild.setPreviousSibling(prev);
+    newChild.setPreviousSibling(previousSibling.get());
     newChild.setNextSibling(&nextChild);
 }
 
@@ -592,14 +594,14 @@ ExceptionOr<void> ContainerNode::replaceChild(Node& newChild, Node& oldChild)
     // If it is, it can be deleted as a side effect of sending mutation events.
     ASSERT(refCount() || parentOrShadowHostNode());
 
-    Ref<ContainerNode> protectedThis(*this);
+    Ref protectedThis { *this };
 
     // Make sure replacing the old child with the new is ok
     auto validityResult = checkPreReplacementValidity(*this, newChild, oldChild, ShouldValidateChildParent::Yes);
     if (validityResult.hasException())
         return validityResult.releaseException();
 
-    RefPtr<Node> refChild = oldChild.nextSibling();
+    RefPtr refChild = oldChild.nextSibling();
     if (refChild.get() == &newChild)
         refChild = refChild->nextSibling();
 
@@ -619,7 +621,7 @@ ExceptionOr<void> ContainerNode::replaceChild(Node& newChild, Node& oldChild)
     }
 
     // Remove the node we're replacing.
-    Ref<Node> protectOldChild(oldChild);
+    Ref protectOldChild { oldChild };
 
     ChildListMutationScope mutation(*this);
 
@@ -756,7 +758,7 @@ void ContainerNode::replaceAll(Node* node)
         return;
     }
 
-    Ref<ContainerNode> protectedThis(*this);
+    Ref protectedThis { *this };
     ChildListMutationScope mutation(*this);
     NodeVector removedChildren;
     auto didRemoveElements = removeAllChildrenWithScriptAssertion(ChildChange::Source::API, removedChildren, DeferChildrenChanged::Yes);
@@ -781,6 +783,7 @@ void ContainerNode::stringReplaceAll(String&& string)
 
 inline void ContainerNode::rebuildSVGExtensionsElementsIfNecessary()
 {
+    // Unable to ref the document as it may have started destruction.
     if (document().svgExtensions() && !is<SVGUseElement>(shadowHost()))
         document().accessSVGExtensions().rebuildElements();
 }
@@ -792,7 +795,7 @@ void ContainerNode::removeChildren()
     if (!m_firstChild)
         return;
 
-    Ref<ContainerNode> protectedThis(*this);
+    Ref protectedThis { *this };
     NodeVector removedChildren;
     removeAllChildrenWithScriptAssertion(ChildChange::Source::API, removedChildren);
 
@@ -816,7 +819,7 @@ ExceptionOr<void> ContainerNode::appendChild(Node& newChild)
 
 ExceptionOr<void> ContainerNode::appendChildWithoutPreInsertionValidityCheck(Node& newChild)
 {
-    Ref<ContainerNode> protectedThis(*this);
+    Ref protectedThis { *this };
 
     NodeVector targets;
     auto removeResult = removeSelfOrChildNodesForInsertion(newChild, targets);
@@ -833,7 +836,7 @@ ExceptionOr<void> ContainerNode::appendChildWithoutPreInsertionValidityCheck(Nod
             return nodeTypeResult.releaseException();
     }
 
-    InspectorInstrumentation::willInsertDOMNode(document(), *this);
+    InspectorInstrumentation::willInsertDOMNode(protectedDocument(), *this);
 
     // Now actually add the child(ren)
     ChildListMutationScope mutation(*this);
@@ -882,6 +885,7 @@ ExceptionOr<void> ContainerNode::appendChild(ChildChange::Source source, Node& n
 
 void ContainerNode::childrenChanged(const ChildChange& change)
 {
+    // Unable to ref the document as it may have started destruction.
     document().incDOMTreeVersion();
 
     if (change.affectsElements == ChildChange::AffectsElements::Yes)
@@ -905,12 +909,12 @@ void ContainerNode::childrenChanged(const ChildChange& change)
 
 void ContainerNode::cloneChildNodes(ContainerNode& clone)
 {
-    Document& targetDocument = clone.document();
+    Ref targetDocument = clone.document();
 
     NodeVector postInsertionNotificationTargets;
     bool hadElement = false;
     for (RefPtr child = firstChild(); child; child = child->nextSibling()) {
-        auto clonedChild = child->cloneNodeInternal(targetDocument, CloningOperation::SelfWithTemplateContent);
+        Ref clonedChild = child->cloneNodeInternal(targetDocument, CloningOperation::SelfWithTemplateContent);
         {
             WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
             ScriptDisallowedScope::InMainThread scriptDisallowedScope;
@@ -954,11 +958,11 @@ static void dispatchChildInsertionEvents(Node& child)
 
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(child));
 
-    RefPtr<Node> c = &child;
-    Ref<Document> document(child.document());
+    RefPtr c = &child;
+    Ref document = child.document();
 
     if (c->parentNode() && document->hasListenerType(Document::ListenerType::DOMNodeInserted))
-        c->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeInsertedEvent, Event::CanBubble::Yes, c->parentNode()));
+        c->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeInsertedEvent, Event::CanBubble::Yes, c->protectedParentNode().get()));
 
     // dispatch the DOMNodeInsertedIntoDocument event to all descendants
     if (c->isConnected() && document->hasListenerType(Document::ListenerType::DOMNodeInsertedIntoDocument)) {
@@ -975,22 +979,22 @@ static void dispatchChildRemovalEvents(Ref<Node>& child)
     if (child->isInShadowTree())
         return;
 
-    Ref<Document> document = child->document();
+    Ref document = child->document();
 
     // dispatch pre-removal mutation events
     if (child->parentNode() && document->hasListenerType(Document::ListenerType::DOMNodeRemoved))
-        child->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeRemovedEvent, Event::CanBubble::Yes, child->parentNode()));
+        child->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeRemovedEvent, Event::CanBubble::Yes, child->protectedParentNode().get()));
 
     // dispatch the DOMNodeRemovedFromDocument event to all descendants
     if (child->isConnected() && document->hasListenerType(Document::ListenerType::DOMNodeRemovedFromDocument)) {
-        for (RefPtr<Node> currentNode = child.copyRef(); currentNode; currentNode = NodeTraversal::next(*currentNode, child.ptr()))
+        for (RefPtr currentNode = child.copyRef(); currentNode; currentNode = NodeTraversal::next(*currentNode, child.ptr()))
             currentNode->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeRemovedFromDocumentEvent, Event::CanBubble::No));
     }
 }
 
 ExceptionOr<Element*> ContainerNode::querySelector(const String& selectors)
 {
-    auto query = document().selectorQueryForString(selectors);
+    auto query = protectedDocument()->selectorQueryForString(selectors);
     if (query.hasException())
         return query.releaseException();
     return query.releaseReturnValue().queryFirst(*this);
@@ -998,7 +1002,7 @@ ExceptionOr<Element*> ContainerNode::querySelector(const String& selectors)
 
 ExceptionOr<Ref<NodeList>> ContainerNode::querySelectorAll(const String& selectors)
 {
-    auto query = document().selectorQueryForString(selectors);
+    auto query = protectedDocument()->selectorQueryForString(selectors);
     if (query.hasException())
         return query.releaseException();
     return query.releaseReturnValue().queryAll(*this);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -641,7 +641,8 @@ public:
     void setStateForNewFormElements(const Vector<AtomString>&);
 
     inline LocalFrameView* view() const; // Defined in LocalFrame.h.
-    inline Page* page() const; // Defined in Page.h
+    inline Page* page() const; // Defined in Page.h.
+    inline CheckedPtr<Page> checkedPage() const; // Defined in Page.h.
     const Settings& settings() const { return m_settings.get(); }
     EditingBehavior editingBehavior() const;
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1465,6 +1465,11 @@ inline Page* Document::page() const
     return m_frame ? m_frame->page() : nullptr;
 }
 
+inline CheckedPtr<Page> Document::checkedPage() const
+{
+    return page();
+}
+
 WTF::TextStream& operator<<(WTF::TextStream&, RenderingUpdateStep);
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1cfcb963f8af7d7055a155939486947e5bfc2ce4
<pre>
Adopt more smart pointers in dom/
<a href="https://bugs.webkit.org/show_bug.cgi?id=263163">https://bugs.webkit.org/show_bug.cgi?id=263163</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/AbortController.cpp:
(WebCore::AbortController::abort):
(WebCore::AbortController::protectedSignal const):
* Source/WebCore/dom/AbortController.h:
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::addSourceSignal):
(WebCore::AbortSignal::signalAbort):
(WebCore::AbortSignal::signalFollow):
* Source/WebCore/dom/ActiveDOMCallback.cpp:
(WebCore::ActiveDOMCallback::canInvokeCallback const):
(WebCore::ActiveDOMCallback::activeDOMObjectsAreSuspended const):
(WebCore::ActiveDOMCallback::activeDOMObjectAreStopped const):
* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::ActiveDOMObject::~ActiveDOMObject):
(WebCore::ActiveDOMObject::suspendIfNeeded):
(WebCore::ActiveDOMObject::queueTaskInEventLoop):
(WebCore::ActiveDOMObject::queueTaskToDispatchEventInternal):
(WebCore::ActiveDOMObject::queueCancellableTaskToDispatchEventInternal):
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::~Attr):
(WebCore::Attr::style):
(WebCore::Attr::detachFromElementWithValue):
* Source/WebCore/dom/BoundaryPoint.cpp:
(WebCore::makeBoundaryPointBeforeNode):
(WebCore::makeBoundaryPointAfterNode):
(WebCore::treeOrder):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::MainThreadBridge::ensureOnMainThread):
(WebCore::BroadcastChannel::BroadcastChannel):
(WebCore::BroadcastChannel::protectedMainThreadBridge const):
(WebCore::BroadcastChannel::postMessage):
(WebCore::BroadcastChannel::close):
(WebCore::BroadcastChannel::isEligibleForMessaging const):
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/CDATASection.cpp:
(WebCore::CDATASection::virtualCreate):
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::CharacterData::~CharacterData):
(WebCore::canUseSetDataOptimization):
(WebCore::CharacterData::setData):
(WebCore::makeChildChange):
(WebCore::CharacterData::parserAppendData):
(WebCore::CharacterData::setDataAndUpdate):
(WebCore::CharacterData::notifyParentAfterChange):
(WebCore::CharacterData::dispatchModifiedEvent):
* Source/WebCore/dom/ChildListMutationScope.cpp:
(WebCore::ChildListMutationAccumulator::childAdded):
(WebCore::ChildListMutationAccumulator::willRemoveChild):
(WebCore::ChildListMutationAccumulator::enqueueMutationRecord):
(WebCore::ChildListMutationAccumulator::protectedTarget const):
* Source/WebCore/dom/ChildListMutationScope.h:
* Source/WebCore/dom/ChildNodeList.cpp:
(WebCore::ChildNodeList::~ChildNodeList):
* Source/WebCore/dom/ClassCollection.cpp:
(WebCore::ClassCollection::~ClassCollection):
* Source/WebCore/dom/ConstantPropertyMap.cpp:
(WebCore::ConstantPropertyMap::protectedDocument const):
(WebCore::ConstantPropertyMap::updateConstantsForSafeAreaInsets):
(WebCore::ConstantPropertyMap::didChangeSafeAreaInsets):
(WebCore::ConstantPropertyMap::updateConstantsForFullscreen):
(WebCore::ConstantPropertyMap::didChangeFullscreenInsets):
(WebCore::ConstantPropertyMap::setFullscreenAutoHideDuration):
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::ContainerNode::removeNodeWithScriptAssertion):
(WebCore::ContainerNode::removeDetachedChildren):
(WebCore::isChildTypeAllowed):
(WebCore::ContainerNode::insertBeforeCommon):
(WebCore::ContainerNode::replaceChild):
(WebCore::ContainerNode::replaceAll):
(WebCore::ContainerNode::rebuildSVGExtensionsElementsIfNecessary):
(WebCore::ContainerNode::removeChildren):
(WebCore::ContainerNode::appendChildWithoutPreInsertionValidityCheck):
(WebCore::ContainerNode::childrenChanged):
(WebCore::ContainerNode::cloneChildNodes):
(WebCore::dispatchChildInsertionEvents):
(WebCore::dispatchChildRemovalEvents):
(WebCore::ContainerNode::querySelectorAll):
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::notifyNodeInsertedIntoDocument):
(WebCore::notifyNodeInsertedIntoTree):
(WebCore::notifyChildNodeInserted):
(WebCore::notifyNodeRemovedFromDocument):
(WebCore::notifyNodeRemovedFromTree):
(WebCore::removeDetachedChildrenInContainer):

Canonical link: <a href="https://commits.webkit.org/269369@main">https://commits.webkit.org/269369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2660fc300acfb5fa3d0b991eec780d87636db18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22374 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22907 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22303 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19429 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25133 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20284 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24391 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/21046 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20499 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5325 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/21037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->