### PR TITLE
Adopt _UIContextMenuAsyncConfiguration to let context menu interactions begin asynchronously

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1656,3 +1656,11 @@
     || PLATFORM(VISION)
 #define HAVE_UISCROLLVIEW_ALLOWS_KEYBOARD_SCROLLING 1
 #endif
+
+#if !PLATFORM(APPLETV) && !PLATFORM(WATCHOS) && __has_include(<UIKit/_UIAsyncDragInteraction.h>)
+#define HAVE_UI_ASYNC_DRAG_INTERACTION 1
+#endif
+
+#if !PLATFORM(WATCHOS) && __has_include(<UIKit/_UIContextMenuAsyncConfiguration.h>)
+#define HAVE_UI_CONTEXT_MENU_ASYNC_CONFIGURATION 1
+#endif

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -126,6 +126,10 @@
 #import <UIKit/_UIAsyncDragInteraction.h>
 #endif
 
+#if HAVE(UI_CONTEXT_MENU_ASYNC_CONFIGURATION)
+#import <UIKit/_UIContextMenuAsyncConfiguration.h>
+#endif
+
 #if HAVE(UIFINDINTERACTION)
 #import <UIKit/UIFindSession_Private.h>
 #import <UIKit/_UIFindInteraction.h>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -581,9 +581,6 @@ struct ImageAnalysisContextMenuActionData {
 #if HAVE(UI_ASYNC_DRAG_INTERACTION)
     , _UIAsyncDragInteractionDelegate
 #endif
-#if HAVE(UI_ASYNC_TEXT_INPUT)
-    , UIAsyncTextInput
-#endif
 >
 
 @property (nonatomic, readonly) CGPoint lastInteractionLocation;


### PR DESCRIPTION
#### 429bb1ad0f79cf369c4c81f7137636f4cfd8eee3
<pre>
Adopt _UIContextMenuAsyncConfiguration to let context menu interactions begin asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=263172">https://bugs.webkit.org/show_bug.cgi?id=263172</a>
rdar://114349359

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Adopt `_UIContextMenuAsyncConfiguration` in WebKit to support async context menu interactions
without the need to use the following private context menu delegate method:

```
- (void)_contextMenuInteraction:(UIContextMenuInteraction *)interaction
    configurationForMenuAtLocation:(CGPoint)location
    completion:(void(^)(UIContextMenuConfiguration *))completion;
```

To use the new context menu async configuration, we simply return `_UIContextMenuAsyncConfiguration`
synchronously from the normal API context menu configuration delegate method; later, when we have
the concrete context menu configuration that we should proceed with, we call
`-fulfillWithConfiguration:` to swap out the placeholder async configuration with the real
configuration, which allows UIKit to proceed with the interaction.

* Source/WTF/wtf/PlatformHave.h:

Add new compile-time feature flags.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:

Drive-by fix: put conformance to `UIAsyncTextInput` behind a runtime flag as well, to make staged
API adoption possible.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Add soft-link support for some of the new classes, to help preserve binary compatibility.

(-[WKContentView _shouldUseUIContextMenuAsyncConfiguration]):

Return `YES` if and only if we&apos;re building for an OS with `_UIContextMenuAsyncConfiguration`, and
`_UIContextMenuAsyncConfiguration` also exists in the runtime.

(-[WKContentView _ensureBinaryCompatibilityWithAsyncInteractionsIfNeeded]):

In order to properly opt into the `_UIContextMenuAsyncConfiguration` codepath, we can&apos;t implement
the legacy async method (`-_contextMenuInteraction:configurationForMenuAtLocation:completion:`),
since that legacy method takes priority (because UIKit only calls one of either the legacy async
method or the normal context menu configuration API delegate method).

However, since we still need to continue supporting the legacy async codepath when the runtime
feature flag is off, we need to implement the legacy async delegate method if the feature flag is
disabled (or `_UIContextMenuAsyncConfiguration` is otherwise unavailable).

To make this all work, we rename the existing async delegate method to have an `_internal` prefix,
and then use `class_addMethod` to dynamically add an implementation of the legacy async codepath if
needed.

(-[WKContentView setUpInteraction]):
(-[WKContentView _dragInteractionClass]):

Drive-by fix: soft link `_UIAsyncDragInteraction` so that we don&apos;t crash on launch, when testing
against builds without UIKit support for `_UIAsyncDragInteraction`.

(-[WKContentView contextMenuInteraction:configurationForMenuAtLocation:]):
(-[WKContentView _internalContextMenuInteraction:configurationForMenuAtLocation:completion:]):
(-[WKContentView _contextMenuInteraction:configurationForMenuAtLocation:completion:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/269394@main">https://commits.webkit.org/269394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9d5ca5c36431e228a68aea723bebc3ef5d92888

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22417 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20750 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21752 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22656 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25175 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26561 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19509 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24416 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21788 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17878 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25836 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6067 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5340 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27113 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/27 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5895 "Passed tests") | 
<!--EWS-Status-Bubble-End-->