### PR TITLE
Regression(269372@main) Crash under SVGPathElement::attributeChanged()

### DIFF
--- a/LayoutTests/fast/svg/path-element-d-attribute-crash-expected.txt
+++ b/LayoutTests/fast/svg/path-element-d-attribute-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/svg/path-element-d-attribute-crash.html
+++ b/LayoutTests/fast/svg/path-element-d-attribute-crash.html
@@ -1,0 +1,9 @@
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+let path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+path.setAttribute('d', 'M10,30 A20,20 0,0,1 50,30 A20,20 0,0,1 90,30 Q90,60 50,90 Q10,60 10,30 z M5,5 L90,90');
+path.removeAttribute('d');
+</script>

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -66,7 +66,9 @@ void SVGPathElement::attributeChanged(const QualifiedName& name, const AtomStrin
 {
     if (name == SVGNames::dAttr) {
         auto& cache = pathSegListCache();
-        if (auto it = cache.find(newValue); it != cache.end())
+        if (newValue.isEmpty())
+            m_pathSegList->baseVal()->updateByteStreamData({ });
+        else if (auto it = cache.find(newValue); it != cache.end())
             m_pathSegList->baseVal()->updateByteStreamData(it->value);
         else {
             if (m_pathSegList->baseVal()->parse(newValue)) {


### PR DESCRIPTION
#### 386d03be6b4ccf4193db9ee540a2d292146ded3d
<pre>
Regression(269372@main) Crash under SVGPathElement::attributeChanged()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263288">https://bugs.webkit.org/show_bug.cgi?id=263288</a>
rdar://117091905

Reviewed by Ryosuke Niwa.

Add a fast path for when the `d` attribute value is empty instead of trying
to look up the value in the cache. The crash was due to trying to look up
a null AtomString in the Cache when the attribute gets removed.

* LayoutTests/fast/svg/path-element-d-attribute-crash-expected.txt: Added.
* LayoutTests/fast/svg/path-element-d-attribute-crash.html: Added.
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/269431@main">https://commits.webkit.org/269431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a65f95a567c01300115fbc08080174ff4730e8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22563 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24470 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22824 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/1294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23095 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22803 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/1294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25322 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/1294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/1294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24529 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/17994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/98 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/20251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5371 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->