### PR TITLE
Add cache for SVGPathElement "d" attribute parsing

### DIFF
--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -50,6 +50,7 @@
 #include "Page.h"
 #include "PerformanceLogging.h"
 #include "RenderTheme.h"
+#include "SVGPathElement.h"
 #include "ScrollingThread.h"
 #include "SelectorQuery.h"
 #include "StyleScope.h"
@@ -89,6 +90,7 @@ static void releaseNoncriticalMemory(MaintainMemoryCache maintainMemoryCache)
     InlineStyleSheetOwner::clearCache();
     HTMLNameCache::clear();
     ImmutableStyleProperties::clearDeduplicationMap();
+    SVGPathElement::clearCache();
 }
 
 static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCache maintainBackForwardCache, MaintainMemoryCache maintainMemoryCache)

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -89,6 +89,7 @@ public:
     void shrinkToFit() { m_data.shrinkToFit(); }
 
     const Data& data() const { return m_data; }
+    void setData(const Data& data) { m_data = data; }
 
 private:
     Data m_data;

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -100,6 +100,8 @@ public:
     Path path() const { return m_pathSegList->currentPath(); }
     size_t approximateMemoryCost() const final { return m_pathSegList->approximateMemoryCost(); }
 
+    static void clearCache();
+
 private:
     SVGPathElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGPathSegList.h
+++ b/Source/WebCore/svg/SVGPathSegList.h
@@ -123,6 +123,14 @@ public:
         return { };
     }
 
+    void updateByteStreamData(const SVGPathByteStream::Data& byteStreamData)
+    {
+        pathByteStreamWillChange();
+        m_pathByteStream.setData(byteStreamData);
+    }
+
+    const SVGPathByteStream& existingPathByteStream() const { return m_pathByteStream; }
+
     const SVGPathByteStream& pathByteStream() const { return const_cast<SVGPathSegList*>(this)->pathByteStream(); }
     SVGPathByteStream& pathByteStream()
     {


### PR DESCRIPTION
#### 75b882901e3326fc37804fbf00641700acc18df7
<pre>
Add cache for SVGPathElement &quot;d&quot; attribute parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=263195">https://bugs.webkit.org/show_bug.cgi?id=263195</a>
rdar://110970184

Reviewed by Ryosuke Niwa.

Add cache for SVGPathElement &quot;d&quot; attribute parsing to avoid spending CPU time
re-parsing the same &quot;d&quot; attribute values.

* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):
* Source/WebCore/svg/SVGPathByteStream.h:
(WebCore::SVGPathByteStream::setData):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::pathSegListCache):
(WebCore::SVGPathElement::attributeChanged):
(WebCore::SVGPathElement::clearCache):
* Source/WebCore/svg/SVGPathElement.h:
* Source/WebCore/svg/SVGPathSegList.h:

Canonical link: <a href="https://commits.webkit.org/269372@main">https://commits.webkit.org/269372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76239c9bba30efd493bc84806e259f54c46c6b73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/22567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20704 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/26830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22902 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/22299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25128 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/19349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26524 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24384 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/21041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17832 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/20495 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5328 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/24730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/21033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->