### PR TITLE
[css-grid] align-items/align-self: last baseline should take into consideration the extra margin from non-orthogonal ancestor subgrids

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt
@@ -12,19 +12,9 @@ PASS .item 4
 PASS .item 5
 PASS .item 6
 PASS .item 7
-FAIL .item 8 assert_equals:
-<div data-offset-y="110" class="item small last"></div>
-offsetTop expected 110 but got 120
-FAIL .item 9 assert_equals:
-<div data-offset-y="168" class="item small first"></div>
-offsetTop expected 168 but got 158
-FAIL .item 10 assert_equals:
-<div data-offset-y="243" class="item small last"></div>
-offsetTop expected 243 but got 270
-FAIL .item 11 assert_equals:
-<div data-offset-y="313" class="item small first"></div>
-offsetTop expected 313 but got 308
-FAIL .item 12 assert_equals:
-<div data-offset-y="385" class="item small last"></div>
-offsetTop expected 385 but got 420
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt
@@ -11,30 +11,30 @@ FAIL .item 3 assert_equals:
 <div data-offset-x="387" class="item first">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 387 but got 372
+offsetLeft expected 387 but got 382
 PASS .item 4
 FAIL .item 5 assert_equals:
 <div data-offset-x="242" class="item first">
       <span></span><br><span></span>
     </div>
-offsetLeft expected 242 but got 227
+offsetLeft expected 242 but got 232
 PASS .item 6
 FAIL .item 7 assert_equals:
 <div data-offset-x="534" class="item small first"></div>
 offsetLeft expected 534 but got 549
 FAIL .item 8 assert_equals:
 <div data-offset-x="465" class="item small last"></div>
-offsetLeft expected 465 but got 470
+offsetLeft expected 465 but got 480
 FAIL .item 9 assert_equals:
 <div data-offset-x="407" class="item small first"></div>
 offsetLeft expected 407 but got 417
 FAIL .item 10 assert_equals:
 <div data-offset-x="332" class="item small last"></div>
-offsetLeft expected 332 but got 320
+offsetLeft expected 332 but got 347
 FAIL .item 11 assert_equals:
 <div data-offset-x="262" class="item small first"></div>
 offsetLeft expected 262 but got 267
 FAIL .item 12 assert_equals:
 <div data-offset-x="190" class="item small last"></div>
-offsetLeft expected 190 but got 170
+offsetLeft expected 190 but got 205
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt
@@ -6,39 +6,15 @@
 
 
 PASS .item 1
-FAIL .item 2 assert_equals:
-<div data-offset-y="58" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetTop expected 58 but got 48
+PASS .item 2
 PASS .item 3
-FAIL .item 4 assert_equals:
-<div data-offset-y="181" class="item last">
-        <span></span><br><span></span>
-      </div>
-offsetTop expected 181 but got 151
-FAIL .item 5 assert_equals:
-<div data-offset-y="291" class="item first">
-      <span></span><br><span></span>
-    </div>
-offsetTop expected 291 but got 266
-FAIL .item 6 assert_equals:
-<div data-offset-y="321" class="item last">
-      <span></span><br><span></span>
-    </div>
-offsetTop expected 321 but got 266
+PASS .item 4
+PASS .item 5
+PASS .item 6
 PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div data-offset-y="126" class="item small first"></div>
-offsetTop expected 126 but got 116
-FAIL .item 10 assert_equals:
-<div data-offset-y="126" class="item small last"></div>
-offsetTop expected 126 but got 123
-FAIL .item 11 assert_equals:
-<div data-offset-y="266" class="item small first"></div>
-offsetTop expected 266 but got 236
-FAIL .item 12 assert_equals:
-<div data-offset-y="266" class="item small last"></div>
-offsetTop expected 266 but got 246
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt
@@ -14,39 +14,39 @@ FAIL .item 2 assert_equals:
 <div data-offset-x="428" class="item last">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 428 but got 421
+offsetLeft expected 428 but got 429
 FAIL .item 3 assert_equals:
 <div data-offset-x="325" class="item first">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 325 but got 308
+offsetLeft expected 325 but got 326
 FAIL .item 4 assert_equals:
 <div data-offset-x="234" class="item last">
         <span></span><br><span></span>
       </div>
-offsetLeft expected 234 but got 236
+offsetLeft expected 234 but got 243
 FAIL .item 5 assert_equals:
 <div data-offset-x="131" class="item first">
       <span></span><br><span></span>
     </div>
-offsetLeft expected 131 but got 111
+offsetLeft expected 131 but got 123
 PASS .item 6
 FAIL .item 7 assert_equals:
 <div data-offset-x="524" class="item small first"></div>
 offsetLeft expected 524 but got 547
 FAIL .item 8 assert_equals:
 <div data-offset-x="393" class="item small last"></div>
-offsetLeft expected 393 but got 426
+offsetLeft expected 393 but got 444
 FAIL .item 9 assert_equals:
 <div data-offset-x="335" class="item small first"></div>
-offsetLeft expected 335 but got 353
+offsetLeft expected 335 but got 361
 FAIL .item 10 assert_equals:
 <div data-offset-x="199" class="item small last"></div>
-offsetLeft expected 199 but got 224
+offsetLeft expected 199 but got 258
 FAIL .item 11 assert_equals:
 <div data-offset-x="141" class="item small first"></div>
-offsetLeft expected 141 but got 151
+offsetLeft expected 141 but got 158
 FAIL .item 12 assert_equals:
 <div data-offset-x="5" class="item small last"></div>
-offsetLeft expected 5 but got 20
+offsetLeft expected 5 but got 55
 

--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "GridBaselineAlignment.h"
 
+#include "AncestorSubgridIterator.h"
 #include "BaselineAlignmentInlines.h"
 #include "RenderBoxInlines.h"
 #include "RenderGrid.h"
@@ -60,8 +61,20 @@ LayoutUnit GridBaselineAlignment::marginUnderForChild(const RenderBox& child, Gr
 
 LayoutUnit GridBaselineAlignment::logicalAscentForChild(const RenderBox& child, GridAxis baselineAxis, ItemPosition position) const
 {
-    LayoutUnit ascent = ascentForChild(child, baselineAxis, position);
-    return (isDescentBaselineForChild(child, baselineAxis) || position == ItemPosition::LastBaseline) ? descentForChild(child, ascent, baselineAxis) : ascent;
+    auto hasOrthogonalAncestorSubgrids = [&] {
+        for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(child, GridTrackSizingDirection::ForRows)) {
+            if (currentAncestorSubgrid.isHorizontalWritingMode() != currentAncestorSubgrid.parent()->isHorizontalWritingMode())
+                return true;
+        }
+        return false;
+    };
+
+    ExtraMarginsFromSubgrids extraMarginsFromAncestorSubgrids;
+    if (baselineAxis == GridAxis::GridColumnAxis && !hasOrthogonalAncestorSubgrids())
+        extraMarginsFromAncestorSubgrids = GridLayoutFunctions::extraMarginForSubgridAncestors(GridTrackSizingDirection::ForRows, child);
+
+    LayoutUnit ascent = ascentForChild(child, baselineAxis, position) + extraMarginsFromAncestorSubgrids.extraTrackStartMargin();
+    return (isDescentBaselineForChild(child, baselineAxis) || position == ItemPosition::LastBaseline) ? descentForChild(child, ascent, baselineAxis, extraMarginsFromAncestorSubgrids) : ascent;
 }
 
 LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxis baselineAxis, ItemPosition position) const
@@ -78,33 +91,14 @@ LayoutUnit GridBaselineAlignment::ascentForChild(const RenderBox& child, GridAxi
         return child.size().height() + margin;
     }
 
-    auto subgridOffset = [&] {
-        if (position == ItemPosition::LastBaseline || baselineAxis == GridAxis::GridRowAxis)
-            return 0_lu;
-
-        auto offset = 0_lu;
-        const auto* currentSubgrid = dynamicDowncast<RenderGrid>(child.parent());
-        while (currentSubgrid && currentSubgrid->isSubgridRows()) {
-            auto isPlacedAtFirstTrackInSubgrid = [&] {
-                return !currentSubgrid->gridSpanForChild(child, GridTrackSizingDirection::ForRows).startLine();
-            }();
-
-            if (!isPlacedAtFirstTrackInSubgrid || GridLayoutFunctions::isOrthogonalParent(*currentSubgrid, *currentSubgrid->parent()))
-                return 0_lu;
-            offset += currentSubgrid->marginAndBorderAndPaddingBefore();
-            currentSubgrid = dynamicDowncast<RenderGrid>(currentSubgrid->parent());
-        }
-        return offset;
-    }();
-
-    return subgridOffset + margin + baseline;
+    return margin + baseline;
 }
 
-LayoutUnit GridBaselineAlignment::descentForChild(const RenderBox& child, LayoutUnit ascent, GridAxis baselineAxis) const
+LayoutUnit GridBaselineAlignment::descentForChild(const RenderBox& child, LayoutUnit ascent, GridAxis baselineAxis, ExtraMarginsFromSubgrids extraMarginsFromAncestorSubgrids) const
 {
     ASSERT(!child.needsLayout());
     if (isParallelToBaselineAxisForChild(child, baselineAxis))
-        return child.marginLogicalHeight() + child.logicalHeight() - ascent;
+        return extraMarginsFromAncestorSubgrids.extraTotalMargin() + child.marginLogicalHeight() + child.logicalHeight() - ascent;
     return child.marginLogicalWidth() + child.logicalWidth() - ascent;
 }
 

--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -68,7 +68,7 @@ private:
     LayoutUnit marginUnderForChild(const RenderBox&, GridAxis) const;
     LayoutUnit logicalAscentForChild(const RenderBox&, GridAxis, ItemPosition) const;
     LayoutUnit ascentForChild(const RenderBox&, GridAxis, ItemPosition) const;
-    LayoutUnit descentForChild(const RenderBox&, LayoutUnit, GridAxis) const;
+    LayoutUnit descentForChild(const RenderBox&, LayoutUnit, GridAxis, ExtraMarginsFromSubgrids) const;
     bool isDescentBaselineForChild(const RenderBox&, GridAxis) const;
     bool isHorizontalBaselineAxis(GridAxis) const;
     bool isOrthogonalChildForBaseline(const RenderBox&) const;

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -40,6 +40,24 @@ enum class GridAxis : uint8_t {
     GridColumnAxis = 1 << 1
 };
 
+struct ExtraMarginsFromSubgrids {
+    inline LayoutUnit extraTrackStartMargin() const { return m_extraMargins.first; }
+    inline LayoutUnit extraTrackEndMargin() const { return m_extraMargins.second; }
+    inline LayoutUnit extraTotalMargin() const { return m_extraMargins.first + m_extraMargins.second; }
+
+    ExtraMarginsFromSubgrids& operator+=(const ExtraMarginsFromSubgrids& rhs)
+    {
+        m_extraMargins.first += rhs.extraTrackStartMargin();
+        m_extraMargins.second += rhs.extraTrackEndMargin();
+        return *this;
+    }
+
+    void addTrackStartMargin(LayoutUnit extraMargin) { m_extraMargins.first += extraMargin; }
+    void addTrackEndMargin(LayoutUnit extraMargin) { m_extraMargins.second += extraMargin; }
+
+    std::pair<LayoutUnit, LayoutUnit> m_extraMargins;
+};
+
 namespace GridLayoutFunctions {
 
 LayoutUnit computeMarginLogicalSizeForChild(const RenderGrid&, GridTrackSizingDirection, const RenderBox&);
@@ -55,7 +73,7 @@ bool hasRelativeOrIntrinsicSizeForChild(const RenderBox& child, GridTrackSizingD
 
 bool isFlippedDirection(const RenderGrid&, GridTrackSizingDirection);
 bool isSubgridReversedDirection(const RenderGrid&, GridTrackSizingDirection outerDirection, const RenderGrid& subgrid);
-LayoutUnit extraMarginForSubgridAncestors(GridTrackSizingDirection, const RenderBox& child);
+ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(GridTrackSizingDirection, const RenderBox& child);
 
 unsigned alignmentContextForBaselineAlignment(const GridSpan&, const ItemPosition& alignment);
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1041,7 +1041,7 @@ bool GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSiz
             // If the item is subgridded in this direction (and thus the tracks it covers are tracks
             // owned by this sizing algorithm), then we want to take the breadth of the tracks we occupy,
             // and subtract any space occupied by the subgrid itself (and any ancestor subgrids).
-            *overrideSize -= GridLayoutFunctions::extraMarginForSubgridAncestors(subgridDirection, child);
+            *overrideSize -= GridLayoutFunctions::extraMarginForSubgridAncestors(subgridDirection, child).extraTotalMargin();
         } else {
             // Otherwise the tracks that this child covers (in this non-subgridded axis) are owned
             // by one of the intermediate RenderGrids (which are subgrids in the other axis), which may


### PR DESCRIPTION
#### b3db1071742474d5876270a3f5bd3d7c391dc083
<pre>
[css-grid] align-items/align-self: last baseline should take into consideration the extra margin from non-orthogonal ancestor subgrids
<a href="https://bugs.webkit.org/show_bug.cgi?id=262646">https://bugs.webkit.org/show_bug.cgi?id=262646</a>
rdar://problem/116484865

Reviewed by Matt Woodrow.

Grid performs last baseline alignment by using the &quot;descent,&quot; value of
grid items, which is the distance from the under side of the grid item&apos;s
margin box to its ascent value. For subgridded items, this can include
extra margins imposed by ancestor subgrids. In order to properly
support subgridded items for last baseline alignment we need the extra
layer of margin on the under side of the grid item so that we can
properly compute its descent value. This patch is a first step at that
by focusing on the scenario in which we are aligning in the grid&apos;s
column axis (align-self/align-items) and there are no orthogonal
ancestor subgrids or orthogonal &quot;root,&quot; grid.

This requires 3 main changes:
1.) Start using extraMarginForSubgridAncestors() to compute the margins
imposed by the ancestor subgrids. Previously, for first baseline
alignment, we were walking up the ancestor subgrid chain and collecting
the extra layer of margin. extraMarginForSubgridAncestors() already did
this (and includes the subgrids&apos; gutters), so we should be using this
instead of duplicating code.

2.) Refactor extraMarginForSubgrid and extraMarginForSubgridAncestors
to return a new type: ExtraMarginsFromSubgrids. Instead of returning the
sum of the extra layer of margins both both sides of the track, this
struct keeps them separate and allows the caller to choose whether they
want the sum or the margins on a specific side.

3.) Pass extraTotalMargin() to descentForChild(). Since the descent
value is computed by finding the distance from the grid item&apos;s under
side of the margin box, extraTotalMargin() is needed to find the correct
side of the item&apos;s margin box with the extra layer of margins.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-008-expected.txt:
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::logicalAscentForChild const):
(WebCore::GridBaselineAlignment::ascentForChild const):
(WebCore::GridBaselineAlignment::descentForChild const):
* Source/WebCore/rendering/GridBaselineAlignment.h:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::extraMarginForSubgrid):
(WebCore::GridLayoutFunctions::extraMarginForSubgridAncestors):
(WebCore::GridLayoutFunctions::marginLogicalSizeForChild):
* Source/WebCore/rendering/GridLayoutFunctions.h:
(WebCore::ExtraMarginsFromSubgrids::extraTrackStartMargin const):
(WebCore::ExtraMarginsFromSubgrids::extraTrackEndMargin const):
(WebCore::ExtraMarginsFromSubgrids::extraTotalMargin const):
(WebCore::ExtraMarginsFromSubgrids::operator+=):
(WebCore::ExtraMarginsFromSubgrids::addTrackStartMargin):
(WebCore::ExtraMarginsFromSubgrids::addTrackEndMargin):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSizeForChild const):

Canonical link: <a href="https://commits.webkit.org/269781@main">https://commits.webkit.org/269781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b360157d9838733f5adc5d3d40699a2f562528dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/22996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21964 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25497 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26818 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18120 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/220 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5625 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->