### PR TITLE
tryCacheArrayPutByVal should use the right ECMAMode.

### DIFF
--- a/JSTests/stress/sloppy-mode-array-put-should-not-throw.js
+++ b/JSTests/stress/sloppy-mode-array-put-should-not-throw.js
@@ -1,0 +1,18 @@
+if (typeof console != "undefined") print = console.log;
+
+const array = [0, 0];
+array.__proto__ = {
+    get x() { }
+}
+
+function opt() {
+    for (const key in array)
+        array[key] = 1;
+}
+
+function main() {
+    for (let i = 0; i < 10000; i++)
+        opt();
+}
+
+main();


### PR DESCRIPTION
#### b55372516a5c399ca427c87b393a7d6975a6c526
<pre>
tryCacheArrayPutByVal should use the right ECMAMode.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263169">https://bugs.webkit.org/show_bug.cgi?id=263169</a>
rdar://114305344

Reviewed by Justin Michaud.

tryCacheArrayPutByVal() was always assuming that the array put is of type ECMAMode::strict().
Fixed it to determine the ECMAMode based on the putByKind.

Note: PutByKind::DefinePrivateNameById, PutByKind::DefinePrivateNameByVal, PutByKind::SetPrivateNameById,
and PutByKind::SetPrivateNameByVal are strict because according to 11.2.2 Strict Code Mode [1]:
&quot;All parts of a ClassDeclaration or a ClassExpression are strict mode code.&quot;, and private names only
manifest in classes.

[1] <a href="https://tc39.es/ecma262/#sec-strict-mode-code">https://tc39.es/ecma262/#sec-strict-mode-code</a>

* JSTests/stress/sloppy-mode-array-put-should-not-throw.js: Added.
(array.__proto__.get x):
(opt):
(main):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::ecmaModeFor):
(JSC::tryCacheArrayPutByVal):
(JSC::repatchArrayPutByVal):

Canonical link: <a href="https://commits.webkit.org/269346@main">https://commits.webkit.org/269346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e7f11f445f80462bb2ee20a0e5d74a0bce07256

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20630 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21639 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25045 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26448 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19383 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24309 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21658 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17753 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25709 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20419 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6050 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24647 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/26984 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2789 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20956 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5877 "Passed tests") | 
<!--EWS-Status-Bubble-End-->