### PR TITLE
[PlayStation][wincairo] fix assertion with SingleWebProcess mode

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -145,6 +145,7 @@ public:
     NetworkProcess& networkProcess() { return m_networkProcess.get(); }
 
     bool isWebTransportEnabled() const { return m_preferencesForWebProcess.isWebTransportEnabled; }
+    bool usesSingleWebProcess() const { return m_preferencesForWebProcess.usesSingleWebProcess; }
 
     void didCleanupResourceLoader(NetworkResourceLoader&);
     void transferKeptAliveLoad(NetworkResourceLoader&);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1002,7 +1002,7 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
 
 void NetworkResourceLoader::sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup(const WebCore::ResourceResponse& response, PrivateRelayed privateRelayed, bool needsContinueDidReceiveResponseMessage)
 {
-    auto browsingContextGroupSwitchDecision = toBrowsingContextGroupSwitchDecision(m_currentCoopEnforcementResult);
+    auto browsingContextGroupSwitchDecision = m_connection->usesSingleWebProcess()? BrowsingContextGroupSwitchDecision::StayInGroup: toBrowsingContextGroupSwitchDecision(m_currentCoopEnforcementResult);
     if (browsingContextGroupSwitchDecision == BrowsingContextGroupSwitchDecision::StayInGroup) {
         send(Messages::WebResourceLoader::DidReceiveResponse { response, privateRelayed, needsContinueDidReceiveResponseMessage, computeResponseMetrics(response) });
         return;

--- a/Source/WebKit/Shared/NetworkProcessPreferencesForWebProcess.h
+++ b/Source/WebKit/Shared/NetworkProcessPreferencesForWebProcess.h
@@ -29,6 +29,7 @@ namespace WebKit {
 
 struct NetworkProcessPreferencesForWebProcess {
     bool isWebTransportEnabled { false };
+    bool usesSingleWebProcess { false };
 
     friend bool operator==(const NetworkProcessPreferencesForWebProcess&, const NetworkProcessPreferencesForWebProcess&) = default;
 };

--- a/Source/WebKit/Shared/NetworkProcessPreferencesForWebProcess.serialization.in
+++ b/Source/WebKit/Shared/NetworkProcessPreferencesForWebProcess.serialization.in
@@ -22,4 +22,5 @@
 
 struct WebKit::NetworkProcessPreferencesForWebProcess {
     bool isWebTransportEnabled;
+    bool usesSingleWebProcess;
 };

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -364,6 +364,7 @@ NetworkProcessPreferencesForWebProcess PageConfiguration::preferencesForNetworkP
 
     return {
         preferences->webTransportEnabled(),
+        processPool().usesSingleWebProcess(),
     };
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -565,6 +565,8 @@ public:
     RefPtr<WebProcessProxy> webProcessForCapabilityGranter(const ExtensionCapabilityGranter&, const String& environmentIdentifier) final;
 #endif
 
+    bool usesSingleWebProcess() const { return m_configuration->usesSingleWebProcess(); }
+
     bool operator==(const WebProcessPool& other) const { return (this == &other); }
 
 private:
@@ -602,8 +604,6 @@ private:
     // Implemented in generated WebProcessPoolMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
-
-    bool usesSingleWebProcess() const { return m_configuration->usesSingleWebProcess(); }
 
 #if PLATFORM(COCOA)
     void addCFNotificationObserver(CFNotificationCallback, CFStringRef name, CFNotificationCenterRef = CFNotificationCenterGetDarwinNotifyCenter());

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -488,6 +488,7 @@ void WebProcessProxy::initializePreferencesForNetworkProcess(const WebPreference
     ASSERT(!m_preferencesForNetworkProcess);
     m_preferencesForNetworkProcess = NetworkProcessPreferencesForWebProcess {
         preferences.getBoolValueForKey(WebPreferencesKey::webTransportEnabledKey()),
+        processPool().usesSingleWebProcess(),
     };
 }
 


### PR DESCRIPTION
#### 5d53332466c251054cb0579d7916b764ee11db0b
<pre>
[PlayStation][wincairo] fix assertion with SingleWebProcess mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=263185">https://bugs.webkit.org/show_bug.cgi?id=263185</a>

Reviewed by Chris Dumez.

The WebPageProxy::continueNavigationInNewProcess() function attempts to
create a new WebProcess to continue processing a response from a
particular websites.
If the application sets usesSingleWebProcess = true, the
WebPageProxy will attempt to reuse an existing process, but
unfortunately there is an assert that is not supposed to do that,
so the application with debug build will crash.

The NetworkResourceLoader in NetworkProcess decides whether to create
a new WebProcess.
So this patch makes two changes:
1. add SingleWebProcess flag to NetworkProcessPreferencesForWebProcess
2. use StayInGroup(do not create a new WebProcess) if SingleWebProcess

Incidentally, besides some ASSERTs, the connection with the automation
target was also not very well considered for SingleWebProcess mode.
For example, WebPageProxy::resetStateAfterProcessTermination() calls
disconnect() to target, but no one reconnects afterwards.
This raises a WebDriver Exception even if it is a release build.
This patch will solve this as well.

Canonical link: <a href="https://commits.webkit.org/278467@main">https://commits.webkit.org/278467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2309d3c8270f3df82572ed0ea5d75dba018903f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52919 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/353 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40532 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21652 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23936 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8048 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54504 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47914 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46947 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11096 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->