### PR TITLE
jsc_fuz/wktr: null ptr deref in WebCore::SVGResources::buildCachedResources(WebCore::RenderElement const&, WebCore::RenderStyle const&) + 368 (SVGResources.cpp:251)

### DIFF
--- a/LayoutTests/svg/crash-svg-null-maskimage-expected.txt
+++ b/LayoutTests/svg/crash-svg-null-maskimage-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/svg/crash-svg-null-maskimage.html
+++ b/LayoutTests/svg/crash-svg-null-maskimage.html
@@ -1,0 +1,8 @@
+<body>
+<svg style="mask-image: none, url()"></svg>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<p>This test passes if it doesn't crash.</p>
+</body>

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -254,7 +254,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
         if (style.hasPositionedMask()) {
             // FIXME: We should support all the values in the CSS mask property, but for now just use the first mask-image if it's a reference.
             auto* maskImage = style.maskImage();
-            auto reresolvedURL = maskImage->reresolvedURL(document);
+            auto reresolvedURL = maskImage ? maskImage->reresolvedURL(document) : URL();
 
             if (!reresolvedURL.isEmpty()) {
                 auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(reresolvedURL.string(), document);


### PR DESCRIPTION
#### f81050aadfd1b78e0993fa1db5695f08a1511117
<pre>
jsc_fuz/wktr: null ptr deref in WebCore::SVGResources::buildCachedResources(WebCore::RenderElement const&amp;, WebCore::RenderStyle const&amp;) + 368 (SVGResources.cpp:251)
<a href="https://bugs.webkit.org/show_bug.cgi?id=263224">https://bugs.webkit.org/show_bug.cgi?id=263224</a>
rdar://116386835.

Reviewed by Chris Dumez.

Modified SVGResources::buildCachedResources API in order to consider passed svg with NULL mask-image.

Test : LayoutTests/svg/crash-svg-null-maskimage.html

* Source/WebCore/rendering/svg/SVGResources.cpp : Modified to check if the maskImage variable is not NULL before dereferrencing.
* LayoutTests/svg/crash-svg-null-maskimage.html : Added test case.
* LayoutTests/svg/crash-svg-null-maskimage-expected.txt : Added test expected file.

Canonical link: <a href="https://commits.webkit.org/269561@main">https://commits.webkit.org/269561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95542895e658eded8174353171edeb136bfb1da9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22053 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25614 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20711 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Ignored 3 pre-existing failure based on results-db; Running upload-test-results") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26917 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24757 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18214 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20509 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5470 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->