### PR TITLE
Adopt even more smart pointers in the DOM

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -142,12 +142,6 @@ private:
     template<typename X, typename Y, typename W, typename Z>
     friend bool operator==(const Ref<X, Y>&, const Ref<W, Z>&);
 
-    template<typename X, typename Y, typename W>
-    friend bool operator==(const Ref<X, Y>&, W*);
-
-    template<typename X, typename Y, typename W>
-    friend bool operator==(W*, const Ref<X, Y>&);
-
     enum AdoptTag { Adopt };
     Ref(T& object, AdoptTag)
         : m_ptr(&object)

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1036,6 +1036,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/Touch.h
     dom/Traversal.h
     dom/TreeScope.h
+    dom/TreeScopeInlines.h
     dom/TreeScopeOrderedMap.h
     dom/TreeWalker.h
     dom/TypedElementDescendantIterator.h

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -459,11 +459,11 @@ AccessibilityObject* AXObjectCache::focusedImageMapUIElement(HTMLAreaElement* ar
     if (!areaElement)
         return nullptr;
     
-    HTMLImageElement* imageElement = areaElement->imageElement();
+    RefPtr imageElement = areaElement->imageElement();
     if (!imageElement)
         return nullptr;
     
-    AccessibilityObject* axRenderImage = areaElement->document().axObjectCache()->getOrCreate(imageElement);
+    AccessibilityObject* axRenderImage = areaElement->document().axObjectCache()->getOrCreate(imageElement.get());
     if (!axRenderImage)
         return nullptr;
     
@@ -4688,7 +4688,7 @@ void AXObjectCache::addRelations(Element& origin, const QualifiedName& attribute
     if (m_document->settings().ariaReflectionForElementReferencesEnabled()) {
         if (Element::isElementReflectionAttribute(m_document->settings(), attribute)) {
             if (auto reflectedElement = origin.getElementAttribute(attribute)) {
-                addRelation(&origin, reflectedElement, attributeToRelationType(attribute));
+                addRelation(&origin, reflectedElement.get(), attributeToRelationType(attribute));
                 return;
             }
         } else if (Element::isElementsArrayReflectionAttribute(m_document->settings(), attribute)) {
@@ -4711,11 +4711,11 @@ void AXObjectCache::addRelations(Element& origin, const QualifiedName& attribute
 
     SpaceSplitString ids(value, SpaceSplitString::ShouldFoldCase::No);
     for (size_t i = 0; i < ids.size(); ++i) {
-        auto* target = origin.treeScope().getElementById(ids[i]);
+        RefPtr target = origin.treeScope().getElementById(ids[i]);
         if (!target || target == &origin)
             continue;
 
-        addRelation(&origin, target, attributeToRelationType(attribute));
+        addRelation(&origin, target.get(), attributeToRelationType(attribute));
     }
 }
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -219,8 +219,8 @@ static Vector<Ref<HTMLLabelElement>> labelsForNode(Node* node)
     const auto& id = element->getIdAttribute();
     if (!id.isEmpty()) {
         if (auto* treeScopeLabels = element->treeScope().labelElementsForId(id); treeScopeLabels && !treeScopeLabels->isEmpty()) {
-            return WTF::compactMap(*treeScopeLabels, [](auto* label) {
-                return RefPtr { dynamicDowncast<HTMLLabelElement>(label) };
+            return WTF::compactMap(*treeScopeLabels, [](auto& label) {
+                return RefPtr<HTMLLabelElement> { dynamicDowncast<HTMLLabelElement>(label.get()) };
             });
         }
     }
@@ -1146,7 +1146,7 @@ Element* AccessibilityNodeObject::anchorElement() const
     return nullptr;
 }
 
-Element* AccessibilityNodeObject::popoverTargetElement() const
+RefPtr<Element> AccessibilityNodeObject::popoverTargetElement() const
 {
     WeakPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(node());
     return formControlElement ? formControlElement->popoverTargetElement() : nullptr;
@@ -1169,12 +1169,12 @@ AccessibilityObject* AccessibilityNodeObject::internalLinkElement() const
     if (!document || !equalIgnoringFragmentIdentifier(document->url(), linkURL))
         return nullptr;
 
-    auto linkedNode = document->findAnchor(fragmentIdentifier);
+    RefPtr linkedNode = document->findAnchor(fragmentIdentifier);
     if (!linkedNode)
         return nullptr;
 
     // The element we find may not be accessible, so find the first accessible object.
-    return firstAccessibleObjectFromNode(linkedNode);
+    return firstAccessibleObjectFromNode(linkedNode.get());
 }
 
 void AccessibilityNodeObject::addRadioButtonGroupChildren(AXCoreObject& parent, AccessibilityChildrenVector& linkedUIElements) const
@@ -2329,7 +2329,7 @@ String AccessibilityNodeObject::textUnderElement(AccessibilityTextUnderElementMo
             // This could happen when this node labels multiple child nodes and we didn't
             // skip in the above ignoredChildNode check.
             auto labeledByElements = downcast<AccessibilityNodeObject>(*child).ariaLabeledByElements();
-            if (labeledByElements.contains(node))
+            if (labeledByElements.containsIf([&](auto& element) { return element.ptr() == node; }))
                 continue;
             
             Vector<AccessibilityText> textOrder;
@@ -2608,11 +2608,11 @@ String AccessibilityNodeObject::accessibilityDescriptionForChildren() const
     return builder.toString();
 }
 
-String AccessibilityNodeObject::descriptionForElements(Vector<Element*>&& elements) const
+String AccessibilityNodeObject::descriptionForElements(const Vector<Ref<Element>>& elements) const
 {
     StringBuilder builder;
-    for (auto* element : elements)
-        appendNameToStringBuilder(builder, accessibleNameForNode(element, node()));
+    for (auto& element : elements)
+        appendNameToStringBuilder(builder, accessibleNameForNode(element.ptr(), node()));
     return builder.toString();
 }
 
@@ -2621,7 +2621,7 @@ String AccessibilityNodeObject::ariaDescribedByAttribute() const
     return descriptionForElements(elementsFromAttribute(aria_describedbyAttr));
 }
 
-Vector<Element*> AccessibilityNodeObject::ariaLabeledByElements() const
+Vector<Ref<Element>> AccessibilityNodeObject::ariaLabeledByElements() const
 {
     // FIXME: should walk the DOM elements only once.
     auto elements = elementsFromAttribute(aria_labelledbyAttr);

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -121,7 +121,7 @@ public:
     Element* actionElement() const override;
     Element* mouseButtonListener(MouseButtonListenerResultFilter = ExcludeBodyElement) const;
     Element* anchorElement() const override;
-    Element* popoverTargetElement() const final;
+    RefPtr<Element> popoverTargetElement() const final;
     AccessibilityObject* internalLinkElement() const;
     void addRadioButtonGroupMembers(AccessibilityChildrenVector& linkedUIElements) const;
     void addRadioButtonGroupChildren(AXCoreObject&, AccessibilityChildrenVector&) const;
@@ -198,8 +198,8 @@ protected:
     HTMLLabelElement* labelElementContainer() const;
 
     String ariaAccessibilityDescription() const;
-    Vector<Element*> ariaLabeledByElements() const;
-    String descriptionForElements(Vector<Element*>&&) const;
+    Vector<Ref<Element>> ariaLabeledByElements() const;
+    String descriptionForElements(const Vector<Ref<Element>>&) const;
     LayoutRect boundingBoxRect() const override;
     String ariaDescribedByAttribute() const override;
     

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -411,7 +411,7 @@ public:
     String expandedTextValue() const override { return String(); }
     bool supportsExpandedTextValue() const override { return false; }
 
-    Vector<Element*> elementsFromAttribute(const QualifiedName&) const;
+    Vector<Ref<Element>> elementsFromAttribute(const QualifiedName&) const;
 
     // Only if isColorWell()
     SRGBA<uint8_t> colorValue() const override;
@@ -428,7 +428,7 @@ public:
     static AccessibilityObject* anchorElementForNode(Node*);
     static AccessibilityObject* headingElementForNode(Node*);
     virtual Element* anchorElement() const { return nullptr; }
-    virtual Element* popoverTargetElement() const { return nullptr; }
+    virtual RefPtr<Element> popoverTargetElement() const { return nullptr; }
     bool supportsPressAction() const override;
     Element* actionElement() const override { return nullptr; }
     virtual LayoutRect boundingBoxRect() const { return { }; }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1507,12 +1507,12 @@ AccessibilityObject* AccessibilityRenderObject::accessibilityParentForImageMap(H
     if (!map)
         return nullptr;
 
-    HTMLImageElement* imageElement = map->imageElement();
+    RefPtr imageElement = map->imageElement();
     if (!imageElement)
         return nullptr;
     
-    if (AXObjectCache* cache = axObjectCache())
-        return cache->getOrCreate(imageElement);
+    if (CheckedPtr cache = axObjectCache())
+        return cache->getOrCreate(imageElement.get());
     
     return nullptr;
 }
@@ -1534,7 +1534,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityRenderObject::documentLin
         } else {
             auto* parent = current->parentNode();
             if (is<HTMLAreaElement>(*current) && is<HTMLMapElement>(parent)) {
-                auto* parentImage = downcast<HTMLMapElement>(parent)->imageElement();
+                RefPtr parentImage = downcast<HTMLMapElement>(parent)->imageElement();
                 auto* parentImageRenderer = parentImage ? parentImage->renderer() : nullptr;
                 if (auto* parentImageAxObject = document.axObjectCache()->getOrCreate(parentImageRenderer)) {
                     for (const auto& child : parentImageAxObject->children()) {

--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
@@ -67,7 +67,7 @@ static bool jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter(JSDOMWindowPr
                 ASSERT(collection->length() > 1);
                 namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), collection);
             } else
-                namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), htmlDocument.windowNamedItem(*atomicPropertyName));
+                namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), htmlDocument.windowNamedItem(*atomicPropertyName).get());
             slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::DontEnum), namedItem);
             return true;
         }

--- a/Source/WebCore/css/StyleSheetList.cpp
+++ b/Source/WebCore/css/StyleSheetList.cpp
@@ -97,9 +97,8 @@ CSSStyleSheet* StyleSheetList::namedItem(const AtomString& name) const
     // ### Bad implementation because returns a single element (are IDs always unique?)
     // and doesn't look for name attribute.
     // But unicity of stylesheet ids is good practice anyway ;)
-    Element* element = m_document->getElementById(name);
-    if (is<HTMLStyleElement>(element))
-        return downcast<HTMLStyleElement>(element)->sheet();
+    if (RefPtr element = dynamicDowncast<HTMLStyleElement>(m_document->getElementById(name)))
+        return element->sheet();
     return nullptr;
 }
 

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -83,20 +83,20 @@ bool CustomElementDefaultARIA::hasAttribute(const QualifiedName& name) const
     return m_map.find(name) != m_map.end();
 }
 
-Element* CustomElementDefaultARIA::elementForAttribute(const Element& thisElement, const QualifiedName& name) const
+RefPtr<Element> CustomElementDefaultARIA::elementForAttribute(const Element& thisElement, const QualifiedName& name) const
 {
     auto it = m_map.find(name);
     if (it == m_map.end())
         return nullptr;
 
-    Element* result = nullptr;
+    RefPtr<Element> result;
     std::visit(WTF::makeVisitor([&](const AtomString& stringValue) {
         if (thisElement.isInTreeScope())
             result = thisElement.treeScope().getElementById(stringValue);
     }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) {
         RefPtr elementValue = weakElementValue.get();
         if (elementValue && isElementVisible(*elementValue, thisElement))
-            result = elementValue.get();
+            result = WTFMove(elementValue);
     }, [&](const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>&) {
         RELEASE_ASSERT_NOT_REACHED();
     }), it->value);

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -46,7 +46,7 @@ public:
     bool hasAttribute(const QualifiedName&) const;
     const AtomString& valueForAttribute(const Element& thisElement, const QualifiedName&) const;
     void setValueForAttribute(const QualifiedName&, const AtomString&);
-    Element* elementForAttribute(const Element& thisElement, const QualifiedName&) const;
+    RefPtr<Element> elementForAttribute(const Element& thisElement, const QualifiedName&) const;
     void setElementForAttribute(const QualifiedName&, Element*);
     Vector<RefPtr<Element>> elementsForAttribute(const Element& thisElement, const QualifiedName&) const;
     void setElementsForAttribute(const QualifiedName&, std::optional<Vector<RefPtr<Element>>>&&);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9018,8 +9018,8 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
 
                     if (!invokerPopover) {
                         if (auto* button = dynamicDowncast<HTMLFormControlElement>(*htmlElement)) {
-                            if (auto* popover = button->popoverTargetElement(); popover && isShowingAutoPopover(*popover))
-                                invokerPopover = popover;
+                            if (RefPtr popover = button->popoverTargetElement(); popover && isShowingAutoPopover(*popover))
+                                invokerPopover = WTFMove(popover);
                         }
                     }
                     if (clickedPopover && invokerPopover)

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -113,7 +113,7 @@ Element* DocumentFragment::getElementById(const AtomString& id) const
 
     // Fast path for ShadowRoot, where we are both a DocumentFragment and a TreeScope.
     if (isTreeScope())
-        return treeScope().getElementById(id);
+        return treeScope().getElementById(id).get();
 
     // Otherwise, fall back to iterating all of the element descendants.
     for (auto& element : descendantsOfType<Element>(*this)) {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2180,7 +2180,7 @@ ExplicitlySetAttrElementsMap* Element::explicitlySetAttrElementsMapIfExists() co
     return hasRareData() ? &elementRareData()->explicitlySetAttrElementsMap() : nullptr;
 }
 
-Element* Element::getElementAttribute(const QualifiedName& attributeName) const
+RefPtr<Element> Element::getElementAttribute(const QualifiedName& attributeName) const
 {
     ASSERT(isElementReflectionAttribute(document().settings(), attributeName));
 
@@ -2188,7 +2188,7 @@ Element* Element::getElementAttribute(const QualifiedName& attributeName) const
         auto it = map->find(attributeName);
         if (it != map->end()) {
             ASSERT(it->value.size() == 1);
-            auto* element = it->value[0].get();
+            RefPtr element = it->value[0].get();
             if (element && isDescendantOrShadowDescendantOf(element->rootNode()))
                 return element;
             return nullptr;
@@ -2245,8 +2245,8 @@ std::optional<Vector<RefPtr<Element>>> Element::getElementsArrayAttribute(const 
     SpaceSplitString ids(getAttribute(attr), SpaceSplitString::ShouldFoldCase::No);
     Vector<RefPtr<Element>> elements;
     for (unsigned i = 0; i < ids.size(); ++i) {
-        if (auto* element = treeScope().getElementById(ids[i]))
-            elements.append(element);
+        if (RefPtr element = treeScope().getElementById(ids[i]))
+            elements.append(WTFMove(element));
     }
     return elements;
 }
@@ -5243,7 +5243,7 @@ ExceptionOr<void> Element::insertAdjacentText(const String& where, String&& text
     return { };
 }
 
-Element* Element::findAnchorElementForLink(String& outAnchorName)
+RefPtr<Element> Element::findAnchorElementForLink(String& outAnchorName)
 {
     if (!isLink())
         return nullptr;

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -143,7 +143,7 @@ public:
     WEBCORE_EXPORT void setIntegralAttribute(const QualifiedName& attributeName, int value);
     WEBCORE_EXPORT unsigned getUnsignedIntegralAttribute(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setUnsignedIntegralAttribute(const QualifiedName& attributeName, unsigned value);
-    WEBCORE_EXPORT Element* getElementAttribute(const QualifiedName& attributeName) const;
+    WEBCORE_EXPORT RefPtr<Element> getElementAttribute(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementAttribute(const QualifiedName& attributeName, Element* value);
     WEBCORE_EXPORT std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<RefPtr<Element>>>&& value);
@@ -721,7 +721,7 @@ public:
     void setLastRememberedLogicalHeight(LayoutUnit);
     void clearLastRememberedLogicalHeight();
 
-    Element* findAnchorElementForLink(String& outAnchorName);
+    RefPtr<Element> findAnchorElementForLink(String& outAnchorName);
 
     ExceptionOr<Ref<WebAnimation>> animate(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>&&, std::optional<std::variant<double, KeyframeAnimationOptions>>&&);
     Vector<RefPtr<WebAnimation>> getAnimations(std::optional<GetAnimationsOptions>);

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -155,7 +155,7 @@ const AtomString& ElementInternals::attributeWithoutSynchronization(const Qualif
     return defaultARIA->valueForAttribute(*element, name);
 }
 
-Element* ElementInternals::getElementAttribute(const QualifiedName& name) const
+RefPtr<Element> ElementInternals::getElementAttribute(const QualifiedName& name) const
 {
     RefPtr element = m_element.get();
     auto* defaultARIA = m_element->customElementDefaultARIAIfExists();

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -66,7 +66,7 @@ public:
     const AtomString& attributeWithoutSynchronization(const QualifiedName&) const;
     void setAttributeWithoutSynchronization(const QualifiedName&, const AtomString& value);
 
-    Element* getElementAttribute(const QualifiedName&) const;
+    RefPtr<Element> getElementAttribute(const QualifiedName&) const;
     void setElementAttribute(const QualifiedName&, Element*);
     std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName&) const;
     void setElementsArrayAttribute(const QualifiedName&, std::optional<Vector<RefPtr<Element>>>&&);

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -57,6 +57,7 @@
 #include "Text.h"
 #include "TextIterator.h"
 #include "TextRecognitionResult.h"
+#include "TreeScopeInlines.h"
 #include "UserAgentStyleSheets.h"
 #include "VisibleSelection.h"
 #include <wtf/Range.h>

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -866,7 +866,7 @@ LayoutRect Node::renderRect(bool* isReplaced)
     CheckedPtr hitRenderer = this->renderer();
     if (!hitRenderer && is<HTMLAreaElement>(*this)) {
         auto& area = downcast<HTMLAreaElement>(*this);
-        if (auto* imageElement = area.imageElement())
+        if (RefPtr imageElement = area.imageElement())
             hitRenderer = imageElement->renderer();
     }
     CheckedPtr renderer = WTFMove(hitRenderer);

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -35,6 +35,7 @@
 #include "SelectorChecker.h"
 #include "StaticNodeList.h"
 #include "StyledElement.h"
+#include "TreeScopeInlines.h"
 #include "TypedElementDescendantIteratorInlines.h"
 
 namespace WebCore {
@@ -208,12 +209,12 @@ ALWAYS_INLINE void SelectorDataList::executeFastPathForIdSelector(const Containe
 
     const AtomString& idToMatch = idSelector->value();
     if (UNLIKELY(rootNode.treeScope().containsMultipleElementsWithId(idToMatch))) {
-        const Vector<Element*>* elements = rootNode.treeScope().getAllElementsById(idToMatch);
+        auto* elements = rootNode.treeScope().getAllElementsById(idToMatch);
         ASSERT(elements);
         bool rootNodeIsTreeScopeRoot = rootNode.isTreeScope();
         for (auto& element : *elements) {
-            if ((rootNodeIsTreeScopeRoot || element->isDescendantOf(rootNode)) && selectorMatches(selectorData, *element, rootNode)) {
-                appendOutputForElement(output, *element);
+            if ((rootNodeIsTreeScopeRoot || element->isDescendantOf(rootNode)) && selectorMatches(selectorData, element, rootNode)) {
+                appendOutputForElement(output, element);
                 if constexpr (std::is_same_v<OutputType, Element*>)
                     return;
             }
@@ -221,7 +222,7 @@ ALWAYS_INLINE void SelectorDataList::executeFastPathForIdSelector(const Containe
         return;
     }
 
-    Element* element = rootNode.treeScope().getElementById(idToMatch);
+    RefPtr element = rootNode.treeScope().getElementById(idToMatch);
     if (!element || !(rootNode.isTreeScope() || element->isDescendantOf(rootNode)))
         return;
     if (selectorMatches(selectorData, *element, rootNode))
@@ -249,7 +250,7 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
     for (; selector; selector = selector->tagHistory()) {
         if (canBeUsedForIdFastPath(*selector)) {
             const AtomString& idToMatch = selector->value();
-            if (ContainerNode* searchRoot = rootNode.treeScope().getElementById(idToMatch)) {
+            if (RefPtr<ContainerNode> searchRoot = rootNode.treeScope().getElementById(idToMatch)) {
                 if (LIKELY(!rootNode.treeScope().containsMultipleElementsWithId(idToMatch))) {
                     if (inAdjacentChain)
                         searchRoot = searchRoot->parentNode();

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include "ExceptionOr.h"
-#include "TreeScopeOrderedMap.h"
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/UniqueRef.h>
@@ -57,6 +56,7 @@ class Node;
 class RadioButtonGroups;
 class SVGElement;
 class ShadowRoot;
+class TreeScopeOrderedMap;
 class WeakPtrImplWithEventTargetData;
 struct SVGResourcesMap;
 
@@ -70,18 +70,18 @@ public:
     Element* focusedElementInScope();
     Element* pointerLockElement() const;
 
-    WEBCORE_EXPORT Element* getElementById(const AtomString&) const;
-    WEBCORE_EXPORT Element* getElementById(const String&) const;
-    Element* getElementById(StringView) const;
-    const Vector<Element*>* getAllElementsById(const AtomString&) const;
-    bool hasElementWithId(const AtomStringImpl&) const;
-    bool containsMultipleElementsWithId(const AtomString& id) const;
+    WEBCORE_EXPORT RefPtr<Element> getElementById(const AtomString&) const;
+    WEBCORE_EXPORT RefPtr<Element> getElementById(const String&) const;
+    RefPtr<Element> getElementById(StringView) const;
+    const Vector<CheckedRef<Element>>* getAllElementsById(const AtomString&) const;
+    inline bool hasElementWithId(const AtomStringImpl&) const; // Defined in TreeScopeInlines.h.
+    inline bool containsMultipleElementsWithId(const AtomString& id) const; // Defined in TreeScopeInlines.h.
     void addElementById(const AtomStringImpl& elementId, Element&, bool notifyObservers = true);
     void removeElementById(const AtomStringImpl& elementId, Element&, bool notifyObservers = true);
 
-    WEBCORE_EXPORT Element* getElementByName(const AtomString&) const;
-    bool hasElementWithName(const AtomStringImpl&) const;
-    bool containsMultipleElementsWithName(const AtomString&) const;
+    WEBCORE_EXPORT RefPtr<Element> getElementByName(const AtomString&) const;
+    inline bool hasElementWithName(const AtomStringImpl&) const; // Defined in TreeScopeInlines.h.
+    inline bool containsMultipleElementsWithName(const AtomString&) const; // Defined in TreeScopeInlines.h.
     void addElementByName(const AtomStringImpl&, Element&);
     void removeElementByName(const AtomStringImpl&, Element&);
 
@@ -97,17 +97,17 @@ public:
 
     void addImageMap(HTMLMapElement&);
     void removeImageMap(HTMLMapElement&);
-    HTMLMapElement* getImageMap(const AtomString&) const;
+    RefPtr<HTMLMapElement> getImageMap(const AtomString&) const;
 
     void addImageElementByUsemap(const AtomStringImpl&, HTMLImageElement&);
     void removeImageElementByUsemap(const AtomStringImpl&, HTMLImageElement&);
-    HTMLImageElement* imageElementByUsemap(const AtomStringImpl&) const;
+    RefPtr<HTMLImageElement> imageElementByUsemap(const AtomStringImpl&) const;
 
     // For accessibility.
     bool shouldCacheLabelsByForAttribute() const { return !!m_labelsByForAttribute; }
     void addLabel(const AtomStringImpl& forAttributeValue, HTMLLabelElement&);
     void removeLabel(const AtomStringImpl& forAttributeValue, HTMLLabelElement&);
-    const Vector<Element*>* labelElementsForId(const AtomString& forAttributeValue);
+    const Vector<CheckedRef<Element>>* labelElementsForId(const AtomString& forAttributeValue);
 
     WEBCORE_EXPORT RefPtr<Element> elementFromPoint(double clientX, double clientY);
     WEBCORE_EXPORT Vector<RefPtr<Element>> elementsFromPoint(double clientX, double clientY);
@@ -118,7 +118,7 @@ public:
     // for an anchor with the given name. ID matching is always case sensitive, but
     // Anchor name matching is case sensitive in strict mode and not case sensitive in
     // quirks mode for historical compatibility reasons.
-    Element* findAnchor(StringView name);
+    RefPtr<Element> findAnchor(StringView name);
 
     ContainerNode& rootNode() const { return m_rootNode; }
 
@@ -180,26 +180,6 @@ private:
 
     std::unique_ptr<SVGResourcesMap> m_svgResourcesMap;
 };
-
-inline bool TreeScope::hasElementWithId(const AtomStringImpl& id) const
-{
-    return m_elementsById && m_elementsById->contains(id);
-}
-
-inline bool TreeScope::containsMultipleElementsWithId(const AtomString& id) const
-{
-    return m_elementsById && id.impl() && m_elementsById->containsMultiple(*id.impl());
-}
-
-inline bool TreeScope::hasElementWithName(const AtomStringImpl& id) const
-{
-    return m_elementsByName && m_elementsByName->contains(id);
-}
-
-inline bool TreeScope::containsMultipleElementsWithName(const AtomString& name) const
-{
-    return m_elementsByName && name.impl() && m_elementsByName->containsMultiple(*name.impl());
-}
 
 TreeScope* commonTreeScope(Node*, Node*);
 

--- a/Source/WebCore/dom/TreeScopeInlines.h
+++ b/Source/WebCore/dom/TreeScopeInlines.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "TreeScopeOrderedMap.h"
+
+namespace WebCore {
+
+inline bool TreeScope::hasElementWithId(const AtomStringImpl& id) const
+{
+    return m_elementsById && m_elementsById->contains(id);
+}
+
+inline bool TreeScope::containsMultipleElementsWithId(const AtomString& id) const
+{
+    return m_elementsById && id.impl() && m_elementsById->containsMultiple(*id.impl());
+}
+
+inline bool TreeScope::hasElementWithName(const AtomStringImpl& id) const
+{
+    return m_elementsByName && m_elementsByName->contains(id);
+}
+
+inline bool TreeScope::containsMultipleElementsWithName(const AtomString& name) const
+{
+    return m_elementsByName && name.impl() && m_elementsByName->containsMultiple(*name.impl());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -96,7 +96,7 @@ void TreeScopeOrderedMap::remove(const AtomStringImpl& key, Element& element)
 }
 
 template <typename KeyMatchingFunction>
-inline Element* TreeScopeOrderedMap::get(const AtomStringImpl& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
+inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomStringImpl& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
 {
     m_map.checkConsistency();
 
@@ -107,34 +107,34 @@ inline Element* TreeScopeOrderedMap::get(const AtomStringImpl& key, const TreeSc
     MapEntry& entry = it->value;
     ASSERT(entry.count);
     if (entry.element) {
-        auto& element = *entry.element;
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&element.treeScope() == &scope);
-        ASSERT_WITH_SECURITY_IMPLICATION(entry.registeredElements.contains(&element));
-        return &element;
+        Ref element = *entry.element;
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&element->treeScope() == &scope);
+        ASSERT_WITH_SECURITY_IMPLICATION(entry.registeredElements.contains(element.ptr()));
+        return element;
     }
 
     // We know there's at least one node that matches; iterate to find the first one.
-    for (auto& element : descendantsOfType<Element>(scope.rootNode())) {
-        if (!element.isInTreeScope())
+    for (Ref element : descendantsOfType<Element>(scope.rootNode())) {
+        if (!element->isInTreeScope())
             continue;
         if (!keyMatches(key, element))
             continue;
-        entry.element = &element;
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&element.treeScope() == &scope);
+        entry.element = element.ptr();
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&element->treeScope() == &scope);
         ASSERT_WITH_SECURITY_IMPLICATION(entry.registeredElements.contains(entry.element));
-        return &element;
+        return element;
     }
 
 #if ASSERT_ENABLED
     // FormListedElement may call getElementById to find its owner form in the middle of a tree removal.
     if (auto* currentScope = ContainerChildRemovalScope::currentScope()) {
         ASSERT(&scope.rootNode() == &currentScope->parentOfRemovedTree().rootNode());
-        Node& removedTree = currentScope->removedChild();
+        Ref removedTree = currentScope->removedChild();
         ASSERT(is<ContainerNode>(removedTree));
-        for (auto& element : descendantsOfType<Element>(downcast<ContainerNode>(removedTree))) {
+        for (Ref element : descendantsOfType<Element>(downcast<ContainerNode>(removedTree.get()))) {
             if (!keyMatches(key, element))
                 continue;
-            bool removedFromAncestorHasNotBeenCalledYet = element.isConnected();
+            bool removedFromAncestorHasNotBeenCalledYet = element->isConnected();
             ASSERT(removedFromAncestorHasNotBeenCalledYet);
             return nullptr;
         }
@@ -146,7 +146,7 @@ inline Element* TreeScopeOrderedMap::get(const AtomStringImpl& key, const TreeSc
 }
 
 template <typename KeyMatchingFunction>
-inline Vector<Element*>* TreeScopeOrderedMap::getAll(const AtomStringImpl& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
+inline Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAll(const AtomStringImpl& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
 {
     m_map.checkConsistency();
 
@@ -162,7 +162,7 @@ inline Vector<Element*>* TreeScopeOrderedMap::getAll(const AtomStringImpl& key, 
         auto elementDescendants = descendantsOfType<Element>(scope.rootNode());
         for (auto it = entry.element ? elementDescendants.beginAt(*entry.element) : elementDescendants.begin(); it; ++it) {
             if (keyMatches(key, *it))
-                entry.orderedList.append(&*it);
+                entry.orderedList.append(*it);
         }
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(entry.orderedList.size() == entry.count);
     }
@@ -170,28 +170,28 @@ inline Vector<Element*>* TreeScopeOrderedMap::getAll(const AtomStringImpl& key, 
     return &entry.orderedList;
 }
 
-Element* TreeScopeOrderedMap::getElementById(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<Element> TreeScopeOrderedMap::getElementById(const AtomStringImpl& key, const TreeScope& scope) const
 {
     return get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
         return element.getIdAttribute().impl() == &key;
     });
 }
 
-Element* TreeScopeOrderedMap::getElementByName(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<Element> TreeScopeOrderedMap::getElementByName(const AtomStringImpl& key, const TreeScope& scope) const
 {
     return get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
         return element.getNameAttribute().impl() == &key;
     });
 }
 
-HTMLMapElement* TreeScopeOrderedMap::getElementByMapName(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<HTMLMapElement> TreeScopeOrderedMap::getElementByMapName(const AtomStringImpl& key, const TreeScope& scope) const
 {
     return downcast<HTMLMapElement>(get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
         return is<HTMLMapElement>(element) && downcast<HTMLMapElement>(element).getName().impl() == &key;
     }));
 }
 
-HTMLImageElement* TreeScopeOrderedMap::getElementByUsemap(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<HTMLImageElement> TreeScopeOrderedMap::getElementByUsemap(const AtomStringImpl& key, const TreeScope& scope) const
 {
     return downcast<HTMLImageElement>(get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
         // FIXME: HTML5 specification says we should match both image and object elements.
@@ -199,28 +199,28 @@ HTMLImageElement* TreeScopeOrderedMap::getElementByUsemap(const AtomStringImpl& 
     }));
 }
 
-const Vector<Element*>* TreeScopeOrderedMap::getElementsByLabelForAttribute(const AtomStringImpl& key, const TreeScope& scope) const
+const Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getElementsByLabelForAttribute(const AtomStringImpl& key, const TreeScope& scope) const
 {
     return getAll(key, scope, [] (const AtomStringImpl& key, const Element& element) {
         return is<HTMLLabelElement>(element) && element.attributeWithoutSynchronization(forAttr).impl() == &key;
     });
 }
 
-Element* TreeScopeOrderedMap::getElementByWindowNamedItem(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<Element> TreeScopeOrderedMap::getElementByWindowNamedItem(const AtomStringImpl& key, const TreeScope& scope) const
 {
     return get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
         return WindowNameCollection::elementMatches(element, &key);
     });
 }
 
-Element* TreeScopeOrderedMap::getElementByDocumentNamedItem(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<Element> TreeScopeOrderedMap::getElementByDocumentNamedItem(const AtomStringImpl& key, const TreeScope& scope) const
 {
     return get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
         return DocumentNameCollection::elementMatches(element, &key);
     });
 }
 
-const Vector<Element*>* TreeScopeOrderedMap::getAllElementsById(const AtomStringImpl& key, const TreeScope& scope) const
+const Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAllElementsById(const AtomStringImpl& key, const TreeScope& scope) const
 {
     return getAll(key, scope, [] (const AtomStringImpl& key, const Element& element) {
         return element.getIdAttribute().impl() == &key;

--- a/Source/WebCore/dom/TreeScopeOrderedMap.h
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "Element.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
@@ -37,7 +39,6 @@
 
 namespace WebCore {
 
-class Element;
 class HTMLImageElement;
 class HTMLLabelElement;
 class HTMLMapElement;
@@ -55,23 +56,23 @@ public:
     bool containsMultiple(const AtomStringImpl&) const;
 
     // concrete instantiations of the get<>() method template
-    Element* getElementById(const AtomStringImpl&, const TreeScope&) const;
-    Element* getElementByName(const AtomStringImpl&, const TreeScope&) const;
-    HTMLMapElement* getElementByMapName(const AtomStringImpl&, const TreeScope&) const;
-    HTMLImageElement* getElementByUsemap(const AtomStringImpl&, const TreeScope&) const;
-    const Vector<Element*>* getElementsByLabelForAttribute(const AtomStringImpl&, const TreeScope&) const;
-    Element* getElementByWindowNamedItem(const AtomStringImpl&, const TreeScope&) const;
-    Element* getElementByDocumentNamedItem(const AtomStringImpl&, const TreeScope&) const;
+    RefPtr<Element> getElementById(const AtomStringImpl&, const TreeScope&) const;
+    RefPtr<Element> getElementByName(const AtomStringImpl&, const TreeScope&) const;
+    RefPtr<HTMLMapElement> getElementByMapName(const AtomStringImpl&, const TreeScope&) const;
+    RefPtr<HTMLImageElement> getElementByUsemap(const AtomStringImpl&, const TreeScope&) const;
+    const Vector<CheckedRef<Element>>* getElementsByLabelForAttribute(const AtomStringImpl&, const TreeScope&) const;
+    RefPtr<Element> getElementByWindowNamedItem(const AtomStringImpl&, const TreeScope&) const;
+    RefPtr<Element> getElementByDocumentNamedItem(const AtomStringImpl&, const TreeScope&) const;
 
-    const Vector<Element*>* getAllElementsById(const AtomStringImpl&, const TreeScope&) const;
+    const Vector<CheckedRef<Element>>* getAllElementsById(const AtomStringImpl&, const TreeScope&) const;
 
     const Vector<AtomString> keys() const;
 
 private:
     template <typename KeyMatchingFunction>
-    Element* get(const AtomStringImpl&, const TreeScope&, const KeyMatchingFunction&) const;
+    RefPtr<Element> get(const AtomStringImpl&, const TreeScope&, const KeyMatchingFunction&) const;
     template <typename KeyMatchingFunction>
-    Vector<Element*>* getAll(const AtomStringImpl&, const TreeScope&, const KeyMatchingFunction&) const;
+    Vector<CheckedRef<Element>>* getAll(const AtomStringImpl&, const TreeScope&, const KeyMatchingFunction&) const;
 
     struct MapEntry {
         MapEntry() { }
@@ -80,15 +81,15 @@ private:
             , count(1)
         { }
 
-        Element* element { nullptr };
+        CheckedPtr<Element> element;
         unsigned count { 0 };
-        Vector<Element*> orderedList;
+        Vector<CheckedRef<Element>> orderedList;
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
-        HashSet<Element*> registeredElements;
+        HashSet<CheckedPtr<Element>> registeredElements;
 #endif
     };
 
-    typedef HashMap<const AtomStringImpl*, MapEntry> Map;
+    using Map = HashMap<const AtomStringImpl*, MapEntry>;
 
     mutable Map m_map;
 };

--- a/Source/WebCore/dom/VisitedLinkState.cpp
+++ b/Source/WebCore/dom/VisitedLinkState.cpp
@@ -65,9 +65,9 @@ void VisitedLinkState::invalidateStyleForAllLinks()
 {
     if (m_linksCheckedForVisitedState.isEmpty())
         return;
-    for (auto& element : descendantsOfType<Element>(m_document)) {
-        if (element.isLink())
-            element.invalidateStyleForSubtree();
+    for (Ref element : descendantsOfType<Element>(m_document)) {
+        if (element->isLink())
+            element->invalidateStyleForSubtree();
     }
 }
 
@@ -84,9 +84,9 @@ void VisitedLinkState::invalidateStyleForLink(SharedStringHash linkHash)
 {
     if (!m_linksCheckedForVisitedState.contains(linkHash))
         return;
-    for (auto& element : descendantsOfType<Element>(m_document)) {
-        if (element.isLink() && linkHashForElement(element) == linkHash)
-            element.invalidateStyleForSubtree();
+    for (Ref element : descendantsOfType<Element>(m_document)) {
+        if (element->isLink() && linkHashForElement(element) == linkHash)
+            element->invalidateStyleForSubtree();
     }
 }
 
@@ -110,11 +110,11 @@ InsideLink VisitedLinkState::determineLinkStateSlowCase(const Element& element)
     if (!hash)
         return InsideLink::InsideVisited;
 
-    auto* frame = element.document().frame();
+    RefPtr frame = element.document().frame();
     if (!frame)
         return InsideLink::InsideUnvisited;
 
-    Page* page = frame->page();
+    CheckedPtr page = frame->page();
     if (!page)
         return InsideLink::InsideUnvisited;
 

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -47,6 +47,7 @@
 #include "RenderImage.h"
 #include "ShadowPseudoIds.h"
 #include "ShadowRoot.h"
+#include "TreeScopeInlines.h"
 #include "UserAgentStyleSheets.h"
 #include <wtf/text/AtomString.h>
 

--- a/Source/WebCore/html/CachedHTMLCollectionInlines.h
+++ b/Source/WebCore/html/CachedHTMLCollectionInlines.h
@@ -29,6 +29,7 @@
 #include "CollectionIndexCacheInlines.h"
 #include "CollectionTraversalInlines.h"
 #include "HTMLCollectionInlines.h"
+#include "TreeScopeInlines.h"
 
 namespace WebCore {
 
@@ -108,7 +109,7 @@ Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(con
 
     ContainerNode& root = rootNode();
     if (traversalType != CollectionTraversalType::CustomForwardOnly && root.isInTreeScope()) {
-        Element* candidate = nullptr;
+        RefPtr<Element> candidate;
 
         TreeScope& treeScope = root.treeScope();
         if (treeScope.hasElementWithId(*name.impl())) {
@@ -128,7 +129,7 @@ Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(con
 
         if (candidate && collection().elementMatches(*candidate)) {
             if (traversalType == CollectionTraversalType::ChildrenOnly ? candidate->parentNode() == &root : candidate->isDescendantOf(root))
-                return candidate;
+                return candidate.get();
         }
     }
 

--- a/Source/WebCore/html/HTMLAreaElement.cpp
+++ b/Source/WebCore/html/HTMLAreaElement.cpp
@@ -196,7 +196,7 @@ Path HTMLAreaElement::getRegion(const LayoutSize& size) const
     return path;
 }
 
-HTMLImageElement* HTMLAreaElement::imageElement() const
+RefPtr<HTMLImageElement> HTMLAreaElement::imageElement() const
 {
     RefPtr<Node> mapElement = parentNode();
     if (!is<HTMLMapElement>(mapElement))
@@ -217,7 +217,7 @@ bool HTMLAreaElement::isMouseFocusable() const
 
 bool HTMLAreaElement::isFocusable() const
 {
-    RefPtr<HTMLImageElement> image = imageElement();
+    RefPtr image = imageElement();
     if (!image || !image->hasFocusableStyle())
         return false;
 
@@ -231,7 +231,7 @@ void HTMLAreaElement::setFocus(bool shouldBeFocused, FocusVisibility visibility)
 
     HTMLAnchorElement::setFocus(shouldBeFocused, visibility);
 
-    RefPtr<HTMLImageElement> imageElement = this->imageElement();
+    RefPtr imageElement = this->imageElement();
     if (!imageElement)
         return;
 

--- a/Source/WebCore/html/HTMLAreaElement.h
+++ b/Source/WebCore/html/HTMLAreaElement.h
@@ -47,7 +47,7 @@ public:
     Path computePathForFocusRing(const LayoutSize& elementSize) const;
 
     // The parent map's image.
-    WEBCORE_EXPORT HTMLImageElement* imageElement() const;
+    WEBCORE_EXPORT RefPtr<HTMLImageElement> imageElement() const;
     
 private:
     HTMLAreaElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -165,14 +165,14 @@ Element* HTMLCollection::namedItemSlow(const AtomString& name) const
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
 
-    if (const Vector<Element*>* idResults = m_namedElementCache->findElementsWithId(name)) {
+    if (auto* idResults = m_namedElementCache->findElementsWithId(name)) {
         if (idResults->size())
-            return idResults->at(0);
+            return idResults->at(0).ptr();
     }
 
-    if (const Vector<Element*>* nameResults = m_namedElementCache->findElementsWithName(name)) {
+    if (auto* nameResults = m_namedElementCache->findElementsWithName(name)) {
         if (nameResults->size())
-            return nameResults->at(0);
+            return nameResults->at(0).ptr();
     }
 
     return nullptr;
@@ -243,12 +243,12 @@ Vector<Ref<Element>> HTMLCollection::namedItems(const AtomString& name) const
 
     if (elementsWithId) {
         elements.appendContainerWithMapping(*elementsWithId, [](auto& element) {
-            return Ref { *element };
+            return Ref { element.get() };
         });
     }
     if (elementsWithName) {
         elements.appendContainerWithMapping(*elementsWithName, [](auto& element) {
-            return Ref { *element };
+            return Ref { element.get() };
         });
     }
 

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -33,8 +33,8 @@ namespace WebCore {
 class CollectionNamedElementCache {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    inline const Vector<Element*>* findElementsWithId(const AtomString& id) const;
-    inline const Vector<Element*>* findElementsWithName(const AtomString& name) const;
+    inline const Vector<CheckedRef<Element>>* findElementsWithId(const AtomString& id) const;
+    inline const Vector<CheckedRef<Element>>* findElementsWithName(const AtomString& name) const;
     const Vector<AtomString>& propertyNames() const { return m_propertyNames; }
     
     inline void appendToIdCache(const AtomString& id, Element&);
@@ -44,9 +44,9 @@ public:
     inline size_t memoryCost() const;
 
 private:
-    typedef HashMap<AtomStringImpl*, Vector<Element*>> StringToElementsMap;
+    typedef HashMap<AtomStringImpl*, Vector<CheckedRef<Element>>> StringToElementsMap;
 
-    inline const Vector<Element*>* find(const StringToElementsMap&, const AtomString& key) const;
+    inline const Vector<CheckedRef<Element>>* find(const StringToElementsMap&, const AtomString& key) const;
     inline void append(StringToElementsMap&, const AtomString& key, Element&);
 
     StringToElementsMap m_idMap;

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -37,12 +37,12 @@ inline ContainerNode& HTMLCollection::rootNode() const
     return ownerNode();
 }
 
-inline const Vector<Element*>* CollectionNamedElementCache::findElementsWithId(const AtomString& id) const
+inline const Vector<CheckedRef<Element>>* CollectionNamedElementCache::findElementsWithId(const AtomString& id) const
 {
     return find(m_idMap, id);
 }
 
-inline const Vector<Element*>* CollectionNamedElementCache::findElementsWithName(const AtomString& name) const
+inline const Vector<CheckedRef<Element>>* CollectionNamedElementCache::findElementsWithName(const AtomString& name) const
 {
     return find(m_nameMap, name);
 }
@@ -66,7 +66,7 @@ inline void CollectionNamedElementCache::didPopulate()
         reportExtraMemoryAllocatedForCollectionIndexCache(cost);
 }
 
-inline const Vector<Element*>* CollectionNamedElementCache::find(const StringToElementsMap& map, const AtomString& key) const
+inline const Vector<CheckedRef<Element>>* CollectionNamedElementCache::find(const StringToElementsMap& map, const AtomString& key) const
 {
     ASSERT(m_didPopulate);
     auto it = map.find(key.impl());
@@ -77,7 +77,7 @@ inline void CollectionNamedElementCache::append(StringToElementsMap& map, const 
 {
     if (!m_idMap.contains(key.impl()) && !m_nameMap.contains(key.impl()))
         m_propertyNames.append(key);
-    map.add(key.impl(), Vector<Element*>()).iterator->value.append(&element);
+    map.add(key.impl(), Vector<CheckedRef<Element>>()).iterator->value.append(element);
 }
 
 inline bool HTMLCollection::isRootedAtTreeScope() const

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Document.h"
+#include "TreeScopeOrderedMap.h"
 
 namespace WebCore {
 
@@ -40,13 +41,13 @@ public:
     Vector<AtomString> supportedPropertyNames() const;
     bool isSupportedPropertyName(const AtomString&) const;
 
-    Element* documentNamedItem(const AtomStringImpl& name) const { return m_documentNamedItem.getElementByDocumentNamedItem(name, *this); }
+    RefPtr<Element> documentNamedItem(const AtomStringImpl& name) const { return m_documentNamedItem.getElementByDocumentNamedItem(name, *this); }
     bool hasDocumentNamedItem(const AtomStringImpl& name) const { return m_documentNamedItem.contains(name); }
     bool documentNamedItemContainsMultipleElements(const AtomStringImpl& name) const { return m_documentNamedItem.containsMultiple(name); }
     void addDocumentNamedItem(const AtomStringImpl&, Element&);
     void removeDocumentNamedItem(const AtomStringImpl&, Element&);
 
-    Element* windowNamedItem(const AtomStringImpl& name) const { return m_windowNamedItem.getElementByWindowNamedItem(name, *this); }
+    RefPtr<Element> windowNamedItem(const AtomStringImpl& name) const { return m_windowNamedItem.getElementByWindowNamedItem(name, *this); }
     bool hasWindowNamedItem(const AtomStringImpl& name) const { return m_windowNamedItem.contains(name); }
     bool windowNamedItemContainsMultipleElements(const AtomStringImpl& name) const { return m_windowNamedItem.containsMultiple(name); }
     void addWindowNamedItem(const AtomStringImpl&, Element&);

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -343,7 +343,7 @@ static const AtomString& hideAtom()
 }
 
 // https://html.spec.whatwg.org/#popover-target-element
-HTMLElement* HTMLFormControlElement::popoverTargetElement() const
+RefPtr<HTMLElement> HTMLFormControlElement::popoverTargetElement() const
 {
     auto canInvokePopovers = [](const HTMLFormControlElement& element) -> bool {
         if (!element.document().settings().popoverAttributeEnabled() || element.document().quirks().shouldDisablePopoverAttributeQuirk())
@@ -362,7 +362,7 @@ HTMLElement* HTMLFormControlElement::popoverTargetElement() const
     if (form() && isSubmitButton())
         return nullptr;
 
-    auto* element = dynamicDowncast<HTMLElement>(getElementAttribute(popovertargetAttr));
+    RefPtr element = dynamicDowncast<HTMLElement>(getElementAttribute(popovertargetAttr));
     if (element && element->popoverState() != PopoverState::None)
         return element;
     return nullptr;

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -98,7 +98,7 @@ public:
 
     virtual String resultForDialogSubmit() const;
 
-    HTMLElement* popoverTargetElement() const;
+    RefPtr<HTMLElement> popoverTargetElement() const;
     const AtomString& popoverTargetAction() const;
     void setPopoverTargetAction(const AtomString& value);
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -674,7 +674,7 @@ bool HTMLImageElement::matchesUsemap(const AtomStringImpl& name) const
     return m_parsedUsemap.impl() == &name;
 }
 
-HTMLMapElement* HTMLImageElement::associatedMapElement() const
+RefPtr<HTMLMapElement> HTMLImageElement::associatedMapElement() const
 {
     return treeScope().getImageMap(m_parsedUsemap);
 }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -80,7 +80,7 @@ public:
     void setLoadManually(bool);
 
     bool matchesUsemap(const AtomStringImpl&) const;
-    HTMLMapElement* associatedMapElement() const;
+    RefPtr<HTMLMapElement> associatedMapElement() const;
 
     WEBCORE_EXPORT const AtomString& alt() const;
 

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -77,7 +77,7 @@ bool HTMLMapElement::mapMouseEvent(LayoutPoint location, const LayoutSize& size,
     return defaultArea;
 }
 
-HTMLImageElement* HTMLMapElement::imageElement()
+RefPtr<HTMLImageElement> HTMLMapElement::imageElement()
 {
     if (m_name.isEmpty())
         return nullptr;

--- a/Source/WebCore/html/HTMLMapElement.h
+++ b/Source/WebCore/html/HTMLMapElement.h
@@ -40,7 +40,7 @@ public:
 
     bool mapMouseEvent(LayoutPoint location, const LayoutSize&, HitTestResult&);
     
-    HTMLImageElement* imageElement();
+    RefPtr<HTMLImageElement> imageElement();
     WEBCORE_EXPORT Ref<HTMLCollection> areas();
 
 private:

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -246,15 +246,10 @@ ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObje
     std::optional<Vector<RefPtr<Node>>> result;
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
-        Vector<RefPtr<Node>> controlledNodes;
-
         auto controlledElements = axObject->elementsFromAttribute(HTMLNames::aria_controlsAttr);
-        for (Element* controlledElement : controlledElements) {
-            if (controlledElement)
-                controlledNodes.append(controlledElement);
-        }
-
-        result = WTFMove(controlledNodes);
+        result = WTF::map(WTFMove(controlledElements), [](auto&& element) -> RefPtr<Node> {
+            return WTFMove(element);
+        });
     }
 
     return result;
@@ -267,15 +262,10 @@ ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObje
     std::optional<Vector<RefPtr<Node>>> result;
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
-        Vector<RefPtr<Node>> flowedNodes;
-
         auto flowedElements = axObject->elementsFromAttribute(HTMLNames::aria_flowtoAttr);
-        for (Element* flowedElement : flowedElements) {
-            if (flowedElement)
-                flowedNodes.append(flowedElement);
-        }
-
-        result = WTFMove(flowedNodes);
+        result = WTF::map(WTFMove(flowedElements), [](auto&& element) -> RefPtr<Node> {
+            return WTFMove(element);
+        });
     }
 
     return result;
@@ -301,15 +291,10 @@ ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObje
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
         if (axObject->supportsARIAOwns()) {
-            Vector<RefPtr<Node>> ownedNodes;
-
             auto ownedElements = axObject->elementsFromAttribute(HTMLNames::aria_ownsAttr);
-            for (Element* ownedElement : ownedElements) {
-                if (ownedElement)
-                    ownedNodes.append(ownedElement);
-            }
-
-            result = WTFMove(ownedNodes);
+            result = WTF::map(WTFMove(ownedElements), [](auto&& element) -> RefPtr<Node> {
+                return WTFMove(element);
+            });
         }
     }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2253,8 +2253,8 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
             auto controlledElements = axObject->elementsFromAttribute(aria_controlsAttr);
             if (controlledElements.size()) {
                 controlledNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
-                for (Element* controlledElement : controlledElements) {
-                    if (auto controlledElementId = pushNodePathToFrontend(controlledElement))
+                for (auto& controlledElement : controlledElements) {
+                    if (auto controlledElementId = pushNodePathToFrontend(controlledElement.ptr()))
                         controlledNodeIds->addItem(controlledElementId);
                 }
             }
@@ -2293,8 +2293,8 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
             auto flowedElements = axObject->elementsFromAttribute(aria_flowtoAttr);
             if (flowedElements.size()) {
                 flowedNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
-                for (Element* flowedElement : flowedElements) {
-                    if (auto flowedElementId = pushNodePathToFrontend(flowedElement))
+                for (auto& flowedElement : flowedElements) {
+                    if (auto flowedElementId = pushNodePathToFrontend(flowedElement.ptr()))
                         flowedNodeIds->addItem(flowedElementId);
                 }
             }
@@ -2365,8 +2365,8 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
                 auto ownedElements = axObject->elementsFromAttribute(aria_ownsAttr);
                 if (ownedElements.size()) {
                     ownedNodeIds = JSON::ArrayOf<Protocol::DOM::NodeId>::create();
-                    for (Element* ownedElement : ownedElements) {
-                        if (auto ownedElementId = pushNodePathToFrontend(ownedElement))
+                    for (auto& ownedElement : ownedElements) {
+                        if (auto ownedElementId = pushNodePathToFrontend(ownedElement.ptr()))
                             ownedNodeIds->addItem(ownedElementId);
                     }
                 }

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -81,7 +81,7 @@ static const HTMLFormControlElement* invokerForPopoverShowingState(const Node* n
     RefPtr invoker = dynamicDowncast<HTMLFormControlElement>(node);
     if (!invoker)
         return nullptr;
-    HTMLElement* popover = invoker->popoverTargetElement();
+    RefPtr popover = invoker->popoverTargetElement();
     if (popover && popover->isPopoverShowing() && popover->popoverData()->invoker() == invoker)
         return invoker.get();
     return nullptr;
@@ -383,8 +383,8 @@ FocusNavigationScope FocusNavigationScope::scopeOwnedByIFrame(HTMLFrameOwnerElem
 FocusNavigationScope FocusNavigationScope::scopeOwnedByPopoverInvoker(const HTMLFormControlElement& invoker)
 {
     ASSERT(invokerForPopoverShowingState(&invoker));
-    HTMLElement* popover = invoker.popoverTargetElement();
-    ASSERT(isOpenPopoverWithInvoker(popover));
+    RefPtr popover = invoker.popoverTargetElement();
+    ASSERT(isOpenPopoverWithInvoker(popover.get()));
     return FocusNavigationScope(*popover);
 }
 
@@ -1243,7 +1243,7 @@ bool FocusController::advanceFocusDirectionally(FocusDirection direction, Keyboa
             startingRect = nodeRectInAbsoluteCoordinates(focusedElement, true /* ignore border */);
         } else if (is<HTMLAreaElement>(*focusedElement)) {
             HTMLAreaElement& area = downcast<HTMLAreaElement>(*focusedElement);
-            container = scrollableEnclosingBoxOrParentFrameForNodeInDirection(direction, area.imageElement());
+            container = scrollableEnclosingBoxOrParentFrameForNodeInDirection(direction, area.imageElement().get());
             startingRect = virtualRectForAreaElementAndDirection(&area, direction);
         }
     }

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -325,9 +325,9 @@ int PrintContext::pageNumberForElement(Element* element, const FloatSize& pageSi
 
 void PrintContext::collectLinkedDestinations(Document& document)
 {
-    for (Element* child = document.documentElement(); child; child = ElementTraversal::next(*child)) {
+    for (RefPtr child = document.documentElement(); child; child = ElementTraversal::next(*child)) {
         String outAnchorName;
-        if (Element* element = child->findAnchorElementForLink(outAnchorName))
+        if (RefPtr element = child->findAnchorElementForLink(outAnchorName))
             m_linkedDestinations->add(outAnchorName, *element);
     }
 }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -502,9 +502,9 @@ std::optional<Event::IsCancelable> Quirks::simulatedMouseEventTypeForTarget(Even
     if (isDomain("airtable.com"_s)) {
         // We want to limit simulated mouse events to elements under <div id="paneContainer"> to allow for column re-ordering and multiple cell selection.
         if (is<Node>(target)) {
-            auto* node = downcast<Node>(target);
-            if (auto* paneContainer = node->treeScope().getElementById(AtomString("paneContainer"_s))) {
-                if (paneContainer->contains(node))
+            RefPtr node = downcast<Node>(target);
+            if (RefPtr paneContainer = node->treeScope().getElementById(AtomString("paneContainer"_s))) {
+                if (paneContainer->contains(node.get()))
                     return Event::IsCancelable::Yes;
             }
         }

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -69,11 +69,11 @@ FocusCandidate::FocusCandidate(Node* node, FocusDirection direction)
 
     if (is<HTMLAreaElement>(*node)) {
         HTMLAreaElement& area = downcast<HTMLAreaElement>(*node);
-        HTMLImageElement* image = area.imageElement();
+        RefPtr image = area.imageElement();
         if (!image || !image->renderer())
             return;
 
-        visibleNode = image;
+        visibleNode = image.get();
         rect = virtualRectForAreaElementAndDirection(&area, direction);
     } else {
         if (!node->renderer())

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -175,9 +175,9 @@ static RefPtr<FilterEffect> createSepiaEffect(const BasicColorMatrixFilterOperat
     return FEColorMatrix::create(FECOLORMATRIX_TYPE_MATRIX, WTFMove(inputParameters));
 }
 
-static SVGFilterElement* referenceFilterElement(const ReferenceFilterOperation& filterOperation, RenderElement& renderer)
+static RefPtr<SVGFilterElement> referenceFilterElement(const ReferenceFilterOperation& filterOperation, RenderElement& renderer)
 {
-    auto* filterElement = ReferencedSVGResources::referencedFilterElement(renderer.treeScopeForSVGReferences(), filterOperation);
+    RefPtr filterElement = ReferencedSVGResources::referencedFilterElement(renderer.treeScopeForSVGReferences(), filterOperation);
 
     if (!filterElement) {
         LOG_WITH_STREAM(Filters, stream << " buildReferenceFilter: failed to find filter renderer, adding pending resource " << filterOperation.fragment());
@@ -192,7 +192,7 @@ static SVGFilterElement* referenceFilterElement(const ReferenceFilterOperation& 
 
 static bool isIdentityReferenceFilter(const ReferenceFilterOperation& filterOperation, RenderElement& renderer)
 {
-    auto filterElement = referenceFilterElement(filterOperation, renderer);
+    RefPtr filterElement = referenceFilterElement(filterOperation, renderer);
     if (!filterElement)
         return false;
 
@@ -201,7 +201,7 @@ static bool isIdentityReferenceFilter(const ReferenceFilterOperation& filterOper
 
 static IntOutsets calculateReferenceFilterOutsets(const ReferenceFilterOperation& filterOperation, RenderElement& renderer, const FloatRect& targetBoundingBox)
 {
-    auto filterElement = referenceFilterElement(filterOperation, renderer);
+    RefPtr filterElement = referenceFilterElement(filterOperation, renderer);
     if (!filterElement)
         return { };
 
@@ -210,11 +210,11 @@ static IntOutsets calculateReferenceFilterOutsets(const ReferenceFilterOperation
 
 static RefPtr<SVGFilter> createReferenceFilter(CSSFilter& filter, const ReferenceFilterOperation& filterOperation, RenderElement& renderer, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
 {
-    auto filterElement = referenceFilterElement(filterOperation, renderer);
+    RefPtr filterElement = referenceFilterElement(filterOperation, renderer);
     if (!filterElement)
         return nullptr;
 
-    auto filterRegion = SVGLengthContext::resolveRectangle<SVGFilterElement>(filterElement, filterElement->filterUnits(), targetBoundingBox);
+    auto filterRegion = SVGLengthContext::resolveRectangle<SVGFilterElement>(filterElement.get(), filterElement->filterUnits(), targetBoundingBox);
 
     return SVGFilter::create(*filterElement, preferredFilterRenderingModes, filter.filterScale(), filterRegion, targetBoundingBox, destinationContext);
 }

--- a/Source/WebCore/rendering/ReferencedSVGResources.h
+++ b/Source/WebCore/rendering/ReferencedSVGResources.h
@@ -58,12 +58,12 @@ public:
 
     // Clipping needs a renderer, filters use an element.
     static LegacyRenderSVGResourceClipper* referencedClipperRenderer(TreeScope&, const ReferencePathOperation&);
-    static SVGFilterElement* referencedFilterElement(TreeScope&, const ReferenceFilterOperation&);
+    static RefPtr<SVGFilterElement> referencedFilterElement(TreeScope&, const ReferenceFilterOperation&);
 
     static LegacyRenderSVGResourceContainer* referencedRenderResource(TreeScope&, const AtomString& fragment);
 
 private:
-    static SVGElement* elementForResourceID(TreeScope&, const AtomString& resourceID, const QualifiedName& tagName);
+    static RefPtr<SVGElement> elementForResourceID(TreeScope&, const AtomString& resourceID, const QualifiedName& tagName);
 
     void addClientForTarget(SVGElement& targetElement, const AtomString&);
     void removeClientForTarget(TreeScope&, const AtomString&);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1544,13 +1544,13 @@ bool RenderBox::hitTestClipPath(const HitTestLocation& hitTestLocation, const La
     }
     case PathOperation::Reference: {
         const auto& referencePathOperation = downcast<ReferencePathOperation>(*style().clipPath());
-        auto* element = document().getElementById(referencePathOperation.fragment());
+        RefPtr element = document().getElementById(referencePathOperation.fragment());
         if (!element || !element->renderer())
             break;
         if (!is<SVGClipPathElement>(*element))
             break;
-        auto& clipper = downcast<LegacyRenderSVGResourceClipper>(*element->renderer());
-        if (!clipper.hitTestClipContent(FloatRect(borderBoxRect()), FloatPoint { hitTestLocationInLocalCoordinates }))
+        CheckedRef clipper = downcast<LegacyRenderSVGResourceClipper>(*element->renderer());
+        if (!clipper->hitTestClipContent(FloatRect(borderBoxRect()), FloatPoint { hitTestLocationInLocalCoordinates }))
             return false;
         break;
     }

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -769,7 +769,7 @@ LayoutUnit RenderImage::minimumReplacedHeight() const
     return imageResource().errorOccurred() ? intrinsicSize().height() : 0_lu;
 }
 
-HTMLMapElement* RenderImage::imageMap() const
+RefPtr<HTMLMapElement> RenderImage::imageMap() const
 {
     auto* imageElement = element();
     if (!imageElement || !is<HTMLImageElement>(imageElement))
@@ -783,7 +783,7 @@ bool RenderImage::nodeAtPoint(const HitTestRequest& request, HitTestResult& resu
     bool inside = RenderReplaced::nodeAtPoint(request, tempResult, locationInContainer, accumulatedOffset, hitTestAction);
 
     if (tempResult.innerNode() && element()) {
-        if (HTMLMapElement* map = imageMap()) {
+        if (RefPtr map = imageMap()) {
             LayoutRect contentBox = contentBoxRect();
             float scaleFactor = 1 / style().effectiveZoom();
             LayoutPoint mapLocation = locationInContainer.point() - toLayoutSize(accumulatedOffset) - locationOffset() - toLayoutSize(contentBox.location());

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -52,7 +52,7 @@ public:
 
     void updateAltText();
 
-    HTMLMapElement* imageMap() const;
+    RefPtr<HTMLMapElement> imageMap() const;
     void areaElementFocusChanged(HTMLAreaElement*);
     
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -92,14 +92,14 @@ void RenderLayerFilters::updateReferenceFilterClients(const FilterOperations& op
             m_externalSVGReferences.append(cachedSVGDocument);
         } else {
             // Reference is internal; add layer as a client so we can trigger filter repaint on SVG attribute change.
-            auto* filterElement = m_layer.renderer().document().getElementById(referenceOperation.fragment());
+            RefPtr filterElement = m_layer.renderer().document().getElementById(referenceOperation.fragment());
             if (!filterElement)
                 continue;
-            auto* renderer = filterElement->renderer();
-            if (!is<RenderSVGResourceFilter>(renderer))
+            CheckedPtr renderer = dynamicDowncast<RenderSVGResourceFilter>(filterElement->renderer());
+            if (!renderer)
                 continue;
-            downcast<RenderSVGResourceFilter>(*renderer).addClientRenderLayer(m_layer);
-            m_internalSVGReferences.append(filterElement);
+            renderer->addClientRenderLayer(m_layer);
+            m_internalSVGReferences.append(WTFMove(filterElement));
         }
     }
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -764,7 +764,7 @@ void RenderObject::addPDFURLRect(const PaintInfo& paintInfo, const LayoutPoint& 
 
     if (paintInfo.context().supportsInternalLinks()) {
         String outAnchorName;
-        Element* linkTarget = element.findAnchorElementForLink(outAnchorName);
+        RefPtr linkTarget = element.findAnchorElementForLink(outAnchorName);
         if (linkTarget) {
             paintInfo.context().setDestinationForRect(outAnchorName, urlRect);
             return;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -897,8 +897,8 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
 
             auto& div = downcast<HTMLDivElement>(*m_element);
             if (div.hasClass() && div.classNames().contains(instreamNativeVideoDivClass)) {
-                auto* video = div.treeScope().getElementById(videoElementID);
-                if (is<HTMLVideoElement>(video) && downcast<HTMLVideoElement>(*video).isFullscreen())
+                RefPtr video = dynamicDowncast<HTMLVideoElement>(div.treeScope().getElementById(videoElementID));
+                if (video && video->isFullscreen())
                     style.setEffectiveDisplay(DisplayType::Block);
             }
         }

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -142,7 +142,7 @@ private:
     RefPtr<LocalFrame> frameForCurrentScale() const;
     Ref<NodeList> collectIntersectionOrEnclosureList(SVGRect&, SVGElement*, bool (*checkFunction)(SVGElement&, SVGRect&));
 
-    SVGViewElement* findViewAnchor(StringView fragmentIdentifier) const;
+    RefPtr<SVGViewElement> findViewAnchor(StringView fragmentIdentifier) const;
     SVGSVGElement* findRootAnchor(const SVGViewElement*) const;
     SVGSVGElement* findRootAnchor(StringView) const;
 

--- a/Source/WebCore/svg/SVGViewSpec.cpp
+++ b/Source/WebCore/svg/SVGViewSpec.cpp
@@ -43,14 +43,11 @@ SVGViewSpec::SVGViewSpec(SVGElement& contextElement)
     });
 }
 
-SVGElement* SVGViewSpec::viewTarget() const
+RefPtr<SVGElement> SVGViewSpec::viewTarget() const
 {
     if (!m_contextElement)
         return nullptr;
-    auto* element = m_contextElement->treeScope().getElementById(m_viewTargetString);
-    if (!is<SVGElement>(element))
-        return nullptr;
-    return downcast<SVGElement>(element);
+    return dynamicDowncast<SVGElement>(m_contextElement->treeScope().getElementById(m_viewTargetString));
 }
 
 void SVGViewSpec::reset()

--- a/Source/WebCore/svg/SVGViewSpec.h
+++ b/Source/WebCore/svg/SVGViewSpec.h
@@ -41,7 +41,7 @@ public:
     void reset();
     void resetContextElement() { m_contextElement = nullptr; }
 
-    SVGElement* viewTarget() const;
+    RefPtr<SVGElement> viewTarget() const;
     const String& viewTargetString() const { return m_viewTargetString; }
 
     String transformString() const { return m_transform->valueAsString(); }

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -559,9 +559,9 @@ void SVGSMILElement::svgAttributeChanged(const QualifiedName& attrName)
     animationAttributeChanged();
 }
 
-inline Element* SVGSMILElement::eventBaseFor(const Condition& condition)
+inline RefPtr<Element> SVGSMILElement::eventBaseFor(const Condition& condition)
 {
-    return condition.m_baseID.isEmpty() ? targetElement() : treeScope().getElementById(condition.m_baseID);
+    return condition.m_baseID.isEmpty() ? RefPtr<Element> { targetElement() } : treeScope().getElementById(condition.m_baseID);
 }
 
 void SVGSMILElement::connectConditions()

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -161,7 +161,7 @@ private:
     };
     bool parseCondition(StringView, BeginOrEnd);
     void parseBeginOrEnd(StringView, BeginOrEnd);
-    Element* eventBaseFor(const Condition&);
+    RefPtr<Element> eventBaseFor(const Condition&);
 
     void disconnectConditions();
 

--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -341,9 +341,9 @@ Value FunId::evaluate() const
 
         // If there are several nodes with the same id, id() should return the first one.
         // In WebKit, getElementById behaves so, too, although its behavior in this case is formally undefined.
-        Node* node = contextScope.getElementById(StringView(idList).substring(startPos, endPos - startPos));
+        RefPtr node = contextScope.getElementById(StringView(idList).substring(startPos, endPos - startPos));
         if (node && resultSet.add(*node).isNewEntry)
-            result.append(node);
+            result.append(WTFMove(node));
         
         startPos = endPos;
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -192,11 +192,11 @@ int InjectedBundle::numberOfPages(WebFrame* frame, double pageWidthInPixels, dou
 
 int InjectedBundle::pageNumberForElementById(WebFrame* frame, const String& id, double pageWidthInPixels, double pageHeightInPixels)
 {
-    auto* coreFrame = frame ? frame->coreLocalFrame() : nullptr;
+    RefPtr coreFrame = frame ? frame->coreLocalFrame() : nullptr;
     if (!coreFrame)
         return -1;
 
-    auto* element = coreFrame->document()->getElementById(id);
+    RefPtr element = coreFrame->document()->getElementById(id);
     if (!element)
         return -1;
 
@@ -205,7 +205,7 @@ int InjectedBundle::pageNumberForElementById(WebFrame* frame, const String& id, 
     if (!pageHeightInPixels)
         pageHeightInPixels = coreFrame->view()->height();
 
-    return PrintContext::pageNumberForElement(element, FloatSize(pageWidthInPixels, pageHeightInPixels));
+    return PrintContext::pageNumberForElement(element.get(), FloatSize(pageWidthInPixels, pageHeightInPixels));
 }
 
 String InjectedBundle::pageSizeAndMarginsInPixels(WebFrame* frame, int pageIndex, int width, int height, int marginTop, int marginRight, int marginBottom, int marginLeft)


### PR DESCRIPTION
#### 100c20fadc5e59baa58f342cec29e7b9dff3c1e5
<pre>
Adopt even more smart pointers in the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=263171">https://bugs.webkit.org/show_bug.cgi?id=263171</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WTF/wtf/Ref.h:
Remove dead declarations (without implementation) which caused linking errors
as I was working on this.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::focusedImageMapUIElement):
(WebCore::AXObjectCache::addRelations):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::labelsForNode):
(WebCore::AccessibilityNodeObject::popoverTargetElement const):
(WebCore::AccessibilityNodeObject::textUnderElement const):
(WebCore::AccessibilityNodeObject::descriptionForElements const):
(WebCore::AccessibilityNodeObject::ariaLabeledByElements const):
(WebCore:: const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isTabItemSelected const):
(WebCore::AccessibilityObject::isExpanded const):
(WebCore::AccessibilityObject::elementsFromAttribute const):
(WebCore:: const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::popoverTargetElement const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::accessibilityParentForImageMap const):
(WebCore::AccessibilityRenderObject::documentLinks):
* Source/WebCore/bindings/js/JSDOMWindowProperties.cpp:
(WebCore::jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter):
* Source/WebCore/css/StyleSheetList.cpp:
(WebCore::StyleSheetList::namedItem const):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::CustomElementDefaultARIA::elementForAttribute const):
* Source/WebCore/dom/CustomElementDefaultARIA.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::handlePopoverLightDismiss):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::getElementById const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::getElementAttribute const):
(WebCore::Element::getElementsArrayAttribute const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::ElementInternals::getElementAttribute const):
* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/ImageOverlay.cpp:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::renderRect):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::executeFastPathForIdSelector const):
(WebCore::filterRootById):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::getElementById const):
(WebCore::TreeScope::getAllElementsById const):
(WebCore::TreeScope::getElementByName const):
(WebCore::TreeScope::getImageMap const):
(WebCore::TreeScope::imageElementByUsemap const):
(WebCore::TreeScope::labelElementsForId):
(WebCore::TreeScope::findAnchor):
(WebCore:: const): Deleted.
(): Deleted.
* Source/WebCore/dom/TreeScope.h:
(WebCore::TreeScope::hasElementWithId const): Deleted.
(WebCore::TreeScope::containsMultipleElementsWithId const): Deleted.
(WebCore::TreeScope::hasElementWithName const): Deleted.
(WebCore::TreeScope::containsMultipleElementsWithName const): Deleted.
* Source/WebCore/dom/TreeScopeInlines.h: Added.
(WebCore::TreeScope::hasElementWithId const):
(WebCore::TreeScope::containsMultipleElementsWithId const):
(WebCore::TreeScope::hasElementWithName const):
(WebCore::TreeScope::containsMultipleElementsWithName const):
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::get const):
(WebCore::TreeScopeOrderedMap::getAll const):
(WebCore::TreeScopeOrderedMap::getElementById const):
(WebCore::TreeScopeOrderedMap::getElementByName const):
(WebCore::TreeScopeOrderedMap::getElementByMapName const):
(WebCore::TreeScopeOrderedMap::getElementByUsemap const):
(WebCore::TreeScopeOrderedMap::getElementsByLabelForAttribute const):
(WebCore::TreeScopeOrderedMap::getElementByWindowNamedItem const):
(WebCore::TreeScopeOrderedMap::getElementByDocumentNamedItem const):
(WebCore::TreeScopeOrderedMap::getAllElementsById const):
(WebCore:: const): Deleted.
* Source/WebCore/dom/TreeScopeOrderedMap.h:
* Source/WebCore/dom/TreeWalker.cpp:
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureToken::UserGestureToken):
* Source/WebCore/dom/VisitedLinkState.cpp:
(WebCore::VisitedLinkState::invalidateStyleForAllLinks):
(WebCore::VisitedLinkState::invalidateStyleForLink):
(WebCore::VisitedLinkState::determineLinkStateSlowCase):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
* Source/WebCore/html/CachedHTMLCollectionInlines.h:
(WebCore::traversalType&gt;::namedItem const):
* Source/WebCore/html/HTMLAreaElement.cpp:
(WebCore::HTMLAreaElement::imageElement const):
(WebCore::HTMLAreaElement::isFocusable const):
(WebCore::HTMLAreaElement::setFocus):
* Source/WebCore/html/HTMLAreaElement.h:
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::namedItemSlow const):
(WebCore::HTMLCollection::namedItems const):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::CollectionNamedElementCache::findElementsWithId const):
(WebCore::CollectionNamedElementCache::findElementsWithName const):
(WebCore::CollectionNamedElementCache::find const):
(WebCore::CollectionNamedElementCache::append):
(WebCore:: const): Deleted.
* Source/WebCore/html/HTMLDocument.h:
(WebCore::HTMLDocument::documentNamedItem const):
(WebCore::HTMLDocument::windowNamedItem const):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::popoverTargetElement const):
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::associatedMapElement const):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::imageElement):
* Source/WebCore/html/HTMLMapElement.h:
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp:
(WebCore::InspectorAuditAccessibilityObject::getControlledNodes):
(WebCore::InspectorAuditAccessibilityObject::getFlowedNodes):
(WebCore::InspectorAuditAccessibilityObject::getOwnedNodes):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForAccessibilityProperties):
* Source/WebCore/page/FocusController.cpp:
(WebCore::invokerForPopoverShowingState):
(WebCore::FocusNavigationScope::scopeOwnedByPopoverInvoker):
(WebCore::FocusController::advanceFocusDirectionally):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::FocusCandidate::FocusCandidate):
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::referenceFilterElement):
(WebCore::isIdentityReferenceFilter):
(WebCore::calculateReferenceFilterOutsets):
(WebCore::createReferenceFilter):
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::removeClientForTarget):
(WebCore::ReferencedSVGResources::updateReferencedResources):
(WebCore::ReferencedSVGResources::elementForResourceID):
(WebCore::ReferencedSVGResources::referencedFilterElement):
* Source/WebCore/rendering/ReferencedSVGResources.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hitTestClipPath const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::imageMap const):
(WebCore::RenderImage::nodeAtPoint):
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::updateReferenceFilterClients):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::getElementById):
* Source/WebCore/svg/SVGViewSpec.cpp:
(WebCore::SVGViewSpec::viewTarget const):
* Source/WebCore/svg/SVGViewSpec.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::eventBaseFor):
* Source/WebCore/svg/animation/SVGSMILElement.h:
* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::FunId::evaluate const):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::pageNumberForElementById):

Canonical link: <a href="https://commits.webkit.org/269380@main">https://commits.webkit.org/269380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2996c8c405b3885caaba3d986be592301a7b9f6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22401 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/15 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22655 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22934 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22640 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19447 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25159 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20302 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19493 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/20 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24407 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21772 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25820 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6066 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5331 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27097 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5894 "Found 2 new JSC stress test failures: microbenchmarks/array-from-object-func.js.lockdown, microbenchmarks/array-from-object.js.lockdown (failure)") | 
<!--EWS-Status-Bubble-End-->