### PR TITLE
Deploy smart more pointers in NodeIterator

### DIFF
--- a/Source/WebCore/dom/NodeIterator.cpp
+++ b/Source/WebCore/dom/NodeIterator.cpp
@@ -46,29 +46,31 @@ inline void NodeIterator::NodePointer::clear()
 
 inline bool NodeIterator::NodePointer::moveToNext(Node& root)
 {
-    if (!node)
+    auto currentNode = protectedNode();
+    if (!currentNode)
         return false;
     if (isPointerBeforeNode) {
         isPointerBeforeNode = false;
         return true;
     }
-    node = NodeTraversal::next(*node, &root);
+    node = NodeTraversal::next(*currentNode, &root);
     return node;
 }
 
 inline bool NodeIterator::NodePointer::moveToPrevious(Node& root)
 {
-    if (!node)
+    auto currentNode = protectedNode();
+    if (!currentNode)
         return false;
     if (!isPointerBeforeNode) {
         isPointerBeforeNode = true;
         return true;
     }
-    if (node == &root) {
+    if (currentNode == &root) {
         node = nullptr;
         return false;
     }
-    node = NodeTraversal::previous(*node);
+    node = NodeTraversal::previous(*currentNode);
     return node;
 }
 
@@ -94,7 +96,7 @@ ExceptionOr<RefPtr<Node>> NodeIterator::nextNode()
     RefPtr<Node> result;
 
     m_candidateNode = m_referenceNode;
-    while (m_candidateNode.moveToNext(root())) {
+    while (m_candidateNode.moveToNext(protectedRoot())) {
         // NodeIterators treat the DOM tree as a flat list of nodes.
         // In other words, FILTER_REJECT does not pass over descendants
         // of the rejected node. Hence, FILTER_REJECT is the same as FILTER_SKIP.
@@ -123,7 +125,7 @@ ExceptionOr<RefPtr<Node>> NodeIterator::previousNode()
     RefPtr<Node> result;
 
     m_candidateNode = m_referenceNode;
-    while (m_candidateNode.moveToPrevious(root())) {
+    while (m_candidateNode.moveToPrevious(protectedRoot())) {
         // NodeIterators treat the DOM tree as a flat list of nodes.
         // In other words, FILTER_REJECT does not pass over descendants
         // of the rejected node. Hence, FILTER_REJECT is the same as FILTER_SKIP.
@@ -159,7 +161,7 @@ void NodeIterator::updateForNodeRemoval(Node& removedNode, NodePointer& referenc
 
     // Iterator is not affected if the removed node is the reference node and is the root.
     // or if removed node is not the reference node, or the ancestor of the reference node.
-    if (!removedNode.isDescendantOf(root()))
+    if (!removedNode.isDescendantOf(protectedRoot()))
         return;
     bool willRemoveReferenceNode = &removedNode == referenceNode.node;
     bool willRemoveReferenceNodeAncestor = referenceNode.node && referenceNode.node->isDescendantOf(removedNode);
@@ -167,12 +169,12 @@ void NodeIterator::updateForNodeRemoval(Node& removedNode, NodePointer& referenc
         return;
 
     if (referenceNode.isPointerBeforeNode) {
-        Node* node = NodeTraversal::next(removedNode, &root());
+        RefPtr node = NodeTraversal::next(removedNode, protectedRoot().ptr());
         if (node) {
             // Move out from under the node being removed if the new reference
             // node is a descendant of the node being removed.
             while (node && node->isDescendantOf(removedNode))
-                node = NodeTraversal::next(*node, &root());
+                node = NodeTraversal::next(*node, protectedRoot().ptr());
             if (node)
                 referenceNode.node = node;
         } else {
@@ -194,7 +196,7 @@ void NodeIterator::updateForNodeRemoval(Node& removedNode, NodePointer& referenc
             }
         }
     } else {
-        Node* node = NodeTraversal::previous(removedNode);
+        RefPtr node = NodeTraversal::previous(removedNode);
         if (node) {
             // Move out from under the node being removed if the reference node is
             // a descendant of the node being removed.
@@ -203,10 +205,10 @@ void NodeIterator::updateForNodeRemoval(Node& removedNode, NodePointer& referenc
                     node = NodeTraversal::previous(*node);
             }
             if (node)
-                referenceNode.node = node;
+                referenceNode.node = WTFMove(node);
         } else {
             // FIXME: This branch doesn't appear to have any LayoutTests.
-            node = NodeTraversal::next(removedNode, &root());
+            node = NodeTraversal::next(removedNode, protectedRoot().ptr());
             // Move out from under the node being removed if the reference node is
             // a descendant of the node being removed.
             if (willRemoveReferenceNodeAncestor) {
@@ -214,7 +216,7 @@ void NodeIterator::updateForNodeRemoval(Node& removedNode, NodePointer& referenc
                     node = NodeTraversal::previous(*node);
             }
             if (node)
-                referenceNode.node = node;
+                referenceNode.node = WTFMove(node);
         }
     }
 }

--- a/Source/WebCore/dom/NodeIterator.h
+++ b/Source/WebCore/dom/NodeIterator.h
@@ -57,6 +57,7 @@ private:
 
         NodePointer() = default;
         NodePointer(Node&, bool);
+        RefPtr<Node> protectedNode() const { return node; }
 
         void clear();
         bool moveToNext(Node& root);

--- a/Source/WebCore/dom/Traversal.h
+++ b/Source/WebCore/dom/Traversal.h
@@ -36,6 +36,7 @@ class NodeIteratorBase {
 public:
     Node& root() { return m_root.get(); }
     const Node& root() const { return m_root.get(); }
+    Ref<Node> protectedRoot() const { return m_root; }
 
     unsigned whatToShow() const { return m_whatToShow; }
     NodeFilter* filter() const { return m_filter.get(); }


### PR DESCRIPTION
#### b2cd6ed8963358c437398ca24646f30699dfffcd
<pre>
Deploy smart more pointers in NodeIterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=263215">https://bugs.webkit.org/show_bug.cgi?id=263215</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/dom/NodeIterator.cpp:
(WebCore::NodeIterator::NodePointer::moveToNext):
(WebCore::NodeIterator::NodePointer::moveToPrevious):
(WebCore::NodeIterator::nextNode):
(WebCore::NodeIterator::previousNode):
(WebCore::NodeIterator::updateForNodeRemoval const):
* Source/WebCore/dom/NodeIterator.h:
* Source/WebCore/dom/Traversal.h:
(WebCore::NodeIteratorBase::protectedRoot const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2cd6ed8963358c437398ca24646f30699dfffcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/83 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22713 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/325 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22990 "Build is in progress. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22698 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/42 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25215 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/36 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26593 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24449 "Build is in progress. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/53 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/42 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/64 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/61 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->