### PR TITLE
[safe-merge-queue] Pending checks are treated as passed

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2496,11 +2496,17 @@ class CheckStatusOfPR(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
             if queue_data:
                 status = queue_data.get('state', None)
                 if status == 0 or status == 3:  # success or N/A
+                    yield self._addToLog('stdio', f'Success\n')
                     continue
                 elif status == 2:  # failure
                     failed_checks.append(queue)
+                    yield self._addToLog('stdio', f'Failure\n')
                 else:  # null
                     missing_checks.append(queue)
+                    yield self._addToLog('stdio', f'Pending\n')
+            else:
+                missing_checks.append(queue)
+                yield self._addToLog('stdio', f'Pending\n')
 
         passed_status_check = self.getProperty('passed_status_check')
         failed_status_check = self.getProperty('failed_status_check')


### PR DESCRIPTION
#### f47d7dd889442f6ad80167e2ace321232029cbe0
<pre>
[safe-merge-queue] Pending checks are treated as passed
<a href="https://bugs.webkit.org/show_bug.cgi?id=263350">https://bugs.webkit.org/show_bug.cgi?id=263350</a>
rdar://117174907

Reviewed by Jonathan Bedard.

Added additional check for pending checks. Turns out iOS tests don&apos;t show up at all.

* Tools/CISupport/ews-build/steps.py:
(CheckStatusOfPR.getQueueStatusFromList):

Canonical link: <a href="https://commits.webkit.org/269530@main">https://commits.webkit.org/269530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a023d3bd6efcc7cd220461bd3b62d75c26fe6152

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21979 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25525 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26835 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24690 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18136 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22559 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/238 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5440 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->