### PR TITLE
[WGSL] Implement index access for matrices

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -719,19 +719,21 @@ void TypeChecker::visit(AST::IndexAccessExpression& access)
         if (isBottom(base))
             return m_types.bottomType();
 
-        if (std::holds_alternative<Types::Array>(*base)) {
+        if (auto* array = std::get_if<Types::Array>(base)) {
             // FIXME: check bounds if index is constant
-            auto& array = std::get<Types::Array>(*base);
-            return array.element;
+            return array->element;
         }
 
-        if (std::holds_alternative<Types::Vector>(*base)) {
+        if (auto* vector = std::get_if<Types::Vector>(base)) {
             // FIXME: check bounds if index is constant
-            auto& vector = std::get<Types::Vector>(*base);
-            return vector.element;
+            return vector->element;
         }
 
-        // FIXME: Implement matrix accesses
+        if (auto* matrix = std::get_if<Types::Matrix>(base)) {
+            // FIXME: check bounds if index is constant
+            return m_types.vectorType(matrix->rows, matrix->element);
+        }
+
         typeError(access.span(), "cannot index type '", *base, "'");
         return nullptr;
     };

--- a/Source/WebGPU/WGSL/tests/valid/access-expression.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/access-expression.wgsl
@@ -1,0 +1,230 @@
+// RUN: %metal-compile main
+
+// 8.5. Composite Value Decomposition Expressions (https://www.w3.org/TR/WGSL/#composite-value-decomposition-expr)
+@compute @workgroup_size(1, 1, 1)
+fn main() {
+    testVectorAccessExpression();
+    testMatrixAccessExpression();
+    testArrayAccessExpression();
+    testStructAccessExpression();
+}
+
+// 8.5.1. Vector Access Expression (https://www.w3.org/TR/WGSL/#vector-access-expr)
+fn testVectorAccessExpression()
+{
+    testVectorSingleComponentSelection();
+    testVectorMultipleComponentSelection();
+    testComponentReferenceFromVectorReference();
+}
+
+// 8.5.1.1. Vector Single Component Selection (https://www.w3.org/TR/WGSL/#vector-single-component)
+fn testVectorSingleComponentSelection()
+{
+    let v2 = vec2<f32>(0);
+    let v3 = vec3<i32>(0);
+    let v4 = vec4<u32>(0);
+
+    _ = v2.x;
+    _ = v3.x;
+    _ = v4.x;
+    _ = v2.r;
+    _ = v3.r;
+    _ = v4.r;
+
+    _ = v2.y;
+    _ = v3.y;
+    _ = v4.y;
+    _ = v2.g;
+    _ = v3.g;
+    _ = v4.g;
+
+    _ = v3.z;
+    _ = v4.z;
+    _ = v3.b;
+    _ = v4.b;
+
+    _ = v4.w;
+    _ = v4.a;
+
+    _ = v2[0];
+    _ = v3[0];
+    _ = v4[0];
+
+    _ = v2[1];
+    _ = v3[1];
+    _ = v4[1];
+
+    _ = v3[2];
+    _ = v4[2];
+
+    _ = v4[3];
+}
+
+// 8.5.1.2. Vector Multiple Component Selection (https://www.w3.org/TR/WGSL/#vector-multi-component)
+fn testVectorMultipleComponentSelection()
+{
+    let v2 = vec2<f32>(0);
+    let v3 = vec3<i32>(0);
+    let v4 = vec4<u32>(0);
+
+    _ = v2.xy;
+    _ = v3.yz;
+    _ = v4.zw;
+    _ = v2.rg;
+    _ = v3.gb;
+    _ = v4.ba;
+
+    _ = v2.xxy;
+    _ = v3.xyz;
+    _ = v4.yzw;
+    _ = v2.rrg;
+    _ = v3.rgb;
+    _ = v4.gba;
+
+    _ = v2.xxyy;
+    _ = v3.xxyz;
+    _ = v4.xyzw;
+    _ = v2.rrgg;
+    _ = v3.rrgb;
+    _ = v4.rgba;
+}
+
+// 8.5.1.3. Component Reference from Vector Reference (https://www.w3.org/TR/WGSL/#vector-multi-component)
+fn testComponentReferenceFromVectorReference()
+{
+    var v2 = vec2<f32>(0);
+    var v3 = vec3<i32>(0);
+    var v4 = vec4<u32>(0);
+
+    v2.x = 0;
+    v3.x = 0;
+    v4.x = 0;
+    v2.r = 0;
+    v3.r = 0;
+    v4.r = 0;
+
+    v2.y = 0;
+    v3.y = 0;
+    v4.y = 0;
+    v2.g = 0;
+    v3.g = 0;
+    v4.g = 0;
+
+    v3.z = 0;
+    v4.z = 0;
+    v3.b = 0;
+    v4.b = 0;
+
+    v4.w = 0;
+    v4.a = 0;
+
+    v2[0] = 0;
+    v3[0] = 0;
+    v4[0] = 0;
+
+    v2[1] = 0;
+    v3[1] = 0;
+    v4[1] = 0;
+
+    v3[2] = 0;
+    v4[2] = 0;
+
+    v4[3] = 0;
+}
+
+// 8.5.2. Matrix Access Expression (https://www.w3.org/TR/WGSL/#matrix-access-expr)
+fn testMatrixAccessExpression()
+{
+    var m2x2 = mat2x2(0, 0, 0, 0);
+    var m2x3 = mat2x3(0, 0, 0, 0, 0, 0);
+    var m2x4 = mat2x4(0, 0, 0, 0, 0, 0, 0, 0);
+    var m3x2 = mat3x2(0, 0, 0, 0, 0, 0);
+    var m3x3 = mat3x3(0, 0, 0, 0, 0, 0, 0, 0, 0);
+    var m3x4 = mat3x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    var m4x2 = mat4x2(0, 0, 0, 0, 0, 0, 0, 0);
+    var m4x3 = mat4x3(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    var m4x4 = mat4x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+    { let x: vec2<f32> = m2x2[0]; }
+    { let x: vec2<f32> = m3x2[0]; }
+    { let x: vec2<f32> = m4x2[0]; }
+    { let x: vec2<f32> = m2x2[1]; }
+    { let x: vec2<f32> = m3x2[1]; }
+    { let x: vec2<f32> = m4x2[1]; }
+    { let x: vec2<f32> = m3x2[2]; }
+    { let x: vec2<f32> = m4x2[2]; }
+    { let x: vec2<f32> = m4x2[3]; }
+
+    { let x: vec3<f32> = m2x3[0]; }
+    { let x: vec3<f32> = m3x3[0]; }
+    { let x: vec3<f32> = m4x3[0]; }
+    { let x: vec3<f32> = m2x3[1]; }
+    { let x: vec3<f32> = m3x3[1]; }
+    { let x: vec3<f32> = m4x3[1]; }
+    { let x: vec3<f32> = m3x3[2]; }
+    { let x: vec3<f32> = m4x3[2]; }
+    { let x: vec3<f32> = m4x3[3]; }
+
+    { let x: vec4<f32> = m2x4[0]; }
+    { let x: vec4<f32> = m3x4[0]; }
+    { let x: vec4<f32> = m4x4[0]; }
+    { let x: vec4<f32> = m2x4[1]; }
+    { let x: vec4<f32> = m3x4[1]; }
+    { let x: vec4<f32> = m4x4[1]; }
+    { let x: vec4<f32> = m3x4[2]; }
+    { let x: vec4<f32> = m4x4[2]; }
+    { let x: vec4<f32> = m4x4[3]; }
+
+    // Reference test
+    m2x2[0] = vec2<f32>(0);
+    m3x2[0] = vec2<f32>(0);
+    m4x2[0] = vec2<f32>(0);
+    m2x2[1] = vec2<f32>(0);
+    m3x2[1] = vec2<f32>(0);
+    m4x2[1] = vec2<f32>(0);
+    m3x2[2] = vec2<f32>(0);
+    m4x2[2] = vec2<f32>(0);
+    m4x2[3] = vec2<f32>(0);
+
+    m2x3[0] = vec3<f32>(0);
+    m3x3[0] = vec3<f32>(0);
+    m4x3[0] = vec3<f32>(0);
+    m2x3[1] = vec3<f32>(0);
+    m3x3[1] = vec3<f32>(0);
+    m4x3[1] = vec3<f32>(0);
+    m3x3[2] = vec3<f32>(0);
+    m4x3[2] = vec3<f32>(0);
+    m4x3[3] = vec3<f32>(0);
+
+    m2x4[0] = vec4<f32>(0);
+    m3x4[0] = vec4<f32>(0);
+    m4x4[0] = vec4<f32>(0);
+    m2x4[1] = vec4<f32>(0);
+    m3x4[1] = vec4<f32>(0);
+    m4x4[1] = vec4<f32>(0);
+    m3x4[2] = vec4<f32>(0);
+    m4x4[2] = vec4<f32>(0);
+    m4x4[3] = vec4<f32>(0);
+}
+
+// 8.5.3. Array Access Expression (https://www.w3.org/TR/WGSL/#array-access-expr)
+@group(0) @binding(0) var<storage, read_write> ga: array<i32>;
+fn testArrayAccessExpression()
+{
+    var a: array<i32, 1> = array(0);
+
+    { let x: i32 = a[0]; };
+    { let x: i32 = ga[0]; };
+
+    a[0] = 0;
+    ga[0] = 0;
+}
+
+// 8.5.4. Structure Access Expression (https://www.w3.org/TR/WGSL/#struct-access-expr)
+struct S { x: i32 };
+fn testStructAccessExpression()
+{
+    var s: S;
+    let x: i32 = s.x;
+    s.x = 0;
+}


### PR DESCRIPTION
#### 22320bd353b3ad1608a61825af92b285f3ee77ab
<pre>
[WGSL] Implement index access for matrices
<a href="https://bugs.webkit.org/show_bug.cgi?id=263230">https://bugs.webkit.org/show_bug.cgi?id=263230</a>

Reviewed by Dan Glastonbury.

The type checker was missing the case for matrix index access,
which should result in a vector.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/valid/access-expression.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/269409@main">https://commits.webkit.org/269409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/178e5685137919ed94642cb6c9b0e697e9d1fdc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22448 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/63 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/23526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/24352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/587 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/22979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21768 "Passed tests") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/22687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/69 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19484 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/25204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/55 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26584 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24440 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/44 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17895 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/36 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5356 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/54 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/52 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->