### PR TITLE
[MSE][GStreamer] Pause after seek is not working

### DIFF
--- a/LayoutTests/media/media-controller-play-then-pause-expected.txt
+++ b/LayoutTests/media/media-controller-play-then-pause-expected.txt
@@ -8,5 +8,7 @@ EVENT(pause)
 RUN(controller.play())
 EVENT(play)
 EXPECTED (controller.playbackState == 'playing') OK
+EXPECTED (!internals.isPlayerPaused(video)) OK
+EXPECTED (!internals.isPlayerPaused(video2)) OK
 END OF TEST
 

--- a/LayoutTests/media/media-controller-play-then-pause.html
+++ b/LayoutTests/media/media-controller-play-then-pause.html
@@ -1,48 +1,35 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="timeout" content="long">
 <script src=media-file.js></script>
 <script src=video-test.js></script>
 <script>
 var controller;
 var video2;
 
-function start() {
-    var videos = document.getElementsByTagName('video');
+async function start() {
+  var videos = document.getElementsByTagName('video');
 	video = videos[0];
 	video2 = videos[1];
 	run('controller = video.controller');
-	controller.addEventListener('canplaythrough', canplaythrough, true);
 	var src = findMediaFile('video', 'content/test');
 	video.src = src;
 	video2.src = src;
-}
+  await waitFor(controller, 'canplaythrough');
 
-function canplaythrough() {
-	consoleWrite("EVENT(canplaythrough)");
-	controller.removeEventListener('canplaythrough', canplaythrough, true);
-	controller.addEventListener('playing', playing, true);
 	run('controller.play()');
-}
+	await waitFor(controller, 'playing');
 
-function playing() {
-	consoleWrite("EVENT(playing)");
-	controller.removeEventListener('playing', playing, true);
-	controller.addEventListener('pause', pause, true);
 	run('controller.pause()');
-}
+	await waitFor(controller, 'pause');
 
-function pause() {
-	consoleWrite("EVENT(pause)");
-	controller.removeEventListener('pause', pause, true);
-	controller.addEventListener('play', playAgain, true);
 	run('controller.play()');
-}
+	await waitFor(controller, 'play');
 
-function playAgain() {
-	consoleWrite("EVENT(play)");
 	testExpected('controller.playbackState', 'playing');
-	controller.removeEventListener('play', playAgain, true);
+  await waitForConditionOrTimeout('!internals.isPlayerPaused(video)');
+  await waitForConditionOrTimeout('!internals.isPlayerPaused(video2)');
 	endTest();
 }
 </script>

--- a/LayoutTests/media/media-source/media-controller-media-source-play-then-pause-expected.txt
+++ b/LayoutTests/media/media-source/media-controller-media-source-play-then-pause-expected.txt
@@ -1,0 +1,29 @@
+
+RUN(controller = video.controller)
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Append all media segments
+RUN(video2.src = URL.createObjectURL(source2))
+EVENT(sourceopen)
+RUN(sourceBuffer2 = source2.addSourceBuffer(loader.type()))
+RUN(sourceBuffer2.appendBuffer(loader.initSegment()))
+EVENT(update)
+Append all media segments
+RUN(controller.play())
+EVENT(playing)
+EXPECTED (!internals.isPlayerPaused(video)) OK
+EXPECTED (!internals.isPlayerPaused(video2)) OK
+RUN(controller.pause())
+EVENT(pause)
+EXPECTED (internals.isPlayerPaused(video)) OK
+EXPECTED (internals.isPlayerPaused(video2)) OK
+RUN(controller.play())
+EVENT(play)
+EXPECTED (controller.playbackState == 'playing') OK
+EXPECTED (!internals.isPlayerPaused(video)) OK
+EXPECTED (!internals.isPlayerPaused(video2)) OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-controller-media-source-play-then-pause.html
+++ b/LayoutTests/media/media-source/media-controller-media-source-play-then-pause.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="timeout" content="long">
+<script src="media-source-loader.js"></script>
+<script src="../video-test.js"></script>
+<script>
+var loader;
+var source;
+var source2;
+var sourceBuffer;
+var sourceBuffer2;
+var controller;
+var video2;
+var i;
+
+function loaderPromise(loader) {
+    return new Promise((resolve, reject) => {
+        loader.onload = resolve;
+        loader.onerror = reject;
+    });
+}
+
+async function start() {
+    loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+    await loaderPromise(loader);
+
+    var videos = document.getElementsByTagName('video');
+	  video = videos[0];
+	  video2 = videos[1];
+	  run('controller = video.controller');
+
+    source = new MediaSource();
+    run('video.src = URL.createObjectURL(source)');
+    await waitFor(source, 'sourceopen');
+    waitFor(video, 'error').then(failTest);
+
+    run('sourceBuffer = source.addSourceBuffer(loader.type())');
+    run('sourceBuffer.appendBuffer(loader.initSegment())');
+    await waitFor(sourceBuffer, 'update');
+
+    consoleWrite('Append all media segments')
+    for (i = 0; i < loader.mediaSegmentsLength(); i++) {
+        sourceBuffer.appendBuffer(loader.mediaSegment(i));
+        await waitFor(sourceBuffer, 'update', true);
+    }
+
+    source2 = new MediaSource();
+    run('video2.src = URL.createObjectURL(source2)');
+    await waitFor(source2, 'sourceopen');
+    waitFor(video2, 'error').then(failTest);
+
+    run('sourceBuffer2 = source2.addSourceBuffer(loader.type())');
+    run('sourceBuffer2.appendBuffer(loader.initSegment())');
+    await waitFor(sourceBuffer2, 'update');
+
+    consoleWrite('Append all media segments')
+    for (i = 0; i < loader.mediaSegmentsLength(); i++) {
+        sourceBuffer2.appendBuffer(loader.mediaSegment(i));
+        await waitFor(sourceBuffer2, 'update', true);
+    }
+
+    run('controller.play()');
+    await waitFor(controller, 'playing');
+    await waitForConditionOrTimeout('!internals.isPlayerPaused(video)', false, 5000);
+    await waitForConditionOrTimeout('!internals.isPlayerPaused(video2)', false, 5000);
+
+	  run('controller.pause()');
+    await waitFor(controller, 'pause');
+    await waitForConditionOrTimeout('internals.isPlayerPaused(video)', false, 5000);
+    await waitForConditionOrTimeout('internals.isPlayerPaused(video2)', false, 5000);
+
+    run('controller.play()');
+	  await waitFor(controller, 'play');
+
+    testExpected('controller.playbackState', 'playing');
+    await waitForConditionOrTimeout('!internals.isPlayerPaused(video)', false, 5000);
+    await waitForConditionOrTimeout('!internals.isPlayerPaused(video2)', false, 5000);
+
+    endTest();
+}
+</script>
+</head>
+<body onload="start()">
+	<video mediaGroup="group" controls></video>
+	<video mediaGroup="group" controls></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-seek-and-play-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-and-play-expected.txt
@@ -1,0 +1,21 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Appended all media segments
+RUN(video.currentTime = 0)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.paused == 'false') OK
+RUN(video.pause())
+EVENT(pause)
+EXPECTED (video.paused == 'true') OK
+RUN(video.currentTime = 1)
+RUN(video.play())
+EVENT(play)
+EXPECTED (video.paused == 'false') OK
+EXPECTED (!internals.isPlayerPaused(video)) OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-and-play.html
+++ b/LayoutTests/media/media-source/media-source-seek-and-play.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="timeout" content="long">
+<script src="media-source-loader.js"></script>
+<script src="../video-test.js"></script>
+<script>
+var loader;
+var source;
+var sourceBuffer;
+var i;
+
+function loaderPromise(loader) {
+    return new Promise((resolve, reject) => {
+        loader.onload = resolve;
+        loader.onerror = reject;
+    });
+}
+
+async function start() {
+
+    findMediaElement();
+
+    let isTestEnded = false;
+    let numberOfInitiatedSeeks = 0;
+    let numberOfCompletedSeeks = 0;
+
+    async function finalCheck() {
+        if (!isTestEnded || numberOfInitiatedSeeks < 2 || numberOfCompletedSeeks < 1) {
+            return;
+        }
+
+        await waitForConditionOrTimeout('!internals.isPlayerPaused(video)', false, 5000, 1000);
+        endTest();
+    }
+
+    video.addEventListener('seeking', event => {
+        numberOfInitiatedSeeks++;
+    });
+
+    video.addEventListener('seeked', event => {
+        numberOfCompletedSeeks++;
+        finalCheck();
+    });
+
+    loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+    await loaderPromise(loader);
+
+    source = new MediaSource();
+    run('video.src = URL.createObjectURL(source)');
+    await waitFor(source, 'sourceopen');
+    waitFor(video, 'error').then(failTest);
+
+    run('sourceBuffer = source.addSourceBuffer(loader.type())');
+    run('sourceBuffer.appendBuffer(loader.initSegment())');
+    await waitFor(sourceBuffer, 'update');
+
+    for (i = 0; i < loader.mediaSegmentsLength(); i++) {
+        sourceBuffer.appendBuffer(loader.mediaSegment(i));
+        await waitFor(sourceBuffer, 'update', true);
+    }
+    consoleWrite('Appended all media segments')
+
+    run('video.currentTime = 0');
+    run('video.play()');
+    await waitFor(video, 'playing');
+    testExpected('video.paused', false);
+
+	  run('video.pause()');
+    await waitFor(video, 'pause');
+    testExpected('video.paused', true);
+
+    run('video.currentTime = 1');
+    run('video.play()');
+	  await waitFor(video, 'play');
+    testExpected('video.paused', false);
+
+    isTestEnded = true;
+    finalCheck();
+}
+</script>
+</head>
+<body onload="start()">
+ 	<video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-video-seek-pause-expected.txt
+++ b/LayoutTests/media/media-source/media-source-video-seek-pause-expected.txt
@@ -1,0 +1,15 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+Append all media segments
+RUN('video.play()')
+EXPECTED (video.paused == 'false') OK
+RUN(video.currentTime = 2)
+RUN(video.pause())
+EXPECTED (internals.isPlayerPaused(video)) OK
+EXPECTED (video.paused == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-video-seek-pause.html
+++ b/LayoutTests/media/media-source/media-source-video-seek-pause.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>media-source-video-seek-pause</title>
+        <script src="../video-test.js"></script>
+        <script src="media-source-loader.js"></script>
+        <script>
+var loader;
+var source;
+var sourceBuffer;
+
+function loaderPromise(loader) {
+    return new Promise((resolve, reject) => {
+        loader.onload = resolve;
+        loader.onerror = reject;
+    });
+}
+
+async function startTest()
+{
+    findMediaElement();
+
+    loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+    await loaderPromise(loader);
+
+    source = new MediaSource();
+    run('video.src = URL.createObjectURL(source)');
+    await waitFor(source, 'sourceopen');
+    waitFor(video, 'error').then(failTest);
+
+    run('sourceBuffer = source.addSourceBuffer(loader.type())');
+    run('sourceBuffer.appendBuffer(loader.initSegment())');
+    await waitFor(sourceBuffer, 'update');
+
+    consoleWrite('Append all media segments')
+    for (i = 0; i < loader.mediaSegmentsLength(); i++) {
+        sourceBuffer.appendBuffer(loader.mediaSegment(i));
+        await waitFor(sourceBuffer, 'update', true);
+    }
+
+    consoleWrite("RUN('video.play()')");
+    await video.play();
+    testExpected('video.paused', false);
+    run('video.currentTime = 2');
+    await sleepFor(5);
+    run('video.pause()');
+    await waitForConditionOrTimeout('internals.isPlayerPaused(video)');
+    testExpected('video.paused', true);
+    endTest();
+}
+        </script>
+    </head>
+    <body onload="startTest()">
+        <video controls></video>
+    </body>
+</html>

--- a/LayoutTests/media/video-seek-pause-expected.txt
+++ b/LayoutTests/media/video-seek-pause-expected.txt
@@ -1,0 +1,11 @@
+
+EVENT(canplaythrough)
+RUN('video.play()')
+EXPECTED (video.paused == 'false') OK
+EXPECTED (internals.isPlayerPaused(video) == 'false') OK
+RUN(video.currentTime = 2)
+RUN(video.pause())
+EXPECTED (internals.isPlayerPaused(video)) OK
+EXPECTED (video.paused == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/video-seek-pause.html
+++ b/LayoutTests/media/video-seek-pause.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>video-seek-pause</title>
+        <script src="video-test.js"></script>
+        <script src="media-file.js"></script>
+        <script>
+async function startTest()
+{
+    findMediaElement();
+    video.src = findMediaFile('video', 'content/test');
+    await waitFor(video, 'canplaythrough');
+    consoleWrite("RUN('video.play()')");
+    await video.play();
+    testExpected('video.paused', false);
+    testExpected('internals.isPlayerPaused(video)', false);
+    run('video.currentTime = 2');
+    await sleepFor(5);
+    run('video.pause()');
+    await waitForConditionOrTimeout('internals.isPlayerPaused(video)', false, 2000);
+    testExpected('video.paused', true);
+    endTest();
+}
+        </script>
+    </head>
+    <body onload="startTest()">
+        <video controls></video>
+    </body>
+</html>

--- a/LayoutTests/media/video-test.js
+++ b/LayoutTests/media/video-test.js
@@ -261,6 +261,39 @@ function waitFor(element, type, silent, success) {
     });
 }
 
+function waitForConditionOrTimeout(condition, silent, completeTimeout, stepTimeout) {
+
+    if (completeTimeout == undefined)
+        completeTimeout = 1000;
+    if (stepTimeout == undefined)
+        stepTimeout = 100;
+
+    return new Promise(resolve => {
+        const initialTimestamp = Date.now();
+
+        function evalConditionOrTimeout() {
+            const result = eval(condition);
+            if (result) {
+                if (!silent)
+                    consoleWrite("EXPECTED (" + condition + ") OK");
+                resolve(result);
+                return;
+            }
+
+            if ((Date.now() - initialTimestamp) > completeTimeout) {
+                if (!silent)
+                    consoleWrite("EXPECTED (" + condition + ") FAIL");
+                resolve(result);
+                return;
+            }
+
+            setTimeout(evalConditionOrTimeout, stepTimeout);
+        }
+
+        evalConditionOrTimeout();
+    });
+}
+
 function waitForAndSucceed(element, type) {
     return waitFor(element, type, false, true);
 }

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -324,6 +324,11 @@ webkit.org/b/266195 media/media-source/media-managedmse-multipletracks-bufferedc
 # Support to pause with 0 rate playback seems to work only in GStreamer ports
 media/media-source/media-source-play-zero-playbackrate.html [ Pass ]
 
+# Test was flaky already before 263317 but it does "enhance its flakyness"
+webkit.org/b/263317 media/video-played-collapse.html [ Failure Pass ]
+webkit.org/b/263317 media/media-source/media-controller-media-source-play-then-pause.html [ Pass Timeout ]
+webkit.org/b/263317 media/media-source/media-source-seek-and-play.html [ Pass Timeout ]
+
 # NOTIFICATION_EVENT tests
 http/tests/workers/service/shownotification-allowed-document.html [ Pass ]
 http/tests/workers/service/shownotification-invalid-data.html [ Pass ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4694,3 +4694,5 @@ imported/w3c/web-platform-tests/css/selectors/valid-invalid-form-fieldset.html [
 webkit.org/b/266669 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html [ Pass Failure ]
 
 webkit.org/b/266996 imported/w3c/web-platform-tests/css/css-writing-modes/mongolian-orientation-002.html [ ImageOnlyFailure ]
+
+webkit.org/b/263317 media/media-controller-play-then-pause.html [ Failure ]

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -273,11 +273,17 @@ protected:
         Playing, // Pipeline is playing and it should be.
     };
 
+    enum class ChangePipelineStateResult {
+        Ok,
+        Rejected,
+        Failed,
+    };
+    ChangePipelineStateResult changePipelineState(GstState);
+
     static bool isAvailable();
 
     virtual void durationChanged();
     virtual void sourceSetup(GstElement*);
-    virtual bool changePipelineState(GstState);
     virtual void updatePlaybackRate();
 
 #if USE(GSTREAMER_HOLEPUNCH)
@@ -347,6 +353,9 @@ protected:
 
     void setCachedPosition(const MediaTime&) const;
 
+    bool isPipelineSeeking(GstState current, GstState pending, GstStateChangeReturn) const;
+    bool isPipelineSeeking() const;
+
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     String m_referrer;
@@ -359,6 +368,7 @@ protected:
     bool m_didErrorOccur { false };
     mutable bool m_isEndReached { false };
     mutable std::optional<bool> m_isLiveStream;
+    bool m_isPipelinePlaying = false;
 
     // m_isPaused represents:
     // A) In MSE streams, whether playback or pause has last been requested with pause() and play(),

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -110,7 +110,6 @@ private:
 
     RefPtr<MediaSourcePrivateGStreamer> m_mediaSourcePrivate;
     MediaTime m_mediaTimeDuration { MediaTime::invalidTime() };
-    bool m_isPipelinePlaying = true;
     Vector<RefPtr<MediaSourceTrackGStreamer>> m_tracks;
 
     bool m_isWaitingForPreroll = true;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4820,6 +4820,12 @@ bool Internals::isPlayerMuted(const HTMLMediaElement& element) const
     return player && player->muted();
 }
 
+bool Internals::isPlayerPaused(const HTMLMediaElement& element) const
+{
+    auto player = element.player();
+    return player && player->paused();
+}
+
 void Internals::beginAudioSessionInterruption()
 {
 #if USE(AUDIO_SESSION)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -804,6 +804,7 @@ public:
     bool elementIsBlockingDisplaySleep(const HTMLMediaElement&) const;
     bool isPlayerVisibleInViewport(const HTMLMediaElement&) const;
     bool isPlayerMuted(const HTMLMediaElement&) const;
+    bool isPlayerPaused(const HTMLMediaElement&) const;
     void beginAudioSessionInterruption();
     void endAudioSessionInterruption();
     void clearAudioSessionInterruptionFlag();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -964,6 +964,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=VIDEO] boolean elementIsBlockingDisplaySleep(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerVisibleInViewport(HTMLMediaElement element);
     [Conditional=VIDEO] boolean isPlayerMuted(HTMLMediaElement element);
+    [Conditional=VIDEO] boolean isPlayerPaused(HTMLMediaElement element);
 
     MockPageOverlay installMockPageOverlay(PageOverlayType type);
     DOMString pageOverlayLayerTreeAsText(optional unsigned short flags = 0);


### PR DESCRIPTION
#### e54b6b08878139eb460ad1094980014450c5e5b8
<pre>
[MSE][GStreamer] Pause after seek is not working
<a href="https://bugs.webkit.org/show_bug.cgi?id=263317">https://bugs.webkit.org/show_bug.cgi?id=263317</a>

Reviewed by Philippe Normand.

When issuing seeks and play or pauses close to each other, there can be race conditions. To solve then first we need to
avoid changing the pipeline state while seeking. Then we need to ensure we know if the pipeline change was rejected or
failed, so the function signature was changed. We also need to consider that when a pause is requested by the element
and the player issues it to the pipeline, we are paused because it can take some time for the pipeline to pause and if
the element queries too fast, it can lead to more race conditions.

* LayoutTests/media/media-controller-play-then-pause-expected.txt:
* LayoutTests/media/media-controller-play-then-pause.html:
* LayoutTests/media/media-source/media-controller-media-source-play-then-pause-expected.txt: Added.
* LayoutTests/media/media-source/media-controller-media-source-play-then-pause.html: Added.
* LayoutTests/media/media-source/media-source-seek-and-play-expected.txt: Added.
* LayoutTests/media/media-source/media-source-seek-and-play.html: Added.
* LayoutTests/media/media-source/media-source-video-seek-pause-expected.txt: Added.
* LayoutTests/media/media-source/media-source-video-seek-pause.html: Added.
* LayoutTests/media/video-seek-pause-expected.txt: Added.
* LayoutTests/media/video-seek-pause.html: Added.
* LayoutTests/media/video-test.js:
(return.new.Promise):
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::isPipelineSeeking const):
(WebCore::MediaPlayerPrivateGStreamer::play):
(WebCore::MediaPlayerPrivateGStreamer::pause):
(WebCore::MediaPlayerPrivateGStreamer::paused const):
(WebCore::MediaPlayerPrivateGStreamer::seekToTarget):
(WebCore::MediaPlayerPrivateGStreamer::changePipelineState):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::updateStates):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isPlayerPaused const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/273977@main">https://commits.webkit.org/273977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8ada138043776631c9514286d6e3b5097b913da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39749 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31673 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33747 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33740 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37721 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35865 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32755 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8432 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->