### PR TITLE
[iOS] Adopt UIScrollView APIs to check for and stop active scrolling/zooming animations

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -108,9 +108,6 @@
 
 #if ENABLE(DRAG_SUPPORT)
 #import <UIKit/NSItemProvider+UIKitAdditions_Private.h>
-#endif
-
-#if ENABLE(DRAG_SUPPORT)
 #import <UIKit/UIDragInteraction.h>
 #import <UIKit/UIDragInteraction_Private.h>
 #import <UIKit/UIDragItem_Private.h>
@@ -1117,7 +1114,6 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 @interface UIScrollView (IPI)
 - (void)_adjustForAutomaticKeyboardInfo:(NSDictionary *)info animated:(BOOL)animated lastAdjustment:(CGFloat*)lastAdjustment;
-- (BOOL)_isScrollingToTop;
 @end
 
 @interface UIPeripheralHost (IPI)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -859,9 +859,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
     _perProcessState.needsResetViewStateAfterCommitLoadForMainFrame = YES;
 
     if (![self _scrollViewIsRubberBandingForRefreshControl])
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [_scrollView _stopScrollingAndZoomingAnimations];
-ALLOW_DEPRECATED_DECLARATIONS_END
+        [_scrollView _wk_stopScrollingAndZooming];
 
 #if HAVE(UIFINDINTERACTION)
     if (_findInteractionEnabled) {
@@ -980,9 +978,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     // FIXME: <rdar://99001670> Get the default list of allowed touch types from UIKit instead of caching the returned value.
     [_scrollView panGestureRecognizer].allowedTouchTypes = scrollingEnabled ? _scrollViewDefaultAllowedTouchTypes.get() : @[ ];
     [_scrollView _setScrollEnabledInternal:YES];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (!layerTreeTransaction.scaleWasSetByUIProcess() && ![_scrollView isZooming] && ![_scrollView isZoomBouncing] && ![_scrollView _isAnimatingZoom] && !WebKit::scalesAreEssentiallyEqual([_scrollView zoomScale], layerTreeTransaction.pageScaleFactor())) {
-ALLOW_DEPRECATED_DECLARATIONS_END
+    if (!layerTreeTransaction.scaleWasSetByUIProcess() && ![_scrollView isZooming] && ![_scrollView isZoomBouncing] && ![_scrollView _wk_isZoomAnimating] && !WebKit::scalesAreEssentiallyEqual([_scrollView zoomScale], layerTreeTransaction.pageScaleFactor())) {
         LOG_WITH_STREAM(VisibleRects, stream << " updating scroll view with pageScaleFactor " << layerTreeTransaction.pageScaleFactor());
 
         // When web-process-originated scale changes occur, pin the
@@ -1360,9 +1356,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
     CGPoint contentOffsetInScrollViewCoordinates = [self _contentOffsetAdjustedForObscuredInset:scaledOffset];
     contentOffsetInScrollViewCoordinates = contentOffsetBoundedInValidRange(_scrollView.get(), contentOffsetInScrollViewCoordinates);
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [_scrollView _stopScrollingAndZoomingAnimations];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    [_scrollView _wk_stopScrollingAndZooming];
     CGPoint scrollViewContentOffset = [_scrollView contentOffset];
 
     if (!CGPointEqualToPoint(contentOffsetInScrollViewCoordinates, scrollViewContentOffset)) {
@@ -2425,9 +2419,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (scrollView.isDragging || scrollView.isZooming)
         stabilityFlags.add(WebKit::ViewStabilityFlag::ScrollViewInteracting);
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (scrollView.isDecelerating || scrollView._isAnimatingZoom || scrollView._isScrollingToTop || scrollView.isZoomBouncing)
-ALLOW_DEPRECATED_DECLARATIONS_END
+    if (scrollView.isDecelerating || scrollView._wk_isZoomAnimating || scrollView._wk_isScrollAnimating || scrollView.isZoomBouncing)
         stabilityFlags.add(WebKit::ViewStabilityFlag::ScrollViewAnimatedScrollOrZoom);
 
     if (scrollView == _scrollView.get() && _isChangingObscuredInsetsInteractively)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -33,6 +33,7 @@
 #import "RemoteScrollingCoordinatorProxyIOS.h"
 #import "RemoteScrollingTree.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "WKScrollView.h"
 #import "WebPageProxy.h"
 #import <QuartzCore/QuartzCore.h>
@@ -326,9 +327,7 @@ bool ScrollingTreeScrollingNodeDelegateIOS::startAnimatedScrollToPosition(FloatP
 void ScrollingTreeScrollingNodeDelegateIOS::stopAnimatedScroll()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    [scrollView() _stopScrollingAndZoomingAnimations];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    [scrollView() _wk_stopScrollingAndZooming];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
@@ -345,7 +344,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::repositionScrollingLayers()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if ([scrollView() _isAnimatingScroll])
+    if (scrollView()._wk_isScrollAnimating)
 ALLOW_DEPRECATED_DECLARATIONS_END
         return;
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -37,7 +37,9 @@
 @property (readonly, nonatomic) BOOL _wk_canScrollVerticallyWithoutBouncing;
 @property (readonly, nonatomic) CGFloat _wk_contentWidthIncludingInsets;
 @property (readonly, nonatomic) CGFloat _wk_contentHeightIncludingInsets;
-
+@property (readonly, nonatomic) BOOL _wk_isScrollAnimating;
+@property (readonly, nonatomic) BOOL _wk_isZoomAnimating;
+- (void)_wk_stopScrollingAndZooming;
 - (CGPoint)_wk_clampToScrollExtents:(CGPoint)contentOffset;
 @end
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -30,6 +30,16 @@
 
 #import "UIKitSPI.h"
 
+#if HAVE(UI_SCROLL_VIEW_APIS_ADDED_IN_RADAR_112474145)
+
+@interface UIScrollView (Staging_112474145)
+@property (nonatomic, readonly, getter=isScrollAnimating) BOOL scrollAnimating;
+@property (nonatomic, readonly, getter=isZoomAnimating) BOOL zoomAnimating;
+- (void)stopScrollingAndZooming;
+@end
+
+#endif // HAVE(UI_SCROLL_VIEW_APIS_ADDED_IN_RADAR_112474145)
+
 @implementation UIScrollView (WebKitInternal)
 
 - (BOOL)_wk_isInterruptingDeceleration
@@ -63,6 +73,37 @@
         contentSize.height + inset.bottom - std::min<CGFloat>(boundsSize.height, self._wk_contentHeightIncludingInsets)
     );
     return contentOffset.x > maxScrollExtent.x || contentOffset.y > maxScrollExtent.y;
+}
+
+- (BOOL)_wk_isScrollAnimating
+{
+#if HAVE(UI_SCROLL_VIEW_APIS_ADDED_IN_RADAR_112474145)
+    static BOOL hasScrollAnimating = [UIScrollView instancesRespondToSelector:@selector(isScrollAnimating)];
+    return hasScrollAnimating && self.scrollAnimating;
+#else
+    return self.isAnimatingScroll;
+#endif
+}
+
+- (BOOL)_wk_isZoomAnimating
+{
+#if HAVE(UI_SCROLL_VIEW_APIS_ADDED_IN_RADAR_112474145)
+    static BOOL hasZoomAnimating = [UIScrollView instancesRespondToSelector:@selector(isZoomAnimating)];
+    return hasZoomAnimating && self.zoomAnimating;
+#else
+    return self.isAnimatingZoom;
+#endif
+}
+
+- (void)_wk_stopScrollingAndZooming
+{
+#if HAVE(UI_SCROLL_VIEW_APIS_ADDED_IN_RADAR_112474145)
+    static BOOL hasStopScrollingAndZooming = [UIScrollView instancesRespondToSelector:@selector(stopScrollingAndZooming)];
+    if (hasStopScrollingAndZooming)
+        [self stopScrollingAndZooming];
+#else
+    [self _stopScrollingAndZoomingAnimations];
+#endif
 }
 
 - (CGPoint)_wk_clampToScrollExtents:(CGPoint)contentOffset


### PR DESCRIPTION
#### 04eccfc4a2c7392fd27b9d44880e776cd784f68e
<pre>
[iOS] Adopt UIScrollView APIs to check for and stop active scrolling/zooming animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=263345">https://bugs.webkit.org/show_bug.cgi?id=263345</a>
rdar://114329712

Reviewed by Richard Robinson.

Stop suppressing several deprecation warnings added in 269381@main; instead, adopt new UIScrollView
API from UIKit, which implements the equivalent functionality:

1. `-_isAnimatingScroll` -&gt; `-_isScrollAnimating`.
2. `-_isAnimatingZoom` -&gt; `-_isZoomAnimating`.
3. `-_stopScrollingAndZoomingAnimations` -&gt; `-stopScrollingAndZooming`.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLoadForMainFrame]):
(-[WKWebView _updateScrollViewForTransaction:]):
(-[WKWebView _scrollToContentScrollPosition:scrollOrigin:animated:]):
(-[WKWebView _viewStabilityState:]):

Replace the `-_isScrollingToTop` check with a more encompassing `-isScrollAnimating` check when
determining view stability.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::stopAnimatedScroll):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::repositionScrollingLayers):
* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:

Add new category helpers on `UIScrollView`, which abstract away the complexity of deciding which
APIs to use, depending on the SDK version and whether the new method and properties are available at
runtime.

Also, add temporary staging declarations so that we can fail gracefully when the new compile-time
flag `HAVE(UI_SCROLL_VIEW_APIS_ADDED_IN_RADAR_112474145)` is enabled, but the requisite APIs are
missing at runtime.

(-[UIScrollView _wk_isScrollAnimating]):
(-[UIScrollView _wk_isZoomAnimating]):
(-[UIScrollView _wk_stopScrollingAndZooming]):

Canonical link: <a href="https://commits.webkit.org/269535@main">https://commits.webkit.org/269535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53febfa6602416a60baeed4a653defabefba94d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24679 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21076 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21983 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25532 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26838 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24693 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18140 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/244 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5444 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->