### PR TITLE
[SVG] Add approximate stroke-bounding-box computation for repainting

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -112,6 +112,8 @@ void RenderSVGContainer::layoutChildren()
 FloatRect RenderSVGContainer::strokeBoundingBox() const
 {
     if (!m_strokeBoundingBox) {
+        // Initialize m_strokeBoundingBox before calling computeDecoratedBoundingBox, since recursively referenced markers can cause us to re-enter here.
+        m_strokeBoundingBox = FloatRect { };
         SVGBoundingBoxComputation boundingBoxComputation(*this);
         m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
     }

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -54,6 +54,7 @@ void RenderSVGEllipse::updateShapeFromElement()
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
     m_strokeBoundingBox = std::nullopt;
+    m_approximateStrokeBoundingBox = std::nullopt;
     m_center = FloatPoint();
     m_radii = FloatSize();
 

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -57,6 +57,7 @@ void RenderSVGPath::updateShapeFromElement()
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = ensurePath().boundingRect();
     m_strokeBoundingBox = std::nullopt;
+    m_approximateStrokeBoundingBox = std::nullopt;
     processMarkerPositions();
     updateZeroLengthSubpaths();
 
@@ -69,7 +70,7 @@ void RenderSVGPath::updateShapeFromElement()
         m_shapeType = ShapeType::Path;
 }
 
-FloatRect RenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const
+FloatRect RenderSVGPath::adjustStrokeBoundingBoxForZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const
 {
     if (style().svgStyle().hasStroke()) {
         // FIXME: zero-length subpaths do not respect vector-effect = non-scaling-stroke.

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -43,7 +43,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGPath"_s; }
 
     void updateShapeFromElement() override;
-    FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const override;
+    FloatRect adjustStrokeBoundingBoxForZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const override;
 
     void strokeShape(GraphicsContext&) const override;
     bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace) override;

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -59,6 +59,7 @@ void RenderSVGRect::updateShapeFromElement()
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
     m_strokeBoundingBox = std::nullopt;
+    m_approximateStrokeBoundingBox = std::nullopt;
     m_innerStrokeRect = FloatRect();
     m_outerStrokeRect = FloatRect();
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -262,6 +262,8 @@ void RenderSVGRoot::layoutChildren()
 FloatRect RenderSVGRoot::strokeBoundingBox() const
 {
     if (!m_strokeBoundingBox) {
+        // Initialize m_strokeBoundingBox before calling computeDecoratedBoundingBox, since recursively referenced markers can cause us to re-enter here.
+        m_strokeBoundingBox = FloatRect { };
         SVGBoundingBoxComputation boundingBoxComputation(*this);
         m_strokeBoundingBox = boundingBoxComputation.computeDecoratedBoundingBox(SVGBoundingBoxComputation::strokeBoundingBoxDecoration);
     }

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -47,6 +47,8 @@ class SVGGraphicsElement;
 class RenderSVGShape : public RenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGShape);
 public:
+    friend FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderElement&);
+
     enum class ShapeType : uint8_t {
         Empty,
         Path,
@@ -90,6 +92,7 @@ public:
 
     FloatRect objectBoundingBox() const final { return m_fillBoundingBox; }
     FloatRect strokeBoundingBox() const final;
+    FloatRect approximateStrokeBoundingBox() const;
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
 
     bool needsHasSVGTransformFlags() const final;
@@ -112,7 +115,7 @@ protected:
     AffineTransform nonScalingStrokeTransform() const;
     Path* nonScalingStrokePath(const Path*, const AffineTransform&) const;
 
-    virtual FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const { return strokeBoundingBox; }
+    virtual FloatRect adjustStrokeBoundingBoxForZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const { return strokeBoundingBox; }
 
 private:
     // Hit-detection separated for the fill and the stroke
@@ -143,9 +146,12 @@ private:
 
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;
 
+    FloatRect calculateApproximateStrokeBoundingBox() const;
+
 protected:
     FloatRect m_fillBoundingBox;
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_approximateStrokeBoundingBox;
 private:
     bool m_needsShapeUpdate { true };
 protected:

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -99,11 +99,8 @@ FloatRect SVGBoundingBoxComputation::handleShapeOrTextOrInline(const SVGBounding
     //    assumption that the element has no dash pattern.
     //
     // Note: The values of the stroke-opacity, stroke-dasharray and stroke-dashoffset do not affect the calculation of the stroke shape.
-    if (options.contains(DecorationOption::IncludeStrokeShape)) {
-        // FIXME: We need to use approximate stroke-bounding-box computation when it gets implemented and CalculateFastRepaintRect is specified.
-        // https://bugs.webkit.org/show_bug.cgi?id=263077
+    if (options.contains(DecorationOption::IncludeStrokeShape))
         box.unite(m_renderer.strokeBoundingBox());
-    }
 
     // 5. If markers is true, then for each marker marker rendered on the element:
     // - For each descendant graphics element child of the "marker" element that defines marker's content:

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -73,6 +73,8 @@ public:
     static const RenderElement* pushMappingToContainer(const RenderElement&, const RenderLayerModelObject* ancestorToStopAt, RenderGeometryMap&);
     static bool checkForSVGRepaintDuringLayout(const RenderElement&);
 
+    static FloatRect calculateApproximateStrokeBoundingBox(const RenderElement&);
+
     // Shared between SVG renderers and resources.
     static void applyStrokeStyleToContext(GraphicsContext&, const RenderStyle&, const RenderElement&);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -154,25 +154,41 @@ void LegacyRenderSVGContainer::addFocusRingRects(Vector<LayoutRect>& rects, cons
 
 void LegacyRenderSVGContainer::updateCachedBoundaries()
 {
-    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, m_repaintBoundingBox);
-    // FIXME: Once we move to the model strictly separating m_repaintBoundingBox and m_strokeBoundingBox, we will just null out m_strokeBoundingBox
-    // here, and lazily compute it in strokeBoundingBox(), which solves conflation. This will happen when we enable approximate repainting bounding box computation.
-    // https://bugs.webkit.org/show_bug.cgi?id=262409
-    //
-    // When computing the strokeBoundingBox, we use the repaintRects of the container's children so that the container's stroke includes
-    // the resources applied to the children (such as clips and filters). This allows filters applied to containers to correctly bound
-    // the children, and also improves inlining of SVG content, as the stroke bound is used in that situation also.
-    m_strokeBoundingBox = m_repaintBoundingBox;
-    SVGRenderSupport::intersectRepaintRectWithResources(*this, m_repaintBoundingBox);
+    m_strokeBoundingBox = std::nullopt;
+    m_repaintBoundingBox = { };
+    m_accurateRepaintBoundingBox = std::nullopt;
+    FloatRect repaintBoundingBox;
+    SVGRenderSupport::computeContainerBoundingBoxes(*this, m_objectBoundingBox, m_objectBoundingBoxValid, repaintBoundingBox);
+    SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox);
+    m_repaintBoundingBox = repaintBoundingBox;
 }
 
 FloatRect LegacyRenderSVGContainer::strokeBoundingBox() const
 {
-    // FIXME: Once we enable approximate repainting bounding box computation, m_strokeBoundingBox becomes std::nullopt in updateCachedBoundaries and gets lazily computed.
-    // https://bugs.webkit.org/show_bug.cgi?id=262409
-    if (!m_strokeBoundingBox)
+    if (!m_strokeBoundingBox) {
+        // Initialize m_strokeBoundingBox before calling computeContainerStrokeBoundingBox, since recursively referenced markers can cause us to re-enter here.
+        m_strokeBoundingBox = FloatRect { };
         m_strokeBoundingBox = SVGRenderSupport::computeContainerStrokeBoundingBox(*this);
+    }
     return *m_strokeBoundingBox;
+}
+
+FloatRect LegacyRenderSVGContainer::repaintRectInLocalCoordinates(RepaintRectCalculation repaintRectCalculation) const
+{
+    if (repaintRectCalculation == RepaintRectCalculation::Fast)
+        return m_repaintBoundingBox;
+
+    if (!m_accurateRepaintBoundingBox) {
+        // Initialize m_accurateRepaintBoundingBox before calling computeContainerBoundingBoxes, since recursively referenced markers can cause us to re-enter here.
+        m_accurateRepaintBoundingBox = FloatRect { };
+        FloatRect objectBoundingBox;
+        FloatRect repaintBoundingBox;
+        bool objectBoundingBoxValid = true;
+        SVGRenderSupport::computeContainerBoundingBoxes(*this, objectBoundingBox, objectBoundingBoxValid, repaintBoundingBox, RepaintRectCalculation::Accurate);
+        SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox);
+        m_accurateRepaintBoundingBox = repaintBoundingBox;
+    }
+    return *m_accurateRepaintBoundingBox;
 }
 
 bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, HitTestResult& result, const FloatPoint& pointInParent, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -52,7 +52,7 @@ protected:
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect strokeBoundingBox() const final;
-    FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return m_repaintBoundingBox; }
+    FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final;
 
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
 
@@ -75,6 +75,7 @@ private:
     FloatRect m_objectBoundingBox;
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
     FloatRect m_repaintBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_accurateRepaintBoundingBox;
 
     bool m_objectBoundingBoxValid { false };
     bool m_needsBoundariesUpdate { true };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -87,7 +87,7 @@ private:
 
     FloatRect objectBoundingBox() const override { return m_objectBoundingBox; }
     FloatRect strokeBoundingBox() const override;
-    FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const override { return m_repaintBoundingBox; }
+    FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const override;
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 
@@ -112,6 +112,7 @@ private:
     bool m_inLayout { false };
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
     FloatRect m_repaintBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_accurateRepaintBoundingBox;
     mutable AffineTransform m_localToParentTransform;
     AffineTransform m_localToBorderBoxTransform;
     WeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -42,6 +42,8 @@ class SVGGraphicsElement;
 class LegacyRenderSVGShape : public LegacyRenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGShape);
 public:
+    friend FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderElement&);
+
     enum class ShapeType : uint8_t {
         Empty,
         Path,
@@ -103,12 +105,14 @@ protected:
 
     virtual FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const { return strokeBoundingBox; }
 
+    FloatRect strokeBoundingBox() const final;
+
 private:
     // Hit-detection separated for the fill and the stroke
     bool fillContains(const FloatPoint&, bool requiresFill = true, const WindRule fillRule = WindRule::NonZero);
     bool strokeContains(const FloatPoint&, bool requiresStroke = true);
 
-    FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return m_repaintBoundingBox; }
+    FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final;
     const AffineTransform& localToParentTransform() const final { return m_localTransform; }
     AffineTransform localTransform() const final { return m_localTransform; }
 
@@ -123,11 +127,12 @@ private:
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) final;
 
     FloatRect objectBoundingBox() const final { return m_fillBoundingBox; }
-    FloatRect strokeBoundingBox() const final;
     FloatRect calculateStrokeBoundingBox() const;
     void updateRepaintBoundingBox();
 
     bool setupNonScalingStrokeContext(AffineTransform&, GraphicsContextStateSaver&);
+
+    FloatRect calculateApproximateStrokeBoundingBox() const;
     
     std::unique_ptr<Path> createPath() const;
 
@@ -143,7 +148,6 @@ protected:
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
 private:
     FloatRect m_repaintBoundingBox;
-    FloatRect m_repaintBoundingBoxExcludingShadow;
 
     bool m_needsBoundariesUpdate : 1;
     bool m_needsShapeUpdate : 1;


### PR DESCRIPTION
#### f7f897982b66445d96622a5b67145280e2ba2d81
<pre>
[SVG] Add approximate stroke-bounding-box computation for repainting
<a href="https://bugs.webkit.org/show_bug.cgi?id=263184">https://bugs.webkit.org/show_bug.cgi?id=263184</a>
rdar://116999242

Reviewed by Cameron McCormack.

This is one step of the patch series implementing approximate repainting rect for SVG path, derived from blink&apos;s work[1].

This patch adds approximate stroke-bounding-box (basically repaint bounding box) implementation. The core concept is that, for very compute costly element (like, path),
for repaint bounding box, we just report approximate repaint bounding box. This can be computed from stroke width etc. Like, let&apos;s
assume that stroke exists at the edge of fill bounding box. Then we can compute approximate repaint bounding box which is always larger-or-equal
to stroke bounding box.

Important thing in this patch is that we are not using approximate stroke-bounding-box computation yet. We will switch
it in the next patch with a few lines of changes. This patch is adding the implementation separately from enablement.

One of the hard thing is that our current implementation is relying on the computation order of this in the tree because of existence of
recursive / circular references of the repaint bounding box via markers. For example, LayoutTests/svg/custom/circular-marker-reference-4.svg
shows how markers can refer to the other marker in a circular manner. And in this case, our current implementation is just using stale
repaint bounding box for one of them, so probably the implementation is wrong already. But in this patch, we do not want to change the behavior.
As a result, we workaround the issue by eagerly compute stroke bounding box when markers exist in LegacyRenderSVGPath. This does not become
a problem in accuracy of stroke bounding box in LBSE since it is implementing SVG2, and SVG2 stroke bounding box does not include markers.

[1]: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=435097">https://bugs.chromium.org/p/chromium/issues/detail?id=435097</a>

* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::strokeBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
(WebCore::RenderSVGEllipse::updateShapeFromElement):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::updateShapeFromElement):
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::updateShapeFromElement):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::strokeBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::strokeBoundingBox const):
(WebCore::RenderSVGShape::approximateStrokeBoundingBox const):
(WebCore::RenderSVGShape::calculateApproximateScalingStrokeBoundingBox const):
(WebCore::RenderSVGShape::calculateApproximateNonScalingStrokeBoundingBox const):
(WebCore::RenderSVGShape::calculateApproximateStrokeBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleShapeOrTextOrInline const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::updateCachedBoundaries):
(WebCore::LegacyRenderSVGContainer::strokeBoundingBox const):
(WebCore::LegacyRenderSVGContainer::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::updateShapeFromElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::updateCachedBoundaries):
(WebCore::LegacyRenderSVGRoot::strokeBoundingBox const):
(WebCore::LegacyRenderSVGRoot::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::strokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::calculateApproximateScalingStrokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::calculateApproximateNonScalingStrokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::calculateApproximateStrokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::updateRepaintBoundingBox):
(WebCore::LegacyRenderSVGShape::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:

Canonical link: <a href="https://commits.webkit.org/269492@main">https://commits.webkit.org/269492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5638851c2f7d359e7696c6ca118be0895619dcac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22757 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24665 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23014 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/1493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/23283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22997 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/1493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25518 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/1493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/1493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/300 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/23283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2863 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->