### PR TITLE
Use AtomString instead of AtomStringImpl in TreeScopeOrderedMap

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
@@ -59,15 +59,15 @@ static bool jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter(JSDOMWindowPr
     auto* document = window.document();
     if (is<HTMLDocument>(document)) {
         auto& htmlDocument = downcast<HTMLDocument>(*document);
-        auto* atomicPropertyName = propertyName.publicName();
-        if (atomicPropertyName && htmlDocument.hasWindowNamedItem(*atomicPropertyName)) {
+        AtomString atomPropertyName = propertyName.publicName();
+        if (!atomPropertyName.isEmpty() && htmlDocument.hasWindowNamedItem(atomPropertyName)) {
             JSValue namedItem;
-            if (UNLIKELY(htmlDocument.windowNamedItemContainsMultipleElements(*atomicPropertyName))) {
-                Ref<HTMLCollection> collection = document->windowNamedItems(atomicPropertyName);
+            if (UNLIKELY(htmlDocument.windowNamedItemContainsMultipleElements(atomPropertyName))) {
+                Ref<HTMLCollection> collection = document->windowNamedItems(atomPropertyName);
                 ASSERT(collection->length() > 1);
                 namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), collection);
             } else
-                namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), htmlDocument.windowNamedItem(*atomicPropertyName).get());
+                namedItem = toJS(lexicalGlobalObject, thisObject->globalObject(), htmlDocument.windowNamedItem(atomPropertyName).get());
             slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::DontEnum), namedItem);
             return true;
         }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2684,14 +2684,14 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
 
         if (auto& idValue = getIdAttribute(); !idValue.isEmpty()) {
             if (newScope)
-                newScope->addElementById(*idValue.impl(), *this);
+                newScope->addElementById(idValue, *this);
             if (newDocument)
                 updateIdForDocument(*newDocument, nullAtom(), idValue, HTMLDocumentNamedItemMapsUpdatingCondition::Always);
         }
 
         if (auto& nameValue = getNameAttribute(); !nameValue.isEmpty()) {
             if (newScope)
-                newScope->addElementByName(*nameValue.impl(), *this);
+                newScope->addElementByName(nameValue, *this);
             if (newDocument)
                 updateNameForDocument(*newDocument, nullAtom(), nameValue);
         }
@@ -2771,14 +2771,14 @@ void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldPar
 
         if (auto& idValue = getIdAttribute(); !idValue.isEmpty()) {
             if (oldScope)
-                oldScope->removeElementById(*idValue.impl(), *this);
+                oldScope->removeElementById(idValue, *this);
             if (oldHTMLDocument)
                 updateIdForDocument(*oldHTMLDocument, idValue, nullAtom(), HTMLDocumentNamedItemMapsUpdatingCondition::Always);
         }
 
         if (auto& nameValue = getNameAttribute(); !nameValue.isEmpty()) {
             if (oldScope)
-                oldScope->removeElementByName(*nameValue.impl(), *this);
+                oldScope->removeElementByName(nameValue, *this);
             if (oldHTMLDocument)
                 updateNameForDocument(*oldHTMLDocument, nameValue, nullAtom());
         }
@@ -4748,9 +4748,9 @@ void Element::updateNameForTreeScope(TreeScope& scope, const AtomString& oldName
     ASSERT(oldName != newName);
 
     if (!oldName.isEmpty())
-        scope.removeElementByName(*oldName.impl(), *this);
+        scope.removeElementByName(oldName, *this);
     if (!newName.isEmpty())
-        scope.addElementByName(*newName.impl(), *this);
+        scope.addElementByName(newName, *this);
 }
 
 void Element::updateNameForDocument(HTMLDocument& document, const AtomString& oldName, const AtomString& newName)
@@ -4763,17 +4763,17 @@ void Element::updateNameForDocument(HTMLDocument& document, const AtomString& ol
     if (WindowNameCollection::elementMatchesIfNameAttributeMatch(*this)) {
         const AtomString& id = WindowNameCollection::elementMatchesIfIdAttributeMatch(*this) ? getIdAttribute() : nullAtom();
         if (!oldName.isEmpty() && oldName != id)
-            document.removeWindowNamedItem(*oldName.impl(), *this);
+            document.removeWindowNamedItem(oldName, *this);
         if (!newName.isEmpty() && newName != id)
-            document.addWindowNamedItem(*newName.impl(), *this);
+            document.addWindowNamedItem(newName, *this);
     }
 
     if (DocumentNameCollection::elementMatchesIfNameAttributeMatch(*this)) {
         const AtomString& id = DocumentNameCollection::elementMatchesIfIdAttributeMatch(*this) ? getIdAttribute() : nullAtom();
         if (!oldName.isEmpty() && oldName != id)
-            document.removeDocumentNamedItem(*oldName.impl(), *this);
+            document.removeDocumentNamedItem(oldName, *this);
         if (!newName.isEmpty() && newName != id)
-            document.addDocumentNamedItem(*newName.impl(), *this);
+            document.addDocumentNamedItem(newName, *this);
     }
 }
 
@@ -4800,9 +4800,9 @@ void Element::updateIdForTreeScope(TreeScope& scope, const AtomString& oldId, co
     ASSERT(oldId != newId);
 
     if (!oldId.isEmpty())
-        scope.removeElementById(*oldId.impl(), *this, notifyObservers == NotifyObservers::Yes);
+        scope.removeElementById(oldId, *this, notifyObservers == NotifyObservers::Yes);
     if (!newId.isEmpty())
-        scope.addElementById(*newId.impl(), *this, notifyObservers == NotifyObservers::Yes);
+        scope.addElementById(newId, *this, notifyObservers == NotifyObservers::Yes);
 }
 
 void Element::updateIdForDocument(HTMLDocument& document, const AtomString& oldId, const AtomString& newId, HTMLDocumentNamedItemMapsUpdatingCondition condition)
@@ -4816,17 +4816,17 @@ void Element::updateIdForDocument(HTMLDocument& document, const AtomString& oldI
     if (WindowNameCollection::elementMatchesIfIdAttributeMatch(*this)) {
         const AtomString& name = condition == HTMLDocumentNamedItemMapsUpdatingCondition::UpdateOnlyIfDiffersFromNameAttribute && WindowNameCollection::elementMatchesIfNameAttributeMatch(*this) ? getNameAttribute() : nullAtom();
         if (!oldId.isEmpty() && oldId != name)
-            document.removeWindowNamedItem(*oldId.impl(), *this);
+            document.removeWindowNamedItem(oldId, *this);
         if (!newId.isEmpty() && newId != name)
-            document.addWindowNamedItem(*newId.impl(), *this);
+            document.addWindowNamedItem(newId, *this);
     }
 
     if (DocumentNameCollection::elementMatchesIfIdAttributeMatch(*this)) {
         const AtomString& name = condition == HTMLDocumentNamedItemMapsUpdatingCondition::UpdateOnlyIfDiffersFromNameAttribute && DocumentNameCollection::elementMatchesIfNameAttributeMatch(*this) ? getNameAttribute() : nullAtom();
         if (!oldId.isEmpty() && oldId != name)
-            document.removeDocumentNamedItem(*oldId.impl(), *this);
+            document.removeDocumentNamedItem(oldId, *this);
         if (!newId.isEmpty() && newId != name)
-            document.addDocumentNamedItem(*newId.impl(), *this);
+            document.addDocumentNamedItem(newId, *this);
     }
 }
 
@@ -4841,9 +4841,9 @@ void Element::updateLabel(TreeScope& scope, const AtomString& oldForAttributeVal
         return;
 
     if (!oldForAttributeValue.isEmpty())
-        scope.removeLabel(*oldForAttributeValue.impl(), downcast<HTMLLabelElement>(*this));
+        scope.removeLabel(oldForAttributeValue, downcast<HTMLLabelElement>(*this));
     if (!newForAttributeValue.isEmpty())
-        scope.addLabel(*newForAttributeValue.impl(), downcast<HTMLLabelElement>(*this));
+        scope.addLabel(newForAttributeValue, downcast<HTMLLabelElement>(*this));
 }
 
 void Element::willModifyAttribute(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue)

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -112,7 +112,7 @@ bool hasOverlay(const HTMLElement& element)
     if (LIKELY(!shadowRoot || shadowRoot->mode() != ShadowRootMode::UserAgent))
         return false;
 
-    return shadowRoot->hasElementWithId(*imageOverlayElementIdentifier().impl());
+    return shadowRoot->hasElementWithId(imageOverlayElementIdentifier());
 }
 
 static RefPtr<HTMLElement> imageOverlayHost(const Node& node)

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -74,16 +74,16 @@ public:
     WEBCORE_EXPORT RefPtr<Element> getElementById(const String&) const;
     RefPtr<Element> getElementById(StringView) const;
     const Vector<CheckedRef<Element>>* getAllElementsById(const AtomString&) const;
-    inline bool hasElementWithId(const AtomStringImpl&) const; // Defined in TreeScopeInlines.h.
+    inline bool hasElementWithId(const AtomString&) const; // Defined in TreeScopeInlines.h.
     inline bool containsMultipleElementsWithId(const AtomString& id) const; // Defined in TreeScopeInlines.h.
-    void addElementById(const AtomStringImpl& elementId, Element&, bool notifyObservers = true);
-    void removeElementById(const AtomStringImpl& elementId, Element&, bool notifyObservers = true);
+    void addElementById(const AtomString& elementId, Element&, bool notifyObservers = true);
+    void removeElementById(const AtomString& elementId, Element&, bool notifyObservers = true);
 
     WEBCORE_EXPORT RefPtr<Element> getElementByName(const AtomString&) const;
-    inline bool hasElementWithName(const AtomStringImpl&) const; // Defined in TreeScopeInlines.h.
+    inline bool hasElementWithName(const AtomString&) const; // Defined in TreeScopeInlines.h.
     inline bool containsMultipleElementsWithName(const AtomString&) const; // Defined in TreeScopeInlines.h.
-    void addElementByName(const AtomStringImpl&, Element&);
-    void removeElementByName(const AtomStringImpl&, Element&);
+    void addElementByName(const AtomString&, Element&);
+    void removeElementByName(const AtomString&, Element&);
 
     Document& documentScope() const { return m_documentScope.get(); }
     Ref<Document> protectedDocumentScope() const;
@@ -99,14 +99,14 @@ public:
     void removeImageMap(HTMLMapElement&);
     RefPtr<HTMLMapElement> getImageMap(const AtomString&) const;
 
-    void addImageElementByUsemap(const AtomStringImpl&, HTMLImageElement&);
-    void removeImageElementByUsemap(const AtomStringImpl&, HTMLImageElement&);
-    RefPtr<HTMLImageElement> imageElementByUsemap(const AtomStringImpl&) const;
+    void addImageElementByUsemap(const AtomString&, HTMLImageElement&);
+    void removeImageElementByUsemap(const AtomString&, HTMLImageElement&);
+    RefPtr<HTMLImageElement> imageElementByUsemap(const AtomString&) const;
 
     // For accessibility.
     bool shouldCacheLabelsByForAttribute() const { return !!m_labelsByForAttribute; }
-    void addLabel(const AtomStringImpl& forAttributeValue, HTMLLabelElement&);
-    void removeLabel(const AtomStringImpl& forAttributeValue, HTMLLabelElement&);
+    void addLabel(const AtomString& forAttributeValue, HTMLLabelElement&);
+    void removeLabel(const AtomString& forAttributeValue, HTMLLabelElement&);
     const Vector<CheckedRef<Element>>* labelElementsForId(const AtomString& forAttributeValue);
 
     WEBCORE_EXPORT RefPtr<Element> elementFromPoint(double clientX, double clientY);

--- a/Source/WebCore/dom/TreeScopeInlines.h
+++ b/Source/WebCore/dom/TreeScopeInlines.h
@@ -29,24 +29,24 @@
 
 namespace WebCore {
 
-inline bool TreeScope::hasElementWithId(const AtomStringImpl& id) const
+inline bool TreeScope::hasElementWithId(const AtomString& id) const
 {
     return m_elementsById && m_elementsById->contains(id);
 }
 
 inline bool TreeScope::containsMultipleElementsWithId(const AtomString& id) const
 {
-    return m_elementsById && id.impl() && m_elementsById->containsMultiple(*id.impl());
+    return m_elementsById && !id.isEmpty() && m_elementsById->containsMultiple(id);
 }
 
-inline bool TreeScope::hasElementWithName(const AtomStringImpl& id) const
+inline bool TreeScope::hasElementWithName(const AtomString& id) const
 {
     return m_elementsByName && m_elementsByName->contains(id);
 }
 
 inline bool TreeScope::containsMultipleElementsWithName(const AtomString& name) const
 {
-    return m_elementsByName && name.impl() && m_elementsByName->containsMultiple(*name.impl());
+    return m_elementsByName && !name.isEmpty() && m_elementsByName->containsMultiple(name);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -48,14 +48,15 @@ void TreeScopeOrderedMap::clear()
     m_map.clear();
 }
 
-void TreeScopeOrderedMap::add(const AtomStringImpl& key, Element& element, const TreeScope& treeScope)
+void TreeScopeOrderedMap::add(const AtomString& key, Element& element, const TreeScope& treeScope)
 {
+    ASSERT_WITH_SECURITY_IMPLICATION(!key.isNull());
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&element.treeScope() == &treeScope);
     ASSERT_WITH_SECURITY_IMPLICATION(treeScope.rootNode().containsIncludingShadowDOM(&element));
 
     if (!element.isInTreeScope())
         return;
-    Map::AddResult addResult = m_map.ensure(&key, [&element] {
+    Map::AddResult addResult = m_map.ensure(key, [&element] {
         return MapEntry(&element);
     });
     MapEntry& entry = addResult.iterator->value;
@@ -74,10 +75,11 @@ void TreeScopeOrderedMap::add(const AtomStringImpl& key, Element& element, const
     entry.orderedList.clear();
 }
 
-void TreeScopeOrderedMap::remove(const AtomStringImpl& key, Element& element)
+void TreeScopeOrderedMap::remove(const AtomString& key, Element& element)
 {
+    ASSERT_WITH_SECURITY_IMPLICATION(!key.isNull());
     m_map.checkConsistency();
-    auto it = m_map.find(&key);
+    auto it = m_map.find(key);
 
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(it != m_map.end());
 
@@ -96,11 +98,12 @@ void TreeScopeOrderedMap::remove(const AtomStringImpl& key, Element& element)
 }
 
 template <typename KeyMatchingFunction>
-inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomStringImpl& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
+inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomString& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
 {
+    ASSERT_WITH_SECURITY_IMPLICATION(!key.isNull());
     m_map.checkConsistency();
 
-    auto it = m_map.find(&key);
+    auto it = m_map.find(key);
     if (it == m_map.end())
         return nullptr;
 
@@ -146,11 +149,12 @@ inline RefPtr<Element> TreeScopeOrderedMap::get(const AtomStringImpl& key, const
 }
 
 template <typename KeyMatchingFunction>
-inline Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAll(const AtomStringImpl& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
+inline Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAll(const AtomString& key, const TreeScope& scope, const KeyMatchingFunction& keyMatches) const
 {
+    ASSERT_WITH_SECURITY_IMPLICATION(!key.isNull());
     m_map.checkConsistency();
 
-    auto mapIterator = m_map.find(&key);
+    auto mapIterator = m_map.find(key);
     if (mapIterator == m_map.end())
         return nullptr;
 
@@ -170,67 +174,67 @@ inline Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAll(const AtomString
     return &entry.orderedList;
 }
 
-RefPtr<Element> TreeScopeOrderedMap::getElementById(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<Element> TreeScopeOrderedMap::getElementById(const AtomString& key, const TreeScope& scope) const
 {
-    return get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
-        return element.getIdAttribute().impl() == &key;
+    return get(key, scope, [] (const AtomString& key, const Element& element) {
+        return element.getIdAttribute() == key;
     });
 }
 
-RefPtr<Element> TreeScopeOrderedMap::getElementByName(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<Element> TreeScopeOrderedMap::getElementByName(const AtomString& key, const TreeScope& scope) const
 {
-    return get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
-        return element.getNameAttribute().impl() == &key;
+    return get(key, scope, [] (const AtomString& key, const Element& element) {
+        return element.getNameAttribute() == key;
     });
 }
 
-RefPtr<HTMLMapElement> TreeScopeOrderedMap::getElementByMapName(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<HTMLMapElement> TreeScopeOrderedMap::getElementByMapName(const AtomString& key, const TreeScope& scope) const
 {
-    return downcast<HTMLMapElement>(get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
-        return is<HTMLMapElement>(element) && downcast<HTMLMapElement>(element).getName().impl() == &key;
+    return downcast<HTMLMapElement>(get(key, scope, [] (const AtomString& key, const Element& element) {
+        return is<HTMLMapElement>(element) && downcast<HTMLMapElement>(element).getName() == key;
     }));
 }
 
-RefPtr<HTMLImageElement> TreeScopeOrderedMap::getElementByUsemap(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<HTMLImageElement> TreeScopeOrderedMap::getElementByUsemap(const AtomString& key, const TreeScope& scope) const
 {
-    return downcast<HTMLImageElement>(get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
+    return downcast<HTMLImageElement>(get(key, scope, [] (const AtomString& key, const Element& element) {
         // FIXME: HTML5 specification says we should match both image and object elements.
         return is<HTMLImageElement>(element) && downcast<HTMLImageElement>(element).matchesUsemap(key);
     }));
 }
 
-const Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getElementsByLabelForAttribute(const AtomStringImpl& key, const TreeScope& scope) const
+const Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getElementsByLabelForAttribute(const AtomString& key, const TreeScope& scope) const
 {
-    return getAll(key, scope, [] (const AtomStringImpl& key, const Element& element) {
-        return is<HTMLLabelElement>(element) && element.attributeWithoutSynchronization(forAttr).impl() == &key;
+    return getAll(key, scope, [] (const AtomString& key, const Element& element) {
+        return is<HTMLLabelElement>(element) && element.attributeWithoutSynchronization(forAttr) == key;
     });
 }
 
-RefPtr<Element> TreeScopeOrderedMap::getElementByWindowNamedItem(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<Element> TreeScopeOrderedMap::getElementByWindowNamedItem(const AtomString& key, const TreeScope& scope) const
 {
-    return get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
-        return WindowNameCollection::elementMatches(element, &key);
+    return get(key, scope, [] (const AtomString& key, const Element& element) {
+        return WindowNameCollection::elementMatches(element, key);
     });
 }
 
-RefPtr<Element> TreeScopeOrderedMap::getElementByDocumentNamedItem(const AtomStringImpl& key, const TreeScope& scope) const
+RefPtr<Element> TreeScopeOrderedMap::getElementByDocumentNamedItem(const AtomString& key, const TreeScope& scope) const
 {
-    return get(key, scope, [] (const AtomStringImpl& key, const Element& element) {
-        return DocumentNameCollection::elementMatches(element, &key);
+    return get(key, scope, [] (const AtomString& key, const Element& element) {
+        return DocumentNameCollection::elementMatches(element, key);
     });
 }
 
-const Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAllElementsById(const AtomStringImpl& key, const TreeScope& scope) const
+const Vector<CheckedRef<Element>>* TreeScopeOrderedMap::getAllElementsById(const AtomString& key, const TreeScope& scope) const
 {
-    return getAll(key, scope, [] (const AtomStringImpl& key, const Element& element) {
-        return element.getIdAttribute().impl() == &key;
+    return getAll(key, scope, [] (const AtomString& key, const Element& element) {
+        return element.getIdAttribute() == key;
     });
 }
 
 const Vector<AtomString> TreeScopeOrderedMap::keys() const
 {
     return WTF::map(m_map, [](auto& entry) -> AtomString {
-        return const_cast<AtomStringImpl*>(entry.key);
+        return entry.key;
     });
 }
 

--- a/Source/WebCore/dom/TreeScopeOrderedMap.h
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.h
@@ -35,7 +35,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
-#include <wtf/text/AtomStringImpl.h>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
@@ -47,32 +47,32 @@ class TreeScope;
 class TreeScopeOrderedMap {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    void add(const AtomStringImpl&, Element&, const TreeScope&);
-    void remove(const AtomStringImpl&, Element&);
+    void add(const AtomString&, Element&, const TreeScope&);
+    void remove(const AtomString&, Element&);
     void clear();
 
-    bool contains(const AtomStringImpl&) const;
-    bool containsSingle(const AtomStringImpl&) const;
-    bool containsMultiple(const AtomStringImpl&) const;
+    bool contains(const AtomString&) const;
+    bool containsSingle(const AtomString&) const;
+    bool containsMultiple(const AtomString&) const;
 
     // concrete instantiations of the get<>() method template
-    RefPtr<Element> getElementById(const AtomStringImpl&, const TreeScope&) const;
-    RefPtr<Element> getElementByName(const AtomStringImpl&, const TreeScope&) const;
-    RefPtr<HTMLMapElement> getElementByMapName(const AtomStringImpl&, const TreeScope&) const;
-    RefPtr<HTMLImageElement> getElementByUsemap(const AtomStringImpl&, const TreeScope&) const;
-    const Vector<CheckedRef<Element>>* getElementsByLabelForAttribute(const AtomStringImpl&, const TreeScope&) const;
-    RefPtr<Element> getElementByWindowNamedItem(const AtomStringImpl&, const TreeScope&) const;
-    RefPtr<Element> getElementByDocumentNamedItem(const AtomStringImpl&, const TreeScope&) const;
+    RefPtr<Element> getElementById(const AtomString&, const TreeScope&) const;
+    RefPtr<Element> getElementByName(const AtomString&, const TreeScope&) const;
+    RefPtr<HTMLMapElement> getElementByMapName(const AtomString&, const TreeScope&) const;
+    RefPtr<HTMLImageElement> getElementByUsemap(const AtomString&, const TreeScope&) const;
+    const Vector<CheckedRef<Element>>* getElementsByLabelForAttribute(const AtomString&, const TreeScope&) const;
+    RefPtr<Element> getElementByWindowNamedItem(const AtomString&, const TreeScope&) const;
+    RefPtr<Element> getElementByDocumentNamedItem(const AtomString&, const TreeScope&) const;
 
-    const Vector<CheckedRef<Element>>* getAllElementsById(const AtomStringImpl&, const TreeScope&) const;
+    const Vector<CheckedRef<Element>>* getAllElementsById(const AtomString&, const TreeScope&) const;
 
     const Vector<AtomString> keys() const;
 
 private:
     template <typename KeyMatchingFunction>
-    RefPtr<Element> get(const AtomStringImpl&, const TreeScope&, const KeyMatchingFunction&) const;
+    RefPtr<Element> get(const AtomString&, const TreeScope&, const KeyMatchingFunction&) const;
     template <typename KeyMatchingFunction>
-    Vector<CheckedRef<Element>>* getAll(const AtomStringImpl&, const TreeScope&, const KeyMatchingFunction&) const;
+    Vector<CheckedRef<Element>>* getAll(const AtomString&, const TreeScope&, const KeyMatchingFunction&) const;
 
     struct MapEntry {
         MapEntry() { }
@@ -89,25 +89,25 @@ private:
 #endif
     };
 
-    using Map = HashMap<const AtomStringImpl*, MapEntry>;
+    using Map = HashMap<AtomString, MapEntry>;
 
     mutable Map m_map;
 };
 
-inline bool TreeScopeOrderedMap::containsSingle(const AtomStringImpl& id) const
+inline bool TreeScopeOrderedMap::containsSingle(const AtomString& id) const
 {
-    auto it = m_map.find(&id);
+    auto it = m_map.find(id);
     return it != m_map.end() && it->value.count == 1;
 }
 
-inline bool TreeScopeOrderedMap::contains(const AtomStringImpl& id) const
+inline bool TreeScopeOrderedMap::contains(const AtomString& id) const
 {
-    return m_map.contains(&id);
+    return m_map.contains(id);
 }
 
-inline bool TreeScopeOrderedMap::containsMultiple(const AtomStringImpl& id) const
+inline bool TreeScopeOrderedMap::containsMultiple(const AtomString& id) const
 {
-    auto it = m_map.find(&id);
+    auto it = m_map.find(id);
     return it != m_map.end() && it->value.count > 1;
 }
 

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -74,7 +74,7 @@ bool hasImageControls(const HTMLElement& element)
     if (!shadowRoot || shadowRoot->mode() != ShadowRootMode::UserAgent)
         return false;
 
-    return shadowRoot->hasElementWithId(*imageControlsElementIdentifier().impl());
+    return shadowRoot->hasElementWithId(imageControlsElementIdentifier());
 }
 
 static RefPtr<HTMLElement> imageControlsHost(const Node& node)

--- a/Source/WebCore/html/CachedHTMLCollectionInlines.h
+++ b/Source/WebCore/html/CachedHTMLCollectionInlines.h
@@ -112,10 +112,10 @@ Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(con
         RefPtr<Element> candidate;
 
         TreeScope& treeScope = root.treeScope();
-        if (treeScope.hasElementWithId(*name.impl())) {
+        if (treeScope.hasElementWithId(name)) {
             if (!treeScope.containsMultipleElementsWithId(name))
                 candidate = treeScope.getElementById(name);
-        } else if (treeScope.hasElementWithName(*name.impl())) {
+        } else if (treeScope.hasElementWithName(name)) {
             if (!treeScope.containsMultipleElementsWithName(name)) {
                 if ((candidate = treeScope.getElementByName(name))) {
                     if (!is<HTMLElement>(*candidate))

--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -124,16 +124,16 @@ Ref<DocumentParser> HTMLDocument::createParser()
 // https://html.spec.whatwg.org/multipage/dom.html#dom-document-nameditem
 std::optional<std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>>> HTMLDocument::namedItem(const AtomString& name)
 {
-    if (name.isNull() || !hasDocumentNamedItem(*name.impl()))
+    if (name.isNull() || !hasDocumentNamedItem(name))
         return std::nullopt;
 
-    if (UNLIKELY(documentNamedItemContainsMultipleElements(*name.impl()))) {
+    if (UNLIKELY(documentNamedItemContainsMultipleElements(name))) {
         auto collection = documentNamedItems(name);
         ASSERT(collection->length() > 1);
         return std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { RefPtr<HTMLCollection> { WTFMove(collection) } };
     }
 
-    auto& element = *documentNamedItem(*name.impl());
+    auto& element = *documentNamedItem(name);
     if (UNLIKELY(is<HTMLIFrameElement>(element))) {
         if (RefPtr domWindow = downcast<HTMLIFrameElement>(element).contentWindow())
             return std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>> { WTFMove(domWindow) };
@@ -144,7 +144,7 @@ std::optional<std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLColl
 
 bool HTMLDocument::isSupportedPropertyName(const AtomString& name) const
 {
-    return !name.isNull() && hasDocumentNamedItem(*name.impl());
+    return !name.isNull() && hasDocumentNamedItem(name);
 }
 
 Vector<AtomString> HTMLDocument::supportedPropertyNames() const
@@ -160,23 +160,23 @@ Vector<AtomString> HTMLDocument::supportedPropertyNames() const
     return properties;
 }
 
-void HTMLDocument::addDocumentNamedItem(const AtomStringImpl& name, Element& item)
+void HTMLDocument::addDocumentNamedItem(const AtomString& name, Element& item)
 {
     m_documentNamedItem.add(name, item, *this);
-    addImpureProperty(AtomString(const_cast<AtomStringImpl*>(&name)));
+    addImpureProperty(name);
 }
 
-void HTMLDocument::removeDocumentNamedItem(const AtomStringImpl& name, Element& item)
+void HTMLDocument::removeDocumentNamedItem(const AtomString& name, Element& item)
 {
     m_documentNamedItem.remove(name, item);
 }
 
-void HTMLDocument::addWindowNamedItem(const AtomStringImpl& name, Element& item)
+void HTMLDocument::addWindowNamedItem(const AtomString& name, Element& item)
 {
     m_windowNamedItem.add(name, item, *this);
 }
 
-void HTMLDocument::removeWindowNamedItem(const AtomStringImpl& name, Element& item)
+void HTMLDocument::removeWindowNamedItem(const AtomString& name, Element& item)
 {
     m_windowNamedItem.remove(name, item);
 }

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -41,17 +41,17 @@ public:
     Vector<AtomString> supportedPropertyNames() const;
     bool isSupportedPropertyName(const AtomString&) const;
 
-    RefPtr<Element> documentNamedItem(const AtomStringImpl& name) const { return m_documentNamedItem.getElementByDocumentNamedItem(name, *this); }
-    bool hasDocumentNamedItem(const AtomStringImpl& name) const { return m_documentNamedItem.contains(name); }
-    bool documentNamedItemContainsMultipleElements(const AtomStringImpl& name) const { return m_documentNamedItem.containsMultiple(name); }
-    void addDocumentNamedItem(const AtomStringImpl&, Element&);
-    void removeDocumentNamedItem(const AtomStringImpl&, Element&);
+    RefPtr<Element> documentNamedItem(const AtomString& name) const { return m_documentNamedItem.getElementByDocumentNamedItem(name, *this); }
+    bool hasDocumentNamedItem(const AtomString& name) const { return m_documentNamedItem.contains(name); }
+    bool documentNamedItemContainsMultipleElements(const AtomString& name) const { return m_documentNamedItem.containsMultiple(name); }
+    void addDocumentNamedItem(const AtomString&, Element&);
+    void removeDocumentNamedItem(const AtomString&, Element&);
 
-    RefPtr<Element> windowNamedItem(const AtomStringImpl& name) const { return m_windowNamedItem.getElementByWindowNamedItem(name, *this); }
-    bool hasWindowNamedItem(const AtomStringImpl& name) const { return m_windowNamedItem.contains(name); }
-    bool windowNamedItemContainsMultipleElements(const AtomStringImpl& name) const { return m_windowNamedItem.containsMultiple(name); }
-    void addWindowNamedItem(const AtomStringImpl&, Element&);
-    void removeWindowNamedItem(const AtomStringImpl&, Element&);
+    RefPtr<Element> windowNamedItem(const AtomString& name) const { return m_windowNamedItem.getElementByWindowNamedItem(name, *this); }
+    bool hasWindowNamedItem(const AtomString& name) const { return m_windowNamedItem.contains(name); }
+    bool windowNamedItemContainsMultipleElements(const AtomString& name) const { return m_windowNamedItem.containsMultiple(name); }
+    void addWindowNamedItem(const AtomString&, Element&);
+    void removeWindowNamedItem(const AtomString&, Element&);
 
     static bool isCaseSensitiveAttribute(const QualifiedName&);
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -360,10 +360,10 @@ void HTMLImageElement::attributeChanged(const QualifiedName& name, const AtomStr
         break;
     case AttributeNames::usemapAttr:
         if (isInTreeScope() && !m_parsedUsemap.isNull())
-            treeScope().removeImageElementByUsemap(*m_parsedUsemap.impl(), *this);
+            treeScope().removeImageElementByUsemap(m_parsedUsemap, *this);
         m_parsedUsemap = parseHTMLHashNameReference(newValue);
         if (isInTreeScope() && !m_parsedUsemap.isNull())
-            treeScope().addImageElementByUsemap(*m_parsedUsemap.impl(), *this);
+            treeScope().addImageElementByUsemap(m_parsedUsemap, *this);
         break;
     case AttributeNames::compositeAttr: {
         // FIXME: images don't support blend modes in their compositing attribute.
@@ -395,9 +395,9 @@ void HTMLImageElement::attributeChanged(const QualifiedName& name, const AtomStr
             const AtomString& id = getIdAttribute();
             if (!id.isEmpty() && id != getNameAttribute()) {
                 if (willHaveName)
-                    document.addDocumentNamedItem(*id.impl(), *this);
+                    document.addDocumentNamedItem(id, *this);
                 else
-                    document.removeDocumentNamedItem(*id.impl(), *this);
+                    document.removeDocumentNamedItem(id, *this);
             }
         }
         m_hadNameBeforeAttributeChanged = willHaveName;
@@ -485,7 +485,7 @@ Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(Insertio
     Node::InsertedIntoAncestorResult insertNotificationRequest = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 
     if (insertionType.treeScopeChanged && !m_parsedUsemap.isNull())
-        treeScope().addImageElementByUsemap(*m_parsedUsemap.impl(), *this);
+        treeScope().addImageElementByUsemap(m_parsedUsemap, *this);
 
     if (is<HTMLPictureElement>(&parentOfInsertedTree) && &parentOfInsertedTree == parentElement()) {
         // FIXME: When the hack in HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface to eagerly call setPictureElement is removed, we can just assert !pictureElement().
@@ -506,7 +506,7 @@ Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(Insertio
 void HTMLImageElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.treeScopeChanged && !m_parsedUsemap.isNull())
-        oldParentOfRemovedTree.treeScope().removeImageElementByUsemap(*m_parsedUsemap.impl(), *this);
+        oldParentOfRemovedTree.treeScope().removeImageElementByUsemap(m_parsedUsemap, *this);
 
     if (is<HTMLPictureElement>(oldParentOfRemovedTree) && !parentElement()) {
         ASSERT(pictureElement() == &oldParentOfRemovedTree);
@@ -669,9 +669,9 @@ Attribute HTMLImageElement::replaceURLsInAttributeValue(const Attribute& attribu
     return Attribute { srcsetAttr, AtomString { replaceURLsInSrcsetAttribute(*this, StringView(attribute.value()), replacementURLStrings) } };
 }
 
-bool HTMLImageElement::matchesUsemap(const AtomStringImpl& name) const
+bool HTMLImageElement::matchesUsemap(const AtomString& name) const
 {
-    return m_parsedUsemap.impl() == &name;
+    return m_parsedUsemap == name;
 }
 
 RefPtr<HTMLMapElement> HTMLImageElement::associatedMapElement() const

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -79,7 +79,7 @@ public:
 
     void setLoadManually(bool);
 
-    bool matchesUsemap(const AtomStringImpl&) const;
+    bool matchesUsemap(const AtomString&) const;
     RefPtr<HTMLMapElement> associatedMapElement() const;
 
     WEBCORE_EXPORT const AtomString& alt() const;

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -81,7 +81,7 @@ RefPtr<HTMLImageElement> HTMLMapElement::imageElement()
 {
     if (m_name.isEmpty())
         return nullptr;
-    return treeScope().imageElementByUsemap(*m_name.impl());
+    return treeScope().imageElementByUsemap(m_name);
 }
 
 void HTMLMapElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLNameCollection.cpp
+++ b/Source/WebCore/html/HTMLNameCollection.cpp
@@ -53,10 +53,10 @@ bool WindowNameCollection::elementMatchesIfNameAttributeMatch(const Element& ele
         || is<HTMLObjectElement>(element);
 }
 
-bool WindowNameCollection::elementMatches(const Element& element, const AtomStringImpl* name)
+bool WindowNameCollection::elementMatches(const Element& element, const AtomString& name)
 {
     // Find only images, forms, applets, embeds and objects by name, but anything by id.
-    return (elementMatchesIfNameAttributeMatch(element) && element.getNameAttribute().impl() == name)
+    return (elementMatchesIfNameAttributeMatch(element) && element.getNameAttribute() == name)
         || element.getIdAttribute() == name;
 }
 
@@ -81,12 +81,12 @@ bool DocumentNameCollection::elementMatchesIfNameAttributeMatch(const Element& e
         || is<HTMLImageElement>(element);
 }
 
-bool DocumentNameCollection::elementMatches(const Element& element, const AtomStringImpl* name)
+bool DocumentNameCollection::elementMatches(const Element& element, const AtomString& name)
 {
     // Find images, forms, applets, embeds, objects and iframes by name, applets and object by id, and images by id
     // but only if they have a name attribute (this very strange rule matches IE).
-    return (elementMatchesIfNameAttributeMatch(element) && element.getNameAttribute().impl() == name)
-        || (elementMatchesIfIdAttributeMatch(element) && element.getIdAttribute().impl() == name);
+    return (elementMatchesIfNameAttributeMatch(element) && element.getNameAttribute() == name)
+        || (elementMatchesIfIdAttributeMatch(element) && element.getIdAttribute() == name);
 }
 
 }

--- a/Source/WebCore/html/HTMLNameCollection.h
+++ b/Source/WebCore/html/HTMLNameCollection.h
@@ -65,7 +65,7 @@ public:
 
     static bool elementMatchesIfIdAttributeMatch(const Element&) { return true; }
     static bool elementMatchesIfNameAttributeMatch(const Element&);
-    static bool elementMatches(const Element&, const AtomStringImpl*);
+    static bool elementMatches(const Element&, const AtomString&);
 
 private:
     WindowNameCollection(Document& document, CollectionType type, const AtomString& name)
@@ -89,7 +89,7 @@ public:
     // For CachedHTMLCollection.
     bool elementMatches(const Element& element) const { return elementMatches(element, m_name.impl()); }
 
-    static bool elementMatches(const Element&, const AtomStringImpl*);
+    static bool elementMatches(const Element&, const AtomString&);
 
 private:
     DocumentNameCollection(Document& document, CollectionType type, const AtomString& name)

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -405,17 +405,17 @@ void HTMLObjectElement::updateExposedState()
         auto& id = getIdAttribute();
         if (!id.isEmpty()) {
             if (m_isExposed)
-                document.addDocumentNamedItem(*id.impl(), *this);
+                document.addDocumentNamedItem(id, *this);
             else
-                document.removeDocumentNamedItem(*id.impl(), *this);
+                document.removeDocumentNamedItem(id, *this);
         }
 
         auto& name = getNameAttribute();
         if (!name.isEmpty() && id != name) {
             if (m_isExposed)
-                document.addDocumentNamedItem(*name.impl(), *this);
+                document.addDocumentNamedItem(name, *this);
             else
-                document.removeDocumentNamedItem(*name.impl(), *this);
+                document.removeDocumentNamedItem(name, *this);
         }
     }
 }


### PR DESCRIPTION
#### f0939c55f2d773fbe9666e902d385acd05100e48
<pre>
Use AtomString instead of AtomStringImpl in TreeScopeOrderedMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=263239">https://bugs.webkit.org/show_bug.cgi?id=263239</a>

Reviewed by Chris Dumez.

Replaced the use of AtomStringImpl* / AtomStringImpl&amp; in TreeScopeOrderedMap with AtomString.

* Source/WebCore/bindings/js/JSDOMWindowProperties.cpp:
(WebCore::jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::updateNameForTreeScope):
(WebCore::Element::updateNameForDocument):
(WebCore::Element::updateIdForTreeScope):
(WebCore::Element::updateIdForDocument):
(WebCore::Element::updateLabel):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::hasOverlay):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::getElementById const):
(WebCore::TreeScope::getAllElementsById const):
(WebCore::TreeScope::addElementById):
(WebCore::TreeScope::removeElementById):
(WebCore::TreeScope::getElementByName const):
(WebCore::TreeScope::addElementByName):
(WebCore::TreeScope::removeElementByName):
(WebCore::TreeScope::addImageMap):
(WebCore::TreeScope::removeImageMap):
(WebCore::TreeScope::getImageMap const):
(WebCore::TreeScope::addImageElementByUsemap):
(WebCore::TreeScope::removeImageElementByUsemap):
(WebCore::TreeScope::imageElementByUsemap const):
(WebCore::TreeScope::addLabel):
(WebCore::TreeScope::removeLabel):
(WebCore::TreeScope::labelElementsForId):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/dom/TreeScopeInlines.h:
(WebCore::TreeScope::hasElementWithId const):
(WebCore::TreeScope::containsMultipleElementsWithId const):
(WebCore::TreeScope::hasElementWithName const):
(WebCore::TreeScope::containsMultipleElementsWithName const):
* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::add):
(WebCore::TreeScopeOrderedMap::remove):
(WebCore::TreeScopeOrderedMap::get const):
(WebCore::TreeScopeOrderedMap::getAll const):
(WebCore::TreeScopeOrderedMap::getElementById const):
(WebCore::TreeScopeOrderedMap::getElementByName const):
(WebCore::TreeScopeOrderedMap::getElementByMapName const):
(WebCore::TreeScopeOrderedMap::getElementByUsemap const):
(WebCore::TreeScopeOrderedMap::getElementsByLabelForAttribute const):
(WebCore::TreeScopeOrderedMap::getElementByWindowNamedItem const):
(WebCore::TreeScopeOrderedMap::getElementByDocumentNamedItem const):
(WebCore::TreeScopeOrderedMap::getAllElementsById const):
(WebCore::TreeScopeOrderedMap::keys const):
* Source/WebCore/dom/TreeScopeOrderedMap.h:
(WebCore::TreeScopeOrderedMap::containsSingle const):
(WebCore::TreeScopeOrderedMap::contains const):
(WebCore::TreeScopeOrderedMap::containsMultiple const):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::hasImageControls):
* Source/WebCore/html/CachedHTMLCollectionInlines.h:
(WebCore::traversalType&gt;::namedItem const):
* Source/WebCore/html/HTMLDocument.cpp:
(WebCore::HTMLDocument::namedItem):
(WebCore::HTMLDocument::isSupportedPropertyName const):
(WebCore::HTMLDocument::addDocumentNamedItem):
(WebCore::HTMLDocument::removeDocumentNamedItem):
(WebCore::HTMLDocument::addWindowNamedItem):
(WebCore::HTMLDocument::removeWindowNamedItem):
* Source/WebCore/html/HTMLDocument.h:
(WebCore::HTMLDocument::documentNamedItem const):
(WebCore::HTMLDocument::hasDocumentNamedItem const):
(WebCore::HTMLDocument::documentNamedItemContainsMultipleElements const):
(WebCore::HTMLDocument::windowNamedItem const):
(WebCore::HTMLDocument::hasWindowNamedItem const):
(WebCore::HTMLDocument::windowNamedItemContainsMultipleElements const):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::attributeChanged):
(WebCore::HTMLImageElement::insertedIntoAncestor):
(WebCore::HTMLImageElement::removedFromAncestor):
(WebCore::HTMLImageElement::matchesUsemap const):
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::imageElement):
* Source/WebCore/html/HTMLNameCollection.cpp:
(WebCore::WindowNameCollection::elementMatches):
(WebCore::DocumentNameCollection::elementMatches):
* Source/WebCore/html/HTMLNameCollection.h:
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::updateExposedState):

Canonical link: <a href="https://commits.webkit.org/269477@main">https://commits.webkit.org/269477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5165cf5e814bb0e0ada9f25f277083bbc68d27d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22593 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24499 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21881 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25352 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/22776 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26717 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19672 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24552 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21960 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18015 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/26010 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22388 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20277 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6103 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/173 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27290 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2855 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/169 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5929 "Passed tests") | 
<!--EWS-Status-Bubble-End-->