### PR TITLE
[GTK] `Tools/gtk/install-dependencies` fails to find `libgl1-mesa-glx` on Ubuntu 23.10

### DIFF
--- a/Tools/gtk/dependencies/apt
+++ b/Tools/gtk/dependencies/apt
@@ -11,7 +11,7 @@ PACKAGES+=(
     libffi-dev
     libgirepository1.0-dev
     libgl1-mesa-dev
-    libgl1-mesa-glx
+    $(aptIfExists libgl1-mesa-glx)
     libgtk-3-dev
     libgudev-1.0-dev
     libhyphen-dev


### PR DESCRIPTION
#### e1dd5aedd4c9d6e2983c74e4ae6b376f8a61c932
<pre>
[GTK] `Tools/gtk/install-dependencies` fails to find `libgl1-mesa-glx` on Ubuntu 23.10
<a href="https://bugs.webkit.org/show_bug.cgi?id=263320">https://bugs.webkit.org/show_bug.cgi?id=263320</a>

Reviewed by Adrian Perez de Castro.

Install it only if it&apos;s available.

* Tools/gtk/dependencies/apt:

Canonical link: <a href="https://commits.webkit.org/269514@main">https://commits.webkit.org/269514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/411ef77fa20fb1d183a2fbee63391b1f9dde13a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21928 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25425 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26783 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24620 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18073 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/166 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5431 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->