### PR TITLE
Adopt inactiveSchedulingPolicy for Web Extension background pages.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1748,11 +1748,11 @@ WKWebViewConfiguration *WebExtensionContext::webViewConfiguration()
 
     configuration._processDisplayName = extension().webProcessDisplayName();
 
+    // FIXME: <https://webkit.org/b/263286> Consider allowing the background page to throttle or be suspended.
     auto *preferences = configuration.preferences;
-#if PLATFORM(MAC)
-    preferences._domTimersThrottlingEnabled = NO;
-#endif
+    preferences._hiddenPageDOMTimerThrottlingEnabled = NO;
     preferences._pageVisibilityBasedProcessSuppressionEnabled = NO;
+    preferences.inactiveSchedulingPolicy = WKInactiveSchedulingPolicyNone;
 
     // FIXME: Configure other extension web view configuration properties.
 

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -145,6 +145,7 @@ static NSString * const WKInspectorResourceScheme = @"inspector-resource";
         if ([_delegate inspectorViewControllerInspectorIsUnderTest:self]) {
             preferences._hiddenPageDOMTimerThrottlingEnabled = NO;
             preferences._pageVisibilityBasedProcessSuppressionEnabled = NO;
+            preferences.inactiveSchedulingPolicy = WKInactiveSchedulingPolicyNone;
         }
     }
 


### PR DESCRIPTION
#### c57208d41ef8e86f8cf6f8412ecc04e25a4e7b1d
<pre>
Adopt inactiveSchedulingPolicy for Web Extension background pages.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263287">https://bugs.webkit.org/show_bug.cgi?id=263287</a>
rdar://problem/117096484

Reviewed by Brian Weinstein, Brent Fulgham and Chris Dumez.

Adopt `_hiddenPageDOMTimerThrottlingEnabled` on all platform, instead of the macOS only `_domTimersThrottlingEnabled`.
Also adopt `inactiveSchedulingPolicy` by setting it to `WKInactiveSchedulingPolicyNone` to prevent runningboard from
suspending the background page and inspector background page.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::webViewConfiguration):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webViewConfiguration]):

Canonical link: <a href="https://commits.webkit.org/269445@main">https://commits.webkit.org/269445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41a9361e0ece74cf62581d567f6547b3d3c6bcf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22560 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20885 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23092 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22800 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19579 "Found 1 new API test failure: TestWebKitAPI.WebArchive.SaveResourcesBlobURL (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25319 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26698 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24530 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/96 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2843 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->