### PR TITLE
[JSC] Fix Map.groupBy and Object.groupBy callback arguments

### DIFF
--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -175,15 +175,9 @@ test/built-ins/Function/internals/Construct/derived-this-uninitialized-realm.js:
 test/built-ins/Function/prototype/toString/built-in-function-object.js:
   default: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
   strict mode: 'Test262Error: Conforms to NativeFunction Syntax: "function $*() {\n    [native code]\n}" (%RegExp%.$*)'
-test/built-ins/Map/groupBy/callback-arg.js:
-  default: 'Test262Error: only two arguments are passed Expected SameValue(«3», «2») to be true'
-  strict mode: 'Test262Error: only two arguments are passed Expected SameValue(«3», «2») to be true'
 test/built-ins/Object/entries/order-after-define-property-with-function.js:
   default: 'Test262Error: Expected [a, name] and [name, a] to have the same contents. '
   strict mode: 'Test262Error: Expected [a, name] and [name, a] to have the same contents. '
-test/built-ins/Object/groupBy/callback-arg.js:
-  default: 'Test262Error: only two arguments are passed Expected SameValue(«3», «2») to be true'
-  strict mode: 'Test262Error: only two arguments are passed Expected SameValue(«3», «2») to be true'
 test/built-ins/Object/keys/order-after-define-property-with-function.js:
   default: 'Test262Error: Expected [a, length] and [length, a] to have the same contents. '
   strict mode: 'Test262Error: Expected [a, length] and [length, a] to have the same contents. '

--- a/Source/JavaScriptCore/builtins/MapConstructor.js
+++ b/Source/JavaScriptCore/builtins/MapConstructor.js
@@ -36,7 +36,7 @@ function groupBy(items, callback)
     var groups = new @Map;
     var k = 0;
     for (var item of items) {
-        var key = callback.@call(@undefined, item, k, items);
+        var key = callback.@call(@undefined, item, k);
         var group = groups.@get(key);
         if (!group) {
             group = [];

--- a/Source/JavaScriptCore/builtins/ObjectConstructor.js
+++ b/Source/JavaScriptCore/builtins/ObjectConstructor.js
@@ -56,7 +56,7 @@ function groupBy(items, callback)
     var groups = @Object.@create(null);
     var k = 0;
     for (var item of items) {
-        var key = @toPropertyKey(callback.@call(@undefined, item, k, items));
+        var key = @toPropertyKey(callback.@call(@undefined, item, k));
         var group = groups[key];
         if (!group) {
             group = [];


### PR DESCRIPTION
#### ab951214497597d341962219a73d4b1ce743f19e
<pre>
[JSC] Fix Map.groupBy and Object.groupBy callback arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=263308">https://bugs.webkit.org/show_bug.cgi?id=263308</a>
rdar://117120234

Reviewed by Alexey Shvayka.

This patch adjusts Map.groupBy / Object.groupBy&apos;s callback arguments to the latest proposal[1].

[1]: <a href="https://github.com/tc39/proposal-array-grouping">https://github.com/tc39/proposal-array-grouping</a>

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/MapConstructor.js:
(groupBy):
* Source/JavaScriptCore/builtins/ObjectConstructor.js:
(groupBy):

Canonical link: <a href="https://commits.webkit.org/269456@main">https://commits.webkit.org/269456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b514f9a70f003b4cfc2edf6c594b1132dc2e1c78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20950 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23161 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22871 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25393 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19705 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/20748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24586 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/21997 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/26049 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6108 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27331 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2846 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5934 "Passed tests") | 
<!--EWS-Status-Bubble-End-->