### PR TITLE
fast/events/touch/ios/selection-handles-after-touch-end.html is not robust against inflated (yet valid) selection handle views

### DIFF
--- a/LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end-expected.txt
@@ -12,11 +12,13 @@ PASS Math.round(selectionRects[0].width) is 250
 PASS Math.round(selectionRects[0].height) is 167
 PASS Math.round(startGrabberRect.left) is 0
 PASS Math.round(startGrabberRect.top) is 3
-PASS Math.round(startGrabberRect.width) is 2
+PASS Math.round(startGrabberRect) is <= Math.round(selectionRects[0].left)
+PASS Math.round(startGrabberRect.left + startGrabberRect.width) is > Math.round(selectionRects[0].left)
 PASS Math.round(startGrabberRect.height) is 167
 PASS Math.round(endGrabberRect.left) is 249
 PASS Math.round(endGrabberRect.top) is 3
-PASS Math.round(endGrabberRect.width) is 2
+PASS Math.round(endGrabberRect.left) is <= Math.round(selectionRects[0].left + selectionRects[0].width)
+PASS Math.round(endGrabberRect.left + endGrabberRect.width) is > Math.round(selectionRects[0].left + selectionRects[0].width)
 PASS Math.round(endGrabberRect.height) is 167
 PASS observedTouchEnd became true
 PASS successfullyParsed is true

--- a/LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end.html
+++ b/LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end.html
@@ -35,13 +35,15 @@ document.addEventListener("touchend", async () => {
     startGrabberRect = await UIHelper.getSelectionStartGrabberViewRect();
     shouldBe("Math.round(startGrabberRect.left)", "0");
     shouldBe("Math.round(startGrabberRect.top)", "3");
-    shouldBe("Math.round(startGrabberRect.width)", "2");
+    shouldBeLessThanOrEqual("Math.round(startGrabberRect)", "Math.round(selectionRects[0].left)");
+    shouldBeGreaterThan("Math.round(startGrabberRect.left + startGrabberRect.width)", "Math.round(selectionRects[0].left)");
     shouldBe("Math.round(startGrabberRect.height)", "167");
 
     endGrabberRect = await UIHelper.getSelectionEndGrabberViewRect();
     shouldBe("Math.round(endGrabberRect.left)", "249");
     shouldBe("Math.round(endGrabberRect.top)", "3");
-    shouldBe("Math.round(endGrabberRect.width)", "2");
+    shouldBeLessThanOrEqual("Math.round(endGrabberRect.left)", "Math.round(selectionRects[0].left + selectionRects[0].width)");
+    shouldBeGreaterThan("Math.round(endGrabberRect.left + endGrabberRect.width)", "Math.round(selectionRects[0].left + selectionRects[0].width)");
     shouldBe("Math.round(endGrabberRect.height)", "167");
 
     observedTouchEnd = true;


### PR DESCRIPTION
#### ed057aadc4b7de3b1db3297e6ad6abb0dd90b77a
<pre>
fast/events/touch/ios/selection-handles-after-touch-end.html is not robust against inflated (yet valid) selection handle views
<a href="https://bugs.webkit.org/show_bug.cgi?id=263295">https://bugs.webkit.org/show_bug.cgi?id=263295</a>
rdar://116418780

Reviewed by Wenson Hsieh.

The fast/events/touch/ios/selection-handles-after-touch-end.html test
makes exact assertions about the width of the text selection handle view
corresponding to the start grabber and the end grabber of a selection.
This means that the test is not robust against the case where the
grabberRect may visibly still have the correct width (2 px), but with a
view that has imperceptible inflated bounds.

We make the test robust to this case by asserting that the
startGrabberRect and endGrabberRect are roughly located around the left
edge and the right edge of the corresponding selection rect instead.

* LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end-expected.txt:
* LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end.html:

Canonical link: <a href="https://commits.webkit.org/269476@main">https://commits.webkit.org/269476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b37e6d5ab86d8407fd31b05113dfc4922f7d8989

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21878 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25361 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26723 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20539 "Found 2 new API test failures: TestWebKitAPI.ServiceWorker.WindowClientNavigate, TestWebKitAPI.ServiceWorker.WindowClientNavigateCrossOrigin (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18020 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20278 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5400 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->