### PR TITLE
Deeply nested SVG patterns can take log time to invalidate the target element

### DIFF
--- a/LayoutTests/svg/custom/pattern-nested-reference-expected.txt
+++ b/LayoutTests/svg/custom/pattern-nested-reference-expected.txt
@@ -1,0 +1,3 @@
+Passes if it does not time out.
+
+

--- a/LayoutTests/svg/custom/pattern-nested-reference.html
+++ b/LayoutTests/svg/custom/pattern-nested-reference.html
@@ -1,0 +1,64 @@
+<body>
+    <p>Passes if it does not time out.</p>
+    <svg id="svg" width="600px" height="400px">
+        <ellipse cx="300" cy="200" rx="250" ry="150" fill="url(#z)" stroke="black" stroke-width="2" />
+    </svg>
+    <script>
+        function createPattern(parent, id, fillURL, colors) {
+            var pattern = document.createElementNS("http://www.w3.org/2000/svg", "pattern");
+            parent.appendChild(pattern);
+
+            pattern.setAttribute("id", id);
+            pattern.setAttribute("x", "10");
+            pattern.setAttribute("y", "10");
+            pattern.setAttribute("width", "100");
+            pattern.setAttribute("height", "100");
+            pattern.setAttribute("patternUnits", "userSpaceOnUse");
+
+            for (i in colors) {
+                var rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+                pattern.appendChild(rect);
+
+                rect.setAttribute("x", i);
+                rect.setAttribute("y", i);
+                rect.setAttribute("width", "100");
+                rect.setAttribute("height", "100");
+                rect.setAttribute("fill", fillURL);
+                rect.setAttribute("stroke", colors[i]);
+            }
+        }
+
+        function setupPatterns() {
+            var svg = document.getElementById("svg");
+
+            const colors = [
+                "green",
+                "brown",
+                "pink",
+                "grey",
+                "cyan",
+                "green",
+                "brown",
+                "pink",
+                "grey",
+                "cyan"
+            ];
+
+            createPattern(svg, "z", "url(#i)", colors);
+            createPattern(svg, "i", "url(#h)", colors);
+            createPattern(svg, "h", "url(#g)", colors);
+            createPattern(svg, "g", "url(#f)", colors);
+            createPattern(svg, "f", "url(#e)", colors);
+            createPattern(svg, "e", "url(#d)", colors);
+            createPattern(svg, "d", "url(#c)", colors);
+            createPattern(svg, "c", "url(#b)", colors);
+            createPattern(svg, "b", "url(#a)", colors);
+            createPattern(svg, "a", "none", colors);
+        }
+
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        setupPatterns();
+    </script>
+</body>

--- a/Source/WebCore/rendering/svg/RenderSVGResource.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResource.h
@@ -59,7 +59,8 @@ public:
     RenderSVGResource() = default;
     virtual ~RenderSVGResource() = default;
 
-    virtual void removeAllClientsFromCache(bool markForInvalidation = true) = 0;
+    void removeAllClientsFromCache(bool markForInvalidation = true);
+    virtual void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) = 0;
     virtual void removeClientFromCache(RenderElement&, bool markForInvalidation = true) = 0;
 
     virtual bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) = 0;
@@ -74,6 +75,7 @@ public:
     static RenderSVGResourceSolidColor* sharedSolidPaintingResource();
 
     static void markForLayoutAndParentResourceInvalidation(RenderObject&, bool needsLayout = true);
+    static void markForLayoutAndParentResourceInvalidationIfNeeded(RenderObject&, bool needsLayout, WeakHashSet<RenderObject>* visitedRenderers);
 
 protected:
     void fillAndStrokePathOrShape(GraphicsContext&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement* shape) const;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -54,13 +54,13 @@ bool RenderSVGResourceFilter::isIdentity() const
     return SVGFilter::isIdentity(filterElement());
 }
 
-void RenderSVGResourceFilter::removeAllClientsFromCache(bool markForInvalidation)
+void RenderSVGResourceFilter::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
 {
-    LOG(Filters, "RenderSVGResourceFilter %p removeAllClientsFromCache", this);
+    LOG(Filters, "RenderSVGResourceFilter %p removeAllClientsFromCacheIfNeeded", this);
 
     m_rendererFilterDataMap.clear();
 
-    markAllClientsForInvalidation(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation);
+    markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
 void RenderSVGResourceFilter::removeClientFromCache(RenderElement& client, bool markForInvalidation)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -62,7 +62,7 @@ public:
     inline SVGFilterElement& filterElement() const;
     bool isIdentity() const;
 
-    void removeAllClientsFromCache(bool markForInvalidation = true) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp
@@ -41,11 +41,11 @@ RenderSVGResourceGradient::RenderSVGResourceGradient(Type type, SVGGradientEleme
 {
 }
 
-void RenderSVGResourceGradient::removeAllClientsFromCache(bool markForInvalidation)
+void RenderSVGResourceGradient::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
 {
     m_gradientMap.clear();
     m_shouldCollectGradientAttributes = true;
-    markAllClientsForInvalidation(markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation);
+    markAllClientsForInvalidationIfNeeded(markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
 void RenderSVGResourceGradient::removeClientFromCache(RenderElement& client, bool markForInvalidation)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -61,7 +61,7 @@ class RenderSVGResourceGradient : public LegacyRenderSVGResourceContainer {
 public:
     SVGGradientElement& gradientElement() const { return static_cast<SVGGradientElement&>(LegacyRenderSVGResourceContainer::element()); }
 
-    void removeAllClientsFromCache(bool markForInvalidation = true) final;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) final;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) final;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) final;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -54,9 +54,9 @@ void RenderSVGResourceMarker::layout()
     LegacyRenderSVGContainer::layout();
 }
 
-void RenderSVGResourceMarker::removeAllClientsFromCache(bool markForInvalidation)
+void RenderSVGResourceMarker::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
 {
-    markAllClientsForInvalidation(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation);
+    markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
 void RenderSVGResourceMarker::removeClientFromCache(RenderElement& client, bool markForInvalidation)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -35,7 +35,7 @@ public:
 
     inline SVGMarkerElement& markerElement() const;
 
-    void removeAllClientsFromCache(bool markForInvalidation = true) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
 
     void draw(PaintInfo&, const AffineTransform&);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -42,12 +42,12 @@ RenderSVGResourceMasker::RenderSVGResourceMasker(SVGMaskElement& element, Render
 
 RenderSVGResourceMasker::~RenderSVGResourceMasker() = default;
 
-void RenderSVGResourceMasker::removeAllClientsFromCache(bool markForInvalidation)
+void RenderSVGResourceMasker::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
 {
     m_maskContentBoundaries = FloatRect();
     m_masker.clear();
 
-    markAllClientsForInvalidation(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation);
+    markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
 void RenderSVGResourceMasker::removeClientFromCache(RenderElement& client, bool markForInvalidation)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
@@ -44,7 +44,7 @@ public:
 
     inline SVGMaskElement& maskElement() const;
 
-    void removeAllClientsFromCache(bool markForInvalidation = true) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     bool drawContentIntoContext(GraphicsContext&, const FloatRect& objectBoundingBox);

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -48,11 +48,11 @@ SVGPatternElement& RenderSVGResourcePattern::patternElement() const
     return downcast<SVGPatternElement>(LegacyRenderSVGResourceContainer::element());
 }
 
-void RenderSVGResourcePattern::removeAllClientsFromCache(bool markForInvalidation)
+void RenderSVGResourcePattern::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
 {
     m_patternMap.clear();
     m_shouldCollectPatternAttributes = true;
-    markAllClientsForInvalidation(markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation);
+    markAllClientsForInvalidationIfNeeded(markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
 void RenderSVGResourcePattern::removeClientFromCache(RenderElement& client, bool markForInvalidation)

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
@@ -45,7 +45,7 @@ public:
     RenderSVGResourcePattern(SVGPatternElement&, RenderStyle&&);
     SVGPatternElement& patternElement() const;
 
-    void removeAllClientsFromCache(bool markForInvalidation = true) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceSolidColor.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceSolidColor.h
@@ -33,7 +33,7 @@ public:
     RenderSVGResourceSolidColor();
     virtual ~RenderSVGResourceSolidColor();
 
-    void removeAllClientsFromCache(bool = true) override { }
+    void removeAllClientsFromCacheIfNeeded(bool, WeakHashSet<RenderObject>*) override { }
     void removeClientFromCache(RenderElement&, bool = true) override { }
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -57,12 +57,12 @@ LegacyRenderSVGResourceClipper::LegacyRenderSVGResourceClipper(SVGClipPathElemen
 
 LegacyRenderSVGResourceClipper::~LegacyRenderSVGResourceClipper() = default;
 
-void LegacyRenderSVGResourceClipper::removeAllClientsFromCache(bool markForInvalidation)
+void LegacyRenderSVGResourceClipper::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers)
 {
     m_clipBoundaries = { };
     m_clipperMap.clear();
 
-    markAllClientsForInvalidation(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation);
+    markAllClientsForInvalidationIfNeeded(markForInvalidation ? LayoutAndBoundariesInvalidation : ParentOnlyInvalidation, visitedRenderers);
 }
 
 void LegacyRenderSVGResourceClipper::removeClientFromCache(RenderElement& client, bool markForInvalidation)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -64,7 +64,7 @@ public:
 
     inline SVGClipPathElement& clipPathElement() const;
 
-    void removeAllClientsFromCache(bool markForInvalidation = true) override;
+    void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, WeakHashSet<RenderObject>* visitedRenderers) override;
     void removeClientFromCache(RenderElement&, bool markForInvalidation = true) override;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -94,6 +94,12 @@ void LegacyRenderSVGResourceContainer::markAllClientsForRepaint()
 
 void LegacyRenderSVGResourceContainer::markAllClientsForInvalidation(InvalidationMode mode)
 {
+    WeakHashSet<RenderObject> visitedRenderers;
+    markAllClientsForInvalidationIfNeeded(mode, &visitedRenderers);
+}
+
+void LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded(InvalidationMode mode, WeakHashSet<RenderObject>* visitedRenderers)
+{
     // FIXME: Style invalidation should either be a pre-layout task or this function
     // should never get called while in layout. See webkit.org/b/208903.
     if ((m_clients.isEmptyIgnoringNullReferences() && m_clientLayers.isEmptyIgnoringNullReferences()) || m_isInvalidating)
@@ -111,14 +117,14 @@ void LegacyRenderSVGResourceContainer::markAllClientsForInvalidation(Invalidatio
             continue;
 
         if (is<LegacyRenderSVGResourceContainer>(client)) {
-            downcast<LegacyRenderSVGResourceContainer>(client).removeAllClientsFromCache(markForInvalidation);
+            downcast<LegacyRenderSVGResourceContainer>(client).removeAllClientsFromCacheIfNeeded(markForInvalidation, visitedRenderers);
             continue;
         }
 
         if (markForInvalidation)
             markClientForInvalidation(client, mode);
 
-        RenderSVGResource::markForLayoutAndParentResourceInvalidation(client, needsLayout);
+        RenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded(client, needsLayout, visitedRenderers);
     }
 
     markAllClientLayersForInvalidation();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -62,6 +62,7 @@ protected:
     virtual bool selfNeedsClientInvalidation() const { return everHadLayout() && selfNeedsLayout(); }
 
     void markAllClientsForInvalidation(InvalidationMode);
+    void markAllClientsForInvalidationIfNeeded(InvalidationMode, WeakHashSet<RenderObject>* visitedRenderers);
     void markClientForInvalidation(RenderObject&, InvalidationMode);
 
 private:


### PR DESCRIPTION
#### 00f03d987c0cec7d2821e3d1086bdf15dc807c0d
<pre>
Deeply nested SVG patterns can take log time to invalidate the target element
<a href="https://bugs.webkit.org/show_bug.cgi?id=263349">https://bugs.webkit.org/show_bug.cgi?id=263349</a>
(rdar://116532387)

Reviewed by Simon Fraser.

The resource&apos;s clients invalidation does not take account the visited renderers.
With nested SVG resources this invalidation can have an exponential complexity.
This leads to DoS since loading the SVG or modifying its resources can take
minutes to finish.

Skipping the visited renderers while invalidating the resource&apos;s clients should
fix this problem. The complexity of the invalidation will be linear in this case.

* LayoutTests/svg/custom/pattern-nested-reference-expected.txt: Added.
* LayoutTests/svg/custom/pattern-nested-reference.html: Added.
* Source/WebCore/rendering/svg/RenderSVGResource.cpp:
(WebCore::RenderSVGResource::removeAllClientsFromCache):
(WebCore::removeFromCacheAndInvalidateDependencies):
(WebCore::RenderSVGResource::markForLayoutAndParentResourceInvalidation):
(WebCore::RenderSVGResource::markForLayoutAndParentResourceInvalidationIfNeeded):
* Source/WebCore/rendering/svg/RenderSVGResource.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::removeAllClientsFromCacheIfNeeded):
(WebCore::RenderSVGResourceFilter::removeAllClientsFromCache): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.cpp:
(WebCore::RenderSVGResourceGradient::removeAllClientsFromCacheIfNeeded):
(WebCore::RenderSVGResourceGradient::removeAllClientsFromCache): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
(WebCore::RenderSVGResourceMarker::removeAllClientsFromCacheIfNeeded):
(WebCore::RenderSVGResourceMarker::removeAllClientsFromCache): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::removeAllClientsFromCacheIfNeeded):
(WebCore::RenderSVGResourceMasker::removeAllClientsFromCache): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::removeAllClientsFromCacheIfNeeded):
(WebCore::RenderSVGResourcePattern::removeAllClientsFromCache): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/RenderSVGResourceSolidColor.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::removeAllClientsFromCacheIfNeeded):
(WebCore::LegacyRenderSVGResourceClipper::removeAllClientsFromCache): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
(WebCore::LegacyRenderSVGResourceContainer::markAllClientsForInvalidation):
(WebCore::LegacyRenderSVGResourceContainer::markAllClientsForInvalidationIfNeeded):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:

Canonical link: <a href="https://commits.webkit.org/269516@main">https://commits.webkit.org/269516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67be94b57db7aa3eb12e582511900f6d3d5b60b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21064 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21978 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/22998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25519 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26830 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24682 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18135 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5432 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->