### PR TITLE
[cssom-view] Implement Element.prototype.checkVisibility API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility-expected.txt
@@ -1,19 +1,21 @@
 hello
 hello
+hello
+slotted
 spacer
 
-FAIL checkVisibility on visibility:hidden element. visibilityhidden.checkVisibility is not a function. (In 'visibilityhidden.checkVisibility({
-    checkVisibilityCSS: true
-  })', 'visibilityhidden.checkVisibility' is undefined)
-FAIL checkVisibility on content-visibility:hidden element. cvhidden.checkVisibility is not a function. (In 'cvhidden.checkVisibility()', 'cvhidden.checkVisibility' is undefined)
-FAIL checkVisibility on content-visibility:auto element. cvauto.checkVisibility is not a function. (In 'cvauto.checkVisibility()', 'cvauto.checkVisibility' is undefined)
-FAIL checkVisibility on content-visibility:auto element which is outside the viewport. cvautooffscreen.checkVisibility is not a function. (In 'cvautooffscreen.checkVisibility()', 'cvautooffscreen.checkVisibility' is undefined)
-FAIL checkVisibility on display:none element. displaynone.checkVisibility is not a function. (In 'displaynone.checkVisibility()', 'displaynone.checkVisibility' is undefined)
-FAIL checkVisibility on opacity:0 element. opacityzero.checkVisibility is not a function. (In 'opacityzero.checkVisibility({
-    checkOpacity: true
-  })', 'opacityzero.checkVisibility' is undefined)
-FAIL checkVisibility on content-visibility:auto with visibility:hidden inside. cvautochild.checkVisibility is not a function. (In 'cvautochild.checkVisibility({checkVisibilityCSS: true})', 'cvautochild.checkVisibility' is undefined)
-FAIL checkVisibility on nested content-visibility:auto containers reports that the content is visible. nestedcvautochild.checkVisibility is not a function. (In 'nestedcvautochild.checkVisibility()', 'nestedcvautochild.checkVisibility' is undefined)
-FAIL checkVisibility on content-visibility:hidden child after forced layout update. cvhiddenchildwithupdate.checkVisibility is not a function. (In 'cvhiddenchildwithupdate.checkVisibility()', 'cvhiddenchildwithupdate.checkVisibility' is undefined)
-FAIL checkVisibility on content-visibility:hidden element after forced layout update. cvhiddenwithupdate.checkVisibility is not a function. (In 'cvhiddenwithupdate.checkVisibility()', 'cvhiddenwithupdate.checkVisibility' is undefined)
+PASS checkVisibility on visibility:hidden element.
+PASS checkVisibility on content-visibility:hidden element.
+PASS checkVisibility on element slotted in content-visibility: hidden shadow host.
+PASS checkVisibility on content-visibility:auto element.
+PASS checkVisibility on content-visibility:auto element which is outside the viewport.
+PASS checkVisibility on display:none element.
+PASS checkVisibility on element slotted in display:none shadow host.
+PASS checkVisibility on display:contents element.
+PASS checkVisibility on opacity:0 element.
+PASS checkVisibility on element slotted in opacity: 0; shadow host.
+PASS checkVisibility on content-visibility:auto with visibility:hidden inside.
+PASS checkVisibility on nested content-visibility:auto containers reports that the content is visible.
+PASS checkVisibility on content-visibility:hidden child after forced layout update.
+PASS checkVisibility on content-visibility:hidden element after forced layout update.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html
@@ -16,13 +16,29 @@
 
 <div id=displaynone style="display:none">hello</div>
 
+<div style="display:none" class="shadow-host-with-slot">
+  <div id="slottedindisplaynone" slot="slot">slotted</div>
+</div>
+
+<div id=displaycontents style="display:contents">
+  <div id=displaycontentschild>hello</div>
+</div>
+
 <div id=opacityzero style="opacity:0">hello</div>
+
+<div style="opacity:0" class="shadow-host-with-slot">
+  <div id="slottedinopacityzero" slot="slot">slotted</div>
+</div>
 
 <div style="content-visibility:hidden">
   <div id=cvhiddenchildwithupdate></div>
 </div>
 
 <div style="content-visibility:hidden" id=cvhiddenwithupdate></div>
+
+<div style="content-visibility:hidden" class="shadow-host-with-slot">
+  <div id="slottedincvhidden" slot="slot">slotted</div>
+</div>
 
 <div style="height:10000px">spacer</div>
 
@@ -41,6 +57,13 @@
 </div>
 
 <script>
+for (const host of document.querySelectorAll(".shadow-host-with-slot")) {
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  const slot = document.createElement("slot");
+  slot.name = "slot";
+  shadowRoot.appendChild(slot);
+}
+
 test(() => {
   assert_false(visibilityhidden.checkVisibility({
     checkVisibilityCSS: true
@@ -55,6 +78,10 @@ test(() => {
 }, 'checkVisibility on content-visibility:hidden element.');
 
 test(() => {
+  assert_false(slottedincvhidden.checkVisibility());
+}, 'checkVisibility on element slotted in content-visibility: hidden shadow host.');
+
+test(() => {
   assert_true(cvauto.checkVisibility());
 }, 'checkVisibility on content-visibility:auto element.');
 
@@ -67,6 +94,15 @@ test(() => {
 }, 'checkVisibility on display:none element.');
 
 test(() => {
+  assert_false(slottedindisplaynone.checkVisibility());
+}, 'checkVisibility on element slotted in display:none shadow host.');
+
+test(() => {
+  assert_false(displaycontents.checkVisibility());
+  assert_true(displaycontentschild.checkVisibility());
+}, 'checkVisibility on display:contents element.');
+
+test(() => {
   assert_false(opacityzero.checkVisibility({
     checkOpacity: true
   }), 'checkOpacity:true');
@@ -74,6 +110,15 @@ test(() => {
     checkOpacity: false
   }), 'checkOpacity:false');
 }, 'checkVisibility on opacity:0 element.');
+
+test(() => {
+  assert_false(slottedinopacityzero.checkVisibility({
+    checkOpacity: true
+  }), 'checkOpacity: true');
+  assert_true(slottedinopacityzero.checkVisibility({
+    checkOpacity: false
+  }), 'checkOpacity: true');
+}, 'checkVisibility on element slotted in opacity: 0; shadow host.');
 
 test(() => {
   cvautocontainer.style.contentVisibility = 'auto';

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2480,6 +2480,20 @@ EditableLinkBehavior:
     WebCore:
       default: EditableLinkBehavior::Default
 
+ElementCheckVisibilityEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "element.checkVisibility() API"
+  humanReadableDescription: "Enable element.checkVisibility() API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 EmbedElementEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1007,6 +1007,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/BroadcastChannel.idl
     dom/CDATASection.idl
     dom/CharacterData.idl
+    dom/CheckVisibilityOptions.idl
     dom/ChildNode.idl
     dom/ClipboardEvent.idl
     dom/Comment.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1311,6 +1311,7 @@ $(PROJECT_DIR)/dom/BeforeUnloadEvent.idl
 $(PROJECT_DIR)/dom/BroadcastChannel.idl
 $(PROJECT_DIR)/dom/CDATASection.idl
 $(PROJECT_DIR)/dom/CharacterData.idl
+$(PROJECT_DIR)/dom/CheckVisibilityOptions.idl
 $(PROJECT_DIR)/dom/ChildNode.idl
 $(PROJECT_DIR)/dom/ClipboardEvent.idl
 $(PROJECT_DIR)/dom/Comment.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -567,6 +567,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSChannelSplitterOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSChannelSplitterOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCharacterData.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCharacterData.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCheckVisibilityOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCheckVisibilityOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSChildNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSChildNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSClipboard.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1014,6 +1014,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/BroadcastChannel.idl \
     $(WebCore)/dom/CDATASection.idl \
     $(WebCore)/dom/CharacterData.idl \
+    $(WebCore)/dom/CheckVisibilityOptions.idl \
     $(WebCore)/dom/ChildNode.idl \
     $(WebCore)/dom/ClipboardEvent.idl \
     $(WebCore)/dom/Comment.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -906,6 +906,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/CDATASection.h
     dom/CallbackResult.h
     dom/CharacterData.h
+    dom/CheckVisibilityOptions.h
     dom/CollectionIndexCache.h
     dom/CollectionIndexCacheInlines.h
     dom/Comment.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3303,6 +3303,7 @@ JSChannelMergerOptions.cpp
 JSChannelSplitterNode.cpp
 JSChannelSplitterOptions.cpp
 JSCharacterData.cpp
+JSCheckVisibilityOptions.cpp
 JSChildNode.cpp
 JSClipboard.cpp
 JSClipboardEvent.cpp

--- a/Source/WebCore/dom/CheckVisibilityOptions.h
+++ b/Source/WebCore/dom/CheckVisibilityOptions.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+struct CheckVisibilityOptions {
+    bool checkOpacity { false };
+    bool checkVisibilityCSS { false };
+};
+
+}

--- a/Source/WebCore/dom/CheckVisibilityOptions.idl
+++ b/Source/WebCore/dom/CheckVisibilityOptions.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface
+dictionary CheckVisibilityOptions {
+    boolean checkOpacity = false;
+    boolean checkVisibilityCSS = false;
+};

--- a/Source/WebCore/dom/Element+CSSOMView.idl
+++ b/Source/WebCore/dom/Element+CSSOMView.idl
@@ -27,6 +27,9 @@
 partial interface Element {
     DOMRectList getClientRects();
     [NewObject] DOMRect getBoundingClientRect();
+
+    [EnabledBySetting=ElementCheckVisibilityEnabled] boolean checkVisibility(optional CheckVisibilityOptions options = {});
+
     undefined scrollIntoView(optional (boolean or ScrollIntoViewOptions) arg);
     [ImplementedAs=scrollTo] undefined scroll(optional ScrollToOptions options);
     [ImplementedAs=scrollTo] undefined scroll(unrestricted double x, unrestricted double y);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -92,6 +92,7 @@ enum class IsSyntheticClick : bool { No, Yes };
 enum class ResolveURLs : uint8_t { No, NoExcludingURLsForPrivacy, Yes, YesExcludingURLsForPrivacy };
 enum class SelectionRestorationMode : uint8_t;
 
+struct CheckVisibilityOptions;
 struct FullscreenOptions;
 struct GetAnimationsOptions;
 struct IntersectionObserverData;
@@ -197,6 +198,8 @@ public:
     inline const Attribute* findAttributeByName(const QualifiedName&) const;
     inline unsigned findAttributeIndexByName(const QualifiedName&) const;
     inline unsigned findAttributeIndexByName(const AtomString&, bool shouldIgnoreAttributeCase) const;
+
+    bool checkVisibility(const CheckVisibilityOptions&);
 
     WEBCORE_EXPORT void scrollIntoView(std::optional<std::variant<bool, ScrollIntoViewOptions>>&& arg);
     WEBCORE_EXPORT void scrollIntoView(bool alignToTop = true);


### PR DESCRIPTION
#### 7d04a9c1b62bc8a8101c390f6a164cf4b3da9cfa
<pre>
[cssom-view] Implement Element.prototype.checkVisibility API
<a href="https://bugs.webkit.org/show_bug.cgi?id=263223">https://bugs.webkit.org/show_bug.cgi?id=263223</a>
rdar://117113659

Reviewed by Simon Fraser.

Implement the API defined at: <a href="https://drafts.csswg.org/cssom-view/#dom-element-checkvisibility">https://drafts.csswg.org/cssom-view/#dom-element-checkvisibility</a>

This is implemented in a way that exclusively queries DOM + style information, to report correct information on skipped subtrees
without performing a forced layout on those subtrees.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html: Resync from upstream
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/CheckVisibilityOptions.h: Added.
* Source/WebCore/dom/CheckVisibilityOptions.idl: Copied from Source/WebCore/dom/Element+CSSOMView.idl.
* Source/WebCore/dom/Element+CSSOMView.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::checkVisibility):
* Source/WebCore/dom/Element.h:

Canonical link: <a href="https://commits.webkit.org/269506@main">https://commits.webkit.org/269506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3098255ae1bc80942397412e2ddef86caf7c9555

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21089 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23024 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25545 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20640 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19836 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24706 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/328 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/26203 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20443 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6138 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5424 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27485 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5967 "Passed tests") | 
<!--EWS-Status-Bubble-End-->