### PR TITLE
Narrow attachment sends load event when its icon is set, test listens

### DIFF
--- a/LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html
+++ b/LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment></attachment>
 <script>
@@ -9,6 +9,10 @@ if (window.internals)
 var attachments = document.getElementsByTagName("attachment");
 for (var i = 0; i < attachments.length; i++)
     attachments[i].file = file;
+</script>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeExpectedScreenshotWhenAttachmentsSettled();
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/attachment/attachment-icon-from-file-extension.html
+++ b/LayoutTests/fast/attachment/attachment-icon-from-file-extension.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
-<html>
+<html class="reftest-wait">
 <body>
 <attachment title="test-file.txt"></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeActualScreenshotWhenAttachmentsSettled();
+</script>
 </body>
 </html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1848,6 +1848,9 @@ imported/w3c/web-platform-tests/css/css-display/display-none-inline-img.html [ I
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-compositing-change.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-content/tall-cross-domain-iframe-in-scrolled.sub.html [ Skip ]
 
+# "reftest-wait" blocks attachment rendering.
+webkit.org/b/263367 fast/attachment/attachment-icon-from-file-extension.html [ Skip ]
+
 # <rdar://problem/42625657> REGRESSION (Mojave): 12 fast/images tests timing out on WK1
 fast/images/animated-heics-draw.html [ Skip ]
 fast/images/animated-heics-verify.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1989,8 +1989,6 @@ webkit.org/b/262915 [ Sonoma+ ] compositing/plugins/pdf/pdf-in-embed-rounded-bor
 
 webkit.org/b/262917 [ Sonoma+ ] compositing/plugins/pdf/pdf-in-embed.html [ Failure ]
 
-webkit.org/b/262978 [ Sonoma+ ] fast/attachment/attachment-icon-from-file-extension.html [ Pass ImageOnlyFailure ]
-
 # webkit.org/b/262987 REGRESSION ( Sonoma): [ Sonoma ] 3 tests in fast/attachment/mac/ are consistently failing
 [ Sonoma+ ] fast/attachment/mac/attachment-keynote.html [ Pass ImageOnlyFailure ]
 [ Sonoma+ ] fast/attachment/mac/attachment-numbers.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -705,11 +705,14 @@ void HTMLAttachmentElement::updateThumbnailForWideLayout(Vector<uint8_t>&& thumb
 void HTMLAttachmentElement::updateIconForNarrowLayout(const RefPtr<Image>& icon, const WebCore::FloatSize& iconSize)
 {
     ASSERT(!isWideLayout());
-    if (!icon)
+    if (!icon) {
+        dispatchEvent(Event::create(eventNames().loadingerrorEvent, Event::CanBubble::No, Event::IsCancelable::No));
         return;
+    }
     m_icon = icon;
     m_iconSize = iconSize;
     invalidateRendering();
+    dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 void HTMLAttachmentElement::updateIconForWideLayout(Vector<uint8_t>&& iconSrcData)
@@ -745,12 +748,13 @@ void HTMLAttachmentElement::requestWideLayoutIconIfNeeded()
     document().page()->attachmentElementClient()->requestAttachmentIcon(uniqueIdentifier(), FloatSize(attachmentIconSize, attachmentIconSize));
 }
 
-void HTMLAttachmentElement::requestIconWithSize(const FloatSize& size) const
+void HTMLAttachmentElement::requestIconWithSize(const FloatSize& size)
 {
     ASSERT(!isWideLayout());
     if (!document().page() || !document().page()->attachmentElementClient())
         return;
 
+    queueTaskToDispatchEvent(TaskSource::InternalAsyncTask, Event::create(eventNames().beforeloadEvent, Event::CanBubble::No, Event::IsCancelable::No));
     document().page()->attachmentElementClient()->requestAttachmentIcon(uniqueIdentifier(), size);
 }
 

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -79,7 +79,7 @@ public:
     String attachmentPath() const;
     RefPtr<Image> thumbnail() const { return m_thumbnail; }
     RefPtr<Image> icon() const { return m_icon; }
-    void requestIconWithSize(const FloatSize&) const;
+    void requestIconWithSize(const FloatSize&);
     void requestWideLayoutIconIfNeeded();
     FloatSize iconSize() const { return m_iconSize; }
     void invalidateRendering();


### PR DESCRIPTION
#### dabfeeb4daebcc58cea4207a19bf6a330a39ae2e
<pre>
Narrow attachment sends load event when its icon is set, test listens
<a href="https://bugs.webkit.org/show_bug.cgi?id=262978">https://bugs.webkit.org/show_bug.cgi?id=262978</a>
rdar://116764174

Reviewed by Aditya Keerthi.

Some tests like attachment-icon-from-file-extension.html fail with an image
error because the attachment icon is not set yet, especially when the icon
request is done is a separate process.

Similar to <a href="https://commits.webkit.org/266144@main">https://commits.webkit.org/266144@main</a> where the wide-layout
attachment would dispatch a load event when its image element was set,
narrow attachments now dispatch the same load event when its icon image gets
set. This can be listened to in tests, so that they know when the attachment
is stable and a screenshot may be taken.

This patch also fixes attachment-icon-from-file-extension.html as a proof of
concept. More tests will be fixed in subsequent patches.
A downside to this fix is that &quot;reftest-wait&quot; seems to prevent painting the
attachement on wk1, so for now this test is skipped there, to be investigated
in <a href="https://bugs.webkit.org/show_bug.cgi?id=263367.">https://bugs.webkit.org/show_bug.cgi?id=263367.</a>

* LayoutTests/fast/attachment/attachment-icon-from-file-extension-expected.html:
* LayoutTests/fast/attachment/attachment-icon-from-file-extension.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::updateIconForNarrowLayout):
(WebCore::HTMLAttachmentElement::requestIconWithSize):
(WebCore::HTMLAttachmentElement::requestIconWithSize const): Deleted.
* Source/WebCore/html/HTMLAttachmentElement.h:

Canonical link: <a href="https://commits.webkit.org/269512@main">https://commits.webkit.org/269512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0ad7d323f6174b054fc30cc30dc270aa5677b08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23327 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23041 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25562 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26862 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24718 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/343 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5429 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/391 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->