### PR TITLE
REGRESSION (STP): Video won't play on bilibili.com

### DIFF
--- a/LayoutTests/fast/dom/document-contentType-DOMParser-expected.txt
+++ b/LayoutTests/fast/dom/document-contentType-DOMParser-expected.txt
@@ -6,6 +6,13 @@ PASS new DOMParser().parseFromString(xslContent, "text/xsl").contentType threw e
 PASS new DOMParser().parseFromString(xmlContent, "text/dummy+xml").contentType threw exception TypeError: Type error.
 PASS new DOMParser().parseFromString(xmlContent, "text/XML").contentType threw exception TypeError: Type error.
 PASS new DOMParser().parseFromString(htmlContent, "TEXT/html").contentType threw exception TypeError: Type error.
+PASS parsedContent.body.firstChild.nodeName is "DIV"
+PASS parsedContent.body.childNodes.length is 2
+PASS parsedContent.body.childNodes[1].nodeName is "#text"
+PASS div.firstChild.nodeName is "#text"
+PASS div.childNodes.length is 3
+PASS div.childNodes[2].nodeName is "#text"
+PASS new DOMParser().parseFromString(htmlContentWithJustSpaces, "text/html").body.childNodes.length is 0
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/document-contentType-DOMParser.html
+++ b/LayoutTests/fast/dom/document-contentType-DOMParser.html
@@ -6,7 +6,7 @@
 </head>
 <body>
  <script>
-  
+
 var htmlContent =
                 "<html>" +
                     "<head>" +
@@ -79,6 +79,21 @@ shouldThrow('new DOMParser().parseFromString(xslContent, "text/xsl").contentType
 shouldThrow('new DOMParser().parseFromString(xmlContent, "text/dummy+xml").contentType', "'TypeError: Type error'");
 shouldThrow('new DOMParser().parseFromString(xmlContent, "text/XML").contentType', "'TypeError: Type error'");
 shouldThrow('new DOMParser().parseFromString(htmlContent, "TEXT/html").contentType', "'TypeError: Type error'");
+
+var htmlContentWithSpace = "\n        <div class=\"bpx-player-container\"></div>        \n";
+var parsedContent = new DOMParser().parseFromString(htmlContentWithSpace, "text/html");
+shouldBeEqualToString('parsedContent.body.firstChild.nodeName', 'DIV');
+shouldBe('parsedContent.body.childNodes.length', '2');
+shouldBeEqualToString('parsedContent.body.childNodes[1].nodeName', '#text');
+
+var div = document.createElement("div");
+div.innerHTML = htmlContentWithSpace;
+shouldBeEqualToString('div.firstChild.nodeName', '#text');
+shouldBe('div.childNodes.length', '3');
+shouldBeEqualToString('div.childNodes[2].nodeName', '#text');
+
+var htmlContentWithJustSpaces = "\n                \n";
+shouldBe('new DOMParser().parseFromString(htmlContentWithJustSpaces, "text/html").body.childNodes.length', '0');
 
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -895,7 +895,7 @@ static bool tryFastParsingHTMLFragmentImpl(const std::span<const CharacterType>&
     return parser.parse(contextElement);
 }
 
-bool tryFastParsingHTMLFragment(const String& source, Document& document, ContainerNode& destinationParent, Element& contextElement, OptionSet<ParserContentPolicy> policy)
+bool tryFastParsingHTMLFragment(StringView source, Document& document, ContainerNode& destinationParent, Element& contextElement, OptionSet<ParserContentPolicy> policy)
 {
     if (!canUseFastPath(contextElement, policy))
         return false;

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
@@ -41,7 +41,7 @@ class Element;
 
 enum class ParserContentPolicy : uint8_t;
 
-WEBCORE_EXPORT bool tryFastParsingHTMLFragment(const String& source, Document&, ContainerNode&, Element& contextElement, OptionSet<ParserContentPolicy>);
+WEBCORE_EXPORT bool tryFastParsingHTMLFragment(StringView source, Document&, ContainerNode&, Element& contextElement, OptionSet<ParserContentPolicy>);
 
 } // namespace WebCore
 

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -60,7 +60,7 @@ ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, cons
     bool usedFastPath = false;
     if (contentType == "text/html"_s) {
         auto body = HTMLBodyElement::create(document);
-        usedFastPath = tryFastParsingHTMLFragment(string, document, body, body, parsingOptions);
+        usedFastPath = tryFastParsingHTMLFragment(StringView { string }.substring(string.find(isNotASCIIWhitespace<UChar>)), document, body, body, parsingOptions);
         if (LIKELY(usedFastPath)) {
             auto html = HTMLHtmlElement::create(document);
             document->appendChild(html);


### PR DESCRIPTION
#### 55a286438b239e94c5a355a1f7510cfa7b4dd033
<pre>
REGRESSION (STP): Video won&apos;t play on bilibili.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=263196">https://bugs.webkit.org/show_bug.cgi?id=263196</a>
rdar://117020123

Reviewed by Chris Dumez.

bilibili injects DOM objects in the tree by calling:
```
var t = (new DOMParser).parseFromString(e, &quot;text/html&quot;);
return document.adoptNode(t.body.firstChild)
```

Per spec, when parsing HTML to create a document through DOMParser::parseFromString() [1]
you are to skip the whitespace tokens for the &quot;initial&quot; insertion mode [2].
The trailing spaces however must be kept [3]
This behaviour was regressed by 267202@main.

On this site, the observable behaviour was that the firstChild became a &quot;#text&quot;
node rather the expected first DIV one.

So we trim the leading whitespaces before calling the fast parser. Which
restore the original behaviour prior 267202@main

[1] <a href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#parse-html-from-a-string">https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#parse-html-from-a-string</a>
[2] <a href="https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode">https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode</a>
[3] <a href="https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-afterbody">https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-afterbody</a>

* LayoutTests/fast/dom/document-contentType-DOMParser-expected.txt:
* LayoutTests/fast/dom/document-contentType-DOMParser.html: Added tests.
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::tryFastParsingHTMLFragment):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.h: Change type to StringView
(WebCore::requires):
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):

Canonical link: <a href="https://commits.webkit.org/269457@main">https://commits.webkit.org/269457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fc9ca812bbf9bd1fe81d0dfa6a7cb39fcbd9f4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23154 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22864 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25386 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26744 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24583 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18034 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20302 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5386 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->