### PR TITLE
[ews-build.webkit.org] Refactor label definitions

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -348,8 +348,6 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
     OPEN_STATES = ('open',)
     PUBLIC_REPOS = ('WebKit/WebKit',)
     SENSATIVE_FIELDS = ('github.title',)
-    UNSAFE_MERGE_QUEUE_LABEL = 'unsafe-merge-queue'
-    MERGE_QUEUE_LABEL = 'merge-queue'
     LABEL_PROCESS_DELAY = 10
     ACCOUNTS_TO_IGNORE = ('webkit-early-warning-system', 'webkit-commit-queue')
     TRAILER_RE = re.compile(r'^(?P<key>[^:()\t\/*]+): (?P<value>.+)')
@@ -515,13 +513,13 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
             return defer.returnValue(([], 'git'))
 
         log.msg(f'Handling PR #{pr_number} with hash: {head_sha}')
-        if action == 'labeled' and self.UNSAFE_MERGE_QUEUE_LABEL in labels:
+        if action == 'labeled' and GitHub.UNSAFE_MERGE_QUEUE_LABEL in labels:
             log.msg(f'PR #{pr_number} ({head_sha}) was labeled for unsafe-merge-queue')
             # 'labeled' is usually an ignored action, override it to force build
             payload['action'] = 'synchronize'
             yield task.deferLater(reactor, self.LABEL_PROCESS_DELAY, lambda: None)
             event = 'unsafe_merge_queue'
-        elif action == 'labeled' and self.MERGE_QUEUE_LABEL in labels:
+        elif action == 'labeled' and GitHub.MERGE_QUEUE_LABEL in labels:
             log.msg(f'PR #{pr_number} ({head_sha}) was labeled for merge-queue')
             # 'labeled' is usually an ignored action, override it to force build
             yield task.deferLater(reactor, self.LABEL_PROCESS_DELAY, lambda: None)

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -27,16 +27,14 @@ from buildbot.steps import trigger
 from .steps import (AddReviewerToCommitMessage, ApplyPatch, ApplyWatchList, Canonicalize, CommitPatch,
                    CheckOutPullRequest, CheckOutSource, CheckOutSpecificRevision, CheckChangeRelevance,
                    CheckStatusOnEWSQueues, CheckStyle, CleanGitRepo, CompileJSC, CompileWebKit, ConfigureBuild, DetermineLabelOwner,
-                   DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests, GitHubMixin,
+                   DownloadBuiltProduct, ExtractBuiltProduct, FetchBranches, FindModifiedLayoutTests, GitHub,
                    InstallGtkDependencies, InstallHooks, InstallWpeDependencies, KillOldProcesses, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch,
                    MapBranchAlias, RemoveAndAddLabels, RetrievePRDataFromLabel, RunAPITests, RunBindingsTests, RunBuildWebKitOrgUnitTests, RunBuildbotCheckConfigForBuildWebKit, RunBuildbotCheckConfigForEWS,
                    RunEWSUnitTests, RunResultsdbpyTests, RunJavaScriptCoreTests, RunWebKit1Tests, RunWebKitPerlTests, RunWebKitPyPython2Tests,
                    RunWebKitPyPython3Tests, RunWebKitTests, RunWebKitTestsRedTree, RunWebKitTestsInStressMode, RunWebKitTestsInStressGuardmallocMode,
                    SetBuildSummary, ShowIdentifier, TriggerCrashLogSubmission, UpdateWorkingDirectory, UpdatePullRequest,
                    ValidateCommitMessage, ValidateChange, ValidateCommitterAndReviewer, WaitForCrashCollection,
-                   InstallBuiltProduct, ValidateRemote, ValidateSquashed)
-
-GITHUB_PROJECTS = ['WebKit/WebKit', 'WebKit/WebKit-security', 'apple/WebKit']
+                   InstallBuiltProduct, ValidateRemote, ValidateSquashed, GITHUB_PROJECTS)
 
 class Factory(factory.BuildFactory):
     findModifiedLayoutTests = False
@@ -382,4 +380,4 @@ class SafeMergeQueueFactory(factory.BuildFactory):
     def __init__(self, platform, configuration=None, architectures=None, additionalArguments=None, **kwargs):
         super().__init__()
         for project in GITHUB_PROJECTS:
-            self.addStep(RetrievePRDataFromLabel(project, label=GitHubMixin.SAFE_MERGE_QUEUE_LABEL))
+            self.addStep(RetrievePRDataFromLabel(project, label=GitHub.SAFE_MERGE_QUEUE_LABEL))


### PR DESCRIPTION
#### 2b681519e6cc39c2a2eb75504661f2ebf163d19c
<pre>
[ews-build.webkit.org] Refactor label definitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=263290">https://bugs.webkit.org/show_bug.cgi?id=263290</a>
rdar://117100014

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/events.py:
(GitHubEventHandlerNoEdits): Use shared label definitions from GitHub.
(GitHubEventHandlerNoEdits.handle_pull_request): Ditto.
* Tools/CISupport/ews-build/factories.py:
(SafeMergeQueueFactory.__init__): Use shared label and remote definitions.
* Tools/CISupport/ews-build/steps.py:
(GitHub): Move labels from GitHubMixin to GitHub class.
(GitHub.user_for_queue): Ditto.
(GitHubMixin): Ditto.
(GitHubMixin._is_pr_blocked): Ditto.
(GitHubMixin._does_pr_has_skip_label): Ditto.
(GitHubMixin._is_pr_in_merge_queue): Ditto.
(ValidateChange.run): Ditto.
(ValidateChange.validate_github): Ditto.
(BlockPullRequest.run): Ditto.
(BlockPullRequest.getResultSummary): Ditto.
(RemoveLabelsFromPullRequest): Ditto.
(RemoveAndAddLabels.__init__): Ditto.
(RemoveAndAddLabels.run): Ditto.
(AddMergeLabelsToPRs.run): Ditto.

Canonical link: <a href="https://commits.webkit.org/269436@main">https://commits.webkit.org/269436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfc6130a8b5408e2c6c78bff2ac4e5e875cda5c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22582 "2 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24488 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/20905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22842 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/1315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23113 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22821 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/1315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25341 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/1315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/1315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24543 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22378 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2836 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->