### PR TITLE
Use more smart pointers in device motion / orientation classes

### DIFF
--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -130,9 +130,8 @@ EventInterface DeviceMotionEvent::eventInterface() const
 #if ENABLE(DEVICE_ORIENTATION)
 void DeviceMotionEvent::requestPermission(Document& document, PermissionPromise&& promise)
 {
-    auto* window = document.domWindow();
-    auto* page = document.page();
-    if (!window || !page)
+    RefPtr window = document.domWindow();
+    if (!window || !document.page())
         return promise.reject(Exception { InvalidStateError, "No browsing context"_s });
 
     String errorMessage;

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
@@ -51,9 +51,9 @@ DeviceOrientationOrMotionPermissionState DeviceOrientationAndMotionAccessControl
         return iterator->value;
 
     // Check per-site setting.
-    if (&document == &m_topDocument || document.securityOrigin().isSameOriginAs(m_topDocument.securityOrigin())) {
-        auto* frame = m_topDocument.frame();
-        if (auto* documentLoader = frame ? frame->loader().documentLoader() : nullptr)
+    if (&document == m_topDocument.ptr() || document.securityOrigin().isSameOriginAs(m_topDocument->securityOrigin())) {
+        RefPtr frame = m_topDocument->frame();
+        if (RefPtr documentLoader = frame ? frame->loader().documentLoader() : nullptr)
             return documentLoader->deviceOrientationAndMotionAccessState();
     }
 
@@ -62,8 +62,8 @@ DeviceOrientationOrMotionPermissionState DeviceOrientationAndMotionAccessControl
 
 void DeviceOrientationAndMotionAccessController::shouldAllowAccess(const Document& document, Function<void(DeviceOrientationOrMotionPermissionState)>&& callback)
 {
-    auto* page = document.page();
-    auto* frame = document.frame();
+    CheckedPtr page = document.page();
+    RefPtr frame = document.frame();
     if (!page || !frame)
         return callback(DeviceOrientationOrMotionPermissionState::Denied);
 
@@ -72,22 +72,25 @@ void DeviceOrientationAndMotionAccessController::shouldAllowAccess(const Documen
         return callback(accessState);
 
     bool mayPrompt = UserGestureIndicator::processingUserGesture(&document);
-    page->chrome().client().shouldAllowDeviceOrientationAndMotionAccess(*document.frame(), mayPrompt, [this, weakThis = WeakPtr { *this }, securityOrigin = Ref { document.securityOrigin() }, callback = WTFMove(callback)](DeviceOrientationOrMotionPermissionState permissionState) mutable {
+    page->chrome().client().shouldAllowDeviceOrientationAndMotionAccess(document.protectedFrame().releaseNonNull(), mayPrompt, [this, weakThis = WeakPtr { *this }, securityOrigin = Ref { document.securityOrigin() }, callback = WTFMove(callback)](DeviceOrientationOrMotionPermissionState permissionState) mutable {
         if (!weakThis)
             return;
 
         m_accessStatePerOrigin.set(securityOrigin->data(), permissionState);
         callback(permissionState);
+        if (!weakThis)
+            return;
 
         if (permissionState != DeviceOrientationOrMotionPermissionState::Granted)
             return;
 
-        for (Frame* frame = m_topDocument.frame(); frame && frame->window(); frame = frame->tree().traverseNext()) {
-            auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        for (RefPtr<Frame> frame = m_topDocument->frame(); frame && frame->window(); frame = frame->tree().traverseNext()) {
+            RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
-            localFrame->window()->startListeningForDeviceOrientationIfNecessary();
-            localFrame->window()->startListeningForDeviceMotionIfNecessary();
+            RefPtr window = localFrame->window();
+            window->startListeningForDeviceOrientationIfNecessary();
+            window->startListeningForDeviceMotionIfNecessary();
         }
     });
 }

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
@@ -30,6 +30,7 @@
 #include "DeviceOrientationOrMotionPermissionState.h"
 #include "ExceptionOr.h"
 #include "SecurityOriginData.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -48,7 +49,7 @@ public:
     void shouldAllowAccess(const Document&, Function<void(DeviceOrientationOrMotionPermissionState)>&&);
 
 private:
-    Document& m_topDocument;
+    CheckedRef<Document> m_topDocument;
     HashMap<SecurityOriginData, DeviceOrientationOrMotionPermissionState> m_accessStatePerOrigin;
 };
 

--- a/Source/WebCore/dom/DeviceOrientationEvent.cpp
+++ b/Source/WebCore/dom/DeviceOrientationEvent.cpp
@@ -119,9 +119,8 @@ EventInterface DeviceOrientationEvent::eventInterface() const
 #if ENABLE(DEVICE_ORIENTATION)
 void DeviceOrientationEvent::requestPermission(Document& document, PermissionPromise&& promise)
 {
-    auto* window = document.domWindow();
-    auto* page = document.page();
-    if (!window || !page)
+    RefPtr window = document.domWindow();
+    if (!window || !document.page())
         return promise.reject(Exception { InvalidStateError, "No browsing context"_s });
 
     String errorMessage;


### PR DESCRIPTION
#### 3eea5b1c8625a9390ae0f3c6e73890e2a0e9dbe5
<pre>
Use more smart pointers in device motion / orientation classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=263339">https://bugs.webkit.org/show_bug.cgi?id=263339</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/DeviceMotionEvent.cpp:
(WebCore::DeviceMotionEvent::requestPermission):
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp:
(WebCore::DeviceOrientationAndMotionAccessController::accessState const):
(WebCore::DeviceOrientationAndMotionAccessController::shouldAllowAccess):
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h:
* Source/WebCore/dom/DeviceOrientationEvent.cpp:
(WebCore::DeviceOrientationEvent::requestPermission):
* Source/WebCore/page/FrameDestructionObserver.h:
* Source/WebCore/page/FrameDestructionObserverInlines.h:
(WebCore::FrameDestructionObserver::protectedFrame const):

Canonical link: <a href="https://commits.webkit.org/269523@main">https://commits.webkit.org/269523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bf00710b68e25235c1bd998963223c424db5f9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21092 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21995 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25548 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26853 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24709 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18156 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/258 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/383 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2874 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->