### PR TITLE
import-w3c-tests should display the WPT Upstream commit ID

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_downloader.py
+++ b/Tools/Scripts/webkitpy/w3c/test_downloader.py
@@ -60,6 +60,7 @@ class TestDownloader(object):
         self._test_suites = []
 
         self.repository_directory = repository_directory
+        self.upstream_revision = None
 
         self.test_repositories = self.load_test_repositories(self._filesystem)
 
@@ -93,6 +94,7 @@ class TestDownloader(object):
             git = self.git(directory)
         _log.info('Checking out revision ' + revision)
         git.checkout(revision, not self._options.verbose)
+        self.upstream_revision = git.rev_parse('HEAD')
 
     def _init_paths_from_expectations(self):
         import_lines = json.loads(self._filesystem.read_text_file(self.import_expectations_path))

--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -181,6 +181,7 @@ class TestImporter(object):
         self._potential_test_resource_files = []
 
         self.import_list = []
+        self.upstream_revision = None
 
         self._test_resource_files_json_path = self.filesystem.join(self.layout_tests_w3c_path, "resources", "resource-files.json")
         self._test_resource_files = json.loads(self.filesystem.read_text_file(self._test_resource_files_json_path)) if self.filesystem.exists(self._test_resource_files_json_path) else None
@@ -203,6 +204,7 @@ class TestImporter(object):
             _log.info('Downloading W3C test repositories')
             self.filesystem.maybe_make_directory(self.tests_download_path)
             self.test_downloader().download_tests(self.options.use_tip_of_tree)
+            self.upstream_revision = self.test_downloader().upstream_revision
             self.source_directory = self.tests_download_path
 
         for test_path in self.test_paths:
@@ -602,7 +604,6 @@ class TestImporter(object):
             self.write_import_log(new_path, copied_files, prefixed_properties, prefixed_property_values)
 
         _log.info('Import complete')
-
         _log.info('IMPORTED %d TOTAL TESTS', total_imported_tests)
         _log.info('Imported %d reftests', total_imported_reftests)
         _log.info('Imported %d JS tests', total_imported_jstests)
@@ -620,6 +621,11 @@ class TestImporter(object):
 
         for prefixed_value in sorted(total_prefixed_property_values, key=lambda p: total_prefixed_property_values[p]):
             _log.info('  %s: %s', prefixed_value, total_prefixed_property_values[prefixed_value])
+
+        if self.upstream_revision:
+            _log.info('\n--------- Please include the following in your commit message: ---------\n')
+            _log.info('Upstream commit: https://github.com/web-platform-tests/wpt/commit/%s', self.upstream_revision)
+            _log.info('-' * 72)
 
         if self._test_resource_files:
             # FIXME: We should check that actual tests are not in the test_resource_files list


### PR DESCRIPTION
#### c9b28dc7ce071a1002f715f988f732a471b222ee
<pre>
import-w3c-tests should display the WPT Upstream commit ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=248445">https://bugs.webkit.org/show_bug.cgi?id=248445</a>
rdar://103141678

Reviewed by Jonathan Bedard.

Collect the WPT upstream ID to copy/paste in the import PR
when importing wpt tests into WebKit.

* Tools/Scripts/webkitpy/w3c/test_downloader.py:
(TestDownloader.__init__):
(TestDownloader.checkout_test_repository):
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.__init__):
(TestImporter.do_import):
(TestImporter.import_tests):

Canonical link: <a href="https://commits.webkit.org/269513@main">https://commits.webkit.org/269513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79156838aac7e35caca0d7c3ecf4efad53d91457

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21962 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25491 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/22914 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20603 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26816 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20848 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24669 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18121 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/216 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5430 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->