### PR TITLE
Generate serialization of WebKit::RTCNetwork

### DIFF
--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -34,9 +34,9 @@
 namespace WebKit {
 
 RTCNetwork::RTCNetwork(const rtc::Network& network)
-    : name(network.name())
-    , description(network.description())
-    , prefix { network.prefix() }
+    : name(network.name().data(), network.name().length())
+    , description(network.description().data(), network.description().length())
+    , prefix(network.prefix())
     , prefixLength(network.prefix_length())
     , type(network.type())
     , id(network.id())
@@ -44,19 +44,38 @@ RTCNetwork::RTCNetwork(const rtc::Network& network)
     , active(network.active())
     , ignored(network.ignored())
     , scopeID(network.scope_id())
-    , ips(network.GetIPs())
-{
-}
+    , ips(WTF::map(network.GetIPs(), [] (const auto& ip) {
+        return InterfaceAddress(ip);
+    })) { }
+
+RTCNetwork::RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<InterfaceAddress>&& ips)
+    : name(WTFMove(name))
+    , description(WTFMove(description))
+    , prefix(prefix)
+    , prefixLength(prefixLength)
+    , type(type)
+    , id(id)
+    , preference(preference)
+    , active(active)
+    , ignored(ignored)
+    , scopeID(scopeID)
+    , ips(WTFMove(ips)) { }
 
 rtc::Network RTCNetwork::value() const
 {
-    rtc::Network network(name.data(), description.data(), prefix.rtcAddress(), prefixLength, rtc::AdapterType(type));
+    rtc::Network network({ name.data(), name.size() }, { description.data(), description.size() }, prefix.rtcAddress(), prefixLength, rtc::AdapterType(type));
     network.set_id(id);
     network.set_preference(preference);
     network.set_active(active);
     network.set_ignored(ignored);
     network.set_scope_id(scopeID);
-    network.SetIPs(ips, true);
+
+    std::vector<rtc::InterfaceAddress> vector;
+    vector.reserve(ips.size());
+    for (auto& ip : ips)
+        vector.push_back(ip.rtcAddress());
+    network.SetIPs(WTFMove(vector), true);
+
     return network;
 }
 
@@ -116,74 +135,6 @@ void RTCNetwork::SocketAddress::encode(IPC::Encoder& encoder) const
     }
     encoder << false;
     encoder << RTCNetwork::IPAddress(value.ipaddr());
-}
-
-std::optional<RTCNetwork> RTCNetwork::decode(IPC::Decoder& decoder)
-{
-    RTCNetwork result;
-    IPC::DataReference name, description;
-    if (!decoder.decode(name))
-        return std::nullopt;
-    result.name = std::string(reinterpret_cast<const char*>(name.data()), name.size());
-    if (!decoder.decode(description))
-        return std::nullopt;
-    result.description = std::string(reinterpret_cast<const char*>(description.data()), description.size());
-    std::optional<IPAddress> prefix;
-    decoder >> prefix;
-    if (!prefix)
-        return std::nullopt;
-    result.prefix = WTFMove(*prefix);
-    if (!decoder.decode(result.prefixLength))
-        return std::nullopt;
-    if (!decoder.decode(result.type))
-        return std::nullopt;
-    if (!decoder.decode(result.id))
-        return std::nullopt;
-    if (!decoder.decode(result.preference))
-        return std::nullopt;
-    if (!decoder.decode(result.active))
-        return std::nullopt;
-    if (!decoder.decode(result.ignored))
-        return std::nullopt;
-    if (!decoder.decode(result.scopeID))
-        return std::nullopt;
-
-    uint64_t length;
-    if (!decoder.decode(length))
-        return std::nullopt;
-    result.ips.reserve(length);
-    for (size_t index = 0; index < length; ++index) {
-        std::optional<IPAddress> address;
-        decoder >> address;
-        if (!address)
-            return std::nullopt;
-        int flags;
-        if (!decoder.decode(flags))
-            return std::nullopt;
-        result.ips.push_back({ address->rtcAddress(), flags });
-    }
-    return result;
-}
-
-void RTCNetwork::encode(IPC::Encoder& encoder) const
-{
-    encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(name.data()), name.length());
-    encoder << IPC::DataReference(reinterpret_cast<const uint8_t*>(description.data()), description.length());
-    encoder << prefix;
-    encoder << prefixLength;
-    encoder << type;
-
-    encoder << id;
-    encoder << preference;
-    encoder << active;
-    encoder << ignored;
-    encoder << scopeID;
-
-    encoder << (uint64_t)ips.size();
-    for (auto& ip : ips) {
-        encoder << IPAddress { ip };
-        encoder << ip.ipv6_flags();
-    }
 }
 
 namespace RTC::Network {

--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -90,17 +90,14 @@ struct RTCNetwork {
     using IPAddress = RTC::Network::IPAddress;
     using InterfaceAddress = RTC::Network::InterfaceAddress;
 
-    RTCNetwork() = default;
     explicit RTCNetwork(const rtc::Network&);
+    explicit RTCNetwork(Vector<char>&& name, Vector<char>&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<InterfaceAddress>&& ips);
 
     rtc::Network value() const;
     static rtc::SocketAddress isolatedCopy(const rtc::SocketAddress&);
 
-    void encode(IPC::Encoder&) const;
-    static std::optional<RTCNetwork> decode(IPC::Decoder&);
-
-    std::string name;
-    std::string description;
+    Vector<char> name;
+    Vector<char> description;
     IPAddress prefix;
     int prefixLength;
     int type;
@@ -109,9 +106,7 @@ struct RTCNetwork {
     bool active;
     bool ignored;
     int scopeID;
-    std::string key;
-    size_t length;
-    std::vector<rtc::InterfaceAddress> ips;
+    Vector<InterfaceAddress> ips;
 };
 
 }

--- a/Source/WebKit/Shared/RTCNetwork.serialization.in
+++ b/Source/WebKit/Shared/RTCNetwork.serialization.in
@@ -22,8 +22,6 @@
 
 #if USE(LIBWEBRTC)
 
-header: "RTCNetwork.h"
-
 [CustomHeader] struct WebKit::RTC::Network::IPAddress {
     std::variant<WebKit::RTC::Network::IPAddress::UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value;
 };
@@ -36,4 +34,17 @@ header: "RTCNetwork.h"
     int ipv6Flags;
 };
 
+struct WebKit::RTCNetwork {
+    Vector<char> name;
+    Vector<char> description;
+    WebKit::RTC::Network::IPAddress prefix;
+    int prefixLength;
+    int type;
+    uint16_t id;
+    int preference;
+    bool active;
+    bool ignored;
+    int scopeID;
+    Vector<WebKit::RTC::Network::InterfaceAddress> ips;
+};
 #endif

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -142,7 +142,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         filteredNetworks = networks;
     else {
         for (auto& network : networks) {
-            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip || ipv6.rtcAddress() == ip; }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.c_str()))))
+            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.data(), network.name.size()))))
                 filteredNetworks.append(network);
         }
     }


### PR DESCRIPTION
#### fcec2d7bc72b88bce82d21af80190c9493772902
<pre>
Generate serialization of WebKit::RTCNetwork
<a href="https://bugs.webkit.org/show_bug.cgi?id=263330">https://bugs.webkit.org/show_bug.cgi?id=263330</a>
rdar://117153936

Reviewed by Youenn Fablet.

The previous attempt didn&apos;t update RTCNetwork::value to reflect that name and description
are no longer null terminated so they need to include their length in the absl::string_view
constructor.  That caused a test to become flaky.  Hopefully this won&apos;t.

* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::RTCNetwork):
(WebKit::RTCNetwork::value const):
(WebKit::ips): Deleted.
(WebKit::RTCNetwork::decode): Deleted.
(WebKit::RTCNetwork::encode const): Deleted.
* Source/WebKit/Shared/RTCNetwork.h:
* Source/WebKit/Shared/RTCNetwork.serialization.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):

Canonical link: <a href="https://commits.webkit.org/269498@main">https://commits.webkit.org/269498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b43aac73fab574b319b994cadecf456d754e035

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21021 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21950 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22946 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25466 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26803 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24643 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18105 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/198 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/326 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2867 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->