### PR TITLE
[SVG] Enable approximate repaint bounding box computation

### DIFF
--- a/LayoutTests/accessibility/svg-bounds-expected.txt
+++ b/LayoutTests/accessibility/svg-bounds-expected.txt
@@ -25,8 +25,8 @@ NoseY: 206
 
 Mouth role: AXRole: AXButton
 Mouth label: AXDescription: smile
-MouthX: 115
-MouthY: 275
+MouthX: 101
+MouthY: 261
 
 
 Text role: AXRole: AXStaticText

--- a/LayoutTests/platform/glib/accessibility/svg-remote-element-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/svg-remote-element-expected.txt
@@ -15,8 +15,8 @@ NoseX: 193
 NoseY: 206
 Mouth AXRole: AXButton
 Mouth AXTitle: smile
-MouthX: 116
-MouthY: 275
+MouthX: 101
+MouthY: 260
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/platform/mac/accessibility/svg-remote-element-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/svg-remote-element-expected.txt
@@ -15,8 +15,8 @@ NoseX: 193
 NoseY: 206
 Mouth AXRole: AXButton
 Mouth AXDescription: smile
-MouthX: 115
-MouthY: 275
+MouthX: 101
+MouthY: 261
 
 PASS successfullyParsed is true
 

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -99,8 +99,12 @@ FloatRect SVGBoundingBoxComputation::handleShapeOrTextOrInline(const SVGBounding
     //    assumption that the element has no dash pattern.
     //
     // Note: The values of the stroke-opacity, stroke-dasharray and stroke-dashoffset do not affect the calculation of the stroke shape.
-    if (options.contains(DecorationOption::IncludeStrokeShape))
-        box.unite(m_renderer.strokeBoundingBox());
+    if (options.contains(DecorationOption::IncludeStrokeShape)) {
+        if (options.contains(DecorationOption::CalculateFastRepaintRect) && is<RenderSVGShape>(m_renderer))
+            box.unite(downcast<RenderSVGShape>(m_renderer).approximateStrokeBoundingBox());
+        else
+            box.unite(m_renderer.strokeBoundingBox());
+    }
 
     // 5. If markers is true, then for each marker marker rendered on the element:
     // - For each descendant graphics element child of the "marker" element that defines marker's content:

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -399,7 +399,7 @@ FloatRect LegacyRenderSVGShape::calculateApproximateStrokeBoundingBox() const
 
 void LegacyRenderSVGShape::updateRepaintBoundingBox()
 {
-    m_repaintBoundingBox = strokeBoundingBox();
+    m_repaintBoundingBox = calculateApproximateStrokeBoundingBox();
     SVGRenderSupport::intersectRepaintRectWithResources(*this, m_repaintBoundingBox);
 }
 


### PR DESCRIPTION
#### 2f7437fb0267ebd9e0c7c9c2504bb0fca8731c91
<pre>
[SVG] Enable approximate repaint bounding box computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=263351">https://bugs.webkit.org/show_bug.cgi?id=263351</a>
rdar://117175423

Reviewed by Cameron McCormack.

This is one step of the patch series implementing approximate repainting rect for SVG path, derived from blink&apos;s work[1].

This patch flips approximate repaint bounding box computation. This also reveals that some accessibility thing is relying
on repaint bounding box while it should not, but for now this patch is keeping it.
This offers 0.53% progression in Speedometer3.0: in subtests, React-Stockcharts-SVG 4.78% progression and Charts-observable-plot 1.37% progression.

[1]: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=435097">https://bugs.chromium.org/p/chromium/issues/detail?id=435097</a>

* LayoutTests/accessibility/svg-bounds-expected.txt:
* LayoutTests/platform/glib/accessibility/svg-remote-element-expected.txt:
* LayoutTests/platform/mac/accessibility/svg-remote-element-expected.txt:
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleShapeOrTextOrInline const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::updateRepaintBoundingBox):

Canonical link: <a href="https://commits.webkit.org/269500@main">https://commits.webkit.org/269500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03fd18ab0f27b886f4e5f87e9cf64201812d15bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21071 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23292 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/21980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23006 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25527 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26841 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24696 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/309 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5420 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->