### PR TITLE
[run-api-tests] Filter out UITextInteractionAssistant log lines

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -23,6 +23,7 @@
 import os
 import logging
 import time
+import re
 
 from webkitcorepy import string_utils
 from webkitcorepy import TaskPool
@@ -163,6 +164,10 @@ class Runner(object):
 
 class _Worker(object):
     instance = None
+    NOISY_OUTPUT = [
+        re.compile(r'^objc\[.+'),
+        re.compile(r'.+UITextInteractionAssistant selectionView.+'),
+    ]
 
     @classmethod
     def setup(cls, port=None):
@@ -183,8 +188,9 @@ class _Worker(object):
     def _filter_noisy_output(cls, output):
         result = ''
         for line in output.splitlines():
-            if line.lstrip().startswith('objc['):
-                continue
+            for expression in cls.NOISY_OUTPUT:
+                if expression.match(line):
+                    continue
             result += line + '\n'
         return result
 


### PR DESCRIPTION
#### 24dffe7545decff097a7c95505a30c48b12245f0
<pre>
[run-api-tests] Filter out UITextInteractionAssistant log lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=263265">https://bugs.webkit.org/show_bug.cgi?id=263265</a>
rdar://117084270

Reviewed by NOBODY (OOPS!).

* Tools/Scripts/webkitpy/api_tests/runner.py:
(_Worker): Add noisy output regexes.
(_Worker._filter_noisy_output): Use regexes.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24dffe7545decff097a7c95505a30c48b12245f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20849 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21835 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22760 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25279 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/22704 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26655 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24497 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17964 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/79 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->