### PR TITLE
Ensure iframe requests include Referer when location.replace or location.assign is called

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Browser sends Referer header in iframe request when location.replace is called from an iframe
+PASS Browser sends Referer header in iframe request when location.assign is called from an iframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-iframe.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Referer with location.replace and location.assign</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <iframe src="/resources/blank.html" hidden></iframe>
+    <script>
+      async_test(function(t) {
+        function on_message(e) {
+        const referrer = e.data;
+        assert_equals(referrer, window.location.href);
+        t.done();
+      }
+      window.addEventListener('message', t.step_func(on_message), false);
+      document.querySelector("iframe").contentWindow.location.replace("resources/iframe-contents.sub.html?replace");
+      }, "Browser sends Referer header in iframe request when location.replace is called from an iframe");
+      async_test(function(t) {
+        function on_message(e) {
+        const referrer = e.data;
+        assert_equals(referrer, window.location.href);
+        t.done();
+      }
+      window.addEventListener('message', t.step_func(on_message), false);
+      document.querySelector("iframe").contentWindow.location.assign("resources/iframe-contents.sub.html?assign");
+      }, "Browser sends Referer header in iframe request when location.assign is called from an iframe");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Browser sends Referer header in nested iframe request when location.replace is called on an iframe
+PASS Browser sends Referer header in nested iframe request when location.assign is called on an iframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Referer with location.replace and location.assign with nested iframes</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <iframe src="resources/iframe-with-iframe.html" hidden></iframe>
+    <script>
+      const iframe = document.querySelector("iframe");
+      async_test(function(t) {
+        function on_message(e) {
+          const referrer = e.data;
+          assert_equals(referrer, iframe.contentWindow.location.href);
+          t.done();
+        }
+        window.addEventListener('message', t.step_func(on_message), false);
+        window.addEventListener('load', function () { 
+            iframe.contentDocument.querySelector("iframe").contentWindow.location.replace("/resources/blank.html");
+        }, false);
+      }, "Browser sends Referer header in nested iframe request when location.replace is called on an iframe");
+      async_test(function(t) {
+        function on_message(e) {
+          const referrer = e.data;
+          assert_equals(referrer, iframe.contentWindow.location.href);
+          t.done();
+        }
+        window.addEventListener('message', t.step_func(on_message), false);
+        window.addEventListener('load', function () { 
+            iframe.contentDocument.querySelector("iframe").contentWindow.location.replace("/resources/blank.html");
+        }, false);
+      }, "Browser sends Referer header in nested iframe request when location.assign is called on an iframe");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-with-nested-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-with-nested-iframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Browser sends Referer header when location.assign is called in iframe document on another nested iframe element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-with-nested-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-with-nested-iframe.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Referer with location.assign and nested frames</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <iframe src="resources/replace-or-assign-call-on-iframe.html?assign" hidden></iframe>
+    <script>
+      async_test(function(t) {
+        function on_message(e) {
+        const nestedIframeReferrer = e.data;
+        assert_equals(nestedIframeReferrer, document.querySelector("iframe").contentWindow.location.href);
+        t.done();
+      }
+      window.addEventListener('message', t.step_func(on_message), false);
+      }, "Browser sends Referer header when location.assign is called in iframe document on another nested iframe element");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/replace-with-nested-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/replace-with-nested-iframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Browser sends Referer header when location.replace is called in iframe document on another nested iframe element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/replace-with-nested-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/replace-with-nested-iframe.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Referer with location.replace and nested frames</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <iframe src="resources/replace-or-assign-call-on-iframe.html?replace" hidden></iframe>
+    <script>
+      async_test(function(t) {
+        function on_message(e) {
+        const nestedIframeReferrer = e.data;
+        assert_equals(nestedIframeReferrer, document.querySelector("iframe").contentWindow.location.href);
+        t.done();
+      }
+      window.addEventListener('message', t.step_func(on_message), false);
+      }, "Browser sends Referer header when location.replace is called in iframe document on another nested iframe element");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-contents.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-contents.sub.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Resource file for test of Referer with location.replace</title>
+  </head>
+  <body>
+    <div></div>
+    <script>
+      const referer = "{{header_or_default(referer, missing)}}"
+      window.parent.postMessage(referer);
+      document.querySelector("div").textContent = `Referer header: ${referer}`;
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-postmessage-to-parent-parent.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-postmessage-to-parent-parent.sub.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Resource file for test of Referer with location.replace</title>
+  </head>
+  <body>
+    <div></div>
+    <script>
+      const referer = "{{header_or_default(referer, missing)}}"
+      window.parent.parent.postMessage(referer);
+      document.querySelector("div").textContent = `Referer header: ${referer}`;
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-with-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-with-iframe.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Resource file for test of Referer with location.replace and location.assign</title>
+  </head>
+  <body>
+    <iframe src="iframe-postmessage-to-parent-parent.sub.html"></iframe>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/replace-or-assign-call-on-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/replace-or-assign-call-on-iframe.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Referer with location.replace and location.assign</title>
+  </head>
+  <body>
+    <iframe src="/resources/blank.html" hidden></iframe>
+    <script>
+      window.addEventListener('message', function (e) {
+        const referrer = e.data;
+        window.parent.postMessage(referrer);
+      });
+      if (window.location.search === "?replace") {
+        document.querySelector("iframe").contentWindow.location.replace("iframe-contents.sub.html?replace");
+      } else if (window.location.search === "?assign") {
+        document.querySelector("iframe").contentWindow.location.assign("iframe-contents.sub.html?assign");
+      }
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/no_window_open_when_term_nesting_level_nonzero.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/no_window_open_when_term_nesting_level_nonzero.window-expected.txt
@@ -5,7 +5,7 @@ CONSOLE MESSAGE: Error: assert_equals: expected no popup during unload expected 
 Harness Error (FAIL), message = Error: assert_equals: expected no popup during unload expected null but got object "[object Window]"
 
 PASS no popups with frame removal
-FAIL no popups with frame navigation assert_equals: expected no popup during visibilitychange expected null but got object "[object Window]"
+FAIL no popups with frame navigation assert_equals: expected no popup during beforeunload expected null but got object "[object Window]"
 FAIL no popups from synchronously reachable window assert_equals: expected no popup during beforeunload expected null but got object "[object Window]"
 FAIL no popups from another synchronously reachable window assert_equals: expected no popup during beforeunload expected null but got object "[object Window]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-expected.txt
@@ -20,6 +20,7 @@ CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: Error
 CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot create an ImageBitmap from an empty buffer
+CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: Cannot create an ImageBitmap from an empty buffer
 
 PASS unhandledrejection: from Promise.reject
 PASS unhandledrejection: from a synchronous rejection in new Promise
@@ -63,5 +64,5 @@ PASS delayed handling: delaying handling rejected promise created from createIma
 PASS mutationObserverMicrotask vs. queueTask ordering is not disturbed inside unhandledrejection events
 FAIL queueTask ordering vs. the task queued for unhandled rejection notification (1) assert_array_equals: expected property 1 to be "queueTask" but got object "[object Promise]" (expected array [object "[object Promise]", "queueTask", object "[object Promise]"] got [object "[object Promise]", object "[object Promise]", "queueTask"])
 FAIL queueTask ordering vs. the task queued for unhandled rejection notification (2) assert_array_equals: expected property 0 to be "queueTask" but got object "[object Promise]" (expected array ["queueTask", object "[object Promise]"] got [object "[object Promise]", "queueTask"])
-FAIL rejectionhandled is dispatched from a queued task, and not immediately assert_array_equals: expected property 4 to be "handled" but got "task after catch" (expected array ["unhandled", "after catch", "catch", "task before catch", "handled", "task after catch"] got ["unhandled", "after catch", "catch", "task before catch", "task after catch", "handled"])
+FAIL rejectionhandled is dispatched from a queued task, and not immediately assert_array_equals: expected property 3 to be "task before catch" but got "handled" (expected array ["unhandled", "after catch", "catch", "task before catch", "handled", "task after catch"] got ["unhandled", "after catch", "catch", "handled", "task before catch", "task after catch"])
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2476,6 +2476,12 @@ void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& comple
     if (completedURL.protocolIsJavaScript() && frameElement() && !frameElement()->protectedDocument()->checkedContentSecurityPolicy()->allowJavaScriptURLs(aboutBlankURL().string(), { }, completedURL.string(), frameElement()))
         return;
 
+    RefPtr localParent = dynamicDowncast<LocalFrame>(frame->tree().parent());
+    // If the loader for activeWindow's frame (browsing context) has no outgoing referrer, set its outgoing referrer
+    // to the URL of its parent frame's Document.
+    if (RefPtr activeFrame = activeWindow.frame(); activeFrame && activeFrame->loader().outgoingReferrer().isEmpty() && localParent)
+        activeFrame->loader().setOutgoingReferrer(document()->completeURL(localParent->document()->url().strippedForUseAsReferrer()));
+
     // We want a new history item if we are processing a user gesture.
     LockHistory lockHistory = (locking != SetLocationLocking::LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
     LockBackForwardList lockBackForwardList = (locking != SetLocationLocking::LockHistoryBasedOnGestureState) ? LockBackForwardList::Yes : LockBackForwardList::No;


### PR DESCRIPTION
#### 1350b5914d017fc41f92edc00eb2b2625136dcf5
<pre>
Ensure iframe requests include Referer when location.replace or location.assign is called
<a href="https://bugs.webkit.org/show_bug.cgi?id=263072">https://bugs.webkit.org/show_bug.cgi?id=263072</a>

Reviewed by Chris Dumez and Alex Christensen.

When the loader for a Frame (e.g, an iframe) has no referrer, then this change
causes the loader&apos;s referrer to be set to the URL of its parent Frame’s Document.

That in turn ensures the associated request is sent with a Referer header —
including in the case where a document calls location.replace or
location.assign on an iframe element — which makes the WebKit behavior
in this case interoperable with existing behavior in Gecko and Blink.

Otherwise, without this change, no Referer header is sent in the
associated request, which breaks interoperability with Gecko and Blink.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-replace-from-top-to-nested-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-with-nested-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/assign-with-nested-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/replace-with-nested-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/replace-with-nested-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-contents.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-postmessage-to-parent-parent.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/iframe-with-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/resources/replace-or-assign-call-on-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/no_window_open_when_term_nesting_level_nonzero.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-expected.txt:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::setLocation):

Canonical link: <a href="https://commits.webkit.org/270741@main">https://commits.webkit.org/270741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d41cba7dc9c0d13b7b01e2b01e03c51cbac1ce8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/4686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23877 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/26398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23939 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/28748 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29460 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1403 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/23152 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6314 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->