### PR TITLE
[ Monterey+ WK2 ] http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html is a flaky TEXT failure

### DIFF
--- a/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html
+++ b/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html
@@ -63,7 +63,6 @@ function addScript(url)
 }
 addScript("resources/cache-mode-hard-reload-serviceworker.py?second-script-dynamic");
 setTimeout(() => addScript("resources/cache-mode-hard-reload-serviceworker.py?third-script-async"), 100);
-setTimeout(() => addScript("resources/cache-mode-hard-reload-serviceworker.py?sixth-script-async"), 1000);
 onload = () => {
     addScript("resources/cache-mode-hard-reload-serviceworker.py?fourth-script-during-onload");
     setTimeout(() => {
@@ -101,9 +100,6 @@ function expectedCacheMode(url)
         return "default";
     if (url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?fifth-script-just-after-onload")
         return "default";
-    if (url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?sixth-script-async")
-        return "default";
-
 }
 
 function validateResults(results)


### PR DESCRIPTION
#### 20a293b6ecc6b41e0584b6162af45ffb7c09d2f8
<pre>
[ Monterey+ WK2 ] http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html is a flaky TEXT failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=259382">https://bugs.webkit.org/show_bug.cgi?id=259382</a>
rdar://112630912

Reviewed by Alex Christensen.

sixth-script-async load is happening based on a timer of 1000 ms.
There is a race between this load and the onload event, which is expected to happen roughly after 700ms.
From the bot results, sixth-script-async sometimes is triggered before the onload event.
Given we have loads that are triggered after the onload event and we ensure they have the correct cache mode,
we do not really need sixth-script-async load check.

Given it is flaky, let&apos;s remove it to make the test stable.

* LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html:

Canonical link: <a href="https://commits.webkit.org/269540@main">https://commits.webkit.org/269540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/262e356b9d0eb34cb9893d8046e7a44b75b975ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20965 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25408 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26762 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18056 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20323 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5448 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->