### PR TITLE
Fix animation of stop-color on <stop>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-ci-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-ci-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Animating 'stop-color' from 'currentColor'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-ci.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-ci.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<title>Animating 'stop-color' from 'currentColor'</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg>
+  <linearGradient id="lg" style="color: green">
+    <stop stop-color="red">
+      <animate attributeName="stop-color" from="currentColor" to="green" dur="10s" fill="freeze"/>
+    </stop>
+  </lineargradient>
+  <rect width="100" height="100" fill="url(#lg)"/>
+</svg>
+<script>
+  async_test(t => {
+    let svg = document.querySelector("svg");
+    svg.pauseAnimations();
+    svg.setCurrentTime(5);
+    onload = t.step_func(() => {
+      requestAnimationFrame(t.step_func_done(() => {
+        let stop = document.querySelector("stop");
+        assert_equals(getComputedStyle(stop).getPropertyValue("stop-color"),
+                      "rgb(0, 128, 0)");
+      }));
+    });
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-escaped-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-escaped-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Animating 'stop-color' from 'currentc\olor'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-escaped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-escaped.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<title>Animating 'stop-color' from 'currentc\olor'</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg>
+  <linearGradient id="lg" style="color: green">
+    <stop stop-color="red">
+      <animate attributeName="stop-color" from="currentc\olor" to="green" dur="10s" fill="freeze"/>
+    </stop>
+  </lineargradient>
+  <rect width="100" height="100" fill="url(#lg)"/>
+</svg>
+<script>
+  async_test(t => {
+    let svg = document.querySelector("svg");
+    svg.pauseAnimations();
+    svg.setCurrentTime(5);
+    onload = t.step_func(() => {
+      requestAnimationFrame(t.step_func_done(() => {
+        let stop = document.querySelector("stop");
+        assert_equals(getComputedStyle(stop).getPropertyValue("stop-color"),
+                      "rgb(0, 128, 0)");
+      }));
+    });
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animating 'stop-color' from 'currentcolor' assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 64, 0, 0.5)"
+PASS Animating 'stop-color' from 'currentcolor'
 

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -39,7 +39,6 @@ css/CSSToLengthConversionData.h
 css/MediaList.h
 css/StyleSheetContents.cpp
 css/StyleSheetContents.h
-css/values/primitives/CSSPrimitiveData.h
 dom/CustomElementReactionQueue.h
 dom/Element.h
 dom/FragmentDirectiveRangeFinder.cpp

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -1804,4 +1804,19 @@ void CSSParser::consumeDeclarationValue(CSSParserTokenRange range, CSSPropertyID
     CSSPropertyParser::parseValue(propertyID, important, range, m_context, topContext().m_parsedProperties, ruleType);
 }
 
+std::optional<Style::Color> CSSParser::parseColorOrCurrentColorWithoutContext(const String& string)
+{
+    if (auto color = CSSParserFastPaths::parseSimpleColor(string, CSSParserContext(HTMLStandardMode)))
+        return *color;
+    // FIXME: Unclear why we want to ignore the boolean argument "strict" and always pass strictCSSParserContext here.
+    auto value = CSSPropertyParser::parseStylePropertyLonghand(CSSPropertyColor, string, strictCSSParserContext());
+    if (!value)
+        return std::nullopt;
+    if (value->isColor())
+        return CSSColorValue::absoluteColor(*value);
+    if (value->valueID() == CSSValueCurrentcolor)
+        return Style::Color();
+    return std::nullopt;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -34,6 +34,7 @@
 #include <WebCore/CSSParserTokenRange.h>
 #include <WebCore/CSSProperty.h>
 #include <WebCore/CSSPropertyNames.h>
+#include <WebCore/StyleColor.h>
 #include <WebCore/StyleRule.h>
 #include <memory>
 #include <wtf/Vector.h>
@@ -123,6 +124,7 @@ public:
     static IsImportant consumeTrailingImportantAndWhitespace(CSSParserTokenRange&);
 
     static RefPtr<StyleRuleNestedDeclarations> parseNestedDeclarations(const CSSParserContext&, const String&);
+    static std::optional<Style::Color> parseColorOrCurrentColorWithoutContext(const String&);
 
     CSSTokenizer* tokenizer() const { return m_tokenizer.get(); }
 

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
@@ -36,13 +36,13 @@ namespace WebCore {
 
 Color SVGAnimationColorFunction::colorFromString(SVGElement& targetElement, const String& string)
 {
-    static MainThreadNeverDestroyed<const AtomString> currentColor("currentColor"_s);
-
-    if (string != currentColor.get())
-        return SVGPropertyTraits<Color>::fromString(string);
-
-    if (auto* renderer = targetElement.renderer())
-        return renderer->style().visitedDependentColor(CSSPropertyColor);
+    if (auto color = SVGPropertyTraits<Color>::parse(string)) {
+        if (color->isCurrentColor()) {
+            if (auto* renderer = targetElement.renderer())
+                return renderer->style().visitedDependentColor(CSSPropertyColor);
+        }
+        return color->resolvedColor();
+    }
 
     return { };
 }

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.h
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <WebCore/CSSParser.h>
 #include <WebCore/CSSPropertyParserConsumer+Color.h>
 #include <WebCore/Color.h>
 #include <WebCore/ColorSerialization.h>
@@ -29,6 +30,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/QualifiedName.h>
 #include <WebCore/SVGParserUtilities.h>
+#include <WebCore/StyleColor.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -48,12 +50,9 @@ template<>
 struct SVGPropertyTraits<Color> {
     static Color initialValue() { return Color(); }
     static Color fromString(const String& string) { return CSSPropertyParserHelpers::deprecatedParseColorRawWithoutContext(string.trim(deprecatedIsSpaceOrNewline)); }
-    static std::optional<Color> parse(const QualifiedName&, const String& string)
+    static std::optional<Style::Color> parse(const String& string)
     {
-        auto color = CSSPropertyParserHelpers::deprecatedParseColorRawWithoutContext(string.trim(deprecatedIsSpaceOrNewline));
-        if (!color.isValid())
-            return std::nullopt;
-        return color;
+        return CSSParser::parseColorOrCurrentColorWithoutContext(string.trim(deprecatedIsSpaceOrNewline));
     }
     static String toString(const Color& type) { return serializationForHTML(type); }
 };


### PR DESCRIPTION
#### 3dd3c8cdda3e6451da955890a75c3df9c0a4cb02
<pre>
Fix animation of stop-color on &lt;stop&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=256956">https://bugs.webkit.org/show_bug.cgi?id=256956</a>

Reviewed by Nikolas Zimmermann.

Accept case-insensitive &apos;currentcolor&apos; on color animations.

Tests: imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-ci.html
       imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-escaped.html
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-ci-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-ci.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-escaped-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-escaped.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animate-stop-currentcolor-expected.txt:
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseColorOrCurrentColorWithoutContext):
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp:
(WebCore::SVGAnimationColorFunction::colorFromString):
* Source/WebCore/svg/properties/SVGPropertyTraits.h:
(WebCore::SVGPropertyTraits&lt;Color&gt;::parse):

Canonical link: <a href="https://commits.webkit.org/302163@main">https://commits.webkit.org/302163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8ba3eaf634747f65e923c39b942886a8b71502e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/125585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/45247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/35994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/132446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/77478 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/127456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/45934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/53807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/95669 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/63559 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/128533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/36710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/112303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/76166 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/35606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/30485 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/75921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/106482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/135119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/52385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/40136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/104138 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/52826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/108519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/103871 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/26991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/49222 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/27535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/49588 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/52275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/58072 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/51629 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/54981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/53323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->