### PR TITLE
[JSC] Top-level function declarations should be lexical in module code

### DIFF
--- a/JSTests/modules/async-function-export.js
+++ b/JSTests/modules/async-function-export.js
@@ -1,5 +1,0 @@
-function f()
-{
-}
-
-export async function f() { }

--- a/JSTests/stress/modules-syntax-error.js
+++ b/JSTests/stress/modules-syntax-error.js
@@ -377,3 +377,32 @@ new import()
 checkModuleSyntaxError(String.raw`
 new import
 `, `SyntaxError: Cannot use new with import.:3`);
+
+// --- top-level function declarations are lexical in module code ---
+
+checkModuleSyntaxError(String.raw`
+var test;
+function test() {}
+`, `SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'test'.:4`);
+
+checkModuleSyntax(String.raw`
+function foo() {
+    var test;
+    function test() {}
+}`);
+
+checkModuleSyntaxError(String.raw`
+function test() {}
+function test() {}
+`, `SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'test'.:4`);
+
+checkModuleSyntax(String.raw`
+function foo() {
+    function test() {}
+    function test() {}
+}`);
+
+checkModuleSyntaxError(String.raw`
+function test() {}
+export async function test() {}
+`, `SyntaxError: Cannot declare an async function that shadows a let/const/class/function variable 'test'.:4`);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1361,10 +1361,6 @@ test/language/expressions/compound-assignment/S11.13.2_A7.8_T4.js:
 test/language/expressions/compound-assignment/S11.13.2_A7.9_T4.js:
   default: 'Test262Error: Expected true but got false'
   strict mode: 'Test262Error: Expected true but got false'
-test/language/expressions/dynamic-import/catch/nested-async-gen-await-eval-script-code-target.js:
-  module: 'Test262:AsyncTestFailure:Test262Error: [object Object]'
-test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-eval-script-code-target.js:
-  module: 'Test262:AsyncTestFailure:Test262Error: [object Object]'
 test/language/expressions/dynamic-import/for-await-resolution-and-error-agen-yield.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: f Expected SameValue(«null», «foo») to be true'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: f Expected SameValue(«null», «foo») to be true'
@@ -1494,22 +1490,10 @@ test/language/import/import-assertions/json-via-namespace.js:
 test/language/literals/regexp/u-astral-char-class-invert.js:
   default: 'Test262Error: Expected SameValue(«�», «null») to be true'
   strict mode: 'Test262Error: Expected SameValue(«�», «null») to be true'
-test/language/module-code/early-dup-top-function-async-generator.js:
-  module: 'Test262: This statement should not be evaluated.'
-test/language/module-code/early-dup-top-function-async.js:
-  module: 'Test262: This statement should not be evaluated.'
-test/language/module-code/early-dup-top-function-generator.js:
-  module: 'Test262: This statement should not be evaluated.'
-test/language/module-code/early-dup-top-function.js:
-  module: 'Test262: This statement should not be evaluated.'
 test/language/module-code/import-assertions/eval-gtbndng-indirect-faux-assertion.js:
   raw: "SyntaxError: Unexpected token '*'. import call expects one or two arguments."
 test/language/module-code/import-assertions/import-assertion-empty.js:
   module: "SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration."
-test/language/module-code/parse-err-hoist-lex-fun.js:
-  module: 'Test262: This statement should not be evaluated.'
-test/language/module-code/parse-err-hoist-lex-gen.js:
-  module: 'Test262: This statement should not be evaluated.'
 test/language/statements/async-generator/generator-created-after-decl-inst.js:
   default: 'Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false'
   strict mode: 'Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false'

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -1071,8 +1071,8 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, ModuleProgramNode* moduleProgramNod
     // So it should be called after putting our lexical environment to the TDZ stack correctly.
 
     for (FunctionMetadataNode* function : moduleProgramNode->functionStack()) {
-        const auto& iterator = moduleProgramNode->varDeclarations().find(function->ident().impl());
-        RELEASE_ASSERT(iterator != moduleProgramNode->varDeclarations().end());
+        const auto& iterator = moduleProgramNode->lexicalVariables().find(function->ident().impl());
+        RELEASE_ASSERT(iterator != moduleProgramNode->lexicalVariables().end());
         RELEASE_ASSERT(!iterator->value.isImported());
 
         VarKind varKind = lookUpVarKind(iterator->key.get(), iterator->value);

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -172,9 +172,6 @@ Parser<LexerType>::Parser(VM& vm, const SourceCode& source, ImplementationVisibi
     if (isModuleParseMode(parseMode))
         m_moduleScopeData = ModuleScopeData::create();
 
-    if (isProgramOrModuleParseMode(parseMode))
-        scope->setIsGlobalCodeScope();
-
     next();
 }
 
@@ -2608,7 +2605,7 @@ template <class TreeBuilder> bool Parser<LexerType>::parseFunctionInfo(TreeBuild
         // BytecodeGenerator emits code to throw TypeError when a class constructor is "call"ed.
         // Set ConstructorKind to None for non-constructor methods of classes.
     
-        if (parentScope->isGlobalCodeScope() && m_defaultConstructorKindForTopLevelFunction != ConstructorKind::None) {
+        if (parentScope->isGlobalCode() && m_defaultConstructorKindForTopLevelFunction != ConstructorKind::None) {
             constructorKind = m_defaultConstructorKindForTopLevelFunction;
             expectedSuperBinding = m_defaultConstructorKindForTopLevelFunction == ConstructorKind::Extends ? SuperBinding::Needed : SuperBinding::NotNeeded;
         }
@@ -5332,7 +5329,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
             semanticFailIfFalse(currentScope()->isFunction() || currentScope()->isStaticBlock() || isFunctionEvalContextType || isClassFieldInitializer, "new.target is only valid inside functions or static blocks");
             baseIsNewTarget = true;
             if (currentScope()->isArrowFunction()) {
-                semanticFailIfFalse(!closestOrdinaryFunctionScope->isGlobalCodeScope() || isFunctionEvalContextType || isClassFieldInitializer, "new.target is not valid inside arrow functions in global code");
+                semanticFailIfFalse(!closestOrdinaryFunctionScope->isGlobalCode() || isFunctionEvalContextType || isClassFieldInitializer, "new.target is not valid inside arrow functions in global code");
                 currentScope()->setInnerArrowFunctionUsesNewTarget();
             }
             ASSERT(lastNewTokenLocation.line);


### PR DESCRIPTION
#### 2838f145f33f94240bcf79e431598adb8625ebbb
<pre>
[JSC] Top-level function declarations should be lexical in module code
<a href="https://bugs.webkit.org/show_bug.cgi?id=263269">https://bugs.webkit.org/show_bug.cgi?id=263269</a>
&lt;rdar://problem/117086061&gt;

Reviewed by Ross Kirsling.

The spec has at least 8 occurrences of

&gt; It is a Syntax Error if the LexicallyDeclaredNames of X contains any duplicate entries.

early error rules that preclude duplicate lexical declarations. For backwards-compatibility,
LexicallyDeclaredNames [1] skips top-level function declarations inside `ScriptBody : StatementList`
by invoking TopLevelLexicallyDeclaredNames [2], which returns an empty list for them [3].

However, the semantics of LexicallyDeclaredNames is entirely different for `ModuleItem`
(also please see note #1). The fact that top-level function declarations are lexical in module code
is also evident during binding initialization [4].

This change makes top-level function declarations in module code behave like `let` rather than `var`,
introducing early errors that come with it, like disallowing duplicates with `var` and `function`.

Since inside declareFunction() we can&apos;t rely neither on `m_scriptMode` (which is always `Module`,
even for nested functions that absolutely should not throw SyntaxError for duplicate declarations),
nor on `m_parseMode` (it&apos;s already the parse mode of the declared function itself), this change
introduces isModuleCode() [5], refactoring parse mode handling in Scope.

Also, this patch aligns declareFunctionAsLet() with declareVariable(), called for `let` declarations,
by adding `m_declaredVariables` check, which may fail only in module code. Removes now incorrect
(for module code only) ASSERT that isn&apos;t particularly useful given how simple declareFunction() now is.

Aligns JSC with V8 and SpiderMonkey.

[1]: <a href="https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames">https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames</a>
[2]: <a href="https://tc39.es/ecma262/#sec-static-semantics-toplevellexicallydeclarednames">https://tc39.es/ecma262/#sec-static-semantics-toplevellexicallydeclarednames</a>
[3]: <a href="https://tc39.es/ecma262/#prod-HoistableDeclaration">https://tc39.es/ecma262/#prod-HoistableDeclaration</a>
[4]: <a href="https://tc39.es/ecma262/#sec-source-text-module-record-initialize-environment">https://tc39.es/ecma262/#sec-source-text-module-record-initialize-environment</a> (step 24.iii)
[5]: <a href="https://tc39.es/ecma262/#sec-types-of-source-code">https://tc39.es/ecma262/#sec-types-of-source-code</a>

* JSTests/modules/async-function-export.js: Moved to JSTests/stress/modules-syntax-error.js.
* JSTests/stress/modules-syntax-error.js:
* JSTests/test262/expectations.yaml: Mark 8 tests as passing.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::Parser):
(JSC::Parser&lt;LexerType&gt;::parseFunctionInfo):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::setSourceParseMode):
(JSC::Scope::isGlobalCode const):
(JSC::Scope::isModuleCode const):
(JSC::Scope::declareFunctionAsLet):
(JSC::Scope::setIsGlobalCode):
(JSC::Scope::setIsModuleCode):
(JSC::Parser::declareFunction):
(JSC::Scope::setIsGlobalCodeScope): Deleted.
(JSC::Scope::isGlobalCodeScope const): Deleted.

Canonical link: <a href="https://commits.webkit.org/269485@main">https://commits.webkit.org/269485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdc9b00b5eaaf30700460e29bc62bd6cd9289786

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/22715 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/23802 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/24622 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/1463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/23245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/24622 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/22955 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/1463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/23802 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/25475 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/1463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/23802 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/25475 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/19781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/1463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/23802 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/25475 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/22080 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/23245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/26133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/23802 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/26133 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/27415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2859 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/27415 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->