### PR TITLE
[ wk2 ] imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html is a flaky text failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
@@ -2,6 +2,7 @@
 
 NOTRUN <video> and VideoFrame constructed VideoFrame AV.1 file streaming unsupported
 PASS CSSImageValue constructed VideoFrame
+PASS Wait for onload event to get access to image data
 PASS Image element constructed VideoFrame
 PASS SVGImageElement constructed VideoFrame
 PASS Canvas element constructed VideoFrame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html
@@ -85,7 +85,11 @@ test(t => {
                     'CSSImageValues are currently always tainted');
 }, 'CSSImageValue constructed VideoFrame');
 
-test(t => {
+promise_test(() => {
+  return new Promise(resolve => onload = resolve);
+}, "Wait for onload event to get access to image data");
+
+promise_test(async t => {
   let frame = new VideoFrame(document.querySelector('img'), {timestamp: 0});
   let canvas = new OffscreenCanvas(frame.displayWidth, frame.displayHeight);
   let ctx = canvas.getContext('2d');
@@ -94,7 +98,7 @@ test(t => {
   frame.close();
 }, 'Image element constructed VideoFrame');
 
-test(t => {
+promise_test(async t => {
   let frame = new VideoFrame(document.querySelector('image'), {timestamp: 0});
   let canvas = new OffscreenCanvas(frame.displayWidth, frame.displayHeight);
   let ctx = canvas.getContext('2d');

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
@@ -2,6 +2,7 @@
 
 FAIL <video> and VideoFrame constructed VideoFrame assert_equals: top left corner expected "Yellow" but got "#ffdd13ff"
 PASS CSSImageValue constructed VideoFrame
+PASS Wait for onload event to get access to image data
 PASS Image element constructed VideoFrame
 PASS SVGImageElement constructed VideoFrame
 PASS Canvas element constructed VideoFrame

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -878,8 +878,6 @@ webkit.org/b/259482 fast/media/managed-media-source-open-crash.html [ Pass Failu
 
 webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]
 
-webkit.org/b/260834 imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html [ Pass Failure ]
-
 webkit.org/b/260926 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click.html [ Pass Failure ]
 
 webkit.org/b/262088 [ Debug ] imported/w3c/web-platform-tests/fetch/private-network-access/iframe.tentative.https.window.html [ Pass Failure ]


### PR DESCRIPTION
#### 90a2dfe440a24e31efa88fad817b4802e2a0bbcc
<pre>
[ wk2 ] imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html is a flaky text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=260834">https://bugs.webkit.org/show_bug.cgi?id=260834</a>
rdar://114596017

Reviewed by Chris Dumez.

The test may try to create a VideoFrame from an image which has not finished loading.
In that case, it will fail.
To prevent this, we transform the test as promise_tests and we add a first promise_test which waits for the onload event to be fired.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt:
* LayoutTests/platform/wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269543@main">https://commits.webkit.org/269543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e999d77330d23b41ca21ee816803c630c43955b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20979 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23190 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25422 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26778 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24627 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18068 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20338 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5452 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->