### PR TITLE
Adopt more smart pointers in the Document class

### DIFF
--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/JSBase.h>
 #include <JavaScriptCore/ScriptFetchParameters.h>
 #include <JavaScriptCore/Strong.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
@@ -77,7 +78,7 @@ enum class ReasonForCallingCanExecuteScripts : uint8_t {
 
 using ValueOrException = Expected<JSC::JSValue, ExceptionDetails>;
 
-class ScriptController : public CanMakeWeakPtr<ScriptController> {
+class ScriptController : public CanMakeWeakPtr<ScriptController>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 
     using RootObjectMap = HashMap<void*, Ref<JSC::Bindings::RootObject>>;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -404,7 +404,7 @@ static const Seconds intersectionObserversInitialUpdateDelay { 2000_ms };
 static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry>>& entries, ResizeObserver& observer)
 {
     for (auto& entry : entries) {
-        if (auto* target = entry->target()) {
+        if (RefPtr target = entry->target()) {
             if (!target->isConnected()) {
                 observer.unobserve(*target);
                 target->clearLastRememberedLogicalWidth();
@@ -412,7 +412,7 @@ static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry
                 continue;
             }
 
-            auto* box = target->renderBox();
+            CheckedPtr box = target->renderBox();
             if (!box) {
                 observer.unobserve(*target);
                 continue;
@@ -501,7 +501,7 @@ static void printNavigationErrorMessage(LocalFrame& frame, const URL& activeURL,
     String message = "Unsafe JavaScript attempt to initiate navigation for frame with URL '" + frame.document()->url().string() + "' from frame with URL '" + activeURL.string() + "'. " + reason + "\n";
 
     // FIXME: should we print to the console of the document performing the navigation instead?
-    frame.document()->domWindow()->printErrorMessage(message);
+    frame.document()->protectedWindow()->printErrorMessage(message);
 }
 
 uint64_t Document::s_globalTreeVersion = 0;
@@ -534,8 +534,8 @@ void Document::configureSharedLogger()
     if (!logger)
         return;
 
-    bool alwaysOnLoggingAllowed = !allDocumentsMap().isEmpty() && WTF::allOf(allDocumentsMap().values(), [](auto* document) {
-        auto* page = document->page();
+    bool alwaysOnLoggingAllowed = !allDocumentsMap().isEmpty() && WTF::allOf(allDocumentsMap().values(), [](auto& document) {
+        CheckedPtr page = document->page();
         return !page || page->sessionID().isAlwaysOnLoggingAllowed();
     });
     logger->setEnabled(sharedLoggerOwner(), alwaysOnLoggingAllowed);
@@ -543,7 +543,7 @@ void Document::configureSharedLogger()
 
 void Document::addToDocumentsMap()
 {
-    auto addResult = allDocumentsMap().add(identifier(), this);
+    auto addResult = allDocumentsMap().add(identifier(), *this);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 
     configureSharedLogger();
@@ -558,7 +558,7 @@ void Document::removeFromDocumentsMap()
 
 auto Document::allDocumentsMap() -> DocumentsMap&
 {
-    static NeverDestroyed<DocumentsMap> documents;
+    static MainThreadNeverDestroyed<DocumentsMap> documents;
     return documents;
 }
 
@@ -581,7 +581,7 @@ static inline IntDegrees currentOrientation(LocalFrame* frame)
 static Ref<CachedResourceLoader> createCachedResourceLoader(LocalFrame* frame)
 {
     if (frame) {
-        if (auto loader = frame->loader().activeDocumentLoader())
+        if (RefPtr loader = frame->loader().activeDocumentLoader())
             return loader->cachedResourceLoader();
     }
     return CachedResourceLoader::create(nullptr);
@@ -656,7 +656,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     if ((frame && frame->ownerElement()) || !url.isEmpty())
         setURL(url);
 
-    m_cachedResourceLoader->setDocument(this);
+    protectedCachedResourceLoader()->setDocument(this);
 
     resetLinkColor();
     resetVisitedLinkColor();
@@ -665,7 +665,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     initSecurityContext();
     initDNSPrefetch();
 
-    m_fontSelector->registerForInvalidationCallbacks(*this);
+    protectedFontSelector()->registerForInvalidationCallbacks(*this);
 
     for (auto& nodeListAndCollectionCount : m_nodeListAndCollectionCounts)
         nodeListAndCollectionCount = 0;
@@ -735,16 +735,16 @@ Document::~Document()
         m_templateDocument->setTemplateDocumentHost(nullptr); // balanced in templateDocument().
 
     // FIXME: Should we reset m_domWindow when we detach from the Frame?
-    if (m_domWindow)
-        m_domWindow->resetUnlessSuspendedForDocumentSuspension();
+    if (RefPtr window = m_domWindow)
+        window->resetUnlessSuspendedForDocumentSuspension();
 
     m_scriptRunner = nullptr;
     m_moduleLoader = nullptr;
 
     removeAllEventListeners();
 
-    if (m_eventLoop)
-        m_eventLoop->removeAssociatedContext(*this);
+    if (RefPtr eventLoop = m_eventLoop)
+        eventLoop->removeAssociatedContext(*this);
 
     // Currently we believe that Document can never outlive the parser.
     // Although the Document may be replaced synchronously, DocumentParsers
@@ -771,7 +771,7 @@ Document::~Document()
     // It's possible for multiple Documents to end up referencing the same CachedResourceLoader (e.g., SVGImages
     // load the initial empty document and the SVGDocument with the same DocumentLoader).
     if (m_cachedResourceLoader->document() == this)
-        m_cachedResourceLoader->setDocument(nullptr);
+        protectedCachedResourceLoader()->setDocument(nullptr);
 
     // We must call clearRareData() here since a Document class inherits TreeScope
     // as well as Node. See a comment on TreeScope.h for the reason.
@@ -879,13 +879,13 @@ void Document::commonTeardown()
 
     scriptRunner().clearPendingScripts();
 
-    if (m_highlightRegistry)
-        m_highlightRegistry->clear();
-    if (m_fragmentHighlightRegistry)
-        m_fragmentHighlightRegistry->clear();
+    if (RefPtr highlightRegistry = m_highlightRegistry)
+        highlightRegistry->clear();
+    if (RefPtr fragmentHighlightRegistry = m_fragmentHighlightRegistry)
+        fragmentHighlightRegistry->clear();
 #if ENABLE(APP_HIGHLIGHTS)
-    if (m_appHighlightRegistry)
-        m_appHighlightRegistry->clear();
+    if (RefPtr appHighlightRegistry = m_appHighlightRegistry)
+        appHighlightRegistry->clear();
 #endif
     m_pendingScrollEventTargetList = nullptr;
 
@@ -897,10 +897,8 @@ void Document::commonTeardown()
     m_didAssociateFormControlsTimer.stop();
 
 #if ENABLE(WEB_RTC)
-    if (m_rtcNetworkManager) {
-        m_rtcNetworkManager->close();
-        m_rtcNetworkManager = nullptr;
-    }
+    if (RefPtr rtcNetworkManager = std::exchange(m_rtcNetworkManager, nullptr))
+        rtcNetworkManager->close();
 #endif
 }
 
@@ -967,8 +965,8 @@ void Document::setCompatibilityMode(DocumentCompatibilityMode mode)
         extensionStyleSheets().invalidateInjectedStyleSheetCache();
     }
 
-    if (renderView())
-        renderView()->updateQuirksMode();
+    if (CheckedPtr view = renderView())
+        view->updateQuirksMode();
 }
 
 String Document::compatMode() const
@@ -1054,13 +1052,13 @@ void Document::childrenChanged(const ChildChange& change)
     // FIXME: Chrome::didReceiveDocType() used to be called only when the doctype changed. We need to check the
     // impact of calling this systematically. If the overhead is negligible, we need to rename didReceiveDocType,
     // otherwise, we need to detect the doc type changes before updating the viewport.
-    if (Page* page = this->page())
+    if (CheckedPtr page = this->page())
         page->chrome().didReceiveDocType(*frame());
 
-    Element* newDocumentElement = childrenOfType<Element>(*this).first();
+    RefPtr newDocumentElement = childrenOfType<Element>(*this).first();
     if (newDocumentElement == m_documentElement)
         return;
-    m_documentElement = newDocumentElement;
+    m_documentElement = WTFMove(newDocumentElement);
     setDocumentElementLanguage(m_documentElement ? m_documentElement->langFromAttribute() : nullAtom());
     setDocumentElementTextDirection(m_documentElement && is<HTMLElement>(m_documentElement) && m_documentElement->usesEffectiveTextDirection()
         ? downcast<HTMLElement>(*m_documentElement).effectiveTextDirection() : TextDirection::LTR);
@@ -1073,7 +1071,7 @@ static ALWAYS_INLINE Ref<HTMLElement> createUpgradeCandidateElement(Document& do
     if (Document::validateCustomElementName(name.localName()) != CustomElementNameValidationStatus::Valid)
         return HTMLUnknownElement::create(name, document);
 
-    auto element = HTMLMaybeFormAssociatedCustomElement::create(name, document);
+    Ref element = HTMLMaybeFormAssociatedCustomElement::create(name, document);
     element->setIsCustomElementUpgradeCandidate();
     return element;
 }
@@ -1096,12 +1094,12 @@ static inline bool isValidHTMLElementName(const QualifiedName& name)
 template<typename NameType>
 static ExceptionOr<Ref<Element>> createHTMLElementWithNameValidation(Document& document, const NameType& name)
 {
-    auto element = HTMLElementFactory::createKnownElement(name, document);
+    RefPtr element = HTMLElementFactory::createKnownElement(name, document);
     if (LIKELY(element))
         return Ref<Element> { element.releaseNonNull() };
 
-    if (auto* window = document.domWindow()) {
-        auto* registry = window->customElementRegistry();
+    if (RefPtr window = document.domWindow()) {
+        RefPtr registry = window->customElementRegistry();
         if (UNLIKELY(registry)) {
             if (RefPtr elementInterface = registry->findInterface(name))
                 return elementInterface->constructElementWithFallback(document, name);
@@ -1172,7 +1170,7 @@ Ref<Text> Document::createEditingTextNode(String&& text)
 
 Ref<CSSStyleDeclaration> Document::createCSSStyleDeclaration()
 {
-    Ref<MutableStyleProperties> propertySet(MutableStyleProperties::create());
+    Ref propertySet = MutableStyleProperties::create();
     return propertySet->ensureCSSStyleDeclaration();
 }
 
@@ -1265,11 +1263,11 @@ bool Document::hasValidNamespaceForAttributes(const QualifiedName& qName)
 
 static Ref<HTMLElement> createFallbackHTMLElement(Document& document, const QualifiedName& name)
 {
-    if (auto* window = document.domWindow()) {
-        auto* registry = window->customElementRegistry();
+    if (RefPtr window = document.domWindow()) {
+        RefPtr registry = window->customElementRegistry();
         if (UNLIKELY(registry)) {
             if (RefPtr elementInterface = registry->findInterface(name)) {
-                auto element = elementInterface->createElement(document);
+                Ref element = elementInterface->createElement(document);
                 element->setIsCustomElementUpgradeCandidate();
                 element->enqueueToUpgrade(*elementInterface);
                 return element;
@@ -1300,7 +1298,7 @@ Ref<Element> Document::createElement(const QualifiedName& name, bool createdByPa
     if (element)
         m_sawElementsInKnownNamespaces = true;
     else
-        element = Element::create(name, document());
+        element = Element::create(name, protectedDocument());
 
     // <image> uses imgTag so we need a special rule.
     ASSERT((name.matches(imageTag) && element->tagQName().matches(imgTag) && element->tagQName().prefix() == name.prefix()) || name == element->tagQName());
@@ -1434,13 +1432,11 @@ ExceptionOr<Ref<Element>> Document::createElementNS(const AtomString& namespaceU
 
 DocumentEventTiming* Document::documentEventTimingFromNavigationTiming()
 {
-    auto* window = domWindow();
+    RefPtr window = domWindow();
     if (!window)
         return nullptr;
-    auto* navigationTiming = window->performance().navigationTiming();
-    if (!navigationTiming)
-        return nullptr;
-    return &navigationTiming->documentEventTiming();
+    RefPtr navigationTiming = window->performance().navigationTiming();
+    return navigationTiming ? &navigationTiming->documentEventTiming() : nullptr;
 }
 
 void Document::setReadyState(ReadyState readyState)
@@ -1530,22 +1526,22 @@ void Document::setVisualUpdatesAllowed(bool visualUpdatesAllowed)
     if (needsLayout)
         updateLayout();
 
-    if (Page* page = this->page()) {
+    if (CheckedPtr page = this->page()) {
         if (frame()->isMainFrame()) {
             frameView->addPaintPendingMilestones(LayoutMilestone::DidFirstPaintAfterSuppressedIncrementalRendering);
             if (page->requestedLayoutMilestones() & LayoutMilestone::DidFirstLayoutAfterSuppressedIncrementalRendering)
-                frame()->loader().didReachLayoutMilestone(LayoutMilestone::DidFirstLayoutAfterSuppressedIncrementalRendering);
+                protectedFrame()->checkedLoader()->didReachLayoutMilestone(LayoutMilestone::DidFirstLayoutAfterSuppressedIncrementalRendering);
         }
     }
 
     if (frameView)
         frameView->updateCompositingLayersAfterLayout();
 
-    if (RenderView* renderView = this->renderView())
+    if (CheckedPtr renderView = this->renderView())
         renderView->repaintViewAndCompositedLayers();
 
     if (RefPtr frame = this->frame())
-        frame->loader().completePageTransitionIfNeeded();
+        frame->checkedLoader()->completePageTransitionIfNeeded();
 }
 
 void Document::visualUpdatesSuppressionTimerFired()
@@ -1586,9 +1582,8 @@ String Document::defaultCharsetForLegacyBindings() const
 
 void Document::setCharset(const String& charset)
 {
-    if (!decoder())
-        return;
-    decoder()->setEncoding(charset, TextResourceDecoder::UserChosenEncoding);
+    if (RefPtr decoder = this->decoder())
+        decoder->setEncoding(charset, TextResourceDecoder::UserChosenEncoding);
 }
 
 void Document::setContentLanguage(const AtomString& language)
@@ -1618,7 +1613,7 @@ void Document::setDocumentElementLanguage(const AtomString& language)
 
     if (oldEffectiveDocumentElementLangauge != effectiveDocumentElementLanguage()) {
         for (auto& element : std::exchange(m_elementsWithLangAttrMatchingDocumentElement, { }))
-            element.updateEffectiveLangStateAndPropagateToDescendants();
+            Ref { element }->updateEffectiveLangStateAndPropagateToDescendants();
     }
 
     if (m_contentLanguage == language)
@@ -1649,10 +1644,15 @@ void Document::setDocumentURI(const String& uri)
     updateBaseURL();
 }
 
+RefPtr<DocumentParser> Document::protectedParser() const
+{
+    return m_parser;
+}
+
 void Document::setContent(const String& content)
 {
     open();
-    m_parser->appendSynchronously(content.impl());
+    protectedParser()->appendSynchronously(content.impl());
     close();
 }
 
@@ -1681,7 +1681,7 @@ String Document::contentType() const
     if (!m_overriddenMIMEType.isNull())
         return m_overriddenMIMEType;
 
-    if (DocumentLoader* documentLoader = loader())
+    if (RefPtr documentLoader = loader())
         return documentLoader->currentContentType();
 
     String mimeType = suggestedMIMEType();
@@ -1705,11 +1705,11 @@ std::optional<BoundaryPoint> Document::caretPositionFromPoint(const LayoutPoint&
         return std::nullopt;
 
     LayoutPoint localPoint;
-    auto node = nodeFromPoint(clientPoint, &localPoint);
+    RefPtr node = nodeFromPoint(clientPoint, &localPoint);
     if (!node)
         return std::nullopt;
 
-    auto* renderer = node->renderer();
+    CheckedPtr renderer = node->renderer();
     if (!renderer)
         return std::nullopt;
 
@@ -1721,11 +1721,11 @@ std::optional<BoundaryPoint> Document::caretPositionFromPoint(const LayoutPoint&
         return std::nullopt;
 
     unsigned offset = rangeCompliantPosition.offsetInContainerNode();
-    node = retargetToScope(*rangeCompliantPosition.containerNode());
+    node = retargetToScope(*rangeCompliantPosition.protectedContainerNode());
     if (node != rangeCompliantPosition.containerNode())
         offset = 0;
 
-    return { { *node, offset } };
+    return { { node.releaseNonNull(), offset } };
 }
 
 bool Document::isBodyPotentiallyScrollable(HTMLBodyElement& body)
@@ -1760,11 +1760,11 @@ Element* Document::scrollingElement()
         // The scrollingElement attribute, on getting, must run these steps:
         // 1. If the Document is in quirks mode, follow these substeps:
         if (inQuirksMode()) {
-            auto* firstBody = body();
+            RefPtr firstBody = body();
             // 1. If the HTML body element exists, and it is not potentially scrollable, return the
             // HTML body element and abort these steps.
             if (firstBody && !isBodyPotentiallyScrollable(*firstBody))
-                return firstBody;
+                return firstBody.get();
 
             // 2. Return null and abort these steps.
             return nullptr;
@@ -1786,7 +1786,7 @@ static String canonicalizedTitle(Document& document, const String& title)
 
     StringBuilder builder;
 
-    auto* decoder = document.decoder();
+    RefPtr decoder = document.decoder();
     auto backslashAsCurrencySymbol = decoder ? decoder->encoding().backslashAsCurrencySymbol() : '\\';
 
     bool previousCharacterWasHTMLSpace = false;
@@ -1826,7 +1826,7 @@ void Document::updateTitle(const StringWithDirection& title)
     }
 
 #if ENABLE(ACCESSIBILITY)
-    if (auto* cache = existingAXObjectCache())
+    if (CheckedPtr cache = existingAXObjectCache())
         cache->onTitleChange(*this);
 #endif
 }
@@ -1838,48 +1838,50 @@ void Document::updateTitleFromTitleElement()
         return;
     }
 
-    if (is<HTMLTitleElement>(*m_titleElement))
-        updateTitle(downcast<HTMLTitleElement>(*m_titleElement).textWithDirection());
-    else if (is<SVGTitleElement>(*m_titleElement)) {
+    if (RefPtr htmlTitle = dynamicDowncast<HTMLTitleElement>(*m_titleElement))
+        updateTitle(htmlTitle->textWithDirection());
+    else if (RefPtr svgTitle = dynamicDowncast<SVGTitleElement>(*m_titleElement)) {
         // FIXME: Does the SVG title element have a text direction?
-        updateTitle({ downcast<SVGTitleElement>(*m_titleElement).textContent(), TextDirection::LTR });
+        updateTitle({ svgTitle->textContent(), TextDirection::LTR });
     }
 }
 
 void Document::setTitle(String&& title)
 {
     RefPtr element = documentElement();
-    if (is<SVGSVGElement>(element)) {
+    if (RefPtr svgElement = dynamicDowncast<SVGSVGElement>(element.get())) {
         if (!m_titleElement) {
-            auto titleElement = SVGTitleElement::create(SVGNames::titleTag, *this);
+            Ref titleElement = SVGTitleElement::create(SVGNames::titleTag, *this);
             m_titleElement = titleElement.copyRef();
-            element->insertBefore(titleElement, element->protectedFirstChild());
+            svgElement->insertBefore(titleElement, svgElement->protectedFirstChild());
         }
         // insertBefore above may have ran scripts which removed m_titleElement.
-        if (m_titleElement)
-            m_titleElement->setTextContent(WTFMove(title));
+        if (RefPtr titleElement = m_titleElement)
+            titleElement->setTextContent(WTFMove(title));
     } else if (is<HTMLElement>(element)) {
         std::optional<String> oldTitle;
         if (!m_titleElement) {
             RefPtr headElement = head();
             if (!headElement)
                 return;
-            m_titleElement = HTMLTitleElement::create(HTMLNames::titleTag, *this);
-            headElement->appendChild(*m_titleElement);
+            Ref titleElement = HTMLTitleElement::create(HTMLNames::titleTag, *this);
+            m_titleElement = titleElement.copyRef();
+            headElement->appendChild(titleElement);
         } else
-            oldTitle = m_titleElement->textContent();
+            oldTitle = protectedTitleElement()->textContent();
 
         // appendChild above may have run scripts which removed m_titleElement.
         if (!m_titleElement)
             return;
 
-        m_titleElement->setTextContent(String { title });
-        auto* textManipulationController = textManipulationControllerIfExists();
+        Ref titleElement = *m_titleElement;
+        titleElement->setTextContent(String { title });
+        CheckedPtr textManipulationController = textManipulationControllerIfExists();
         if (UNLIKELY(textManipulationController)) {
             if (!oldTitle)
-                textManipulationController->didAddOrCreateRendererForNode(*m_titleElement);
+                textManipulationController->didAddOrCreateRendererForNode(titleElement);
             else if (*oldTitle != title)
-                textManipulationController->didUpdateContentForNode(*m_titleElement);
+                textManipulationController->didUpdateContentForNode(titleElement);
         }
     }
 }
@@ -1916,16 +1918,21 @@ template<typename TitleElement> Element* selectNewTitleElement(Document& documen
     return newTitleElement;
 }
 
+RefPtr<Element> Document::protectedTitleElement() const
+{
+    return m_titleElement;
+}
+
 void Document::updateTitleElement(Element& changingTitleElement)
 {
     // Most documents use HTML title rules.
     // Documents with SVG document elements use SVG title rules.
     auto selectTitleElement = is<SVGSVGElement>(documentElement())
         ? selectNewTitleElement<SVGTitleElement> : selectNewTitleElement<HTMLTitleElement>;
-    auto newTitleElement = selectTitleElement(*this, m_titleElement.get(), changingTitleElement);
+    RefPtr newTitleElement = selectTitleElement(*this, protectedTitleElement().get(), changingTitleElement);
     if (m_titleElement == newTitleElement)
         return;
-    m_titleElement = newTitleElement;
+    m_titleElement = WTFMove(newTitleElement);
     updateTitleFromTitleElement();
 }
 
@@ -2140,14 +2147,13 @@ void Document::resolveStyle(ResolveStyleType type)
     if (!m_renderView)
         return;
 
-    auto& frameView = m_renderView->frameView();
-    Ref protectedFrameView { frameView };
+    Ref frameView = m_renderView->frameView();
 
     if (isInWebProcess()) {
-        RELEASE_ASSERT(!frameView.isPainting());
+        RELEASE_ASSERT(!frameView->isPainting());
         RELEASE_ASSERT(!m_inStyleRecalc);
     } else {
-        if (frameView.isPainting())
+        if (frameView->isPainting())
             return;
         if (m_inStyleRecalc)
             return;
@@ -2165,7 +2171,7 @@ void Document::resolveStyle(ResolveStyleType type)
         element->updateUserAgentShadowTree();
 
     styleScope().flushPendingUpdate();
-    frameView.willRecalcStyle();
+    frameView->willRecalcStyle();
 
     InspectorInstrumentation::willRecalculateStyle(*this);
 
@@ -2205,8 +2211,8 @@ void Document::resolveStyle(ResolveStyleType type)
 
                 updateRenderTree(WTFMove(styleUpdate));
 
-                if (frameView.layoutContext().needsLayout())
-                    frameView.layoutContext().layout();
+                if (frameView->layoutContext().needsLayout())
+                    frameView->layoutContext().layout();
             }
 
             styleUpdate = resolver.resolve();
@@ -2224,19 +2230,19 @@ void Document::resolveStyle(ResolveStyleType type)
 
         if (styleUpdate) {
             updateRenderTree(WTFMove(styleUpdate));
-            frameView.styleAndRenderTreeDidChange();
+            frameView->styleAndRenderTreeDidChange();
         }
 
-        updatedCompositingLayers = frameView.updateCompositingLayersAfterStyleChange();
+        updatedCompositingLayers = frameView->updateCompositingLayersAfterStyleChange();
 
         if (m_renderView->needsLayout())
-            frameView.layoutContext().scheduleLayout();
+            frameView->layoutContext().scheduleLayout();
 
         // As a result of the style recalculation, the currently hovered element might have been
         // detached (for example, by setting display:none in the :hover style), schedule another mouseMove event
         // to check if any other elements ended up under the mouse pointer due to re-layout.
         if (m_hoveredElement && !m_hoveredElement->renderer()) {
-            if (auto* localMainFrame = dynamicDowncast<LocalFrame>(frameView.frame().mainFrame()))
+            if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(frameView->frame().mainFrame()))
                 localMainFrame->eventHandler().dispatchFakeMouseMoveEventSoon();
         }
 
@@ -2249,8 +2255,8 @@ void Document::resolveStyle(ResolveStyleType type)
     // Some animated images may now be inside the viewport due to style recalc,
     // resume them if necessary if there is no layout pending. Otherwise, we'll
     // check if they need to be resumed after layout.
-    if (updatedCompositingLayers && !frameView.needsLayout())
-        frameView.viewportContentsChanged();
+    if (updatedCompositingLayers && !frameView->needsLayout())
+        frameView->viewportContentsChanged();
 }
 
 void Document::updateTextRenderer(Text& text, unsigned offsetOfReplacedText, unsigned lengthOfReplacedText)
@@ -2363,7 +2369,7 @@ void Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
         if (RefPtr owner = ownerElement())
-            owner->document().updateLayout(layoutOptions, context);
+            owner->protectedDocument()->updateLayout(layoutOptions, context);
 
         updateStyleIfNeeded();
 
@@ -2384,7 +2390,7 @@ void Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
     }
 
     if (layoutOptions.contains(LayoutOptions::RunPostLayoutTasksSynchronously) && view())
-        view()->flushAnyPendingPostLayoutTasks();
+        protectedView()->flushAnyPendingPostLayoutTasks();
 
     if (layoutOptions.contains(LayoutOptions::IgnorePendingStylesheets)) {
         if (RefPtr frameView = view())
@@ -2450,7 +2456,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
     // layout.
     bool requireFullLayout = false;
     if (RefPtr owner = ownerElement()) {
-        if (owner->document().updateLayoutIfDimensionsOutOfDate(*owner))
+        if (owner->protectedDocument()->updateLayoutIfDimensionsOutOfDate(*owner))
             requireFullLayout = true;
     }
 
@@ -2458,7 +2464,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
 
     updateStyleIfNeeded();
 
-    RenderObject* renderer = element.renderer();
+    CheckedPtr renderer = element.renderer();
     if (!renderer || renderer->needsLayout()) {
         // If we don't have a renderer or if the renderer needs layout for any reason, give up.
         requireFullLayout = true;
@@ -2474,20 +2480,19 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
     bool hasSpecifiedLogicalHeight = renderer && renderer->style().logicalMinHeight() == Length(0, LengthType::Fixed) && renderer->style().logicalHeight().isFixed() && renderer->style().logicalMaxHeight().isAuto();
 
     if (!requireFullLayout) {
-        RenderBox* previousBox = nullptr;
-        RenderBox* currentBox = nullptr;
+        CheckedPtr<RenderBox> previousBox;
+        CheckedPtr<RenderBox> currentBox;
 
         // Check our containing block chain. If anything in the chain needs a layout, then require a full layout.
-        for (RenderObject* currRenderer = element.renderer(); currRenderer && !currRenderer->isRenderView(); currRenderer = currRenderer->container()) {
+        for (CheckedPtr currentRenderer = element.renderer(); currentRenderer && !currentRenderer->isRenderView(); currentRenderer = currentRenderer->container()) {
 
             // Require the entire container chain to be boxes.
-            if (!is<RenderBox>(currRenderer)) {
+            if (!is<RenderBox>(*currentRenderer)) {
                 requireFullLayout = true;
                 break;
             }
 
-            previousBox = currentBox;
-            currentBox = downcast<RenderBox>(currRenderer);
+            previousBox = std::exchange(currentBox, downcast<RenderBox>(currentRenderer.get()));
 
             if (currentBox->style().containerType() != ContainerType::Normal) {
                 requireFullLayout = true;
@@ -2497,7 +2502,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
             // If a box needs layout for itself or if a box has changed children and sizes its width to
             // its content, then require a full layout.
             if (currentBox->selfNeedsLayout() ||
-                (checkingLogicalWidth && currRenderer->needsLayout() && currentBox->sizesLogicalWidthToFitContent(MainOrPreferredSize))) {
+                (checkingLogicalWidth && currentRenderer->needsLayout() && currentBox->sizesLogicalWidthToFitContent(MainOrPreferredSize))) {
                 requireFullLayout = true;
                 break;
             }
@@ -2505,7 +2510,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
             // If a block contains floats and the child's height isn't specified, then
             // give up also, since our height could end up being influenced by the floats.
             if (checkingLogicalHeight && !hasSpecifiedLogicalHeight && currentBox->isRenderBlockFlow()) {
-                RenderBlockFlow* currentBlockFlow = downcast<RenderBlockFlow>(currentBox);
+                CheckedRef currentBlockFlow = downcast<RenderBlockFlow>(*currentBox);
                 if (currentBlockFlow->containsFloats() && previousBox && !previousBox->isFloatingOrOutOfFlowPositioned()) {
                     requireFullLayout = true;
                     break;
@@ -2521,7 +2526,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
                 break;
             }
 
-            if (currRenderer == frameView->layoutContext().subtreeLayoutRoot())
+            if (currentRenderer == frameView->layoutContext().subtreeLayoutRoot())
                 break;
         }
     }
@@ -2605,7 +2610,7 @@ bool Document::isResolvingContainerQueriesForSelfOrAncestor() const
 {
     if (m_isResolvingContainerQueries)
         return true;
-    if (auto* owner = ownerElement())
+    if (RefPtr owner = ownerElement())
         return owner->document().isResolvingContainerQueriesForSelfOrAncestor();
     return false;
 }
@@ -2621,16 +2626,17 @@ void Document::createRenderTree()
 
     // FIXME: It would be better if we could pass the resolved document style directly here.
     m_renderView = createRenderer<RenderView>(*this, RenderStyle::create());
-    Node::setRenderer(m_renderView.get());
+    CheckedPtr renderView = m_renderView.get();
+    Node::setRenderer(renderView.get());
 
-    renderView()->setIsInWindow(true);
+    renderView->setIsInWindow(true);
 
     resolveStyle(ResolveStyleType::Rebuild);
 }
 
 void Document::didBecomeCurrentDocumentInFrame()
 {
-    m_frame->script().updateDocument();
+    protectedFrame()->checkedScript()->updateDocument();
 
     // Many of these functions have event handlers which can detach the frame synchronously, so we must check repeatedly in this function.
     if (!m_frame)
@@ -2693,7 +2699,7 @@ void Document::willDetachPage()
     contentChangeObserver().willDetachPage();
 #endif
     if (domWindow() && frame())
-        InspectorInstrumentation::frameWindowDiscarded(*frame(), domWindow());
+        InspectorInstrumentation::frameWindowDiscarded(protectedFrame().releaseNonNull(), protectedWindow().get());
 }
 
 void Document::attachToCachedFrame(CachedFrameBase& cachedFrame)
@@ -2701,7 +2707,7 @@ void Document::attachToCachedFrame(CachedFrameBase& cachedFrame)
     RELEASE_ASSERT(cachedFrame.document() == this);
     ASSERT(cachedFrame.view());
     ASSERT(m_backForwardCacheState == Document::InBackForwardCache);
-    observeFrame(&cachedFrame.view()->frame());
+    observeFrame(cachedFrame.view()->protectedFrame().ptr());
 }
 
 void Document::detachFromCachedFrame(CachedFrameBase& cachedFrame)
@@ -2711,6 +2717,11 @@ void Document::detachFromCachedFrame(CachedFrameBase& cachedFrame)
     ASSERT(m_frame == &cachedFrame.view()->frame());
     ASSERT(m_backForwardCacheState == Document::InBackForwardCache);
     detachFromFrame();
+}
+
+RefPtr<Element> Document::protectedDocumentElement() const
+{
+    return m_documentElement;
 }
 
 void Document::destroyRenderTree()
@@ -2730,14 +2741,14 @@ void Document::destroyRenderTree()
 
     documentWillBecomeInactive();
 
-    if (view())
-        view()->willDestroyRenderTree();
+    if (RefPtr view = this->view())
+        view->willDestroyRenderTree();
 
     m_pendingRenderTreeUpdate = { };
     m_initialContainingBlockStyle = { };
 
-    if (m_documentElement)
-        RenderTreeUpdater::tearDownRenderers(*m_documentElement);
+    if (RefPtr documentElement = m_documentElement)
+        RenderTreeUpdater::tearDownRenderers(*documentElement);
 
     clearChildNeedsStyleRecalc();
 
@@ -2759,8 +2770,13 @@ void Document::destroyRenderTree()
     m_textAutoSizing = nullptr;
 #endif
 
-    if (view())
-        view()->didDestroyRenderTree();
+    if (RefPtr view = this->view())
+        view->didDestroyRenderTree();
+}
+
+Ref<UndoManager> Document::protectedUndoManager() const
+{
+    return m_undoManager;
 }
 
 void Document::willBeRemovedFromFrame()
@@ -2769,8 +2785,8 @@ void Document::willBeRemovedFromFrame()
         return;
 
 #if ENABLE(WEB_RTC)
-    if (m_rtcNetworkManager)
-        m_rtcNetworkManager->unregisterMDNSNames();
+    if (RefPtr rtcNetworkManager = m_rtcNetworkManager)
+        rtcNetworkManager->unregisterMDNSNames();
 #endif
 
 #if ENABLE(SERVICE_WORKER)
@@ -2782,14 +2798,14 @@ void Document::willBeRemovedFromFrame()
     clearTouchEventHandlersAndListeners();
 #endif
 
-    m_undoManager->removeAllItems();
+    protectedUndoManager()->removeAllItems();
 
     m_textManipulationController = nullptr; // Free nodes kept alive by TextManipulationController.
 
 #if ENABLE(ACCESSIBILITY)
     if (this != &topDocument()) {
         // Let the ax cache know that this subframe goes out of scope.
-        if (auto* cache = existingAXObjectCache())
+        if (CheckedPtr cache = existingAXObjectCache())
             cache->prepareForDocumentDestruction(*this);
     }
 #endif
@@ -2803,7 +2819,7 @@ void Document::willBeRemovedFromFrame()
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
     if (m_domWindow && m_frame)
-        m_domWindow->willDetachDocumentFromFrame();
+        protectedWindow()->willDetachDocumentFromFrame();
 
     styleScope().clearResolver();
 
@@ -2813,7 +2829,7 @@ void Document::willBeRemovedFromFrame()
     if (is<PluginDocument>(*this))
         downcast<PluginDocument>(*this).detachFromPluginElement();
 
-    if (auto* page = this->page()) {
+    if (CheckedPtr page = this->page()) {
 #if ENABLE(POINTER_LOCK)
         page->pointerLockController().documentDetached(*this);
 #endif
@@ -2829,14 +2845,14 @@ void Document::willBeRemovedFromFrame()
 
 #if ENABLE(TOUCH_EVENTS)
     if (m_touchEventTargets && m_touchEventTargets->size() && parentDocument())
-        parentDocument()->didRemoveEventTargetNode(*this);
+        protectedParentDocument()->didRemoveEventTargetNode(*this);
 #endif
 
     if (m_wheelEventTargets && m_wheelEventTargets->size() && parentDocument())
-        parentDocument()->didRemoveEventTargetNode(*this);
+        protectedParentDocument()->didRemoveEventTargetNode(*this);
 
-    if (m_mediaQueryMatcher)
-        m_mediaQueryMatcher->documentDestroyed();
+    if (RefPtr mediaQueryMatcher = m_mediaQueryMatcher)
+        mediaQueryMatcher->documentDestroyed();
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     if (!m_clientToIDMap.isEmpty() && page()) {
@@ -2845,11 +2861,11 @@ void Document::willBeRemovedFromFrame()
     }
 #endif
 
-    m_cachedResourceLoader->stopUnusedPreloadsTimer();
+    protectedCachedResourceLoader()->stopUnusedPreloadsTimer();
 
     if (page() && !m_mediaState.isEmpty()) {
         m_mediaState = MediaProducer::IsNotPlaying;
-        page()->updateIsPlayingMedia();
+        checkedPage()->updateIsPlayingMedia();
     }
 
     selection().willBeRemovedFromFrame();
@@ -2870,14 +2886,19 @@ void Document::willBeRemovedFromFrame()
     RELEASE_ASSERT(m_backForwardCacheState != Document::InBackForwardCache);
 }
 
+Ref<ReportingScope> Document::protectedReportingScope() const
+{
+    return m_reportingScope;
+}
+
 void Document::removeAllEventListeners()
 {
     EventTarget::removeAllEventListeners();
 
-    if (m_domWindow)
-        m_domWindow->removeAllEventListeners();
+    if (RefPtr window = m_domWindow)
+        window->removeAllEventListeners();
 
-    m_reportingScope->removeAllObservers();
+    protectedReportingScope()->removeAllObservers();
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     clearTouchEventHandlersAndListeners();
@@ -2990,31 +3011,31 @@ AXObjectCache* Document::axObjectCache() const
     // document.  This is because we need to be able to get from any WebCoreAXObject
     // to any other WebCoreAXObject on the same page.  Using a single cache allows
     // lookups across nested webareas (i.e. multiple documents).
-    Document& topDocument = this->topDocument();
+    Ref topDocument = this->topDocument();
 
     // If the document has already been detached, do not make a new axObjectCache.
-    if (!topDocument.hasLivingRenderTree())
+    if (!topDocument->hasLivingRenderTree())
         return nullptr;
 
-    ASSERT(&topDocument == this || !m_axObjectCache);
-    if (!topDocument.m_axObjectCache) {
-        topDocument.m_axObjectCache = makeUnique<AXObjectCache>(topDocument);
+    ASSERT(topDocument.ptr() == this || !m_axObjectCache);
+    if (!topDocument->m_axObjectCache) {
+        topDocument->m_axObjectCache = makeUnique<AXObjectCache>(topDocument);
         hasEverCreatedAnAXObjectCache = true;
     }
-    return topDocument.m_axObjectCache.get();
+    return topDocument->m_axObjectCache.get();
 }
 
 void Document::setVisuallyOrdered()
 {
     m_visuallyOrdered = true;
-    if (renderView())
-        renderView()->mutableStyle().setRTLOrdering(Order::Visual);
+    if (CheckedPtr renderView = this->renderView())
+        renderView->mutableStyle().setRTLOrdering(Order::Visual);
 }
 
 Ref<DocumentParser> Document::createParser()
 {
     // FIXME: this should probably pass the frame instead
-    return XMLDocumentParser::create(*this, view(), m_parserContentPolicy);
+    return XMLDocumentParser::create(*this, protectedView().get(), m_parserContentPolicy);
 }
 
 bool Document::hasHighlight() const
@@ -3046,7 +3067,7 @@ HighlightRegistry& Document::appHighlightRegistry()
 {
     if (!m_appHighlightRegistry) {
         m_appHighlightRegistry = HighlightRegistry::create();
-        if (auto* currentPage = page())
+        if (CheckedPtr currentPage = page())
             m_appHighlightRegistry->setHighlightVisibility(currentPage->chrome().client().appHighlightsVisiblility());
     }
     return *m_appHighlightRegistry;
@@ -3098,7 +3119,7 @@ void Document::updateHighlightPositions()
 #endif
 
     for (auto& weakRangeData : highlightRanges) {
-        if (auto* highlightRange = weakRangeData.get()) {
+        if (RefPtr highlightRange = weakRangeData.get()) {
             VisibleSelection visibleSelection(makeSimpleRange(highlightRange->range()));
             auto range = makeSimpleRange(highlightRange->range());
 
@@ -3130,7 +3151,7 @@ ExceptionOr<RefPtr<WindowProxy>> Document::openForBindings(LocalDOMWindow& activ
     if (!m_domWindow)
         return Exception { InvalidAccessError };
 
-    return m_domWindow->open(activeWindow, firstWindow, url, name, features);
+    return protectedWindow()->open(activeWindow, firstWindow, url, name, features);
 }
 
 ExceptionOr<Document&> Document::openForBindings(Document* entryDocument, const String&, const String&)
@@ -3156,8 +3177,8 @@ ExceptionOr<void> Document::open(Document* entryDocument)
     if (m_activeParserWasAborted)
         return { };
 
-    if (m_frame) {
-        if (ScriptableDocumentParser* parser = scriptableDocumentParser()) {
+    if (RefPtr frame = this->frame()) {
+        if (RefPtr parser = scriptableDocumentParser()) {
             if (parser->isParsing()) {
                 // FIXME: HTML5 doesn't tell us to check this, it might not be correct.
                 if (parser->isExecutingScript())
@@ -3168,12 +3189,12 @@ ExceptionOr<void> Document::open(Document* entryDocument)
             }
         }
 
-        bool isNavigating = m_frame->loader().policyChecker().delegateIsDecidingNavigationPolicy() || m_frame->loader().state() == FrameState::Provisional || m_frame->navigationScheduler().hasQueuedNavigation();
-        if (m_frame->loader().policyChecker().delegateIsDecidingNavigationPolicy())
-            m_frame->loader().policyChecker().stopCheck();
+        bool isNavigating = frame->loader().policyChecker().delegateIsDecidingNavigationPolicy() || frame->loader().state() == FrameState::Provisional || frame->navigationScheduler().hasQueuedNavigation();
+        if (frame->loader().policyChecker().delegateIsDecidingNavigationPolicy())
+            frame->loader().policyChecker().stopCheck();
         // Null-checking m_frame again as `policyChecker().stopCheck()` may have cleared it.
         if (isNavigating && m_frame)
-            m_frame->loader().stopAllLoaders();
+            protectedFrame()->checkedLoader()->stopAllLoaders();
     }
 
     removeAllEventListeners();
@@ -3191,15 +3212,15 @@ ExceptionOr<void> Document::open(Document* entryDocument)
     }
 
     implicitOpen();
-    if (ScriptableDocumentParser* parser = scriptableDocumentParser())
+    if (RefPtr parser = scriptableDocumentParser())
         parser->setWasCreatedByScript(true);
 
-    if (m_frame) {
+    if (RefPtr frame = this->frame()) {
         // Set document's is initial about:blank to false.
         // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document-open-steps (step 13)
-        m_frame->loader().advanceStatePastInitialEmptyDocument();
-
-        m_frame->loader().didExplicitOpen();
+        CheckedRef frameLoader = frame->loader();
+        frameLoader->advanceStatePastInitialEmptyDocument();
+        frameLoader->didExplicitOpen();
     }
 
     return { };
@@ -3208,23 +3229,21 @@ ExceptionOr<void> Document::open(Document* entryDocument)
 // https://html.spec.whatwg.org/#fully-active
 bool Document::isFullyActive() const
 {
-    auto* frame = this->frame();
+    RefPtr frame = this->frame();
     if (!frame || frame->document() != this)
         return false;
 
     if (frame->isMainFrame())
         return true;
 
-    auto* parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent());
+    RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent());
     return parentFrame && parentFrame->document() && parentFrame->document()->isFullyActive();
 }
 
 void Document::detachParser()
 {
-    if (!m_parser)
-        return;
-    m_parser->detach();
-    m_parser = nullptr;
+    if (RefPtr parser = std::exchange(m_parser, nullptr))
+        parser->detach();
 }
 
 void Document::cancelParsing()
@@ -3232,7 +3251,7 @@ void Document::cancelParsing()
     if (!m_parser)
         return;
 
-    if (m_parser->processingData())
+    if (protectedParser()->processingData())
         m_activeParserWasAborted = true;
 
     // We have to clear the parser to avoid possibly triggering
@@ -3253,7 +3272,7 @@ void Document::implicitOpen()
     m_parser = createParser();
 
     if (hasActiveParserYieldToken())
-        m_parser->didBeginYieldingParser();
+        protectedParser()->didBeginYieldingParser();
 
     setParsing(true);
     setReadyState(ReadyState::Loading);
@@ -3261,15 +3280,15 @@ void Document::implicitOpen()
 
 std::unique_ptr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
-    auto* cachedFont = m_fontLoader->cachedFont(completeURL(url), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
+    CachedResourceHandle cachedFont = m_fontLoader->cachedFont(completeURL(url), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
     return cachedFont ? makeUnique<CachedFontLoadRequest>(*cachedFont, *this) : nullptr;
 }
 
 void Document::beginLoadingFontSoon(FontLoadRequest& request)
 {
     ASSERT(is<CachedFontLoadRequest>(request));
-    auto& font = downcast<CachedFontLoadRequest>(request).cachedFont();
-    m_fontLoader->beginLoadingFontSoon(font);
+    CachedResourceHandle font = downcast<CachedFontLoadRequest>(request).cachedFont();
+    m_fontLoader->beginLoadingFontSoon(*font);
 }
 
 HTMLBodyElement* Document::body() const
@@ -3306,8 +3325,8 @@ ExceptionOr<void> Document::setBodyOrFrameset(RefPtr<HTMLElement>&& newBody)
         return Exception { HierarchyRequestError };
 
     if (currentBody)
-        return m_documentElement->replaceChild(*newBody, *currentBody);
-    return m_documentElement->appendChild(*newBody);
+        return protectedDocumentElement()->replaceChild(*newBody, *currentBody);
+    return protectedDocumentElement()->appendChild(*newBody);
 }
 
 Location* Document::location() const
@@ -3345,7 +3364,7 @@ void Document::close()
 
 void Document::explicitClose()
 {
-    if (RefPtr<DocumentParser> parser = m_parser)
+    if (RefPtr parser = m_parser)
         parser->finish();
 
     if (!m_frame) {
@@ -3370,11 +3389,11 @@ void Document::implicitClose()
         return;
 
     // Call to dispatchWindowLoadEvent can blow us from underneath.
-    Ref<Document> protectedThis(*this);
+    Ref protectedThis { *this };
 
     m_processingLoadEvent = true;
 
-    ScriptableDocumentParser* parser = scriptableDocumentParser();
+    RefPtr parser = scriptableDocumentParser();
     m_wellFormed = parser && parser->wellFormed();
 
     // We have to clear the parser, in case someone document.write()s from the
@@ -3387,8 +3406,8 @@ void Document::implicitClose()
     //  -When any new HTMLLinkElement is inserted into the document
     // But those add a dynamic component to the favicon that has UI
     // ramifications, and we need to decide what is the Right Thing To Do(tm)
-    RefPtr f = frame();
-    if (f) {
+    RefPtr frame = this->frame();
+    if (frame) {
 #if ENABLE(XSLT)
         // Apply XSL transforms before load events so that event handlers can access the transformed DOM tree.
         applyPendingXSLTransformsNowIfScheduled();
@@ -3400,10 +3419,10 @@ void Document::implicitClose()
         // FIXME: We shouldn't be dispatching pending events globally on all Documents here.
         // For now, only do this when there is a Frame, otherwise this could cause JS reentrancy
         // below SVG font parsing, for example. <https://webkit.org/b/136269>
-        if (auto* currentPage = page()) {
-            ImageLoader::dispatchPendingLoadEvents(currentPage);
-            HTMLLinkElement::dispatchPendingLoadEvents(currentPage);
-            HTMLStyleElement::dispatchPendingLoadEvents(currentPage);
+        if (CheckedPtr currentPage = page()) {
+            ImageLoader::dispatchPendingLoadEvents(currentPage.get());
+            HTMLLinkElement::dispatchPendingLoadEvents(currentPage.get());
+            HTMLStyleElement::dispatchPendingLoadEvents(currentPage.get());
         }
 
         if (svgExtensions())
@@ -3413,16 +3432,17 @@ void Document::implicitClose()
     dispatchWindowLoadEvent();
     dispatchPageshowEvent(PageshowEventPersistence::NotPersisted);
 
-    if (f)
-        f->loader().dispatchOnloadEvents();
+    if (frame)
+        frame->checkedLoader()->dispatchOnloadEvents();
 
     // An event handler may have removed the frame
-    if (!frame()) {
+    frame = this->frame();
+    if (!frame) {
         m_processingLoadEvent = false;
         return;
     }
 
-    frame()->loader().checkCallImplicitClose();
+    frame->checkedLoader()->checkCallImplicitClose();
 
     // We used to force a synchronous display and flush here. This really isn't
     // necessary and can in fact be actively harmful if pages are loading at a rate of > 60fps
@@ -3432,7 +3452,7 @@ void Document::implicitClose()
 
         // Always do a layout after loading if needed.
         if (view() && renderView() && (!renderView()->firstChild() || renderView()->needsLayout()))
-            view()->layoutContext().layout();
+            protectedView()->layoutContext().layout();
     }
 
     m_processingLoadEvent = false;
@@ -3441,7 +3461,7 @@ void Document::implicitClose()
         fontFaceSet->documentDidFinishLoading();
 
 #if PLATFORM(COCOA) || PLATFORM(WIN) || PLATFORM(GTK)
-    if (f && hasLivingRenderTree() && AXObjectCache::accessibilityEnabled()) {
+    if (frame && hasLivingRenderTree() && AXObjectCache::accessibilityEnabled()) {
         // The AX cache may have been cleared at this point, but we need to make sure it contains an
         // AX object to send the notification to. getOrCreate will make sure that an valid AX object
         // exists in the cache (we ignore the return value because we don't need it here). This is
@@ -3473,7 +3493,7 @@ void Document::setParsing(bool b)
         m_sharedObjectPool = makeUnique<DocumentSharedObjectPool>();
 
     if (!m_bParsing && view() && !view()->needsLayout())
-        view()->fireLayoutRelatedMilestonesIfNeeded();
+        protectedView()->fireLayoutRelatedMilestonesIfNeeded();
 }
 
 bool Document::shouldScheduleLayout() const
@@ -3526,7 +3546,7 @@ void Document::enqueuePaintTimingEntryIfNeeded()
     if (frame() && frame()->isMainFrame())
         WTFEmitSignpost(this, "Page Load: First Contentful Paint");
 
-    domWindow()->performance().reportFirstContentfulPaint();
+    protectedWindow()->performance().reportFirstContentfulPaint();
     m_didEnqueueFirstContentfulPaint = true;
 }
 
@@ -3554,7 +3574,7 @@ ExceptionOr<void> Document::write(Document* entryDocument, SegmentedString&& tex
     }
 
     ASSERT(m_parser);
-    m_parser->insert(WTFMove(text));
+    protectedParser()->insert(WTFMove(text));
     return { };
 }
 
@@ -3585,7 +3605,7 @@ ExceptionOr<void> Document::writeln(Document* entryDocument, FixedVector<String>
 
 Seconds Document::minimumDOMTimerInterval() const
 {
-    auto* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return ScriptExecutionContext::minimumDOMTimerInterval();
     return page->settings().minimumDOMTimerInterval();
@@ -3619,7 +3639,7 @@ Seconds Document::domTimerAlignmentInterval(bool hasReachedMaxNestingLevel) cons
     if (m_isTimerThrottlingEnabled)
         alignmentInterval = std::max(alignmentInterval, DOMTimer::hiddenPageAlignmentInterval());
 
-    if (Page* page = this->page())
+    if (CheckedPtr page = this->page())
         alignmentInterval = std::max(alignmentInterval, page->domTimerAlignmentInterval());
 
     if (!topOrigin().isSameOriginDomain(securityOrigin()) && !hasHadUserInteraction())
@@ -3663,7 +3683,7 @@ const URL& Document::urlForBindings() const
         if (m_url.url().isEmpty() || !loader() || !isTopDocument() || !frame())
             return false;
 
-        auto* policySourceLoader = topDocument().loader();
+        RefPtr policySourceLoader = topDocument().loader();
         if (policySourceLoader && !policySourceLoader->request().url().hasSpecialScheme() && url().protocolIsInHTTPFamily())
             policySourceLoader = loader();
 
@@ -3730,9 +3750,9 @@ URL Document::fallbackBaseURL() const
     }
 
     if (documentURL.isAboutBlank()) {
-        auto* creator = parentDocument();
+        RefPtr creator = parentDocument();
         if (!creator && frame()) {
-            if (auto* localOpener = dynamicDowncast<LocalFrame>(frame()->loader().opener()))
+            if (RefPtr localOpener = dynamicDowncast<LocalFrame>(frame()->loader().opener()))
                 creator = localOpener->document();
         }
         if (creator)
@@ -3767,31 +3787,31 @@ void Document::setBaseURLOverride(const URL& url)
 void Document::processBaseElement()
 {
     // Find the first href attribute in a base element and the first target attribute in a base element.
-    const AtomString* href = nullptr;
-    const AtomString* target = nullptr;
+    AtomString href;
+    AtomString target;
     auto baseDescendants = descendantsOfType<HTMLBaseElement>(*this);
     for (auto& base : baseDescendants) {
-        if (!href) {
-            const AtomString& value = base.attributeWithoutSynchronization(hrefAttr);
+        if (href.isNull()) {
+            auto& value = base.attributeWithoutSynchronization(hrefAttr);
             if (!value.isNull()) {
-                href = &value;
-                if (target)
+                href = value;
+                if (!target.isNull())
                     break;
             }
         }
-        if (!target) {
-            const AtomString& value = base.attributeWithoutSynchronization(targetAttr);
+        if (target.isNull()) {
+            auto& value = base.attributeWithoutSynchronization(targetAttr);
             if (!value.isNull()) {
-                target = &value;
-                if (href)
+                target = value;
+                if (!href.isNull())
                     break;
             }
         }
     }
 
     URL baseElementURL;
-    if (href)
-        baseElementURL = completeURL(href->string(), fallbackBaseURL());
+    if (!href.isNull())
+        baseElementURL = completeURL(href, fallbackBaseURL());
     if (m_baseElementURL != baseElementURL) {
         if (!contentSecurityPolicy()->allowBaseURI(baseElementURL))
             m_baseElementURL = { };
@@ -3799,38 +3819,41 @@ void Document::processBaseElement()
             m_baseElementURL = { };
             addConsoleMessage(MessageSource::Security, MessageLevel::Error, "Blocked setting " + baseElementURL.stringCenterEllipsizedToLength() + " as the base URL because it does not have an allowed scheme.");
         } else
-            m_baseElementURL = baseElementURL;
+            m_baseElementURL = WTFMove(baseElementURL);
         updateBaseURL();
     }
 
-    m_baseTarget = target ? *target : nullAtom();
+    m_baseTarget = WTFMove(target);
 }
 
 String Document::userAgent(const URL& url) const
 {
-    return frame() ? frame()->loader().userAgent(url) : String();
+    RefPtr frame = this->frame();
+    return frame ? frame->checkedLoader()->userAgent(url) : String();
 }
 
 void Document::disableEval(const String& errorMessage)
 {
-    if (!frame())
+    RefPtr frame = this->frame();
+    if (!frame)
         return;
 
-    frame()->script().setEvalEnabled(false, errorMessage);
+    frame->checkedScript()->setEvalEnabled(false, errorMessage);
 }
 
 void Document::disableWebAssembly(const String& errorMessage)
 {
-    if (!frame())
+    RefPtr frame = this->frame();
+    if (!frame)
         return;
 
-    frame()->script().setWebAssemblyEnabled(false, errorMessage);
+    frame->checkedScript()->setWebAssemblyEnabled(false, errorMessage);
 }
 
 IDBClient::IDBConnectionProxy* Document::idbConnectionProxy()
 {
     if (!m_idbConnectionProxy) {
-        Page* currentPage = page();
+        CheckedPtr currentPage = page();
         if (!currentPage)
             return nullptr;
         m_idbConnectionProxy = &currentPage->idbConnection().proxy();
@@ -3851,7 +3874,7 @@ SocketProvider* Document::socketProvider()
 RefPtr<RTCDataChannelRemoteHandlerConnection> Document::createRTCDataChannelRemoteHandlerConnection()
 {
     ASSERT(isMainThread());
-    auto* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return nullptr;
     return page->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
@@ -3964,8 +3987,8 @@ bool Document::canNavigateInternal(LocalFrame& targetFrame)
         if (&targetFrame == m_frame->loader().opener())
             return true;
 
-        if (auto* localOpener = dynamicDowncast<LocalFrame>(targetFrame.loader().opener())) {
-            if (canAccessAncestor(securityOrigin(), localOpener))
+        if (RefPtr localOpener = dynamicDowncast<LocalFrame>(targetFrame.loader().opener())) {
+            if (canAccessAncestor(securityOrigin(), localOpener.get()))
                 return true;
         }
     }
@@ -4001,7 +4024,7 @@ bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(LocalFrame&
     // Only prevent navigations by unsandboxed iframes. Such navigations by sandboxed iframes would have already been blocked unless
     // "allow-top-navigation" / "allow-top-navigation-by-user-activation" was explicitly specified.
     // We also want to guard against bypassing this block via an iframe-provided CSP sandbox.
-    auto* ownerElement = m_frame->ownerElement();
+    RefPtr ownerElement = m_frame->ownerElement();
     if ((!ownerElement || ownerElement->sandboxFlags() == sandboxFlags()) && sandboxFlags() != SandboxNone) {
         // Navigation is only allowed if the parent of the sandboxed iframe is first-party.
         RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
@@ -4110,7 +4133,7 @@ void Document::processMetaHttpEquiv(const String& equiv, const AtomString& conte
 
     case HTTPHeaderName::Refresh:
         if (frame)
-            frame->loader().scheduleRefreshIfNeeded(*this, content, IsMetaRefresh::Yes);
+            frame->checkedLoader()->scheduleRefreshIfNeeded(*this, content, IsMetaRefresh::Yes);
         break;
 
     case HTTPHeaderName::SetCookie:
@@ -4128,10 +4151,10 @@ void Document::processMetaHttpEquiv(const String& equiv, const AtomString& conte
 
     case HTTPHeaderName::XFrameOptions:
         if (frame) {
-            FrameLoader& frameLoader = frame->loader();
+            CheckedRef frameLoader = frame->loader();
             ResourceLoaderIdentifier requestIdentifier;
-            if (frameLoader.activeDocumentLoader() && frameLoader.activeDocumentLoader()->mainResourceLoader())
-                requestIdentifier = frameLoader.activeDocumentLoader()->mainResourceLoader()->identifier();
+            if (frameLoader->activeDocumentLoader() && frameLoader->activeDocumentLoader()->mainResourceLoader())
+                requestIdentifier = frameLoader->activeDocumentLoader()->mainResourceLoader()->identifier();
 
             String message = "The X-Frame-Option '" + content + "' supplied in a <meta> element was ignored. X-Frame-Options may only be provided by an HTTP header sent with the document.";
             addConsoleMessage(MessageSource::Security, MessageLevel::Error, message, requestIdentifier.toUInt64());
@@ -4167,10 +4190,11 @@ void Document::dispatchDisabledAdaptationsDidChangeForMainFrame()
     if (!frame()->isMainFrame())
         return;
 
-    if (!page())
+    CheckedPtr page = this->page();
+    if (!page)
         return;
 
-    page()->chrome().dispatchDisabledAdaptationsDidChange(m_disabledAdaptations);
+    page->chrome().dispatchDisabledAdaptationsDidChange(m_disabledAdaptations);
 }
 
 void Document::processViewport(const String& features, ViewportArguments::Type origin)
@@ -4195,7 +4219,7 @@ void Document::processViewport(const String& features, ViewportArguments::Type o
 
 ViewportArguments Document::viewportArguments() const
 {
-    auto* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return m_viewportArguments;
     return page->overrideViewportArguments().value_or(m_viewportArguments);
@@ -4203,12 +4227,13 @@ ViewportArguments Document::viewportArguments() const
 
 void Document::updateViewportArguments()
 {
-    if (page() && frame()->isMainFrame()) {
+    CheckedPtr page = this->page();
+    if (page && frame()->isMainFrame()) {
 #if ASSERT_ENABLED
         m_didDispatchViewportPropertiesChanged = true;
 #endif
-        page()->chrome().dispatchViewportPropertiesDidChange(viewportArguments());
-        page()->chrome().didReceiveDocType(*frame());
+        page->chrome().dispatchViewportPropertiesDidChange(viewportArguments());
+        page->chrome().didReceiveDocType(protectedFrame().releaseNonNull());
     }
 }
 
@@ -4250,7 +4275,7 @@ void Document::themeColorChanged()
 {
     scheduleRenderingUpdate({ });
 
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         page->chrome().client().themeColorChanged();
 }
 
@@ -4311,7 +4336,7 @@ void Document::processColorScheme(const String& colorSchemeString)
     if (RefPtr frameView = view())
         frameView->recalculateBaseBackgroundColor();
 
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         page->updateStyleAfterChangeInEnvironment();
 }
 
@@ -4344,7 +4369,7 @@ void Document::processFormatDetection(const String& features)
 
 void Document::processWebAppOrientations()
 {
-    if (Page* page = this->page())
+    if (CheckedPtr page = this->page())
         page->chrome().client().webAppOrientationsUpdated();
 }
 
@@ -4398,7 +4423,7 @@ MouseEventWithHitTestResults Document::prepareMouseEvent(const HitTestRequest& r
     auto captureElementChanged = CaptureChange::No;
     if (!request.readOnly()) {
         RefPtr targetElement = result.targetElement();
-        if (auto* page = this->page()) {
+        if (CheckedPtr page = this->page()) {
             // Before we dispatch a new mouse event, we must run the Process Pending Capture Element steps as defined
             // in https://w3c.github.io/pointerevents/#process-pending-pointer-capture.
             auto& pointerCaptureController = page->pointerCaptureController();
@@ -4412,7 +4437,7 @@ MouseEventWithHitTestResults Document::prepareMouseEvent(const HitTestRequest& r
                 captureElementChanged = CaptureChange::Yes;
             // If we have a capture element, we must target it instead of what would normally hit-test for this event.
             if (captureElement)
-                targetElement = captureElement;
+                targetElement = WTFMove(captureElement);
         }
         updateHoverActiveState(request, targetElement.get(), captureElementChanged);
     }
@@ -4461,7 +4486,7 @@ bool Document::canAcceptChild(const Node& newChild, const Node* refChild, Accept
         return true;
     case DOCUMENT_FRAGMENT_NODE: {
         bool hasSeenElementChild = false;
-        for (auto* node = downcast<DocumentFragment>(newChild).firstChild(); node; node = node->nextSibling()) {
+        for (RefPtr node = downcast<DocumentFragment>(newChild).firstChild(); node; node = node->nextSibling()) {
             if (is<Element>(*node)) {
                 if (hasSeenElementChild)
                     return false;
@@ -4473,7 +4498,7 @@ bool Document::canAcceptChild(const Node& newChild, const Node* refChild, Accept
         break;
     }
     case DOCUMENT_TYPE_NODE: {
-        auto* existingDocType = childrenOfType<DocumentType>(*this).first();
+        RefPtr existingDocType = childrenOfType<DocumentType>(*this).first();
         if (operation == AcceptChildOperation::Replace) {
             //  parent has a doctype child that is not child, or an element is preceding child.
             if (existingDocType && existingDocType != refChild)
@@ -4515,7 +4540,7 @@ bool Document::canAcceptChild(const Node& newChild, const Node* refChild, Accept
 
 Ref<Node> Document::cloneNodeInternal(Document&, CloningOperation type)
 {
-    Ref<Document> clone = cloneDocumentWithoutChildren();
+    Ref clone = cloneDocumentWithoutChildren();
     clone->cloneDataFromDocument(*this);
     switch (type) {
     case CloningOperation::OnlySelf:
@@ -4546,10 +4571,15 @@ void Document::cloneDataFromDocument(const Document& other)
     m_documentURI = other.documentURI();
 
     setCompatibilityMode(other.m_compatibilityMode);
-    setContextDocument(other.contextDocument());
+    setContextDocument(other.protectedContextDocument());
     setSecurityOriginPolicy(other.securityOriginPolicy());
     overrideMIMEType(other.contentType());
-    setDecoder(other.decoder());
+    setDecoder(other.protectedDecoder());
+}
+
+RefPtr<TextResourceDecoder> Document::protectedDecoder() const
+{
+    return m_decoder;
 }
 
 StyleSheetList& Document::styleSheets()
@@ -4653,8 +4683,7 @@ static bool serviceScrollAnimationForScrollableArea(const ScrollableArea* scroll
 void Document::runScrollSteps()
 {
     // Service user scroll animations before scroll event dispatch.
-    RefPtr frameView = view();
-    if (frameView) {
+    if (RefPtr frameView = view()) {
         MonotonicTime now = MonotonicTime::now();
         bool scrollAnimationsInProgress = serviceScrollAnimationForScrollableArea(frameView.get(), now);
         HashSet<CheckedPtr<ScrollableArea>> scrollableAreasToUpdate;
@@ -4672,7 +4701,7 @@ void Document::runScrollSteps()
                 scrollAnimationsInProgress = true;
         }
         if (scrollAnimationsInProgress)
-            page()->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
+            checkedPage()->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
 
         frameView->updateScrollAnchoringElementsForScrollableAreas();
         frameView->updateScrollAnchoringPositionForScrollableAreas();
@@ -4740,7 +4769,7 @@ void Document::noteUserInteractionWithMediaElement()
     if (m_userHasInteractedWithMediaElement)
         return;
 
-    if (!topDocument().userDidInteractWithPage())
+    if (!protectedTopDocument()->userDidInteractWithPage())
         return;
 
     m_userHasInteractedWithMediaElement = true;
@@ -4778,7 +4807,7 @@ void Document::updateIsPlayingMedia()
 
     m_mediaState = state;
 
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         page->updateIsPlayingMedia();
 
 #if ENABLE(MEDIA_STREAM)
@@ -4862,7 +4891,7 @@ void Document::flushAutofocusCandidates()
             continue;
         }
 
-        if (auto* parser = scriptableDocumentParser(); parser && parser->hasScriptsWaitingForStylesheets())
+        if (RefPtr parser = scriptableDocumentParser(); parser && parser->hasScriptsWaitingForStylesheets())
             break;
         m_autofocusCandidates.removeFirst();
 
@@ -4895,8 +4924,8 @@ void Document::hoveredElementDidDetach(Element& element)
     m_hoveredElement = element.parentElement();
     while (m_hoveredElement && !m_hoveredElement->renderer())
         m_hoveredElement = m_hoveredElement->parentElement();
-    if (frame())
-        frame()->eventHandler().scheduleHoverStateUpdate();
+    if (RefPtr frame = this->frame())
+        frame->eventHandler().scheduleHoverStateUpdate();
 }
 
 void Document::elementInActiveChainDidDetach(Element& element)
@@ -4912,7 +4941,7 @@ void Document::elementInActiveChainDidDetach(Element& element)
 void Document::updateEventRegions()
 {
     // FIXME: Move updateTouchEventRegions() here, but it should only happen for the top document.
-    if (auto* view = renderView()) {
+    if (CheckedPtr view = renderView()) {
         if (view->usesCompositing())
             view->compositor().updateEventRegions();
     }
@@ -4925,10 +4954,8 @@ void Document::scheduleDeferredAXObjectCacheUpdate()
 
     m_scheduledDeferredAXObjectCacheUpdate = true;
     eventLoop().queueTask(TaskSource::InternalAsyncTask, [weakThis = WeakPtr { *this }] {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-        protectedThis->flushDeferredAXObjectCacheUpdate();
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->flushDeferredAXObjectCacheUpdate();
     });
 }
 
@@ -4939,24 +4966,24 @@ void Document::flushDeferredAXObjectCacheUpdate()
 
     m_scheduledDeferredAXObjectCacheUpdate = false;
 
-    if (AXObjectCache* cache = existingAXObjectCache())
+    if (CheckedPtr cache = existingAXObjectCache())
         cache->performDeferredCacheUpdate();
 }
 
 void Document::updateAccessibilityObjectRegions()
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    if (auto* cache = existingAXObjectCache())
+    if (CheckedPtr cache = existingAXObjectCache())
         cache->willUpdateObjectRegions();
 
-    if (auto* view = renderView())
-        view->frameView().updateAccessibilityObjectRegions();
+    if (CheckedPtr view = renderView())
+        view->protectedFrameView()->updateAccessibilityObjectRegions();
 #endif
 }
 
 void Document::invalidateEventRegionsForFrame(HTMLFrameOwnerElement& element)
 {
-    auto* renderer = element.renderer();
+    CheckedPtr renderer = element.renderer();
     if (!renderer)
         return;
     if (auto* layer = renderer->enclosingLayer()) {
@@ -4964,7 +4991,7 @@ void Document::invalidateEventRegionsForFrame(HTMLFrameOwnerElement& element)
             return;
     }
     if (RefPtr ownerElement = this->ownerElement())
-        ownerElement->document().invalidateEventRegionsForFrame(*ownerElement);
+        ownerElement->protectedDocument()->invalidateEventRegionsForFrame(*ownerElement);
 }
 
 void Document::invalidateEventListenerRegions()
@@ -4974,13 +5001,14 @@ void Document::invalidateEventListenerRegions()
 
     // We don't track style validity for Document and full rebuild is too big of a hammer.
     // Instead just mutate the style directly and trigger a minimal style update.
-    auto& rootStyle = renderView()->mutableStyle();
+    CheckedPtr renderView = this->renderView();
+    auto& rootStyle = renderView->mutableStyle();
     auto changed = Style::Adjuster::adjustEventListenerRegionTypesForRootStyle(rootStyle, *this);
 
     if (changed)
         scheduleFullStyleRebuild();
     else
-        documentElement()->invalidateStyleInternal();
+        protectedDocumentElement()->invalidateStyleInternal();
 }
 
 void Document::invalidateRenderingDependentRegions()
@@ -4990,7 +5018,7 @@ void Document::invalidateRenderingDependentRegions()
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    if (auto* page = this->page()) {
+    if (CheckedPtr page = this->page()) {
         if (RefPtr frameView = view()) {
             if (RefPtr scrollingCoordinator = page->scrollingCoordinator())
                 scrollingCoordinator->frameViewEventTrackingRegionsChanged(*frameView);
@@ -5002,6 +5030,11 @@ void Document::invalidateRenderingDependentRegions()
 bool Document::setFocusedElement(Element* element)
 {
     return setFocusedElement(element, { });
+}
+
+RefPtr<Element> Document::protectedFocusedElement() const
+{
+    return m_focusedElement;
 }
 
 bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions& options)
@@ -5016,7 +5049,7 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
     if (backForwardCacheState() != NotInBackForwardCache)
         return false;
 
-    RefPtr<Element> oldFocusedElement = WTFMove(m_focusedElement);
+    RefPtr oldFocusedElement = WTFMove(m_focusedElement);
 
     // Remove focus from the existing focus node (if any)
     if (oldFocusedElement) {
@@ -5055,19 +5088,19 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
             // Match the order in HTMLTextFormControlElement::dispatchBlurEvent.
             if (is<HTMLInputElement>(*oldFocusedElement))
                 downcast<HTMLInputElement>(*oldFocusedElement).endEditing();
-            if (page())
-                page()->chrome().client().elementDidBlur(*oldFocusedElement);
+            if (CheckedPtr page = this->page())
+                page->chrome().client().elementDidBlur(*oldFocusedElement);
             ASSERT(!m_focusedElement);
         }
 
         if (oldFocusedElement->isRootEditableElement())
             editor().didEndEditing();
 
-        if (view()) {
+        if (RefPtr view = this->view()) {
             if (RefPtr oldWidget = widgetForElement(oldFocusedElement.get()))
                 oldWidget->setFocus(false);
             else
-                view()->setFocus(false);
+                view->setFocus(false);
         }
 
         if (is<HTMLInputElement>(oldFocusedElement)) {
@@ -5101,48 +5134,49 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
         }
         // Set focus on the new node
         m_focusedElement = newFocusedElement;
-        setFocusNavigationStartingNode(m_focusedElement.get());
-        m_focusedElement->setFocus(true, options.visibility);
+        RefPtr focusedElement = m_focusedElement;
+        setFocusNavigationStartingNode(focusedElement.get());
+        focusedElement->setFocus(true, options.visibility);
         if (options.trigger != FocusTrigger::Bindings)
             m_latestFocusTrigger = options.trigger;
 
         scheduleContentRelevancyUpdate(ContentRelevancy::Focused);
 
         // The setFocus call triggers a blur and a focus event. Event handlers could cause the focused element to be cleared.
-        if (m_focusedElement != newFocusedElement) {
+        if (m_focusedElement != focusedElement) {
             // handler shifted focus
             return false;
         }
 
         // Dispatch the focus event and let the node do any other focus related activities (important for text fields)
-        m_focusedElement->dispatchFocusEvent(oldFocusedElement.copyRef(), options);
+        focusedElement->dispatchFocusEvent(oldFocusedElement.copyRef(), options);
 
-        if (m_focusedElement != newFocusedElement) {
+        if (m_focusedElement != focusedElement) {
             // handler shifted focus
             return false;
         }
 
-        m_focusedElement->dispatchFocusInEventIfNeeded(oldFocusedElement.copyRef()); // DOM level 3 bubbling focus event.
+        focusedElement->dispatchFocusInEventIfNeeded(oldFocusedElement.copyRef()); // DOM level 3 bubbling focus event.
 
-        if (m_focusedElement != newFocusedElement) {
+        if (m_focusedElement != focusedElement) {
             // handler shifted focus
             return false;
         }
 
-        if (m_focusedElement->isRootEditableElement())
+        if (focusedElement->isRootEditableElement())
             editor().didBeginEditing();
 
         // eww, I suck. set the qt focus correctly
         // ### find a better place in the code for this
         if (view()) {
-            RefPtr focusWidget = widgetForElement(m_focusedElement.get());
+            RefPtr focusWidget = widgetForElement(focusedElement.get());
             if (focusWidget) {
                 // Make sure a widget has the right size before giving it focus.
                 // Otherwise, we are testing edge cases of the Widget code.
                 // Specifically, in WebCore this does not work well for text fields.
                 updateLayout();
                 // Re-get the widget in case updating the layout changed things.
-                focusWidget = widgetForElement(m_focusedElement.get());
+                focusWidget = widgetForElement(focusedElement.get());
             }
             if (focusWidget)
                 focusWidget->setFocus(true);
@@ -5154,15 +5188,15 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
     if (m_focusedElement) {
 #if PLATFORM(GTK)
         // GTK relies on creating the AXObjectCache when a focus change happens.
-        if (auto* cache = axObjectCache())
+        if (CheckedPtr cache = axObjectCache())
 #else
-        if (auto* cache = existingAXObjectCache())
+        if (CheckedPtr cache = existingAXObjectCache())
 #endif
             cache->onFocusChange(oldFocusedElement.get(), newFocusedElement);
     }
 
-    if (page())
-        page()->chrome().focusedElementChanged(m_focusedElement.get());
+    if (CheckedPtr page = this->page())
+        page->chrome().focusedElementChanged(protectedFocusedElement().get());
 
     return true;
 }
@@ -5201,25 +5235,25 @@ Element* Document::focusNavigationStartingNode(FocusDirection direction) const
     if (!m_focusNavigationStartingNode)
         return nullptr;
 
-    Node* node = m_focusNavigationStartingNode.get();
+    RefPtr node = m_focusNavigationStartingNode;
 
     // When the node was removed from the document tree. This case is not specified in the spec:
     // https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point
     // Current behaivor is to move the sequential navigation node to / after (based on the focus direction)
     // the previous sibling of the removed node.
     if (m_focusNavigationStartingNodeIsRemoved) {
-        Node* nextNode = NodeTraversal::next(*node);
+        RefPtr nextNode = NodeTraversal::next(*node);
         if (!nextNode)
-            nextNode = node;
+            nextNode = WTFMove(node);
         if (direction == FocusDirection::Forward)
             return ElementTraversal::previous(*nextNode);
         if (is<Element>(*nextNode))
-            return downcast<Element>(nextNode);
+            return downcast<Element>(nextNode.get());
         return ElementTraversal::next(*nextNode);
     }
 
     if (is<Element>(*node))
-        return downcast<Element>(node);
+        return downcast<Element>(node.get());
     if (Element* elementBeforeNextFocusableElement = direction == FocusDirection::Forward ? ElementTraversal::previous(*node) : ElementTraversal::next(*node))
         return elementBeforeNextFocusableElement;
     return node->parentOrShadowHostElement();
@@ -5316,7 +5350,7 @@ void Document::moveNodeIteratorsToNewDocument(Node& node, Document& newDocument)
 void Document::updateRangesAfterChildrenChanged(ContainerNode& container)
 {
     for (auto& range : m_ranges)
-        range->nodeChildrenChanged(container);
+        Ref { range.get() }->nodeChildrenChanged(container);
 }
 
 void Document::nodeChildrenWillBeRemoved(ContainerNode& container)
@@ -5327,15 +5361,15 @@ void Document::nodeChildrenWillBeRemoved(ContainerNode& container)
     adjustFocusNavigationNodeOnNodeRemoval(container, NodeRemoval::ChildrenOfNode);
 
     for (auto& range : m_ranges)
-        range->nodeChildrenWillBeRemoved(container);
+        Ref { range.get() }->nodeChildrenWillBeRemoved(container);
 
     for (auto& it : m_nodeIterators) {
-        for (Node* n = container.firstChild(); n; n = n->nextSibling())
+        for (RefPtr n = container.firstChild(); n; n = n->nextSibling())
             it.nodeWillBeRemoved(*n);
     }
 
     if (RefPtr frame = this->frame()) {
-        for (Node* n = container.firstChild(); n; n = n->nextSibling()) {
+        for (RefPtr n = container.firstChild(); n; n = n->nextSibling()) {
             frame->eventHandler().nodeWillBeRemoved(*n);
             frame->selection().nodeWillBeRemoved(*n);
             frame->page()->dragCaretController().nodeWillBeRemoved(*n);
@@ -5343,7 +5377,7 @@ void Document::nodeChildrenWillBeRemoved(ContainerNode& container)
     }
 
     if (m_markers->hasMarkers()) {
-        for (Text* textNode = TextNodeTraversal::firstChild(container); textNode; textNode = TextNodeTraversal::nextSibling(*textNode))
+        for (RefPtr textNode = TextNodeTraversal::firstChild(container); textNode; textNode = TextNodeTraversal::nextSibling(*textNode))
             m_markers->removeMarkers(*textNode);
     }
 }
@@ -5355,11 +5389,11 @@ void Document::nodeWillBeRemoved(Node& node)
     adjustFocusedNodeOnNodeRemoval(node);
     adjustFocusNavigationNodeOnNodeRemoval(node);
 
-    for (auto& it : m_nodeIterators)
-        it.nodeWillBeRemoved(node);
+    for (auto& nodeIterator : m_nodeIterators)
+        Ref { nodeIterator }->nodeWillBeRemoved(node);
 
     for (auto& range : m_ranges)
-        range->nodeWillBeRemoved(node);
+        Ref { range.get() }->nodeWillBeRemoved(node);
 
     if (RefPtr frame = this->frame()) {
         frame->eventHandler().nodeWillBeRemoved(node);
@@ -5376,12 +5410,12 @@ void Document::parentlessNodeMovedToNewDocument(Node& node)
     Vector<WeakPtr<Range>, 5> rangesAffected;
 
     for (auto& range : m_ranges) {
-        if (range->parentlessNodeMovedToNewDocumentAffectsRange(node))
+        if (Ref { range.get() }->parentlessNodeMovedToNewDocumentAffectsRange(node))
             rangesAffected.append(range.get());
     }
 
-    for (auto& range : rangesAffected) {
-        if (range)
+    for (auto& weakRange : rangesAffected) {
+        if (RefPtr range = weakRange.get())
             range->updateRangeForParentlessNodeMovedToNewDocument(node);
     }
 }
@@ -5406,7 +5440,7 @@ void Document::adjustFocusNavigationNodeOnNodeRemoval(Node& node, NodeRemoval no
 void Document::textInserted(Node& text, unsigned offset, unsigned length)
 {
     for (auto& range : m_ranges)
-        range->textInserted(text, offset, length);
+        Ref { range.get() }->textInserted(text, offset, length);
 
     // Update the markers for spelling and grammar checking.
     m_markers->shiftMarkers(text, offset, length);
@@ -5420,7 +5454,7 @@ void Document::textInserted(Node& text, unsigned offset, unsigned length)
 void Document::textRemoved(Node& text, unsigned offset, unsigned length)
 {
     for (auto& range : m_ranges)
-        range->textRemoved(text, offset, length);
+        Ref { range.get() }->textRemoved(text, offset, length);
 
     // Update the markers for spelling and grammar checking.
     m_markers->removeMarkers(text, { offset, offset + length });
@@ -5432,7 +5466,7 @@ void Document::textNodesMerged(Text& oldNode, unsigned offset)
     if (!m_ranges.isEmpty()) {
         NodeWithIndex oldNodeWithIndex(&oldNode);
         for (auto& range : m_ranges)
-            range->textNodesMerged(oldNodeWithIndex, offset);
+            Ref { range.get() }->textNodesMerged(oldNodeWithIndex, offset);
     }
 
     // FIXME: This should update markers for spelling and grammar checking.
@@ -5441,7 +5475,7 @@ void Document::textNodesMerged(Text& oldNode, unsigned offset)
 void Document::textNodeSplit(Text& oldNode)
 {
     for (auto& range : m_ranges)
-        range->textNodeSplit(oldNode);
+        Ref { range.get() }->textNodeSplit(oldNode);
 
     // FIXME: This should update markers for spelling and grammar checking.
 }
@@ -5466,7 +5500,7 @@ void Document::takeDOMWindowFrom(Document& document)
     ASSERT(backForwardCacheState() == NotInBackForwardCache);
 
     m_domWindow = WTFMove(document.m_domWindow);
-    m_domWindow->didSecureTransitionTo(*this);
+    protectedWindow()->didSecureTransitionTo(*this);
 
     ASSERT(m_domWindow->document() == this);
     ASSERT(m_domWindow->frame() == m_frame);
@@ -5486,6 +5520,11 @@ Document& Document::contextDocument() const
     return const_cast<Document&>(*this);
 }
 
+Ref<Document> Document::protectedContextDocument() const
+{
+    return contextDocument();
+}
+
 void Document::setAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& attributeValue, DOMWrapperWorld& isolatedWorld)
 {
     setAttributeEventListener(eventType, JSLazyEventListener::create(*this, attributeName, attributeValue), isolatedWorld);
@@ -5497,15 +5536,14 @@ void Document::setWindowAttributeEventListener(const AtomString& eventType, cons
         return;
     if (!m_domWindow->frame())
         return;
-    m_domWindow->setAttributeEventListener(eventType, JSLazyEventListener::create(*m_domWindow, attributeName, attributeValue), isolatedWorld);
+    protectedWindow()->setAttributeEventListener(eventType, JSLazyEventListener::create(*m_domWindow, attributeName, attributeValue), isolatedWorld);
 }
 
 void Document::dispatchWindowEvent(Event& event, EventTarget* target)
 {
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
-    if (!m_domWindow)
-        return;
-    m_domWindow->dispatchEvent(event, target);
+    if (RefPtr window = m_domWindow)
+        window->dispatchEvent(event, target);
 }
 
 void Document::dispatchWindowLoadEvent()
@@ -5513,9 +5551,9 @@ void Document::dispatchWindowLoadEvent()
     ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isScriptAllowed());
     if (!m_domWindow)
         return;
-    m_domWindow->dispatchLoadEvent();
+    protectedWindow()->dispatchLoadEvent();
     m_loadEventFinished = true;
-    m_cachedResourceLoader->documentDidFinishLoadEvent();
+    protectedCachedResourceLoader()->documentDidFinishLoadEvent();
 }
 
 void Document::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
@@ -5528,9 +5566,8 @@ void Document::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
 void Document::queueTaskToDispatchEventOnWindow(TaskSource source, Ref<Event>&& event)
 {
     eventLoop().queueTask(source, [this, protectedThis = Ref { *this }, event = WTFMove(event)] {
-        if (!m_domWindow)
-            return;
-        m_domWindow->dispatchEvent(event);
+        if (RefPtr window = m_domWindow)
+            window->dispatchEvent(event);
     });
 }
 
@@ -5538,7 +5575,7 @@ void Document::enqueueOverflowEvent(Ref<Event>&& event)
 {
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/overflow_event
     // FIXME: This event is totally unspecified.
-    auto* target = event->target();
+    RefPtr target = event->target();
     RELEASE_ASSERT(target);
     RELEASE_ASSERT(is<Node>(target));
     eventLoop().queueTask(TaskSource::DOMManipulation, [protectedTarget = GCReachableRef<Node>(downcast<Node>(*target)), event = WTFMove(event)] {
@@ -5714,7 +5751,7 @@ ExceptionOr<String> Document::cookie()
         return String();
 
     if (!isDOMCookieCacheValid() && page())
-        setCachedDOMCookies(page()->cookieJar().cookies(*this, cookieURL));
+        setCachedDOMCookies(checkedPage()->cookieJar().cookies(*this, cookieURL));
 
     return String { cachedDOMCookies() };
 }
@@ -5735,8 +5772,8 @@ ExceptionOr<void> Document::setCookie(const String& value)
         return { };
 
     invalidateDOMCookieCache();
-    if (page())
-        page()->cookieJar().setCookies(*this, cookieURL, value);
+    if (CheckedPtr page = this->page())
+        page->cookieJar().setCookies(*this, cookieURL, value);
     return { };
 }
 
@@ -5764,7 +5801,7 @@ String Document::referrer()
 
 String Document::referrerForBindings()
 {
-    auto* policySourceLoader = topDocument().loader();
+    RefPtr policySourceLoader = topDocument().loader();
     if (!policySourceLoader)
         return referrer();
 
@@ -6012,7 +6049,7 @@ bool Document::shouldMaskURLForBindingsInternal(const URL& urlToMask) const
     if (urlToMask.protocolIs(url().protocol()))
         return false;
 
-    auto* page = this->page();
+    CheckedPtr page = this->page();
     if (UNLIKELY(!page))
         return false;
 
@@ -6049,12 +6086,12 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
 
     m_backForwardCacheState = state;
 
-    auto* v = view();
-    Page* page = this->page();
+    RefPtr frameView = view();
+    CheckedPtr page = this->page();
 
     switch (state) {
     case InBackForwardCache:
-        if (v) {
+        if (frameView) {
             // FIXME: There is some scrolling related work that needs to happen whenever a page goes into the
             // back/forward cache and similar work that needs to occur when it comes out. This is where we do the work
             // that needs to happen when we enter, and the work that needs to happen when we exit is in
@@ -6062,9 +6099,9 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
             // called too early on in the process of a page exiting the cache for that work to be possible in this
             // function. It would be nice if there was more symmetry here.
             // https://bugs.webkit.org/show_bug.cgi?id=98698
-            v->cacheCurrentScrollPosition();
+            frameView->cacheCurrentScrollPosition();
             if (page && m_frame->isMainFrame()) {
-                v->resetScrollbarsAndClearContentsSize();
+                frameView->resetScrollbarsAndClearContentsSize();
                 if (RefPtr scrollingCoordinator = page->scrollingCoordinator())
                     scrollingCoordinator->clearAllNodes();
             }
@@ -6079,14 +6116,14 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
 
         clearSharedObjectPool();
 
-        if (m_idbConnectionProxy)
-            m_idbConnectionProxy->setContextSuspended(*scriptExecutionContext(), true);
+        if (RefPtr idbConnectionProxy = m_idbConnectionProxy)
+            idbConnectionProxy->setContextSuspended(*scriptExecutionContext(), true);
         break;
     case NotInBackForwardCache:
         if (childNeedsStyleRecalc())
             scheduleStyleRecalc();
-        if (m_idbConnectionProxy)
-            m_idbConnectionProxy->setContextSuspended(*scriptExecutionContext(), false);
+        if (RefPtr idbConnectionProxy = m_idbConnectionProxy)
+            idbConnectionProxy->setContextSuspended(*scriptExecutionContext(), false);
         break;
     case AboutToEnterBackForwardCache:
         break;
@@ -6108,7 +6145,7 @@ void Document::suspend(ReasonForSuspension reason)
     documentWillBecomeInactive();
 
     for (auto& element : m_documentSuspensionCallbackElements)
-        element.prepareForDocumentSuspension();
+        Ref { element }->prepareForDocumentSuspension();
 
 #if ASSERT_ENABLED
     // Clear the update flag to be able to check if the viewport arguments update
@@ -6116,17 +6153,17 @@ void Document::suspend(ReasonForSuspension reason)
     m_didDispatchViewportPropertiesChanged = false;
 #endif
 
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         page->lockAllOverlayScrollbarsToHidden(true);
 
-    if (auto* view = renderView()) {
+    if (CheckedPtr view = renderView()) {
         if (view->usesCompositing())
             view->compositor().cancelCompositingLayerUpdate();
     }
 
 #if ENABLE(WEB_RTC)
-    if (m_rtcNetworkManager)
-        m_rtcNetworkManager->unregisterMDNSNames();
+    if (RefPtr rtcNetworkManager = m_rtcNetworkManager)
+        rtcNetworkManager->unregisterMDNSNames();
 #endif
 
 #if ENABLE(SERVICE_WORKER)
@@ -6155,10 +6192,10 @@ void Document::resume(ReasonForSuspension reason)
     for (auto element : copyToVectorOf<Ref<Element>>(m_documentSuspensionCallbackElements))
         element->resumeFromDocumentSuspension();
 
-    if (renderView())
-        renderView()->setIsInWindow(true);
+    if (CheckedPtr view = renderView())
+        view->setIsInWindow(true);
 
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         page->lockAllOverlayScrollbarsToHidden(false);
 
     ASSERT(m_frame);
@@ -6192,7 +6229,7 @@ void Document::unregisterForDocumentSuspensionCallbacks(Element& element)
 
 bool Document::requiresUserGestureForAudioPlayback() const
 {
-    if (DocumentLoader* loader = this->loader()) {
+    if (RefPtr loader = this->loader()) {
         // If an audio playback policy was set during navigation, use it. If not, use the global settings.
         AutoplayPolicy policy = loader->autoplayPolicy();
         if (policy != AutoplayPolicy::Default)
@@ -6204,7 +6241,7 @@ bool Document::requiresUserGestureForAudioPlayback() const
 
 bool Document::requiresUserGestureForVideoPlayback() const
 {
-    if (DocumentLoader* loader = this->loader()) {
+    if (RefPtr loader = this->loader()) {
         // If a video playback policy was set during navigation, use it. If not, use the global settings.
         AutoplayPolicy policy = loader->autoplayPolicy();
         if (policy != AutoplayPolicy::Default)
@@ -6216,7 +6253,7 @@ bool Document::requiresUserGestureForVideoPlayback() const
 
 bool Document::mediaDataLoadsAutomatically() const
 {
-    if (auto* loader = this->loader()) {
+    if (RefPtr loader = this->loader()) {
         AutoplayPolicy policy = loader->autoplayPolicy();
         if (policy != AutoplayPolicy::Default)
             return policy != AutoplayPolicy::Deny;
@@ -6233,8 +6270,8 @@ void Document::storageBlockingStateDidChange()
 // Used only by WebKitLegacy.
 void Document::privateBrowsingStateDidChange(PAL::SessionID sessionID)
 {
-    if (m_logger)
-        m_logger->setEnabled(this, sessionID.isAlwaysOnLoggingAllowed());
+    if (RefPtr logger = m_logger)
+        logger->setEnabled(this, sessionID.isAlwaysOnLoggingAllowed());
 
 #if ENABLE(VIDEO)
     forEachMediaElement([sessionID] (HTMLMediaElement& element) {
@@ -6247,8 +6284,8 @@ void Document::privateBrowsingStateDidChange(PAL::SessionID sessionID)
 
 void Document::registerForCaptionPreferencesChangedCallbacks(HTMLMediaElement& element)
 {
-    if (page())
-        page()->group().ensureCaptionPreferences().setInterestedInCaptionPreferenceChanges();
+    if (CheckedPtr page = this->page())
+        page->group().ensureCaptionPreferences().setInterestedInCaptionPreferenceChanges();
 
     m_captionPreferencesChangedElements.add(element);
 }
@@ -6262,7 +6299,7 @@ void Document::captionPreferencesChanged()
 {
     ASSERT(!m_captionPreferencesChangedElements.hasNullReferences());
     m_captionPreferencesChangedElements.forEach([](HTMLMediaElement& element) {
-        element.captionPreferencesChanged();
+        Ref { element }->captionPreferencesChanged();
     });
 }
 
@@ -6278,8 +6315,8 @@ void Document::clearMediaElementShowingTextTrack()
 
 void Document::updateTextTrackRepresentationImageIfNeeded()
 {
-    if (m_mediaElementShowingTextTrack)
-        m_mediaElementShowingTextTrack->updateTextTrackRepresentationImageIfNeeded();
+    if (RefPtr mediaElement = m_mediaElementShowingTextTrack.get())
+        mediaElement->updateTextTrackRepresentationImageIfNeeded();
 }
 
 #endif
@@ -6413,7 +6450,7 @@ void Document::applyPendingXSLTransformsTimerFired()
         if (!frame() || frame()->documentIsBeingReplaced())
             return;
 
-        auto processor = XSLTProcessor::create();
+        Ref processor = XSLTProcessor::create();
         processor->setXSLStyleSheet(downcast<XSLStyleSheet>(processingInstruction->sheet()));
         String resultMIMEType;
         String newSource;
@@ -6421,7 +6458,7 @@ void Document::applyPendingXSLTransformsTimerFired()
         if (!processor->transformToString(*this, resultMIMEType, newSource, resultEncoding))
             continue;
         // FIXME: If the transform failed we should probably report an error (like Mozilla does).
-        processor->createDocumentFromSource(newSource, resultEncoding, resultMIMEType, this, frame());
+        processor->createDocumentFromSource(newSource, resultEncoding, resultMIMEType, this, protectedFrame().get());
     }
 }
 
@@ -6577,7 +6614,7 @@ void Document::finishedParsing()
     ASSERT(!scriptableDocumentParser() || m_readyState != ReadyState::Loading);
     setParsing(false);
 
-    Ref<Document> protectedThis(*this);
+    Ref protectedThis { *this };
 
     scriptRunner().documentFinishedParsing();
 
@@ -6589,7 +6626,7 @@ void Document::finishedParsing()
     }
 
     // FIXME: Schedule a task to fire DOMContentLoaded event instead. See webkit.org/b/82931
-    auto* documentLoader = loader();
+    RefPtr documentLoader = loader();
     bool isInMiddleOfInitializingIframe = documentLoader && documentLoader->isInFinishedLoadingOfEmptyDocument();
     if (!isInMiddleOfInitializingIframe)
         eventLoop().performMicrotaskCheckpoint();
@@ -6624,7 +6661,7 @@ void Document::finishedParsing()
         // See https://bugs.webkit.org/show_bug.cgi?id=36864 starting around comment 35.
         updateStyleIfNeeded();
 
-        frame->loader().finishedParsing();
+        frame->checkedLoader()->finishedParsing();
         InspectorInstrumentation::domContentLoadedEventFired(*frame);
     }
 
@@ -6916,12 +6953,12 @@ bool Document::isSecureContext() const
 
 void Document::updateURLForPushOrReplaceState(const URL& url)
 {
-    RefPtr f = frame();
-    if (!f)
+    RefPtr frame = this->frame();
+    if (!frame)
         return;
 
     setURL(url);
-    f->loader().setOutgoingReferrer(url);
+    frame->loader().setOutgoingReferrer(url);
 
     if (RefPtr documentLoader = loader())
         documentLoader->replaceRequestURLForSameDocumentNavigation(url);
@@ -7007,7 +7044,7 @@ void Document::initDNSPrefetch()
     m_isDNSPrefetchEnabled = settings().dnsPrefetchingEnabled() && securityOrigin().protocol() == "http"_s;
 
     // Inherit DNS prefetch opt-out from parent frame
-    if (Document* parent = parentDocument()) {
+    if (RefPtr parent = parentDocument()) {
         if (!parent->isDNSPrefetchEnabled())
             m_isDNSPrefetchEnabled = false;
     }
@@ -7033,7 +7070,7 @@ void Document::getParserLocation(String& completedURL, unsigned& line, unsigned&
     if (!parsing())
         return;
 
-    ScriptableDocumentParser* parser = scriptableDocumentParser();
+    RefPtr parser = scriptableDocumentParser();
     if (!parser)
         return;
 
@@ -7054,7 +7091,7 @@ void Document::addConsoleMessage(std::unique_ptr<Inspector::ConsoleMessage>&& co
         return;
     }
 
-    if (Page* page = this->page())
+    if (CheckedPtr page = this->page())
         page->console().addMessage(WTFMove(consoleMessage));
 }
 
@@ -7065,11 +7102,11 @@ void Document::addConsoleMessage(MessageSource source, MessageLevel level, const
         return;
     }
 
-    if (Page* page = this->page())
+    if (CheckedPtr page = this->page())
         page->console().addMessage(source, level, message, requestIdentifier, this);
 
-    if (m_consoleMessageListener)
-        m_consoleMessageListener->scheduleCallback(*this, message);
+    if (RefPtr consoleMessageListener = m_consoleMessageListener)
+        consoleMessageListener->scheduleCallback(*this, message);
 }
 
 void Document::addMessage(MessageSource source, MessageLevel level, const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber, RefPtr<Inspector::ScriptCallStack>&& callStack, JSC::JSGlobalObject* state, unsigned long requestIdentifier)
@@ -7079,7 +7116,7 @@ void Document::addMessage(MessageSource source, MessageLevel level, const String
         return;
     }
 
-    if (Page* page = this->page())
+    if (CheckedPtr page = this->page())
         page->console().addMessage(source, level, message, sourceURL, lineNumber, columnNumber, WTFMove(callStack), state, requestIdentifier);
 }
 
@@ -7092,7 +7129,7 @@ void Document::postTask(Task&& task)
         if (!document)
             return;
 
-        Page* page = document->page();
+        CheckedPtr page = document->page();
         if ((page && page->defersLoading() && document->activeDOMObjectsAreSuspended()) || !document->m_pendingTasks.isEmpty())
             document->m_pendingTasks.append(WTFMove(task));
         else
@@ -7155,7 +7192,7 @@ void Document::suspendScheduledTasks(ReasonForSuspension reason)
     // It is not currently possible to suspend parser unless loading is deferred, because new data arriving from network
     // will trigger parsing, and leave the scheduler in an inconsistent state where it doesn't know whether it's suspended or not.
     if (reason == ReasonForSuspension::WillDeferLoading && m_parser)
-        m_parser->suspendScheduledTasks();
+        protectedParser()->suspendScheduledTasks();
 
     m_scheduledTasksAreSuspended = true;
 }
@@ -7168,7 +7205,7 @@ void Document::resumeScheduledTasks(ReasonForSuspension reason)
     ASSERT(m_scheduledTasksAreSuspended);
 
     if (reason == ReasonForSuspension::WillDeferLoading && m_parser)
-        m_parser->resumeScheduledTasks();
+        protectedParser()->resumeScheduledTasks();
 
 #if ENABLE(XSLT)
     if (m_hasPendingXSLTransforms)
@@ -7186,20 +7223,21 @@ void Document::resumeScheduledTasks(ReasonForSuspension reason)
 
 void Document::suspendScriptedAnimationControllerCallbacks()
 {
-    if (m_scriptedAnimationController)
-        m_scriptedAnimationController->suspend();
+    if (RefPtr scriptedAnimationController = m_scriptedAnimationController)
+        scriptedAnimationController->suspend();
 }
 
 void Document::resumeScriptedAnimationControllerCallbacks()
 {
-    if (m_scriptedAnimationController)
-        m_scriptedAnimationController->resume();
+    if (RefPtr scriptedAnimationController = m_scriptedAnimationController)
+        scriptedAnimationController->resume();
 }
 
 void Document::serviceRequestAnimationFrameCallbacks()
 {
-    if (m_scriptedAnimationController && domWindow())
-        m_scriptedAnimationController->serviceRequestAnimationFrameCallbacks(domWindow()->frozenNowTimestamp());
+    RefPtr scriptedAnimationController = m_scriptedAnimationController;
+    if (scriptedAnimationController && domWindow())
+        scriptedAnimationController->serviceRequestAnimationFrameCallbacks(domWindow()->frozenNowTimestamp());
 }
 
 void Document::serviceCaretAnimation()
@@ -7218,17 +7256,17 @@ void Document::serviceRequestVideoFrameCallbacks()
         if (!is<HTMLVideoElement>(element))
             return;
 
-        auto& videoElement = downcast<HTMLVideoElement>(element);
-        if (videoElement.shouldServiceRequestVideoFrameCallbacks()) {
+        Ref videoElement = downcast<HTMLVideoElement>(element);
+        if (videoElement->shouldServiceRequestVideoFrameCallbacks()) {
             isServicingRequestVideoFrameCallbacks = true;
-            videoElement.serviceRequestVideoFrameCallbacks(now);
+            videoElement->serviceRequestVideoFrameCallbacks(now);
         }
     });
 
     if (!isServicingRequestVideoFrameCallbacks)
         return;
 
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::VideoFrameCallbacks);
 #endif
 }
@@ -7341,7 +7379,7 @@ void Document::simulateDeviceOrientationChange(double alpha, double beta, double
 
 void Document::exitPointerLock()
 {
-    Page* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return;
     if (auto* target = page->pointerLockController().element()) {
@@ -7368,21 +7406,21 @@ void Document::loadEventDelayTimerFired()
     // FIXME: Should this also call DocumentLoader::checkLoadComplete?
     // FIXME: Not obvious why checkCompleted needs to go first. The order these are called is
     // visible to WebKit clients, but it's more like a race than a well-defined relationship.
-    Ref<Document> protectedThis(*this);
+    Ref protectedThis { *this };
     checkCompleted();
     if (RefPtr frame = this->frame())
-        frame->loader().checkLoadComplete();
+        frame->checkedLoader()->checkLoadComplete();
 }
 
 void Document::checkCompleted()
 {
     if (RefPtr frame = this->frame())
-        frame->loader().checkCompleted();
+        frame->checkedLoader()->checkCompleted();
 }
 
 double Document::monotonicTimestamp() const
 {
-    auto* loader = this->loader();
+    RefPtr loader = this->loader();
     if (!loader)
         return 0.0;
     return (MonotonicTime::now() - loader->timing().startTime()).seconds();
@@ -7416,9 +7454,8 @@ void Document::cancelAnimationFrame(int id)
 void Document::clearScriptedAnimationController()
 {
     // FIXME: consider using ActiveDOMObject.
-    if (m_scriptedAnimationController)
-        m_scriptedAnimationController->clearDocumentPointer();
-    m_scriptedAnimationController = nullptr;
+    if (RefPtr scriptedAnimationController = std::exchange(m_scriptedAnimationController, nullptr))
+        scriptedAnimationController->clearDocumentPointer();
 }
 
 int Document::requestIdleCallback(Ref<IdleRequestCallback>&& callback, Seconds timeout)
@@ -7446,22 +7483,23 @@ HttpEquivPolicy Document::httpEquivPolicy() const
 
 void Document::wheelEventHandlersChanged(Node* node)
 {
-    Page* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return;
 
     if (RefPtr frameView = view()) {
-        if (ScrollingCoordinator* scrollingCoordinator = page->scrollingCoordinator())
+        if (RefPtr scrollingCoordinator = page->scrollingCoordinator())
             scrollingCoordinator->frameViewEventTrackingRegionsChanged(*frameView);
     }
 
 #if ENABLE(WHEEL_EVENT_REGIONS)
+    // Unable to ref the element as its deletion may have started.
     if (auto* element = dynamicDowncast<Element>(node)) {
         // Style is affected via eventListenerRegionTypes().
         element->invalidateStyle();
     }
 
-    m_frame->invalidateContentEventRegionsIfNeeded(LocalFrame::InvalidateContentEventRegionsReason::EventHandlerChange);
+    protectedFrame()->invalidateContentEventRegionsIfNeeded(LocalFrame::InvalidateContentEventRegionsReason::EventHandlerChange);
 #else
     UNUSED_PARAM(node);
 #endif
@@ -7558,14 +7596,14 @@ void Document::didRemoveEventTargetNode(Node& handler)
     if (m_touchEventTargets) {
         m_touchEventTargets->removeAll(&handler);
         if ((&handler == this || m_touchEventTargets->isEmpty()) && parentDocument())
-            parentDocument()->didRemoveEventTargetNode(*this);
+            protectedParentDocument()->didRemoveEventTargetNode(*this);
     }
 #endif
 
     if (m_wheelEventTargets) {
         m_wheelEventTargets->removeAll(&handler);
         if ((&handler == this || m_wheelEventTargets->isEmpty()) && parentDocument())
-            parentDocument()->didRemoveEventTargetNode(*this);
+            protectedParentDocument()->didRemoveEventTargetNode(*this);
     }
 }
 
@@ -7588,7 +7626,7 @@ unsigned Document::touchEventHandlerCount() const
 void Document::didAddOrRemoveMouseEventHandler(Node& node)
 {
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if (auto* element = dynamicDowncast<Element>(node)) {
+    if (RefPtr element = dynamicDowncast<Element>(node)) {
         // Style is affected via eventListenerRegionTypes().
         element->invalidateStyle();
     }
@@ -7674,7 +7712,7 @@ void Document::updateLastHandledUserGestureTimestamp(MonotonicTime time)
     didChangeTimerAlignmentInterval();
 
     if (RefPtr element = ownerElement())
-        element->document().updateLastHandledUserGestureTimestamp(time);
+        element->protectedDocument()->updateLastHandledUserGestureTimestamp(time);
 }
 
 bool Document::processingUserGestureForMedia() const
@@ -7691,7 +7729,7 @@ bool Document::processingUserGestureForMedia() const
     if (settings().mediaUserGestureInheritsFromDocument())
         return topDocument().hasHadUserInteraction();
 
-    auto* loader = this->loader();
+    RefPtr loader = this->loader();
     if (loader && loader->allowedAutoplayQuirks().contains(AutoplayQuirk::InheritedUserGestures))
         return topDocument().hasHadUserInteraction();
 
@@ -7744,7 +7782,7 @@ bool Document::allowsContentJavaScript() const
         return !m_contextDocument || m_contextDocument->allowsContentJavaScript();
     }
 
-    return m_frame->loader().client().allowsContentJavaScriptFromMostRecentNavigation() == AllowsContentJavaScript::Yes;
+    return protectedFrame()->loader().client().allowsContentJavaScriptFromMostRecentNavigation() == AllowsContentJavaScript::Yes;
 }
 
 Element* eventTargetElementForDocument(Document* document)
@@ -7763,12 +7801,12 @@ Element* eventTargetElementForDocument(Document* document)
 
 void Document::convertAbsoluteToClientQuads(Vector<FloatQuad>& quads, const RenderStyle& style)
 {
-    if (!view())
+    RefPtr frameView = view();
+    if (!frameView)
         return;
 
-    const auto& frameView = *view();
-    float inverseFrameScale = frameView.absoluteToDocumentScaleFactor(style.effectiveZoom());
-    auto documentToClientOffset = frameView.documentToClientOffset();
+    float inverseFrameScale = frameView->absoluteToDocumentScaleFactor(style.effectiveZoom());
+    auto documentToClientOffset = frameView->documentToClientOffset();
 
     for (auto& quad : quads) {
         if (inverseFrameScale != 1)
@@ -7780,12 +7818,12 @@ void Document::convertAbsoluteToClientQuads(Vector<FloatQuad>& quads, const Rend
 
 void Document::convertAbsoluteToClientRects(Vector<FloatRect>& rects, const RenderStyle& style)
 {
-    if (!view())
+    RefPtr frameView = view();
+    if (!frameView)
         return;
 
-    auto& frameView = *view();
-    float inverseFrameScale = frameView.absoluteToDocumentScaleFactor(style.effectiveZoom());
-    auto documentToClientOffset = frameView.documentToClientOffset();
+    float inverseFrameScale = frameView->absoluteToDocumentScaleFactor(style.effectiveZoom());
+    auto documentToClientOffset = frameView->documentToClientOffset();
 
     for (auto& rect : rects) {
         if (inverseFrameScale != 1)
@@ -7797,12 +7835,12 @@ void Document::convertAbsoluteToClientRects(Vector<FloatRect>& rects, const Rend
 
 void Document::convertAbsoluteToClientRect(FloatRect& rect, const RenderStyle& style)
 {
-    if (!view())
+    RefPtr frameView = view();
+    if (!frameView)
         return;
 
-    const auto& frameView = *view();
-    rect = frameView.absoluteToDocumentRect(rect, style.effectiveZoom());
-    rect = frameView.documentToClientRect(rect);
+    rect = frameView->absoluteToDocumentRect(rect, style.effectiveZoom());
+    rect = frameView->documentToClientRect(rect);
 }
 
 bool Document::hasActiveParser()
@@ -7813,13 +7851,14 @@ bool Document::hasActiveParser()
 void Document::decrementActiveParserCount()
 {
     --m_activeParserCount;
-    if (!frame())
+    RefPtr frame = this->frame();
+    if (!frame)
         return;
 
     // FIXME: We should call DocumentLoader::checkLoadComplete as well here,
     // but it seems to cause http/tests/security/feed-urls-from-remote.html
     // to timeout on Mac WK1; see http://webkit.org/b/110554 and http://webkit.org/b/110401.
-    frame()->loader().checkLoadComplete();
+    frame->checkedLoader()->checkLoadComplete();
 }
 
 DocumentParserYieldToken::DocumentParserYieldToken(Document& document)
@@ -7842,7 +7881,7 @@ DocumentParserYieldToken::~DocumentParserYieldToken()
     if (--m_document->m_parserYieldTokenCount)
         return;
 
-    m_document->scriptRunner().didEndYieldingParser();
+    Ref { *m_document }->scriptRunner().didEndYieldingParser();
     if (RefPtr parser = m_document->parser())
         parser->didEndYieldingParser();
 }
@@ -7855,12 +7894,12 @@ static Element* findNearestCommonComposedAncestor(Element* elementA, Element* el
     if (elementA == elementB)
         return elementA;
 
-    HashSet<Element*> ancestorChain;
+    HashSet<CheckedRef<Element>> ancestorChain;
     for (auto* element = elementA; element; element = element->parentElementInComposedTree())
-        ancestorChain.add(element);
+        ancestorChain.add(*element);
 
     for (auto* element = elementB; element; element = element->parentElementInComposedTree()) {
-        if (ancestorChain.contains(element))
+        if (ancestorChain.contains(*element))
             return element;
     }
     return nullptr;
@@ -7894,7 +7933,7 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
         if (!oldActiveElement && newActiveElement && request.active() && !request.touchMove()) {
             // We are setting the :active chain and freezing it. If future moves happen, they
             // will need to reference this chain.
-            for (RenderElement* curr = newActiveElement->renderer(); curr; curr = curr->parent()) {
+            for (CheckedPtr curr = newActiveElement->renderer(); curr; curr = curr->parent()) {
                 RefPtr element = curr->element();
                 if (!element || curr->isTextOrLineBreak())
                     continue;
@@ -7913,7 +7952,7 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
     // at the time the mouse went down, unless the capture element changed.
     bool mustBeInActiveChain = request.active() && request.move() && captureElementChanged == CaptureChange::No;
 
-    RefPtr<Element> oldHoveredElement = WTFMove(m_hoveredElement);
+    RefPtr oldHoveredElement = WTFMove(m_hoveredElement);
 
     // A touch release does not set a new hover target; clearing the element we're working with
     // will clear the chain of hovered elements all the way to the top of the tree.
@@ -8009,13 +8048,14 @@ Document& Document::ensureTemplateDocument()
     if (const Document* document = templateDocument())
         return const_cast<Document&>(*document);
 
-    if (isHTMLDocument())
-        m_templateDocument = HTMLDocument::create(nullptr, m_settings, aboutBlankURL(), { });
-    else
-        m_templateDocument = create(m_settings, aboutBlankURL());
-
-    m_templateDocument->setContextDocument(contextDocument());
-    m_templateDocument->setTemplateDocumentHost(this); // balanced in dtor.
+    Ref templateDocument = [&]() -> Ref<Document> {
+        if (isHTMLDocument())
+            return HTMLDocument::create(nullptr, m_settings, aboutBlankURL(), { });
+        return create(m_settings, aboutBlankURL());
+    }();
+    m_templateDocument = templateDocument.copyRef();
+    templateDocument->setContextDocument(contextDocument());
+    templateDocument->setTemplateDocumentHost(this); // balanced in dtor.
 
     return *m_templateDocument;
 }
@@ -8026,7 +8066,7 @@ Ref<DocumentFragment> Document::documentFragmentForInnerOuterHTML()
         m_documentFragmentForInnerOuterHTML = DocumentFragment::create(*this);
         m_documentFragmentForInnerOuterHTML->setIsDocumentFragmentForInnerOuterHTML();
     } else if (UNLIKELY(m_documentFragmentForInnerOuterHTML->hasChildNodes()))
-        m_documentFragmentForInnerOuterHTML->removeChildren();
+        Ref { *m_documentFragmentForInnerOuterHTML }->removeChildren();
     return *m_documentFragmentForInnerOuterHTML;
 }
 
@@ -8043,14 +8083,14 @@ EditingBehavior Document::editingBehavior() const
 float Document::deviceScaleFactor() const
 {
     float deviceScaleFactor = 1.0;
-    if (Page* documentPage = page())
+    if (CheckedPtr documentPage = page())
         deviceScaleFactor = documentPage->deviceScaleFactor();
     return deviceScaleFactor;
 }
 
 bool Document::useSystemAppearance() const
 {
-    if (auto* documentPage = page())
+    if (CheckedPtr documentPage = page())
         return documentPage->useSystemAppearance();
     return false;
 }
@@ -8075,7 +8115,7 @@ bool Document::useDarkAppearance(const RenderStyle* style) const
 #endif
 
     bool pageUsesDarkAppearance = false;
-    if (Page* documentPage = page())
+    if (CheckedPtr documentPage = page())
         pageUsesDarkAppearance = documentPage->useDarkAppearance();
 
     if (useSystemAppearance())
@@ -8091,7 +8131,7 @@ bool Document::useDarkAppearance(const RenderStyle* style) const
 
 bool Document::useElevatedUserInterfaceLevel() const
 {
-    if (auto* documentPage = page())
+    if (CheckedPtr documentPage = page())
         return documentPage->useElevatedUserInterfaceLevel();
     return false;
 }
@@ -8113,7 +8153,7 @@ CompositeOperator Document::compositeOperatorForBackgroundColor(const Color& col
     if (LIKELY(!settings().punchOutWhiteBackgroundsInDarkMode() || !Color::isWhiteColor(color) || !renderer.useDarkAppearance()))
         return CompositeOperator::SourceOver;
 
-    auto* frameView = view();
+    RefPtr frameView = view();
     if (!frameView)
         return CompositeOperator::SourceOver;
 
@@ -8124,7 +8164,7 @@ CompositeOperator Document::compositeOperatorForBackgroundColor(const Color& col
 
 void Document::didAssociateFormControl(Element& element)
 {
-    auto* page = this->page();
+    CheckedPtr page = this->page();
     if (!page || !page->chrome().client().shouldNotifyOnFormChanges())
         return;
 
@@ -8141,9 +8181,9 @@ void Document::didAssociateFormControlsTimerFired()
         return std::nullopt;
     });
 
-    if (auto page = this->page(); page && !controls.isEmpty()) {
+    if (CheckedPtr page = this->page(); page && !controls.isEmpty()) {
         ASSERT(m_frame);
-        page->chrome().client().didAssociateFormControls(controls, *m_frame);
+        page->chrome().client().didAssociateFormControls(controls, protectedFrame().releaseNonNull());
     }
 }
 
@@ -8167,7 +8207,7 @@ void Document::didLoadResourceSynchronously(const URL& url)
     // in this case, to be safe.
     invalidateDOMCookieCache();
 
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         page->cookieJar().clearCacheForHost(url.host().toString());
 }
 
@@ -8176,7 +8216,8 @@ void Document::ensurePlugInsInjectedScript(DOMWrapperWorld& world)
     if (m_hasInjectedPlugInsScript)
         return;
 
-    auto& scriptController = frame()->script();
+    RefPtr frame = this->frame();
+    auto& scriptController = frame->script();
 
     // Use the JS file provided by the Chrome client, or fallback to the default one.
     String jsString = page()->chrome().client().plugInExtraScript();
@@ -8192,18 +8233,14 @@ void Document::ensurePlugInsInjectedScript(DOMWrapperWorld& world)
 
 bool Document::wrapCryptoKey(const Vector<uint8_t>& key, Vector<uint8_t>& wrappedKey)
 {
-    Page* page = this->page();
-    if (!page)
-        return false;
-    return page->chrome().client().wrapCryptoKey(key, wrappedKey);
+    CheckedPtr page = this->page();
+    return page && page->chrome().client().wrapCryptoKey(key, wrappedKey);
 }
 
 bool Document::unwrapCryptoKey(const Vector<uint8_t>& wrappedKey, Vector<uint8_t>& key)
 {
-    Page* page = this->page();
-    if (!page)
-        return false;
-    return page->chrome().client().unwrapCryptoKey(wrappedKey, key);
+    CheckedPtr page = this->page();
+    return page && page->chrome().client().unwrapCryptoKey(wrappedKey, key);
 }
 
 #endif // ENABLE(WEB_CRYPTO)
@@ -8217,10 +8254,10 @@ Element* Document::activeElement()
 
 bool Document::hasFocus() const
 {
-    Page* page = this->page();
+    CheckedPtr page = this->page();
     if (!page || !page->focusController().isActive() || !page->focusController().isFocused())
         return false;
-    if (auto* focusedFrame = page->focusController().focusedFrame()) {
+    if (RefPtr focusedFrame = page->focusController().focusedFrame()) {
         if (focusedFrame->tree().isDescendantOf(frame()))
             return true;
     }
@@ -8231,7 +8268,7 @@ bool Document::hasFocus() const
 
 void Document::addPlaybackTargetPickerClient(MediaPlaybackTargetClient& client)
 {
-    Page* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return;
 
@@ -8255,15 +8292,13 @@ void Document::removePlaybackTargetPickerClient(MediaPlaybackTargetClient& clien
     m_idToClientMap.remove(clientId);
     m_clientToIDMap.remove(it);
 
-    Page* page = this->page();
-    if (!page)
-        return;
-    page->removePlaybackTargetPickerClient(clientId);
+    if (CheckedPtr page = this->page())
+        page->removePlaybackTargetPickerClient(clientId);
 }
 
 void Document::showPlaybackTargetPicker(MediaPlaybackTargetClient& client, bool isVideo, RouteSharingPolicy routeSharingPolicy, const String& routingContextUID)
 {
-    Page* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return;
 
@@ -8281,7 +8316,7 @@ void Document::showPlaybackTargetPicker(MediaPlaybackTargetClient& client, bool 
 
 void Document::playbackTargetPickerClientStateDidChange(MediaPlaybackTargetClient& client, MediaProducerMediaStateFlags state)
 {
-    Page* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return;
 
@@ -8332,7 +8367,7 @@ void Document::playbackTargetPickerWasDismissed(PlaybackTargetClientContextIdent
 
 ShouldOpenExternalURLsPolicy Document::shouldOpenExternalURLsPolicyToPropagate() const
 {
-    if (DocumentLoader* documentLoader = loader())
+    if (RefPtr documentLoader = loader())
         return documentLoader->shouldOpenExternalURLsPolicyToPropagate();
 
     return ShouldOpenExternalURLsPolicy::ShouldNotAllow;
@@ -8342,7 +8377,7 @@ bool Document::shouldEnforceHTTP09Sandbox() const
 {
     if (m_isSynthesized || !m_frame)
         return false;
-    DocumentLoader* documentLoader = m_frame->loader().activeDocumentLoader();
+    RefPtr documentLoader = m_frame->loader().activeDocumentLoader();
     return documentLoader && documentLoader->response().isHTTP09();
 }
 
@@ -8352,15 +8387,15 @@ bool Document::shouldEnforceQuickLookSandbox() const
 {
     if (m_isSynthesized || !m_frame)
         return false;
-    DocumentLoader* documentLoader = m_frame->loader().activeDocumentLoader();
+    RefPtr documentLoader = m_frame->loader().activeDocumentLoader();
     return documentLoader && documentLoader->response().isQuickLook();
 }
 
 void Document::applyQuickLookSandbox()
 {
-    auto& documentLoader = *m_frame->loader().activeDocumentLoader();
-    auto documentURL = documentLoader.documentURL();
-    auto& responseURL = documentLoader.responseURL();
+    Ref documentLoader = *m_frame->loader().activeDocumentLoader();
+    auto documentURL = documentLoader->documentURL();
+    auto& responseURL = documentLoader->responseURL();
     ASSERT(!documentURL.protocolIs(QLPreviewProtocol));
     ASSERT(responseURL.protocolIs(QLPreviewProtocol));
 
@@ -8388,7 +8423,7 @@ bool Document::shouldEnforceContentDispositionAttachmentSandbox() const
     if (m_isSynthesized)
         return false;
 
-    if (auto* documentLoader = m_frame ? m_frame->loader().activeDocumentLoader() : nullptr)
+    if (RefPtr documentLoader = m_frame ? m_frame->loader().activeDocumentLoader() : nullptr)
         return documentLoader->response().isAttachment();
     return false;
 }
@@ -8425,7 +8460,7 @@ void Document::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedS
         m_intersectionObserversInitialUpdateTimer.stop();
         requestedSteps.add(RenderingUpdateStep::IntersectionObservations);
     }
-    if (auto page = this->page())
+    if (CheckedPtr page = this->page())
         page->scheduleRenderingUpdate(requestedSteps);
 }
 
@@ -8468,8 +8503,8 @@ void Document::updateIntersectionObservations(const Vector<WeakPtr<IntersectionO
             intersectionObserversWithPendingNotifications.append(observer);
     }
 
-    for (const auto& observer : intersectionObserversWithPendingNotifications) {
-        if (observer)
+    for (auto& weakObserver : intersectionObserversWithPendingNotifications) {
+        if (RefPtr observer = weakObserver.get())
             observer->notify();
     }
 }
@@ -8509,8 +8544,9 @@ size_t Document::gatherResizeObservations(size_t deeperThan)
 {
     LOG_WITH_STREAM(ResizeObserver, stream << "Document " << *this << " gatherResizeObservations");
     size_t minDepth = ResizeObserver::maxElementDepth();
-    for (const auto& observer : m_resizeObservers) {
-        if (!observer->hasObservations())
+    for (auto& weakObserver : m_resizeObservers) {
+        RefPtr observer = weakObserver.get();
+        if (!observer || !observer->hasObservations())
             continue;
         auto depth = observer->gatherObservations(deeperThan);
         minDepth = std::min(minDepth, depth);
@@ -8534,7 +8570,8 @@ void Document::deliverResizeObservations()
         m_resizeObserverForContainIntrinsicSize->deliverObservations();
 
     auto observersToNotify = m_resizeObservers;
-    for (const auto& observer : observersToNotify) {
+    for (auto& weakObserver : observersToNotify) {
+        RefPtr observer = weakObserver.get();
         if (!observer || !observer->hasActiveObservations())
             continue;
         observer->deliverObservations();
@@ -8552,8 +8589,8 @@ bool Document::hasSkippedResizeObservations() const
 
 void Document::setHasSkippedResizeObservations(bool skipped)
 {
-    for (const auto& observer : m_resizeObservers)
-        observer->setHasSkippedObservations(skipped);
+    for (auto& observer : m_resizeObservers)
+        Ref { *observer }->setHasSkippedObservations(skipped);
 }
 
 void Document::updateResizeObservations(Page& page)
@@ -8602,7 +8639,7 @@ const AtomString& Document::dir() const
 
 void Document::setDir(const AtomString& value)
 {
-    auto* documentElement = this->documentElement();
+    RefPtr documentElement = this->documentElement();
     if (is<HTMLHtmlElement>(documentElement))
         downcast<HTMLHtmlElement>(*documentElement).setDir(value);
 }
@@ -8670,9 +8707,7 @@ void Document::setBgColor(const AtomString& value)
 const AtomString& Document::fgColor() const
 {
     RefPtr bodyElement = body();
-    if (!bodyElement)
-        return emptyAtom();
-    return bodyElement->attributeWithoutSynchronization(textAttr);
+    return bodyElement ? bodyElement->attributeWithoutSynchronization(textAttr) : emptyAtom();
 }
 
 void Document::setFgColor(const AtomString& value)
@@ -8684,9 +8719,7 @@ void Document::setFgColor(const AtomString& value)
 const AtomString& Document::alinkColor() const
 {
     RefPtr bodyElement = body();
-    if (!bodyElement)
-        return emptyAtom();
-    return bodyElement->attributeWithoutSynchronization(alinkAttr);
+    return bodyElement ? bodyElement->attributeWithoutSynchronization(alinkAttr) : emptyAtom();
 }
 
 void Document::setAlinkColor(const AtomString& value)
@@ -8698,9 +8731,7 @@ void Document::setAlinkColor(const AtomString& value)
 const AtomString& Document::linkColorForBindings() const
 {
     RefPtr bodyElement = body();
-    if (!bodyElement)
-        return emptyAtom();
-    return bodyElement->attributeWithoutSynchronization(linkAttr);
+    return bodyElement ? bodyElement->attributeWithoutSynchronization(linkAttr) : emptyAtom();
 }
 
 void Document::setLinkColorForBindings(const AtomString& value)
@@ -8712,9 +8743,7 @@ void Document::setLinkColorForBindings(const AtomString& value)
 const AtomString& Document::vlinkColor() const
 {
     RefPtr bodyElement = body();
-    if (!bodyElement)
-        return emptyAtom();
-    return bodyElement->attributeWithoutSynchronization(vlinkAttr);
+    return bodyElement ? bodyElement->attributeWithoutSynchronization(vlinkAttr) : emptyAtom();
 }
 
 void Document::setVlinkColor(const AtomString& value)
@@ -8726,10 +8755,11 @@ void Document::setVlinkColor(const AtomString& value)
 Logger& Document::logger()
 {
     if (!m_logger) {
-        m_logger = Logger::create(this);
-        auto* page = this->page();
-        m_logger->setEnabled(this, page && page->sessionID().isAlwaysOnLoggingAllowed());
-        m_logger->addObserver(*this);
+        Ref logger = Logger::create(this);
+        m_logger = logger.copyRef();
+        CheckedPtr page = this->page();
+        logger->setEnabled(this, page && page->sessionID().isAlwaysOnLoggingAllowed());
+        logger->addObserver(*this);
     }
 
     return *m_logger;
@@ -8862,7 +8892,7 @@ DocumentTimelinesController& Document::ensureTimelinesController()
 
 void Document::updateAnimationsAndSendEvents()
 {
-    auto domWindow = this->domWindow();
+    RefPtr domWindow = this->domWindow();
     if (!domWindow)
         return;
 
@@ -8900,7 +8930,7 @@ Vector<RefPtr<WebAnimation>> Document::matchingAnimations(const Function<bool(El
     // such as updates to CSS Animations and CSS Transitions. This requires updating layout as
     // well since resolving layout-dependent media queries could yield animations.
     if (RefPtr owner = ownerElement())
-        owner->document().updateLayout();
+        owner->protectedDocument()->updateLayout();
     updateStyleIfNeeded();
 
     Vector<RefPtr<WebAnimation>> animations;
@@ -9017,7 +9047,7 @@ void Document::hideAllPopoversUntil(HTMLElement* endpoint, FocusPreviousElement 
         if (!foundEndPoint)
             return closeAllOpenPopovers();
         while (lastToHide && lastToHide->isPopoverShowing()) {
-            auto* topmostAutoPopover = this->topmostAutoPopover();
+            RefPtr topmostAutoPopover = this->topmostAutoPopover();
             if (!topmostAutoPopover)
                 break;
             topmostAutoPopover->hidePopoverInternal(focusPreviousElement, fireEvents);
@@ -9038,20 +9068,20 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
         return;
 
     RefPtr popoverToAvoidHiding = [&]() -> HTMLElement* {
-        auto* startElement = is<Element>(target) ? &downcast<Element>(target) : target.parentElement();
+        RefPtr startElement = is<Element>(target) ? &downcast<Element>(target) : target.parentElement();
         auto [clickedPopover, invokerPopover] = [&]() {
             RefPtr<HTMLElement> clickedPopover;
             RefPtr<HTMLElement> invokerPopover;
             auto isShowingAutoPopover = [](HTMLElement& element) -> bool {
                 return element.popoverState() == PopoverState::Auto && element.popoverData()->visibilityState() == PopoverVisibilityState::Showing;
             };
-            for (RefPtr element = startElement; element; element = element->parentElementInComposedTree()) {
-                if (auto* htmlElement = dynamicDowncast<HTMLElement>(element.get())) {
+            for (RefPtr element = WTFMove(startElement); element; element = element->parentElementInComposedTree()) {
+                if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(*element)) {
                     if (!clickedPopover && isShowingAutoPopover(*htmlElement))
                         clickedPopover = htmlElement;
 
                     if (!invokerPopover) {
-                        if (auto* button = dynamicDowncast<HTMLFormControlElement>(*htmlElement)) {
+                        if (RefPtr button = dynamicDowncast<HTMLFormControlElement>(*htmlElement)) {
                             if (RefPtr popover = button->popoverTargetElement(); popover && isShowingAutoPopover(*popover))
                                 invokerPopover = WTFMove(popover);
                         }
@@ -9190,7 +9220,7 @@ void Document::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Ve
         });
         return;
     }
-    auto* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return;
 
@@ -9201,36 +9231,38 @@ void Document::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Ve
         return;
 
     eventLoop().queueTask(TaskSource::InternalAsyncTask, [weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }, level, messageSource, logMessages = WTFMove(logMessages)]() mutable {
-        if (!weakThis || !weakThis->page())
+        RefPtr document = weakThis.get();
+        if (!document || !document->page())
             return;
 
         auto messageLevel = messageLevelFromWTFLogLevel(level);
-        auto* globalObject = mainWorldGlobalObject(weakThis->frame());
+        auto* globalObject = mainWorldGlobalObject(document->frame());
         auto message = makeUnique<Inspector::ConsoleMessage>(messageSource, MessageType::Log, messageLevel, WTFMove(logMessages), globalObject);
-        weakThis->addConsoleMessage(WTFMove(message));
+        document->addConsoleMessage(WTFMove(message));
     });
 }
 
 #if ENABLE(SERVICE_WORKER)
-void Document::setServiceWorkerConnection(SWClientConnection* serviceWorkerConnection)
+void Document::setServiceWorkerConnection(RefPtr<SWClientConnection>&& serviceWorkerConnection)
 {
     if (m_serviceWorkerConnection == serviceWorkerConnection || m_hasPreparedForDestruction || m_isSuspended)
         return;
 
-    if (m_serviceWorkerConnection)
-        m_serviceWorkerConnection->unregisterServiceWorkerClient(identifier());
+    if (RefPtr oldServiceWorkerConnection = m_serviceWorkerConnection)
+        oldServiceWorkerConnection->unregisterServiceWorkerClient(identifier());
 
-    m_serviceWorkerConnection = serviceWorkerConnection;
+    m_serviceWorkerConnection = WTFMove(serviceWorkerConnection);
     updateServiceWorkerClientData();
 }
 
 void Document::updateServiceWorkerClientData()
 {
-    if (!m_serviceWorkerConnection)
+    RefPtr serviceWorkerConnection = m_serviceWorkerConnection;
+    if (!serviceWorkerConnection)
         return;
 
     auto controllingServiceWorkerRegistrationIdentifier = activeServiceWorker() ? std::make_optional<ServiceWorkerRegistrationIdentifier>(activeServiceWorker()->registrationIdentifier()) : std::nullopt;
-    m_serviceWorkerConnection->registerServiceWorkerClient(clientOrigin(), ServiceWorkerClientData::from(*this), controllingServiceWorkerRegistrationIdentifier, userAgent(url()));
+    serviceWorkerConnection->registerServiceWorkerClient(clientOrigin(), ServiceWorkerClientData::from(*this), controllingServiceWorkerRegistrationIdentifier, userAgent(url()));
 }
 
 void Document::navigateFromServiceWorker(const URL& url, CompletionHandler<void(bool)>&& callback)
@@ -9240,7 +9272,7 @@ void Document::navigateFromServiceWorker(const URL& url, CompletionHandler<void(
         return;
     }
     eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr<Document, WeakPtrImplWithEventTargetData> { *this }, url, callback = WTFMove(callback)]() mutable {
-        auto* frame = weakThis ? weakThis->frame() : nullptr;
+        RefPtr frame = weakThis ? weakThis->frame() : nullptr;
         if (!frame) {
             callback(false);
             return;
@@ -9289,7 +9321,7 @@ void Document::frameWasDisconnectedFromOwner()
     if (!frame())
         return;
 
-    if (auto* window = domWindow())
+    if (RefPtr window = domWindow())
         window->willDetachDocumentFromFrame();
 
     detachFromFrame();
@@ -9302,18 +9334,17 @@ bool Document::hitTest(const HitTestRequest& request, HitTestResult& result)
 
 bool Document::hitTest(const HitTestRequest& request, const HitTestLocation& location, HitTestResult& result)
 {
-    Ref<Document> protectedThis(*this);
+    Ref protectedThis { *this };
 
     if (!renderView())
         return false;
 
-    auto& frameView = renderView()->frameView();
-    Ref<FrameView> protector(frameView);
+    Ref frameView = renderView()->frameView();
 
     // If hit testing can descend into child frames, then we should make sure those frames have an updated layout
     // before proceeding
     if (request.allowsAnyFrameContent())
-        frameView.updateLayoutAndStyleIfNeededRecursive();
+        frameView->updateLayoutAndStyleIfNeededRecursive();
     else
         updateLayout();
 
@@ -9329,9 +9360,9 @@ bool Document::hitTest(const HitTestRequest& request, const HitTestLocation& loc
     if (!resultLayer || ScrollbarTheme::theme().usesOverlayScrollbars()) {
         // FIXME: Consider if this test should be done unconditionally.
         if (request.allowsFrameScrollbars()) {
-            IntPoint windowPoint = frameView.contentsToWindow(location.roundedPoint());
-            if (auto* frameScrollbar = frameView.scrollbarAtPoint(windowPoint)) {
-                result.setScrollbar(frameScrollbar);
+            IntPoint windowPoint = frameView->contentsToWindow(location.roundedPoint());
+            if (RefPtr frameScrollbar = frameView->scrollbarAtPoint(windowPoint)) {
+                result.setScrollbar(WTFMove(frameScrollbar));
                 return true;
             }
         }
@@ -9400,11 +9431,11 @@ bool Document::isRunningUserScripts() const
 
 void Document::setAsRunningUserScripts()
 {
-    auto& top = topDocument();
-    if (this == &top)
+    Ref top = topDocument();
+    if (this == top.ptr())
         m_isRunningUserScripts = true;
     else
-        top.setAsRunningUserScripts();
+        top->setAsRunningUserScripts();
 }
 
 void Document::didRejectSyncXHRDuringPageDismissal()
@@ -9454,7 +9485,7 @@ HTMLVideoElement* Document::pictureInPictureElement() const
 
 void Document::setPictureInPictureElement(HTMLVideoElement* element)
 {
-    auto* oldElement = m_pictureInPictureElement.get();
+    RefPtr oldElement = m_pictureInPictureElement.get();
     if (oldElement == element)
         return;
 
@@ -9580,11 +9611,11 @@ void Document::whenVisible(Function<void()>&& callback)
 NotificationClient* Document::notificationClient()
 {
 #if ENABLE(NOTIFICATIONS)
-    auto* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return nullptr;
 
-    return &NotificationController::from(page)->client();
+    return &NotificationController::from(page.get())->client();
 #else
     return nullptr;
 #endif
@@ -9592,7 +9623,7 @@ NotificationClient* Document::notificationClient()
 
 GraphicsClient* Document::graphicsClient()
 {
-    auto* page = this->page();
+    CheckedPtr page = this->page();
     if (!page)
         return nullptr;
     return &page->chrome();
@@ -9600,7 +9631,7 @@ GraphicsClient* Document::graphicsClient()
 
 std::optional<PAL::SessionID> Document::sessionID() const
 {
-    if (auto* page = this->page())
+    if (CheckedPtr page = this->page())
         return page->sessionID();
 
     return std::nullopt;
@@ -9675,27 +9706,25 @@ RefPtr<ResizeObserver> Document::ensureResizeObserverForContainIntrinsicSize()
 
 void Document::observeForContainIntrinsicSize(Element& element)
 {
-    auto ro = ensureResizeObserverForContainIntrinsicSize();
-    ro->observe(element);
+    RefPtr resizeObserver = ensureResizeObserverForContainIntrinsicSize();
+    resizeObserver->observe(element);
 }
 
 void Document::unobserveForContainIntrinsicSize(Element& element)
 {
-    if (!m_resizeObserverForContainIntrinsicSize)
-        return;
-    m_resizeObserverForContainIntrinsicSize->unobserve(element);
+    if (RefPtr resizeObserverForContainIntrinsicSize = m_resizeObserverForContainIntrinsicSize)
+        resizeObserverForContainIntrinsicSize->unobserve(element);
 }
 
 void Document::resetObservationSizeForContainIntrinsicSize(Element& target)
 {
-    if (!m_resizeObserverForContainIntrinsicSize)
-        return;
-    m_resizeObserverForContainIntrinsicSize->resetObservationSize(target);
+    if (RefPtr resizeObserverForContainIntrinsicSize = m_resizeObserverForContainIntrinsicSize)
+        resizeObserverForContainIntrinsicSize->resetObservationSize(target);
 }
 
 NoiseInjectionPolicy Document::noiseInjectionPolicy() const
 {
-    if (auto* loader = topDocument().loader()) {
+    if (RefPtr loader = topDocument().loader()) {
         if (loader->advancedPrivacyProtections().contains(AdvancedPrivacyProtections::FingerprintingProtections))
             return NoiseInjectionPolicy::Minimal;
     }
@@ -9706,7 +9735,7 @@ std::optional<uint64_t> Document::noiseInjectionHashSalt() const
 {
     if (!page() || noiseInjectionPolicy() == NoiseInjectionPolicy::None)
         return std::nullopt;
-    return page()->noiseInjectionHashSaltForDomain(RegistrableDomain { m_url });
+    return checkedPage()->noiseInjectionHashSaltForDomain(RegistrableDomain { m_url });
 }
 
 ContentVisibilityDocumentState& Document::contentVisibilityDocumentState()
@@ -9748,11 +9777,23 @@ void Document::updateContentRelevancyForScrollIfNeeded(const Element& scrollAnch
 
 String Document::mediaKeysStorageDirectory()
 {
-    auto* currentPage = page();
-    if (!currentPage)
-        return emptyString();
+    CheckedPtr currentPage = page();
+    return currentPage ? currentPage->ensureMediaKeysStorageDirectoryForOrigin(securityOrigin().data()) : emptyString();
+}
 
-    return currentPage->ensureMediaKeysStorageDirectoryForOrigin(securityOrigin().data());
+RefPtr<LocalDOMWindow> Document::protectedWindow() const
+{
+    return m_domWindow;
+}
+
+Ref<CachedResourceLoader> Document::protectedCachedResourceLoader() const
+{
+    return m_cachedResourceLoader;
+}
+
+Ref<CSSFontSelector> Document::protectedFontSelector() const
+{
+    return m_fontSelector;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -429,7 +429,7 @@ public:
 
     void removedLastRef();
 
-    using DocumentsMap = HashMap<ScriptExecutionContextIdentifier, Document*>;
+    using DocumentsMap = HashMap<ScriptExecutionContextIdentifier, CheckedRef<Document>>;
     WEBCORE_EXPORT static DocumentsMap::ValuesIteratorRange allDocuments();
     WEBCORE_EXPORT static DocumentsMap& allDocumentsMap();
 
@@ -462,6 +462,7 @@ public:
     WEBCORE_EXPORT DOMImplementation& implementation();
     
     Element* documentElement() const { return m_documentElement.get(); }
+    RefPtr<Element> protectedDocumentElement() const;
     static ptrdiff_t documentElementMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentElement); }
 
     WEBCORE_EXPORT Element* activeElement();
@@ -615,6 +616,7 @@ public:
 
     CSSFontSelector& fontSelector() { return m_fontSelector; }
     const CSSFontSelector& fontSelector() const { return m_fontSelector; }
+    Ref<CSSFontSelector> protectedFontSelector() const;
 
     WEBCORE_EXPORT bool haveStylesheetsLoaded() const;
     bool isIgnoringPendingStylesheets() const { return m_ignorePendingStylesheets; }
@@ -641,6 +643,7 @@ public:
     void setStateForNewFormElements(const Vector<AtomString>&);
 
     inline LocalFrameView* view() const; // Defined in LocalFrame.h.
+    RefPtr<LocalFrameView> protectedView() const;
     inline Page* page() const; // Defined in Page.h.
     inline CheckedPtr<Page> checkedPage() const; // Defined in Page.h.
     const Settings& settings() const { return m_settings.get(); }
@@ -694,6 +697,7 @@ public:
     WEBCORE_EXPORT void pageSizeAndMarginsInPixels(int pageIndex, IntSize& pageSize, int& marginTop, int& marginRight, int& marginBottom, int& marginLeft);
 
     CachedResourceLoader& cachedResourceLoader() { return m_cachedResourceLoader; }
+    Ref<CachedResourceLoader> protectedCachedResourceLoader() const;
 
     void didBecomeCurrentDocumentInFrame();
     void destroyRenderTree();
@@ -809,6 +813,7 @@ public:
     
     virtual Ref<DocumentParser> createParser();
     DocumentParser* parser() const { return m_parser.get(); }
+    RefPtr<DocumentParser> protectedParser() const;
     ScriptableDocumentParser* scriptableDocumentParser() const;
     
     bool printing() const { return m_printing; }
@@ -861,6 +866,7 @@ public:
     WEBCORE_EXPORT bool setFocusedElement(Element*);
     WEBCORE_EXPORT bool setFocusedElement(Element*, const FocusOptions&);
     Element* focusedElement() const { return m_focusedElement.get(); }
+    RefPtr<Element> protectedFocusedElement() const;
     inline bool wasLastFocusByClick() const;
     void setLatestFocusTrigger(FocusTrigger trigger) { m_latestFocusTrigger = trigger; }
     UserActionElementSet& userActionElements()  { return m_userActionElements; }
@@ -936,14 +942,18 @@ public:
     void createDOMWindow();
     void takeDOMWindowFrom(Document&);
 
+    // FIXME: Consider renaming to window().
     LocalDOMWindow* domWindow() const { return m_domWindow.get(); }
+    RefPtr<LocalDOMWindow> protectedWindow() const;
+
     // In DOM Level 2, the Document's LocalDOMWindow is called the defaultView.
     WEBCORE_EXPORT WindowProxy* windowProxy() const;
 
     inline bool hasBrowsingContext() const; // Defined in DocumentInlines.h.
 
     Document& contextDocument() const;
-    void setContextDocument(Document& document) { m_contextDocument = document; }
+    Ref<Document> protectedContextDocument() const;
+    void setContextDocument(Ref<Document>&& document) { m_contextDocument = WTFMove(document); }
     
     OptionSet<ParserContentPolicy> parserContentPolicy() const { return m_parserContentPolicy; }
     void setParserContentPolicy(OptionSet<ParserContentPolicy> policy) { m_parserContentPolicy = policy; }
@@ -1124,6 +1134,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<String> queryCommandValue(const String& command);
 
     UndoManager& undoManager() const { return m_undoManager.get(); }
+    Ref<UndoManager> protectedUndoManager() const;
 
     // designMode support
     enum class DesignMode : bool { Off, On };
@@ -1132,7 +1143,9 @@ public:
     WEBCORE_EXPORT void setDesignMode(const String&);
 
     Document* parentDocument() const;
+    RefPtr<Document> protectedParentDocument() const { return parentDocument(); }
     WEBCORE_EXPORT Document& topDocument() const;
+    Ref<Document> protectedTopDocument() const { return topDocument(); }
     bool isTopDocument() const { return &topDocument() == this; }
     
     ScriptRunner& scriptRunner() { return *m_scriptRunner; }
@@ -1238,6 +1251,7 @@ public:
 
     void setDecoder(RefPtr<TextResourceDecoder>&&);
     TextResourceDecoder* decoder() const { return m_decoder.get(); }
+    RefPtr<TextResourceDecoder> protectedDecoder() const;
 
     WEBCORE_EXPORT String displayStringModifiedByEncoding(const String&) const;
 
@@ -1667,7 +1681,7 @@ public:
 #endif
 
 #if ENABLE(SERVICE_WORKER)
-    void setServiceWorkerConnection(SWClientConnection*);
+    void setServiceWorkerConnection(RefPtr<SWClientConnection>&&);
     void updateServiceWorkerClientData() final;
     WEBCORE_EXPORT void navigateFromServiceWorker(const URL&, CompletionHandler<void(bool)>&&);
 #endif
@@ -1783,6 +1797,7 @@ public:
     std::optional<PAL::SessionID> sessionID() const final;
 
     ReportingScope& reportingScope() const { return m_reportingScope.get(); }
+    Ref<ReportingScope> protectedReportingScope() const;
     WEBCORE_EXPORT String endpointURIForToken(const String&) const final;
 
     bool hasSleepDisabler() const { return !!m_sleepDisabler; }
@@ -1826,6 +1841,7 @@ private:
     friend class IgnoreDestructiveWriteCountIncrementer;
 
     void updateTitleElement(Element& changingTitleElement);
+    RefPtr<Element> protectedTitleElement() const;
     void willDetachPage() final;
     void frameDestroyed() final;
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -436,7 +436,7 @@ Node::~Node()
     document().decrementReferencingNodeCount();
 
 #if ENABLE(TOUCH_EVENTS) && PLATFORM(IOS_FAMILY) && (ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS))
-    for (auto* document : Document::allDocuments()) {
+    for (auto& document : Document::allDocuments()) {
         ASSERT_WITH_SECURITY_IMPLICATION(!document->touchEventListenersContain(*this));
         ASSERT_WITH_SECURITY_IMPLICATION(!document->touchEventHandlersContain(*this));
         ASSERT_WITH_SECURITY_IMPLICATION(!document->touchEventTargetsContain(*this));

--- a/Source/WebCore/fileapi/BlobURL.cpp
+++ b/Source/WebCore/fileapi/BlobURL.cpp
@@ -57,9 +57,9 @@ static const Document* blobOwner(const SecurityOrigin& blobOrigin)
     if (!isMainThread())
         return nullptr;
 
-    for (const auto* document : Document::allDocuments()) {
+    for (auto& document : Document::allDocuments()) {
         if (document->securityOrigin().isSameOriginAs(blobOrigin))
-            return document;
+            return document.ptr();
     }
     return nullptr;
 }

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -556,7 +556,7 @@ void showLayoutTree(const InitialContainingBlock& initialContainingBlock)
 
 void printLayoutTreeForLiveDocuments()
 {
-    for (const auto* document : Document::allDocuments()) {
+    for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
         if (document->frame() && document->frame()->isMainFrame())
@@ -565,7 +565,7 @@ void printLayoutTreeForLiveDocuments()
         // FIXME: Need to find a way to output geometry without layout context.
         auto& renderView = *document->renderView();
         auto layoutTree = TreeBuilder::buildLayoutTree(renderView);
-        auto layoutState = LayoutState { *document, layoutTree->root() };
+        auto layoutState = LayoutState { document, layoutTree->root() };
 
         LayoutContext(layoutState).layout(renderView.size());
         showLayoutTree(downcast<InitialContainingBlock>(layoutState.root()), &layoutState);

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -45,6 +45,7 @@
 #include "SecurityContext.h"
 #include "StoredCredentialsPolicy.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
@@ -97,7 +98,7 @@ WEBCORE_EXPORT bool isReload(FrameLoadType);
 
 using ContentPolicyDecisionFunction = Function<void(PolicyAction, PolicyCheckIdentifier)>;
 
-class FrameLoader final {
+class FrameLoader final : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(FrameLoader);
 public:

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -783,6 +783,26 @@ void LocalFrame::clearTimers()
     clearTimers(m_view.get(), document());
 }
 
+CheckedRef<const FrameLoader> LocalFrame::checkedLoader() const
+{
+    return m_loader.get();
+}
+
+CheckedRef<FrameLoader> LocalFrame::checkedLoader()
+{
+    return m_loader.get();
+}
+
+CheckedRef<ScriptController> LocalFrame::checkedScript()
+{
+    return m_script.get();
+}
+
+CheckedRef<const ScriptController> LocalFrame::checkedScript() const
+{
+    return m_script.get();
+}
+
 void LocalFrame::willDetachPage()
 {
     if (LocalFrame* parent = dynamicDowncast<LocalFrame>(tree().parent()))
@@ -1180,6 +1200,11 @@ LocalFrame* LocalFrame::contentFrameFromWindowOrFrameElement(JSContextRef contex
     if (!jsNode || !is<HTMLFrameOwnerElement>(jsNode->wrapped()))
         return nullptr;
     return dynamicDowncast<LocalFrame>(downcast<HTMLFrameOwnerElement>(jsNode->wrapped()).contentFrame());
+}
+
+RefPtr<LocalFrameView> Document::protectedView() const
+{
+    return view();
 }
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -149,10 +149,14 @@ public:
     const EventHandler& eventHandler() const { return m_eventHandler; }
     const FrameLoader& loader() const { return m_loader.get(); }
     FrameLoader& loader() { return m_loader.get(); }
+    CheckedRef<const FrameLoader> checkedLoader() const;
+    CheckedRef<FrameLoader> checkedLoader();
     FrameSelection& selection() { return document()->selection(); }
     const FrameSelection& selection() const { return document()->selection(); }
     ScriptController& script() { return m_script; }
     const ScriptController& script() const { return m_script; }
+    CheckedRef<ScriptController> checkedScript();
+    CheckedRef<const ScriptController> checkedScript() const;
     void resetScript();
 
     WEBCORE_EXPORT bool isRootFrame() const;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6007,6 +6007,11 @@ LocalFrame& LocalFrameView::frame() const
     return m_frame;
 }
 
+Ref<LocalFrame> LocalFrameView::protectedFrame() const
+{
+    return m_frame;
+}
+
 RenderView* LocalFrameView::renderView() const
 {
     return m_frame->contentRenderer();

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -110,6 +110,7 @@ public:
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
 
     WEBCORE_EXPORT LocalFrame& frame() const final;
+    Ref<LocalFrame> protectedFrame() const;
 
     WEBCORE_EXPORT RenderView* renderView() const;
 

--- a/Source/WebCore/page/mac/PageMac.mm
+++ b/Source/WebCore/page/mac/PageMac.mm
@@ -81,9 +81,9 @@ void Page::platformInitialize()
             });
 
             WTFLogAlways("%u live documents:", Document::allDocuments().size());
-            for (const auto* document : Document::allDocuments()) {
-                const char* documentType = is<SVGDocument>(document) ? "SVGDocument" : "Document";
-                WTFLogAlways("%s %p %" PRIu64 "-%s (refCount %d, referencingNodeCount %d) %s", documentType, document, document->identifier().processIdentifier().toUInt64(), document->identifier().toString().utf8().data(), document->refCount(), document->referencingNodeCount(), document->url().string().utf8().data());
+            for (auto& document : Document::allDocuments()) {
+                const char* documentType = is<SVGDocument>(document.get()) ? "SVGDocument" : "Document";
+                WTFLogAlways("%s %p %" PRIu64 "-%s (refCount %d, referencingNodeCount %d) %s", documentType, document.ptr(), document->identifier().processIdentifier().toUInt64(), document->identifier().toString().utf8().data(), document->refCount(), document->referencingNodeCount(), document->url().string().utf8().data());
             }
         });
     });

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -169,9 +169,9 @@ void HitTestResult::setURLElement(Element* n)
     m_innerURLElement = n; 
 }
 
-void HitTestResult::setScrollbar(Scrollbar* s)
+void HitTestResult::setScrollbar(RefPtr<Scrollbar>&& scrollbar)
 {
-    m_scrollbar = s;
+    m_scrollbar = WTFMove(scrollbar);
 }
 
 LocalFrame* HitTestResult::innerNodeFrame() const

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -64,7 +64,7 @@ public:
     void setURLElement(Element*);
     Element* URLElement() const { return m_innerURLElement.get(); }
 
-    void setScrollbar(Scrollbar*);
+    void setScrollbar(RefPtr<Scrollbar>&&);
     Scrollbar* scrollbar() const { return m_scrollbar.get(); }
 
     bool isOverWidget() const { return m_isOverWidget; }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2707,7 +2707,7 @@ TextStream& operator<<(TextStream& ts, const RenderObject& renderer)
 
 void printPaintOrderTreeForLiveDocuments()
 {
-    for (const auto* document : Document::allDocuments()) {
+    for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
         if (document->frame() && document->frame()->isMainFrame())
@@ -2719,7 +2719,7 @@ void printPaintOrderTreeForLiveDocuments()
 
 void printRenderTreeForLiveDocuments()
 {
-    for (const auto* document : Document::allDocuments()) {
+    for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
         if (document->frame() && document->frame()->isMainFrame())
@@ -2731,7 +2731,7 @@ void printRenderTreeForLiveDocuments()
 
 void printLayerTreeForLiveDocuments()
 {
-    for (const auto* document : Document::allDocuments()) {
+    for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
         if (document->frame() && document->frame()->isMainFrame())
@@ -2743,11 +2743,11 @@ void printLayerTreeForLiveDocuments()
 
 void printGraphicsLayerTreeForLiveDocuments()
 {
-    for (const auto* document : Document::allDocuments()) {
+    for (auto& document : Document::allDocuments()) {
         if (!document->renderView())
             continue;
         if (document->frame() && document->frame()->isMainFrame()) {
-            WTFLogAlways("Graphics layer tree for root document %p %s", document, document->url().string().utf8().data());
+            WTFLogAlways("Graphics layer tree for root document %p %s", document.ptr(), document->url().string().utf8().data());
             showGraphicsLayerTreeForCompositor(document->renderView()->compositor());
         }
     }

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -74,6 +74,7 @@ public:
     float zoomFactor() const;
 
     LocalFrameView& frameView() const { return m_frameView; }
+    Ref<LocalFrameView> protectedFrameView() const { return m_frameView; }
 
     Layout::InitialContainingBlock& initialContainingBlock() { return m_initialContainingBlock.get(); }
     const Layout::InitialContainingBlock& initialContainingBlock() const { return m_initialContainingBlock.get(); }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -800,7 +800,7 @@ ExceptionOr<double> Internals::svgAnimationsInterval(SVGSVGElement& element) con
 Vector<Ref<SVGSVGElement>> Internals::allSVGSVGElements() const
 {
     Vector<Ref<SVGSVGElement>> elements;
-    for (auto* document : Document::allDocuments()) {
+    for (auto& document : Document::allDocuments()) {
         if (!document->svgExtensions())
             continue;
         elements.appendVector(document->accessSVGExtensions().allSVGSVGElements());
@@ -2912,7 +2912,7 @@ unsigned Internals::numberOfIDBTransactions() const
 unsigned Internals::numberOfLiveNodes() const
 {
     unsigned nodeCount = 0;
-    for (auto* document : Document::allDocuments())
+    for (auto& document : Document::allDocuments())
         nodeCount += document->referencingNodeCount();
     return nodeCount;
 }

--- a/Source/WebCore/workers/service/SWClientConnection.cpp
+++ b/Source/WebCore/workers/service/SWClientConnection.cpp
@@ -92,7 +92,7 @@ bool SWClientConnection::postTaskForJob(ServiceWorkerJobIdentifier jobIdentifier
         return false;
     }
     auto isPosted = dispatchToContextThreadIfNecessary(iterator->value, [jobIdentifier, task = WTFMove(task)] (ScriptExecutionContext& context) mutable {
-        if (auto* container = context.serviceWorkerContainer()) {
+        if (RefPtr container = context.serviceWorkerContainer()) {
             if (auto* job = container->job(jobIdentifier))
                 task(*job);
         }
@@ -131,7 +131,7 @@ void SWClientConnection::startScriptFetchForServer(ServiceWorkerJobIdentifier jo
 
 static void postMessageToContainer(ScriptExecutionContext& context, MessageWithMessagePorts&& message, ServiceWorkerData&& sourceData, String&& sourceOrigin)
 {
-    if (auto* container = context.ensureServiceWorkerContainer())
+    if (RefPtr container = context.ensureServiceWorkerContainer())
         container->postMessage(WTFMove(message), WTFMove(sourceData), WTFMove(sourceOrigin));
 }
 
@@ -139,7 +139,7 @@ void SWClientConnection::postMessageToServiceWorkerClient(ScriptExecutionContext
 {
     ASSERT(isMainThread());
 
-    if (auto* destinationDocument = Document::allDocumentsMap().get(destinationContextIdentifier)) {
+    if (RefPtr destinationDocument = Document::allDocumentsMap().get(destinationContextIdentifier)) {
         postMessageToContainer(*destinationDocument, WTFMove(message), WTFMove(sourceData), WTFMove(sourceOrigin));
         return;
     }
@@ -158,14 +158,14 @@ void SWClientConnection::updateRegistrationState(ServiceWorkerRegistrationIdenti
 {
     ASSERT(isMainThread());
 
-    for (auto* document : Document::allDocuments()) {
-        if (auto* container = document->serviceWorkerContainer())
+    for (auto& document : Document::allDocuments()) {
+        if (RefPtr container = document->serviceWorkerContainer())
             container->updateRegistrationState(identifier, state, serviceWorkerData);
     }
 
     forDedicatedAndSharedWorkers([identifier, state, &serviceWorkerData] {
         return [identifier, state, serviceWorkerData = crossThreadCopy(serviceWorkerData)] (auto& context) mutable {
-            if (auto* container = context.serviceWorkerContainer())
+            if (RefPtr container = context.serviceWorkerContainer())
                 container->updateRegistrationState(identifier, state, WTFMove(serviceWorkerData));
         };
     });
@@ -175,14 +175,14 @@ void SWClientConnection::updateWorkerState(ServiceWorkerIdentifier identifier, S
 {
     ASSERT(isMainThread());
 
-    for (auto* document : Document::allDocuments()) {
-        if (auto* container = document->serviceWorkerContainer())
+    for (auto& document : Document::allDocuments()) {
+        if (RefPtr container = document->serviceWorkerContainer())
             container->updateWorkerState(identifier, state);
     }
 
     forDedicatedAndSharedWorkers([identifier, state] {
         return [identifier, state] (auto& context) {
-            if (auto* container = context.serviceWorkerContainer())
+            if (RefPtr container = context.serviceWorkerContainer())
                 container->updateWorkerState(identifier, state);
         };
     });
@@ -192,14 +192,14 @@ void SWClientConnection::fireUpdateFoundEvent(ServiceWorkerRegistrationIdentifie
 {
     ASSERT(isMainThread());
 
-    for (auto* document : Document::allDocuments()) {
-        if (auto* container = document->serviceWorkerContainer())
+    for (auto& document : Document::allDocuments()) {
+        if (RefPtr container = document->serviceWorkerContainer())
             container->queueTaskToFireUpdateFoundEvent(identifier);
     }
 
     forDedicatedAndSharedWorkers([identifier] {
         return [identifier] (auto& context) {
-            if (auto* container = context.serviceWorkerContainer())
+            if (RefPtr container = context.serviceWorkerContainer())
                 container->queueTaskToFireUpdateFoundEvent(identifier);
         };
     });
@@ -209,17 +209,17 @@ void SWClientConnection::setRegistrationLastUpdateTime(ServiceWorkerRegistration
 {
     ASSERT(isMainThread());
 
-    for (auto* document : Document::allDocuments()) {
-        if (auto* container = document->serviceWorkerContainer()) {
-            if (auto* registration = container->registration(identifier))
+    for (auto& document : Document::allDocuments()) {
+        if (RefPtr container = document->serviceWorkerContainer()) {
+            if (RefPtr registration = container->registration(identifier))
                 registration->setLastUpdateTime(lastUpdateTime);
         }
     }
 
     forDedicatedAndSharedWorkers([identifier, lastUpdateTime] {
         return [identifier, lastUpdateTime] (auto& context) {
-            if (auto* container = context.serviceWorkerContainer()) {
-                if (auto* registration = container->registration(identifier))
+            if (RefPtr container = context.serviceWorkerContainer()) {
+                if (RefPtr registration = container->registration(identifier))
                     registration->setLastUpdateTime(lastUpdateTime);
             }
         };
@@ -230,17 +230,17 @@ void SWClientConnection::setRegistrationUpdateViaCache(ServiceWorkerRegistration
 {
     ASSERT(isMainThread());
 
-    for (auto* document : Document::allDocuments()) {
-        if (auto* container = document->serviceWorkerContainer()) {
-            if (auto* registration = container->registration(identifier))
+    for (auto& document : Document::allDocuments()) {
+        if (RefPtr container = document->serviceWorkerContainer()) {
+            if (RefPtr registration = container->registration(identifier))
                 registration->setUpdateViaCache(updateViaCache);
         }
     }
 
     forDedicatedAndSharedWorkers([identifier, updateViaCache] {
         return [identifier, updateViaCache] (auto& context) {
-            if (auto* container = context.serviceWorkerContainer()) {
-                if (auto* registration = container->registration(identifier))
+            if (RefPtr container = context.serviceWorkerContainer()) {
+                if (RefPtr registration = container->registration(identifier))
                     registration->setUpdateViaCache(updateViaCache);
             }
         };
@@ -255,8 +255,8 @@ static void forAllWorkers(const Function<Function<void(ScriptExecutionContext&)>
 
 void SWClientConnection::updateBackgroundFetchRegistration(const BackgroundFetchInformation& information)
 {
-    for (auto* document : Document::allDocuments())
-        BackgroundFetchRegistration::updateIfExisting(*document, information);
+    for (auto& document : Document::allDocuments())
+        BackgroundFetchRegistration::updateIfExisting(Ref { document.get() }, information);
 
     // FIXME: this code path for service worker should follow background fetch event code path.
     forAllWorkers([&information] {
@@ -272,7 +272,7 @@ static void updateController(ScriptExecutionContext& context, const std::optiona
         context.setActiveServiceWorker(ServiceWorker::getOrCreate(context, ServiceWorkerData { *newController }));
     else
         context.setActiveServiceWorker(nullptr);
-    if (auto* container = context.serviceWorkerContainer())
+    if (RefPtr container = context.serviceWorkerContainer())
         container->queueTaskToDispatchControllerChangeEvent();
 }
 
@@ -282,7 +282,7 @@ void SWClientConnection::notifyClientsOfControllerChange(const HashSet<ScriptExe
     ASSERT(!contextIdentifiers.isEmpty());
 
     for (auto& clientIdentifier : contextIdentifiers) {
-        if (auto* document = Document::allDocumentsMap().get(clientIdentifier)) {
+        if (RefPtr document = Document::allDocumentsMap().get(clientIdentifier)) {
             updateController(*document, newController);
             continue;
         }
@@ -291,7 +291,7 @@ void SWClientConnection::notifyClientsOfControllerChange(const HashSet<ScriptExe
         });
         if (wasDispatched)
             continue;
-        if (auto* sharedWorker = SharedWorkerThreadProxy::byIdentifier(clientIdentifier)) {
+        if (RefPtr sharedWorker = SharedWorkerThreadProxy::byIdentifier(clientIdentifier)) {
             sharedWorker->thread().runLoop().postTask([newController = crossThreadCopy(newController)] (auto& context) mutable {
                 updateController(context, newController);
             });
@@ -307,7 +307,7 @@ void SWClientConnection::clearPendingJobs()
     auto jobSources = WTFMove(m_scheduledJobSources);
     for (auto& keyValue : jobSources) {
         dispatchToContextThreadIfNecessary(keyValue.value, [identifier = keyValue.key] (auto& context) {
-            if (auto* container = context.serviceWorkerContainer()) {
+            if (RefPtr container = context.serviceWorkerContainer()) {
                 if (auto* job = container->job(identifier))
                     job->failedWithException(Exception { TypeError, "Internal error"_s });
             }
@@ -317,8 +317,8 @@ void SWClientConnection::clearPendingJobs()
 
 void SWClientConnection::registerServiceWorkerClients()
 {
-    for (auto* document : Document::allDocuments())
-        document->updateServiceWorkerClientData();
+    for (auto& document : Document::allDocuments())
+        Ref { document.get() }->updateServiceWorkerClientData();
 
     SharedWorkerContextManager::singleton().forEachSharedWorker([] { return [] (auto& context) { context.updateServiceWorkerClientData(); }; });
     Worker::forEachWorker([] { return [] (auto& context) { context.updateServiceWorkerClientData(); }; });

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -336,7 +336,7 @@ InjectedBundle::DocumentIDToURLMap InjectedBundle::liveDocumentURLs(bool exclude
 {
     DocumentIDToURLMap result;
 
-    for (const auto* document : Document::allDocuments())
+    for (auto& document : Document::allDocuments())
         result.add(document->identifier().object(), document->url().string());
 
     if (excludeDocumentsInPageGroupPages) {

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2082,10 +2082,10 @@ void WebProcess::grantUserMediaDeviceSandboxExtensions(MediaDeviceSandboxExtensi
 static inline void checkDocumentsCaptureStateConsistency(const Vector<String>& extensionIDs)
 {
 #if ASSERT_ENABLED
-    bool isCapturingAudio = WTF::anyOf(Document::allDocumentsMap().values(), [](auto* document) {
+    bool isCapturingAudio = WTF::anyOf(Document::allDocumentsMap().values(), [](auto& document) {
         return document->mediaState() & MediaProducer::MicrophoneCaptureMask;
     });
-    bool isCapturingVideo = WTF::anyOf(Document::allDocumentsMap().values(), [](auto* document) {
+    bool isCapturingVideo = WTF::anyOf(Document::allDocumentsMap().values(), [](auto& document) {
         return document->mediaState() & MediaProducer::VideoCaptureMask;
     });
 


### PR DESCRIPTION
#### fa36ebb5c3c7bffd7215478e377baeb89ebc86da
<pre>
Adopt more smart pointers in the Document class
<a href="https://bugs.webkit.org/show_bug.cgi?id=263342">https://bugs.webkit.org/show_bug.cgi?id=263342</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/dom/Document.cpp:
(WebCore::CallbackForContainIntrinsicSize):
(WebCore::printNavigationErrorMessage):
(WebCore::Document::configureSharedLogger):
(WebCore::Document::addToDocumentsMap):
(WebCore::Document::allDocumentsMap):
(WebCore::createCachedResourceLoader):
(WebCore::m_frameIdentifier):
(WebCore::Document::~Document):
(WebCore::Document::commonTeardown):
(WebCore::Document::setCompatibilityMode):
(WebCore::Document::childrenChanged):
(WebCore::createUpgradeCandidateElement):
(WebCore::createHTMLElementWithNameValidation):
(WebCore::Document::createCSSStyleDeclaration):
(WebCore::createFallbackHTMLElement):
(WebCore::Document::createElement):
(WebCore::Document::documentEventTimingFromNavigationTiming):
(WebCore::Document::setVisualUpdatesAllowed):
(WebCore::Document::setCharset):
(WebCore::Document::setDocumentElementLanguage):
(WebCore::Document::protectedParser const):
(WebCore::Document::setContent):
(WebCore::Document::contentType const):
(WebCore::Document::caretPositionFromPoint):
(WebCore::Document::scrollingElement):
(WebCore::canonicalizedTitle):
(WebCore::Document::updateTitle):
(WebCore::Document::updateTitleFromTitleElement):
(WebCore::Document::setTitle):
(WebCore::Document::protectedTitleElement const):
(WebCore::Document::updateTitleElement):
(WebCore::Document::resolveStyle):
(WebCore::Document::updateLayout):
(WebCore::Document::updateLayoutIfDimensionsOutOfDate):
(WebCore::Document::isResolvingContainerQueriesForSelfOrAncestor const):
(WebCore::Document::createRenderTree):
(WebCore::Document::didBecomeCurrentDocumentInFrame):
(WebCore::Document::willDetachPage):
(WebCore::Document::attachToCachedFrame):
(WebCore::Document::protectedDocumentElement const):
(WebCore::Document::destroyRenderTree):
(WebCore::Document::protectedUndoManager const):
(WebCore::Document::willBeRemovedFromFrame):
(WebCore::Document::protectedReportingScope const):
(WebCore::Document::removeAllEventListeners):
(WebCore::Document::axObjectCache const):
(WebCore::Document::setVisuallyOrdered):
(WebCore::Document::createParser):
(WebCore::Document::appHighlightRegistry):
(WebCore::Document::updateHighlightPositions):
(WebCore::Document::openForBindings):
(WebCore::Document::open):
(WebCore::Document::isFullyActive const):
(WebCore::Document::detachParser):
(WebCore::Document::cancelParsing):
(WebCore::Document::implicitOpen):
(WebCore::Document::fontLoadRequest):
(WebCore::Document::beginLoadingFontSoon):
(WebCore::Document::setBodyOrFrameset):
(WebCore::Document::explicitClose):
(WebCore::Document::implicitClose):
(WebCore::Document::setParsing):
(WebCore::Document::enqueuePaintTimingEntryIfNeeded):
(WebCore::Document::write):
(WebCore::Document::minimumDOMTimerInterval const):
(WebCore::Document::domTimerAlignmentInterval const):
(WebCore::Document::urlForBindings const):
(WebCore::Document::fallbackBaseURL const):
(WebCore::Document::processBaseElement):
(WebCore::Document::userAgent const):
(WebCore::Document::disableEval):
(WebCore::Document::disableWebAssembly):
(WebCore::Document::idbConnectionProxy):
(WebCore::Document::createRTCDataChannelRemoteHandlerConnection):
(WebCore::Document::canNavigateInternal):
(WebCore::Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking):
(WebCore::Document::dispatchDisabledAdaptationsDidChangeForMainFrame):
(WebCore::Document::viewportArguments const):
(WebCore::Document::updateViewportArguments):
(WebCore::Document::themeColorChanged):
(WebCore::Document::processColorScheme):
(WebCore::Document::metaElementColorSchemeChanged):
(WebCore::Document::processWebAppOrientations):
(WebCore::Document::prepareMouseEvent):
(WebCore::Document::canAcceptChild const):
(WebCore::Document::cloneNodeInternal):
(WebCore::Document::cloneDataFromDocument):
(WebCore::Document::protectedDecoder const):
(WebCore::Document::runScrollSteps):
(WebCore::Document::noteUserInteractionWithMediaElement):
(WebCore::Document::updateIsPlayingMedia):
(WebCore::Document::flushAutofocusCandidates):
(WebCore::Document::hoveredElementDidDetach):
(WebCore::Document::updateEventRegions):
(WebCore::Document::scheduleDeferredAXObjectCacheUpdate):
(WebCore::Document::flushDeferredAXObjectCacheUpdate):
(WebCore::Document::updateAccessibilityObjectRegions):
(WebCore::Document::invalidateEventRegionsForFrame):
(WebCore::Document::invalidateEventListenerRegions):
(WebCore::Document::invalidateRenderingDependentRegions):
(WebCore::Document::protectedFocusedElement const):
(WebCore::Document::setFocusedElement):
(WebCore::Document::focusNavigationStartingNode const):
(WebCore::Document::updateRangesAfterChildrenChanged):
(WebCore::Document::nodeChildrenWillBeRemoved):
(WebCore::Document::nodeWillBeRemoved):
(WebCore::Document::parentlessNodeMovedToNewDocument):
(WebCore::Document::textInserted):
(WebCore::Document::textRemoved):
(WebCore::Document::textNodesMerged):
(WebCore::Document::textNodeSplit):
(WebCore::Document::takeDOMWindowFrom):
(WebCore::Document::protectedContextDocument const):
(WebCore::Document::setWindowAttributeEventListener):
(WebCore::Document::dispatchWindowEvent):
(WebCore::Document::dispatchWindowLoadEvent):
(WebCore::Document::queueTaskToDispatchEventOnWindow):
(WebCore::Document::enqueueOverflowEvent):
(WebCore::Document::cookie):
(WebCore::Document::setCookie):
(WebCore::Document::referrerForBindings):
(WebCore::Document::shouldMaskURLForBindingsInternal const):
(WebCore::Document::setBackForwardCacheState):
(WebCore::Document::suspend):
(WebCore::Document::resume):
(WebCore::Document::requiresUserGestureForAudioPlayback const):
(WebCore::Document::requiresUserGestureForVideoPlayback const):
(WebCore::Document::mediaDataLoadsAutomatically const):
(WebCore::Document::privateBrowsingStateDidChange):
(WebCore::Document::registerForCaptionPreferencesChangedCallbacks):
(WebCore::Document::captionPreferencesChanged):
(WebCore::Document::updateTextTrackRepresentationImageIfNeeded):
(WebCore::Document::applyPendingXSLTransformsTimerFired):
(WebCore::Document::finishedParsing):
(WebCore::Document::updateURLForPushOrReplaceState):
(WebCore::Document::initDNSPrefetch):
(WebCore::Document::getParserLocation const):
(WebCore::Document::addConsoleMessage):
(WebCore::Document::addMessage):
(WebCore::Document::postTask):
(WebCore::Document::suspendScheduledTasks):
(WebCore::Document::resumeScheduledTasks):
(WebCore::Document::suspendScriptedAnimationControllerCallbacks):
(WebCore::Document::resumeScriptedAnimationControllerCallbacks):
(WebCore::Document::serviceRequestAnimationFrameCallbacks):
(WebCore::Document::serviceRequestVideoFrameCallbacks):
(WebCore::Document::exitPointerLock):
(WebCore::Document::loadEventDelayTimerFired):
(WebCore::Document::monotonicTimestamp const):
(WebCore::Document::clearScriptedAnimationController):
(WebCore::Document::wheelEventHandlersChanged):
(WebCore::Document::didRemoveEventTargetNode):
(WebCore::Document::didAddOrRemoveMouseEventHandler):
(WebCore::Document::updateLastHandledUserGestureTimestamp):
(WebCore::Document::processingUserGestureForMedia const):
(WebCore::Document::allowsContentJavaScript const):
(WebCore::Document::convertAbsoluteToClientQuads):
(WebCore::Document::convertAbsoluteToClientRects):
(WebCore::Document::convertAbsoluteToClientRect):
(WebCore::Document::decrementActiveParserCount):
(WebCore::DocumentParserYieldToken::~DocumentParserYieldToken):
(WebCore::findNearestCommonComposedAncestor):
(WebCore::Document::updateHoverActiveState):
(WebCore::Document::ensureTemplateDocument):
(WebCore::Document::documentFragmentForInnerOuterHTML):
(WebCore::Document::deviceScaleFactor const):
(WebCore::Document::useSystemAppearance const):
(WebCore::Document::useDarkAppearance const):
(WebCore::Document::useElevatedUserInterfaceLevel const):
(WebCore::Document::compositeOperatorForBackgroundColor const):
(WebCore::Document::didAssociateFormControl):
(WebCore::Document::didAssociateFormControlsTimerFired):
(WebCore::Document::didLoadResourceSynchronously):
(WebCore::Document::ensurePlugInsInjectedScript):
(WebCore::Document::wrapCryptoKey):
(WebCore::Document::unwrapCryptoKey):
(WebCore::Document::hasFocus const):
(WebCore::Document::addPlaybackTargetPickerClient):
(WebCore::Document::removePlaybackTargetPickerClient):
(WebCore::Document::showPlaybackTargetPicker):
(WebCore::Document::playbackTargetPickerClientStateDidChange):
(WebCore::Document::shouldOpenExternalURLsPolicyToPropagate const):
(WebCore::Document::shouldEnforceHTTP09Sandbox const):
(WebCore::Document::shouldEnforceQuickLookSandbox const):
(WebCore::Document::applyQuickLookSandbox):
(WebCore::Document::shouldEnforceContentDispositionAttachmentSandbox const):
(WebCore::Document::scheduleRenderingUpdate):
(WebCore::Document::updateIntersectionObservations):
(WebCore::Document::gatherResizeObservations):
(WebCore::Document::deliverResizeObservations):
(WebCore::Document::setHasSkippedResizeObservations):
(WebCore::Document::setDir):
(WebCore::Document::fgColor const):
(WebCore::Document::alinkColor const):
(WebCore::Document::linkColorForBindings const):
(WebCore::Document::vlinkColor const):
(WebCore::Document::logger):
(WebCore::Document::updateAnimationsAndSendEvents):
(WebCore::Document::matchingAnimations):
(WebCore::Document::hideAllPopoversUntil):
(WebCore::Document::handlePopoverLightDismiss):
(WebCore::Document::didLogMessage):
(WebCore::Document::setServiceWorkerConnection):
(WebCore::Document::updateServiceWorkerClientData):
(WebCore::Document::navigateFromServiceWorker):
(WebCore::Document::frameWasDisconnectedFromOwner):
(WebCore::Document::hitTest):
(WebCore::Document::setAsRunningUserScripts):
(WebCore::Document::setPictureInPictureElement):
(WebCore::Document::notificationClient):
(WebCore::Document::graphicsClient):
(WebCore::Document::sessionID const):
(WebCore::Document::observeForContainIntrinsicSize):
(WebCore::Document::unobserveForContainIntrinsicSize):
(WebCore::Document::resetObservationSizeForContainIntrinsicSize):
(WebCore::Document::noiseInjectionPolicy const):
(WebCore::Document::noiseInjectionHashSalt const):
(WebCore::Document::mediaKeysStorageDirectory):
(WebCore::Document::protectedWindow const):
(WebCore::Document::protectedCachedResourceLoader const):
(WebCore::Document::protectedFontSelector const):
* Source/WebCore/dom/Document.h:
(WebCore::Document::setContextDocument):
(WebCore::Document::protectedParentDocument const):
(WebCore::Document::protectedTopDocument const):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::~Node):
* Source/WebCore/fileapi/BlobURL.cpp:
(WebCore::blobOwner):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::printLayoutTreeForLiveDocuments):
* Source/WebCore/page/FrameDestructionObserver.h:
* Source/WebCore/page/FrameDestructionObserverInlines.h:
(WebCore::FrameDestructionObserver::protectedFrame const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::Document::protectedView const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::protectedFrame const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseNoncriticalMemory):
(WebCore::releaseCriticalMemory):
* Source/WebCore/page/mac/PageMac.mm:
(WebCore::Page::platformInitialize):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::setScrollbar):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::printPaintOrderTreeForLiveDocuments):
(WebCore::printRenderTreeForLiveDocuments):
(WebCore::printLayerTreeForLiveDocuments):
(WebCore::printGraphicsLayerTreeForLiveDocuments):
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::allSVGSVGElements const):
(WebCore::Internals::numberOfLiveNodes const):
* Source/WebCore/workers/service/SWClientConnection.cpp:
(WebCore::SWClientConnection::postTaskForJob):
(WebCore::postMessageToContainer):
(WebCore::SWClientConnection::postMessageToServiceWorkerClient):
(WebCore::SWClientConnection::updateRegistrationState):
(WebCore::SWClientConnection::updateWorkerState):
(WebCore::SWClientConnection::fireUpdateFoundEvent):
(WebCore::SWClientConnection::setRegistrationLastUpdateTime):
(WebCore::SWClientConnection::setRegistrationUpdateViaCache):
(WebCore::SWClientConnection::updateBackgroundFetchRegistration):
(WebCore::updateController):
(WebCore::SWClientConnection::notifyClientsOfControllerChange):
(WebCore::SWClientConnection::clearPendingJobs):
(WebCore::SWClientConnection::registerServiceWorkerClients):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::liveDocumentURLs):

Canonical link: <a href="https://commits.webkit.org/269557@main">https://commits.webkit.org/269557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62aa0297e1057c5ec0d5ff491548d99ed472c815

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22878 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/881 "Build is being retried. Recent messages:OS: Sonoma (14.0), Xcode: 15.0") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/23974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/24787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23137 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/1989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/23413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/24787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23118 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/1989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/25645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/1989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/23974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/1989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/23974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/415 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/23413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/23974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->