### PR TITLE
Adopt more smart pointers in WebCore/

### DIFF
--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -65,36 +65,33 @@ EncodedJSValue constructJSHTMLElement(JSGlobalObject* lexicalGlobalObject, CallF
     if (newTarget == htmlElementConstructorValue)
         return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);
 
-    auto& document = downcast<Document>(*context);
+    Ref document = downcast<Document>(*context);
 
-    auto* window = document.domWindow();
+    RefPtr window = document->domWindow();
     if (!window)
         return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);
 
-    auto* registry = window->customElementRegistry();
+    RefPtr registry = window->customElementRegistry();
     if (!registry)
         return throwVMTypeError(lexicalGlobalObject, scope, "new.target is not a valid custom element constructor"_s);
 
-    auto* elementInterface = registry->findInterface(newTarget);
+    RefPtr elementInterface = registry->findInterface(newTarget);
     if (!elementInterface)
         return throwVMTypeError(lexicalGlobalObject, scope, "new.target does not define a custom element"_s);
 
     if (!elementInterface->isUpgradingElement()) {
-        Ref<Document> protectedDocument(document);
-        Ref<JSCustomElementInterface> protectedElementInterface(*elementInterface);
-
         Structure* baseStructure = getDOMStructure<JSHTMLElement>(vm, *newTargetGlobalObject);
         auto* newElementStructure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure);
         RETURN_IF_EXCEPTION(scope, { });
 
-        Ref<HTMLElement> element = elementInterface->createElement(document);
+        Ref element = elementInterface->createElement(document);
         element->setIsDefinedCustomElement(*elementInterface);
         auto* jsElement = JSHTMLElement::create(newElementStructure, newTargetGlobalObject, element.get());
         cacheWrapper(newTargetGlobalObject->world(), element.ptr(), jsElement);
         return JSValue::encode(jsElement);
     }
 
-    Element* elementToUpgrade = elementInterface->lastElementInConstructionStack();
+    RefPtr elementToUpgrade = elementInterface->lastElementInConstructionStack();
     if (!elementToUpgrade) {
         throwTypeError(lexicalGlobalObject, scope, "Cannot instantiate a custom element inside its own constructor during upgrades"_s);
         return JSValue::encode(jsUndefined());

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -63,6 +63,7 @@ public:
     void replaceAll(Node*);
 
     ContainerNode& rootNode() const { return downcast<ContainerNode>(Node::rootNode()); }
+    Ref<ContainerNode> protectedRootNode() const { return downcast<ContainerNode>(Node::rootNode()); }
 
     // These methods are only used during parsing.
     // They don't send DOM mutation events or handle reparenting.

--- a/Source/WebCore/dom/CurrentScriptIncrementer.h
+++ b/Source/WebCore/dom/CurrentScriptIncrementer.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <wtf/CheckedRef.h>
 #include "Document.h"
 #include "ScriptElement.h"
 
@@ -40,16 +41,18 @@ public:
         : m_document(document)
     {
         bool shouldPushNullForCurrentScript = scriptElement.element().isInShadowTree() || scriptElement.scriptType() != ScriptType::Classic;
-        m_document.pushCurrentScript(shouldPushNullForCurrentScript ? nullptr : &scriptElement.element());
+        protectedDocument()->pushCurrentScript(shouldPushNullForCurrentScript ? nullptr : &scriptElement.element());
     }
 
     ~CurrentScriptIncrementer()
     {
-        m_document.popCurrentScript();
+        protectedDocument()->popCurrentScript();
     }
 
 private:
-    Document& m_document;
+    Ref<Document> protectedDocument() const { return m_document.get(); }
+
+    CheckedRef<Document> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -47,7 +47,7 @@ void CustomElementDefaultARIA::setValueForAttribute(const QualifiedName& name, c
 
 static bool isElementVisible(const Element& element, const Element& thisElement)
 {
-    return !element.isConnected() || element.isInDocumentTree() || thisElement.isDescendantOrShadowDescendantOf(element.rootNode());
+    return !element.isConnected() || element.isInDocumentTree() || thisElement.isDescendantOrShadowDescendantOf(element.protectedRootNode());
 }
 
 const AtomString& CustomElementDefaultARIA::valueForAttribute(const Element& thisElement, const QualifiedName& name) const
@@ -56,14 +56,14 @@ const AtomString& CustomElementDefaultARIA::valueForAttribute(const Element& thi
     if (it == m_map.end())
         return nullAtom();
 
-    const AtomString* result = &nullAtom();
-    std::visit(WTF::makeVisitor([&](const AtomString& stringValue) {
-        result = &stringValue;
-    }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) {
+    return std::visit(WTF::makeVisitor([&](const AtomString& stringValue) -> const AtomString& {
+        return stringValue;
+    }, [&](const WeakPtr<Element, WeakPtrImplWithEventTargetData>& weakElementValue) -> const AtomString& {
         RefPtr elementValue = weakElementValue.get();
         if (elementValue && isElementVisible(*elementValue, thisElement))
-            result = &elementValue->attributeWithoutSynchronization(HTMLNames::idAttr);
-    }, [&](const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& elements) {
+            return elementValue->attributeWithoutSynchronization(HTMLNames::idAttr);
+        return nullAtom();
+    }, [&](const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& elements) -> const AtomString& {
         StringBuilder idList;
         for (auto& weakElement : elements) {
             RefPtr element = weakElement.get();
@@ -73,9 +73,9 @@ const AtomString& CustomElementDefaultARIA::valueForAttribute(const Element& thi
                 idList.append(element->attributeWithoutSynchronization(HTMLNames::idAttr));
             }
         }
+        // FIXME: This should probably be using the idList we just built.
+        return nullAtom();
     }), it->value);
-
-    return *result;
 }
 
 bool CustomElementDefaultARIA::hasAttribute(const QualifiedName& name) const
@@ -144,7 +144,7 @@ void CustomElementDefaultARIA::setElementsForAttribute(const QualifiedName& name
             elements.append(WeakPtr<Element, WeakPtrImplWithEventTargetData> { *element });
         }
     }
-    m_map.set(name, elements);
+    m_map.set(name, WTFMove(elements));
 }
 
-}; // namespace WebCore
+} // namespace WebCore

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -142,15 +142,15 @@ void CustomElementReactionQueue::tryToUpgradeElement(Element& element)
 {
     ASSERT(CustomElementReactionDisallowedScope::isReactionAllowed());
     ASSERT(element.isCustomElementUpgradeCandidate());
-    auto* window = element.document().domWindow();
+    RefPtr window = element.document().domWindow();
     if (!window)
         return;
 
-    auto* registry = window->customElementRegistry();
+    RefPtr registry = window->customElementRegistry();
     if (!registry)
         return;
 
-    auto* elementInterface = registry->findInterface(element);
+    RefPtr elementInterface = registry->findInterface(element);
     if (!elementInterface)
         return;
 
@@ -337,8 +337,8 @@ inline void CustomElementQueue::invokeAll()
     // It's possible for more elements to be enqueued if some IDL attributes were missing CEReactions.
     // Invoke callbacks slightly later here instead of crashing / ignoring those cases.
     for (unsigned i = 0; i < m_elements.size(); ++i) {
-        auto& element = m_elements[i].get();
-        auto* queue = element.reactionQueue();
+        Ref element = m_elements[i].get();
+        auto* queue = element->reactionQueue();
         ASSERT(queue);
         queue->invokeAll(element);
     }
@@ -393,9 +393,9 @@ void CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue(Element
         return;
     }
 
-    auto*& queue = CustomElementReactionStack::s_currentProcessingStack->m_queue;
-    if (!queue) // We use a raw pointer to avoid genearing code to delete it in ~CustomElementReactionStack.
-        queue = new CustomElementQueue;
+    auto& queue = CustomElementReactionStack::s_currentProcessingStack->m_queue;
+    if (!queue)
+        queue = makeUnique<CustomElementQueue>();
     queue->add(element);
 }
 
@@ -409,7 +409,6 @@ void CustomElementReactionStack::processQueue(JSC::JSGlobalObject* state)
 {
     ASSERT(m_queue);
     m_queue->processQueue(state);
-    delete m_queue;
     m_queue = nullptr;
 }
 
@@ -418,7 +417,6 @@ Vector<GCReachableRef<Element>, 4> CustomElementReactionStack::takeElements()
     if (!m_queue)
         return { };
     auto elements = m_queue->takeElements();
-    delete m_queue;
     m_queue = nullptr;
     return elements;
 }

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -99,7 +99,7 @@ class CustomElementQueue {
     WTF_MAKE_NONCOPYABLE(CustomElementQueue);
 public:
     CustomElementQueue();
-    ~CustomElementQueue();
+    WEBCORE_EXPORT ~CustomElementQueue();
 
     void add(Element&);
     void processQueue(JSC::JSGlobalObject*);
@@ -233,7 +233,7 @@ public:
 private:
     WEBCORE_EXPORT void processQueue(JSC::JSGlobalObject*);
 
-    CustomElementQueue* m_queue { nullptr }; // Use raw pointer to avoid generating delete in the destructor.
+    std::unique_ptr<CustomElementQueue> m_queue;
     CustomElementReactionStack* const m_previousProcessingStack;
     JSC::JSGlobalObject* const m_state;
 

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -58,16 +58,16 @@ CustomElementRegistry::~CustomElementRegistry() = default;
 
 Document* CustomElementRegistry::document() const
 {
-    return m_window.document();
+    return m_window ? m_window->document() : nullptr;
 }
 
 // https://dom.spec.whatwg.org/#concept-shadow-including-tree-order
 static void enqueueUpgradeInShadowIncludingTreeOrder(ContainerNode& node, JSCustomElementInterface& elementInterface)
 {
-    for (Element* element = ElementTraversal::firstWithin(node); element; element = ElementTraversal::next(*element)) {
+    for (RefPtr element = ElementTraversal::firstWithin(node); element; element = ElementTraversal::next(*element)) {
         if (element->isCustomElementUpgradeCandidate() && element->tagQName().matches(elementInterface.name()))
             element->enqueueToUpgrade(elementInterface);
-        if (auto* shadowRoot = element->shadowRoot()) {
+        if (RefPtr shadowRoot = element->shadowRoot()) {
             if (shadowRoot->mode() != ShadowRootMode::UserAgent)
                 enqueueUpgradeInShadowIncludingTreeOrder(*shadowRoot, elementInterface);
         }
@@ -89,7 +89,7 @@ RefPtr<DeferredPromise> CustomElementRegistry::addElementDefinition(Ref<JSCustom
     if (elementInterface->isShadowDisabled())
         m_disabledShadowSet.add(localName);
 
-    if (auto* document = m_window.document()) {
+    if (RefPtr document = this->document()) {
         // ungap/@custom-elements detection for quirk (rdar://problem/111008826).
         if (localName == extendsLi.get())
             document->quirks().setNeedsConfigurableIndexedPropertiesQuirk();
@@ -116,7 +116,7 @@ JSCustomElementInterface* CustomElementRegistry::findInterface(const AtomString&
     return m_nameMap.get(name);
 }
 
-JSCustomElementInterface* CustomElementRegistry::findInterface(const JSC::JSObject* constructor) const
+RefPtr<JSCustomElementInterface> CustomElementRegistry::findInterface(const JSC::JSObject* constructor) const
 {
     Locker locker { m_constructorMapLock };
     return m_constructorMap.get(constructor);
@@ -130,7 +130,7 @@ bool CustomElementRegistry::containsConstructor(const JSC::JSObject* constructor
 
 JSC::JSValue CustomElementRegistry::get(const AtomString& name)
 {
-    if (auto* elementInterface = m_nameMap.get(name))
+    if (RefPtr elementInterface = m_nameMap.get(name))
         return elementInterface->constructor();
     return JSC::jsUndefined();
 }
@@ -140,7 +140,7 @@ String CustomElementRegistry::getName(JSC::JSValue constructorValue)
     auto* constructor = constructorValue.getObject();
     if (!constructor)
         return String { };
-    auto* elementInterface = findInterface(constructor);
+    RefPtr elementInterface = findInterface(constructor);
     if (!elementInterface)
         return String { };
     return elementInterface->name().localName();
@@ -148,10 +148,10 @@ String CustomElementRegistry::getName(JSC::JSValue constructorValue)
 
 static void upgradeElementsInShadowIncludingDescendants(ContainerNode& root)
 {
-    for (auto& element : descendantsOfType<Element>(root)) {
-        if (element.isCustomElementUpgradeCandidate())
+    for (Ref element : descendantsOfType<Element>(root)) {
+        if (element->isCustomElementUpgradeCandidate())
             CustomElementReactionQueue::tryToUpgradeElement(element);
-        if (auto* shadowRoot = element.shadowRoot())
+        if (RefPtr shadowRoot = element->shadowRoot())
             upgradeElementsInShadowIncludingDescendants(*shadowRoot);
     }
 }

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -30,6 +30,7 @@
 #include <wtf/Lock.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/RobinHoodHashSet.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -66,7 +67,7 @@ public:
     JSCustomElementInterface* findInterface(const Element&) const;
     JSCustomElementInterface* findInterface(const QualifiedName&) const;
     JSCustomElementInterface* findInterface(const AtomString&) const;
-    JSCustomElementInterface* findInterface(const JSC::JSObject*) const;
+    RefPtr<JSCustomElementInterface> findInterface(const JSC::JSObject*) const;
     bool containsConstructor(const JSC::JSObject*) const;
 
     JSC::JSValue get(const AtomString&);
@@ -80,7 +81,7 @@ public:
 private:
     CustomElementRegistry(LocalDOMWindow&, ScriptExecutionContext*);
 
-    LocalDOMWindow& m_window;
+    WeakPtr<LocalDOMWindow, WeakPtrImplWithEventTargetData> m_window;
     HashMap<AtomString, Ref<JSCustomElementInterface>> m_nameMap;
     HashMap<const JSC::JSObject*, JSCustomElementInterface*> m_constructorMap WTF_GUARDED_BY_LOCK(m_constructorMapLock);
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>> m_promiseMap;

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -118,20 +118,21 @@ static AtomString convertPropertyNameToAttributeName(const String& name)
 
 void DatasetDOMStringMap::ref()
 {
-    m_element.ref();
+    m_element->ref();
 }
 
 void DatasetDOMStringMap::deref()
 {
-    m_element.deref();
+    m_element->deref();
 }
 
 bool DatasetDOMStringMap::isSupportedPropertyName(const String& propertyName) const
 {
-    if (!m_element.hasAttributes())
+    Ref element = m_element.get();
+    if (!element->hasAttributes())
         return false;
 
-    auto attributeIteratorAccessor = m_element.attributesIterator();
+    auto attributeIteratorAccessor = element->attributesIterator();
     if (attributeIteratorAccessor.attributeCount() == 1) {
         // Avoid creating AtomString when there is only one attribute.
         const auto& attribute = *attributeIteratorAccessor.begin();
@@ -152,10 +153,11 @@ Vector<String> DatasetDOMStringMap::supportedPropertyNames() const
 {
     Vector<String> names;
 
-    if (!m_element.hasAttributes())
+    Ref element = m_element.get();
+    if (!element->hasAttributes())
         return names;
 
-    for (auto& attribute : m_element.attributesIterator()) {
+    for (auto& attribute : element->attributesIterator()) {
         if (isValidAttributeName(attribute.localName()))
             names.append(convertAttributeNameToPropertyName(attribute.localName()));
     }
@@ -165,8 +167,9 @@ Vector<String> DatasetDOMStringMap::supportedPropertyNames() const
 
 const AtomString* DatasetDOMStringMap::item(const String& propertyName) const
 {
-    if (m_element.hasAttributes()) {
-        AttributeIteratorAccessor attributeIteratorAccessor = m_element.attributesIterator();
+    Ref element = m_element.get();
+    if (element->hasAttributes()) {
+        AttributeIteratorAccessor attributeIteratorAccessor = element->attributesIterator();
 
         if (attributeIteratorAccessor.attributeCount() == 1) {
             // Avoid creating AtomString when there is only one attribute.
@@ -196,12 +199,17 @@ ExceptionOr<void> DatasetDOMStringMap::setNamedItem(const String& name, const At
 {
     if (!isValidPropertyName(name))
         return Exception { SyntaxError };
-    return m_element.setAttribute(convertPropertyNameToAttributeName(name), value);
+    return protectedElement()->setAttribute(convertPropertyNameToAttributeName(name), value);
 }
 
 bool DatasetDOMStringMap::deleteNamedProperty(const String& name)
 {
-    return m_element.removeAttribute(convertPropertyNameToAttributeName(name));
+    return protectedElement()->removeAttribute(convertPropertyNameToAttributeName(name));
+}
+
+Ref<Element> DatasetDOMStringMap::protectedElement() const
+{
+    return m_element.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DatasetDOMStringMap.h
+++ b/Source/WebCore/dom/DatasetDOMStringMap.h
@@ -27,6 +27,7 @@
 
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -50,12 +51,13 @@ public:
     ExceptionOr<void> setNamedItem(const String& name, const AtomString& value);
     bool deleteNamedProperty(const String& name);
 
-    Element& element() { return m_element; }
+    Element& element() { return m_element.get(); }
+    Ref<Element> protectedElement() const;
 
 private:
     const AtomString* item(const String& name) const;
 
-    Element& m_element;
+    CheckedRef<Element> m_element;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9e25f5119e3b28d5b60d91aefb59847295d99f1b
<pre>
Adopt more smart pointers in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=263268">https://bugs.webkit.org/show_bug.cgi?id=263268</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::protectedRootNode const):
* Source/WebCore/dom/CurrentScriptIncrementer.h:
(WebCore::CurrentScriptIncrementer::CurrentScriptIncrementer):
(WebCore::CurrentScriptIncrementer::~CurrentScriptIncrementer):
(WebCore::CurrentScriptIncrementer::protectedDocument const):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::isElementVisible):
(WebCore::CustomElementDefaultARIA::valueForAttribute const):
(WebCore::CustomElementDefaultARIA::setElementsForAttribute):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::tryToUpgradeElement):
(WebCore::CustomElementQueue::invokeAll):
(WebCore::CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue):
(WebCore::CustomElementReactionStack::processQueue):
(WebCore::CustomElementReactionStack::takeElements):
* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::document const):
(WebCore::enqueueUpgradeInShadowIncludingTreeOrder):
(WebCore::CustomElementRegistry::addElementDefinition):
(WebCore::CustomElementRegistry::get):
(WebCore::CustomElementRegistry::getName):
(WebCore::upgradeElementsInShadowIncludingDescendants):
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::DatasetDOMStringMap::ref):
(WebCore::DatasetDOMStringMap::deref):
(WebCore::DatasetDOMStringMap::isSupportedPropertyName const):
(WebCore::DatasetDOMStringMap::supportedPropertyNames const):
(WebCore::DatasetDOMStringMap::item const):
(WebCore::DatasetDOMStringMap::setNamedItem):
(WebCore::DatasetDOMStringMap::deleteNamedProperty):
(WebCore::DatasetDOMStringMap::protectedElement const):
* Source/WebCore/dom/DatasetDOMStringMap.h:

Canonical link: <a href="https://commits.webkit.org/269465@main">https://commits.webkit.org/269465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccdb4b16effd5a21fd83e4cc8f758d74053751e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24438 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21845 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22771 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25290 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26676 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24508 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17974 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/86 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5389 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->