### PR TITLE
Font fallback should ignore generic families for codepoints in PUA

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">
+<style>
+.target {
+    font-family: serif, sans-serif, cursive, fantasy, monospace, system-ui, emoji, math, fangsong, ui-serif, ui-sans-serif, ui-monospace, ui-rounded, 'Times';
+}
+p {
+    font-size: 22px;
+}
+.times {
+    font-family: 'Times';
+}
+</style>
+</head>
+<body>
+"If a given character is a Private-Use Area Unicode codepoint, user agents must only match font families named in the font-family list that are not generic families. If none of the families named in the font-family list contain a glyph for that codepoint, user agents must display some form of missing glyph symbol for that character rather than attempting installed font fallback for that codepoint." - <a href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">css-fonts-4</a>
+<h3>The first line should render as the second. This means that no generic font was used during fallback and the first non generic font was used. </h3>
+<p class="times">&#xE0AD;&#xE0AE;&#xE0AD;&#xE0AF;&#xE0B0;&#xE0B1;&#xE0C0;&#xE0C1;&#xE0D3;&#xE0D4;</p>
+<p class="times">&#xE0AD;&#xE0AE;&#xE0AD;&#xE0AF;&#xE0B0;&#xE0B1;&#xE0C0;&#xE0C1;&#xE0D3;&#xE0D4;</p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">
+<style>
+.target {
+    font-family: serif, sans-serif, cursive, fantasy, monospace, system-ui, emoji, math, fangsong, ui-serif, ui-sans-serif, ui-monospace, ui-rounded, 'Times';
+}
+p {
+    font-size: 22px;
+}
+.times {
+    font-family: 'Times';
+}
+</style>
+</head>
+<body>
+"If a given character is a Private-Use Area Unicode codepoint, user agents must only match font families named in the font-family list that are not generic families. If none of the families named in the font-family list contain a glyph for that codepoint, user agents must display some form of missing glyph symbol for that character rather than attempting installed font fallback for that codepoint." - <a href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">css-fonts-4</a>
+<h3>The first line should render as the second. This means that no generic font was used during fallback and the first non generic font was used. </h3>
+<p class="times">&#xE0AD;&#xE0AE;&#xE0AD;&#xE0AF;&#xE0B0;&#xE0B1;&#xE0C0;&#xE0C1;&#xE0D3;&#xE0D4;</p>
+<p class="times">&#xE0AD;&#xE0AE;&#xE0AD;&#xE0AF;&#xE0B0;&#xE0B1;&#xE0C0;&#xE0C1;&#xE0D3;&#xE0D4;</p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">
+<link rel="match" href="./font-unicode-PUA-ref.html">
+<style>
+.target {
+    font-family: serif, sans-serif, cursive, fantasy, monospace, system-ui, emoji, math, fangsong, ui-serif, ui-sans-serif, ui-monospace, ui-rounded, 'Times';
+}
+p {
+    font-size: 22px;
+}
+.times {
+    font-family: 'Times';
+}
+</style>
+</head>
+<body>
+"If a given character is a Private-Use Area Unicode codepoint, user agents must only match font families named in the font-family list that are not generic families. If none of the families named in the font-family list contain a glyph for that codepoint, user agents must display some form of missing glyph symbol for that character rather than attempting installed font fallback for that codepoint." - <a href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">css-fonts-4</a>
+<h3>The first line should render as the second. This means that no generic font was used during fallback and the first non generic font was used. </h3>
+<p class="target">&#xE0AD;&#xE0AE;&#xE0AD;&#xE0AF;&#xE0B0;&#xE0B1;&#xE0C0;&#xE0C1;&#xE0D3;&#xE0D4;</p>
+<p class="times">&#xE0AD;&#xE0AE;&#xE0AD;&#xE0AF;&#xE0B0;&#xE0B1;&#xE0C0;&#xE0C1;&#xE0D3;&#xE0D4;</p>
+</body>
+</html>

--- a/LayoutTests/platform/mac/fast/text/softbank-emoji-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/softbank-emoji-expected.txt
@@ -5,8 +5,8 @@ layer at (0,0) size 800x246
     RenderBody {BODY} at (8,8) size 784x230
       RenderBlock {DIV} at (0,0) size 784x230
         RenderBlock {DIV} at (0,0) size 784x115
-          RenderText {#text} at (0,0) size 238x115
-            text run at (0,0) width 238: "\x{E001} a \x{E001}"
+          RenderText {#text} at (0,0) size 256x115
+            text run at (0,0) width 256: "\x{E001} a \x{E001}"
         RenderBlock {DIV} at (0,115) size 784x115
-          RenderText {#text} at (0,0) size 64x115
-            text run at (0,0) width 64: "\x{E001}"
+          RenderText {#text} at (0,0) size 73x115
+            text run at (0,0) width 73: "\x{E001}"

--- a/LayoutTests/platform/wpe/fast/text/softbank-emoji-expected.txt
+++ b/LayoutTests/platform/wpe/fast/text/softbank-emoji-expected.txt
@@ -5,8 +5,8 @@ layer at (0,0) size 800x246
     RenderBody {BODY} at (8,8) size 784x230
       RenderBlock {DIV} at (0,0) size 784x230
         RenderBlock {DIV} at (0,0) size 784x115
-          RenderText {#text} at (0,1) size 262x112
-            text run at (0,1) width 262: "\x{E001} a \x{E001}"
+          RenderText {#text} at (0,1) size 268x112
+            text run at (0,1) width 268: "\x{E001} a \x{E001}"
         RenderBlock {DIV} at (0,115) size 784x115
-          RenderText {#text} at (0,1) size 75x112
-            text run at (0,1) width 75: "\x{E001}"
+          RenderText {#text} at (0,1) size 78x112
+            text run at (0,1) width 78: "\x{E001}"

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -382,11 +382,13 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     bool resolveGenericFamilyFirst = familyName == m_fontFamilyNames.at(FamilyNamesIndex::StandardFamily);
 
     AtomString familyForLookup = familyName;
-    std::optional<FontDescription> overrideFontDescription;
+    bool isGeneric = false;
     const FontDescription* fontDescriptionForLookup = &fontDescription;
     auto resolveAndAssignGenericFamily = [&] {
-        if (auto genericFamilyOptional = resolveGenericFamily(fontDescription, familyName))
+        if (auto genericFamilyOptional = resolveGenericFamily(fontDescription, familyName)) {
             familyForLookup = *genericFamilyOptional;
+            isGeneric = true;
+        }
     };
 
     const auto& fontPaletteValues = lookupFontPaletteValues(familyName, fontDescription);
@@ -399,7 +401,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     if (face) {
         if (document && document->settings().webAPIStatisticsEnabled())
             ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), true);
-        return face->fontRanges(*fontDescriptionForLookup, fontPaletteValues, fontFeatureValues);
+        return { face->fontRanges(*fontDescriptionForLookup, fontPaletteValues, fontFeatureValues), isGeneric };
     }
 
     if (!resolveGenericFamilyFirst)
@@ -408,7 +410,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     auto font = FontCache::forCurrentThread().fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues, 1.0 });
     if (document && document->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), !!font);
-    return FontRanges { WTFMove(font) };
+    return { FontRanges { WTFMove(font) }, isGeneric };
 }
 
 void CSSFontSelector::clearFonts()

--- a/Source/WebCore/platform/graphics/FontRanges.cpp
+++ b/Source/WebCore/platform/graphics/FontRanges.cpp
@@ -28,6 +28,7 @@
 
 #include "Font.h"
 #include "FontSelector.h"
+#include "platform/text/CharacterProperties.h"
 #include <wtf/Assertions.h>
 #include <wtf/text/WTFString.h>
 
@@ -38,7 +39,11 @@ const Font* FontRanges::Range::font(ExternalResourceDownloadPolicy policy) const
     return m_fontAccessor->font(policy);
 }
 
-FontRanges::FontRanges() = default;
+FontRanges::FontRanges(FontRanges&& other, bool isGeneric)
+: m_ranges { WTFMove(other.m_ranges) }
+, m_isGeneric { isGeneric }
+{
+}
 
 class TrivialFontAccessor final : public FontAccessor {
 public:
@@ -77,6 +82,9 @@ FontRanges::~FontRanges() = default;
 GlyphData FontRanges::glyphDataForCharacter(UChar32 character, ExternalResourceDownloadPolicy policy) const
 {
     const Font* resultFont = nullptr;
+    if (isGeneric() && isPrivateUseAreaCharacter(character))
+        return GlyphData();
+
     for (auto& range : m_ranges) {
         if (range.from() <= character && character <= range.to()) {
             if (auto* font = range.font(policy)) {
@@ -86,7 +94,7 @@ GlyphData FontRanges::glyphDataForCharacter(UChar32 character, ExternalResourceD
                         resultFont = font;
                 } else {
                     auto glyphData = font->glyphDataForCharacter(character);
-                    if (glyphData.glyph) {
+                    if (glyphData.font) {
                         auto* glyphDataFont = glyphData.font;
                         if (glyphDataFont && glyphDataFont->visibility() == Font::Visibility::Visible && resultFont && resultFont->visibility() == Font::Visibility::Invisible)
                             return GlyphData(glyphData.glyph, &glyphDataFont->invisibleFont());

--- a/Source/WebCore/platform/graphics/FontRanges.h
+++ b/Source/WebCore/platform/graphics/FontRanges.h
@@ -70,11 +70,12 @@ public:
         Ref<FontAccessor> m_fontAccessor;
     };
 
-    FontRanges();
+    FontRanges() = default;
     explicit FontRanges(RefPtr<Font>&&);
     ~FontRanges();
 
     FontRanges(const FontRanges&) = default;
+    FontRanges(FontRanges&& other, bool isGeneric);
     FontRanges& operator=(FontRanges&&) = default;
 
     bool isNull() const { return m_ranges.isEmpty(); }
@@ -89,9 +90,11 @@ public:
     WEBCORE_EXPORT const Font* fontForCharacter(UChar32) const;
     WEBCORE_EXPORT const Font& fontForFirstRange() const;
     bool isLoading() const;
+    bool isGeneric() const { return m_isGeneric; }
 
 private:
     Vector<Range, 1> m_ranges;
+    bool m_isGeneric { false };
 };
 
 }

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -424,8 +424,9 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
         if (rtl())
             characterToWrite = u_charMirror(characterToWrite);
 
-        Glyph glyph;
-        glyph = advanceInternalState.nextRangeFont->glyphForCharacter(characterToWrite);
+        Glyph glyph = glyphData.glyph;
+        if (glyphData.font != advanceInternalState.nextRangeFont || character != characterToWrite)
+            glyph = advanceInternalState.nextRangeFont->glyphForCharacter(characterToWrite);
 
         if (!glyph && !characterMustDrawSomething) {
             commitCurrentFontRange(advanceInternalState);

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -421,7 +421,10 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
     bool triedBaseCharacterFont = false;
 
     for (unsigned i = 0; !fallbackRangesAt(i).isNull(); ++i) {
-        const Font* font = fallbackRangesAt(i).fontForCharacter(baseCharacter);
+        auto& fontRanges = fallbackRangesAt(i);
+        if (fontRanges.isGeneric() && isPrivateUseAreaCharacter(baseCharacter))
+            continue;
+        const Font* font = fontRanges.fontForCharacter(baseCharacter);
         if (!font)
             continue;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/text/CharacterProperties.h
+++ b/Source/WebCore/platform/text/CharacterProperties.h
@@ -98,4 +98,10 @@ inline bool isControlCharacter(UChar32 character)
     return u_charType(character) == U_CONTROL_CHAR;
 }
 
+inline bool isPrivateUseAreaCharacter(UChar32 character)
+{
+    auto block = ublock_getCode(character);
+    return block == UBLOCK_PRIVATE_USE_AREA || block == UBLOCK_SUPPLEMENTARY_PRIVATE_USE_AREA_A || block == UBLOCK_SUPPLEMENTARY_PRIVATE_USE_AREA_B;
+}
+
 }


### PR DESCRIPTION
#### 4535075b56fdb33a076f51fe92cd0bb8832797c8
<pre>
Font fallback should ignore generic families for codepoints in PUA
<a href="https://bugs.webkit.org/show_bug.cgi?id=263261">https://bugs.webkit.org/show_bug.cgi?id=263261</a>
rdar://115901340

Reviewed by Cameron McCormack.

According to spec: <a href="https://drafts.csswg.org/css-fonts-4/#char-handling-issues">https://drafts.csswg.org/css-fonts-4/#char-handling-issues</a>

&quot;If a given character is a Private-Use Area Unicode codepoint, user agents must only match font families named in the font-family list that are not generic families. If none of the families named in the font-family list contain a glyph for that codepoint, user agents must display some form of missing glyph symbol for that character rather than attempting installed font fallback for that codepoint.&quot;

We are currently not ignoring generic font families for font fallback when a code point is in the private-use area (PUA).
This patch changes that. Now FontRanges has a flag to signal that the Font represented by the FontRanges
object came from a generic family. That way, we can skip it during font fallback when finding
the glyph data for a codepoint that is in the private-user area.

After attempting all user-specified font-families, if we couldn&apos;t find a font that can represent such codepoint,
we then use the .notdef glyph (glyph 0) and the last resource font of WebKit for it.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/matching/font-unicode-PUA.html: Added.
* LayoutTests/platform/mac/fast/text/softbank-emoji-expected.txt:
* LayoutTests/platform/wpe/fast/text/softbank-emoji-expected.txt:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::fontRangesForFamily):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::realizeNextFallback):
(WebCore::FontCascadeFonts::glyphDataForVariant):
(WebCore::FontCascadeFonts::glyphDataForCharacter):
* Source/WebCore/platform/graphics/FontRanges.cpp:
(WebCore::FontRanges::FontRanges):
(WebCore::FontRanges::glyphDataForCharacter const):
* Source/WebCore/platform/graphics/FontRanges.h:
(WebCore::FontRanges::isGeneric const):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::advanceInternal):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::fontForCombiningCharacterSequence const):
* Source/WebCore/platform/text/CharacterProperties.h:
(WebCore::isPrivateUseAreaCharacter):

Canonical link: <a href="https://commits.webkit.org/269524@main">https://commits.webkit.org/269524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f3f691eb838d213f1689084d5455b0765f71d17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23343 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25578 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20667 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18172 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5435 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->