### PR TITLE
Refactor `StackTraceSymbolResolver`

### DIFF
--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -156,19 +156,10 @@ void JSGlobalObjectInspectorController::appendAPIBacktrace(ScriptCallStack& call
     static constexpr int framesToShow = 31;
     static constexpr int framesToSkip = 3; // WTFGetBacktrace, appendAPIBacktrace, reportAPIException.
 
-    void* samples[framesToShow + framesToSkip];
-    int frames = framesToShow + framesToSkip;
-    WTFGetBacktrace(samples, &frames);
-
-    void** stack = samples + framesToSkip;
-    int size = frames - framesToSkip;
-    for (int i = 0; i < size; ++i) {
-        auto demangled = StackTraceSymbolResolver::demangle(stack[i]);
-        if (demangled)
-            callStack.append(ScriptCallFrame(String::fromLatin1(demangled->demangledName() ? demangled->demangledName() : demangled->mangledName()), "[native code]"_s, noSourceID, 0, 0));
-        else
-            callStack.append(ScriptCallFrame("?"_s, "[native code]"_s, noSourceID, 0, 0));
-    }
+    std::unique_ptr<StackTrace> stackTrace = StackTrace::captureStackTrace(framesToShow, framesToSkip);
+    StackTraceSymbolResolver(*stackTrace).forEach([&](int, void*, const char* name) {
+        callStack.append(ScriptCallFrame(name ? String::fromLatin1(name) : "?"_s, "[native code]"_s, noSourceID, 0, 0));
+    });
 }
 
 void JSGlobalObjectInspectorController::reportAPIException(JSGlobalObject* globalObject, Exception* exception)

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -835,13 +835,13 @@ String SamplingProfiler::StackFrame::displayName(VM& vm)
 
     switch (frameType) {
     case FrameType::C:
-#if HAVE(DLADDR)
         if (frameType == FrameType::C) {
-            auto demangled = StackTraceSymbolResolver::demangle(const_cast<void*>(cCodePC));
-            if (demangled)
-                return String::fromLatin1(demangled->demangledName() ? demangled->demangledName() : demangled->mangledName());
+            auto mangledName = StackTraceSymbolResolver::resolve(const_cast<void*>(cCodePC));
+            if (mangledName) {
+                auto demangledName = StackTraceSymbolResolver::demangle(mangledName);
+                return String::fromLatin1(demangledName ? demangledName.get() : mangledName);
+            }
         }
-#endif
         return "(unknown C PC)"_s;
 
     case FrameType::Unknown:


### PR DESCRIPTION
#### acb01d8d2300679ecdab25ebdcc007788a4512dc
<pre>
Refactor `StackTraceSymbolResolver`
<a href="https://bugs.webkit.org/show_bug.cgi?id=263250">https://bugs.webkit.org/show_bug.cgi?id=263250</a>

Reviewed by NOBODY (OOPS!).

Resolving a stack trace consists of two steps:
- Resolving a symbol using platform-specific system calls or libraries
- Demangle a symbol name using C++ ABI mangling rules

This patch adds two `StackTraceSymbolResolver`&apos;s methods which implement
these two steps.

`StackTraceSymbolResolver::resolve()` encapsulates all the platform-specific code
required to get a symbol name from the operation system or by parsing the binary.
And `StackTraceSymbolResolver::damangle()` then demangles this name.

These methods are used in `StackTraceSymbolResolver::forEach()`
which becomes much simpler now.

* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::appendAPIBacktrace):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::StackFrame::displayName):
* Source/WTF/wtf/StackTrace.cpp:
(WTF::backtraceFullCallback):
(WTF::StackTraceSymbolResolver::resolve const):
(WTF::StackTraceSymbolResolver::demangle):
(WTF::StackTracePrinter::dump const):
(WTF::symbolize): Deleted.
* Source/WTF/wtf/StackTrace.h:
(WTF::StackTraceSymbolResolver::forEach const):
(WTF::StackTraceSymbolResolver::DemangleEntry::mangledName const): Deleted.
(WTF::StackTraceSymbolResolver::DemangleEntry::demangledName const): Deleted.
(WTF::StackTraceSymbolResolver::DemangleEntry::DemangleEntry): Deleted.
(): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15dae857a9ce919d5fd92eaacc0f80889a8abb56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24617 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22616 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/4826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22997 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27323 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28376 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21400 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/22454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26178 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23888 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/195 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/31297 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3177 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6866 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2326 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/31266 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2239 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6540 "Passed tests") | 
<!--EWS-Status-Bubble-End-->