### PR TITLE
[WGSL] Remove stale or unhelpful fixmes

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVariableQualifier.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariableQualifier.h
@@ -31,7 +31,6 @@
 
 namespace WGSL::AST {
 
-// FIXME: Perhaps this class is not needed if we have spanned identifier?
 class VariableQualifier final : public Node {
     WGSL_AST_BUILDER_NODE(VariableQualifier);
 public:

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -209,7 +209,6 @@ MangledName NameManglerVisitor::makeMangledName(const String& name, MangledName:
 
 void NameManglerVisitor::readVariable(AST::Identifier& name) const
 {
-    // FIXME: this should be unconditional
     if (const auto* mangledName = ContextProvider::readVariable(name))
         m_callGraph.ast().replace(&name, AST::Identifier::makeWithSpan(name.span(), mangledName->toString()));
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1534,7 +1534,6 @@ void FunctionDefinitionWriter::visit(AST::BoolLiteral& literal)
 
 void FunctionDefinitionWriter::visit(AST::AbstractIntegerLiteral& literal)
 {
-    // FIXME: this might not serialize all values correctly
     m_stringBuilder.append(literal.value());
     auto& primitiveType = std::get<Types::Primitive>(*literal.inferredType());
     if (primitiveType.kind == Types::Primitive::U32)
@@ -1543,19 +1542,16 @@ void FunctionDefinitionWriter::visit(AST::AbstractIntegerLiteral& literal)
 
 void FunctionDefinitionWriter::visit(AST::Signed32Literal& literal)
 {
-    // FIXME: this might not serialize all values correctly
     m_stringBuilder.append(literal.value());
 }
 
 void FunctionDefinitionWriter::visit(AST::Unsigned32Literal& literal)
 {
-    // FIXME: this might not serialize all values correctly
     m_stringBuilder.append(literal.value(), "u");
 }
 
 void FunctionDefinitionWriter::visit(AST::AbstractFloatLiteral& literal)
 {
-    // FIXME: this might not serialize all values correctly
     NumberToStringBuffer buffer;
     WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
 
@@ -1564,7 +1560,6 @@ void FunctionDefinitionWriter::visit(AST::AbstractFloatLiteral& literal)
 
 void FunctionDefinitionWriter::visit(AST::Float32Literal& literal)
 {
-    // FIXME: this might not serialize all values correctly
     NumberToStringBuffer buffer;
     WTF::numberToStringWithTrailingPoint(literal.value(), buffer);
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -583,7 +583,6 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
 
     if (ident.ident == "workgroup_size"_s) {
         CONSUME_TYPE(ParenLeft);
-        // FIXME: should more kinds of literals be accepted here?
         PARSE(x, Expression);
         AST::Expression::Ptr maybeY = nullptr;
         AST::Expression::Ptr maybeZ = nullptr;
@@ -866,7 +865,6 @@ Result<AddressSpace> Parser<Lexer>::parseAddressSpace()
     START_PARSE();
 
     CONSUME_TYPE_NAMED(identifier, Identifier);
-    // FIXME: remove `handle` from the parsing
     if (auto* addressSpace = WGSL::parseAddressSpace(identifier.ident); addressSpace && *addressSpace != AddressSpace::Handle)
         return { *addressSpace };
 
@@ -1357,8 +1355,6 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePostfixExpression(AST::Expressi
     START_PARSE();
 
     AST::Expression::Ref expr = WTFMove(base);
-    // FIXME: add the case for array/vector/matrix access
-
     for (;;) {
         switch (current().type) {
         case TokenType::BracketLeft: {
@@ -1414,11 +1410,6 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
             PARSE(arguments, ArgumentExpressionList);
             RETURN_ARENA_NODE(CallExpression, WTFMove(arrayType), WTFMove(arguments));
         }
-        // FIXME: WGSL grammar has an ambiguity when trying to distinguish the
-        // use of < as either the less-than operator or the beginning of a
-        // template-parameter list. Here we are checking for vector or matrix
-        // type names. Alternatively, those names could be turned into keywords
-
         if (current().type == TokenType::TemplateArgsLeft || current().type == TokenType::ParenLeft) {
             PARSE(type, TypeNameAfterIdentifier, WTFMove(ident), _startOfElementPosition);
             PARSE(arguments, ArgumentExpressionList);
@@ -1466,7 +1457,6 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
 template<typename Lexer>
 Result<AST::Expression::Ref> Parser<Lexer>::parseExpression()
 {
-    // FIXME: Fill in
     PARSE(unary, UnaryExpression);
     if (canContinueBitwiseExpression(current()))
         return parseBitwiseExpressionPostUnary(WTFMove(unary));

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -133,7 +133,6 @@ FOREACH_KEYWORD(ENUM_ENTRY)
     Placeholder,
     TemplateArgsLeft,
     TemplateArgsRight,
-    // FIXME: add all the other special tokens
 };
 
 String toString(TokenType);

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -156,7 +156,6 @@ private:
 
     TypeStore& m_types;
     Vector<Error> m_errors;
-    // FIXME: maybe these should live in the context
     HashMap<String, Vector<OverloadCandidate>> m_overloadedOperations;
     HashMap<String, ConstantFunction> m_constantFunctions;
 };
@@ -329,8 +328,6 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
 
 std::optional<FailedCheck> TypeChecker::check()
 {
-    // FIXME: fill in struct fields in a second pass since declarations might be
-    // out of order
     for (auto& structure : m_shaderModule.structures())
         visit(structure);
 
@@ -1081,8 +1078,7 @@ void TypeChecker::visit(AST::ElaboratedTypeExpression& type)
 
 void TypeChecker::visit(AST::ReferenceTypeExpression&)
 {
-    // FIXME: we don't yet parse reference types
-    ASSERT_NOT_REACHED();
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 void TypeChecker::visitAttributes(AST::Attribute::List& attributes)

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -69,7 +69,6 @@ std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const
     PhaseTimes phaseTimes;
     auto shaderModule = makeUniqueRef<ShaderModule>(wgsl, configuration);
 
-    // FIXME: add more validation
     CHECK_PASS(parse);
     CHECK_PASS(reorderGlobals);
     CHECK_PASS(typeCheck);

--- a/Source/WebGPU/WGSL/tests/valid/name-mangling.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/name-mangling.wgsl
@@ -12,7 +12,7 @@ struct MyStruct2 {
   myStructField2: MyStruct1,
 };
 
-// FIXME: this still appears in a struct field
+// CHECK-NOT-L: myGlobal1
 @group(0) @binding(0) var<storage> myGlobal1: MyStruct2;
 
 // CHECK-NOT-L: myGlobal2

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2542,8 +2542,6 @@ fn testTextureSampleGrad()
 @compute @workgroup_size(1)
 fn testTextureSampleLevel()
 {
-    // FIXME: add declarations for texture depth
-
     // [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2], F32) => Vector[F32, 4],
     _ = textureSampleLevel(t2d, s, vec2f(0), 0);
 


### PR DESCRIPTION
#### a983bc7f77aa2c12b7633c8209928b9a94104b82
<pre>
[WGSL] Remove stale or unhelpful fixmes
<a href="https://bugs.webkit.org/show_bug.cgi?id=263228">https://bugs.webkit.org/show_bug.cgi?id=263228</a>
rdar://117047230

Reviewed by Dan Glastonbury.

Remove FIXMEs that were forgotten or that are no longer relevant.

* Source/WebGPU/WGSL/AST/ASTVariableQualifier.h:
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::readVariable const):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
(WGSL::Parser&lt;Lexer&gt;::parseAddressSpace):
(WGSL::Parser&lt;Lexer&gt;::parsePostfixExpression):
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
(WGSL::Parser&lt;Lexer&gt;::parseExpression):
* Source/WebGPU/WGSL/Token.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::check):
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
* Source/WebGPU/WGSL/tests/valid/name-mangling.wgsl:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/269410@main">https://commits.webkit.org/269410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d95a50f0d6eea30a3ad04ba1adbf2b56d240b912

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24346 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20772 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/57 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25198 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/49 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26578 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20457 "Found 2 new API test failures: TestWebKitAPI.ServiceWorker.WindowClientNavigateCrossOrigin, TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24433 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17894 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34 "Build is in progress. Recent messages:") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5355 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->