### PR TITLE
Websites/perf.webkit.org/tools/js/remote.js should support different "Authorization" schemes

### DIFF
--- a/Websites/perf.webkit.org/tools/run-tests.py
+++ b/Websites/perf.webkit.org/tools/run-tests.py
@@ -18,7 +18,12 @@ def main():
         if not os.path.isdir(target_dir):
             subprocess.call(['npm', 'install', package_name], cwd=node_modules_dir)
 
-    mocha_path = os.path.join(node_modules_dir, 'mocha/bin/mocha')
+    possible_mocha_paths = [
+        os.path.join(node_modules_dir, 'mocha/bin/_mocha'),
+        os.path.join(node_modules_dir, 'mocha/bin/mocha'),
+    ]
+    mocha_path = next((mocha for mocha in possible_mocha_paths if os.path.exists(mocha)), None)
+    assert mocha_path, 'Mocha CLI was not found.'
     test_paths = sys.argv[1:] or ['unit-tests', 'server-tests']
     return subprocess.call([mocha_path] + test_paths)
 

--- a/Websites/perf.webkit.org/unit-tests/tools-js-remote-tests.js
+++ b/Websites/perf.webkit.org/unit-tests/tools-js-remote-tests.js
@@ -43,7 +43,7 @@ describe('RemoteAPI', function () {
             assert.throws(function () { remote.configure({scheme: 'http', host: 'build.webkit.org', port: 80, auth: 1}); });
         });
 
-        it('should accept a configuration with auth', function () {
+        it('should accept a configuration with basic auth username and password', function () {
             let remote = new RemoteAPI();
             assert.doesNotThrow(function () {
                 remote.configure({
@@ -58,7 +58,7 @@ describe('RemoteAPI', function () {
             });
         });
 
-        it('should reject auth without username or password or when either is not a string', function () {
+        it('should reject basic auth without username or password or when either is not a string', function () {
             let remote = new RemoteAPI();
             assert.throws(function () { remote.configure({scheme: 'http', host: 'build.webkit.org', port: 80, auth: {}}); });
             assert.throws(function () { remote.configure({scheme: 'http', host: 'build.webkit.org', port: 80, auth: {username: 'a'}}); });
@@ -66,6 +66,68 @@ describe('RemoteAPI', function () {
             assert.throws(function () { remote.configure({scheme: 'http', host: 'build.webkit.org', port: 80, auth: {username: 1, password: 'a'}}); });
             assert.throws(function () { remote.configure({scheme: 'http', host: 'build.webkit.org', port: 80, auth: {username: 'a', password: 1}}); });
         });
+
+        it('should accept a configuration with basic auth defined as auth.scheme and auth.parameter', function () {
+            let remote = new RemoteAPI();
+            assert.doesNotThrow(function () {
+                remote.configure({
+                    scheme: 'https',
+                    host: 'build.webkit.org',
+                    auth: {
+                        'scheme': 'Basic',
+                        'parameter': 'webkitten:super-secret',
+                    },
+                });
+            });
+        });
+
+        it('should accept a configuration with arbitrary auth.scheme and auth.parameter', function () {
+            let remote = new RemoteAPI();
+            assert.doesNotThrow(function () {
+                remote.configure({
+                    scheme: 'https',
+                    host: 'build.webkit.org',
+                    auth: {
+                        'scheme': 'Arbitrary',
+                        'parameter': 'arbitrary0=ZERO,arbitrary1=3.1459',
+                    },
+                });
+            });
+        });
+
+        it('should set expected Authorization value with valid server auth objects', function () {
+            let remote = new RemoteAPI();
+            remote.configure({
+                scheme: 'https',
+                host: 'build.webkit.org',
+                auth: {
+                    'username': 'webkitten',
+                    'password': 'super-secret',
+                },
+            });
+            assert.equal(remote._server.auth, 'Basic webkitten:super-secret');
+
+            remote.configure({
+                scheme: 'https',
+                host: 'build.webkit.org',
+                auth: {
+                    'scheme': 'Bearer',
+                    'parameter': 'not-very-random-text',
+                },
+            });
+            assert.equal(remote._server.auth, 'Bearer not-very-random-text');
+        });
+
+        it('should reject auth values without expected paired string properties (scheme and parameter, username and password)', function () {
+            let remote = new RemoteAPI();
+            assert.throws(function () { remote.configure({scheme: 'https', host: 'build.webkit.org', auth: {}}); });
+            assert.throws(function () { remote.configure({scheme: 'https', host: 'build.webkit.org', auth: {username: ''}}); });
+            assert.throws(function () { remote.configure({scheme: 'https', host: 'build.webkit.org', auth: {password: ''}}); });
+            assert.throws(function () { remote.configure({scheme: 'https', host: 'build.webkit.org', auth: {scheme: ''}}); });
+            assert.throws(function () { remote.configure({scheme: 'https', host: 'build.webkit.org', auth: {parameter: ''}}); });
+            assert.throws(function () { remote.configure({scheme: 'https', host: 'build.webkit.org', auth: {username: '', scheme: ''}}); });
+        });
+
     });
 
     describe('url', function () {


### PR DESCRIPTION
#### d7ed0ce8749d4cafc65970f662bf459b8ea43f30
<pre>
Websites/perf.webkit.org/tools/js/remote.js should support different &quot;Authorization&quot; schemes
<a href="https://bugs.webkit.org/show_bug.cgi?id=263210">https://bugs.webkit.org/show_bug.cgi?id=263210</a>
rdar://117033333

Reviewed by Dewei Zhu.

The `Authorization` header is now handled outside the `http.request` object. `server.auth` is not passed as `http.request` option.

The `NodeRemoteAPI` (aka `RemoteAPI`) now sets the `Authorization` header explicilty if `server.auth` is defined. If a scheme is specified it sets the `Authorization` header value to `&lt;scheme&gt; &lt;parameter&gt;`. Otherwise, it is assumed to be basic authentication and sets the `Authorization` header value to `Basic &lt;username&gt;:&lt;password&gt;`. This preserves backwards compatibility.

Added unit tests. `run-tests.py` will look for Mocha CLI  in another path.

* Websites/perf.webkit.org/tools/js/remote.js:
(NodeRemoteAPI.prototype.configure):
(NodeRemoteAPI.prototype.sendHttpRequest):
* Websites/perf.webkit.org/tools/run-tests.py:
(main):
* Websites/perf.webkit.org/unit-tests/tools-js-remote-tests.js:
(assert.doesNotThrow):
(assert.throws):

Canonical link: <a href="https://commits.webkit.org/269771@main">https://commits.webkit.org/269771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49e3ffdad4109881806c2bca86aa7d6fc7eed047

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24545 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21633 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23973 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26186 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21171 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27427 "4 flakes 114 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25178 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18612 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/845 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/5618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->