### PR TITLE
Use more smart pointers in DataTransfer classes

### DIFF
--- a/Source/WebCore/dom/ContextDestructionObserver.cpp
+++ b/Source/WebCore/dom/ContextDestructionObserver.cpp
@@ -32,7 +32,6 @@
 namespace WebCore {
 
 ContextDestructionObserver::ContextDestructionObserver(ScriptExecutionContext* scriptExecutionContext)
-    : m_scriptExecutionContext(nullptr)
 {
     observeContext(scriptExecutionContext);
 }
@@ -60,6 +59,11 @@ void ContextDestructionObserver::observeContext(ScriptExecutionContext* scriptEx
 void ContextDestructionObserver::contextDestroyed()
 {
     m_scriptExecutionContext = nullptr;
+}
+
+RefPtr<ScriptExecutionContext> ContextDestructionObserver::protectedScriptExecutionContext() const
+{
+    return m_scriptExecutionContext.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ContextDestructionObserver.h
+++ b/Source/WebCore/dom/ContextDestructionObserver.h
@@ -26,6 +26,9 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
+#include <wtf/Forward.h>
+
 namespace WebCore {
 
 class ScriptExecutionContext;
@@ -34,7 +37,8 @@ class ContextDestructionObserver {
 public:
     WEBCORE_EXPORT virtual void contextDestroyed();
 
-    ScriptExecutionContext* scriptExecutionContext() const { return m_scriptExecutionContext; }
+    ScriptExecutionContext* scriptExecutionContext() const { return m_scriptExecutionContext.get(); }
+    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
 protected:
     WEBCORE_EXPORT explicit ContextDestructionObserver(ScriptExecutionContext*);
@@ -42,7 +46,7 @@ protected:
     void observeContext(ScriptExecutionContext*);
 
 private:
-    ScriptExecutionContext* m_scriptExecutionContext;
+    CheckedPtr<ScriptExecutionContext> m_scriptExecutionContext;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -59,14 +59,14 @@ namespace WebCore {
 class DragImageLoader final : private CachedImageClient {
     WTF_MAKE_NONCOPYABLE(DragImageLoader); WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit DragImageLoader(DataTransfer*);
+    explicit DragImageLoader(DataTransfer&);
     void startLoading(CachedResourceHandle<CachedImage>&);
     void stopLoading(CachedResourceHandle<CachedImage>&);
     void moveToDataTransfer(DataTransfer&);
 
 private:
     void imageChanged(CachedImage*, const IntRect*) override;
-    DataTransfer* m_dataTransfer;
+    CheckedRef<DataTransfer> m_dataTransfer;
 };
 
 #endif
@@ -214,19 +214,19 @@ String DataTransfer::readStringFromPasteboard(Document& document, const String& 
     if (!is<StaticPasteboard>(*m_pasteboard) && lowercaseType == "text/html"_s) {
         if (!document.frame())
             return { };
-        WebContentMarkupReader reader { *document.frame() };
+        WebContentMarkupReader reader { document.protectedFrame().releaseNonNull() };
         m_pasteboard->read(reader, policy);
         return reader.takeMarkup();
     }
 
     if (!is<StaticPasteboard>(*m_pasteboard) && lowercaseType == "text/uri-list"_s) {
-        return readURLsFromPasteboardAsString(document.page(), *m_pasteboard, [] (auto&) {
+        return readURLsFromPasteboardAsString(document.checkedPage().get(), *m_pasteboard, [] (auto&) {
             return true;
         });
     }
 
     auto string = m_pasteboard->readString(lowercaseType);
-    if (auto* page = document.page())
+    if (CheckedPtr page = document.page())
         return page->applyLinkDecorationFiltering(string, LinkDecorationFilteringTrigger::Paste);
 
     return string;
@@ -279,7 +279,7 @@ void DataTransfer::setDataFromItemList(Document& document, const String& type, c
         sanitizedData = data; // Nothing to sanitize.
 
     if (type == "text/uri-list"_s || type == textPlainContentTypeAtom()) {
-        if (auto* page = document.page())
+        if (CheckedPtr page = document.page())
             sanitizedData = page->applyLinkDecorationFiltering(sanitizedData, LinkDecorationFilteringTrigger::Copy);
     }
 
@@ -538,7 +538,7 @@ void DataTransfer::setDragImage(Element& element, int x, int y)
     if (!forDrag() || !canWriteData())
         return;
 
-    CachedImage* image = nullptr;
+    CachedResourceHandle<CachedImage> image;
     if (is<HTMLImageElement>(element) && !element.isConnected())
         image = downcast<HTMLImageElement>(element).cachedImage();
 
@@ -549,7 +549,7 @@ void DataTransfer::setDragImage(Element& element, int x, int y)
     m_dragImage = image;
     if (m_dragImage) {
         if (!m_dragImageLoader)
-            m_dragImageLoader = makeUnique<DragImageLoader>(this);
+            m_dragImageLoader = makeUnique<DragImageLoader>(*this);
         m_dragImageLoader->startLoading(m_dragImage);
     }
 
@@ -585,11 +585,11 @@ DragImageRef DataTransfer::createDragImage(IntPoint& location) const
     location = m_dragLocation;
 
     if (m_dragImage)
-        return createDragImageFromImage(m_dragImage->image(), ImageOrientation::Orientation::None);
+        return createDragImageFromImage(m_dragImage->protectedImage().get(), ImageOrientation::Orientation::None);
 
     if (m_dragImageElement) {
-        if (auto* frame = m_dragImageElement->document().frame())
-            return createDragImageForNode(*frame, *m_dragImageElement);
+        if (RefPtr frame = m_dragImageElement->document().frame())
+            return createDragImageForNode(*frame, dragImageElement().releaseNonNull());
     }
 
     // We do not have enough information to create a drag image, use the default icon.
@@ -598,14 +598,14 @@ DragImageRef DataTransfer::createDragImage(IntPoint& location) const
 
 #endif
 
-DragImageLoader::DragImageLoader(DataTransfer* dataTransfer)
+DragImageLoader::DragImageLoader(DataTransfer& dataTransfer)
     : m_dataTransfer(dataTransfer)
 {
 }
 
 void DragImageLoader::moveToDataTransfer(DataTransfer& newDataTransfer)
 {
-    m_dataTransfer = &newDataTransfer;
+    m_dataTransfer = newDataTransfer;
 }
 
 void DragImageLoader::startLoading(CachedResourceHandle<WebCore::CachedImage>& image)

--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -26,6 +26,7 @@
 #include "CachedResourceHandle.h"
 #include "DragActions.h"
 #include "DragImage.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -42,7 +43,7 @@ class Pasteboard;
 class ScriptExecutionContext;
 enum class WebContentReadingPolicy : bool;
 
-class DataTransfer : public RefCounted<DataTransfer> {
+class DataTransfer : public RefCounted<DataTransfer>, public CanMakeCheckedPtr {
 public:
     // https://html.spec.whatwg.org/multipage/dnd.html#drag-data-store-mode
     enum class StoreMode { Invalid, ReadWrite, Readonly, Protected };

--- a/Source/WebCore/dom/DataTransferItem.cpp
+++ b/Source/WebCore/dom/DataTransferItem.cpp
@@ -89,12 +89,12 @@ void DataTransferItem::getAsString(Document& document, RefPtr<StringCallback>&& 
     if (!callback || !m_list || m_file)
         return;
 
-    auto& dataTransfer = m_list->dataTransfer();
-    if (!dataTransfer.canReadData())
+    Ref dataTransfer = m_list->dataTransfer();
+    if (!dataTransfer->canReadData())
         return;
 
     // FIXME: Make this async.
-    callback->scheduleCallback(document, dataTransfer.getDataForItem(document, m_type));
+    callback->scheduleCallback(document, dataTransfer->getDataForItem(document, m_type));
 }
 
 RefPtr<File> DataTransferItem::getAsFile() const

--- a/Source/WebCore/dom/DataTransferItemList.h
+++ b/Source/WebCore/dom/DataTransferItemList.h
@@ -35,6 +35,7 @@
 #include "DataTransfer.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -54,9 +55,9 @@ public:
     ~DataTransferItemList();
 
     // DataTransfer owns DataTransferItemList, and DataTransfer is kept alive as long as DataTransferItemList is alive.
-    void ref() { m_dataTransfer.ref(); }
-    void deref() { m_dataTransfer.deref(); }
-    DataTransfer& dataTransfer() { return m_dataTransfer; }
+    void ref() { m_dataTransfer->ref(); }
+    void deref() { m_dataTransfer->deref(); }
+    DataTransfer& dataTransfer() { return m_dataTransfer.get(); }
 
     // DOM API
     unsigned length() const;
@@ -80,7 +81,7 @@ private:
     Vector<Ref<DataTransferItem>>& ensureItems() const;
     Document* document() const;
 
-    DataTransfer& m_dataTransfer;
+    CheckedRef<DataTransfer> m_dataTransfer;
     mutable std::optional<Vector<Ref<DataTransferItem>>> m_items;
 };
 

--- a/Source/WebCore/dom/DataTransferMac.mm
+++ b/Source/WebCore/dom/DataTransferMac.mm
@@ -43,17 +43,17 @@ DragImageRef DataTransfer::createDragImage(IntPoint& location) const
 {
     DragImageRef result = nil;
     if (m_dragImageElement) {
-        if (auto* frame = m_dragImageElement->document().frame()) {
+        if (RefPtr frame = m_dragImageElement->document().frame()) {
             IntRect imageRect;
             IntRect elementRect;
-            result = createDragImageForImage(*frame, *m_dragImageElement, imageRect, elementRect);
+            result = createDragImageForImage(*frame, dragImageElement().releaseNonNull(), imageRect, elementRect);
             // Client specifies point relative to element, not the whole image, which may include child
             // layers spread out all over the place.
             location.setX(elementRect.x() - imageRect.x() + m_dragLocation.x());
             location.setY(imageRect.height() - (elementRect.y() - imageRect.y() + m_dragLocation.y()));
         }
     } else if (m_dragImage) {
-        result = m_dragImage->image()->snapshotNSImage();
+        result = m_dragImage->protectedImage()->snapshotNSImage();
         
         location = m_dragLocation;
         location.setY([result size].height - location.y());

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -254,6 +254,11 @@ Image* CachedImage::image() const
     return &Image::nullImage();
 }
 
+RefPtr<Image> CachedImage::protectedImage() const
+{
+    return image();
+}
+
 Image* CachedImage::imageForRenderer(const RenderObject* renderer)
 {
     if (errorOccurred() && m_shouldPaintBrokenImage) {

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -56,6 +56,7 @@ public:
     virtual ~CachedImage();
 
     WEBCORE_EXPORT Image* image() const; // Returns the nullImage() if the image is not available yet.
+    WEBCORE_EXPORT RefPtr<Image> protectedImage() const;
     WEBCORE_EXPORT Image* imageForRenderer(const RenderObject*); // Returns the nullImage() if the image is not available yet.
     bool hasImage() const { return m_image.get(); }
     bool hasSVGImage() const;

--- a/Source/WebCore/page/FrameDestructionObserver.h
+++ b/Source/WebCore/page/FrameDestructionObserver.h
@@ -40,6 +40,7 @@ public:
     WEBCORE_EXPORT virtual void willDetachPage();
 
     inline LocalFrame* frame() const; // Defined in FrameDestructionObserverInlines.h.
+    inline RefPtr<LocalFrame> protectedFrame() const; // Defined in FrameDestructionObserverInlines.h.
 
 protected:
     WEBCORE_EXPORT virtual ~FrameDestructionObserver();

--- a/Source/WebCore/page/FrameDestructionObserverInlines.h
+++ b/Source/WebCore/page/FrameDestructionObserverInlines.h
@@ -35,4 +35,9 @@ inline LocalFrame* FrameDestructionObserver::frame() const
     return m_frame.get();
 }
 
+inline RefPtr<LocalFrame> FrameDestructionObserver::protectedFrame() const
+{
+    return m_frame.get();
+}
+
 }


### PR DESCRIPTION
#### 0fb6b6e8b8ce6a37849a972e561e815997672e3e
<pre>
Use more smart pointers in DataTransfer classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=263332">https://bugs.webkit.org/show_bug.cgi?id=263332</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/ContextDestructionObserver.cpp:
(WebCore::ContextDestructionObserver::protectedScriptExecutionContext const):
* Source/WebCore/dom/ContextDestructionObserver.h:
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::readStringFromPasteboard const):
(WebCore::DataTransfer::setDataFromItemList):
(WebCore::DataTransfer::setDragImage):
(WebCore::DataTransfer::createDragImage const):
(WebCore::DragImageLoader::DragImageLoader):
(WebCore::DragImageLoader::moveToDataTransfer):
* Source/WebCore/dom/DataTransfer.h:
* Source/WebCore/dom/DataTransferItem.cpp:
(WebCore::DataTransferItem::getAsString const):
* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::DataTransferItemList::add):
(WebCore::DataTransferItemList::remove):
(WebCore::DataTransferItemList::clear):
(WebCore::DataTransferItemList::ensureItems const):
* Source/WebCore/dom/DataTransferItemList.h:
* Source/WebCore/dom/DataTransferMac.mm:
(WebCore::DataTransfer::createDragImage const):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::image const):
(WebCore::CachedImage::protectedImage const):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/page/FrameDestructionObserver.h:
* Source/WebCore/page/FrameDestructionObserverInlines.h:
(WebCore::FrameDestructionObserver::protectedFrame const):

Canonical link: <a href="https://commits.webkit.org/269496@main">https://commits.webkit.org/269496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b438a66dbb912ac525ff3cd3c7e04fb983a74fbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24620 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21027 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23243 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22953 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25473 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26810 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24651 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18108 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5419 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->