### PR TITLE
[css-grid] Introduce AncestorSubgridIterator

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2522,6 +2522,7 @@ plugins/DOMPluginArray.cpp
 plugins/PluginData.cpp
 plugins/PluginInfoProvider.cpp
 rendering/AccessibilityRegionContext.cpp
+rendering/AncestorSubgridIterator.cpp
 rendering/AutoTableLayout.cpp
 rendering/BackgroundPainter.cpp
 rendering/BaselineAlignment.cpp

--- a/Source/WebCore/rendering/AncestorSubgridIterator.cpp
+++ b/Source/WebCore/rendering/AncestorSubgridIterator.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AncestorSubgridIterator.h"
+
+#include "RenderIterator.h"
+
+namespace WebCore {
+
+AncestorSubgridIterator::AncestorSubgridIterator() { }
+
+AncestorSubgridIterator::AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, GridTrackSizingDirection direction)
+    : m_firstAncestorSubgrid(firstAncestorSubgrid)
+    , m_direction(direction)
+{
+    ASSERT_IMPLIES(firstAncestorSubgrid,  firstAncestorSubgrid->isSubgrid(direction));
+}
+
+
+AncestorSubgridIterator::AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, WeakPtr<RenderGrid> currentAncestorSubgrid, GridTrackSizingDirection direction)
+    : m_firstAncestorSubgrid(firstAncestorSubgrid)
+    , m_currentAncestorSubgrid(currentAncestorSubgrid)
+    , m_direction(direction)
+{
+    ASSERT_IMPLIES(firstAncestorSubgrid, firstAncestorSubgrid->isSubgrid(direction));
+}
+
+AncestorSubgridIterator::AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, WeakPtr<RenderGrid> currentAncestorSubgrid, std::optional<GridTrackSizingDirection> direction)
+    : m_firstAncestorSubgrid(firstAncestorSubgrid)
+    , m_currentAncestorSubgrid(currentAncestorSubgrid)
+    , m_direction(direction)
+{
+}
+
+AncestorSubgridIterator AncestorSubgridIterator::begin()
+{
+    return AncestorSubgridIterator(m_firstAncestorSubgrid, m_firstAncestorSubgrid, m_direction);
+}
+
+AncestorSubgridIterator AncestorSubgridIterator::end()
+{
+    return AncestorSubgridIterator(m_firstAncestorSubgrid, nullptr, m_direction);
+}
+
+AncestorSubgridIterator& AncestorSubgridIterator::operator++()
+{
+    ASSERT(m_firstAncestorSubgrid && m_currentAncestorSubgrid && m_direction);
+
+    if (m_firstAncestorSubgrid && m_currentAncestorSubgrid && m_direction) {
+        auto nextAncestor = RenderTraversal::findAncestorOfType<RenderGrid>(*m_currentAncestorSubgrid);
+        m_currentAncestorSubgrid = (nextAncestor && nextAncestor->isSubgrid(GridLayoutFunctions::flowAwareDirectionForChild(*nextAncestor, *m_firstAncestorSubgrid, m_direction.value()))) ? nextAncestor : nullptr;
+    }
+    return *this;
+}
+
+RenderGrid& AncestorSubgridIterator::operator*()
+{
+    ASSERT(m_currentAncestorSubgrid);
+    return *m_currentAncestorSubgrid;
+}
+
+bool AncestorSubgridIterator::operator==(const AncestorSubgridIterator& other) const
+{
+    return m_currentAncestorSubgrid == other.m_currentAncestorSubgrid && m_firstAncestorSubgrid == other.m_firstAncestorSubgrid && m_direction == other.m_direction;
+}
+
+AncestorSubgridIterator ancestorSubgridsOfGridItem(const RenderBox& gridItem,  const GridTrackSizingDirection direction)
+{
+    ASSERT(gridItem.parent()->isRenderGrid());
+    if (const auto* gridItemParent = dynamicDowncast<RenderGrid>(gridItem.parent()); gridItemParent && gridItemParent->isSubgrid(direction))
+        return AncestorSubgridIterator(gridItemParent, direction);
+    return AncestorSubgridIterator();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/AncestorSubgridIterator.h
+++ b/Source/WebCore/rendering/AncestorSubgridIterator.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GridPositionsResolver.h"
+#include "RenderGrid.h"
+
+class RenderGrid;
+
+namespace WebCore {
+
+class AncestorSubgridIterator {
+public:
+    AncestorSubgridIterator();
+    AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, GridTrackSizingDirection);
+
+    RenderGrid& operator*();
+
+    bool operator==(const AncestorSubgridIterator&) const;
+
+    AncestorSubgridIterator& operator++();
+    AncestorSubgridIterator begin();
+    AncestorSubgridIterator end();
+private:
+    AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, WeakPtr<RenderGrid> currentAncestor, GridTrackSizingDirection);
+    AncestorSubgridIterator(WeakPtr<RenderGrid> firstAncestorSubgrid, WeakPtr<RenderGrid> currentAncestor, std::optional<GridTrackSizingDirection>);
+
+    const WeakPtr<const RenderGrid> m_firstAncestorSubgrid;
+    WeakPtr<RenderGrid> m_currentAncestorSubgrid { nullptr };
+    const std::optional<GridTrackSizingDirection> m_direction;
+
+};
+
+AncestorSubgridIterator ancestorSubgridsOfGridItem(const RenderBox& gridItem, const GridTrackSizingDirection);
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "GridLayoutFunctions.h"
 
+#include "AncestorSubgridIterator.h"
 #include "LengthFunctions.h"
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
@@ -104,24 +105,11 @@ static LayoutUnit extraMarginForSubgrid(const RenderGrid& parent, unsigned start
 
 LayoutUnit extraMarginForSubgridAncestors(GridTrackSizingDirection direction, const RenderBox& child)
 {
-    const RenderGrid* grid = downcast<RenderGrid>(child.parent());
     LayoutUnit mbp;
-
-    while (grid->isSubgrid(direction)) {
-        GridSpan span = grid->gridSpanForChild(child, direction);
-
-        mbp += extraMarginForSubgrid(*grid, span.startLine(), span.endLine(), direction);
-
-        const RenderElement* parent = grid->parent();
-        if (!parent || !is<RenderGrid>(parent))
-            break;
-
-        const RenderGrid* parentGrid = downcast<RenderGrid>(parent);
-        direction = flowAwareDirectionForParent(*grid, *parentGrid, direction);
-
-        grid = parentGrid;
+    for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(child, direction)) {
+        GridSpan span = currentAncestorSubgrid.gridSpanForChild(child, direction);
+        mbp += extraMarginForSubgrid(currentAncestorSubgrid, span.startLine(), span.endLine(), direction);
     }
-
     return mbp;
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -35,6 +35,8 @@
 #include "RenderSVGShapeInlines.h"
 #include "RenderStyleInlines.h"
 #include "SVGPathElement.h"
+#include "SVGResources.h"
+#include "SVGResourcesCache.h"
 #include "SVGSubpathData.h"
 #include <wtf/IsoMallocInlines.h>
 


### PR DESCRIPTION
#### dfe2536d72733b14b2167988444f227ac3ca799f
<pre>
[css-grid] Introduce AncestorSubgridIterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=263262">https://bugs.webkit.org/show_bug.cgi?id=263262</a>
rdar://117083828

Reviewed by Matt Woodrow.

This patch adds an iterator that can be used to traverse a chain of
ancestor subgrids and also uses it in a few different places where it
can be used. The iterator is very similar to the RenderAncestorIterator,
but the main difference is that we need to check if the next ancestor
we are traversing is a subgrid in the appropriate direction.

There are two main ways to use the iterator:
1.) Providing the first subgrid ancestor that will be used in the
traversal along with the traversal direction.

2.) Using the ancestorSubgridsOfGridItem helper function. This is
useful when you have a subgridded item that you want to traverse the
ancestor subgrids of.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/AncestorSubgridIterator.cpp: Added.
(WebCore::AncestorSubgridIterator::AncestorSubgridIterator):
(WebCore::AncestorSubgridIterator::begin):
(WebCore::AncestorSubgridIterator::end):
(WebCore::AncestorSubgridIterator::operator++):
(WebCore::AncestorSubgridIterator::operator*):
(WebCore::AncestorSubgridIterator::operator== const):
(WebCore::ancestorSubgridsOfGridItem):
* Source/WebCore/rendering/AncestorSubgridIterator.h: Added.
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::extraMarginForSubgridAncestors):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):
* Source/WebCore/rendering/style/GridPositionsResolver.cpp:
(WebCore::NamedLineCollection::NamedLineCollection):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:

Canonical link: <a href="https://commits.webkit.org/269443@main">https://commits.webkit.org/269443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9bd4b56bad07b76f576e08e17a348f68d51fd7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21840 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22767 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25286 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26671 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24504 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17969 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/85 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5375 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->