### PR TITLE
[ Ventura WK1 Release ] http/wpt/workers/modules/dedicated-worker-import-csp.html is a constant failure

### DIFF
--- a/LayoutTests/http/wpt/workers/modules/resources/dynamic-import-remote-origin-script-worker.sub.js
+++ b/LayoutTests/http/wpt/workers/modules/resources/dynamic-import-remote-origin-script-worker.sub.js
@@ -1,6 +1,6 @@
 // Import a remote origin script.
 const importUrl =
-    'https://127.0.0.1:{{ports[https][0]}}/workers/modules/resources/export-on-load-script.js';
+    'https://localhost:{{ports[https][0]}}/workers/modules/resources/export-on-load-script.js';
 if ('DedicatedWorkerGlobalScope' in self &&
     self instanceof DedicatedWorkerGlobalScope) {
   import(importUrl)

--- a/LayoutTests/http/wpt/workers/modules/resources/static-import-remote-origin-script-worker.sub.js
+++ b/LayoutTests/http/wpt/workers/modules/resources/static-import-remote-origin-script-worker.sub.js
@@ -1,5 +1,5 @@
 // Import a remote origin script.
-import * as module from 'https://127.0.0.1:{{ports[https][0]}}/workers/modules/resources/export-on-load-script.py';
+import * as module from 'https://localhost:{{ports[https][0]}}/workers/modules/resources/export-on-load-script.py';
 if ('DedicatedWorkerGlobalScope' in self &&
     self instanceof DedicatedWorkerGlobalScope) {
   self.onmessage = e => {


### PR DESCRIPTION
#### 19432c811205d65e97b69c2bb60c4d316c46df4e
<pre>
[ Ventura WK1 Release ] http/wpt/workers/modules/dedicated-worker-import-csp.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=260111">https://bugs.webkit.org/show_bug.cgi?id=260111</a>
rdar://113780242

Reviewed by Alex Christensen.

This test is passing fine on internal bots but not public bots.
A hunch is that the <a href="https://127.0.0.1">https://127.0.0.1</a>:9443 subresource loads might sometimes be refused by DRT.
Given <a href="https://localhost">https://localhost</a>:9443 loads are accepted by DRT before running these tests, we migrate these subresource loads to <a href="https://localhost">https://localhost</a>:9443. CSP checks are not related to 127.0.0.1 or localhost, so this does not change what is being tested.

This is hypothetical fix since I was not able to reproduce locally.

* LayoutTests/http/wpt/workers/modules/resources/dynamic-import-remote-origin-script-worker.sub.js:
* LayoutTests/http/wpt/workers/modules/resources/static-import-remote-origin-script-worker.sub.js:

Canonical link: <a href="https://commits.webkit.org/269538@main">https://commits.webkit.org/269538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1a4694fa04fe766b594aeebb0f0515323239992

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/20989 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1422 "Hash f1a4694f for PR 19231 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21930 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22910 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/1422 "Hash f1a4694f for PR 19231 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25432 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/1422 "Hash f1a4694f for PR 19231 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26780 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/1422 "Hash f1a4694f for PR 19231 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24617 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18077 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/170 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5446 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->