### PR TITLE
Drop redundant check in `skipOptionalSVGSpacesOrDelimiter`

### DIFF
--- a/Source/WebCore/svg/SVGParserUtilities.h
+++ b/Source/WebCore/svg/SVGParserUtilities.h
@@ -98,7 +98,7 @@ template<typename CharacterType> constexpr bool skipOptionalSVGSpacesOrDelimiter
     if (characters.hasCharactersRemaining() && !isSVGSpace(*characters) && *characters != delimiter)
         return false;
     if (skipOptionalSVGSpaces(characters)) {
-        if (characters.hasCharactersRemaining() && *characters == delimiter) {
+        if (*characters == delimiter) {
             characters++;
             skipOptionalSVGSpaces(characters);
         }


### PR DESCRIPTION
#### 56bcdb9d373033e3326d00b30c0f679dffb06a5f
<pre>
Drop redundant check in `skipOptionalSVGSpacesOrDelimiter`

<a href="https://bugs.webkit.org/show_bug.cgi?id=263272">https://bugs.webkit.org/show_bug.cgi?id=263272</a>

Reviewed by Simon Fraser.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/2642784">https://chromium-review.googlesource.com/c/chromium/src/+/2642784</a>

skipOptionalSVGSpaces() returns true if this condition (m_position &lt; m_end) is
true, so we don&apos;t need to check it again.

* Source/WebCore/svg/SVGParserUtilities.h:
(skipOptionalSVGSpacesOrDelimiter):

Canonical link: <a href="https://commits.webkit.org/269478@main">https://commits.webkit.org/269478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/983b5a87d826faf34b12958d598bfa181b17cdc6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22796 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/1443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21847 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22776 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/1443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25295 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/136 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26684 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/1443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24514 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/17978 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/88 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5398 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/138 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->