### PR TITLE
URL in saved iframe resource is wrong when iframe embeds another iframe

### DIFF
--- a/Source/WebCore/loader/archive/ArchiveResource.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResource.cpp
@@ -34,17 +34,17 @@
 
 namespace WebCore {
 
-inline ArchiveResource::ArchiveResource(Ref<FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response, const String& fileName)
+inline ArchiveResource::ArchiveResource(Ref<FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response, const String& relativeFilePath)
     : SubstituteResource(URL { url }, ResourceResponse { response }, WTFMove(data))
     , m_mimeType(mimeType)
     , m_textEncoding(textEncoding)
     , m_frameName(frameName)
-    , m_fileName(fileName)
+    , m_relativeFilePath(relativeFilePath)
     , m_shouldIgnoreWhenUnarchiving(false)
 {
 }
 
-RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response, const String& fileName)
+RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&& data, const URL& url, const String& mimeType, const String& textEncoding, const String& frameName, const ResourceResponse& response, const String& relativeFilePath)
 {
     if (!data)
         return nullptr;
@@ -53,9 +53,9 @@ RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&&
         // Provide a valid HTTP status code for http URLs since we have logic in WebCore that validates it.
         if (url.protocolIsInHTTPFamily())
             syntheticResponse.setHTTPStatusCode(200);
-        return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, WTFMove(syntheticResponse), fileName));
+        return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, WTFMove(syntheticResponse), relativeFilePath));
     }
-    return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, response, fileName));
+    return adoptRef(*new ArchiveResource(data.releaseNonNull(), url, mimeType, textEncoding, frameName, response, relativeFilePath));
 }
 
 RefPtr<ArchiveResource> ArchiveResource::create(RefPtr<FragmentedSharedBuffer>&& data, const URL& url, const ResourceResponse& response)
@@ -67,10 +67,10 @@ Expected<String, ArchiveError> ArchiveResource::saveToDisk(const String& directo
 {
     ASSERT(!RunLoop::isMain());
 
-    if (directory.isEmpty() || m_fileName.isEmpty())
+    if (directory.isEmpty() || m_relativeFilePath.isEmpty())
         return makeUnexpected(ArchiveError::InvalidFilePath);
 
-    auto filePath = FileSystem::pathByAppendingComponent(directory, m_fileName);
+    auto filePath = FileSystem::pathByAppendingComponent(directory, m_relativeFilePath);
     FileSystem::makeAllDirectories(FileSystem::parentPath(filePath));
     auto fileData = data().extractData();
     int bytesWritten = FileSystem::overwriteEntireFile(filePath, { fileData.data(), fileData.size() });

--- a/Source/WebCore/loader/archive/ArchiveResource.h
+++ b/Source/WebCore/loader/archive/ArchiveResource.h
@@ -41,11 +41,11 @@ public:
     const String& mimeType() const { return m_mimeType; }
     const String& textEncoding() const { return m_textEncoding; }
     const String& frameName() const { return m_frameName; }
-    const String& fileName() const { return m_fileName; }
+    const String& relativeFilePath() const { return m_relativeFilePath; }
 
     void ignoreWhenUnarchiving() { m_shouldIgnoreWhenUnarchiving = true; }
     bool shouldIgnoreWhenUnarchiving() const { return m_shouldIgnoreWhenUnarchiving; }
-    void setFileName(const String& fileName) { m_fileName = fileName; }
+    void setRelativeFilePath(const String& relativeFilePath) { m_relativeFilePath = relativeFilePath; }
     Expected<String, ArchiveError> saveToDisk(const String& directory);
 
 private:
@@ -54,7 +54,7 @@ private:
     String m_mimeType;
     String m_textEncoding;
     String m_frameName;
-    String m_fileName;
+    String m_relativeFilePath;
 
     bool m_shouldIgnoreWhenUnarchiving;
 };


### PR DESCRIPTION
#### 5b6b22b02a763782fcc6eda23cdaed106f32c55f
<pre>
URL in saved iframe resource is wrong when iframe embeds another iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=263209">https://bugs.webkit.org/show_bug.cgi?id=263209</a>
rdar://116882918

Reviewed by Ryosuke Niwa.

Main resources of iframes are stored under the same directory (subresources directory), so the rewritten url of an
iframe should not contain the name of directory when the iframe is embeded in another iframe. For example, if an iframe
with src set to &apos;iframe1.html&apos; contains another iframe with src set to &apos;iframe2.html&apos;, and their corresponding file
paths are &apos;[subresources_directory]/frame1.html&apos; and &apos;[subresources_directory]/frame2.html&apos;, then the src of iframe2 in
frame1.html should be &apos;frame2.html&apos;, not &apos;subresources/frame2.html&apos;.

This patch also renames fileName to (relative)filePath in ArchiveResource and LegacyWebArchive, because the variable is
indeed a file path that can contain directory name.

Test: WebArchive.SaveResourcesIframeInIframe

* Source/WebCore/loader/archive/ArchiveResource.cpp:
(WebCore::ArchiveResource::ArchiveResource):
(WebCore::ArchiveResource::create):
(WebCore::ArchiveResource::saveToDisk):
* Source/WebCore/loader/archive/ArchiveResource.h:
(WebCore::ArchiveResource::relativeFilePath const):
(WebCore::ArchiveResource::setRelativeFilePath):
(WebCore::ArchiveResource::fileName const): Deleted.
(WebCore::ArchiveResource::setFileName): Deleted.
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createPropertyListRepresentation):
(WebCore::LegacyWebArchive::createResource):
(WebCore::LegacyWebArchive::create):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/269429@main">https://commits.webkit.org/269429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97aa58b2cbc51b2d1684d466a196fe4271980391

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22524 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24431 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23057 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22764 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25283 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26658 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24501 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17967 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/83 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5368 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->