### PR TITLE
Revert 269399@main

### DIFF
--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -90,14 +90,17 @@ struct RTCNetwork {
     using IPAddress = RTC::Network::IPAddress;
     using InterfaceAddress = RTC::Network::InterfaceAddress;
 
+    RTCNetwork() = default;
     explicit RTCNetwork(const rtc::Network&);
-    explicit RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<char>&& key, size_t length, Vector<InterfaceAddress>&& ips);
 
     rtc::Network value() const;
     static rtc::SocketAddress isolatedCopy(const rtc::SocketAddress&);
 
-    Vector<char> name;
-    Vector<char> description;
+    void encode(IPC::Encoder&) const;
+    static std::optional<RTCNetwork> decode(IPC::Decoder&);
+
+    std::string name;
+    std::string description;
     IPAddress prefix;
     int prefixLength;
     int type;
@@ -106,9 +109,9 @@ struct RTCNetwork {
     bool active;
     bool ignored;
     int scopeID;
-    Vector<char> key;
+    std::string key;
     size_t length;
-    Vector<InterfaceAddress> ips;
+    std::vector<rtc::InterfaceAddress> ips;
 };
 
 }

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -22,6 +22,8 @@
 
 #if USE(LIBWEBRTC)
 
+header: "RTCNetwork.h"
+
 [CustomHeader] struct WebKit::RTC::Network::IPAddress {
     std::variant<WebKit::RTC::Network::IPAddress::UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value;
 };
@@ -34,19 +36,4 @@
     int ipv6Flags;
 };
 
-struct WebKit::RTCNetwork {
-    Vector<char> name;
-    Vector<char> description;
-    WebKit::RTC::Network::IPAddress prefix;
-    int prefixLength;
-    int type;
-    uint16_t id;
-    int preference;
-    bool active;
-    bool ignored;
-    int scopeID;
-    Vector<char> key;
-    size_t length;
-    Vector<WebKit::RTC::Network::InterfaceAddress> ips;
-};
 #endif

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -142,7 +142,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         filteredNetworks = networks;
     else {
         for (auto& network : networks) {
-            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.data(), network.name.size()))))
+            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip || ipv6.rtcAddress() == ip; }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.c_str()))))
                 filteredNetworks.append(network);
         }
     }


### PR DESCRIPTION
#### 10709eb1fcbe2bd31ccc5f997b89f31b8d128e59
<pre>
Revert 269399@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=263247">https://bugs.webkit.org/show_bug.cgi?id=263247</a>

Unreviewed.

It regressed the test webrtc/vp8-then-h264.html

* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::RTCNetwork):
(WebKit::ips):
(WebKit::RTCNetwork::value const):
(WebKit::RTCNetwork::decode):
(WebKit::RTCNetwork::encode const):
* Source/WebKit/Shared/RTCNetwork.h:
* Source/WebKit/Shared/RTCNetwork.serialization.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):

Canonical link: <a href="https://commits.webkit.org/269407@main">https://commits.webkit.org/269407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de53b326dc036d834da4db799dffdf981e7b6b1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20829 "Built successfully") 
| | [💥 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1181 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23032 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22740 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/1181 "An unexpected error occured. Recent messages:Failed to print configuration") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25257 "Built successfully") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/1181 "An unexpected error occured. Recent messages:Failed to print configuration") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/1181 "An unexpected error occured. Recent messages:Failed to print configuration") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/89 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/66 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/106 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2817 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->