### PR TITLE
For ScrollRequestType::CancelAnimatedScroll populate requestedDataBeforeAnimatedScroll

### DIFF
--- a/LayoutTests/fast/scrolling/programmatic-scroll-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/scrolling/programmatic-scroll-crash.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-crash.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollBy({top:1000, left:15, behavior:"smooth"});
+            window.scrollBy(50,100);
+            window.scrollTo();
+            window.scrollBy({top:0, left:12, behavior:"smooth"});
+
+            await UIHelper.ensurePresentationUpdate();
+            if (window.testRunner)
+                testRunner.dumpAsText();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <p>This test passes if it does not crash.</p>
+
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/programmatic-scroll-merge-cancel-expected.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-merge-cancel-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollBy(40,40);
+
+            await UIHelper.ensurePresentationUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/programmatic-scroll-merge-cancel.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-merge-cancel.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollBy(20,20);
+            window.scrollBy({top:0, left:15, behavior:"smooth"});
+            window.scrollBy(20,20);
+
+            await UIHelper.ensurePresentationUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>


### PR DESCRIPTION
#### fe116ce9694929a3ca27b8e660c04d645e22e4fe
<pre>
For ScrollRequestType::CancelAnimatedScroll populate requestedDataBeforeAnimatedScroll
<a href="https://bugs.webkit.org/show_bug.cgi?id=263344">https://bugs.webkit.org/show_bug.cgi?id=263344</a>
<a href="https://rdar.apple.com/114103570">rdar://114103570</a>

Reviewed by NOBODY (OOPS!).

When we get a ScrollRequestType::PositionUpdate (Non-Animated) then a ScrollRequestType::CancelAnimatedScroll,
we have some logic to set scrollPositionOrDelta so if we get an animated scroll after, this scroll position
could be forwarded. Now that we need to know the request type to access scrollPositionOrDelta, reuse
 requestedDataBeforeAnimatedScroll to pass forward the scrollPositionOrDelta and the type of the non animated
position update. Also, take this into account for non-animated ScrollRequestType::DeltaUpdate, and
add the scrollPositionOrDelta to the new delta update if it exists on the ScrollRequestType::CancelAnimatedScroll.

* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::RequestedScrollData::merge):
(WebCore::operator&lt;&lt;):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe116ce9694929a3ca27b8e660c04d645e22e4fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/25273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/3814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/26528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/27384 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/23186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/25545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/5531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/1247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/23398 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/25515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/2826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/21808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/27962 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/2509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/22748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/28859 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/23058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/23104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/26692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/2461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/748 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/3814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/22496 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/2902 "Built successfully") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/2796 "Built successfully") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->