### PR TITLE
REGRESSION(269016@main) [Win] fast/forms/listbox-zero-item-height.html is randomly failing

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -2564,9 +2564,8 @@ animations/no-style-recalc-during-accelerated-animation.html [ Pass Failure ]
 
 webkit.org/b/133151 js/cached-window-properties.html [ Skip ] # Slow
 
-webkit.org/b/263101 fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-svg.html [ ImageOnlyFailure Pass ]
-webkit.org/b/263101 fast/css3-text/css3-text-decoration/text-decoration-thickness.html [ ImageOnlyFailure Pass ]
-webkit.org/b/263101 fast/forms/listbox-zero-item-height.html [ Failure Pass ]
+fast/css3-text/css3-text-decoration/text-decoration-thickness.html [ ImageOnlyFailure ]
+fast/forms/listbox-zero-item-height.html [ Failure ]
 
 fast/css/unicode-escape-in-8bit-string.html [ ImageOnlyFailure ]
 fast/css/word-spacing-characters.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/win/SimpleFontDataCairoWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SimpleFontDataCairoWin.cpp
@@ -62,7 +62,8 @@ void Font::platformInit()
     GetTextFace(dc, LF_FACESIZE, faceName);
 
     OUTLINETEXTMETRIC metrics;
-    GetOutlineTextMetrics(dc, sizeof(metrics), &metrics);
+    if (!GetOutlineTextMetrics(dc, sizeof(metrics), &metrics))
+        return;
 
     float xHeight = metrics.otmTextMetrics.tmAscent * 0.56f; // Best guess for xHeight if no x glyph is present.
     GLYPHMETRICS gm;


### PR DESCRIPTION
#### 15855ea0a70708ea758ab7917dafe852e1fbd711
<pre>
REGRESSION(269016@main) [Win] fast/forms/listbox-zero-item-height.html is randomly failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=263101">https://bugs.webkit.org/show_bug.cgi?id=263101</a>

Reviewed by Ross Kirsling.

The following tests were randomly failing after 269016@main..

  fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-svg.html
  fast/css3-text/css3-text-decoration/text-decoration-thickness.html
  fast/forms/listbox-zero-item-height.html

Uninitialized OUTLINETEXTMETRIC was used if GetOutlineTextMetrics
failed. Check the return value of GetOutlineTextMetrics.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/graphics/win/SimpleFontDataCairoWin.cpp:

Canonical link: <a href="https://commits.webkit.org/269354@main">https://commits.webkit.org/269354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc762dea26beae61a345ea26c122eaa359adba13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20664 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21674 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25083 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26484 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20327 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20465 "Found 1 new test failure: webrtc/vp8-then-h264.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24344 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/20997 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24685 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2792 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/20991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->