### PR TITLE
[web-animations] remove the WebAnimationsMutableTimelinesEnabled flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7407,20 +7407,6 @@ WebAnimationsIterationCompositeEnabled:
     WebCore:
       default: true
 
-WebAnimationsMutableTimelinesEnabled:
-  type: bool
-  status: stable
-  category: animation
-  humanReadableName: "Web Animations mutable timelines"
-  humanReadableDescription: "Support for setting the timeline property of an Animation object"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 WebArchiveDebugModeEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/animation/KeyframeAnimationOptions.idl
+++ b/Source/WebCore/animation/KeyframeAnimationOptions.idl
@@ -27,6 +27,6 @@ typedef unsigned long FramesPerSecond;
 
 dictionary KeyframeAnimationOptions : KeyframeEffectOptions {
     DOMString id = "";
-    [EnabledBySetting=WebAnimationsMutableTimelinesEnabled] AnimationTimeline? timeline;
+    AnimationTimeline? timeline;
     [EnabledBySetting=WebAnimationsCustomFrameRateEnabled] (FramesPerSecond or AnimationFrameRatePreset) frameRate = "auto";
 };

--- a/Source/WebCore/animation/WebAnimation.idl
+++ b/Source/WebCore/animation/WebAnimation.idl
@@ -51,7 +51,7 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
     attribute DOMString id;
     [ImplementedAs=bindingsEffect] attribute AnimationEffect? effect;
-    [EnabledConditionallyReadWriteBySetting=WebAnimationsMutableTimelinesEnabled] attribute AnimationTimeline? timeline;
+    attribute AnimationTimeline? timeline;
     [ImplementedAs=bindingsStartTime] attribute CSSNumberish? startTime;
     [ImplementedAs=bindingsCurrentTime] attribute CSSNumberish? currentTime;
     attribute double playbackRate;


### PR DESCRIPTION
#### 9c2a7feebac7ceca545d08da8ed6fa731f8e2af3
<pre>
[web-animations] remove the WebAnimationsMutableTimelinesEnabled flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=263365">https://bugs.webkit.org/show_bug.cgi?id=263365</a>

Reviewed by Antti Koivisto.

That flag has been enabled by default for well over a year (March 25, 2022) in 248874@main.
It&apos;s outlived its purpose so we can remove it now.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/animation/KeyframeAnimationOptions.idl:
* Source/WebCore/animation/WebAnimation.idl:

Canonical link: <a href="https://commits.webkit.org/269517@main">https://commits.webkit.org/269517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f65981688314b6822ec50c6e64f11d1dce553b83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24704 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23053 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1540 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23322 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23036 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/1540 "Failed to compile WebKit") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25557 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/1540 "Failed to compile WebKit") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26861 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19848 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/1540 "Failed to compile WebKit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24717 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22158 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18161 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/26215 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/263 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6139 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/388 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27497 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2873 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/326 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5968 "Passed tests") | 
<!--EWS-Status-Bubble-End-->