### PR TITLE
Generate serialization of WebKit::RTCNetwork

### DIFF
--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -36,7 +36,7 @@ namespace WebKit {
 RTCNetwork::RTCNetwork(const rtc::Network& network)
     : name(network.name())
     , description(network.description())
-    , prefix { network.prefix() }
+    , prefix(network.prefix())
     , prefixLength(network.prefix_length())
     , type(network.type())
     , id(network.id())
@@ -44,9 +44,24 @@ RTCNetwork::RTCNetwork(const rtc::Network& network)
     , active(network.active())
     , ignored(network.ignored())
     , scopeID(network.scope_id())
-    , ips(network.GetIPs())
-{
-}
+    , ips(WTF::map(network.GetIPs(), [] (const auto& ip) {
+        return InterfaceAddress(ip);
+    })) { }
+
+RTCNetwork::RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<char>&& key, size_t length, Vector<InterfaceAddress>&& ips)
+    : name(WTFMove(name))
+    , description(WTFMove(description))
+    , prefix(prefix)
+    , prefixLength(prefixLength)
+    , type(type)
+    , id(id)
+    , preference(preference)
+    , active(active)
+    , ignored(ignored)
+    , scopeID(scopeID)
+    , key(WTFMove(key))
+    , length(length)
+    , ips(WTFMove(ips)) { }
 
 rtc::Network RTCNetwork::value() const
 {
@@ -56,7 +71,13 @@ rtc::Network RTCNetwork::value() const
     network.set_active(active);
     network.set_ignored(ignored);
     network.set_scope_id(scopeID);
-    network.SetIPs(ips, true);
+
+    std::vector<rtc::InterfaceAddress> vector;
+    vector.reserve(ips.size());
+    for (auto& ip : ips)
+        vector.push_back(ip.rtcAddress());
+    network.SetIPs(WTFMove(vector), true);
+
     return network;
 }
 
@@ -116,74 +137,6 @@ void RTCNetwork::SocketAddress::encode(IPC::Encoder& encoder) const
     }
     encoder << false;
     encoder << RTCNetwork::IPAddress(value.ipaddr());
-}
-
-std::optional<RTCNetwork> RTCNetwork::decode(IPC::Decoder& decoder)
-{
-    RTCNetwork result;
-    IPC::DataReference name, description;
-    if (!decoder.decode(name))
-        return std::nullopt;
-    result.name = std::string(reinterpret_cast<const char*>(name.data()), name.size());
-    if (!decoder.decode(description))
-        return std::nullopt;
-    result.description = std::string(reinterpret_cast<const char*>(description.data()), description.size());
-    std::optional<IPAddress> prefix;
-    decoder >> prefix;
-    if (!prefix)
-        return std::nullopt;
-    result.prefix = WTFMove(*prefix);
-    if (!decoder.decode(result.prefixLength))
-        return std::nullopt;
-    if (!decoder.decode(result.type))
-        return std::nullopt;
-    if (!decoder.decode(result.id))
-        return std::nullopt;
-    if (!decoder.decode(result.preference))
-        return std::nullopt;
-    if (!decoder.decode(result.active))
-        return std::nullopt;
-    if (!decoder.decode(result.ignored))
-        return std::nullopt;
-    if (!decoder.decode(result.scopeID))
-        return std::nullopt;
-
-    uint64_t length;
-    if (!decoder.decode(length))
-        return std::nullopt;
-    result.ips.reserve(length);
-    for (size_t index = 0; index < length; ++index) {
-        std::optional<IPAddress> address;
-        decoder >> address;
-        if (!address)
-            return std::nullopt;
-        int flags;
-        if (!decoder.decode(flags))
-            return std::nullopt;
-        result.ips.push_back({ address->rtcAddress(), flags });
-    }
-    return result;
-}
-
-void RTCNetwork::encode(IPC::Encoder& encoder) const
-{
-    encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(name.data()), name.length());
-    encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(description.data()), description.length());
-    encoder << prefix;
-    encoder << prefixLength;
-    encoder << type;
-
-    encoder << id;
-    encoder << preference;
-    encoder << active;
-    encoder << ignored;
-    encoder << scopeID;
-
-    encoder << (uint64_t)ips.size();
-    for (auto& ip : ips) {
-        encoder << IPAddress { ip };
-        encoder << ip.ipv6_flags();
-    }
 }
 
 namespace RTC::Network {

--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -90,17 +90,14 @@ struct RTCNetwork {
     using IPAddress = RTC::Network::IPAddress;
     using InterfaceAddress = RTC::Network::InterfaceAddress;
 
-    RTCNetwork() = default;
     explicit RTCNetwork(const rtc::Network&);
+    explicit RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<char>&& key, size_t length, Vector<InterfaceAddress>&& ips);
 
     rtc::Network value() const;
     static rtc::SocketAddress isolatedCopy(const rtc::SocketAddress&);
 
-    void encode(IPC::Encoder&) const;
-    static std::optional<RTCNetwork> decode(IPC::Decoder&);
-
-    std::string name;
-    std::string description;
+    Vector<char> name;
+    Vector<char> description;
     IPAddress prefix;
     int prefixLength;
     int type;
@@ -109,9 +106,9 @@ struct RTCNetwork {
     bool active;
     bool ignored;
     int scopeID;
-    std::string key;
+    Vector<char> key;
     size_t length;
-    std::vector<rtc::InterfaceAddress> ips;
+    Vector<InterfaceAddress> ips;
 };
 
 }

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -22,8 +22,6 @@
 
 #if USE(LIBWEBRTC)
 
-header: "RTCNetwork.h"
-
 [CustomHeader] struct WebKit::RTC::Network::IPAddress {
     std::variant<WebKit::RTC::Network::IPAddress::UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value;
 };
@@ -36,4 +34,19 @@ header: "RTCNetwork.h"
     int ipv6Flags;
 };
 
+struct WebKit::RTCNetwork {
+    Vector<char> name;
+    Vector<char> description;
+    WebKit::RTC::Network::IPAddress prefix;
+    int prefixLength;
+    int type;
+    uint16_t id;
+    int preference;
+    bool active;
+    bool ignored;
+    int scopeID;
+    Vector<char> key;
+    size_t length;
+    Vector<WebKit::RTC::Network::InterfaceAddress> ips;
+};
 #endif

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -142,7 +142,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         filteredNetworks = networks;
     else {
         for (auto& network : networks) {
-            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip || ipv6.rtcAddress() == ip; }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.c_str()))))
+            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.data(), network.name.size()))))
                 filteredNetworks.append(network);
         }
     }


### PR DESCRIPTION
#### 18bb952e5f633f6653f94627228706007629c82d
<pre>
Generate serialization of WebKit::RTCNetwork
<a href="https://bugs.webkit.org/show_bug.cgi?id=263238">https://bugs.webkit.org/show_bug.cgi?id=263238</a>

Reviewed by Youenn Fablet.

IPAddress and InterfaceAddress seem to have not been the problem.
Let&apos;s try the next piece, RTCNetwork.

* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::RTCNetwork):
(WebKit::RTCNetwork::value const):
(WebKit::ips): Deleted.
(WebKit::RTCNetwork::decode): Deleted.
(WebKit::RTCNetwork::encode const): Deleted.
* Source/WebKit/Shared/RTCNetwork.h:
* Source/WebKit/Shared/RTCNetwork.serialization.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):

Canonical link: <a href="https://commits.webkit.org/269399@main">https://commits.webkit.org/269399@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dcccde788872fec19441a86d4f8b164fd5370d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/89 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24367 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20791 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/22994 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22702 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/52 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25219 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/44 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26596 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24452 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/57 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/46 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5344 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/68 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/65 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->