### PR TITLE
Begin serializing RTCNetwork structures

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -395,6 +395,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/Pasteboard.serialization.in
     Shared/PlatformPopupMenuData.serialization.in
     Shared/PolicyDecision.serialization.in
+    Shared/RTCNetwork.serialization.in
     Shared/RemoteWorkerInitializationData.serialization.in
     Shared/RemoteWorkerType.serialization.in
     Shared/ResourceLoadInfo.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -235,6 +235,7 @@ $(PROJECT_DIR)/Shared/PlatformPopupMenuData.serialization.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
 $(PROJECT_DIR)/Shared/PolicyDecision.serialization.in
 $(PROJECT_DIR)/Shared/PushMessageForTesting.serialization.in
+$(PROJECT_DIR)/Shared/RTCNetwork.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
 $(PROJECT_DIR)/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
 $(PROJECT_DIR)/Shared/RemoteWorkerInitializationData.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -567,6 +567,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/PlatformPopupMenuData.serialization.in \
 	Shared/PolicyDecision.serialization.in \
 	Shared/PushMessageForTesting.serialization.in \
+	Shared/RTCNetwork.serialization.in \
 	Shared/RemoteWorkerInitializationData.serialization.in \
 	Shared/RemoteWorkerType.serialization.in \
 	Shared/ResourceLoadInfo.serialization.in \

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -110,10 +110,12 @@ void NetworkManagerWrapper::onNetworksChanged()
 {
     RELEASE_LOG(WebRTC, "NetworkManagerWrapper::onNetworksChanged");
 
-    RTCNetwork::IPAddress ipv4;
-    m_manager->GetDefaultLocalAddress(AF_INET, &ipv4.value);
-    RTCNetwork::IPAddress ipv6;
-    m_manager->GetDefaultLocalAddress(AF_INET6, &ipv6.value);
+    rtc::IPAddress ipv4RTC;
+    m_manager->GetDefaultLocalAddress(AF_INET, &ipv4RTC);
+    RTCNetwork::IPAddress ipv4(ipv4RTC);
+    rtc::IPAddress ipv6RTC;
+    m_manager->GetDefaultLocalAddress(AF_INET6, &ipv6RTC);
+    RTCNetwork::IPAddress ipv6(ipv6RTC);
 
     auto networks = m_manager->GetNetworks();
 

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -1,0 +1,39 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(LIBWEBRTC)
+
+header: "RTCNetwork.h"
+
+[CustomHeader] struct WebKit::RTC::Network::IPAddress {
+    std::variant<WebKit::RTC::Network::IPAddress::UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value;
+};
+
+[Nested] struct WebKit::RTC::Network::IPAddress::UnspecifiedFamily {
+};
+
+[CustomHeader] struct WebKit::RTC::Network::InterfaceAddress {
+    WebKit::RTC::Network::IPAddress address;
+    int ipv6Flags;
+};
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5745,6 +5745,7 @@
 		5CD4F01C28B6ADDB00F9ECEA /* generate-serializers.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = "generate-serializers.py"; sourceTree = "<group>"; };
 		5CD748B523C8EB190092A999 /* WebURLSchemeHandlerIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebURLSchemeHandlerIdentifier.h; sourceTree = "<group>"; };
 		5CD748B523C8EB190092A9B5 /* NetworkResourceLoadIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkResourceLoadIdentifier.h; sourceTree = "<group>"; };
+		5CDFAD9C2ACFA9480040A8D8 /* RTCNetwork.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RTCNetwork.serialization.in; sourceTree = "<group>"; };
 		5CE0C366229F2D3D003695F0 /* APIContextMenuElementInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIContextMenuElementInfo.cpp; sourceTree = "<group>"; };
 		5CE0C367229F2D3E003695F0 /* APIContextMenuElementInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIContextMenuElementInfo.h; sourceTree = "<group>"; };
 		5CE0C368229F2D4A003695F0 /* WKContextMenuElementInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKContextMenuElementInfo.mm; sourceTree = "<group>"; };
@@ -8368,6 +8369,7 @@
 				5C00993B2417FB7E00D53C25 /* ResourceLoadStatisticsParameters.h */,
 				410482CB1DDD2FB500F006D0 /* RTCNetwork.cpp */,
 				410482CC1DDD2FB500F006D0 /* RTCNetwork.h */,
+				5CDFAD9C2ACFA9480040A8D8 /* RTCNetwork.serialization.in */,
 				41B28B091F83AD3E00FB52AC /* RTCPacketOptions.cpp */,
 				41B28B081F83AD3E00FB52AC /* RTCPacketOptions.h */,
 				41B8D85628C9B8D100E5FA37 /* RTCWebKitEncodedFrameInfo.h */,

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -120,7 +120,7 @@ void LibWebRTCNetwork::signalReadPacket(WebCore::LibWebRTCSocketIdentifier ident
 {
     ASSERT(!WTF::isMainRunLoop());
     if (auto* socket = m_socketFactory.socket(identifier))
-        socket->signalReadPacket(data.data(), data.size(), rtc::SocketAddress(address.value, port), timestamp);
+        socket->signalReadPacket(data.data(), data.size(), rtc::SocketAddress(address.rtcAddress(), port), timestamp);
 }
 
 void LibWebRTCNetwork::signalSentPacket(WebCore::LibWebRTCSocketIdentifier identifier, int rtcPacketID, int64_t sendTimeMs)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -142,7 +142,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         filteredNetworks = networks;
     else {
         for (auto& network : networks) {
-            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.value == ip || ipv6.value == ip; }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.c_str()))))
+            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip || ipv6.rtcAddress() == ip; }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.c_str()))))
                 filteredNetworks.append(network);
         }
     }
@@ -153,7 +153,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
             networkList[index] = std::make_unique<rtc::Network>(networks[index].value());
 
         bool hasChanged;
-        set_default_local_addresses(ipv4.value, ipv6.value);
+        set_default_local_addresses(ipv4.rtcAddress(), ipv6.rtcAddress());
         MergeNetworkList(WTFMove(networkList), &hasChanged);
         if (hasChanged || forceSignaling)
             SignalNetworksChanged();

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp
@@ -47,7 +47,7 @@ void WebRTCResolver::setResolvedAddress(const Vector<RTCNetwork::IPAddress>& add
     auto& factory = m_socketFactory;
 
     auto rtcAddresses = addresses.map([](auto& address) {
-        return address.value;
+        return address.rtcAddress();
     });
     WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([&factory, identifier, rtcAddresses = WTFMove(rtcAddresses)]() {
         auto* resolver = factory.resolver(identifier);


### PR DESCRIPTION
#### 829fc2e8c8ea1d582570950cced6e199906a75fe
<pre>
Begin serializing RTCNetwork structures
<a href="https://bugs.webkit.org/show_bug.cgi?id=263206">https://bugs.webkit.org/show_bug.cgi?id=263206</a>
rdar://117030766

Reviewed by Youenn Fablet.

This is the simple pieces of a previous attempt that caused a regression, but only in post-commit tests
for an unknown reason.  I&apos;ll land this, watch the bots, then land more, watch the bots, etc.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkManagerWrapper::onNetworksChanged):
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::value const):
(WebKit::RTCNetwork::SocketAddress::decode):
(WebKit::RTCNetwork::decode):
(WebKit::RTC::Network::IPAddress::IPAddress):
(WebKit::RTC::Network::IPAddress::rtcAddress const):
(WebKit::RTC::Network::InterfaceAddress::InterfaceAddress):
(WebKit::RTC::Network::InterfaceAddress::rtcAddress const):
(WebKit::RTCNetwork::IPAddress::decode): Deleted.
(WebKit::RTCNetwork::IPAddress::encode const): Deleted.
* Source/WebKit/Shared/RTCNetwork.h:
(WebKit::RTC::Network::IPAddress::UnspecifiedFamily::operator== const):
(WebKit::RTC::Network::IPAddress::IPAddress):
(WebKit::RTC::Network::InterfaceAddress::InterfaceAddress):
(WebKit::RTC::Network::SocketAddress::SocketAddress):
(WebKit::RTCNetwork::IPAddress::IPAddress): Deleted.
(WebKit::RTCNetwork::SocketAddress::SocketAddress): Deleted.
* Source/WebKit/Shared/RTCNetwork.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::LibWebRTCNetwork::signalReadPacket):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.cpp:
(WebKit::WebRTCResolver::setResolvedAddress):

Canonical link: <a href="https://commits.webkit.org/269385@main">https://commits.webkit.org/269385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a33dbbfacf89cc331673dee14f0a21ebe6dc1a5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22397 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/14 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24301 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20731 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22930 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22636 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/11 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25156 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26549 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24404 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/9 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2808 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->