### PR TITLE
[CoordinatedGraphics] Remove CompositingCoordinator::syncLayerState()

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -1064,17 +1064,15 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
     }
 }
 
-void CoordinatedGraphicsLayer::syncPendingStateChangesIncludingSubLayers()
+bool CoordinatedGraphicsLayer::checkPendingStateChangesIncludingSubLayers()
 {
-    if (m_nicosia.performLayerSync)
-        m_coordinator->syncLayerState();
-    m_nicosia.performLayerSync = false;
-
+    bool performLayerSync = std::exchange(m_nicosia.performLayerSync, false);
     if (maskLayer())
-        downcast<CoordinatedGraphicsLayer>(*maskLayer()).syncPendingStateChangesIncludingSubLayers();
+        performLayerSync |= downcast<CoordinatedGraphicsLayer>(*maskLayer()).checkPendingStateChangesIncludingSubLayers();
 
     for (auto& child : children())
-        downcast<CoordinatedGraphicsLayer>(child.get()).syncPendingStateChangesIncludingSubLayers();
+        performLayerSync |= downcast<CoordinatedGraphicsLayer>(child.get()).checkPendingStateChangesIncludingSubLayers();
+    return performLayerSync;
 }
 
 void CoordinatedGraphicsLayer::deviceOrPageScaleFactorChanged()

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -53,7 +53,6 @@ public:
     virtual void attachLayer(CoordinatedGraphicsLayer*) = 0;
     virtual Nicosia::PaintingEngine& paintingEngine() = 0;
     virtual RefPtr<Nicosia::ImageBackingStore> imageBackingStore(uint64_t, Function<RefPtr<Nicosia::Buffer>()>) = 0;
-    virtual void syncLayerState() = 0;
 };
 
 class WEBCORE_EXPORT CoordinatedGraphicsLayer : public GraphicsLayer {
@@ -127,7 +126,7 @@ public:
     PlatformLayer* platformLayer() const override;
 #endif
 
-    void syncPendingStateChangesIncludingSubLayers();
+    bool checkPendingStateChangesIncludingSubLayers();
     void updateContentBuffersIncludingSubLayers();
 
     FloatPoint computePositionRelativeToBase();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h
@@ -80,7 +80,9 @@ public:
     WebCore::GraphicsLayer* rootLayer() const { return m_rootLayer.get(); }
     WebCore::GraphicsLayer* rootCompositingLayer() const { return m_rootCompositingLayer; }
 
-    void forceFrameSync() { m_shouldSyncFrame = true; }
+#if !HAVE(DISPLAY_LINK)
+    void forceFrameSync() { m_forceFrameSync = true; }
+#endif
 
     bool flushPendingLayerChanges(OptionSet<WebCore::FinalizeRenderingUpdateFlags>);
     void syncDisplayState();
@@ -95,7 +97,6 @@ private:
     void attachLayer(WebCore::CoordinatedGraphicsLayer*) override;
     Nicosia::PaintingEngine& paintingEngine() override;
     RefPtr<Nicosia::ImageBackingStore> imageBackingStore(uint64_t, Function<RefPtr<Nicosia::Buffer>()>) override;
-    void syncLayerState() override;
 
     // GraphicsLayerFactory
     Ref<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayer::Type, WebCore::GraphicsLayerClient&) override;
@@ -103,7 +104,7 @@ private:
     // Nicosia::SceneIntegration::Client
     void requestUpdate() override;
 
-    void initializeRootCompositingLayerIfNeeded();
+    bool initializeRootCompositingLayerIfNeeded();
 
     void purgeBackingStores();
 
@@ -130,12 +131,14 @@ private:
     // We don't send the messages related to releasing resources to renderer during purging, because renderer already had removed all resources.
     bool m_isPurging { false };
     bool m_isFlushingLayerChanges { false };
-    bool m_shouldSyncFrame { false };
     bool m_didInitializeRootCompositingLayer { false };
 
     WebCore::FloatRect m_visibleContentsRect;
 
     double m_lastAnimationServiceTime { 0 };
+#if !HAVE(DISPLAY_LINK)
+    bool m_forceFrameSync { false };
+#endif
 };
 
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -163,10 +163,12 @@ void LayerTreeHost::layerFlushTimerFired()
     if (!m_coordinator.rootCompositingLayer())
         return;
 
+#if !HAVE(DISPLAY_LINK)
     // If a force-repaint callback was registered, we should force a 'frame sync' that
     // will guarantee us a call to renderNextFrame() once the update is complete.
     if (m_forceRepaintAsync.callback)
         m_coordinator.forceFrameSync();
+#endif
 
     OptionSet<FinalizeRenderingUpdateFlags> flags;
 #if PLATFORM(GTK)
@@ -477,8 +479,10 @@ void LayerTreeHost::renderNextFrame(bool forceRepaint)
 
     if (scheduledWhileWaitingForRenderer || m_layerFlushTimer.isActive() || forceRepaint) {
         m_layerFlushTimer.stop();
+#if !HAVE(DISPLAY_LINK)
         if (forceRepaint)
             m_coordinator.forceFrameSync();
+#endif
         layerFlushTimerFired();
     }
 }


### PR DESCRIPTION
#### 5a023aa726196215720ffeeffccda978615dd478
<pre>
[CoordinatedGraphics] Remove CompositingCoordinator::syncLayerState()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263368">https://bugs.webkit.org/show_bug.cgi?id=263368</a>

Reviewed by Žan Doberšek.

The coordinator calls syncPendingStateChangesIncludingSubLayers on the
root graphics layer, that doesn&apos;t really sync anything, every layer
checks if there&apos;s a pending stater sync and calls
CompositingCoordinator::syncLayerState() to mark m_shouldSyncFrame as
true. We can remove the dependency of the layer on the compositor by
making syncPendingStateChangesIncludingSubLayers return whether the sync
should happen or not.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::checkPendingStateChangesIncludingSubLayers):
(WebCore::CoordinatedGraphicsLayer::syncPendingStateChangesIncludingSubLayers): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
(WebKit::CompositingCoordinator::initializeRootCompositingLayerIfNeeded):
(WebKit::CompositingCoordinator::syncLayerState): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::layerFlushTimerFired):
(WebKit::LayerTreeHost::renderNextFrame):

Canonical link: <a href="https://commits.webkit.org/269560@main">https://commits.webkit.org/269560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72fc977c24f0355183977df189f0eb1bc8daacd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22003 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25564 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26863 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24719 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/345 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18164 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/393 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2895 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->