### PR TITLE
[macOS] Block log daemon in the WebContent process

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -232,6 +232,7 @@ function mac_process_webcontent_shared_entitlements()
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" > 140000 ))
         then
+            plistbuddy Add :com.apple.private.disable-log-mach-ports bool YES
             notify_entitlements
         fi
 

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1100,9 +1100,10 @@
 #endif
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-(allow mach-lookup (with telemetry) (global-name
-    "com.apple.logd"
-    "com.apple.logd.events"))
+(with-filter (require-not (require-entitlement "com.apple.private.disable-log-mach-ports"))
+    (allow mach-lookup (global-name
+        "com.apple.logd"
+        "com.apple.logd.events")))
 #else
 (allow mach-lookup (global-name
     "com.apple.logd"


### PR DESCRIPTION
#### 421340cc76a728fba2dc8949c4343ac84292fbb9
<pre>
[macOS] Block log daemon in the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=263253">https://bugs.webkit.org/show_bug.cgi?id=263253</a>
<a href="https://rdar.apple.com/117079468">rdar://117079468</a>

Reviewed by NOBODY (OOPS!).

Logs are now being forwarded from the WebContent process to the Networking process, so we can
block access to the log service in the sandbox.

On macOS, we are entering the sandbox during the initialization of the WebKit child processes,
so we need to add an entitlement to make sure no connections to the log service are being
opened before we enter the sandbox. This is not needed on iOS, since we apply the sandbox
from first instruction there.

* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/421340cc76a728fba2dc8949c4343ac84292fbb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42829 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38116 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22944 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19406 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46648 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20278 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51331 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21791 "Failed to checkout and rebase branch from PR 19168") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45398 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23079 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44355 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23576 "Failed to checkout and rebase branch from PR 19168") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22787 "Failed to checkout and rebase branch from PR 19168") | | | 
<!--EWS-Status-Bubble-End-->