### PR TITLE
[SVG] Use propagated RepaintRectCalculation more

### DIFF
--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1436,3 +1436,15 @@ void showNodeTree(const WebCore::RenderObject*);
 void showLineTree(const WebCore::RenderObject*);
 void showRenderTree(const WebCore::RenderObject*);
 #endif
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::RepaintRectCalculation> {
+    using values = EnumValues<
+        WebCore::RepaintRectCalculation,
+        WebCore::RepaintRectCalculation::Fast,
+        WebCore::RepaintRectCalculation::Accurate
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -265,7 +265,7 @@ FloatRect RenderSVGPath::computeMarkerBoundingBox(const SVGBoundingBoxComputatio
         if (auto* marker = markerForType(m_markerPositions[i].type, markerStart, markerMid, markerEnd)) {
             // FIXME: [LBSE] Upstream RenderSVGResourceMarker changes
             // boundaries.unite(marker->computeMarkerBoundingBox(options, marker->markerTransformation(m_markerPositions[i].origin, m_markerPositions[i].angle, strokeWidth())));
-            RepaintRectCalculation repaintRectCalculation = options.contains(SVGBoundingBoxComputation::DecorationOption::CalculateFastRepaintRect) ? RepaintRectCalculation::Fast : RepaintRectCalculation::Accurate;
+            auto repaintRectCalculation = options.contains(SVGBoundingBoxComputation::DecorationOption::CalculateFastRepaintRect) ? RepaintRectCalculation::Fast : RepaintRectCalculation::Accurate;
             boundaries.unite(marker->markerBoundaries(repaintRectCalculation, marker->markerTransformation(m_markerPositions[i].origin, m_markerPositions[i].angle, strokeWidth())));
         }
     }

--- a/Source/WebCore/rendering/svg/RenderSVGResource.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResource.h
@@ -65,7 +65,7 @@ public:
 
     virtual bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) = 0;
     virtual void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement* /* shape */) { }
-    virtual FloatRect resourceBoundingBox(const RenderObject&) = 0;
+    virtual FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) = 0;
 
     virtual RenderSVGResourceType resourceType() const = 0;
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -221,7 +221,7 @@ void RenderSVGResourceFilter::postApplyResource(RenderElement& renderer, Graphic
     LOG_WITH_STREAM(Filters, stream << "RenderSVGResourceFilter " << this << " postApplyResource done\n");
 }
 
-FloatRect RenderSVGResourceFilter::resourceBoundingBox(const RenderObject& object)
+FloatRect RenderSVGResourceFilter::resourceBoundingBox(const RenderObject& object, RepaintRectCalculation)
 {
     return SVGLengthContext::resolveRectangle<SVGFilterElement>(&filterElement(), filterElement().filterUnits(), object.objectBoundingBox());
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -68,7 +68,7 @@ public:
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) override;
 
-    FloatRect resourceBoundingBox(const RenderObject&) override;
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) override;
 
     inline SVGUnitTypes::SVGUnitType filterUnits() const;
     inline SVGUnitTypes::SVGUnitType primitiveUnits() const;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -66,7 +66,7 @@ public:
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) final;
     void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) final;
-    FloatRect resourceBoundingBox(const RenderObject&) final { return FloatRect(); }
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) final { return FloatRect(); }
 
 protected:
     RenderSVGResourceGradient(Type, SVGGradientElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -51,7 +51,7 @@ public:
     AffineTransform markerTransformation(const FloatPoint& origin, float angle, float strokeWidth) const;
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override { return false; }
-    FloatRect resourceBoundingBox(const RenderObject&) override { return FloatRect(); }
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) override { return FloatRect(); }
 
     FloatPoint referencePoint() const;
     std::optional<float> angle() const;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
@@ -24,6 +24,7 @@
 #include "LegacyRenderSVGResourceContainer.h"
 #include "SVGUnitTypes.h"
 
+#include <wtf/EnumeratedArray.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
@@ -49,7 +50,7 @@ public:
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     bool drawContentIntoContext(GraphicsContext&, const FloatRect& objectBoundingBox);
     bool drawContentIntoContext(GraphicsContext&, const FloatRect& destinationRect, const FloatRect& sourceRect, ImagePaintingOptions);
-    FloatRect resourceBoundingBox(const RenderObject&) override;
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) override;
 
     inline SVGUnitTypes::SVGUnitType maskUnits() const;
     inline SVGUnitTypes::SVGUnitType maskContentUnits() const;
@@ -62,9 +63,9 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGResourceMasker"_s; }
 
     bool drawContentIntoMaskImage(MaskerData*, const DestinationColorSpace&, RenderObject*);
-    void calculateMaskContentRepaintRect();
+    void calculateMaskContentRepaintRect(RepaintRectCalculation);
 
-    FloatRect m_maskContentBoundaries;
+    EnumeratedArray<RepaintRectCalculation, FloatRect> m_maskContentBoundaries;
     HashMap<RenderObject*, std::unique_ptr<MaskerData>> m_masker;
 };
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
@@ -50,7 +50,7 @@ public:
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) override;
-    FloatRect resourceBoundingBox(const RenderObject&) override { return FloatRect(); }
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) override { return FloatRect(); }
 
     RenderSVGResourceType resourceType() const override { return PatternResourceType; }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceSolidColor.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceSolidColor.h
@@ -38,7 +38,7 @@ public:
 
     bool applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override;
     void postApplyResource(RenderElement&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>, const Path*, const RenderElement*) override;
-    FloatRect resourceBoundingBox(const RenderObject&) override { return FloatRect(); }
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) override { return FloatRect(); }
 
     RenderSVGResourceType resourceType() const override { return SolidColorResourceType; }
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -589,7 +589,7 @@ FloatRect RenderSVGText::strokeBoundingBox() const
     return strokeBoundaries;
 }
 
-FloatRect RenderSVGText::repaintRectInLocalCoordinates(RepaintRectCalculation) const
+FloatRect RenderSVGText::repaintRectInLocalCoordinates(RepaintRectCalculation repaintRectCalculation) const
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     if (document().settings().layerBasedSVGEngineEnabled())
@@ -597,7 +597,7 @@ FloatRect RenderSVGText::repaintRectInLocalCoordinates(RepaintRectCalculation) c
 #endif
 
     FloatRect repaintRect = strokeBoundingBox();
-    SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintRect);
+    SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintRect, repaintRectCalculation);
 
     if (const ShadowData* textShadow = style().textShadow())
         textShadow->adjustRectForShadow(repaintRect);

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -260,19 +260,20 @@ void SVGBoundingBoxComputation::adjustBoxForClippingAndEffects(const SVGBounding
 
     if (includeFilter || includeClipper || includeMasker) {
         if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(m_renderer)) {
+            auto repaintRectCalculation = options.contains(DecorationOption::CalculateFastRepaintRect) ? RepaintRectCalculation::Fast : RepaintRectCalculation::Accurate;
             if (includeFilter) {
                 if (auto* filter = resources->filter())
-                    box = filter->resourceBoundingBox(m_renderer);
+                    box = filter->resourceBoundingBox(m_renderer, repaintRectCalculation);
             }
 
             if (includeClipper) {
                 if (auto* clipper = resources->clipper())
-                    box.intersect(clipper->resourceBoundingBox(m_renderer));
+                    box.intersect(clipper->resourceBoundingBox(m_renderer, repaintRectCalculation));
             }
 
             if (includeMasker) {
                 if (auto* masker = resources->masker())
-                    box.intersect(masker->resourceBoundingBox(m_renderer));
+                    box.intersect(masker->resourceBoundingBox(m_renderer, repaintRectCalculation));
             }
         }
     }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -185,7 +185,7 @@ FloatRect SVGRenderSupport::computeContainerStrokeBoundingBox(const RenderElemen
 
         FloatRect childStrokeBoundingBox = current.strokeBoundingBox();
         if (is<RenderElement>(current))
-            SVGRenderSupport::intersectRepaintRectWithResources(downcast<RenderElement>(current), childStrokeBoundingBox);
+            SVGRenderSupport::intersectRepaintRectWithResources(downcast<RenderElement>(current), childStrokeBoundingBox, RepaintRectCalculation::Accurate);
         const AffineTransform& transform = current.localToParentTransform();
         if (transform.isIdentity())
             strokeBoundingBox.unite(childStrokeBoundingBox);
@@ -328,20 +328,20 @@ bool SVGRenderSupport::isOverflowHidden(const RenderElement& renderer)
     return isNonVisibleOverflow(renderer.style().overflowX());
 }
 
-void SVGRenderSupport::intersectRepaintRectWithResources(const RenderElement& renderer, FloatRect& repaintRect)
+void SVGRenderSupport::intersectRepaintRectWithResources(const RenderElement& renderer, FloatRect& repaintRect, RepaintRectCalculation repaintRectCalculation)
 {
     auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer);
     if (!resources)
         return;
 
     if (RenderSVGResourceFilter* filter = resources->filter())
-        repaintRect = filter->resourceBoundingBox(renderer);
+        repaintRect = filter->resourceBoundingBox(renderer, repaintRectCalculation);
 
     if (LegacyRenderSVGResourceClipper* clipper = resources->clipper())
-        repaintRect.intersect(clipper->resourceBoundingBox(renderer));
+        repaintRect.intersect(clipper->resourceBoundingBox(renderer, repaintRectCalculation));
 
     if (RenderSVGResourceMasker* masker = resources->masker())
-        repaintRect.intersect(masker->resourceBoundingBox(renderer));
+        repaintRect.intersect(masker->resourceBoundingBox(renderer, repaintRectCalculation));
 }
 
 bool SVGRenderSupport::filtersForceContainerLayout(const RenderElement& renderer)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -53,7 +53,7 @@ public:
     static bool isOverflowHidden(const RenderElement&);
 
     // Calculates the repaintRect in combination with filter, clipper and masker in local coordinates.
-    static void intersectRepaintRectWithResources(const RenderElement&, FloatRect&);
+    static void intersectRepaintRectWithResources(const RenderElement&, FloatRect&, RepaintRectCalculation = RepaintRectCalculation::Fast);
 
     // Determines whether a container needs to be laid out because it's filtered and a child is being laid out.
     static bool filtersForceContainerLayout(const RenderElement&);

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -615,7 +615,7 @@ void writeResources(TextStream& ts, const RenderObject& renderer, OptionSet<Rend
                 writeNameAndQuotedValue(ts, "masker", resourceID);
                 ts << " ";
                 writeStandardPrefix(ts, *masker, behavior, WriteIndentOrNot::No);
-                ts << " " << masker->resourceBoundingBox(renderer) << "\n";
+                ts << " " << masker->resourceBoundingBox(renderer, RepaintRectCalculation::Accurate) << "\n";
             }
         }
     }
@@ -627,7 +627,7 @@ void writeResources(TextStream& ts, const RenderObject& renderer, OptionSet<Rend
             writeNameAndQuotedValue(ts, "clipPath", resourceClipPath->fragment());
             ts << " ";
             writeStandardPrefix(ts, *clipper, behavior, WriteIndentOrNot::No);
-            ts << " " << clipper->resourceBoundingBox(renderer) << "\n";
+            ts << " " << clipper->resourceBoundingBox(renderer, RepaintRectCalculation::Accurate) << "\n";
         }
     }
     if (style.hasFilter()) {
@@ -642,7 +642,7 @@ void writeResources(TextStream& ts, const RenderObject& renderer, OptionSet<Rend
                     writeNameAndQuotedValue(ts, "filter", id);
                     ts << " ";
                     writeStandardPrefix(ts, *filter, behavior, WriteIndentOrNot::No);
-                    ts << " " << filter->resourceBoundingBox(renderer) << "\n";
+                    ts << " " << filter->resourceBoundingBox(renderer, RepaintRectCalculation::Accurate) << "\n";
                 }
             }
         }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -185,7 +185,7 @@ FloatRect LegacyRenderSVGContainer::repaintRectInLocalCoordinates(RepaintRectCal
         FloatRect repaintBoundingBox;
         bool objectBoundingBoxValid = true;
         SVGRenderSupport::computeContainerBoundingBoxes(*this, objectBoundingBox, objectBoundingBoxValid, repaintBoundingBox, RepaintRectCalculation::Accurate);
-        SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox);
+        SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox, RepaintRectCalculation::Accurate);
         m_accurateRepaintBoundingBox = repaintBoundingBox;
     }
     return *m_accurateRepaintBoundingBox;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -22,6 +22,7 @@
 #include "LegacyRenderSVGResourceContainer.h"
 #include "SVGUnitTypes.h"
 
+#include <wtf/EnumeratedArray.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
@@ -74,7 +75,7 @@ public:
     // objectBoundingBox ia used to compute clip path geometry when clipPathUnits="objectBoundingBox".
     // clippedContentBounds is the bounds of the content to which clipping is being applied.
     bool applyClippingToContext(GraphicsContext&, RenderElement&, const FloatRect& objectBoundingBox, const FloatRect& clippedContentBounds, float effectiveZoom = 1);
-    FloatRect resourceBoundingBox(const RenderObject&) override;
+    FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation) override;
 
     RenderSVGResourceType resourceType() const override { return ClipperResourceType; }
     
@@ -92,9 +93,9 @@ private:
     ClipperData::Inputs computeInputs(const GraphicsContext&, const RenderElement&, const FloatRect& objectBoundingBox, const FloatRect& clippedContentBounds, float effectiveZoom);
     bool pathOnlyClipping(GraphicsContext&, const AffineTransform&, const FloatRect&, float effectiveZoom);
     bool drawContentIntoMaskImage(ImageBuffer&, const FloatRect& objectBoundingBox, float effectiveZoom);
-    void calculateClipContentRepaintRect();
+    void calculateClipContentRepaintRect(RepaintRectCalculation);
 
-    FloatRect m_clipBoundaries;
+    EnumeratedArray<RepaintRectCalculation, FloatRect> m_clipBoundaries;
     HashMap<const RenderObject*, std::unique_ptr<ClipperData>> m_clipperMap;
 };
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -448,7 +448,7 @@ FloatRect LegacyRenderSVGRoot::repaintRectInLocalCoordinates(RepaintRectCalculat
         FloatRect repaintBoundingBox;
         bool objectBoundingBoxValid = true;
         SVGRenderSupport::computeContainerBoundingBoxes(*this, objectBoundingBox, objectBoundingBoxValid, repaintBoundingBox, RepaintRectCalculation::Accurate);
-        SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox);
+        SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox, RepaintRectCalculation::Accurate);
         repaintBoundingBox.inflate(horizontalBorderAndPaddingExtent());
         m_accurateRepaintBoundingBox = repaintBoundingBox;
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -409,7 +409,7 @@ FloatRect LegacyRenderSVGShape::repaintRectInLocalCoordinates(RepaintRectCalcula
         return m_repaintBoundingBox;
 
     FloatRect strokeBoundingBox = this->strokeBoundingBox();
-    SVGRenderSupport::intersectRepaintRectWithResources(*this, strokeBoundingBox);
+    SVGRenderSupport::intersectRepaintRectWithResources(*this, strokeBoundingBox, RepaintRectCalculation::Accurate);
     return strokeBoundingBox;
 }
 


### PR DESCRIPTION
#### f010e6048d0b9463e6476cb3fb26ceef751a8469
<pre>
[SVG] Use propagated RepaintRectCalculation more
<a href="https://bugs.webkit.org/show_bug.cgi?id=263360">https://bugs.webkit.org/show_bug.cgi?id=263360</a>
rdar://117184769

Reviewed by Cameron McCormack.

This patch more strictly propagating RepaintRectCalculation instead of using RepaintRectCalculation::Accurate.
This makes the code places explicit that they are using RepaintRectCalculation::Accurate explicitly. The reason
of this use is that they are confusing repaint bounding box and stroke bounding box and using RepaintRectCalculation::Accurate
to get resource rects / marker rects. And we can easily see the code using RepaintRectCalculation::Accurate by just grepping it.
This indicates that these places should use stroke bounding box correctly instead.

Cameron and I discussed and agreed that we should remove RepaintRectCalculation::Accurate eventually. So these FloatRects for Accurate
are temporary ones. By doing these use explicit, we can look into these things easily and remove them eventually. Basically use of Accurate
is a sign of wrong implementations.

* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/svg/RenderSVGResource.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::resourceBoundingBox):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::removeAllClientsFromCache):
(WebCore::RenderSVGResourceMasker::calculateMaskContentRepaintRect):
(WebCore::RenderSVGResourceMasker::resourceBoundingBox):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/RenderSVGResourceSolidColor.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::adjustBoxForClippingAndEffects const):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeContainerStrokeBoundingBox):
(WebCore::SVGRenderSupport::intersectRepaintRectWithResources):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeResources):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::removeAllClientsFromCache):
(WebCore::LegacyRenderSVGResourceClipper::calculateClipContentRepaintRect):
(WebCore::LegacyRenderSVGResourceClipper::resourceBoundingBox):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::repaintRectInLocalCoordinates const):

Canonical link: <a href="https://commits.webkit.org/269529@main">https://commits.webkit.org/269529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c76a5fb7602a6163d7e83e5d0a9e5fddd62add1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/21997 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25550 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26855 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18157 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/384 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2878 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->