### PR TITLE
Enable calculating quota based on disk space in WebKitTestRunner

### DIFF
--- a/LayoutTests/http/tests/IndexedDB/storage-limit-1.https.html
+++ b/LayoutTests/http/tests/IndexedDB/storage-limit-1.https.html
@@ -5,8 +5,10 @@
 </head>
 <body>
 <script>
-if (window.testRunner)
+if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     testRunner.setAllowStorageQuotaIncrease(false);
+}
 
 description("This test makes sure that storage of indexedDB and Cache API do not grow unboundedly.");
 
@@ -22,6 +24,9 @@ window.caches.open("test").then(cache => {
             break;
         } catch (e) { }
     }
+    // Enable fixed quota in the new network process.
+    if (window.testRunner)
+        testRunner.setOriginQuotaRatioEnabled(false);
     indexedDBTest(prepareDatabase, onOpenSuccess, {'suffix': '-1'});
 }).catch(e => {
     testFailed("Cache API store operation failed: " + e);

--- a/LayoutTests/http/tests/IndexedDB/storage-limit-2.https.html
+++ b/LayoutTests/http/tests/IndexedDB/storage-limit-2.https.html
@@ -5,8 +5,10 @@
 </head>
 <body>
 <script>
-if (window.testRunner)
+if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     testRunner.setAllowStorageQuotaIncrease(false);
+}
 
 description("This test makes sure that storage of indexedDB and Cache API do not grow unboundedly.");
 
@@ -41,6 +43,9 @@ async function onOpenSuccess(event)
                 break;
             } catch (e) { }
         }
+        // Enable fixed quota in the new network process.
+        if (window.testRunner)
+            testRunner.setOriginQuotaRatioEnabled(false);
         cacheTest();
     }
 }

--- a/LayoutTests/http/tests/IndexedDB/storage-limit.https.html
+++ b/LayoutTests/http/tests/IndexedDB/storage-limit.https.html
@@ -5,8 +5,10 @@
 </head>
 <body>
 <script>
-if (window.testRunner) 
+if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     testRunner.setAllowStorageQuotaIncrease(false);
+}
 
 description("This test makes sure that storage of indexedDB does not grow unboundedly.");
 

--- a/LayoutTests/http/wpt/cache-storage/cache-quota-add.any.js
+++ b/LayoutTests/http/wpt/cache-storage/cache-quota-add.any.js
@@ -1,7 +1,9 @@
 // META: script=/common/gc.js
 
-if (window.testRunner)
+if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     testRunner.setAllowStorageQuotaIncrease(false);
+}
 
 async function doCleanup()
 {

--- a/LayoutTests/http/wpt/cache-storage/cache-quota-after-restart.any.js
+++ b/LayoutTests/http/wpt/cache-storage/cache-quota-after-restart.any.js
@@ -3,6 +3,9 @@ var response30ko = new Response(new ArrayBuffer(30 * 1024));
 var response400 = new Response(new ArrayBuffer(400 * 1024));
 let cache;
 
+if (window.testRunner)
+    testRunner.setOriginQuotaRatioEnabled(false);
+
 promise_test(async (test) => {
     if (!window.testRunner)
         return Promise.reject("Test requires internals");

--- a/LayoutTests/http/wpt/cache-storage/cache-quota.any.js
+++ b/LayoutTests/http/wpt/cache-storage/cache-quota.any.js
@@ -4,8 +4,10 @@
 var test_url = 'https://example.com/foo';
 var test_body = 'Hello world!';
 
-if (window.testRunner)
+if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     testRunner.setAllowStorageQuotaIncrease(false);
+}
 
 function getResponseBodySizeWithPadding(response)
 {

--- a/LayoutTests/http/wpt/cache-storage/quota-third-party.https.html
+++ b/LayoutTests/http/wpt/cache-storage/quota-third-party.https.html
@@ -8,6 +8,7 @@
 <body>
     <script>
 if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     // Log user interaction for this domain to avoid deleting its
     // website data (including caches) when a frame navigation occurs.
     testRunner.setStatisticsHasHadUserInteraction("https://127.0.0.1:9443", true);

--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html
@@ -7,6 +7,7 @@
 // FileSystemSyncAccessHandle requires to hold at least 1 MB space.
 const quota = 1024 * 1024;
 if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     testRunner.setQuota(quota);
     testRunner.setAllowStorageQuotaIncrease(false);
 }

--- a/LayoutTests/storage/indexeddb/resources/request-size-estimate.js
+++ b/LayoutTests/storage/indexeddb/resources/request-size-estimate.js
@@ -3,8 +3,10 @@ if (this.importScripts) {
     importScripts('shared.js');
 }
 
-if (window.testRunner)
+if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     testRunner.setAllowStorageQuotaIncrease(false);
+}
 
 description('This test verifies that estimated size of IDB database task is not smaller than or close to actual space increase (maybe subject to our implementation of backing store.)');
 

--- a/LayoutTests/storage/indexeddb/resources/storage-limit.js
+++ b/LayoutTests/storage/indexeddb/resources/storage-limit.js
@@ -3,8 +3,10 @@ if (this.importScripts) {
     importScripts('shared.js');
 }
 
-if (window.testRunner)
+if (window.testRunner) {
+    testRunner.setOriginQuotaRatioEnabled(false);
     testRunner.setAllowStorageQuotaIncrease(false);
+}
 
 var quota = 400 * 1024; // default quota for testing.
 description("This test makes sure that storage of indexedDB does not grow unboundedly.");

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2366,6 +2366,14 @@ void NetworkProcess::resetQuota(PAL::SessionID sessionID, CompletionHandler<void
     completionHandler();
 }
 
+void NetworkProcess::setOriginQuotaRatioEnabledForTesting(PAL::SessionID sessionID, bool enabled, CompletionHandler<void()>&& completionHandler)
+{
+    if (auto* session = networkSession(sessionID))
+        return session->storageManager().setOriginQuotaRatioEnabledForTesting(enabled, WTFMove(completionHandler));
+
+    completionHandler();
+}
+
 void NetworkProcess::resetStoragePersistedState(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
     if (auto* session = networkSession(sessionID))

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -307,6 +307,7 @@ public:
     void storeServiceWorkerRegistrations(PAL::SessionID, CompletionHandler<void()>&&);
 
     void resetQuota(PAL::SessionID, CompletionHandler<void()>&&);
+    void setOriginQuotaRatioEnabledForTesting(PAL::SessionID, bool enabled, CompletionHandler<void()>&&);
 #if PLATFORM(IOS_FAMILY)
     void setBackupExclusionPeriodForTesting(PAL::SessionID, Seconds, CompletionHandler<void()>&&);
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -191,6 +191,7 @@ messages -> NetworkProcess LegacyReceiver {
     ResetServiceWorkerFetchTimeoutForTesting() -> () Synchronous
 
     ResetQuota(PAL::SessionID sessionID) -> ()
+    SetOriginQuotaRatioEnabledForTesting(PAL::SessionID sessionID, bool enabled) -> ();
 #if PLATFORM(IOS_FAMILY)
     SetBackupExclusionPeriodForTesting(PAL::SessionID sessionID, Seconds period) -> ()
 #endif

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -113,6 +113,7 @@ public:
     void requestSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&);
     void resetQuotaForTesting(CompletionHandler<void()>&&);
     void resetQuotaUpdatedBasedOnUsageForTesting(WebCore::ClientOrigin&&);
+    void setOriginQuotaRatioEnabledForTesting(bool enabled, CompletionHandler<void()>&&);
 #if PLATFORM(IOS_FAMILY)
     void setBackupExclusionPeriodForTesting(Seconds, CompletionHandler<void()>&&);
 #endif
@@ -243,6 +244,7 @@ private:
     };
     void performEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
+    OriginQuotaManager::Parameters originQuotaManagerParameters(const WebCore::ClientOrigin&);
 
     WeakPtr<NetworkProcess> m_process;
     PAL::SessionID m_sessionID;
@@ -262,6 +264,7 @@ private:
     String m_customCacheStoragePath;
     String m_customServiceWorkerStoragePath;
     uint64_t m_defaultOriginQuota;
+    bool m_originQuotaRatioEnabled { true };
     std::optional<double> m_originQuotaRatio;
     std::optional<double> m_totalQuotaRatio;
     std::optional<uint64_t> m_standardVolumeCapacity;

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -38,7 +38,13 @@ public:
     using GetUsageFunction = Function<uint64_t()>;
     using IncreaseQuotaFunction = Function<void(QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t requestedIncrease)>;
     using NotifySpaceGrantedFunction = Function<void(uint64_t)>;
-    static Ref<OriginQuotaManager> create(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&& = { }, NotifySpaceGrantedFunction&& = { });
+    struct Parameters {
+        uint64_t quota { 0 };
+        uint64_t standardReportedQuota { 0 };
+        IncreaseQuotaFunction increaseQuotaFunction;
+        NotifySpaceGrantedFunction notifySpaceGrantedFunction;
+    };
+    static Ref<OriginQuotaManager> create(Parameters&&, GetUsageFunction&&);
     uint64_t reportedQuota();
     uint64_t usage();
     enum class Decision : bool { Deny, Grant };
@@ -48,9 +54,10 @@ public:
 
     void resetQuotaUpdatedBasedOnUsageForTesting();
     void resetQuotaForTesting();
+    void updateParametersForTesting(Parameters&&);
 
 private:
-    OriginQuotaManager(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&&, NotifySpaceGrantedFunction&&);
+    OriginQuotaManager(Parameters&&, GetUsageFunction&&);
     void handleRequests();
     bool grantWithCurrentQuota(uint64_t spaceRequested);
     bool grantFastPath(uint64_t spaceRequested);

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -58,7 +58,7 @@ class OriginStorageManager : public CanMakeWeakPtr<OriginStorageManager> {
 public:
     static String originFileIdentifier();
 
-    OriginStorageManager(uint64_t quota, uint64_t standardReportedQuota, OriginQuotaManager::IncreaseQuotaFunction&&, OriginQuotaManager::NotifySpaceGrantedFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
+    OriginStorageManager(OriginQuotaManager::Parameters&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, UnifiedOriginStorageLevel);
     ~OriginStorageManager();
 
     void connectionClosed(IPC::Connection::UniqueID);
@@ -98,7 +98,7 @@ public:
 #endif
 
 private:
-    Ref<OriginQuotaManager> createQuotaManager();
+    Ref<OriginQuotaManager> createQuotaManager(OriginQuotaManager::Parameters&&);
     enum class StorageBucketMode : bool;
     class StorageBucket;
     StorageBucket& defaultBucket();
@@ -108,11 +108,7 @@ private:
     String m_customLocalStoragePath;
     String m_customIDBStoragePath;
     String m_customCacheStoragePath;
-    uint64_t m_quota;
-    uint64_t m_standardReportedQuota;
-    OriginQuotaManager::IncreaseQuotaFunction m_increaseQuotaFunction;
-    OriginQuotaManager::NotifySpaceGrantedFunction m_notifySpaceGrantedFunction;
-    RefPtr<OriginQuotaManager> m_quotaManager;
+    Ref<OriginQuotaManager> m_quotaManager;
     UnifiedOriginStorageLevel m_level;
     Markable<WallTime> m_originFileCreationTimestamp;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -911,6 +911,14 @@ void WKWebsiteDataStoreClearStorage(WKWebsiteDataStoreRef dataStoreRef, void* co
     });
 }
 
+void WKWebsiteDataStoreSetOriginQuotaRatioEnabled(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, WKWebsiteDataStoreResetQuotaCallback callback)
+{
+    WebKit::toImpl(dataStoreRef)->setOriginQuotaRatioEnabledForTesting(enabled, [context, callback] {
+        if (callback)
+            callback(context);
+    });
+}
+
 void WKWebsiteDataStoreClearAppBoundSession(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreClearAppBoundSessionFunction completionHandler)
 {
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h
@@ -219,6 +219,9 @@ WK_EXPORT void WKWebsiteDataStoreUpdateBundleIdentifierInNetworkProcess(WKWebsit
 typedef void (*WKWebsiteDataStoreClearBundleIdentifierInNetworkProcessFunction)(void* functionContext);
 WK_EXPORT void WKWebsiteDataStoreClearBundleIdentifierInNetworkProcess(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreClearBundleIdentifierInNetworkProcessFunction completionHandler);
 
+typedef void (*KWebsiteDataStoreSetOriginQuotaRatioEnabledCallback)(void* functionContext);
+WK_EXPORT void WKWebsiteDataStoreSetOriginQuotaRatioEnabled(WKWebsiteDataStoreRef dataStoreRef, bool enabled, void* context, KWebsiteDataStoreSetOriginQuotaRatioEnabledCallback callback);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2515,6 +2515,15 @@ void WebsiteDataStore::setCompletionHandlerForRemovalFromNetworkProcess(Completi
     m_completionHandlerForRemovalFromNetworkProcess = WTFMove(completionHandler);
 }
 
+void WebsiteDataStore::setOriginQuotaRatioEnabledForTesting(bool enabled, CompletionHandler<void()>&& completionHandler)
+{
+    RefPtr networkProcess = networkProcessIfExists();
+    if (!networkProcess)
+        return completionHandler();
+
+    networkProcess->sendWithAsyncReply(Messages::NetworkProcess::SetOriginQuotaRatioEnabledForTesting(m_sessionID, enabled), WTFMove(completionHandler));
+}
+
 #if ENABLE(SERVICE_WORKER)
 
 void WebsiteDataStore::updateServiceWorkerInspectability()

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -482,6 +482,8 @@ public:
     void processPushMessage(WebPushMessage&&, CompletionHandler<void(bool)>&&);
 #endif
 
+    void setOriginQuotaRatioEnabledForTesting(bool enabled, CompletionHandler<void()>&&);
+
 private:
     enum class ForceReinitialization : bool { No, Yes };
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -78,6 +78,7 @@ interface TestRunner {
     unsigned long domCacheSize(DOMString origin);
     undefined setAllowStorageQuotaIncrease(boolean value);
     undefined setQuota(unsigned long long quota);
+    undefined setOriginQuotaRatioEnabled(boolean value);
 
     // Special options.
     undefined keepWebHistory();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -2138,6 +2138,11 @@ void TestRunner::setQuota(uint64_t quota)
     postSynchronousMessage("SetQuota", quota);
 }
 
+void TestRunner::setOriginQuotaRatioEnabled(bool enabled)
+{
+    postSynchronousPageMessage("SetOriginQuotaRatioEnabled", enabled);
+}
+
 void TestRunner::getApplicationManifestThen(JSValueRef callback)
 {
     cacheTestRunnerCallback(GetApplicationManifestCallbackID, callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -180,6 +180,7 @@ public:
     uint64_t domCacheSize(JSStringRef origin);
     void setAllowStorageQuotaIncrease(bool);
     void setQuota(uint64_t);
+    void setOriginQuotaRatioEnabled(bool);
 
     // Failed load condition testing
     void forceImmediateCompletion();

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -674,9 +674,6 @@ void TestController::configureWebsiteDataStoreTemporaryDirectories(WKWebsiteData
         WKWebsiteDataStoreConfigurationSetCookieStorageFile(configuration, toWK(makeString(temporaryFolder, pathSeparator, "cookies", pathSeparator, randomNumber, pathSeparator, "cookiejar.db")).get());
 #endif
         WKWebsiteDataStoreConfigurationSetPerOriginStorageQuota(configuration, 400 * 1024);
-        // Clear quota ratio so WebKit does not calculate quota based on disk space.
-        WKWebsiteDataStoreConfigurationClearOriginQuotaRatio(configuration);
-        WKWebsiteDataStoreConfigurationClearTotalQuotaRatio(configuration);
         WKWebsiteDataStoreConfigurationSetNetworkCacheSpeculativeValidationEnabled(configuration, true);
         WKWebsiteDataStoreConfigurationSetStaleWhileRevalidateEnabled(configuration, true);
         WKWebsiteDataStoreConfigurationSetTestingSessionEnabled(configuration, true);
@@ -1219,6 +1216,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     setHidden(false);
     setAllowStorageQuotaIncrease(true);
     setQuota(40 * KB);
+    setOriginQuotaRatioEnabled(true);
 
     if (!platformResetStateToConsistentValues(options))
         return false;
@@ -3431,6 +3429,13 @@ void TestController::clearStorage()
 {
     StorageVoidCallbackContext context(*this);
     WKWebsiteDataStoreClearStorage(TestController::websiteDataStore(), &context, StorageVoidCallback);
+    runUntil(context.done, noTimeout);
+}
+
+void TestController::setOriginQuotaRatioEnabled(bool enabled)
+{
+    StorageVoidCallbackContext context(*this);
+    WKWebsiteDataStoreSetOriginQuotaRatioEnabled(websiteDataStore(), enabled, &context, StorageVoidCallback);
     runUntil(context.done, noTimeout);
 }
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -321,6 +321,7 @@ public:
 
     void setAllowStorageQuotaIncrease(bool);
     void setQuota(uint64_t);
+    void setOriginQuotaRatioEnabled(bool);
 
     bool didReceiveServerRedirectForProvisionalNavigation() const { return m_didReceiveServerRedirectForProvisionalNavigation; }
     void clearDidReceiveServerRedirectForProvisionalNavigation() { m_didReceiveServerRedirectForProvisionalNavigation = false; }

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1394,6 +1394,11 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetOriginQuotaRatioEnabled")) {
+        TestController::singleton().setOriginQuotaRatioEnabled(booleanValue(messageBody));
+        return nullptr;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "InjectUserScript")) {
         TestController::singleton().injectUserScript(stringValue(messageBody));
         return nullptr;


### PR DESCRIPTION
#### 12630df61ee89415d3f76e3f96dc2799ab491ade
<pre>
Enable calculating quota based on disk space in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=263323">https://bugs.webkit.org/show_bug.cgi?id=263323</a>
rdar://117139033

Reviewed by Youenn Fablet.

When originQuotaRatio and totalQuotaRatio of WebsiteDataStoreConfiguration are non-null, quota is calculated based on
disk space and ratio values. Since 263250@main, these values are non-null by default, which means WebKit apps by default
have quota calculated based on disk space instead of using a fixed quota value.

To ensure quota-related tests run correctly, WebKitTestRunner currently still uses fixed quota, by explicitly setting
originQuotaRatio and totalQuotaRatio to null (see TestController::configureWebsiteDataStoreTemporaryDirectories). This
is not ideal as WebKit has different behavior in different quota mechanisms. For example, when origin quota is reached,
in old mechanism (fixed quota), WebKit ask clients whether to increase quota before proceeding with storage task; in new
mechanism (quota calculated based on disk space), task will fail directly. This difference has impacted our performance
testing (run-perf-tests) -- in old mechanism, many IPCs may be sent when the storage is big. To make WebKitTestRunner
test the new default behavior, this patch makes originQuotaRatio and totalQuotaRatio in WebKitTestRunner non-null.

Some layout tests rely on the old quota mechanism. For example, they may want to check if quota error can be correctly
thrown and handled with a small amount of data. To keep those tests working, this patch adds
TestRunner::setOriginQuotaRatioEnabled that allows a test to ask for old quota mechanism: when originQuotaRatioEnabled
is false, network process uses fixed quota. originQuotaRatioEnabled is reset to true between tests to make sure old
quota mechanism are only used for tests that needs it.

* LayoutTests/http/tests/IndexedDB/storage-limit-1.https.html:
* LayoutTests/http/tests/IndexedDB/storage-limit-2.https.html:
* LayoutTests/http/tests/IndexedDB/storage-limit.https.html:
* LayoutTests/http/wpt/cache-storage/cache-quota-add.any.js:
* LayoutTests/http/wpt/cache-storage/cache-quota-after-restart.any.js:
* LayoutTests/http/wpt/cache-storage/cache-quota.any.js:
* LayoutTests/http/wpt/cache-storage/quota-third-party.https.html:
* LayoutTests/storage/filesystemaccess/sync-access-handle-storage-limit-worker.html:
* LayoutTests/storage/indexeddb/resources/request-size-estimate.js:
* LayoutTests/storage/indexeddb/resources/storage-limit.js:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setOriginQuotaRatioEnabledForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::originQuotaManagerParameters):
(WebKit::NetworkStorageManager::originStorageManager):
(WebKit::NetworkStorageManager::setOriginQuotaRatioEnabledForTesting):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp:
(WebKit::OriginQuotaManager::create):
(WebKit::OriginQuotaManager::OriginQuotaManager):
(WebKit::OriginQuotaManager::updateParametersForTesting):
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h:
(WebKit::OriginQuotaManager::create): Deleted.
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::createQuotaManager):
(WebKit::OriginStorageManager::OriginStorageManager):
(WebKit::OriginStorageManager::quotaManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreSetOriginQuotaRatioEnabled):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setOriginQuotaRatioEnabledForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setOriginQuotaRatioEnabled):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::configureWebsiteDataStoreTemporaryDirectories):
(WTR::TestController::resetStateToConsistentValues):
(WTR::TestController::setOriginQuotaRatioEnabled):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/269553@main">https://commits.webkit.org/269553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57071651b45f1050fdacd6fd220b49d578a8df01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24706 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21103 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21999 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25559 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26860 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24716 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18162 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20459 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->