### PR TITLE
An SVG element with a CSS reference filter fails to repaint when the filter changes

### DIFF
--- a/LayoutTests/svg/filters/css-repaint-reference-filter-on-root-expected.txt
+++ b/LayoutTests/svg/filters/css-repaint-reference-filter-on-root-expected.txt
@@ -1,0 +1,4 @@
+(repaint rects
+  (rect 49 313 100 111)
+)
+

--- a/LayoutTests/svg/filters/css-repaint-reference-filter-on-root.html
+++ b/LayoutTests/svg/filters/css-repaint-reference-filter-on-root.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        svg {
+            display: block;
+            margin: 20px;
+            height: 200px;
+        }
+
+        .container {
+            padding: 10px;
+            width: 300px;
+            margin: 10px;
+            border: 1px solid black;
+        }
+    </style>
+    <script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+    <script>
+        function repaintTest()
+        {
+            let filter = document.getElementById('targetFilter');
+            filter.querySelector('feColorMatrix').setAttribute('values', '90')
+        }
+
+        window.addEventListener('load', () => {
+            runRepaintTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="container">
+        <svg id="gammaTarget1" width="100" height="100">
+            <filter id="targetFilter">
+              <feColorMatrix type="hueRotate" values="180" />
+            </filter>
+            <rect width="100" height="100" fill="red" filter="url(#targetFilter)"/>
+        </svg>
+    </div>
+    <div class="container">
+        <svg width="100" height="100" style="filter: url(#targetFilter);">
+            <rect width="100" height="100" fill="red"/>
+        </svg>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5623,9 +5623,7 @@ void RenderLayer::updateFiltersAfterStyleChange(StyleDifference diff, const Rend
         return;
     }
 
-    // Add the filter as a client to this renderer, unless we are a RenderLayer accommodating
-    // an SVG. In that case it takes care of its own resource management for filters.
-    if (renderer().style().filter().hasReferenceFilter() && !renderer().isSVGRootOrLegacySVGRoot()) {
+    if (renderer().style().filter().hasReferenceFilter()) {
         ensureLayerFilters();
         m_filters->updateReferenceFilterClients(renderer().style().filter());
     } else if (m_filters)


### PR DESCRIPTION
#### ea2c363617419ea80c547fa4f2b1d645e619301e
<pre>
An SVG element with a CSS reference filter fails to repaint when the filter changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=263229">https://bugs.webkit.org/show_bug.cgi?id=263229</a>
rdar://117047658

Reviewed by Nikolas Zimmermann.

If an SVG element has a CSS filter which references an SVG element (which may be a child of that SVG,
or some other SVG in the document), then we fail to repaint the SVG when the filter changes.

This is a followup to 267236@main, removing the `&amp;&amp; !renderer().isSVGRootOrLegacySVGRoot()` check in
`RenderLayer::updateFiltersAfterStyleChange()`, since in this configuration we do need to have
the RenderLayer track the filter dependencies.

* LayoutTests/svg/filters/css-repaint-reference-filter-on-root-expected.txt: Added.
* LayoutTests/svg/filters/css-repaint-reference-filter-on-root.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateFiltersAfterStyleChange):

Canonical link: <a href="https://commits.webkit.org/269413@main">https://commits.webkit.org/269413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79609a97ef6fa9f49fbf65fd09fa4fa599ceccd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/60 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20774 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21766 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/64 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25201 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/51 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26582 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24437 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/42 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17892 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/35 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20147 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5359 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/52 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/50 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->