### PR TITLE
Simplify `skipOptionalSVGSpacesOrDelimiter` post 269478@main

### DIFF
--- a/Source/WebCore/svg/SVGParserUtilities.h
+++ b/Source/WebCore/svg/SVGParserUtilities.h
@@ -95,15 +95,21 @@ template<typename CharacterType> constexpr bool skipOptionalSVGSpacesOrDelimiter
 
 template<typename CharacterType> constexpr bool skipOptionalSVGSpacesOrDelimiter(StringParsingBuffer<CharacterType>& characters, char delimiter = ',')
 {
-    if (characters.hasCharactersRemaining() && !isSVGSpace(*characters) && *characters != delimiter)
+    if (!characters.hasCharactersRemaining())
         return false;
-    if (skipOptionalSVGSpaces(characters)) {
-        if (*characters == delimiter) {
-            characters++;
-            skipOptionalSVGSpaces(characters);
-        }
-    }
-    return characters.hasCharactersRemaining();
+
+    if (!isSVGSpace(*characters) && *characters != delimiter)
+        return false;
+
+    // There are only spaces in the remaining characters.
+    if (!skipOptionalSVGSpaces(characters))
+        return false;
+
+    if (*characters != delimiter)
+        return true;
+
+    // A delimiter is hit. Skip the following spaces also e.g. " , ".
+    return skipOptionalSVGSpaces(++characters);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 18a4504a0de8c421869c219869894c4e4685e747
<pre>
Simplify `skipOptionalSVGSpacesOrDelimiter` post 269478@main

<a href="https://bugs.webkit.org/show_bug.cgi?id=263336">https://bugs.webkit.org/show_bug.cgi?id=263336</a>

Reviewed by Said Abou-Hallawa.

This patch is to address and add suggested changes by Said to further simplify `skipOptionalSVGSpacesOrDelimiter` function.

*  Source/WebCore/svg/SVGParserUtilities.h:
(skipOptionalSVGSpacesOrDelimiter):

Canonical link: <a href="https://commits.webkit.org/269532@main">https://commits.webkit.org/269532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45857a6f0d42d161e578989c1e69645ce7d8f6a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21034 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21960 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25483 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26814 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24657 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18115 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/210 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5438 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->