### PR TITLE
Fix flaky drag and drop test

### DIFF
--- a/LayoutTests/editing/pasteboard/datatransfer-types-dropping-text-file-promise.html
+++ b/LayoutTests/editing/pasteboard/datatransfer-types-dropping-text-file-promise.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html>
-<body>
+<body onload="onLoad()">
 <div id="target" contentEditable="true" ondrop="check(event)"></div>
 <script src="../../resources/js-test-pre.js"></script>
 <script>
 description('When dropping a file promise, dataTransfer.types must contain "Files" and not "text/uri-list". This test requires eventSender.beginDragWithFilePromises.');
 
 function runTest() {
-    jsTestIsAsync = true;
     const target = document.getElementById('target');
     eventSender.beginDragWithFilePromises(['../resources/abe.png']);
     eventSender.mouseMoveTo(target.offsetLeft + 5, target.offsetTop + 5);
@@ -22,12 +21,16 @@ function check(event) {
     finishJSTest();
 }
 
-if (window.eventSender)
-    runTest();
-else
-    testFailed('This test requires eventSender.beginDragWithFilePromises');
+function onLoad() {
+    if (window.eventSender)
+        runTest();
+    else
+        testFailed('This test requires eventSender.beginDragWithFilePromises');
+}
 
+jsTestIsAsync = true;
 var successfullyParsed = true;
+
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -18,7 +18,7 @@ editing/pasteboard/data-transfer-set-data-sanitize-html-when-dragging-in-null-or
 editing/pasteboard/data-transfer-set-data-sanitize-url-when-dragging-in-null-origin.html [ Pass ]
 editing/pasteboard/data-transfer-item-list-add-file-on-drag.html [ Pass ]
 editing/pasteboard/datatransfer-items-drop-plaintext-file-promise.html [ Pass ]
-webkit.org/b/261318 editing/pasteboard/datatransfer-types-dropping-text-file-promise.html [ Pass Failure ] # change this back to "Pass" once fixed
+editing/pasteboard/datatransfer-types-dropping-text-file-promise.html [ Pass ]
 editing/pasteboard/drag-drop-href-as-url.html [ Pass ]
 editing/pasteboard/drag-end-crash-accessing-item-list.html [ Pass ]
 editing/pasteboard/drag-file-promises-to-editable-element-as-URLs.html [ Pass ]


### PR DESCRIPTION
#### df3d039f2f080e67eb94d694889303a29113a176
<pre>
Fix flaky drag and drop test
<a href="https://bugs.webkit.org/show_bug.cgi?id=263279">https://bugs.webkit.org/show_bug.cgi?id=263279</a>
rdar://115155299

Reviewed by Brent Fulgham and Ryosuke Niwa.

Start the test in the body&apos;s onload handler when everything has been parsed, since 261705@main
changed behavior in HTML parser yielding.

* LayoutTests/editing/pasteboard/datatransfer-types-dropping-text-file-promise.html:
* LayoutTests/platform/mac-wk1/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269475@main">https://commits.webkit.org/269475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/883ebcfc67428d93d0afe5a0f137d16dc98fb31c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20976 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23187 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22897 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25419 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26773 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24610 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18066 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20336 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5397 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->