### PR TITLE
SVGResourcesCache::addResourcesFromRenderObject should not allocate SVGResources unconditionally

### DIFF
--- a/Source/WebCore/rendering/svg/SVGResources.h
+++ b/Source/WebCore/rendering/svg/SVGResources.h
@@ -44,7 +44,7 @@ class SVGResources {
 public:
     SVGResources();
 
-    bool buildCachedResources(const RenderElement&, const RenderStyle&);
+    static std::unique_ptr<SVGResources> buildCachedResources(const RenderElement&, const RenderStyle&);
     void layoutDifferentRootIfNeeded(const LegacyRenderSVGRoot*);
 
     // Ordinary resources

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -37,8 +37,8 @@ void SVGResourcesCache::addResourcesFromRenderer(RenderElement& renderer, const 
     ASSERT(!m_cache.contains(&renderer));
 
     // Build a list of all resources associated with the passed RenderObject
-    auto newResources = makeUnique<SVGResources>();
-    if (!newResources->buildCachedResources(renderer, style))
+    auto newResources = SVGResources::buildCachedResources(renderer, style);
+    if (!newResources)
         return;
 
     // Put object in cache.


### PR DESCRIPTION
#### 236dd9dd2c2c2cf873fc7de8d3d15bd685176724
<pre>
SVGResourcesCache::addResourcesFromRenderObject should not allocate SVGResources unconditionally
<a href="https://bugs.webkit.org/show_bug.cgi?id=98684">https://bugs.webkit.org/show_bug.cgi?id=98684</a>

Reviewed by Nikolas Zimmermann.

Only allocate SVGResources where needed and possible (not pending).

* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):
(WebCore::SVGResources::setClipper):
(WebCore::SVGResources::setFilter):
(WebCore::SVGResources::setMarkerStart):
(WebCore::SVGResources::setMarkerMid):
(WebCore::SVGResources::setMarkerEnd):
(WebCore::SVGResources::setMasker):
(WebCore::SVGResources::setFill):
(WebCore::SVGResources::setStroke):
(WebCore::SVGResources::setLinkedResource):
* Source/WebCore/rendering/svg/SVGResources.h:
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::addResourcesFromRenderer):

Canonical link: <a href="https://commits.webkit.org/269397@main">https://commits.webkit.org/269397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f151c8b6ac7c07f0876b3fae0ce70e75dada4074

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24266 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21708 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25121 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26517 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24377 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/21034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17826 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20488 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5343 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/21026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->