### PR TITLE
Deploy smart more pointers in NodeIterator

### DIFF
--- a/Source/WebCore/dom/NodeIterator.h
+++ b/Source/WebCore/dom/NodeIterator.h
@@ -57,6 +57,7 @@ private:
 
         NodePointer() = default;
         NodePointer(Node&, bool);
+        RefPtr<Node> protectedNode() const { return node; }
 
         void clear();
         bool moveToNext(Node& root);

--- a/Source/WebCore/dom/Traversal.h
+++ b/Source/WebCore/dom/Traversal.h
@@ -36,6 +36,7 @@ class NodeIteratorBase {
 public:
     Node& root() { return m_root.get(); }
     const Node& root() const { return m_root.get(); }
+    Ref<Node> protectedRoot() const { return m_root; }
 
     unsigned whatToShow() const { return m_whatToShow; }
     NodeFilter* filter() const { return m_filter.get(); }


### PR DESCRIPTION
#### e859d6e29925ba88cefafded1874a752e28af5fe
<pre>
Deploy smart more pointers in NodeIterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=263215">https://bugs.webkit.org/show_bug.cgi?id=263215</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/NodeIterator.cpp:
(WebCore::NodeIterator::NodePointer::moveToNext):
(WebCore::NodeIterator::NodePointer::moveToPrevious):
(WebCore::NodeIterator::nextNode):
(WebCore::NodeIterator::previousNode):
(WebCore::NodeIterator::updateForNodeRemoval const):
* Source/WebCore/dom/NodeIterator.h:
* Source/WebCore/dom/Traversal.h:
(WebCore::NodeIteratorBase::protectedRoot const):

Canonical link: <a href="https://commits.webkit.org/269398@main">https://commits.webkit.org/269398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cea03d3d07888685123686ec54f063f8ef0c985

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/88 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20790 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22993 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21778 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22701 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/48 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25218 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/42 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26595 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24451 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/56 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17907 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/45 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/67 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2815 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/64 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->