### PR TITLE
[CoordinatedGraphics] CompositingCoordinator doesn't need to implement GraphicsLayerClient

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -115,7 +115,6 @@ void CompositingCoordinator::setViewOverlayRootLayer(GraphicsLayer* graphicsLaye
 void CompositingCoordinator::sizeDidChange(const IntSize& newSize)
 {
     m_rootLayer->setSize(newSize);
-    notifyFlushRequired(m_rootLayer.get());
 }
 
 bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderingUpdateFlags> flags)
@@ -225,22 +224,6 @@ void CompositingCoordinator::syncLayerState()
     m_shouldSyncFrame = true;
 }
 
-void CompositingCoordinator::notifyFlushRequired(const GraphicsLayer*)
-{
-    if (m_rootLayer && !isFlushingLayerChanges())
-        m_client.notifyFlushRequired();
-}
-
-float CompositingCoordinator::deviceScaleFactor() const
-{
-    return m_page.corePage()->deviceScaleFactor();
-}
-
-float CompositingCoordinator::pageScaleFactor() const
-{
-    return m_page.corePage()->pageScaleFactor();
-}
-
 Ref<GraphicsLayer> CompositingCoordinator::createGraphicsLayer(GraphicsLayer::Type layerType, GraphicsLayerClient& client)
 {
     auto layer = adoptRef(*new CoordinatedGraphicsLayer(layerType, client));
@@ -272,11 +255,6 @@ void CompositingCoordinator::setVisibleContentsRect(const FloatRect& rect)
     }
 }
 
-void CompositingCoordinator::deviceOrPageScaleFactorChanged()
-{
-    m_rootLayer->deviceOrPageScaleFactorChanged();
-}
-
 void CompositingCoordinator::detachLayer(CoordinatedGraphicsLayer* layer)
 {
     if (m_isPurging)
@@ -301,10 +279,6 @@ void CompositingCoordinator::attachLayer(CoordinatedGraphicsLayer* layer)
     m_registeredLayers.add(layer->id(), layer);
     layer->setNeedsVisibleRectAdjustment();
     notifyFlushRequired(layer);
-}
-
-void CompositingCoordinator::renderNextFrame()
-{
 }
 
 void CompositingCoordinator::purgeBackingStores()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -62,7 +62,6 @@ public:
     class Client {
     public:
         virtual void didFlushRootLayer(const WebCore::FloatRect& visibleContentRect) = 0;
-        virtual void notifyFlushRequired() = 0;
         virtual void commitSceneState(const RefPtr<Nicosia::Scene>&) = 0;
         virtual void updateScene() = 0;
     };
@@ -75,10 +74,8 @@ public:
     void setRootCompositingLayer(WebCore::GraphicsLayer*);
     void setViewOverlayRootLayer(WebCore::GraphicsLayer*);
     void sizeDidChange(const WebCore::IntSize&);
-    void deviceOrPageScaleFactorChanged();
 
     void setVisibleContentsRect(const WebCore::FloatRect&);
-    void renderNextFrame();
 
     WebCore::GraphicsLayer* rootLayer() const { return m_rootLayer.get(); }
     WebCore::GraphicsLayer* rootCompositingLayer() const { return m_rootCompositingLayer; }
@@ -91,11 +88,6 @@ public:
     double nextAnimationServiceTime() const;
 
 private:
-    // GraphicsLayerClient
-    void notifyFlushRequired(const WebCore::GraphicsLayer*) override;
-    float deviceScaleFactor() const override;
-    float pageScaleFactor() const override;
-
     // CoordinatedGraphicsLayerClient
     bool isFlushingLayerChanges() const override { return m_isFlushingLayerChanges; }
     WebCore::FloatRect visibleContentsRect() const override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -340,7 +340,6 @@ void LayerTreeHost::deviceOrPageScaleFactorChanged()
     if (m_surface->hostResize(m_webPage.size()))
         m_layerTreeContext.contextID = m_surface->surfaceID();
 
-    m_coordinator.deviceOrPageScaleFactorChanged();
     m_webPage.corePage()->pageOverlayController().didChangeDeviceScaleFactor();
     IntSize scaledSize(m_webPage.size());
     scaledSize.scale(m_webPage.deviceScaleFactor());
@@ -461,7 +460,6 @@ void LayerTreeHost::renderNextFrame(bool forceRepaint)
 {
     m_isWaitingForRenderer = false;
     bool scheduledWhileWaitingForRenderer = std::exchange(m_scheduledWhileWaitingForRenderer, false);
-    m_coordinator.renderNextFrame();
 
     if (m_forceRepaintAsync.callback) {
         // If the asynchronous force-repaint needs a separate fresh flush, it was due to

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -122,7 +122,6 @@ private:
 
     // CompositingCoordinator::Client
     void didFlushRootLayer(const WebCore::FloatRect& visibleContentRect) override;
-    void notifyFlushRequired() override { scheduleLayerFlush(); };
     void commitSceneState(const RefPtr<Nicosia::Scene>&) override;
     void updateScene() override;
 


### PR DESCRIPTION
#### 5603d66937036498bba6f4127730ab430fcd8322
<pre>
[CoordinatedGraphics] CompositingCoordinator doesn&apos;t need to implement GraphicsLayerClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=263319">https://bugs.webkit.org/show_bug.cgi?id=263319</a>

Reviewed by Alejandro G. Castro.

The compositing coordinator is passed as the client of the root layer,
which doesn&apos;t have backing store and it&apos;s handled manually, so every
time it changes we are already scheduling a layer flush.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::sizeDidChange):
(WebKit::CompositingCoordinator::notifyFlushRequired): Deleted.
(WebKit::CompositingCoordinator::deviceScaleFactor const): Deleted.
(WebKit::CompositingCoordinator::pageScaleFactor const): Deleted.
(WebKit::CompositingCoordinator::deviceOrPageScaleFactorChanged): Deleted.
(WebKit::CompositingCoordinator::renderNextFrame): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::deviceOrPageScaleFactorChanged):
(WebKit::LayerTreeHost::renderNextFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:

Canonical link: <a href="https://commits.webkit.org/269509@main">https://commits.webkit.org/269509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8a3f003333f4d8a539616691a5222598d135172

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23735 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20967 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21917 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25410 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26765 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20765 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24602 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18059 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/156 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/284 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2871 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->