### PR TITLE
IPC deserialization: Clip IntRect rather than fail to decode entirely

### DIFF
--- a/LayoutTests/security/clip-invalid-rect-2-expected.txt
+++ b/LayoutTests/security/clip-invalid-rect-2-expected.txt
@@ -1,0 +1,2 @@
+ALERT: Test passed because nothing crashed
+some text

--- a/LayoutTests/security/clip-invalid-rect-2.html
+++ b/LayoutTests/security/clip-invalid-rect-2.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+    body {
+        letter-spacing: 1000000000px;
+    }
+</style>
+<script>
+    onload = () => {
+        document.execCommand('SelectAll');
+
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            alert("Test passed because nothing crashed");
+        }
+    };
+</script>
+some text
+</html>

--- a/LayoutTests/security/clip-invalid-rect-expected.txt
+++ b/LayoutTests/security/clip-invalid-rect-expected.txt
@@ -1,0 +1,2 @@
+ALERT: Test passed because nothing crashed
+

--- a/LayoutTests/security/clip-invalid-rect.html
+++ b/LayoutTests/security/clip-invalid-rect.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+    div {
+        transform: scaleX(1000000);
+        font-size-adjust: 10;
+    }
+
+    #b {
+        transform: scaleX(-1) skewX(100deg);
+    }
+</style>
+<script>
+    onload = () => {
+        let body = document.createElement('body');
+        body.id = 'b';
+        d.append(body);
+        document.execCommand('SelectAll');
+
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            alert("Test passed because nothing crashed");
+        }
+    };
+</script>
+<div id="d"></div>
+<video></video>
+</html>

--- a/Source/WebCore/platform/graphics/IntRect.cpp
+++ b/Source/WebCore/platform/graphics/IntRect.cpp
@@ -158,6 +158,18 @@ bool IntRect::isValid() const
     return !max.hasOverflowed();
 }
 
+IntRect IntRect::toRectWithExtentsClippedToNumericLimits() const
+{
+    using T = int32_t;
+    IntRect clippedRect { *this };
+    constexpr auto max = std::numeric_limits<T>::max();
+    if (sumOverflows<T>(x(), width()))
+        clippedRect.setWidth(max - x());
+    if (sumOverflows<T>(y(), height()))
+        clippedRect.setHeight(max - y());
+    return clippedRect;
+}
+
 TextStream& operator<<(TextStream& ts, const IntRect& r)
 {
     if (ts.hasFormattingFlag(TextStream::Formatting::SVGStyleRect))

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -189,6 +189,7 @@ public:
 
     // Return false if x + width or y + height overflows.
     WEBCORE_EXPORT bool isValid() const;
+    WEBCORE_EXPORT IntRect WARN_UNUSED_RETURN toRectWithExtentsClippedToNumericLimits() const;
 
     friend bool operator==(const IntRect&, const IntRect&) = default;
 

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -161,6 +161,8 @@ struct EditorState {
     std::optional<PostLayoutData> postLayoutData;
     std::optional<VisualData> visualData;
 
+    void clipOwnedRectExtentsToNumericLimits();
+
 private:
     friend TextStream& operator<<(TextStream&, const EditorState&);
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -894,7 +894,7 @@ void RemoteScrollingCoordinatorTransaction::dump() const
 {
     WTFLogAlways("%s", description().utf8().data());
 }
-#endif
+#endif // !defined(NDEBUG) || !LOG_DISABLED
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -788,6 +788,7 @@ void WebChromeClient::mouseDidMoveOverElement(const HitTestResult& hitTestResult
 
     // Notify the UIProcess.
     WebHitTestResultData webHitTestResultData(hitTestResult, toolTip);
+    webHitTestResultData.elementBoundingBox = webHitTestResultData.elementBoundingBox.toRectWithExtentsClippedToNumericLimits();
     page->send(Messages::WebPageProxy::MouseDidMoveOverElement(webHitTestResultData, wkModifiers, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1376,6 +1376,9 @@ EditorState WebPage::editorState(ShouldPerformLayout shouldPerformLayout) const
     Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
 
     EditorState result;
+    auto sanitizeEditorStateOnceCreated = makeScopeExit([&result] {
+        result.clipOwnedRectExtentsToNumericLimits();
+    });
 
 #if ENABLE(PDF_PLUGIN)
     if (auto* pluginView = focusedPluginViewForFrame(frame)) {
@@ -4055,7 +4058,7 @@ IntPoint WebPage::screenToRootView(const IntPoint& point)
     
 IntRect WebPage::rootViewToScreen(const IntRect& rect)
 {
-    auto sendResult = sendSync(Messages::WebPageProxy::RootViewToScreen(rect));
+    auto sendResult = sendSync(Messages::WebPageProxy::RootViewToScreen(rect.toRectWithExtentsClippedToNumericLimits()));
     auto [screenRect] = sendResult.takeReplyOr(IntRect { });
     return screenRect;
 }

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -944,6 +944,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FloatPoint locati
     RefPtr<API::Object> userData;
     injectedBundleContextMenuClient().prepareForImmediateAction(*this, hitTestResult, userData);
 
+    immediateActionResult.elementBoundingBox = immediateActionResult.elementBoundingBox.toRectWithExtentsClippedToNumericLimits();
     send(Messages::WebPageProxy::DidPerformImmediateActionHitTest(immediateActionResult, immediateActionHitTestPreventsDefault, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
 }
 


### PR DESCRIPTION
#### 9cf3ea6461529a8a721197cc381b0d6e90813686
<pre>
IPC deserialization: Clip IntRect rather than fail to decode entirely
<a href="https://bugs.webkit.org/show_bug.cgi?id=258222">https://bugs.webkit.org/show_bug.cgi?id=258222</a>
rdar://109925899
Reviewed by Chris Dumez.

We hardened IntRect decoding by using IntRect::isValid as a validator in
262412@main, however this has the inadvertent effect of terminating a
sending process if they send a degenerately large IntRect (i.e. one that
overflows at x + width or y + height and thus fails IntRect::isValid).

The messages with degerate rects reposinble for recently reported
deserialization crashes are namely `WebPageProxy::RootViewToScreen`,
`WebPageProxy::EditorStateChanged`,
`RemoteLayerTreeDrawingAreaProxy::CommitLayerTree`, and
`WebPageProxy::MouseDidMoveOverElement`. In this patch, we suggest
clipping the IntRect at the IPC sender call-site, thereby avoiding
overflow issues and not crashing the sending process. For the
`EditorState` case, it makes more sense to sanitize the owned rects in
`WebPage::editorState()`, which is a layer before the IPC sender
call-site.

* LayoutTests/security/clip-invalid-rect-expected.txt: Added.
* LayoutTests/security/clip-invalid-rect.html: Added.
* LayoutTests/security/clip-invalid-rect-2-expected.txt: Added.
* LayoutTests/security/clip-invalid-rect-2.html: Added.
Layout tests that crash trying to decode degenerate IntRect messages.

* Source/WebCore/platform/graphics/IntRect.cpp:
(WebCore::IntRect::toRectWithExtentsClippedToNumericLimits const):
* Source/WebCore/platform/graphics/IntRect.h:
Add a function that returns an IntRect with clipped size such that there
is no int32_t overflow at x + width or y + height.

* Source/WebKit/Shared/EditorState.cpp:
* Source/WebKit/Shared/EditorState.h:
(WebKit::EditorState::clipOwnedRectExtentsToNumericLimits):
Add a function that performs clipping of the rects owned by an EditorState
object.

* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
Drive-by fix to improve readability of a conditional directive.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::mouseDidMoveOverElement):
Perform `IntRect` clipping before sending a `MouseDidMoveOverElement` IPC
message.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):
Perform `IntRect` clipping for all the rects owned by an EditorState,
thus sanitizing both the `EditorStateChanged` and the `CommitLayerTree`
IPC messages.
(WebKit::WebPage::rootViewToScreen):
Perform `IntRect` clipping before sending a `RootViewToScreen` IPC
message.

* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):
Perform `IntRect` clipping before sending a `MouseDidMoveOverElement` IPC
message.

Canonical link: <a href="https://commits.webkit.org/265870.4@safari-7616-branch">https://commits.webkit.org/265870.4@safari-7616-branch</a>

Canonical link: <a href="https://commits.webkit.org/269494@main">https://commits.webkit.org/269494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cffa94da7672a54022bf7dc05d83e4e7119798b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24618 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23241 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22951 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25471 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26809 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24652 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/259 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5414 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->