### PR TITLE
Save iframe resources with same URL in different files

### DIFF
--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -277,11 +277,9 @@ String MarkupAccumulator::resolveURLIfNeeded(const Element& element, const Strin
 {
     if (!m_replacementURLStrings.isEmpty()) {
         if (auto frame = frameForAttributeReplacement(element)) {
-            if (frame->loader().documentLoader()->response().url().protocolIsData()) {
-                auto replacementString = m_replacementURLStrings.get(frame->frameID().toString());
-                if (!replacementString.isEmpty())
-                    return replacementString;
-            }
+            auto replacementString = m_replacementURLStrings.get(frame->frameID().toString());
+            if (!replacementString.isEmpty())
+                return replacementString;
         }
 
         auto resolvedURLString = element.resolveURLStringIfNeeded(urlString);

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -569,10 +569,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
                 auto subframeMainResourceURL = subframeMainResource ? subframeMainResource->url() : URL { };
                 if (!subframeMainResourceURL.isEmpty()) {
                     auto subframeMainResourceRelativePath = frame.isMainFrame() ? subframeMainResource->relativeFilePath() : FileSystem::lastComponentOfPathIgnoringTrailingSlash(subframeMainResource->relativeFilePath());
-                    if (subframeMainResourceURL.isAboutSrcDoc() || subframeMainResourceURL.isAboutBlank() || subframeMainResourceURL.protocolIsData())
-                        uniqueSubresources.add(childFrame->frameID().toString(), subframeMainResourceRelativePath);
-                    else
-                        uniqueSubresources.add(subframeMainResourceURL.string(), subframeMainResourceRelativePath);
+                    uniqueSubresources.add(childFrame->frameID().toString(), subframeMainResourceRelativePath);
                 }
                 subframeArchives.append(subframeArchive.releaseNonNull());
             } else


### PR DESCRIPTION
#### 55ccc87da50d687aaa9af0119d2e4e6095327fd5
<pre>
Save iframe resources with same URL in different files
<a href="https://bugs.webkit.org/show_bug.cgi?id=263220">https://bugs.webkit.org/show_bug.cgi?id=263220</a>
rdar://116882637

Reviewed by Ryosuke Niwa.

In current implementation, if multiple iframe elements point to the same URL, we only create one file and make all the
elements point to that file. However, iframe content is usually modified by script, which means iframe pages with
the same URL usually have different content. To ensure the content is correctly captured, we now create one file for
each iframe main resource. This also matches behavior of other browsers.

Test: WebArchive.SaveResourcesIframesWithSameURL

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::resolveURLIfNeeded const):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/269472@main">https://commits.webkit.org/269472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49c15300aa73c9054ae65059c92c6736b37d1600

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22569 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21861 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22807 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25326 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26708 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24532 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18000 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->