### PR TITLE
[Win] http/tests/cookies/document-cookie-during-iframe-parsing.html is timing out

### DIFF
--- a/LayoutTests/http/tests/cookies/resources/set-cookie-and-serve.py
+++ b/LayoutTests/http/tests/cookies/resources/set-cookie-and-serve.py
@@ -9,14 +9,15 @@ cookie_name = query.get('cookie-name', [''])[0]
 cookie_value = query.get('cookie-value', [''])[0]
 destination = query.get('destination', [''])[0]
 
-sys.stdout.write(
+sys.stdout.buffer.write(
     'Content-Type: text/html\r\n'
     'Cache-Control: no-store\r\n'
-    'Set-Cookie: {}={}; path=/\r\n'.format(cookie_name, cookie_value)
+    'Set-Cookie: {}={}; path=/\r\n'.format(cookie_name, cookie_value).encode()
 )
 
-with open(os.path.join(os.path.dirname(__file__), destination), 'r') as file:
+with open(os.path.join(os.path.dirname(__file__), destination), 'rb') as file:
     content = file.read()
-    sys.stdout.write('Content-Length: {}\r\n\r\n{}'.format(len(content), content))
+    sys.stdout.buffer.write('Content-Length: {}\r\n\r\n'.format(len(content)).encode())
+    sys.stdout.buffer.write(content)
 
 sys.exit(0)

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -920,8 +920,6 @@ webkit.org/b/209455 http/wpt/misc/no-last-modified.html [ Failure Pass ]
 
 http/tests/IndexedDB/storage-limit-1.https.html [ Failure ]
 http/tests/IndexedDB/storage-limit.https.html [ Failure ]
-http/tests/cookies/document-cookie-after-showModalDialog.html [ Timeout ]
-http/tests/cookies/document-cookie-during-iframe-parsing.html [ Timeout ]
 http/tests/cookies/document-cookie-multiple-cookies.html [ Failure ]
 http/tests/misc/form-post-textplain-cross-site.html [ Failure ]
 http/tests/misc/form-post-textplain.html [ Failure ]


### PR DESCRIPTION
#### f40446c2645c3cf9a055b3fb0cc3af486b297891
<pre>
[Win] http/tests/cookies/document-cookie-during-iframe-parsing.html is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=263364">https://bugs.webkit.org/show_bug.cgi?id=263364</a>

Reviewed by Ross Kirsling.

Windows Python replaces &apos;\n&apos; to &apos;\r\n&apos; for sys.stdout. Use
sys.stdout.buffer.write instead of sys.stdout.write.

* LayoutTests/http/tests/cookies/resources/set-cookie-and-serve.py:
* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/269590@main">https://commits.webkit.org/269590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2bd39638f126c88fe6191cad8fce597a8e1601

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21207 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23480 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25675 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23092 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26959 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19947 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24811 "Passed tests") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/442 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22702 "Failed resultsdbpy unit tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20549 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/853 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/28028 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2914 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/610 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6009 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running jscore-test") | 
<!--EWS-Status-Bubble-End-->