### PR TITLE
Fix build with recent SDKs.

### DIFF
--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -78,6 +78,8 @@ static void connectionEventHandler(xpc_object_t request)
 static void registerScheduledActivityHandler()
 {
     NSLog(@"Registering XPC activity");
+
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     xpc_activity_register("com.apple.webkit.adattributiond.activity", XPC_ACTIVITY_CHECK_IN, ^(xpc_activity_t activity) {
         if (xpc_activity_get_state(activity) == XPC_ACTIVITY_STATE_CHECK_IN) {
             NSLog(@"Activity checking in");
@@ -97,6 +99,7 @@ static void registerScheduledActivityHandler()
             xpc_activity_set_criteria(activity, criteria.get());
             return;
         }
+ALLOW_DEPRECATED_DECLARATIONS_END
 
         dispatch_async(dispatch_get_main_queue(), ^{
             NSLog(@"XPC activity happening");


### PR DESCRIPTION
#### afe960e5ca97b3df4bf4fb8718867518779e5f8f
<pre>
Fix build with recent SDKs.
rdar://117076457
<a href="https://bugs.webkit.org/show_bug.cgi?id=263251">https://bugs.webkit.org/show_bug.cgi?id=263251</a>

Unreviewed build fix.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::registerScheduledActivityHandler):

Canonical link: <a href="https://commits.webkit.org/269412@main">https://commits.webkit.org/269412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23d9c66949521f4b9119b47e2e930e61579e9ac4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22509 "Build is being retried. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23588 "Build is being retried. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24414 "Build is being retried. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20838 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/1229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23041 "Build is being retried. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/24414 "Build is being retried. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22749 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/1229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25266 "Build is being retried. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/22693 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/1229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/25266 "Build is being retried. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19595 "Build is being retried. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/1229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/25266 "Build is being retried. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/97 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/23041 "Build is being retried. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22306 "Build is in progress. Recent messages:") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/72 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/115 "Build is being retried. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27206 "Build is in progress. Recent messages:") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2819 "Build is being retried. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Checked out pull request; Running add-reviewer-to-commit-message; Canonicalized commit; Pushed commit to WebKit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/24/builds/27206 "Build is in progress. Recent messages:") | 
<!--EWS-Status-Bubble-End-->