### PR TITLE
Use smart pointers for LegacyRootInlineBox and RenderFragmentedFlow

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
@@ -114,7 +114,7 @@ public:
     }
 
 private:
-    const LegacyRootInlineBox* m_rootInlineBox;
+    WeakPtr<const LegacyRootInlineBox> m_rootInlineBox;
 };
 
 }

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -31,6 +31,7 @@
 
 #include "LayerFragment.h"
 #include "RenderBlockFlow.h"
+#include "RenderFragmentedFlow.h"
 #include "VisiblePosition.h"
 #include <memory>
 
@@ -55,7 +56,7 @@ public:
     virtual void attachFragment();
     virtual void detachFragment();
 
-    RenderFragmentedFlow* fragmentedFlow() const { return m_fragmentedFlow; }
+    RenderFragmentedFlow* fragmentedFlow() const { return m_fragmentedFlow.get(); }
 
     // Valid fragments do not create circular dependencies with other flows.
     bool isValid() const { return m_isValid; }
@@ -144,7 +145,7 @@ private:
     LayoutPoint mapFragmentPointIntoFragmentedFlowCoordinates(const LayoutPoint&);
 
 protected:
-    RenderFragmentedFlow* m_fragmentedFlow;
+    WeakPtr<RenderFragmentedFlow> m_fragmentedFlow;
 
 private:
     LayoutRect m_fragmentedFlowPortionRect;

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -108,7 +108,7 @@ bool RenderMultiColumnSet::containsRendererInFragmentedFlow(const RenderObject& 
 {
     if (!previousSiblingMultiColumnSet() && !nextSiblingMultiColumnSet()) {
         // There is only one set. This is easy, then.
-        return renderer.isDescendantOf(m_fragmentedFlow);
+        return renderer.isDescendantOf(m_fragmentedFlow.get());
     }
 
     RenderObject* firstRenderer = firstRendererInFragmentedFlow();

--- a/Source/WebCore/rendering/line/LineLayoutState.h
+++ b/Source/WebCore/rendering/line/LineLayoutState.h
@@ -35,6 +35,7 @@
 
 #include "LayoutRect.h"
 #include "RenderBlockFlow.h"
+#include "RenderFragmentedFlow.h"
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -116,14 +117,13 @@ public:
     LayoutUnit endLineLogicalTop() const { return m_endLineLogicalTop; }
     void setEndLineLogicalTop(LayoutUnit logicalTop) { m_endLineLogicalTop = logicalTop; }
 
-    LegacyRootInlineBox* endLine() const { return m_endLine; }
+    LegacyRootInlineBox* endLine() const { return m_endLine.get(); }
     void setEndLine(LegacyRootInlineBox* line) { m_endLine = line; }
 
     LayoutUnit adjustedLogicalLineTop() const { return m_adjustedLogicalLineTop; }
     void setAdjustedLogicalLineTop(LayoutUnit value) { m_adjustedLogicalLineTop = value; }
 
-    RenderFragmentedFlow* fragmentedFlow() const { return m_fragmentedFlow; }
-    void setFragmentedFlow(RenderFragmentedFlow* thread) { m_fragmentedFlow = thread; }
+    RenderFragmentedFlow* fragmentedFlow() const { return m_fragmentedFlow.get(); }
 
     bool endLineMatched() const { return m_endLineMatched; }
     void setEndLineMatched(bool endLineMatched) { m_endLineMatched = endLineMatched; }
@@ -156,11 +156,11 @@ public:
 private:
     LineInfo m_lineInfo;
     LayoutUnit m_endLineLogicalTop;
-    LegacyRootInlineBox* m_endLine { nullptr };
+    WeakPtr<LegacyRootInlineBox> m_endLine;
 
     LayoutUnit m_adjustedLogicalLineTop;
 
-    RenderFragmentedFlow* m_fragmentedFlow { nullptr };
+    WeakPtr<RenderFragmentedFlow> m_fragmentedFlow;
 
     FloatList m_floatList;
     // FIXME: Should this be a range object instead of two ints?


### PR DESCRIPTION
#### bcf9bd0103da3f0ccf52973036629a854dc698d3
<pre>
Use smart pointers for LegacyRootInlineBox and RenderFragmentedFlow
<a href="https://bugs.webkit.org/show_bug.cgi?id=263203">https://bugs.webkit.org/show_bug.cgi?id=263203</a>
rdar://117027337

Reviewed by Antti Koivisto.

* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h:
* Source/WebCore/rendering/RenderFragmentContainer.h:
(WebCore::RenderFragmentContainer::fragmentedFlow const):
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::containsRendererInFragmentedFlow const):
* Source/WebCore/rendering/line/LineLayoutState.h:
(WebCore::LineLayoutState::endLine const):
(WebCore::LineLayoutState::fragmentedFlow const):

Canonical link: <a href="https://commits.webkit.org/269488@main">https://commits.webkit.org/269488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/817bf11d19a5066de3a4248dee2c3ba6d238ad02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21755 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25180 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26566 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24421 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17879 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2861 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->