### PR TITLE
Adopt more smart pointers in ContentVisibilityDocumentState

### DIFF
--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -57,7 +57,7 @@ private:
         ASSERT(!entries.isEmpty());
 
         for (auto& entry : entries) {
-            if (auto* element = entry->target())
+            if (RefPtr element = entry->target())
                 element->document().contentVisibilityDocumentState().updateViewportProximity(*element, entry->isIntersecting() ? ViewportProximity::Near : ViewportProximity::Far);
         }
         return { };
@@ -73,7 +73,7 @@ void ContentVisibilityDocumentState::observe(Element& element)
 {
     Ref document = element.document();
     auto& state = document->contentVisibilityDocumentState();
-    if (auto* intersectionObserver = state.intersectionObserver(document))
+    if (RefPtr intersectionObserver = state.intersectionObserver(document))
         intersectionObserver->observe(element);
 }
 
@@ -81,7 +81,7 @@ void ContentVisibilityDocumentState::unobserve(Element& element)
 {
     Ref document = element.document();
     auto& state = document->contentVisibilityDocumentState();
-    if (auto& intersectionObserver = state.m_observer) {
+    if (RefPtr intersectionObserver = state.m_observer) {
         intersectionObserver->unobserve(element);
         state.removeViewportProximity(element);
     }
@@ -96,7 +96,7 @@ IntersectionObserver* ContentVisibilityDocumentState::intersectionObserver(Docum
         auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options));
         if (observer.hasException())
             return nullptr;
-        m_observer = observer.returnValue().ptr();
+        m_observer = observer.releaseReturnValue();
     }
     return m_observer.get();
 }
@@ -130,7 +130,7 @@ bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(El
         setRelevancyValue(ContentRelevancy::Selected, targetContainsSelection(target));
 
     auto hasTopLayerinSubtree = [](const Element& target) {
-        for (auto& element : target.document().topLayerElements()) {
+        for (Ref element : target.document().topLayerElements()) {
             if (element->isDescendantOf(target))
                 return true;
         }
@@ -158,8 +158,8 @@ bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(El
 DidUpdateAnyContentRelevancy ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements(OptionSet<ContentRelevancy> relevancyToCheck) const
 {
     auto didUpdateAnyContentRelevancy = DidUpdateAnyContentRelevancy::No;
-    for (auto target : m_observer->observationTargets()) {
-        if (target) {
+    for (auto& weakTarget : m_observer->observationTargets()) {
+        if (RefPtr target = weakTarget.get()) {
             if (checkRelevancyOfContentVisibilityElement(*target, relevancyToCheck))
                 didUpdateAnyContentRelevancy = DidUpdateAnyContentRelevancy::Yes;
         }
@@ -172,16 +172,16 @@ HadInitialVisibleContentVisibilityDetermination ContentVisibilityDocumentState::
     if (!m_observer)
         return HadInitialVisibleContentVisibilityDetermination::No;
     Vector<Ref<Element>> elementsToCheck;
-    for (auto target : m_observer->observationTargets()) {
-        if (target) {
+    for (auto& weakTarget : m_observer->observationTargets()) {
+        if (RefPtr target = weakTarget.get()) {
             bool checkForInitialDetermination = !m_elementViewportProximities.contains(*target) && !target->isRelevantToUser();
             if (checkForInitialDetermination)
-                elementsToCheck.append(*target);
+                elementsToCheck.append(target.releaseNonNull());
         }
     }
     auto hadInitialVisibleContentVisibilityDetermination = HadInitialVisibleContentVisibilityDetermination::No;
     if (!elementsToCheck.isEmpty()) {
-        elementsToCheck.first()->document().updateIntersectionObservations({ m_observer });
+        elementsToCheck.first()->protectedDocument()->updateIntersectionObservations({ m_observer });
         for (auto& element : elementsToCheck) {
             checkRelevancyOfContentVisibilityElement(element, { ContentRelevancy::OnScreen });
             if (element->isRelevantToUser())
@@ -199,10 +199,10 @@ void ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded(con
 {
     if (!m_observer)
         return;
-    auto findSkippedContentRoot = [](const Element& element) -> const Element* {
-        const Element* found = nullptr;
+    auto findSkippedContentRoot = [](const Element& element) -> RefPtr<const Element> {
+        RefPtr<const Element> found;
         if (element.renderer() && element.renderer()->isSkippedContent()) {
-            for (auto candidate = &element; candidate; candidate = candidate->parentElementInComposedTree()) {
+            for (RefPtr candidate = &element; candidate; candidate = candidate->parentElementInComposedTree()) {
                 if (candidate->renderer() && candidate->renderStyle()->contentVisibility() == ContentVisibility::Auto)
                     found = candidate;
             }
@@ -210,15 +210,15 @@ void ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded(con
         return found;
     };
 
-    if (auto* scrollAnchorRoot = findSkippedContentRoot(scrollAnchor)) {
-        for (auto target : m_observer->observationTargets()) {
-            if (target) {
+    if (RefPtr scrollAnchorRoot = findSkippedContentRoot(scrollAnchor)) {
+        for (auto& weakTarget : m_observer->observationTargets()) {
+            if (RefPtr target = weakTarget.get()) {
                 ASSERT(target->renderer() && target->renderStyle()->contentVisibility() == ContentVisibility::Auto);
                 updateViewportProximity(*target, ViewportProximity::Far);
             }
         }
         updateViewportProximity(*scrollAnchorRoot, ViewportProximity::Near);
-        scrollAnchorRoot->document().updateRelevancyOfContentVisibilityElements();
+        scrollAnchorRoot->protectedDocument()->updateRelevancyOfContentVisibilityElements();
     }
 }
 
@@ -227,7 +227,7 @@ void ContentVisibilityDocumentState::updateViewportProximity(const Element& elem
     // No need to schedule content relevancy update for first time call, since
     // that will be handled by determineInitialVisibleContentVisibility.
     if (m_elementViewportProximities.contains(element))
-        element.document().scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
+        element.protectedDocument()->scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
     m_elementViewportProximities.ensure(element, [] {
         return ViewportProximity::Far;
     }).iterator->value = viewportProximity;
@@ -242,17 +242,16 @@ void ContentVisibilityDocumentState::updateAnimations(const Element& element, Is
 {
     if (wasSkipped == IsSkippedContent::No || becomesSkipped == IsSkippedContent::Yes)
         return;
-    for (auto* animation : WebAnimation::instances()) {
-        if (!animation->isDeclarativeAnimation())
+    for (RefPtr animation : WebAnimation::instances()) {
+        RefPtr declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation.releaseNonNull());
+        if (!declarativeAnimation)
             continue;
-
-        auto& declarativeAnimation = downcast<DeclarativeAnimation>(*animation);
-        auto owningElement = declarativeAnimation.owningElement();
+        auto owningElement = declarativeAnimation->owningElement();
         if (!owningElement || !owningElement->element.isDescendantOrShadowDescendantOf(&element))
             continue;
 
-        if (auto* timeline = declarativeAnimation.timeline())
-            timeline->animationTimingDidChange(declarativeAnimation);
+        if (RefPtr timeline = declarativeAnimation->timeline())
+            timeline->animationTimingDidChange(*declarativeAnimation);
     }
 }
 


### PR DESCRIPTION
#### a1ad490d8e42d1d9904153c766b1c7d141799915
<pre>
Adopt more smart pointers in ContentVisibilityDocumentState
<a href="https://bugs.webkit.org/show_bug.cgi?id=263237">https://bugs.webkit.org/show_bug.cgi?id=263237</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::observe):
(WebCore::ContentVisibilityDocumentState::unobserve):
(WebCore::ContentVisibilityDocumentState::intersectionObserver):
(WebCore::ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement const):
(WebCore::ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements const):
(WebCore::ContentVisibilityDocumentState::determineInitialVisibleContentVisibility const):
(WebCore::ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded):
(WebCore::ContentVisibilityDocumentState::updateViewportProximity):
(WebCore::ContentVisibilityDocumentState::updateAnimations):

Canonical link: <a href="https://commits.webkit.org/269408@main">https://commits.webkit.org/269408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e90e021fe74691bc4cfb19cc7f18618dac214e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/86 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20789 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21777 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22700 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25217 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/22644 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/84 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26594 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19546 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24450 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21829 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/55 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17906 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/25878 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22257 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/44 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20165 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6075 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5354 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/66 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27157 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/63 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5902 "Passed tests") | 
<!--EWS-Status-Bubble-End-->