### PR TITLE
Update JSC stress tests to support ICU 74

### DIFF
--- a/JSTests/stress/array-toLocaleString.js
+++ b/JSTests/stress/array-toLocaleString.js
@@ -43,4 +43,8 @@ shouldBe([ undefined, undefined ].toLocaleString(), ',');
 
 // Test that parameters are passed through properly.
 shouldThrow(() => [ new Date ].toLocaleString('i'), RangeError);
-shouldBeOneOf([ new Date(NaN), new Date(0) ].toLocaleString('zh-Hans-CN-u-nu-hanidec', { timeZone: 'UTC' }), [ 'Invalid Date,一九七〇/一/一 〇〇:〇〇:〇〇', 'Invalid Date,一九七〇/一/一 上午一二:〇〇:〇〇' ]);
+shouldBeOneOf([ new Date(NaN), new Date(0) ].toLocaleString('zh-Hans-CN-u-nu-hanidec', { timeZone: 'UTC' }), [
+    'Invalid Date,一九七〇/一/一 〇:〇〇:〇〇',
+    'Invalid Date,一九七〇/一/一 〇〇:〇〇:〇〇',
+    'Invalid Date,一九七〇/一/一 上午一二:〇〇:〇〇'
+]);

--- a/JSTests/stress/date-toLocaleString.js
+++ b/JSTests/stress/date-toLocaleString.js
@@ -49,8 +49,16 @@ shouldBe(new Date(NaN).toLocaleString(), "Invalid Date");
 // Test for DateTimeFormat behavior.
 // Test that locale parameter is passed through properly.
 shouldThrow(() => new Date().toLocaleString('i'), RangeError);
-shouldBeOneOf(new Date(0).toLocaleString('zh-Hans-CN-u-nu-hanidec', { timeZone: 'UTC' }), [ '一九七〇/一/一 〇〇:〇〇:〇〇', '一九七〇/一/一 上午一二:〇〇:〇〇' ]);
-shouldBeOneOf(new Date(0).toLocaleString('zh-Hans-CN', { timeZone: 'UTC', numberingSystem: 'hanidec' }), [ '一九七〇/一/一 〇〇:〇〇:〇〇', '一九七〇/一/一 上午一二:〇〇:〇〇' ]);
+shouldBeOneOf(new Date(0).toLocaleString('zh-Hans-CN-u-nu-hanidec', { timeZone: 'UTC' }), [
+    '一九七〇/一/一 〇:〇〇:〇〇',
+    '一九七〇/一/一 〇〇:〇〇:〇〇',
+    '一九七〇/一/一 上午一二:〇〇:〇〇'
+]);
+shouldBeOneOf(new Date(0).toLocaleString('zh-Hans-CN', { timeZone: 'UTC', numberingSystem: 'hanidec' }), [
+    '一九七〇/一/一 〇:〇〇:〇〇',
+    '一九七〇/一/一 〇〇:〇〇:〇〇',
+    '一九七〇/一/一 上午一二:〇〇:〇〇'
+]);
 shouldBe(new Date(0).toLocaleString('en-u-ca-chinese', { timeZone: 'UTC', year: 'numeric' }), '1969(ji-you)');
 shouldBe(new Date(0).toLocaleString('en', { timeZone: 'UTC', year: 'numeric', calendar: 'chinese' }), '1969(ji-you)');
 
@@ -129,8 +137,8 @@ shouldBe(new Date(NaN).toLocaleTimeString(), 'Invalid Date');
 // Test for DateTimeFormat behavior.
 // Test that locale parameter is passed through properly.
 shouldThrow(() => new Date().toLocaleTimeString('i'), RangeError);
-shouldBeOneOf(new Date(0).toLocaleTimeString('zh-Hans-CN-u-nu-hanidec', { timeZone: 'UTC' }), [ "〇〇:〇〇:〇〇", "上午一二:〇〇:〇〇" ]);
-shouldBeOneOf(new Date(0).toLocaleTimeString('zh-Hans-CN', { timeZone: 'UTC', numberingSystem: 'hanidec' }), [ "〇〇:〇〇:〇〇", "上午一二:〇〇:〇〇" ]);
+shouldBeOneOf(new Date(0).toLocaleTimeString('zh-Hans-CN-u-nu-hanidec', { timeZone: 'UTC' }), [ "〇:〇〇:〇〇", "〇〇:〇〇:〇〇", "上午一二:〇〇:〇〇" ]);
+shouldBeOneOf(new Date(0).toLocaleTimeString('zh-Hans-CN', { timeZone: 'UTC', numberingSystem: 'hanidec' }), [ "〇:〇〇:〇〇", "〇〇:〇〇:〇〇", "上午一二:〇〇:〇〇" ]);
 shouldBe(new Date(0).toLocaleTimeString('en-u-ca-chinese', { timeZone: 'UTC', year: 'numeric' }), '1969(ji-you), 12:00:00 AM');
 shouldBe(new Date(0).toLocaleTimeString('en', { timeZone: 'UTC', year: 'numeric', calendar: 'chinese' }), '1969(ji-you), 12:00:00 AM');
 

--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -755,7 +755,7 @@ shouldBe(JSON.stringify(Intl.DateTimeFormat('zh', { era: 'short', year: 'numeric
     shouldBe(JSON.stringify(actual), JSON.stringify(expected));
 }
 {
-    shouldBeOneOf(new Date(0).toLocaleTimeString('zh-Hans-CN', { timeZone: 'UTC', numberingSystem: 'hanidec', hour: "numeric", minute: "numeric", second: "numeric", fractionalSecondDigits: 2 }), [ "〇〇:〇〇:〇〇.〇〇", "上午一二:〇〇:〇〇.〇〇" ]);
+    shouldBeOneOf(new Date(0).toLocaleTimeString('zh-Hans-CN', { timeZone: 'UTC', numberingSystem: 'hanidec', hour: "numeric", minute: "numeric", second: "numeric", fractionalSecondDigits: 2 }), [ "〇:〇〇:〇〇.〇〇", "〇〇:〇〇:〇〇.〇〇", "上午一二:〇〇:〇〇.〇〇" ]);
 }
 {
     const dtf = new Intl.DateTimeFormat('en-AU', { timeZone: 'Australia/Melbourne', year: 'numeric' });


### PR DESCRIPTION
#### 00ee523e133c96a5459ae343549700553140fb94
<pre>
Update JSC stress tests to support ICU 74
<a href="https://bugs.webkit.org/show_bug.cgi?id=263304">https://bugs.webkit.org/show_bug.cgi?id=263304</a>

Reviewed by Yusuke Suzuki.

There only seems to be one change we need to adapt for this release:
Han decimal time display changed such that the hour 0 is now 〇 instead of 〇〇.

* JSTests/stress/array-toLocaleString.js:
* JSTests/stress/date-toLocaleString.js:
* JSTests/stress/intl-datetimeformat.js:

Canonical link: <a href="https://commits.webkit.org/269451@main">https://commits.webkit.org/269451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/464cef79c4bc365d648513f83e8746a4e273d855

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24532 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20942 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23153 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22863 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25385 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26742 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19697 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24578 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21989 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/26041 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6107 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5381 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27323 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5933 "Passed tests") | 
<!--EWS-Status-Bubble-End-->