### PR TITLE
Adopt more smart pointers in the Element class

### DIFF
--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -114,7 +114,8 @@ public:
 
     void disconnectDescendantFrames();
 
-    RenderElement* renderer() const;
+    inline RenderElement* renderer() const; // Defined in RenderElement.h.
+    inline CheckedPtr<RenderElement> checkedRenderer() const; // Defined in RenderElement.h.
 
     // Return a bounding box in absolute coordinates enclosing this node and all its descendants.
     // This gives the area within which events may get handled by a hander registered on this node.

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -165,9 +165,9 @@ static_assert(sizeof(Element) == sizeof(SameSizeAsElement), "Element should stay
 using namespace HTMLNames;
 using namespace XMLNames;
 
-static HashMap<Element*, Vector<RefPtr<Attr>>>& attrNodeListMap()
+static HashMap<CheckedRef<Element>, Vector<RefPtr<Attr>>>& attrNodeListMap()
 {
-    static NeverDestroyed<HashMap<Element*, Vector<RefPtr<Attr>>>> map;
+    static NeverDestroyed<HashMap<CheckedRef<Element>, Vector<RefPtr<Attr>>>> map;
     return map;
 }
 
@@ -175,26 +175,26 @@ static Vector<RefPtr<Attr>>* attrNodeListForElement(Element& element)
 {
     if (!element.hasSyntheticAttrChildNodes())
         return nullptr;
-    ASSERT(attrNodeListMap().contains(&element));
-    return &attrNodeListMap().find(&element)->value;
+    ASSERT(attrNodeListMap().contains(element));
+    return &attrNodeListMap().find(element)->value;
 }
 
 static Vector<RefPtr<Attr>>& ensureAttrNodeListForElement(Element& element)
 {
     if (element.hasSyntheticAttrChildNodes()) {
-        ASSERT(attrNodeListMap().contains(&element));
-        return attrNodeListMap().find(&element)->value;
+        ASSERT(attrNodeListMap().contains(element));
+        return attrNodeListMap().find(element)->value;
     }
-    ASSERT(!attrNodeListMap().contains(&element));
+    ASSERT(!attrNodeListMap().contains(element));
     element.setHasSyntheticAttrChildNodes(true);
-    return attrNodeListMap().add(&element, Vector<RefPtr<Attr>>()).iterator->value;
+    return attrNodeListMap().add(element, Vector<RefPtr<Attr>>()).iterator->value;
 }
 
 static void removeAttrNodeListForElement(Element& element)
 {
     ASSERT(element.hasSyntheticAttrChildNodes());
-    ASSERT(attrNodeListMap().contains(&element));
-    attrNodeListMap().remove(&element);
+    ASSERT(attrNodeListMap().contains(element));
+    attrNodeListMap().remove(element);
     element.setHasSyntheticAttrChildNodes(false);
 }
 
@@ -222,29 +222,29 @@ static bool shouldAutofocus(const Element& element)
     if (!element.hasAttributeWithoutSynchronization(HTMLNames::autofocusAttr))
         return false;
 
-    auto& document = element.document();
-    if (!element.isInDocumentTree() || !document.hasBrowsingContext())
+    Ref document = element.document();
+    if (!element.isInDocumentTree() || !document->hasBrowsingContext())
         return false;
 
-    if (document.isSandboxed(SandboxAutomaticFeatures)) {
+    if (document->isSandboxed(SandboxAutomaticFeatures)) {
         // FIXME: This message should be moved off the console once a solution to https://bugs.webkit.org/show_bug.cgi?id=103274 exists.
-        document.addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked autofocusing on a form control because the form's frame is sandboxed and the 'allow-scripts' permission is not set."_s);
+        document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked autofocusing on a form control because the form's frame is sandboxed and the 'allow-scripts' permission is not set."_s);
         return false;
     }
-    if (!document.frame()->isMainFrame() && !document.topOrigin().isSameOriginDomain(document.securityOrigin())) {
-        document.addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked autofocusing on a form control in a cross-origin subframe."_s);
+    if (!document->frame()->isMainFrame() && !document->topOrigin().isSameOriginDomain(document->securityOrigin())) {
+        document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked autofocusing on a form control in a cross-origin subframe."_s);
         return false;
     }
 
-    if (document.topDocument().isAutofocusProcessed())
+    if (document->topDocument().isAutofocusProcessed())
         return false;
 
     return true;
 }
 
-static HashMap<CheckedPtr<Element>, ElementIdentifier>& elementIdentifiersMap()
+static HashMap<CheckedRef<Element>, ElementIdentifier>& elementIdentifiersMap()
 {
-    static MainThreadNeverDestroyed<HashMap<CheckedPtr<Element>, ElementIdentifier>> map;
+    static MainThreadNeverDestroyed<HashMap<CheckedRef<Element>, ElementIdentifier>> map;
     return map;
 }
 
@@ -264,7 +264,7 @@ Element::~Element()
     ASSERT(!beforePseudoElement());
     ASSERT(!afterPseudoElement());
 
-    elementIdentifiersMap().remove(this);
+    elementIdentifiersMap().remove(*this);
     disconnectFromIntersectionObservers();
 
     disconnectFromResizeObservers();
@@ -407,7 +407,7 @@ bool Element::isKeyboardFocusable(KeyboardEvent*) const
 {
     if (!(isFocusable() && !shouldBeIgnoredInSequentialFocusNavigation() && tabIndexSetExplicitly().value_or(0) >= 0))
         return false;
-    if (auto* root = shadowRoot()) {
+    if (RefPtr root = shadowRoot()) {
         if (root->delegatesFocus())
             return false;
     }
@@ -440,7 +440,7 @@ static bool isCompatibilityMouseEvent(const MouseEvent& mouseEvent)
 enum class ShouldIgnoreMouseEvent : bool { No, Yes };
 static ShouldIgnoreMouseEvent dispatchPointerEventIfNeeded(Element& element, const MouseEvent& mouseEvent, const PlatformMouseEvent& platformEvent, bool& didNotSwallowEvent)
 {
-    if (auto* page = element.document().page()) {
+    if (CheckedPtr page = element.document().page()) {
         auto& pointerCaptureController = page->pointerCaptureController();
 #if ENABLE(TOUCH_EVENTS)
         if (platformEvent.pointerId() != mousePointerID && mouseEvent.type() != eventNames().clickEvent && pointerCaptureController.preventsCompatibilityMouseEventsForIdentifier(platformEvent.pointerId()))
@@ -451,7 +451,7 @@ static ShouldIgnoreMouseEvent dispatchPointerEventIfNeeded(Element& element, con
         if (platformEvent.syntheticClickType() != SyntheticClickType::NoTap)
             return ShouldIgnoreMouseEvent::No;
 
-        if (auto pointerEvent = pointerCaptureController.pointerEventForMouseEvent(mouseEvent, platformEvent.pointerId(), platformEvent.pointerType())) {
+        if (RefPtr pointerEvent = pointerCaptureController.pointerEventForMouseEvent(mouseEvent, platformEvent.pointerId(), platformEvent.pointerType())) {
             pointerCaptureController.dispatchEvent(*pointerEvent, &element);
             if (isCompatibilityMouseEvent(mouseEvent) && pointerCaptureController.preventsCompatibilityMouseEventsForIdentifier(pointerEvent->pointerId()))
                 return ShouldIgnoreMouseEvent::Yes;
@@ -475,7 +475,7 @@ Element::DispatchMouseEventResult Element::dispatchMouseEvent(const PlatformMous
     if (isForceEvent(platformEvent) && !document().hasListenerTypeForEventType(platformEvent.type()))
         return { Element::EventIsDispatched::No, eventIsDefaultPrevented };
 
-    Ref<MouseEvent> mouseEvent = MouseEvent::create(eventType, document().windowProxy(), platformEvent, detail, relatedTarget);
+    Ref mouseEvent = MouseEvent::create(eventType, document().windowProxy(), platformEvent, detail, relatedTarget);
 
     if (mouseEvent->type().isEmpty())
         return { Element::EventIsDispatched::Yes, eventIsDefaultPrevented }; // Shouldn't happen.
@@ -488,12 +488,12 @@ Element::DispatchMouseEventResult Element::dispatchMouseEvent(const PlatformMous
 
     auto isParentProcessAFullWebBrowser = false;
 #if PLATFORM(IOS_FAMILY)
-    if (auto* frame = document().frame())
+    if (RefPtr frame = document().frame())
         isParentProcessAFullWebBrowser = frame->loader().client().isParentProcessAFullWebBrowser();
 #elif PLATFORM(MAC)
     isParentProcessAFullWebBrowser = MacApplication::isSafari();
 #endif
-    if (Quirks::StorageAccessResult::ShouldCancelEvent == document().quirks().triggerOptionalStorageAccessQuirk(*this, platformEvent, eventType, detail, relatedTarget, isParentProcessAFullWebBrowser, isSyntheticClick))
+    if (Quirks::StorageAccessResult::ShouldCancelEvent == protectedDocument()->quirks().triggerOptionalStorageAccessQuirk(*this, platformEvent, eventType, detail, relatedTarget, isParentProcessAFullWebBrowser, isSyntheticClick))
         return { Element::EventIsDispatched::No, eventIsDefaultPrevented };
 
     ASSERT(!mouseEvent->target() || mouseEvent->target() != relatedTarget);
@@ -508,7 +508,7 @@ Element::DispatchMouseEventResult Element::dispatchMouseEvent(const PlatformMous
         // of the DOM specs, but is used for compatibility with the ondblclick="" attribute. This is treated
         // as a separate event in other DOM-compliant browsers like Firefox, and so we do the same.
         // FIXME: Is it okay that mouseEvent may have been mutated by scripts via initMouseEvent in dispatchEvent above?
-        Ref<MouseEvent> doubleClickEvent = MouseEvent::create(eventNames().dblclickEvent,
+        Ref doubleClickEvent = MouseEvent::create(eventNames().dblclickEvent,
             mouseEvent->bubbles() ? Event::CanBubble::Yes : Event::CanBubble::No,
             mouseEvent->cancelable() ? Event::IsCancelable::Yes : Event::IsCancelable::No,
             Event::IsComposed::Yes,
@@ -528,7 +528,7 @@ Element::DispatchMouseEventResult Element::dispatchMouseEvent(const PlatformMous
 
 bool Element::dispatchWheelEvent(const PlatformWheelEvent& platformEvent, OptionSet<EventHandling>& processing, Event::IsCancelable isCancelable)
 {
-    auto event = WheelEvent::create(platformEvent, document().windowProxy(), isCancelable);
+    Ref event = WheelEvent::create(platformEvent, document().windowProxy(), isCancelable);
 
     // Events with no deltas are important because they convey platform information about scroll gestures
     // and momentum beginning or ending. However, those events should not be sent to the DOM since some
@@ -556,9 +556,9 @@ bool Element::dispatchWheelEvent(const PlatformWheelEvent& platformEvent, Option
 
 bool Element::dispatchKeyEvent(const PlatformKeyboardEvent& platformEvent)
 {
-    auto event = KeyboardEvent::create(platformEvent, document().windowProxy());
+    Ref event = KeyboardEvent::create(platformEvent, document().windowProxy());
 
-    if (auto* frame = document().frame()) {
+    if (RefPtr frame = document().frame()) {
         if (frame->eventHandler().accessibilityPreventsEventPropagation(event))
             event->stopPropagation();
     }
@@ -595,16 +595,18 @@ void Element::cloneShadowTreeIfPossible(Element& newHost)
     if (!oldShadowRoot || !oldShadowRoot->isCloneable())
         return;
 
-    Ref clone = oldShadowRoot->cloneNodeInternal(newHost.document(), Node::CloningOperation::SelfWithTemplateContent);
-    RELEASE_ASSERT(is<ShadowRoot>(clone));
-    auto& clonedShadowRoot = downcast<ShadowRoot>(clone.get());
-    newHost.addShadowRoot(clonedShadowRoot);
+    Ref clonedShadowRoot = [&] {
+        Ref clone = oldShadowRoot->cloneNodeInternal(newHost.document(), Node::CloningOperation::SelfWithTemplateContent);
+        RELEASE_ASSERT(is<ShadowRoot>(clone));
+        return downcast<ShadowRoot>(WTFMove(clone));
+    }();
+    newHost.addShadowRoot(clonedShadowRoot.copyRef());
     oldShadowRoot->cloneChildNodes(clonedShadowRoot);
 }
 
 Ref<Element> Element::cloneElementWithChildren(Document& targetDocument)
 {
-    Ref<Element> clone = cloneElementWithoutChildren(targetDocument);
+    Ref clone = cloneElementWithoutChildren(targetDocument);
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { clone };
     cloneShadowTreeIfPossible(clone);
     cloneChildNodes(clone);
@@ -613,7 +615,7 @@ Ref<Element> Element::cloneElementWithChildren(Document& targetDocument)
 
 Ref<Element> Element::cloneElementWithoutChildren(Document& targetDocument)
 {
-    Ref<Element> clone = cloneElementWithoutAttributesAndChildren(targetDocument);
+    Ref clone = cloneElementWithoutAttributesAndChildren(targetDocument);
 
     // This will catch HTML elements in the wrong namespace that are not correctly copied.
     // This is a sanity check as HTML overloads some of the DOM methods.
@@ -634,7 +636,7 @@ Ref<Attr> Element::detachAttribute(unsigned index)
 
     const Attribute& attribute = elementData()->attributeAt(index);
 
-    RefPtr<Attr> attrNode = attrIfExists(attribute.name());
+    RefPtr attrNode = attrIfExists(attribute.name());
     if (attrNode)
         detachAttrNodeFromElementWithValue(attrNode.get(), attribute.value());
     else
@@ -810,37 +812,37 @@ bool Element::isFocusable() const
 bool Element::isUserActionElementInActiveChain() const
 {
     ASSERT(isUserActionElement());
-    return document().userActionElements().isInActiveChain(*this);
+    return protectedDocument()->userActionElements().isInActiveChain(*this);
 }
 
 bool Element::isUserActionElementActive() const
 {
     ASSERT(isUserActionElement());
-    return document().userActionElements().isActive(*this);
+    return protectedDocument()->userActionElements().isActive(*this);
 }
 
 bool Element::isUserActionElementFocused() const
 {
     ASSERT(isUserActionElement());
-    return document().userActionElements().isFocused(*this);
+    return protectedDocument()->userActionElements().isFocused(*this);
 }
 
 bool Element::isUserActionElementHovered() const
 {
     ASSERT(isUserActionElement());
-    return document().userActionElements().isHovered(*this);
+    return protectedDocument()->userActionElements().isHovered(*this);
 }
 
 bool Element::isUserActionElementDragged() const
 {
     ASSERT(isUserActionElement());
-    return document().userActionElements().isBeingDragged(*this);
+    return protectedDocument()->userActionElements().isBeingDragged(*this);
 }
 
 bool Element::isUserActionElementHasFocusVisible() const
 {
     ASSERT(isUserActionElement());
-    return document().userActionElements().hasFocusVisible(*this);
+    return protectedDocument()->userActionElements().hasFocusVisible(*this);
 }
 
 FormListedElement* Element::asFormListedElement()
@@ -856,7 +858,7 @@ ValidatedFormListedElement* Element::asValidatedFormListedElement()
 bool Element::isUserActionElementHasFocusWithin() const
 {
     ASSERT(isUserActionElement());
-    return document().userActionElements().hasFocusWithin(*this);
+    return protectedDocument()->userActionElements().hasFocusWithin(*this);
 }
 
 void Element::setActive(bool value, Style::InvalidationScope invalidationScope)
@@ -868,11 +870,12 @@ void Element::setActive(bool value, Style::InvalidationScope invalidationScope)
         document().userActionElements().setActive(*this, value);
     }
 
-    if (!renderer())
+    CheckedPtr renderer = this->renderer();
+    if (!renderer)
         return;
 
-    if (renderer()->style().hasEffectiveAppearance())
-        renderer()->theme().stateChanged(*renderer(), ControlStates::States::Pressed);
+    if (renderer->style().hasEffectiveAppearance())
+        renderer->theme().stateChanged(*renderer, ControlStates::States::Pressed);
 }
 
 static bool shouldAlwaysHaveFocusVisibleWhenFocused(const Element& element)
@@ -886,15 +889,15 @@ void Element::setFocus(bool value, FocusVisibility visibility)
         return;
     
     Style::PseudoClassChangeInvalidation focusStyleInvalidation(*this, { { CSSSelector::PseudoClassType::Focus, value }, { CSSSelector::PseudoClassType::FocusVisible, value } });
-    document().userActionElements().setFocused(*this, value);
+    protectedDocument()->userActionElements().setFocused(*this, value);
 
     // Shadow host with a slot that contain focused element is not considered focused.
-    for (auto* root = containingShadowRoot(); root; root = root->host()->containingShadowRoot()) {
+    for (RefPtr root = containingShadowRoot(); root; root = root->host()->containingShadowRoot()) {
         root->setContainsFocusedElement(value);
         root->host()->invalidateStyle();
     }
 
-    for (auto* element = this; element; element = element->parentElementInComposedTree())
+    for (RefPtr element = this; element; element = element->parentElementInComposedTree())
         element->setHasFocusWithin(value);
 
     setHasFocusVisible(value && (visibility == FocusVisibility::Visible || shouldAlwaysHaveFocusVisibleWhenFocused(*this)));
@@ -902,7 +905,8 @@ void Element::setFocus(bool value, FocusVisibility visibility)
 
 void Element::setHasFocusVisible(bool value)
 {
-    if (!document().settings().focusVisibleEnabled())
+    Ref document = this->document();
+    if (!document->settings().focusVisibleEnabled())
         return;
 
 #if ASSERT_ENABLED
@@ -913,7 +917,7 @@ void Element::setHasFocusVisible(bool value)
     if (hasFocusVisible() == value)
         return;
 
-    document().userActionElements().setHasFocusVisible(*this, value);
+    document->userActionElements().setHasFocusVisible(*this, value);
 }
 
 void Element::setHasFocusWithin(bool value)
@@ -922,16 +926,16 @@ void Element::setHasFocusWithin(bool value)
         return;
     {
         Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::FocusWithin, value);
-        document().userActionElements().setHasFocusWithin(*this, value);
+        protectedDocument()->userActionElements().setHasFocusWithin(*this, value);
     }
 }
 
 void Element::setHasTentativeFocus(bool value)
 {
     // Tentative focus is used when trying to set the focus on a new element.
-    for (auto& ancestor : composedTreeAncestors(*this)) {
-        ASSERT(ancestor.hasFocusWithin() != value);
-        document().userActionElements().setHasFocusWithin(ancestor, value);
+    for (Ref ancestor : composedTreeAncestors(*this)) {
+        ASSERT(ancestor->hasFocusWithin() != value);
+        protectedDocument()->userActionElements().setHasFocusWithin(ancestor, value);
     }
 }
 
@@ -941,11 +945,13 @@ void Element::setHovered(bool value, Style::InvalidationScope invalidationScope,
         return;
     {
         Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Hover, value, invalidationScope);
-        document().userActionElements().setHovered(*this, value);
+        protectedDocument()->userActionElements().setHovered(*this, value);
     }
 
-    if (auto* style = renderStyle(); style && style->hasEffectiveAppearance())
-        renderer()->theme().stateChanged(*renderer(), ControlStates::States::Hovered);
+    if (auto* style = renderStyle(); style && style->hasEffectiveAppearance()) {
+        CheckedPtr renderer = this->renderer();
+        renderer->theme().stateChanged(*renderer, ControlStates::States::Hovered);
+    }
 }
 
 void Element::setBeingDragged(bool value)
@@ -954,7 +960,7 @@ void Element::setBeingDragged(bool value)
         return;
 
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Drag, value);
-    document().userActionElements().setBeingDragged(*this, value);
+    protectedDocument()->userActionElements().setBeingDragged(*this, value);
 }
 
 inline ScrollAlignment toScrollAlignmentForInlineDirection(std::optional<ScrollLogicalPosition> position, WritingMode writingMode, bool isLTR)
@@ -1045,7 +1051,7 @@ inline ScrollAlignment toScrollAlignmentForBlockDirection(std::optional<ScrollLo
     }
 }
 
-static std::optional<std::pair<RenderElement*, LayoutRect>> listBoxElementScrollIntoView(const Element& element)
+static std::optional<std::pair<CheckedRef<RenderElement>, LayoutRect>> listBoxElementScrollIntoView(const Element& element)
 {
     auto owningSelectElement = [](const Element& element) -> HTMLSelectElement* {
         if (is<HTMLOptionElement>(element))
@@ -1057,34 +1063,35 @@ static std::optional<std::pair<RenderElement*, LayoutRect>> listBoxElementScroll
         return nullptr;
     };
 
-    auto* selectElement = owningSelectElement(element);
+    RefPtr selectElement = owningSelectElement(element);
     if (!selectElement || !selectElement->renderer() || !is<RenderListBox>(selectElement->renderer()))
-        return { };
+        return std::nullopt;
 
-    auto& renderListBox = downcast<RenderListBox>(*selectElement->renderer());
+    CheckedRef renderListBox = downcast<RenderListBox>(*selectElement->renderer());
     
     auto itemIndex = selectElement->listItems().find(&element);
     if (itemIndex != notFound)
-        renderListBox.scrollToRevealElementAtListIndex(itemIndex);
+        renderListBox->scrollToRevealElementAtListIndex(itemIndex);
     else
         itemIndex = 0;
 
-    auto itemLocalRect = renderListBox.itemBoundingBoxRect({ }, itemIndex);
-    return std::pair<RenderElement*, LayoutRect> { &renderListBox, itemLocalRect };
+    auto itemLocalRect = renderListBox->itemBoundingBoxRect({ }, itemIndex);
+    return std::pair<CheckedRef<RenderElement>, LayoutRect> { WTFMove(renderListBox), itemLocalRect };
 }
 
 void Element::scrollIntoView(std::optional<std::variant<bool, ScrollIntoViewOptions>>&& arg)
 {
-    document().updateContentRelevancyForScrollIfNeeded(*this);
+    Ref document = this->document();
+    document->updateContentRelevancyForScrollIfNeeded(*this);
 
-    document().updateLayoutIgnorePendingStylesheets();
+    document->updateLayoutIgnorePendingStylesheets();
 
-    RenderElement* renderer = nullptr;
+    CheckedPtr<RenderElement> renderer;
     bool insideFixed = false;
     LayoutRect absoluteBounds;
 
     if (auto listBoxScrollResult = listBoxElementScrollIntoView(*this)) {
-        renderer = listBoxScrollResult->first;
+        renderer = WTFMove(listBoxScrollResult->first);
         absoluteBounds = listBoxScrollResult->second;
 
         auto listBoxAbsoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
@@ -1124,52 +1131,56 @@ void Element::scrollIntoView(std::optional<std::variant<bool, ScrollIntoViewOpti
 
 void Element::scrollIntoView(bool alignToTop) 
 {
-    document().updateLayoutIgnorePendingStylesheets();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
-    if (!renderer())
+    CheckedPtr renderer = this->renderer();
+    if (!renderer)
         return;
 
     bool insideFixed;
-    LayoutRect absoluteBounds = renderer()->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
+    LayoutRect absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
 
     // Align to the top / bottom and to the closest edge.
     auto alignY = alignToTop ? ScrollAlignment::alignTopAlways : ScrollAlignment::alignBottomAlways;
     auto alignX = ScrollAlignment::alignToEdgeIfNeeded;
     alignX.disableLegacyHorizontalVisibilityThreshold();
 
-    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer(), insideFixed, { SelectionRevealMode::Reveal, alignX, alignY, ShouldAllowCrossOriginScrolling::No });
+    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, { SelectionRevealMode::Reveal, alignX, alignY, ShouldAllowCrossOriginScrolling::No });
 }
 
 void Element::scrollIntoViewIfNeeded(bool centerIfNeeded)
 {
-    document().updateContentRelevancyForScrollIfNeeded(*this);
+    Ref document = this->document();
+    document->updateContentRelevancyForScrollIfNeeded(*this);
 
-    document().updateLayoutIgnorePendingStylesheets();
+    document->updateLayoutIgnorePendingStylesheets();
 
-    if (!renderer())
+    CheckedPtr renderer = this->renderer();
+    if (!renderer)
         return;
 
     bool insideFixed;
-    LayoutRect absoluteBounds = renderer()->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
+    LayoutRect absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
 
     auto alignY = centerIfNeeded ? ScrollAlignment::alignCenterIfNeeded : ScrollAlignment::alignToEdgeIfNeeded;
     auto alignX = centerIfNeeded ? ScrollAlignment::alignCenterIfNeeded : ScrollAlignment::alignToEdgeIfNeeded;
     alignX.disableLegacyHorizontalVisibilityThreshold();
 
-    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer(), insideFixed, { SelectionRevealMode::Reveal, alignX, alignY, ShouldAllowCrossOriginScrolling::No });
+    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, { SelectionRevealMode::Reveal, alignX, alignY, ShouldAllowCrossOriginScrolling::No });
 }
 
 void Element::scrollIntoViewIfNotVisible(bool centerIfNotVisible)
 {
-    document().updateLayoutIgnorePendingStylesheets();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets();
     
-    if (!renderer())
+    CheckedPtr renderer = this->renderer();
+    if (!renderer)
         return;
     
     bool insideFixed;
-    LayoutRect absoluteBounds = renderer()->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
+    LayoutRect absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
     auto align = centerIfNotVisible ? ScrollAlignment::alignCenterIfNotVisible : ScrollAlignment::alignToEdgeIfNotVisible;
-    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer(), insideFixed, { SelectionRevealMode::Reveal, align, align, ShouldAllowCrossOriginScrolling::No });
+    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, { SelectionRevealMode::Reveal, align, align, ShouldAllowCrossOriginScrolling::No });
 }
 
 void Element::scrollBy(const ScrollToOptions& options)
@@ -1190,23 +1201,24 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
 {
     LOG_WITH_STREAM(Scrolling, stream << "Element " << *this << " scrollTo " << options.left << ", " << options.top);
 
-    if (!document().settings().CSSOMViewScrollingAPIEnabled()) {
+    Ref document = this->document();
+    if (!document->settings().CSSOMViewScrollingAPIEnabled()) {
         // If the element is the root element and document is in quirks mode, terminate these steps.
         // Note that WebKit always uses quirks mode document scrolling behavior. See Document::scrollingElement().
-        if (this == document().documentElement())
+        if (this == document->documentElement())
             return;
     }
     
-    if (auto* view = document().view())
+    if (RefPtr view = document->view())
         view->cancelScheduledScrolls();
 
-    document().updateLayoutIgnorePendingStylesheets();
+    document->updateLayoutIgnorePendingStylesheets();
 
-    if (document().scrollingElement() == this) {
+    if (document->scrollingElement() == this) {
         // If the element is the scrolling element and is not potentially scrollable,
         // invoke scroll() on window with options as the only argument, and terminate these steps.
         // FIXME: Scrolling an independently scrollable body is broken: webkit.org/b/161612.
-        RefPtr window = document().domWindow();
+        RefPtr window = document->domWindow();
         if (!window)
             return;
 
@@ -1216,7 +1228,7 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
 
     // If the element does not have any associated CSS layout box, the element has no associated scrolling box,
     // or the element has no overflow, terminate these steps.
-    RenderBox* renderer = renderBox();
+    CheckedPtr renderer = renderBox();
     if (!renderer || !renderer->hasNonVisibleOverflow())
         return;
 
@@ -1241,9 +1253,9 @@ void Element::scrollTo(double x, double y)
 
 void Element::scrollByUnits(int units, ScrollGranularity granularity)
 {
-    document().updateLayoutIgnorePendingStylesheets();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
-    auto* renderer = this->renderer();
+    CheckedPtr renderer = this->renderer();
     if (!renderer)
         return;
 
@@ -1274,8 +1286,8 @@ static double localZoomForRenderer(const RenderElement& renderer)
     if (renderer.style().effectiveZoom() != 1) {
         // Need to find the nearest enclosing RenderElement that set up
         // a differing zoom, and then we divide our result by it to eliminate the zoom.
-        const RenderElement* prev = &renderer;
-        for (RenderElement* curr = prev->parent(); curr; curr = curr->parent()) {
+        CheckedPtr prev = &renderer;
+        for (CheckedPtr curr = prev->parent(); curr; curr = curr->parent()) {
             if (curr->style().effectiveZoom() != prev->style().effectiveZoom()) {
                 zoomFactor = prev->style().zoom();
                 break;
@@ -1347,8 +1359,8 @@ int Element::offsetLeftForBindings()
 
 int Element::offsetLeft()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
-    if (RenderBoxModelObject* renderer = renderBoxModelObject())
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    if (CheckedPtr renderer = renderBoxModelObject())
         return adjustOffsetForZoomAndSubpixelLayout(*renderer, renderer->offsetLeft());
     return 0;
 }
@@ -1376,16 +1388,16 @@ int Element::offsetTopForBindings()
 
 int Element::offsetTop()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
-    if (RenderBoxModelObject* renderer = renderBoxModelObject())
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    if (CheckedPtr renderer = renderBoxModelObject())
         return adjustOffsetForZoomAndSubpixelLayout(*renderer, renderer->offsetTop());
     return 0;
 }
 
 int Element::offsetWidth()
 {
-    document().updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width);
-    if (RenderBoxModelObject* renderer = renderBoxModelObject()) {
+    protectedDocument()->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width);
+    if (CheckedPtr renderer = renderBoxModelObject()) {
         auto offsetWidth = LayoutUnit { roundToInt(renderer->offsetWidth()) };
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(offsetWidth, *renderer).toDouble());
     }
@@ -1394,17 +1406,17 @@ int Element::offsetWidth()
 
 int Element::offsetHeight()
 {
-    document().updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height);
-    if (RenderBoxModelObject* renderer = renderBoxModelObject()) {
+    protectedDocument()->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height);
+    if (CheckedPtr renderer = renderBoxModelObject()) {
         auto offsetHeight = LayoutUnit { roundToInt(renderer->offsetHeight()) };
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(offsetHeight, *renderer).toDouble());
     }
     return 0;
 }
 
-Element* Element::offsetParentForBindings()
+RefPtr<Element> Element::offsetParentForBindings()
 {
-    Element* element = offsetParent();
+    RefPtr element = offsetParent();
     if (!element || !element->isInShadowTree())
         return element;
     while (element && !isDescendantOrShadowDescendantOf(&element->rootNode()))
@@ -1414,21 +1426,19 @@ Element* Element::offsetParentForBindings()
 
 Element* Element::offsetParent()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
-    auto renderer = this->renderer();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    CheckedPtr renderer = this->renderer();
     if (!renderer)
         return nullptr;
-    auto offsetParent = renderer->offsetParent();
-    if (!offsetParent)
-        return nullptr;
-    return offsetParent->element();
+    CheckedPtr offsetParent = renderer->offsetParent();
+    return offsetParent ? offsetParent->element() : nullptr;
 }
 
 int Element::clientLeft()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
-    if (auto* renderer = renderBox()) {
+    if (CheckedPtr renderer = renderBox()) {
         auto clientLeft = LayoutUnit { roundToInt(renderer->clientLeft()) };
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(clientLeft, *renderer).toDouble());
     }
@@ -1437,9 +1447,9 @@ int Element::clientLeft()
 
 int Element::clientTop()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
-    if (auto* renderer = renderBox()) {
+    if (CheckedPtr renderer = renderBox()) {
         auto clientTop = LayoutUnit { roundToInt(renderer->clientTop()) };
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(clientTop, *renderer).toDouble());
     }
@@ -1448,20 +1458,21 @@ int Element::clientTop()
 
 int Element::clientWidth()
 {
-    document().updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width);
+    Ref document = this->document();
+    document->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width);
 
-    if (!document().hasLivingRenderTree())
+    if (!document->hasLivingRenderTree())
         return 0;
 
-    RenderView& renderView = *document().renderView();
+    CheckedRef renderView = *document->renderView();
 
     // When in strict mode, clientWidth for the document element should return the width of the containing frame.
     // When in quirks mode, clientWidth for the body element should return the width of the containing frame.
-    bool inQuirksMode = document().inQuirksMode();
-    if ((!inQuirksMode && document().documentElement() == this) || (inQuirksMode && isHTMLElement() && document().bodyOrFrameset() == this))
-        return adjustForAbsoluteZoom(renderView.frameView().layoutWidth(), renderView);
+    bool inQuirksMode = document->inQuirksMode();
+    if ((!inQuirksMode && document->documentElement() == this) || (inQuirksMode && isHTMLElement() && document->bodyOrFrameset() == this))
+        return adjustForAbsoluteZoom(renderView->frameView().layoutWidth(), renderView);
     
-    if (RenderBox* renderer = renderBox()) {
+    if (CheckedPtr renderer = renderBox()) {
         auto clientWidth = LayoutUnit { roundToInt(renderer->clientWidth()) };
         // clientWidth/Height is the visual portion of the box content, not including
         // borders or scroll bars, but includes padding. And per
@@ -1482,19 +1493,20 @@ int Element::clientWidth()
 
 int Element::clientHeight()
 {
-    document().updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height);
-    if (!document().hasLivingRenderTree())
+    Ref document = this->document();
+    document->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height);
+    if (!document->hasLivingRenderTree())
         return 0;
 
-    RenderView& renderView = *document().renderView();
+    CheckedRef renderView = *document->renderView();
 
     // When in strict mode, clientHeight for the document element should return the height of the containing frame.
     // When in quirks mode, clientHeight for the body element should return the height of the containing frame.
-    bool inQuirksMode = document().inQuirksMode();
-    if ((!inQuirksMode && document().documentElement() == this) || (inQuirksMode && isHTMLElement() && document().bodyOrFrameset() == this))
-        return adjustForAbsoluteZoom(renderView.frameView().layoutHeight(), renderView);
+    bool inQuirksMode = document->inQuirksMode();
+    if ((!inQuirksMode && document->documentElement() == this) || (inQuirksMode && isHTMLElement() && document->bodyOrFrameset() == this))
+        return adjustForAbsoluteZoom(renderView->frameView().layoutHeight(), renderView);
 
-    if (RenderBox* renderer = renderBox()) {
+    if (CheckedPtr renderer = renderBox()) {
         auto clientHeight = LayoutUnit { roundToInt(renderer->clientHeight()) };
         // clientWidth/Height is the visual portion of the box content, not including
         // borders or scroll bars, but includes padding. And per
@@ -1521,110 +1533,116 @@ ALWAYS_INLINE LocalFrame* Element::documentFrameWithNonNullView() const
 
 int Element::scrollLeft()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    Ref document = this->document();
+    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
-    if (document().scrollingElement() == this) {
-        if (auto* frame = documentFrameWithNonNullView())
+    if (document->scrollingElement() == this) {
+        if (RefPtr frame = documentFrameWithNonNullView())
             return adjustContentsScrollPositionOrSizeForZoom(frame->view()->contentsScrollPosition().x(), *frame);
         return 0;
     }
 
-    if (auto* renderer = renderBox())
+    if (CheckedPtr renderer = renderBox())
         return adjustForAbsoluteZoom(renderer->scrollLeft(), *renderer);
     return 0;
 }
 
 int Element::scrollTop()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    Ref document = this->document();
+    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
-    if (document().scrollingElement() == this) {
-        if (auto* frame = documentFrameWithNonNullView())
+    if (document->scrollingElement() == this) {
+        if (RefPtr frame = documentFrameWithNonNullView())
             return adjustContentsScrollPositionOrSizeForZoom(frame->view()->contentsScrollPosition().y(), *frame);
         return 0;
     }
 
-    if (RenderBox* renderer = renderBox())
+    if (CheckedPtr renderer = renderBox())
         return adjustForAbsoluteZoom(renderer->scrollTop(), *renderer);
     return 0;
 }
 
 void Element::setScrollLeft(int newLeft)
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    Ref document = this->document();
+    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
     auto options = ScrollPositionChangeOptions::createProgrammatic();
     options.animated = useSmoothScrolling(ScrollBehavior::Auto, this) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
 
-    if (document().scrollingElement() == this) {
+    if (document->scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
             IntPoint position(static_cast<int>(newLeft * frame->pageZoomFactor() * frame->frameScaleFactor()), frame->view()->scrollY());
-            frame->view()->setScrollPosition(position, options);
+            frame->protectedView()->setScrollPosition(position, options);
         }
         return;
     }
 
-    if (WeakPtr renderer = renderBox()) {
+    if (CheckedPtr renderer = renderBox()) {
         int clampedLeft = clampToInteger(newLeft * renderer->style().effectiveZoom());
         renderer->setScrollLeft(clampedLeft, options);
-        if (auto* scrollableArea = renderer && renderer->layer() ? renderer->layer()->scrollableArea() : nullptr)
+        if (CheckedPtr scrollableArea = renderer && renderer->layer() ? renderer->layer()->scrollableArea() : nullptr)
             scrollableArea->setScrollShouldClearLatchedState(true);
     }
 }
 
 void Element::setScrollTop(int newTop)
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    Ref document = this->document();
+    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
     auto options = ScrollPositionChangeOptions::createProgrammatic();
     options.animated = useSmoothScrolling(ScrollBehavior::Auto, this) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
 
-    if (document().scrollingElement() == this) {
+    if (document->scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
             IntPoint position(frame->view()->scrollX(), static_cast<int>(newTop * frame->pageZoomFactor() * frame->frameScaleFactor()));
-            frame->view()->setScrollPosition(position, options);
+            frame->protectedView()->setScrollPosition(position, options);
         }
         return;
     }
 
-    if (WeakPtr renderer = renderBox()) {
+    if (CheckedPtr renderer = renderBox()) {
         int clampedTop = clampToInteger(newTop * renderer->style().effectiveZoom());
         renderer->setScrollTop(clampedTop, options);
-        if (auto* scrollableArea = renderer && renderer->layer() ? renderer->layer()->scrollableArea() : nullptr)
+        if (CheckedPtr scrollableArea = renderer && renderer->layer() ? renderer->layer()->scrollableArea() : nullptr)
             scrollableArea->setScrollShouldClearLatchedState(true);
     }
 }
 
 int Element::scrollWidth()
 {
-    document().updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width);
+    Ref document = this->document();
+    document->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width);
 
-    if (document().scrollingElement() == this) {
+    if (document->scrollingElement() == this) {
         // FIXME (webkit.org/b/182289): updateLayoutIfDimensionsOutOfDate seems to ignore zoom level change.
-        document().updateLayoutIgnorePendingStylesheets();
-        if (auto* frame = documentFrameWithNonNullView())
+        document->updateLayoutIgnorePendingStylesheets();
+        if (RefPtr frame = documentFrameWithNonNullView())
             return adjustContentsScrollPositionOrSizeForZoom(frame->view()->contentsWidth(), *frame);
         return 0;
     }
 
-    if (auto* renderer = renderBox())
+    if (CheckedPtr renderer = renderBox())
         return adjustForAbsoluteZoom(renderer->scrollWidth(), *renderer);
     return 0;
 }
 
 int Element::scrollHeight()
 {
-    document().updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height);
+    Ref document = this->document();
+    document->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height);
 
-    if (document().scrollingElement() == this) {
+    if (document->scrollingElement() == this) {
         // FIXME (webkit.org/b/182289): updateLayoutIfDimensionsOutOfDate seems to ignore zoom level change.
-        document().updateLayoutIgnorePendingStylesheets();
-        if (auto* frame = documentFrameWithNonNullView())
+        document->updateLayoutIgnorePendingStylesheets();
+        if (RefPtr frame = documentFrameWithNonNullView())
             return adjustContentsScrollPositionOrSizeForZoom(frame->view()->contentsHeight(), *frame);
         return 0;
     }
 
-    if (auto* renderer = renderBox())
+    if (CheckedPtr renderer = renderBox())
         return adjustForAbsoluteZoom(renderer->scrollHeight(), *renderer);
     return 0;
 }
@@ -1632,7 +1650,7 @@ int Element::scrollHeight()
 inline bool shouldObtainBoundsFromSVGModel(const Element* element)
 {
     ASSERT(element);
-    if (auto* svg = dynamicDowncast<SVGElement>(element))
+    if (RefPtr svg = dynamicDowncast<SVGElement>(element))
         return svg->hasAssociatedSVGLayoutBox();
 
     return false;
@@ -1657,9 +1675,10 @@ inline bool shouldObtainBoundsFromBoxModel(const Element* element)
 
 IntRect Element::boundsInRootViewSpace()
 {
-    document().updateLayoutIgnorePendingStylesheets();
+    Ref document = this->document();
+    document->updateLayoutIgnorePendingStylesheets();
 
-    auto* view = document().view();
+    RefPtr view = document->view();
     if (!view)
         return IntRect();
 
@@ -1669,10 +1688,10 @@ IntRect Element::boundsInRootViewSpace()
         // Get the bounding rectangle from the SVG model.
         SVGElement& svgElement = downcast<SVGElement>(*this);
         if (auto localRect = svgElement.getBoundingBox())
-            quads.append(renderer()->localToAbsoluteQuad(*localRect));
+            quads.append(checkedRenderer()->localToAbsoluteQuad(*localRect));
     } else if (shouldObtainBoundsFromBoxModel(this)) {
         // Get the bounding rectangle from the box model.
-        renderer()->absoluteQuads(quads);
+        checkedRenderer()->absoluteQuads(quads);
     }
 
     return view->contentsToRootView(enclosingIntRect(unitedBoundingBoxes(quads)));
@@ -1680,8 +1699,8 @@ IntRect Element::boundsInRootViewSpace()
 
 IntRect Element::boundingBoxInRootViewCoordinates() const
 {
-    if (RenderObject* renderer = this->renderer())
-        return document().view()->contentsToRootView(renderer->absoluteBoundingBoxRect());
+    if (CheckedPtr renderer = this->renderer())
+        return protectedDocument()->view()->contentsToRootView(renderer->absoluteBoundingBoxRect());
     return IntRect();
 }
 
@@ -1695,10 +1714,10 @@ static bool layoutOverflowRectContainsAllDescendants(const RenderBox& renderBox)
 
     // If there are any position:fixed inside of us, game over.
     if (auto* viewPositionedObjects = renderBox.view().positionedObjects()) {
-        for (auto& positionedBox : *viewPositionedObjects) {
-            if (&positionedBox == &renderBox)
+        for (CheckedRef positionedBox : *viewPositionedObjects) {
+            if (positionedBox.ptr() == &renderBox)
                 continue;
-            if (positionedBox.isFixedPositioned() && renderBox.element()->contains(positionedBox.protectedElement().get()))
+            if (positionedBox->isFixedPositioned() && renderBox.element()->contains(positionedBox->protectedElement().get()))
                 return false;
         }
     }
@@ -1709,12 +1728,12 @@ static bool layoutOverflowRectContainsAllDescendants(const RenderBox& renderBox)
     }
 
     // This renderer may have positioned descendants whose containing block is some ancestor.
-    if (auto* containingBlock = RenderObject::containingBlockForPositionType(PositionType::Absolute, renderBox)) {
+    if (CheckedPtr containingBlock = RenderObject::containingBlockForPositionType(PositionType::Absolute, renderBox)) {
         if (auto* positionedObjects = containingBlock->positionedObjects()) {
-            for (auto& positionedBox : *positionedObjects) {
-                if (&positionedBox == &renderBox)
+            for (CheckedRef positionedBox : *positionedObjects) {
+                if (positionedBox.ptr() == &renderBox)
                     continue;
-                if (renderBox.protectedElement()->contains(positionedBox.protectedElement().get()))
+                if (renderBox.protectedElement()->contains(positionedBox->protectedElement().get()))
                     return false;
             }
         }
@@ -1735,15 +1754,15 @@ LayoutRect Element::absoluteEventBounds(bool& boundsIncludeAllDescendantElements
         // Get the bounding rectangle from the SVG model.
         SVGElement& svgElement = downcast<SVGElement>(*this);
         if (auto localRect = svgElement.getBoundingBox())
-            result = LayoutRect(renderer()->localToAbsoluteQuad(*localRect, UseTransforms, &includesFixedPositionElements).boundingBox());
+            result = LayoutRect(checkedRenderer()->localToAbsoluteQuad(*localRect, UseTransforms, &includesFixedPositionElements).boundingBox());
     } else {
-        auto* renderer = this->renderer();
-        if (is<RenderBox>(renderer)) {
+        CheckedPtr renderer = this->renderer();
+        if (is<RenderBox>(renderer.get())) {
             auto& box = downcast<RenderBox>(*renderer);
 
             bool computedBounds = false;
             
-            if (RenderFragmentedFlow* fragmentedFlow = box.enclosingFragmentedFlow()) {
+            if (CheckedPtr fragmentedFlow = box.enclosingFragmentedFlow()) {
                 bool wasFixed = false;
                 Vector<FloatQuad> quads;
                 if (fragmentedFlow->absoluteQuadsForBox(quads, &wasFixed, &box)) {
@@ -1752,9 +1771,8 @@ LayoutRect Element::absoluteEventBounds(bool& boundsIncludeAllDescendantElements
                 } else {
                     // Probably columns. Just return the bounds of the multicol block for now.
                     // FIXME: this doesn't handle nested columns.
-                    RenderElement* multicolContainer = fragmentedFlow->parent();
-                    if (multicolContainer && is<RenderBox>(multicolContainer)) {
-                        auto overflowRect = downcast<RenderBox>(*multicolContainer).layoutOverflowRect();
+                    if (CheckedPtr multicolContainer = dynamicDowncast<RenderBox>(fragmentedFlow->parent())) {
+                        auto overflowRect = multicolContainer->layoutOverflowRect();
                         result = LayoutRect(multicolContainer->localToAbsoluteQuad(FloatRect(overflowRect), UseTransforms, &includesFixedPositionElements).boundingBox());
                         computedBounds = true;
                     }
@@ -1780,9 +1798,9 @@ LayoutRect Element::absoluteEventBoundsOfElementAndDescendants(bool& includesFix
     if (boundsIncludeDescendants)
         return result;
 
-    for (auto& child : childrenOfType<Element>(*this)) {
+    for (Ref child : childrenOfType<Element>(*this)) {
         bool includesFixedPosition = false;
-        LayoutRect childBounds = child.absoluteEventBoundsOfElementAndDescendants(includesFixedPosition);
+        LayoutRect childBounds = child->absoluteEventBoundsOfElementAndDescendants(includesFixedPosition);
         includesFixedPositionElements |= includesFixedPosition;
         result.unite(childBounds);
     }
@@ -1793,14 +1811,13 @@ LayoutRect Element::absoluteEventBoundsOfElementAndDescendants(bool& includesFix
 LayoutRect Element::absoluteEventHandlerBounds(bool& includesFixedPositionElements)
 {
     // This is not web-exposed, so don't call the FOUC-inducing updateLayoutIgnorePendingStylesheets().
-    auto* frameView = document().view();
-    if (!frameView)
+    if (!document().view())
         return LayoutRect();
 
     return absoluteEventBoundsOfElementAndDescendants(includesFixedPositionElements);
 }
 
-static std::optional<std::pair<RenderObject*, LayoutRect>> listBoxElementBoundingBox(const Element& element)
+static std::optional<std::pair<CheckedRef<RenderObject>, LayoutRect>> listBoxElementBoundingBox(const Element& element)
 {
     auto owningSelectElement = [](const Element& element) -> HTMLSelectElement* {
         if (is<HTMLOptionElement>(element))
@@ -1812,28 +1829,28 @@ static std::optional<std::pair<RenderObject*, LayoutRect>> listBoxElementBoundin
         return nullptr;
     };
 
-    auto* selectElement = owningSelectElement(element);
+    RefPtr selectElement = owningSelectElement(element);
     if (!selectElement || !selectElement->renderer() || !is<RenderListBox>(selectElement->renderer()))
         return std::nullopt;
 
-    auto& listBoxRenderer = downcast<RenderListBox>(*selectElement->renderer());
+    CheckedRef listBoxRenderer = downcast<RenderListBox>(*selectElement->renderer());
     std::optional<LayoutRect> boundingBox;
     if (is<HTMLOptionElement>(element))
-        boundingBox = listBoxRenderer.localBoundsOfOption(downcast<HTMLOptionElement>(element));
+        boundingBox = listBoxRenderer->localBoundsOfOption(downcast<HTMLOptionElement>(element));
     else if (is<HTMLOptGroupElement>(element))
-        boundingBox = listBoxRenderer.localBoundsOfOptGroup(downcast<HTMLOptGroupElement>(element));
+        boundingBox = listBoxRenderer->localBoundsOfOptGroup(downcast<HTMLOptGroupElement>(element));
 
     if (!boundingBox)
         return { };
 
-    return std::pair<RenderObject*, LayoutRect> { &listBoxRenderer, boundingBox.value() };
+    return std::pair<CheckedRef<RenderObject>, LayoutRect> { WTFMove(listBoxRenderer), boundingBox.value() };
 }
 
 Ref<DOMRectList> Element::getClientRects()
 {
     document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
 
-    RenderObject* renderer = this->renderer();
+    CheckedPtr<RenderObject> renderer = this->renderer();
 
     Vector<FloatQuad> quads;
 
@@ -1841,7 +1858,7 @@ Ref<DOMRectList> Element::getClientRects()
         if (auto localRect = downcast<SVGElement>(*this).getBoundingBox())
             quads.append(renderer->localToAbsoluteQuad(*localRect));
     } else if (auto pair = listBoxElementBoundingBox(*this)) {
-        renderer = pair.value().first;
+        renderer = WTFMove(pair.value().first);
         quads.append(renderer->localToAbsoluteQuad(FloatQuad { pair.value().second }));
     } else if (shouldObtainBoundsFromBoxModel(this))
         renderer->absoluteQuads(quads);
@@ -1851,19 +1868,19 @@ Ref<DOMRectList> Element::getClientRects()
     if (quads.isEmpty())
         return DOMRectList::create();
 
-    document().convertAbsoluteToClientQuads(quads, renderer->style());
+    protectedDocument()->convertAbsoluteToClientQuads(quads, renderer->style());
     return DOMRectList::create(quads);
 }
 
-std::optional<std::pair<RenderObject*, FloatRect>> Element::boundingAbsoluteRectWithoutLayout() const
+std::optional<std::pair<CheckedPtr<RenderObject>, FloatRect>> Element::boundingAbsoluteRectWithoutLayout() const
 {
-    RenderObject* renderer = this->renderer();
+    CheckedPtr<RenderObject> renderer = this->renderer();
     Vector<FloatQuad> quads;
     if (shouldObtainBoundsFromSVGModel(this)) {
         if (auto localRect = downcast<SVGElement>(*this).getBoundingBox())
             quads.append(renderer->localToAbsoluteQuad(*localRect));
     } else if (auto pair = listBoxElementBoundingBox(*this)) {
-        renderer = pair.value().first;
+        renderer = WTFMove(pair.value().first);
         quads.append(renderer->localToAbsoluteQuad(FloatQuad { pair.value().second }));
     } else if (shouldObtainBoundsFromBoxModel(this))
         renderer->absoluteQuads(quads);
@@ -1871,18 +1888,19 @@ std::optional<std::pair<RenderObject*, FloatRect>> Element::boundingAbsoluteRect
     if (quads.isEmpty())
         return std::nullopt;
 
-    return std::make_pair(renderer, unitedBoundingBoxes(quads));
+    return std::make_pair(WTFMove(renderer), unitedBoundingBoxes(quads));
 }
 
 FloatRect Element::boundingClientRect()
 {
-    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+    Ref document = this->document();
+    document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
     auto pair = boundingAbsoluteRectWithoutLayout();
     if (!pair)
         return { };
-    RenderObject* renderer = pair->first;
+    CheckedPtr renderer = WTFMove(pair->first);
     FloatRect result = pair->second;
-    document().convertAbsoluteToClientRect(result, renderer->style());
+    document->convertAbsoluteToClientRect(result, renderer->style());
     return result;
 }
 
@@ -1893,7 +1911,7 @@ Ref<DOMRect> Element::getBoundingClientRect()
 
 IntRect Element::screenRect() const
 {
-    if (RenderObject* renderer = this->renderer())
+    if (CheckedPtr renderer = this->renderer())
         return document().view()->contentsToScreen(renderer->absoluteBoundingBoxRect());
     return IntRect();
 }
@@ -2076,7 +2094,7 @@ void Element::notifyAttributeChanged(const QualifiedName& name, const AtomString
     if (oldValue != newValue) {
         invalidateNodeListAndCollectionCachesInAncestorsForAttribute(name);
 
-        if (auto* cache = document().existingAXObjectCache())
+        if (CheckedPtr cache = document().existingAXObjectCache())
             cache->deferAttributeChangeIfNeeded(this, name, oldValue, newValue);
     }
 }
@@ -2116,8 +2134,8 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
             invalidateStyleForSubtree();
         break;
     case AttributeNames::slotAttr:
-        if (auto* parent = parentElement()) {
-            if (auto* shadowRoot = parent->shadowRoot())
+        if (RefPtr parent = parentElement()) {
+            if (RefPtr shadowRoot = parent->shadowRoot())
                 shadowRoot->hostChildElementDidChangeSlotAttribute(*this, oldValue, newValue);
         }
         break;
@@ -2125,31 +2143,35 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
         partAttributeChanged(newValue);
         break;
     case AttributeNames::exportpartsAttr:
-        if (auto* shadowRoot = this->shadowRoot()) {
+        if (RefPtr shadowRoot = this->shadowRoot()) {
             shadowRoot->invalidatePartMappings();
             Style::Invalidator::invalidateShadowParts(*shadowRoot);
         }
         break;
     case AttributeNames::accesskeyAttr:
-        document().invalidateAccessKeyCache();
+        protectedDocument()->invalidateAccessKeyCache();
         break;
     case AttributeNames::XML::langAttr:
-    case AttributeNames::langAttr:
+    case AttributeNames::langAttr: {
         if (name == HTMLNames::langAttr)
             setHasLangAttr(!newValue.isNull());
         else
             setHasXMLLangAttr(!newValue.isNull());
-        if (document().documentElement() == this)
-            document().setDocumentElementLanguage(langFromAttribute());
+        Ref document = this->document();
+        if (document->documentElement() == this)
+            document->setDocumentElementLanguage(langFromAttribute());
         else
             updateEffectiveLangStateAndPropagateToDescendants();
         break;
-    default:
-        if (isElementReflectionAttribute(document().settings(), name) || isElementsArrayReflectionAttribute(document().settings(), name)) {
+    }
+    default: {
+        Ref document = this->document();
+        if (isElementReflectionAttribute(document->settings(), name) || isElementsArrayReflectionAttribute(document->settings(), name)) {
             if (auto* map = explicitlySetAttrElementsMapIfExists())
                 map->remove(name);
         }
         break;
+    }
     }
 }
 
@@ -2159,13 +2181,13 @@ void Element::updateEffectiveLangStateAndPropagateToDescendants()
     updateEffectiveLangState();
 
     for (auto it = descendantsOfType<Element>(*this).begin(); it;) {
-        auto& element = *it;
-        if (element.hasLanguageAttribute()) {
+        Ref element = *it;
+        if (element->hasLanguageAttribute()) {
             it.traverseNextSkippingChildren();
             continue;
         }
         Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassType::Lang, Style::PseudoClassChangeInvalidation::AnyValue);
-        element.updateEffectiveLangStateFromParent();
+        element->updateEffectiveLangStateFromParent();
         it.traverseNext();
     }
 }
@@ -2217,7 +2239,7 @@ void Element::setElementAttribute(const QualifiedName& attributeName, Element* e
 
     explicitlySetAttrElementsMap().set(attributeName, Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> { element });
     
-    if (auto* cache = document().existingAXObjectCache())
+    if (CheckedPtr cache = document().existingAXObjectCache())
         cache->updateRelations(*this, attributeName);
 }
 
@@ -2267,9 +2289,11 @@ void Element::setElementsArrayAttribute(const QualifiedName& attributeName, std:
     auto newElements = copyToVectorOf<WeakPtr<Element, WeakPtrImplWithEventTargetData>>(*elements);
     explicitlySetAttrElementsMap().set(attributeName, WTFMove(newElements));
     
-    if (auto* cache = document().existingAXObjectCache()) {
-        for (auto element : elements.value())
+    if (CheckedPtr cache = document().existingAXObjectCache()) {
+        for (auto element : elements.value()) {
+            // FIXME: Should this pass `element` instead of `*this`?
             cache->updateRelations(*this, attributeName);
+        }
     }
 }
 
@@ -2331,7 +2355,7 @@ bool Element::allowsDoubleTapGesture() const
     if (renderStyle() && renderStyle()->touchActions() != TouchAction::Auto)
         return false;
 
-    Element* parent = parentElement();
+    RefPtr parent = parentElement();
     return !parent || parent->allowsDoubleTapGesture();
 }
 
@@ -2356,7 +2380,7 @@ void invalidateForSiblingCombinators(Element* sibling)
         if (sibling->styleIsAffectedByPreviousSibling())
             sibling->invalidateStyleInternal();
         if (sibling->descendantsAffectedByPreviousSibling()) {
-            for (auto* siblingChild = sibling->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
+            for (RefPtr siblingChild = sibling->firstElementChild(); siblingChild; siblingChild = siblingChild->nextElementSibling())
                 siblingChild->invalidateStyleForSubtreeInternal();
         }
         if (!sibling->affectsNextSiblingElementStyle())
@@ -2496,8 +2520,8 @@ void Element::parserSetAttributes(std::span<const Attribute> attributes)
     ASSERT(!m_elementData);
 
     if (attributes.size()) {
-        if (document().sharedObjectPool())
-            m_elementData = document().sharedObjectPool()->cachedShareableElementDataWithAttributes(attributes);
+        if (auto* sharedObjectPool = document().sharedObjectPool())
+            m_elementData = sharedObjectPool->cachedShareableElementDataWithAttributes(attributes);
         else
             m_elementData = ShareableElementData::createWithAttributes(attributes);
 
@@ -2552,10 +2576,10 @@ void Element::updateEffectiveLangStateFromParent()
     ASSERT(!hasLanguageAttribute());
     ASSERT(parentNode() != &document());
 
-    auto* parent = parentOrShadowHostElement();
+    RefPtr parent = parentOrShadowHostElement();
 
     if (!parent || parent == document().documentElement()) {
-        setEffectiveLangKnownToMatchDocumentElement(parent);
+        setEffectiveLangKnownToMatchDocumentElement(parent.get());
         if (hasRareData())
             elementRareData()->setEffectiveLang(nullAtom());
         return;
@@ -2584,8 +2608,10 @@ void Element::updateEffectiveLangState()
         return;
     }
 
-    if (hasLangAttrKnownToMatchDocumentElement())
+    if (hasLangAttrKnownToMatchDocumentElement()) {
+        // Unable to protect the document as it may have started destruction.
         document().removeElementWithLangAttrMatchingDocumentElement(*this);
+    }
 
     setEffectiveLangKnownToMatchDocumentElement(false);
     ensureElementRareData().setEffectiveLang(lang);
@@ -2680,17 +2706,17 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
         }
 
         if (shouldAutofocus(*this))
-            document().topDocument().appendAutofocusCandidate(*this);
+            Ref { document().topDocument() }->appendAutofocusCandidate(*this);
     }
 
     if (parentNode() == &parentOfInsertedTree) {
-        if (auto* shadowRoot = parentNode()->shadowRoot())
+        if (RefPtr shadowRoot = parentNode()->shadowRoot())
             shadowRoot->hostChildElementDidChange(*this);
     }
 
     if (parentNode() == &parentOfInsertedTree && is<Document>(*parentNode())) {
         clearEffectiveLangStateOnNewDocumentElement();
-        document().setDocumentElementLanguage(langFromAttribute());
+        protectedDocument()->setDocumentElementLanguage(langFromAttribute());
     } else if (!hasLanguageAttribute())
         updateEffectiveLangStateFromParent();
 
@@ -2702,7 +2728,7 @@ void Element::clearEffectiveLangStateOnNewDocumentElement()
     ASSERT(parentNode() == &document());
 
     if (hasLangAttrKnownToMatchDocumentElement()) {
-        document().removeElementWithLangAttrMatchingDocumentElement(*this);
+        protectedDocument()->removeElementWithLangAttrMatchingDocumentElement(*this);
         setEffectiveLangKnownToMatchDocumentElement(false);
     }
 
@@ -2723,7 +2749,7 @@ bool Element::hasEffectiveLangState() const
 
 void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
-    if (auto* page = document().page()) {
+    if (CheckedPtr page = document().page()) {
 #if ENABLE(POINTER_LOCK)
         page->pointerLockController().elementWasRemoved(*this);
 #endif
@@ -2765,7 +2791,7 @@ void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldPar
     }
 
     if (!parentNode()) {
-        if (auto* shadowRoot = oldParentOfRemovedTree.shadowRoot())
+        if (RefPtr shadowRoot = oldParentOfRemovedTree.shadowRoot())
             shadowRoot->hostChildElementDidChange(*this);
     }
 
@@ -2817,7 +2843,7 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
     ASSERT(!newShadowRoot->hasChildNodes());
     ASSERT(!shadowRoot());
 
-    ShadowRoot& shadowRoot = newShadowRoot;
+    Ref shadowRoot = newShadowRoot;
     {
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
@@ -2826,8 +2852,8 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
 
         ensureElementRareData().setShadowRoot(WTFMove(newShadowRoot));
 
-        shadowRoot.setHost(this);
-        shadowRoot.setParentTreeScope(treeScope());
+        shadowRoot->setHost(this);
+        shadowRoot->setParentTreeScope(treeScope());
 
         NodeVector postInsertionNotificationTargets;
         notifyChildNodeInserted(*this, shadowRoot, postInsertionNotificationTargets);
@@ -2838,7 +2864,7 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
         invalidateStyleAndRenderersForSubtree();
     }
 
-    if (shadowRoot.mode() == ShadowRootMode::UserAgent)
+    if (shadowRoot->mode() == ShadowRootMode::UserAgent)
         didAddUserAgentShadowRoot(shadowRoot);
 }
 
@@ -2889,8 +2915,8 @@ static bool canAttachAuthorShadowRoot(const Element& element)
     }
 
     if (auto localName = element.localName(); Document::validateCustomElementName(localName) == CustomElementNameValidationStatus::Valid) {
-        if (auto* window = element.document().domWindow()) {
-            auto* registry = window->customElementRegistry();
+        if (RefPtr window = element.document().domWindow()) {
+            RefPtr registry = window->customElementRegistry();
             if (registry && registry->isShadowDisabled(localName))
                 return false;
         }
@@ -2916,13 +2942,12 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init)
     }
     if (init.mode == ShadowRootMode::UserAgent)
         return Exception { TypeError };
-    auto shadow = ShadowRoot::create(document(), init.mode, init.slotAssignment,
+    Ref shadow = ShadowRoot::create(document(), init.mode, init.slotAssignment,
         init.delegatesFocus ? ShadowRoot::DelegatesFocus::Yes : ShadowRoot::DelegatesFocus::No,
         init.cloneable ? ShadowRoot::Cloneable::Yes : ShadowRoot::Cloneable::No,
         isPrecustomizedOrDefinedCustomElement() ? ShadowRoot::AvailableToElementInternals::Yes : ShadowRoot::AvailableToElementInternals::No);
-    auto& result = shadow.get();
-    addShadowRoot(WTFMove(shadow));
-    return result;
+    addShadowRoot(shadow.copyRef());
+    return shadow.get();
 }
 
 ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, bool delegatesFocus)
@@ -2930,15 +2955,15 @@ ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, b
     auto exceptionOrShadowRoot = attachShadow({ mode, delegatesFocus, /* cloneable */ true });
     if (exceptionOrShadowRoot.hasException())
         return exceptionOrShadowRoot.releaseException();
-    auto& shadowRoot = exceptionOrShadowRoot.releaseReturnValue();
-    shadowRoot.setIsDeclarativeShadowRoot(true);
-    shadowRoot.setIsAvailableToElementInternals(true);
-    return shadowRoot;
+    Ref shadowRoot = exceptionOrShadowRoot.releaseReturnValue();
+    shadowRoot->setIsDeclarativeShadowRoot(true);
+    shadowRoot->setIsAvailableToElementInternals(true);
+    return shadowRoot.get();
 }
 
-ShadowRoot* Element::shadowRootForBindings(JSC::JSGlobalObject& lexicalGlobalObject) const
+RefPtr<ShadowRoot> Element::shadowRootForBindings(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
-    auto* shadow = shadowRoot();
+    RefPtr shadow = shadowRoot();
     if (!shadow)
         return nullptr;
     if (shadow->mode() == ShadowRootMode::Open)
@@ -2956,7 +2981,7 @@ RefPtr<ShadowRoot> Element::userAgentShadowRoot() const
 
 ShadowRoot& Element::ensureUserAgentShadowRoot()
 {
-    if (auto shadow = userAgentShadowRoot())
+    if (RefPtr shadow = userAgentShadowRoot())
         return *shadow;
     return createUserAgentShadowRoot();
 }
@@ -2964,7 +2989,7 @@ ShadowRoot& Element::ensureUserAgentShadowRoot()
 ShadowRoot& Element::createUserAgentShadowRoot()
 {
     ASSERT(!userAgentShadowRoot());
-    auto newShadow = ShadowRoot::create(document(), ShadowRootMode::UserAgent);
+    Ref newShadow = ShadowRoot::create(document(), ShadowRootMode::UserAgent);
     ShadowRoot& shadow = newShadow;
     addShadowRoot(WTFMove(newShadow));
     return shadow;
@@ -3085,7 +3110,7 @@ void Element::childrenChanged(const ChildChange& change)
 {
     ContainerNode::childrenChanged(change);
 
-    if (auto* shadowRoot = this->shadowRoot()) {
+    if (RefPtr shadowRoot = this->shadowRoot()) {
         switch (change.type) {
         case ChildChange::Type::ElementInserted:
         case ChildChange::Type::ElementRemoved:
@@ -3115,7 +3140,7 @@ void Element::setAttributeEventListener(const AtomString& eventType, const Quali
 void Element::removeAllEventListeners()
 {
     ContainerNode::removeAllEventListeners();
-    if (ShadowRoot* shadowRoot = this->shadowRoot())
+    if (RefPtr shadowRoot = this->shadowRoot())
         shadowRoot->removeAllEventListeners();
 }
 
@@ -3198,7 +3223,7 @@ void Element::attachAttributeNodeIfNeeded(Attr& attrNode)
 
 ExceptionOr<RefPtr<Attr>> Element::setAttributeNode(Attr& attrNode)
 {
-    RefPtr<Attr> oldAttrNode = attrIfExists(attrNode.localName(), shouldIgnoreAttributeCase(*this));
+    RefPtr oldAttrNode = attrIfExists(attrNode.localName(), shouldIgnoreAttributeCase(*this));
     if (oldAttrNode.get() == &attrNode)
         return oldAttrNode;
 
@@ -3245,8 +3270,8 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNode(Attr& attrNode)
 
 ExceptionOr<RefPtr<Attr>> Element::setAttributeNodeNS(Attr& attrNode)
 {
-    RefPtr<Attr> oldAttrNode = attrIfExists(attrNode.qualifiedName());
-    if (oldAttrNode.get() == &attrNode)
+    RefPtr oldAttrNode = attrIfExists(attrNode.qualifiedName());
+    if (oldAttrNode == &attrNode)
         return oldAttrNode;
 
     // InUseAttributeError: Raised if node is an Attr that is already an attribute of another Element object.
@@ -3295,9 +3320,9 @@ ExceptionOr<Ref<Attr>> Element::removeAttributeNode(Attr& attr)
     if (existingAttributeIndex == ElementData::attributeNotFound)
         return Exception { NotFoundError };
 
-    Ref<Attr> oldAttrNode { attr };
+    Ref oldAttrNode { attr };
 
-    detachAttrNodeFromElementWithValue(&attr, m_elementData->attributeAt(existingAttributeIndex).value());
+    detachAttrNodeFromElementWithValue(oldAttrNode.ptr(), m_elementData->attributeAt(existingAttributeIndex).value());
     removeAttributeInternal(existingAttributeIndex, InSynchronizationOfLazyAttribute::No);
 
     return oldAttrNode;
@@ -3332,7 +3357,7 @@ void Element::removeAttributeInternal(unsigned index, InSynchronizationOfLazyAtt
     QualifiedName name = elementData.attributeAt(index).name();
     AtomString valueBeingRemoved = elementData.attributeAt(index).value();
 
-    if (RefPtr<Attr> attrNode = attrIfExists(name))
+    if (RefPtr attrNode = attrIfExists(name))
         detachAttrNodeFromElementWithValue(attrNode.get(), elementData.attributeAt(index).value());
 
     if (inSynchronizationOfLazyAttribute == InSynchronizationOfLazyAttribute::Yes) {
@@ -3429,7 +3454,7 @@ bool Element::hasAttributeNS(const AtomString& namespaceURI, const AtomString& l
 
 static RefPtr<ShadowRoot> shadowRootWithDelegatesFocus(const Element& element)
 {
-    if (auto* root = element.shadowRoot()) {
+    if (RefPtr root = element.shadowRoot()) {
         if (root->delegatesFocus())
             return root;
     }
@@ -3455,25 +3480,25 @@ static bool isProgramaticallyFocusable(Element& element)
 // https://html.spec.whatwg.org/multipage/interaction.html#autofocus-delegate
 static RefPtr<Element> autoFocusDelegate(ContainerNode& target, FocusTrigger trigger)
 {
-    if (auto* root = target.shadowRoot(); root && !root->delegatesFocus())
+    if (RefPtr root = target.shadowRoot(); root && !root->delegatesFocus())
         return nullptr;
 
-    for (auto& element : descendantsOfType<Element>(target)) {
-        if (!element.hasAttributeWithoutSynchronization(HTMLNames::autofocusAttr))
+    for (Ref element : descendantsOfType<Element>(target)) {
+        if (!element->hasAttributeWithoutSynchronization(HTMLNames::autofocusAttr))
             continue;
         if (auto root = shadowRootWithDelegatesFocus(element)) {
-            if (auto target = Element::findFocusDelegateForTarget(*root, trigger))
+            if (RefPtr target = Element::findFocusDelegateForTarget(*root, trigger))
                 return target;
         }
         switch (trigger) {
         case FocusTrigger::Click:
-            if (element.isMouseFocusable())
-                return &element;
+            if (element->isMouseFocusable())
+                return element;
             break;
         case FocusTrigger::Other:
         case FocusTrigger::Bindings:
             if (isProgramaticallyFocusable(element))
-                return &element;
+                return element;
             break;
         }
     }
@@ -3483,24 +3508,24 @@ static RefPtr<Element> autoFocusDelegate(ContainerNode& target, FocusTrigger tri
 // https://html.spec.whatwg.org/multipage/interaction.html#focus-delegate
 RefPtr<Element> Element::findFocusDelegateForTarget(ContainerNode& target, FocusTrigger trigger)
 {
-    if (auto* root = target.shadowRoot(); root && !root->delegatesFocus())
+    if (RefPtr root = target.shadowRoot(); root && !root->delegatesFocus())
         return nullptr;
-    if (auto element = autoFocusDelegate(target, trigger))
+    if (RefPtr element = autoFocusDelegate(target, trigger))
         return element;
-    for (auto& element : descendantsOfType<Element>(target)) {
+    for (Ref element : descendantsOfType<Element>(target)) {
         switch (trigger) {
         case FocusTrigger::Click:
-            if (element.isMouseFocusable())
-                return &element;
+            if (element->isMouseFocusable())
+                return element;
             break;
         case FocusTrigger::Other:
         case FocusTrigger::Bindings:
             if (isProgramaticallyFocusable(element))
-                return &element;
+                return element;
             break;
         }
-        if (auto root = shadowRootWithDelegatesFocus(element)) {
-            if (auto target = findFocusDelegateForTarget(*root, trigger))
+        if (RefPtr root = shadowRootWithDelegatesFocus(element)) {
+            if (RefPtr target = findFocusDelegateForTarget(*root, trigger))
                 return target;
         }
     }
@@ -3526,8 +3551,8 @@ void Element::focus(const FocusOptions& options)
 
     Ref document { this->document() };
     if (document->focusedElement() == this) {
-        if (document->page())
-            document->page()->chrome().client().elementDidRefocus(*this, options);
+        if (CheckedPtr page = document->page())
+            page->chrome().client().elementDidRefocus(*this, options);
         return;
     }
 
@@ -3543,11 +3568,11 @@ void Element::focus(const FocusOptions& options)
     if (&newTarget->document() != document.ptr())
         return;
 
-    if (auto root = shadowRootWithDelegatesFocus(*this)) {
+    if (RefPtr root = shadowRootWithDelegatesFocus(*this)) {
         RefPtr currentlyFocusedElement = document->focusedElement();
         if (root->containsIncludingShadowDOM(currentlyFocusedElement.get())) {
-            if (document->page())
-                document->page()->chrome().client().elementDidRefocus(*currentlyFocusedElement, options);
+            if (CheckedPtr page = document->page())
+                page->chrome().client().elementDidRefocus(*currentlyFocusedElement, options);
             return;
         }
 
@@ -3557,9 +3582,9 @@ void Element::focus(const FocusOptions& options)
     } else if (!isProgramaticallyFocusable(*newTarget))
         return;
 
-    if (Page* page = document->page()) {
-        auto& frame = *document->frame();
-        if (!frame.hasHadUserInteraction() && !frame.isMainFrame() && !document->topOrigin().isSameOriginDomain(document->securityOrigin()))
+    if (CheckedPtr page = document->page()) {
+        Ref frame = *document->frame();
+        if (!frame->hasHadUserInteraction() && !frame->isMainFrame() && !document->topOrigin().isSameOriginDomain(document->securityOrigin()))
             return;
 
         FocusOptions optionsWithVisibility = options;
@@ -3571,7 +3596,7 @@ void Element::focus(const FocusOptions& options)
         // Focus and change event handlers can cause us to lose our last ref.
         // If a focus event handler changes the focus to a different node it
         // does not make sense to continue and update appearence.
-        if (!CheckedRef(page->focusController())->setFocusedElement(newTarget.get(), *document->frame(), optionsWithVisibility))
+        if (!CheckedRef(page->focusController())->setFocusedElement(newTarget.get(), frame, optionsWithVisibility))
             return;
     }
 
@@ -3594,7 +3619,7 @@ void Element::findTargetAndUpdateFocusAppearance(SelectionRestorationMode select
         revealMode = SelectionRevealMode::RevealUpToMainFrame;
 #endif
 
-    auto target = focusAppearanceUpdateTarget();
+    RefPtr target = focusAppearanceUpdateTarget();
     if (!target)
         return;
 
@@ -3639,7 +3664,7 @@ void Element::blur()
         if (RefPtr frame = document().frame())
             CheckedRef(frame->page()->focusController())->setFocusedElement(nullptr, *frame);
         else
-            document().setFocusedElement(nullptr);
+            protectedDocument()->setFocusedElement(nullptr);
     }
 }
 
@@ -3650,30 +3675,32 @@ void Element::runFocusingStepsForAutofocus()
 
 void Element::dispatchFocusInEventIfNeeded(RefPtr<Element>&& oldFocusedElement)
 {
-    if (!document().hasListenerType(Document::ListenerType::FocusIn))
+    Ref document = this->document();
+    if (!document->hasListenerType(Document::ListenerType::FocusIn))
         return;
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
-    dispatchScopedEvent(FocusEvent::create(eventNames().focusinEvent, Event::CanBubble::Yes, Event::IsCancelable::No, document().windowProxy(), 0, WTFMove(oldFocusedElement)));
+    dispatchScopedEvent(FocusEvent::create(eventNames().focusinEvent, Event::CanBubble::Yes, Event::IsCancelable::No, document->windowProxy(), 0, WTFMove(oldFocusedElement)));
 }
 
 void Element::dispatchFocusOutEventIfNeeded(RefPtr<Element>&& newFocusedElement)
 {
-    if (!document().hasListenerType(Document::ListenerType::FocusOut))
+    Ref document = this->document();
+    if (!document->hasListenerType(Document::ListenerType::FocusOut))
         return;
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
-    dispatchScopedEvent(FocusEvent::create(eventNames().focusoutEvent, Event::CanBubble::Yes, Event::IsCancelable::No, document().windowProxy(), 0, WTFMove(newFocusedElement)));
+    dispatchScopedEvent(FocusEvent::create(eventNames().focusoutEvent, Event::CanBubble::Yes, Event::IsCancelable::No, document->windowProxy(), 0, WTFMove(newFocusedElement)));
 }
 
 void Element::dispatchFocusEvent(RefPtr<Element>&& oldFocusedElement, const FocusOptions& options)
 {
-    if (auto* page = document().page())
+    if (CheckedPtr page = document().page())
         page->chrome().client().elementDidFocus(*this, options);
     dispatchEvent(FocusEvent::create(eventNames().focusEvent, Event::CanBubble::No, Event::IsCancelable::No, document().windowProxy(), 0, WTFMove(oldFocusedElement)));
 }
 
 void Element::dispatchBlurEvent(RefPtr<Element>&& newFocusedElement)
 {
-    if (auto* page = document().page())
+    if (CheckedPtr page = document().page())
         page->chrome().client().elementDidBlur(*this);
     dispatchEvent(FocusEvent::create(eventNames().blurEvent, Event::CanBubble::No, Event::IsCancelable::No, document().windowProxy(), 0, WTFMove(newFocusedElement)));
 }
@@ -3690,7 +3717,7 @@ bool Element::dispatchMouseForceWillBegin()
     if (!document().hasListenerType(Document::ListenerType::ForceWillBegin))
         return false;
 
-    auto* frame = document().frame();
+    RefPtr frame = document().frame();
     if (!frame)
         return false;
 
@@ -3710,7 +3737,7 @@ void Element::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventIn
 {
     document().eventLoop().queueTask(TaskSource::DOMManipulation, [this, protectedThis = Ref { *this }, event = SecurityPolicyViolationEvent::create(eventNames().securitypolicyviolationEvent, WTFMove(eventInit), Event::IsTrusted::Yes)] {
         if (!isConnected())
-            document().dispatchEvent(event);
+            protectedDocument()->dispatchEvent(event);
         else
             dispatchEvent(event);
     });
@@ -3718,10 +3745,9 @@ void Element::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventIn
 
 ExceptionOr<void> Element::mergeWithNextTextNode(Text& node)
 {
-    auto* next = node.nextSibling();
-    if (!is<Text>(next))
+    RefPtr textNext = dynamicDowncast<Text>(node.nextSibling());
+    if (!textNext)
         return { };
-    Ref<Text> textNext { downcast<Text>(*next) };
     node.appendData(textNext->data());
     return textNext->remove();
 }
@@ -3747,8 +3773,8 @@ ExceptionOr<void> Element::setOuterHTML(const String& html)
         return Exception { NoModificationAllowedError, "Cannot set outerHTML on element because its parent is not an Element"_s };
     }
 
-    RefPtr<Node> prev = previousSibling();
-    RefPtr<Node> next = nextSibling();
+    RefPtr prev = previousSibling();
+    RefPtr next = nextSibling();
 
     auto fragment = createFragmentForInnerOuterHTML(*parent, html, { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::AllowPluginContent });
     if (fragment.hasException())
@@ -3759,7 +3785,7 @@ ExceptionOr<void> Element::setOuterHTML(const String& html)
         return replaceResult.releaseException();
 
     // The following is not part of the specification but matches Blink's behavior as of June 2021.
-    RefPtr<Node> node = next ? next->previousSibling() : nullptr;
+    RefPtr node = next ? next->previousSibling() : nullptr;
     if (is<Text>(node)) {
         auto result = mergeWithNextTextNode(downcast<Text>(*node));
         if (result.hasException())
@@ -3775,16 +3801,16 @@ ExceptionOr<void> Element::setOuterHTML(const String& html)
 
 ExceptionOr<void> Element::setInnerHTML(const String& html)
 {
-    ContainerNode* container;
-    if (!is<HTMLTemplateElement>(*this))
-        container = this;
-    else
-        container = &downcast<HTMLTemplateElement>(*this).content();
+    Ref container = [this]() -> Ref<ContainerNode> {
+        if (!is<HTMLTemplateElement>(*this))
+            return *this;
+        return downcast<HTMLTemplateElement>(*this).content();
+    }();
 
     // Parsing empty string creates additional elements only inside <html> container
     // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhtml
-    if (html.isEmpty() && !is<HTMLHtmlElement>(*container)) {
-        ChildListMutationScope mutation(*container);
+    if (html.isEmpty() && !is<HTMLHtmlElement>(container)) {
+        ChildListMutationScope mutation(container);
         container->removeChildren();
         return { };
     }
@@ -3793,13 +3819,13 @@ ExceptionOr<void> Element::setInnerHTML(const String& html)
     if (fragment.hasException())
         return fragment.releaseException();
 
-    return replaceChildrenWithFragment(*container, fragment.releaseReturnValue());
+    return replaceChildrenWithFragment(container, fragment.releaseReturnValue());
 }
 
 String Element::innerText()
 {
     // We need to update layout, since plainText uses line boxes in the render tree.
-    document().updateLayoutIgnorePendingStylesheets();
+    protectedDocument()->updateLayoutIgnorePendingStylesheets();
 
     if (!renderer())
         return textContent(true);
@@ -3837,25 +3863,23 @@ void Element::setPseudo(const AtomString& value)
 
 void Element::willBecomeFullscreenElement()
 {
-    for (auto& child : descendantsOfType<Element>(*this))
-        child.ancestorWillEnterFullscreen();
+    for (Ref child : descendantsOfType<Element>(*this))
+        child->ancestorWillEnterFullscreen();
 }
 
 static void forEachRenderLayer(Element& element, const std::function<void(RenderLayer&)>& function)
 {
-    auto* renderer = element.renderer();
-    if (!renderer || !is<RenderLayerModelObject>(renderer))
+    CheckedPtr layerModelObject = dynamicDowncast<RenderLayerModelObject>(element.renderer());
+    if (!layerModelObject)
         return;
-        
-    auto& layerModelObject = downcast<RenderLayerModelObject>(*renderer);
 
-    if (!is<RenderBoxModelObject>(layerModelObject)) {
-        if (layerModelObject.hasLayer())
-            function(*layerModelObject.layer());
+    if (!is<RenderBoxModelObject>(*layerModelObject)) {
+        if (layerModelObject->hasLayer())
+            function(*layerModelObject->layer());
         return;
     }
 
-    RenderBoxModelObject::forRendererAndContinuations(downcast<RenderBoxModelObject>(*renderer), [function](RenderBoxModelObject& renderer) {
+    RenderBoxModelObject::forRendererAndContinuations(downcast<RenderBoxModelObject>(*layerModelObject), [function](RenderBoxModelObject& renderer) {
         if (renderer.hasLayer())
             function(*renderer.layer());
     });
@@ -3870,15 +3894,16 @@ void Element::addToTopLayer()
         layer.establishesTopLayerWillChange();
     });
 
-    document().addTopLayerElement(*this);
+    Ref document = this->document();
+    document->addTopLayerElement(*this);
     setNodeFlag(NodeFlag::IsInTopLayer);
 
-    document().scheduleContentRelevancyUpdate(ContentRelevancy::IsInTopLayer);
+    document->scheduleContentRelevancyUpdate(ContentRelevancy::IsInTopLayer);
 
     // Invalidate inert state
     invalidateStyleInternal();
-    if (document().documentElement())
-        document().documentElement()->invalidateStyleInternal();
+    if (RefPtr documentElement = document->documentElement())
+        documentElement->invalidateStyleInternal();
 
     forEachRenderLayer(*this, [](RenderLayer& layer) {
         layer.establishesTopLayerDidChange();
@@ -3897,13 +3922,14 @@ void Element::removeFromTopLayer()
     // We need to call Styleable::fromRenderer() while this element is still contained in
     // Document::topLayerElements(), since Styleable::fromRenderer() relies on this to
     // find the backdrop's associated element.
-    if (auto* renderer = this->renderer()) {
-        if (auto backdrop = renderer->backdropRenderer()) {
+    if (CheckedPtr renderer = this->renderer()) {
+        if (CheckedPtr backdrop = renderer->backdropRenderer().get()) {
             if (auto styleable = Styleable::fromRenderer(*backdrop))
                 styleable->cancelDeclarativeAnimations();
         }
     }
 
+    // Unable to protect the document as it may have started destruction.
     document().removeTopLayerElement(*this);
     clearNodeFlag(NodeFlag::IsInTopLayer);
 
@@ -3911,9 +3937,9 @@ void Element::removeFromTopLayer()
 
     // Invalidate inert state
     invalidateStyleInternal();
-    if (document().documentElement())
-        document().documentElement()->invalidateStyleInternal();
-    if (auto* modalElement = document().activeModalDialog())
+    if (RefPtr documentElement = document().documentElement())
+        documentElement->invalidateStyleInternal();
+    if (RefPtr modalElement = document().activeModalDialog())
         modalElement->invalidateStyleInternal();
 
     forEachRenderLayer(*this, [](RenderLayer& layer) {
@@ -3970,25 +3996,26 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
 {
     ASSERT(isConnected());
 
-    document().styleScope().flushPendingUpdate();
+    Ref document = this->document();
+    document->styleScope().flushPendingUpdate();
 
     bool isInDisplayNoneTree = false;
 
     // Traverse the ancestor chain to find the rootmost element that has invalid computed style.
-    auto* rootmostInvalidElement = [&]() -> const Element* {
+    RefPtr rootmostInvalidElement = [&]() -> RefPtr<const Element> {
         // In ResolveComputedStyleMode::RenderedOnly case we check for display:none ancestors.
-        if (mode == ResolveComputedStyleMode::Normal && !document().hasPendingStyleRecalc() && existingComputedStyle())
+        if (mode == ResolveComputedStyleMode::Normal && !document->hasPendingStyleRecalc() && existingComputedStyle())
             return nullptr;
 
-        if (document().hasPendingFullStyleRebuild())
-            return document().documentElement();
+        if (document->hasPendingFullStyleRebuild())
+            return document->documentElement();
 
-        if (!document().documentElement() || document().documentElement()->hasNodeFlag(NodeFlag::IsComputedStyleInvalidFlag))
-            return document().documentElement();
+        if (!document->documentElement() || document->documentElement()->hasNodeFlag(NodeFlag::IsComputedStyleInvalidFlag))
+            return document->documentElement();
 
-        const Element* rootmost = nullptr;
+        RefPtr<const Element> rootmost;
 
-        for (auto* element = this; element; element = element->parentElementInComposedTree()) {
+        for (RefPtr element = this; element; element = element->parentElementInComposedTree()) {
             if (element->hasNodeFlag(NodeFlag::IsComputedStyleInvalidFlag)) {
                 rootmost = element;
                 continue;
@@ -4013,16 +4040,16 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
         return existingComputedStyle();
     }
 
-    auto* ancestorWithValidStyle = rootmostInvalidElement->parentElementInComposedTree();
+    RefPtr ancestorWithValidStyle = rootmostInvalidElement->parentElementInComposedTree();
 
     Vector<RefPtr<Element>, 32> elementsRequiringComputedStyle;
-    for (auto* toResolve = this; toResolve != ancestorWithValidStyle; toResolve = toResolve->parentElementInComposedTree())
+    for (RefPtr toResolve = this; toResolve != ancestorWithValidStyle; toResolve = toResolve->parentElementInComposedTree())
         elementsRequiringComputedStyle.append(toResolve);
 
     auto* computedStyle = ancestorWithValidStyle ? ancestorWithValidStyle->existingComputedStyle() : nullptr;
 
     // On iOS request delegates called during styleForElement may result in re-entering WebKit and killing the style resolver.
-    Style::PostResolutionCallbackDisabler disabler(document(), Style::PostResolutionCallbackDisabler::DrainCallbacks::No);
+    Style::PostResolutionCallbackDisabler disabler(document, Style::PostResolutionCallbackDisabler::DrainCallbacks::No);
 
     // Resolve and cache styles starting from the most distant ancestor.
     // FIXME: This is not as efficient as it could be. For example if an ancestor has a non-inherited style change but
@@ -4030,19 +4057,19 @@ const RenderStyle* Element::resolveComputedStyle(ResolveComputedStyleMode mode)
     for (auto& element : makeReversedRange(elementsRequiringComputedStyle)) {
         if (computedStyle && computedStyle->containerType() != ContainerType::Normal) {
             // If we find a query container we need to bail out and do full style update to resolve it.
-            if (document().updateStyleIfNeeded())
+            if (document->updateStyleIfNeeded())
                 return this->computedStyle();
         };
-        auto style = document().styleForElementIgnoringPendingStylesheets(*element, computedStyle);
+        auto style = document->styleForElementIgnoringPendingStylesheets(*element, computedStyle);
         computedStyle = style.get();
         ElementRareData& rareData = element->ensureElementRareData();
         if (auto* existing = rareData.computedStyle()) {
             auto change = Style::determineChange(*existing, *style);
             if (change > Style::Change::NonInherited) {
-                for (auto& child : composedTreeChildren(*element)) {
+                for (Ref child : composedTreeChildren(*element)) {
                     if (!is<Element>(child))
                         continue;
-                    downcast<Element>(child).setNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
+                    downcast<Element>(child.get()).setNodeFlag(NodeFlag::IsComputedStyleInvalidFlag);
                 }
             }
         }
@@ -4064,9 +4091,10 @@ const RenderStyle& Element::resolvePseudoElementStyle(PseudoId pseudoElementSpec
     ASSERT(parentStyle);
     ASSERT(!parentStyle->getCachedPseudoStyle(pseudoElementSpecifier));
 
-    Style::PostResolutionCallbackDisabler disabler(document(), Style::PostResolutionCallbackDisabler::DrainCallbacks::No);
+    Ref document = this->document();
+    Style::PostResolutionCallbackDisabler disabler(document, Style::PostResolutionCallbackDisabler::DrainCallbacks::No);
 
-    auto style = document().styleForElementIgnoringPendingStylesheets(*this, parentStyle, pseudoElementSpecifier);
+    auto style = document->styleForElementIgnoringPendingStylesheets(*this, parentStyle, pseudoElementSpecifier);
     if (!style) {
         style = RenderStyle::createPtr();
         style->inheritFrom(*parentStyle);
@@ -4083,7 +4111,7 @@ const RenderStyle* Element::computedStyle(PseudoId pseudoElementSpecifier)
     if (!isConnected())
         return nullptr;
 
-    if (PseudoElement* pseudoElement = beforeOrAfterPseudoElement(*this, pseudoElementSpecifier))
+    if (RefPtr pseudoElement = beforeOrAfterPseudoElement(*this, pseudoElementSpecifier))
         return pseudoElement->computedStyle();
 
     // FIXME: This should call resolveComputedStyle() unconditionally so we check if the style is valid.
@@ -4171,7 +4199,7 @@ const AtomString& Element::langFromAttribute() const
 
 Locale& Element::locale() const
 {
-    return document().getCachedLocale(effectiveLang());
+    return protectedDocument()->getCachedLocale(effectiveLang());
 }
 
 void Element::normalizeAttributes()
@@ -4394,7 +4422,7 @@ void Element::webkitRequestFullscreen()
 // FIXME: Options are currently ignored.
 void Element::requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&& promise)
 {
-    document().fullscreenManager().requestFullscreenForElement(*this, WTFMove(promise), FullscreenManager::EnforceIFrameAllowFullscreenRequirement);
+    protectedDocument()->fullscreenManager().requestFullscreenForElement(*this, WTFMove(promise), FullscreenManager::EnforceIFrameAllowFullscreenRequirement);
 }
 
 void Element::setFullscreenFlag(bool flag)
@@ -4420,22 +4448,22 @@ void Element::setIFrameFullscreenFlag(bool flag)
 
 ExceptionOr<void> Element::setPointerCapture(int32_t pointerId)
 {
-    if (document().page())
-        return document().page()->pointerCaptureController().setPointerCapture(this, pointerId);
+    if (CheckedPtr page  =document().page())
+        return page->pointerCaptureController().setPointerCapture(this, pointerId);
     return { };
 }
 
 ExceptionOr<void> Element::releasePointerCapture(int32_t pointerId)
 {
-    if (document().page())
-        return document().page()->pointerCaptureController().releasePointerCapture(this, pointerId);
+    if (CheckedPtr page = document().page())
+        return page->pointerCaptureController().releasePointerCapture(this, pointerId);
     return { };
 }
 
 bool Element::hasPointerCapture(int32_t pointerId)
 {
-    if (document().page())
-        return document().page()->pointerCaptureController().hasPointerCapture(this, pointerId);
+    if (CheckedPtr page = document().page())
+        return page->pointerCaptureController().hasPointerCapture(this, pointerId);
     return false;
 }
 
@@ -4443,8 +4471,8 @@ bool Element::hasPointerCapture(int32_t pointerId)
 
 void Element::requestPointerLock()
 {
-    if (document().page())
-        document().page()->pointerLockController().requestPointerLock(this);
+    if (CheckedPtr page = document().page())
+        page->pointerLockController().requestPointerLock(this);
 }
 
 #endif
@@ -4931,8 +4959,8 @@ void Element::resetComputedStyle()
         element.elementRareData()->setComputedStyle(nullptr);
     };
     reset(*this);
-    for (auto& child : descendantsOfType<Element>(*this)) {
-        if (!child.hasRareData() || !child.elementRareData()->computedStyle() || child.hasDisplayContents())
+    for (Ref child : descendantsOfType<Element>(*this)) {
+        if (!child->hasRareData() || !child->elementRareData()->computedStyle() || child->hasDisplayContents())
             continue;
         reset(child);
     }
@@ -4970,11 +4998,12 @@ void Element::clearHoverAndActiveStatusBeforeDetachingRenderer()
 {
     if (!isUserActionElement())
         return;
+    Ref document = this->document();
     if (hovered())
-        document().hoveredElementDidDetach(*this);
+        document->hoveredElementDidDetach(*this);
     if (isInActiveChain())
-        document().elementInActiveChainDidDetach(*this);
-    document().userActionElements().clearActiveAndHovered(*this);
+        document->elementInActiveChainDidDetach(*this);
+    document->userActionElements().clearActiveAndHovered(*this);
 }
 
 void Element::willRecalcStyle(Style::Change)
@@ -5135,7 +5164,7 @@ ExceptionOr<Node*> Element::insertAdjacent(const String& where, Ref<Node>&& newC
     // Opera also appears to disallow such usage.
 
     if (equalLettersIgnoringASCIICase(where, "beforebegin"_s)) {
-        auto* parent = this->parentNode();
+        RefPtr parent = this->parentNode();
         if (!parent)
             return nullptr;
         auto result = parent->insertBefore(newChild, this);
@@ -5159,7 +5188,7 @@ ExceptionOr<Node*> Element::insertAdjacent(const String& where, Ref<Node>&& newC
     }
 
     if (equalLettersIgnoringASCIICase(where, "afterend"_s)) {
-        auto* parent = this->parentNode();
+        RefPtr parent = this->parentNode();
         if (!parent)
             return nullptr;
         auto result = parent->insertBefore(newChild, protectedNextSibling());
@@ -5183,7 +5212,7 @@ ExceptionOr<Element*> Element::insertAdjacentElement(const String& where, Elemen
 static ExceptionOr<ContainerNode&> contextNodeForInsertion(const String& where, Element& element)
 {
     if (equalLettersIgnoringASCIICase(where, "beforebegin"_s) || equalLettersIgnoringASCIICase(where, "afterend"_s)) {
-        auto* parent = element.parentNode();
+        RefPtr parent = element.parentNode();
         if (!parent || is<Document>(*parent))
             return Exception { NoModificationAllowedError };
         return *parent;
@@ -5199,10 +5228,10 @@ static ExceptionOr<Ref<Element>> contextElementForInsertion(const String& where,
     auto contextNodeResult = contextNodeForInsertion(where, element);
     if (contextNodeResult.hasException())
         return contextNodeResult.releaseException();
-    auto& contextNode = contextNodeResult.releaseReturnValue();
-    if (!is<Element>(contextNode) || (contextNode.document().isHTMLDocument() && is<HTMLHtmlElement>(contextNode)))
-        return Ref<Element> { HTMLBodyElement::create(contextNode.document()) };
-    return Ref<Element> { downcast<Element>(contextNode) };
+    Ref contextNode = contextNodeResult.releaseReturnValue();
+    if (!is<Element>(contextNode) || (contextNode->document().isHTMLDocument() && is<HTMLHtmlElement>(contextNode)))
+        return Ref<Element> { HTMLBodyElement::create(contextNode->protectedDocument()) };
+    return downcast<Element>(contextNode);
 }
 
 // https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml
@@ -5252,14 +5281,14 @@ RefPtr<Element> Element::findAnchorElementForLink(String& outAnchorName)
     if (href.isNull())
         return nullptr;
 
-    Document& document = this->document();
-    URL url = document.completeURL(href);
+    Ref document = this->document();
+    URL url = document->completeURL(href);
     if (!url.isValid())
         return nullptr;
 
-    if (url.hasFragmentIdentifier() && equalIgnoringFragmentIdentifier(url, document.baseURL())) {
+    if (url.hasFragmentIdentifier() && equalIgnoringFragmentIdentifier(url, document->baseURL())) {
         outAnchorName = url.fragmentIdentifier().toString();
-        return document.findAnchor(outAnchorName);
+        return document->findAnchor(outAnchorName);
     }
 
     return nullptr;
@@ -5286,11 +5315,12 @@ ExceptionOr<Ref<WebAnimation>> Element::animate(JSC::JSGlobalObject& lexicalGlob
         keyframeEffectOptions = keyframeEffectOptionsVariant;
     }
 
-    auto keyframeEffectResult = KeyframeEffect::create(lexicalGlobalObject, document(), this, WTFMove(keyframes), WTFMove(keyframeEffectOptions));
+    Ref document = this->document();
+    auto keyframeEffectResult = KeyframeEffect::create(lexicalGlobalObject, document, this, WTFMove(keyframes), WTFMove(keyframeEffectOptions));
     if (keyframeEffectResult.hasException())
         return keyframeEffectResult.releaseException();
 
-    auto animation = WebAnimation::create(document(), &keyframeEffectResult.returnValue().get());
+    Ref animation = WebAnimation::create(document, &keyframeEffectResult.returnValue().get());
     animation->setId(WTFMove(id));
     if (timeline)
         animation->setTimeline(timeline->get());
@@ -5308,8 +5338,9 @@ Vector<RefPtr<WebAnimation>> Element::getAnimations(std::optional<GetAnimationsO
     // If we are to return animations in the subtree, we can get all of the document's animations and filter
     // animations targeting that are not registered on this element, one of its pseudo elements or a child's
     // pseudo element.
+    Ref document = this->document();
     if (options && options->subtree) {
-        return document().matchingAnimations([&] (Element& target) -> bool {
+        return document->matchingAnimations([&] (Element& target) -> bool {
             return contains(&target);
         });
     }
@@ -5318,9 +5349,9 @@ Vector<RefPtr<WebAnimation>> Element::getAnimations(std::optional<GetAnimationsO
     // such as updates to CSS Animations and CSS Transitions. This requires updating layout as
     // well since resolving layout-dependent media queries could yield animations.
     // FIXME: We might be able to use ComputedStyleExtractor which is more optimized.
-    if (RefPtr owner = document().ownerElement())
-        owner->document().updateLayout();
-    document().updateStyleIfNeeded();
+    if (RefPtr owner = document->ownerElement())
+        owner->protectedDocument()->updateLayout();
+    document->updateStyleIfNeeded();
 
     Vector<RefPtr<WebAnimation>> animations;
     if (auto* effectStack = keyframeEffectStack(PseudoId::None)) {
@@ -5334,14 +5365,14 @@ Vector<RefPtr<WebAnimation>> Element::getAnimations(std::optional<GetAnimationsO
 
 ElementIdentifier Element::identifier() const
 {
-    return elementIdentifiersMap().ensure(const_cast<Element*>(this), [] { return ElementIdentifier::generate(); }).iterator->value;
+    return elementIdentifiersMap().ensure(const_cast<Element&>(*this), [] { return ElementIdentifier::generate(); }).iterator->value;
 }
 
 Element* Element::fromIdentifier(ElementIdentifier identifier)
 {
     for (auto& [element, elementIdentifier] : elementIdentifiersMap()) {
         if (elementIdentifier == identifier)
-            return element.get();
+            return element.ptr();
     }
     return nullptr;
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -223,7 +223,7 @@ public:
 
     // FIXME: Replace uses of offsetParent in the platform with calls
     // to the render layer and merge bindingsOffsetParent and offsetParent.
-    WEBCORE_EXPORT Element* offsetParentForBindings();
+    WEBCORE_EXPORT RefPtr<Element> offsetParentForBindings();
 
     inline const Element* rootElement() const;
 
@@ -245,7 +245,7 @@ public:
     // This does not update layout, and uses absoluteBoundingBoxRect().
     WEBCORE_EXPORT IntRect boundingBoxInRootViewCoordinates() const;
 
-    WEBCORE_EXPORT std::optional<std::pair<RenderObject*, FloatRect>> boundingAbsoluteRectWithoutLayout() const;
+    WEBCORE_EXPORT std::optional<std::pair<CheckedPtr<RenderObject>, FloatRect>> boundingAbsoluteRectWithoutLayout() const;
 
     WEBCORE_EXPORT FloatRect boundingClientRect();
 
@@ -350,7 +350,7 @@ public:
     virtual bool rendererIsEverNeeded() { return true; }
 
     inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
-    ShadowRoot* shadowRootForBindings(JSC::JSGlobalObject&) const;
+    RefPtr<ShadowRoot> shadowRootForBindings(JSC::JSGlobalObject&) const;
 
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&);
     ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, bool delegatesFocus);

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -141,6 +141,7 @@ public:
     Document* document() const;
     RefPtr<Document> protectedDocument() const;
     LocalFrameView* view() const;
+    inline RefPtr<LocalFrameView> protectedView() const; // Defined in LocalFrameView.h.
 
     Editor& editor() { return document()->editor(); }
     const Editor& editor() const { return document()->editor(); }

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -1095,6 +1095,11 @@ inline void LocalFrameView::incrementVisuallyNonEmptyCharacterCount(const String
     incrementVisuallyNonEmptyCharacterCountSlowCase(inlineText);
 }
 
+inline RefPtr<LocalFrameView> LocalFrame::protectedView() const
+{
+    return m_view;
+}
+
 WTF::TextStream& operator<<(WTF::TextStream&, const LocalFrameView&);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -560,6 +560,11 @@ inline RenderElement* ContainerNode::renderer() const
     return downcast<RenderElement>(Node::renderer());
 }
 
+inline CheckedPtr<RenderElement> ContainerNode::checkedRenderer() const
+{
+    return renderer();
+}
+
 inline RenderObject* RenderElement::firstInFlowChild() const
 {
     if (auto* firstChild = this->firstChild()) {

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -43,6 +43,10 @@ class HTMLSelectElement;
 class RenderListBox final : public RenderBlockFlow, public ScrollableArea {
     WTF_MAKE_ISO_ALLOCATED(RenderListBox);
 public:
+    // Resolve ambiguity for CanMakeCheckedPtr.
+    void incrementPtrCount() const { static_cast<const RenderBlockFlow*>(this)->incrementPtrCount(); }
+    void decrementPtrCount() const { static_cast<const RenderBlockFlow*>(this)->decrementPtrCount(); }
+
     RenderListBox(HTMLSelectElement&, RenderStyle&&);
     virtual ~RenderListBox();
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -307,7 +307,7 @@ void WebFullScreenManager::updateMainVideoElement()
             if (!rendererAndBounds)
                 continue;
 
-            auto [renderer, bounds] = *rendererAndBounds;
+            auto& [renderer, bounds] = *rendererAndBounds;
             if (!renderer || bounds.isEmpty())
                 continue;
 

--- a/Source/WebKitLegacy/mac/DOM/DOMElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMElement.mm
@@ -165,7 +165,7 @@ DOMElement *kit(WebCore::Element* value)
 - (DOMElement *)offsetParent
 {
     WebCore::JSMainThreadNullState state;
-    return kit(unwrap(*self).offsetParentForBindings());
+    return kit(unwrap(*self).offsetParentForBindings().get());
 }
 
 - (NSString *)innerHTML


### PR DESCRIPTION
#### dce93e1455ea9430b1385ffe812a7f19d7e23cfc
<pre>
Adopt more smart pointers in the Element class
<a href="https://bugs.webkit.org/show_bug.cgi?id=263271">https://bugs.webkit.org/show_bug.cgi?id=263271</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::attrNodeListMap):
(WebCore::attrNodeListForElement):
(WebCore::ensureAttrNodeListForElement):
(WebCore::removeAttrNodeListForElement):
(WebCore::shouldAutofocus):
(WebCore::elementIdentifiersMap):
(WebCore::Element::~Element):
(WebCore::Element::isKeyboardFocusable const):
(WebCore::dispatchPointerEventIfNeeded):
(WebCore::Element::dispatchMouseEvent):
(WebCore::Element::dispatchWheelEvent):
(WebCore::Element::dispatchKeyEvent):
(WebCore::Element::cloneShadowTreeIfPossible):
(WebCore::Element::cloneElementWithChildren):
(WebCore::Element::cloneElementWithoutChildren):
(WebCore::Element::detachAttribute):
(WebCore::Element::isUserActionElementInActiveChain const):
(WebCore::Element::isUserActionElementActive const):
(WebCore::Element::isUserActionElementFocused const):
(WebCore::Element::isUserActionElementHovered const):
(WebCore::Element::isUserActionElementDragged const):
(WebCore::Element::isUserActionElementHasFocusVisible const):
(WebCore::Element::isUserActionElementHasFocusWithin const):
(WebCore::Element::setActive):
(WebCore::Element::setFocus):
(WebCore::Element::setHasFocusVisible):
(WebCore::Element::setHasFocusWithin):
(WebCore::Element::setHasTentativeFocus):
(WebCore::Element::setHovered):
(WebCore::Element::setBeingDragged):
(WebCore::listBoxElementScrollIntoView):
(WebCore::Element::scrollIntoView):
(WebCore::Element::scrollIntoViewIfNeeded):
(WebCore::Element::scrollIntoViewIfNotVisible):
(WebCore::Element::scrollTo):
(WebCore::Element::scrollByUnits):
(WebCore::localZoomForRenderer):
(WebCore::Element::offsetLeft):
(WebCore::Element::offsetTop):
(WebCore::Element::offsetWidth):
(WebCore::Element::offsetHeight):
(WebCore::Element::offsetParentForBindings):
(WebCore::Element::offsetParent):
(WebCore::Element::clientLeft):
(WebCore::Element::clientTop):
(WebCore::Element::clientWidth):
(WebCore::Element::clientHeight):
(WebCore::Element::scrollLeft):
(WebCore::Element::scrollTop):
(WebCore::Element::setScrollLeft):
(WebCore::Element::setScrollTop):
(WebCore::Element::scrollWidth):
(WebCore::Element::scrollHeight):
(WebCore::shouldObtainBoundsFromSVGModel):
(WebCore::Element::boundsInRootViewSpace):
(WebCore::Element::boundingBoxInRootViewCoordinates const):
(WebCore::layoutOverflowRectContainsAllDescendants):
(WebCore::Element::absoluteEventBounds):
(WebCore::Element::absoluteEventBoundsOfElementAndDescendants):
(WebCore::Element::absoluteEventHandlerBounds):
(WebCore::listBoxElementBoundingBox):
(WebCore::Element::getClientRects):
(WebCore::Element::boundingAbsoluteRectWithoutLayout const):
(WebCore::Element::boundingClientRect):
(WebCore::Element::screenRect const):
(WebCore::Element::notifyAttributeChanged):
(WebCore::Element::attributeChanged):
(WebCore::Element::updateEffectiveLangStateAndPropagateToDescendants):
(WebCore::Element::setElementAttribute):
(WebCore::Element::setElementsArrayAttribute):
(WebCore::Element::allowsDoubleTapGesture const):
(WebCore::invalidateForSiblingCombinators):
(WebCore::Element::parserSetAttributes):
(WebCore::Element::updateEffectiveLangStateFromParent):
(WebCore::Element::updateEffectiveLangState):
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::clearEffectiveLangStateOnNewDocumentElement):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::addShadowRoot):
(WebCore::canAttachAuthorShadowRoot):
(WebCore::Element::shadowRootForBindings const):
(WebCore::Element::ensureUserAgentShadowRoot):
(WebCore::Element::createUserAgentShadowRoot):
(WebCore::Element::childrenChanged):
(WebCore::Element::removeAllEventListeners):
(WebCore::Element::setAttributeNode):
(WebCore::Element::setAttributeNodeNS):
(WebCore::Element::removeAttributeNode):
(WebCore::Element::removeAttributeInternal):
(WebCore::shadowRootWithDelegatesFocus):
(WebCore::autoFocusDelegate):
(WebCore::Element::findFocusDelegateForTarget):
(WebCore::Element::focus):
(WebCore::Element::findTargetAndUpdateFocusAppearance):
(WebCore::Element::blur):
(WebCore::Element::dispatchFocusInEventIfNeeded):
(WebCore::Element::dispatchFocusOutEventIfNeeded):
(WebCore::Element::dispatchFocusEvent):
(WebCore::Element::dispatchBlurEvent):
(WebCore::Element::dispatchMouseForceWillBegin):
(WebCore::Element::enqueueSecurityPolicyViolationEvent):
(WebCore::Element::mergeWithNextTextNode):
(WebCore::Element::setOuterHTML):
(WebCore::Element::setInnerHTML):
(WebCore::Element::innerText):
(WebCore::Element::willBecomeFullscreenElement):
(WebCore::forEachRenderLayer):
(WebCore::Element::addToTopLayer):
(WebCore::Element::removeFromTopLayer):
(WebCore::Element::resolveComputedStyle):
(WebCore::Element::resolvePseudoElementStyle):
(WebCore::Element::computedStyle):
(WebCore::Element::locale const):
(WebCore::Element::requestFullscreen):
(WebCore::Element::setPointerCapture):
(WebCore::Element::releasePointerCapture):
(WebCore::Element::hasPointerCapture):
(WebCore::Element::requestPointerLock):
(WebCore::Element::resetComputedStyle):
(WebCore::Element::clearHoverAndActiveStatusBeforeDetachingRenderer):
(WebCore::contextElementForInsertion):
(WebCore::Element::findAnchorElementForLink):
(WebCore::Element::animate):
(WebCore::Element::getAnimations):
(WebCore::Element::identifier const):
(WebCore::Element::fromIdentifier):
* Source/WebCore/dom/Element.h:
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.h:
(WebCore::LocalFrame::protectedView const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::ContainerNode::checkedRenderer const):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::updateMainVideoElement):

Canonical link: <a href="https://commits.webkit.org/269449@main">https://commits.webkit.org/269449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0031153c9220fcae758b451710cba24b7bcff53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22554 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20879 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21856 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22794 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25313 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26699 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24531 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/124 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/94 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5380 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->