### PR TITLE
Add <input type=checkbox switch> macOS implementation

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2043,6 +2043,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/controls/SearchFieldResultsPart.h
     platform/graphics/controls/SliderThumbPart.h
     platform/graphics/controls/SliderTrackPart.h
+    platform/graphics/controls/SwitchThumbPart.h
+    platform/graphics/controls/SwitchTrackPart.h
     platform/graphics/controls/TextAreaPart.h
     platform/graphics/controls/TextFieldPart.h
     platform/graphics/controls/ToggleButtonPart.h

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		DD20DE3627BC90D80093D175 /* NSSharingServicePickerSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C77857F1F45130F00F4EBB6 /* NSSharingServicePickerSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD20DE3727BC90D80093D175 /* NSSharingServiceSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C7785801F45130F00F4EBB6 /* NSSharingServiceSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD20DE3827BC90D80093D175 /* NSSpellCheckerSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C7785811F45130F00F4EBB6 /* NSSpellCheckerSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DD20DE3827BC90D80093D176 /* NSSwitchSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C7785811F45130F00F4EBB7 /* NSSwitchSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD20DE3927BC90D80093D175 /* NSTextFinderSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C7785821F45130F00F4EBB6 /* NSTextFinderSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD20DE3A27BC90D80093D175 /* NSTextInputContextSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 93DB7D3624626BCC004BD8A3 /* NSTextInputContextSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD20DE3B27BC90D80093D175 /* NSUndoManagerSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 93DB7D3924626F86004BD8A3 /* NSUndoManagerSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -469,6 +470,7 @@
 		0C77857F1F45130F00F4EBB6 /* NSSharingServicePickerSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSSharingServicePickerSPI.h; sourceTree = "<group>"; };
 		0C7785801F45130F00F4EBB6 /* NSSharingServiceSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSSharingServiceSPI.h; sourceTree = "<group>"; };
 		0C7785811F45130F00F4EBB6 /* NSSpellCheckerSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSSpellCheckerSPI.h; sourceTree = "<group>"; };
+		0C7785811F45130F00F4EBB7 /* NSSwitchSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSSwitchSPI.h; sourceTree = "<group>"; };
 		0C7785821F45130F00F4EBB6 /* NSTextFinderSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSTextFinderSPI.h; sourceTree = "<group>"; };
 		0C7785831F45130F00F4EBB6 /* NSViewSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSViewSPI.h; sourceTree = "<group>"; };
 		0C7785841F45130F00F4EBB6 /* NSWindowSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSWindowSPI.h; sourceTree = "<group>"; };
@@ -886,6 +888,7 @@
 				0C77857F1F45130F00F4EBB6 /* NSSharingServicePickerSPI.h */,
 				0C7785801F45130F00F4EBB6 /* NSSharingServiceSPI.h */,
 				0C7785811F45130F00F4EBB6 /* NSSpellCheckerSPI.h */,
+				0C7785811F45130F00F4EBB7 /* NSSwitchSPI.h */,
 				72BA2A872951462500678507 /* NSTextFieldCellSPI.h */,
 				0C7785821F45130F00F4EBB6 /* NSTextFinderSPI.h */,
 				93DB7D3624626BCC004BD8A3 /* NSTextInputContextSPI.h */,
@@ -1384,6 +1387,7 @@
 				DD20DE3727BC90D80093D175 /* NSSharingServiceSPI.h in Headers */,
 				DD20DE3827BC90D80093D175 /* NSSpellCheckerSPI.h in Headers */,
 				DD20DDFB27BC90D70093D175 /* NSStringSPI.h in Headers */,
+				DD20DE3827BC90D80093D176 /* NSSwitchSPI.h in Headers */,
 				DD20DE3927BC90D80093D175 /* NSTextFinderSPI.h in Headers */,
 				DD20DE3A27BC90D80093D175 /* NSTextInputContextSPI.h in Headers */,
 				DD20DDFC27BC90D70093D175 /* NSTouchBarSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/PlatformMac.cmake
+++ b/Source/WebCore/PAL/pal/PlatformMac.cmake
@@ -139,6 +139,7 @@ list(APPEND PAL_PUBLIC_HEADERS
     spi/mac/NSSharingServicePickerSPI.h
     spi/mac/NSSharingServiceSPI.h
     spi/mac/NSSpellCheckerSPI.h
+    spi/mac/NSSwitchSPI.h
     spi/mac/NSTextFinderSPI.h
     spi/mac/NSTextInputContextSPI.h
     spi/mac/NSUndoManagerSPI.h

--- a/Source/WebCore/PAL/pal/spi/mac/CoreUISPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/CoreUISPI.h
@@ -69,5 +69,10 @@ extern const CFStringRef kCUIWidgetButtonLittleArrows;
 extern const CFStringRef kCUIWidgetProgressIndeterminateBar;
 extern const CFStringRef kCUIWidgetProgressBar;
 extern const CFStringRef kCUIWidgetScrollBarTrackCorner;
+extern const CFStringRef kCUIWidgetSwitchKnob;
+extern const CFStringRef kCUIWidgetSwitchBorder;
+extern const CFStringRef kCUIWidgetSwitchFill;
+extern const CFStringRef kCUIWidgetSwitchFillMask;
+extern const CFStringRef kCUIWidgetSwitchOnOffLabel;
 
 #endif

--- a/Source/WebCore/PAL/pal/spi/mac/NSSwitchSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSSwitchSPI.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if USE(APPKIT)
+
+@interface NSSwitch ()
+- (NSRect)_trackFrameInRect:(NSRect)boundsRect;
+- (NSRect)_knobFrameInTrackFrame:(NSRect)trackFrameRect thumbIsOnRight:(BOOL)isOnRight;
+@end
+
+#endif // USE(APPKIT)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1609,6 +1609,8 @@ html/shadow/ProgressShadowElement.cpp
 html/shadow/ShadowPseudoIds.cpp
 html/shadow/SliderThumbElement.cpp
 html/shadow/SpinButtonElement.cpp
+html/shadow/SwitchThumbElement.cpp
+html/shadow/SwitchTrackElement.cpp
 html/shadow/TextControlInnerElements.cpp
 html/shadow/TextPlaceholderElement.cpp
 html/track/AudioTrack.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -501,6 +501,8 @@ platform/graphics/mac/controls/SearchFieldMac.mm
 platform/graphics/mac/controls/SearchFieldResultsMac.mm
 platform/graphics/mac/controls/SliderThumbMac.mm
 platform/graphics/mac/controls/SliderTrackMac.mm
+platform/graphics/mac/controls/SwitchThumbMac.mm
+platform/graphics/mac/controls/SwitchTrackMac.mm
 platform/graphics/mac/controls/TextAreaMac.mm
 platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/ToggleButtonMac.mm

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -383,7 +383,8 @@ constexpr CSSValueID toCSSValueID(StyleAppearance e)
     case StyleAppearance::SearchFieldCancelButton:
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderThumbVertical:
-    case StyleAppearance::Switch:
+    case StyleAppearance::SwitchThumb:
+    case StyleAppearance::SwitchTrack:
         ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
         return CSSValueNone;
     }

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -844,6 +844,10 @@ input:is([type="radio"], [type="checkbox"]) {
 #endif
 }
 
+input[type="checkbox"][switch] {
+    margin: initial;
+}
+
 input:is([type="button"], [type="submit"], [type="reset"]) {
     white-space: pre;
 }

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -327,8 +327,8 @@ void BaseDateAndTimeInputType::showPicker()
 
 void BaseDateAndTimeInputType::createShadowSubtree()
 {
-    ASSERT(needsShadowSubtree());
     ASSERT(element());
+    ASSERT(needsShadowSubtree());
 
     auto& element = *this->element();
     auto& document = element.document();

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -42,6 +42,7 @@ public:
     }
 
     bool valueMissing(const String&) const final;
+    bool needsShadowSubtree() const final;
 
 private:
     explicit CheckboxInputType(HTMLInputElement& element)
@@ -51,6 +52,7 @@ private:
 
     const AtomString& formControlType() const final;
     String valueMissingText() const final;
+    void createShadowSubtree() final;
     void attributeChanged(const QualifiedName&) final;
     void handleKeyupEvent(KeyboardEvent&) final;
     void willDispatchClick(InputElementClickState&) final;

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -139,8 +139,8 @@ Color ColorInputType::valueAsColor() const
 
 void ColorInputType::createShadowSubtree()
 {
-    ASSERT(needsShadowSubtree());
     ASSERT(element());
+    ASSERT(needsShadowSubtree());
     ASSERT(element()->shadowRoot());
 
     Document& document = element()->document();

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -268,8 +268,8 @@ void FileInputType::setValue(const String&, bool valueChanged, TextFieldEventBeh
 
 void FileInputType::createShadowSubtree()
 {
-    ASSERT(needsShadowSubtree());
     ASSERT(element());
+    ASSERT(needsShadowSubtree());
     ASSERT(element()->shadowRoot());
 
     auto button = element()->multiple() ? UploadButtonElement::createForMultiple(element()->document()) : UploadButtonElement::create(element()->document());

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -677,6 +677,7 @@ void InputType::destroyShadowSubtree()
         return;
 
     root->removeChildren();
+    m_hasCreatedShadowSubtree = false;
 }
 
 Decimal InputType::parseToNumber(const String&, const Decimal& defaultValue) const

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -208,7 +208,7 @@ public:
     bool isInteractiveContent() const;
     bool isLabelable() const;
     bool isEnumeratable() const;
-    bool needsShadowSubtree() const { return !nonShadowRootTypes.contains(m_type); }
+    virtual bool needsShadowSubtree() const { return !nonShadowRootTypes.contains(m_type); }
     bool hasCreatedShadowSubtree() const { return m_hasCreatedShadowSubtree; }
 
     // Form value functions.

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -247,8 +247,8 @@ auto RangeInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
 
 void RangeInputType::createShadowSubtree()
 {
-    ASSERT(needsShadowSubtree());
     ASSERT(element());
+    ASSERT(needsShadowSubtree());
     ASSERT(element()->userAgentShadowRoot());
 
     Document& document = element()->document();

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -107,6 +107,7 @@ bool SearchInputType::needsContainer() const
 
 void SearchInputType::createShadowSubtree()
 {
+    ASSERT(element());
     ASSERT(needsShadowSubtree());
     ASSERT(!m_resultsButton);
     ASSERT(!m_cancelButton);
@@ -118,7 +119,6 @@ void SearchInputType::createShadowSubtree()
     ASSERT(container);
     ASSERT(textWrapper);
 
-    ASSERT(element());
     m_resultsButton = SearchFieldResultsButtonElement::create(element()->document());
     container->insertBefore(*m_resultsButton, textWrapper.copyRef());
     updateResultButtonPseudoType(*m_resultsButton, element()->maxResults());

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -326,8 +326,8 @@ bool TextFieldInputType::shouldHaveCapsLockIndicator() const
 
 void TextFieldInputType::createShadowSubtree()
 {
-    ASSERT(needsShadowSubtree());
     ASSERT(element());
+    ASSERT(needsShadowSubtree());
     ASSERT(element()->shadowRoot());
     ASSERT(!element()->shadowRoot()->hasChildNodes());
 

--- a/Source/WebCore/html/shadow/SwitchThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SwitchThumbElement.h"
+
+#include "ResolvedStyle.h"
+#include "ScriptDisallowedScope.h"
+
+namespace WebCore {
+
+using namespace HTMLNames;
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SwitchThumbElement);
+
+Ref<SwitchThumbElement> SwitchThumbElement::create(Document& document)
+{
+    auto element = adoptRef(*new SwitchThumbElement(document));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
+    return element;
+}
+
+SwitchThumbElement::SwitchThumbElement(Document& document)
+    : HTMLDivElement(HTMLNames::divTag, document, CreateSwitchThumbElement)
+{
+}
+
+std::optional<Style::ResolvedStyle> SwitchThumbElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* hostStyle)
+{
+    if (!hostStyle)
+        return std::nullopt;
+
+    auto elementStyle = resolveStyle(resolutionContext);
+    if (hostStyle->effectiveAppearance() == StyleAppearance::Auto) {
+        elementStyle.style->setEffectiveAppearance(StyleAppearance::SwitchThumb);
+        elementStyle.style->setWidth({ 38, LengthType::Fixed });
+        elementStyle.style->setHeight({ 24, LengthType::Fixed });
+        elementStyle.style->setMarginTop({ -24, LengthType::Fixed });
+    }
+
+    return elementStyle;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchThumbElement.h
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "HTMLDivElement.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class HTMLInputElement;
+class TouchEvent;
+
+class SwitchThumbElement final : public HTMLDivElement {
+    WTF_MAKE_ISO_ALLOCATED(SwitchThumbElement);
+public:
+    static Ref<SwitchThumbElement> create(Document&);
+private:
+    constexpr static auto CreateSwitchThumbElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    SwitchThumbElement(Document&);
+
+    std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle*) final;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchTrackElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SwitchTrackElement.h"
+
+#include "ResolvedStyle.h"
+#include "ScriptDisallowedScope.h"
+
+namespace WebCore {
+
+using namespace HTMLNames;
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SwitchTrackElement);
+
+Ref<SwitchTrackElement> SwitchTrackElement::create(Document& document)
+{
+    auto element = adoptRef(*new SwitchTrackElement(document));
+    ScriptDisallowedScope::EventAllowedScope eventAllowedScope { element };
+    return element;
+}
+
+SwitchTrackElement::SwitchTrackElement(Document& document)
+    : HTMLDivElement(HTMLNames::divTag, document, CreateSwitchTrackElement)
+{
+}
+
+std::optional<Style::ResolvedStyle> SwitchTrackElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* hostStyle)
+{
+    if (!hostStyle)
+        return std::nullopt;
+
+    auto elementStyle = resolveStyle(resolutionContext);
+    if (hostStyle->effectiveAppearance() == StyleAppearance::Auto) {
+        elementStyle.style->setEffectiveAppearance(StyleAppearance::SwitchTrack);
+        elementStyle.style->setWidth({ 38, LengthType::Fixed });
+        elementStyle.style->setHeight({ 24, LengthType::Fixed });
+    }
+
+    return elementStyle;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchTrackElement.h
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "HTMLDivElement.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class HTMLInputElement;
+class TouchEvent;
+
+class SwitchTrackElement final : public HTMLDivElement {
+    WTF_MAKE_ISO_ALLOCATED(SwitchTrackElement);
+public:
+    static Ref<SwitchTrackElement> create(Document&);
+private:
+    constexpr static auto CreateSwitchTrackElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    SwitchTrackElement(Document&);
+
+    std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle*) final;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/ControlFactory.h
+++ b/Source/WebCore/platform/graphics/controls/ControlFactory.h
@@ -42,6 +42,8 @@ class SearchFieldPart;
 class SearchFieldResultsPart;
 class SliderThumbPart;
 class SliderTrackPart;
+class SwitchThumbPart;
+class SwitchTrackPart;
 class TextAreaPart;
 class TextFieldPart;
 class ToggleButtonPart;
@@ -74,6 +76,8 @@ public:
     virtual std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSwitchThumb(SwitchThumbPart&) = 0;
+    virtual std::unique_ptr<PlatformControl> createPlatformSwitchTrack(SwitchTrackPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) = 0;
     virtual std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) = 0;

--- a/Source/WebCore/platform/graphics/controls/SwitchThumbPart.h
+++ b/Source/WebCore/platform/graphics/controls/SwitchThumbPart.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class SwitchThumbPart final : public ControlPart {
+public:
+    static Ref<SwitchThumbPart> create()
+    {
+        return adoptRef(*new SwitchThumbPart());
+    }
+
+private:
+    SwitchThumbPart()
+        : ControlPart(StyleAppearance::SwitchThumb)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformSwitchThumb(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/SwitchTrackPart.h
+++ b/Source/WebCore/platform/graphics/controls/SwitchTrackPart.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ControlFactory.h"
+#include "ControlPart.h"
+
+namespace WebCore {
+
+class SwitchTrackPart final : public ControlPart {
+public:
+    static Ref<SwitchTrackPart> create()
+    {
+        return adoptRef(*new SwitchTrackPart());
+    }
+
+private:
+    SwitchTrackPart()
+        : ControlPart(StyleAppearance::SwitchTrack)
+    {
+    }
+
+    std::unique_ptr<PlatformControl> createPlatformControl() final
+    {
+        return controlFactory().createPlatformSwitchTrack(*this);
+    }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h
+++ b/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h
@@ -50,6 +50,8 @@ private:
     std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchThumb(SwitchThumbPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchTrack(SwitchTrackPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;

--- a/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm
+++ b/Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm
@@ -111,6 +111,18 @@ std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformSliderTrack(Sl
     return nullptr;
 }
 
+std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformSwitchThumb(SwitchThumbPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformSwitchTrack(SwitchTrackPart&)
+{
+    notImplemented();
+    return nullptr;
+}
+
 std::unique_ptr<PlatformControl> ControlFactoryIOS::createPlatformTextArea(TextAreaPart&)
 {
     notImplemented();

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h
@@ -67,6 +67,8 @@ private:
     std::unique_ptr<PlatformControl> createPlatformSearchFieldResults(SearchFieldResultsPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderThumb(SliderThumbPart&) final;
     std::unique_ptr<PlatformControl> createPlatformSliderTrack(SliderTrackPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchThumb(SwitchThumbPart&) final;
+    std::unique_ptr<PlatformControl> createPlatformSwitchTrack(SwitchTrackPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextArea(TextAreaPart&) final;
     std::unique_ptr<PlatformControl> createPlatformTextField(TextFieldPart&) final;
     std::unique_ptr<PlatformControl> createPlatformToggleButton(ToggleButtonPart&) final;
@@ -80,6 +82,7 @@ private:
     NSSearchFieldCell *searchFieldCell() const;
     NSMenu *searchMenuTemplate() const;
     NSSliderCell *sliderCell() const;
+    NSSwitch *switchControl() const;
     NSTextFieldCell *textFieldCell() const;
 
     mutable RetainPtr<WebControlView> m_drawingView;
@@ -96,6 +99,7 @@ private:
     mutable RetainPtr<NSSearchFieldCell> m_searchFieldCell;
     mutable RetainPtr<NSMenu> m_searchMenuTemplate;
     mutable RetainPtr<NSSliderCell> m_sliderCell;
+    mutable RetainPtr<NSSwitch> m_switchControl;
     mutable RetainPtr<NSTextFieldCell> m_textFieldCell;
 };
 

--- a/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm
@@ -44,6 +44,8 @@
 #import "SearchFieldResultsPart.h"
 #import "SliderThumbMac.h"
 #import "SliderTrackMac.h"
+#import "SwitchThumbMac.h"
+#import "SwitchTrackMac.h"
 #import "TextAreaMac.h"
 #import "TextFieldMac.h"
 #import "ToggleButtonMac.h"
@@ -209,6 +211,17 @@ NSSliderCell *ControlFactoryMac::sliderCell() const
     return m_sliderCell.get();
 }
 
+NSSwitch *ControlFactoryMac::switchControl() const
+{
+    if (!m_switchControl) {
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        m_switchControl = adoptNS([[NSSwitch alloc] init]);
+        [m_switchControl setWantsLayer:YES];
+        END_BLOCK_OBJC_EXCEPTIONS
+    }
+    return m_switchControl.get();
+}
+
 NSTextFieldCell *ControlFactoryMac::textFieldCell() const
 {
     if (!m_textFieldCell) {
@@ -293,6 +306,16 @@ std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSliderThumb(Sl
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSliderTrack(SliderTrackPart& part)
 {
     return makeUnique<SliderTrackMac>(part, *this);
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSwitchThumb(SwitchThumbPart& part)
+{
+    return makeUnique<SwitchThumbMac>(part, *this, switchControl());
+}
+
+std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformSwitchTrack(SwitchTrackPart& part)
+{
+    return makeUnique<SwitchTrackMac>(part, *this, switchControl());
 }
 
 std::unique_ptr<PlatformControl> ControlFactoryMac::createPlatformTextArea(TextAreaPart& part)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class SwitchThumbPart;
+
+class SwitchThumbMac final : public ControlMac {
+public:
+    SwitchThumbMac(SwitchThumbPart&, ControlFactoryMac&, NSSwitch*);
+
+private:
+    void draw(GraphicsContext&, const FloatRoundedRect&, float, const ControlStyle&) override;
+
+    RetainPtr<NSSwitch> m_switchPtr;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SwitchThumbMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ControlFactoryMac.h"
+#import "FloatRoundedRect.h"
+#import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "SwitchThumbPart.h"
+#import <pal/spi/mac/CoreUISPI.h>
+#import <pal/spi/mac/NSAppearanceSPI.h>
+#import <pal/spi/mac/NSSwitchSPI.h>
+
+namespace WebCore {
+
+SwitchThumbMac::SwitchThumbMac(SwitchThumbPart& owningPart, ControlFactoryMac& controlFactory, NSSwitch *switchPtr)
+    : ControlMac(owningPart, controlFactory)
+    , m_switchPtr(switchPtr)
+{
+    ASSERT(m_owningPart.type() == StyleAppearance::SwitchThumb);
+}
+
+void SwitchThumbMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
+{
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    bool isOn = style.states.contains(ControlStyle::State::Checked);
+    bool isEnabled = style.states.contains(ControlStyle::State::Enabled);
+    bool isPressed = style.states.contains(ControlStyle::State::Pressed);
+
+    auto inflatedRect = borderRect.rect();
+    inflatedRect.inflateY(-1 / 2.f);
+
+    auto trackRect = [m_switchPtr _trackFrameInRect:inflatedRect];
+
+    trackRect.origin.x -= inflatedRect.x();
+    trackRect.origin.y -= inflatedRect.y();
+
+    auto knobRect = [m_switchPtr _knobFrameInTrackFrame:trackRect thumbIsOnRight:isOn];
+    auto imageBuffer = context.createImageBuffer(inflatedRect.size(), deviceScaleFactor);
+
+    if (!imageBuffer)
+        return;
+
+    auto cgContext = imageBuffer->context().platformContext();
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    [[NSAppearance currentDrawingAppearance] _drawInRect:knobRect context:cgContext options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchKnob,
+        (__bridge NSString *)kCUIStateKey: (__bridge NSString *)(!isEnabled ? kCUIStateDisabled : isPressed ? kCUIStatePressed : kCUIStateActive),
+        (__bridge NSString *)kCUISizeKey: (__bridge NSString *)kCUISizeRegular,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    if (style.states.contains(ControlStyle::State::RightToLeft)) {
+        context.translate(2 * inflatedRect.x() + inflatedRect.width(), 0);
+        context.scale(FloatSize(-1, 1));
+    }
+
+    context.drawConsumingImageBuffer(WTFMove(imageBuffer), inflatedRect.location());
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import "ControlMac.h"
+
+namespace WebCore {
+
+class SwitchTrackMac;
+
+class SwitchTrackMac final : public ControlMac {
+public:
+    SwitchTrackMac(SwitchTrackPart&, ControlFactoryMac&, NSSwitch *);
+
+private:
+    void draw(GraphicsContext&, const FloatRoundedRect&, float, const ControlStyle&) override;
+
+    RetainPtr<NSSwitch> m_switchPtr;
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SwitchTrackMac.h"
+
+#if PLATFORM(MAC)
+
+#import "ControlFactoryMac.h"
+#import "FloatRoundedRect.h"
+#import "GraphicsContext.h"
+#import "LocalCurrentGraphicsContext.h"
+#import "LocalDefaultSystemAppearance.h"
+#import "SwitchTrackPart.h"
+#import <pal/spi/mac/CoreUISPI.h>
+#import <pal/spi/mac/NSAppearanceSPI.h>
+#import <pal/spi/mac/NSSwitchSPI.h>
+
+namespace WebCore {
+
+SwitchTrackMac::SwitchTrackMac(SwitchTrackPart& part, ControlFactoryMac& controlFactory, NSSwitch *switchPtr)
+    : ControlMac(part, controlFactory)
+    , m_switchPtr(switchPtr)
+{
+}
+
+void SwitchTrackMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
+{
+    LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
+
+    bool isOn = style.states.contains(ControlStyle::State::Checked);
+    bool isEnabled = style.states.contains(ControlStyle::State::Enabled);
+    bool isPressed = style.states.contains(ControlStyle::State::Pressed);
+    bool isInActiveWindow = style.states.contains(ControlStyle::State::WindowActive);
+
+    auto inflatedRect = borderRect.rect();
+    inflatedRect.inflateY(-1 / 2.f);
+
+    auto trackRect = [m_switchPtr _trackFrameInRect:inflatedRect];
+
+    trackRect.origin.x -= inflatedRect.x();
+    trackRect.origin.y -= inflatedRect.y();
+    FloatRect maskFloatRect(trackRect);
+
+    auto imageBuffer = context.createImageBuffer(inflatedRect.size(), deviceScaleFactor);
+    auto maskBuffer = context.createImageBuffer(maskFloatRect.size(), deviceScaleFactor);
+
+    if (!imageBuffer || !maskBuffer)
+        return;
+
+    auto cgContext = imageBuffer->context().platformContext();
+    auto cgContextForMask = maskBuffer->context().platformContext();
+
+    GraphicsContextStateSaver stateSaver(context);
+
+    [[NSAppearance currentDrawingAppearance] _drawInRect: NSMakeRect(0, 0, NSWidth(trackRect), NSHeight(trackRect)) context:cgContextForMask options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchFillMask,
+        (__bridge NSString *)kCUISizeKey: (__bridge NSString *)kCUISizeRegular,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    imageBuffer->context().clipToImageBuffer(*maskBuffer, trackRect);
+
+    [[NSAppearance currentDrawingAppearance] _drawInRect:trackRect context:cgContext options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchFill,
+        (__bridge NSString *)kCUIStateKey: (__bridge NSString *)(!isEnabled ? kCUIStateDisabled : isPressed ? kCUIStatePressed : kCUIStateActive),
+        (__bridge NSString *)kCUIValueKey: @(isOn ? 1 : 0),
+        (__bridge NSString *)kCUIPresentationStateKey: (__bridge NSString *)(isInActiveWindow ? kCUIPresentationStateActiveKey : kCUIPresentationStateInactive),
+        (__bridge NSString *)kCUISizeKey: (__bridge NSString *)kCUISizeRegular,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    [[NSAppearance currentDrawingAppearance] _drawInRect:trackRect context:cgContext options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchBorder,
+        (__bridge NSString *)kCUISizeKey: (__bridge NSString *)kCUISizeRegular,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    // FIXME: this should be conditional upon "Differentiate without color"
+    [[NSAppearance currentDrawingAppearance] _drawInRect:trackRect context:cgContext options:@{
+        (__bridge NSString *)kCUIWidgetKey: (__bridge NSString *)kCUIWidgetSwitchOnOffLabel,
+        (__bridge NSString *)kCUIValueKey: @(isOn ? 1 : 0),
+        (__bridge NSString *)kCUISizeKey: (__bridge NSString *)kCUISizeRegular,
+        (__bridge NSString *)kCUIScaleKey: @(deviceScaleFactor),
+    }];
+
+    if (style.states.contains(ControlStyle::State::RightToLeft)) {
+        context.translate(2 * inflatedRect.x() + inflatedRect.width(), 0);
+        context.scale(FloatSize(-1, 1));
+    }
+
+    context.drawConsumingImageBuffer(WTFMove(imageBuffer), inflatedRect.location());
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -171,6 +171,8 @@ bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, Style
     case StyleAppearance::SliderThumbVertical:
     case StyleAppearance::SliderHorizontal:
     case StyleAppearance::SliderVertical:
+    case StyleAppearance::SwitchThumb:
+    case StyleAppearance::SwitchTrack:
     case StyleAppearance::SquareButton:
     case StyleAppearance::TextArea:
     case StyleAppearance::TextField:
@@ -215,7 +217,9 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
         || type == StyleAppearance::SliderThumbVertical
         || type == StyleAppearance::SliderHorizontal
         || type == StyleAppearance::SliderVertical
-        || type == StyleAppearance::SquareButton;
+        || type == StyleAppearance::SquareButton
+        || type == StyleAppearance::SwitchThumb
+        || type == StyleAppearance::SwitchTrack;
 }
 
 bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& renderer) const

--- a/Source/WebCore/style/StyleAppearance.cpp
+++ b/Source/WebCore/style/StyleAppearance.cpp
@@ -139,8 +139,11 @@ TextStream& operator<<(TextStream& ts, StyleAppearance appearance)
     case StyleAppearance::SliderThumbVertical:
         ts << "sliderthumb-vertical";
         break;
-    case StyleAppearance::Switch:
-        ts << "switch";
+    case StyleAppearance::SwitchThumb:
+        ts << "switch-thumb";
+        break;
+    case StyleAppearance::SwitchTrack:
+        ts << "switch-track";
         break;
     }
     return ts;

--- a/Source/WebCore/style/StyleAppearance.h
+++ b/Source/WebCore/style/StyleAppearance.h
@@ -78,7 +78,8 @@ enum class StyleAppearance : uint8_t {
     SearchFieldCancelButton,
     SliderThumbHorizontal,
     SliderThumbVertical,
-    Switch
+    SwitchThumb,
+    SwitchTrack
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, StyleAppearance);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -143,6 +143,8 @@
 #include <WebCore/SourceAlpha.h>
 #include <WebCore/SourceGraphic.h>
 #include <WebCore/SpotLightSource.h>
+#include <WebCore/SwitchThumbPart.h>
+#include <WebCore/SwitchTrackPart.h>
 #include <WebCore/SystemImage.h>
 #include <WebCore/TestReportBody.h>
 #include <WebCore/TextAreaPart.h>
@@ -1259,7 +1261,8 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
     case WebCore::StyleAppearance::SearchFieldCancelButton:
     case WebCore::StyleAppearance::SliderThumbHorizontal:
     case WebCore::StyleAppearance::SliderThumbVertical:
-    case WebCore::StyleAppearance::Switch:
+    case WebCore::StyleAppearance::SwitchThumb:
+    case WebCore::StyleAppearance::SwitchTrack:
         break;
     }
 }
@@ -1382,8 +1385,11 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::StyleAppearance::SliderThumbVertical:
         return WebCore::SliderThumbPart::create(*type);
 
-    case WebCore::StyleAppearance::Switch:
-        break;
+    case WebCore::StyleAppearance::SwitchThumb:
+        return WebCore::SwitchThumbPart::create();
+
+    case WebCore::StyleAppearance::SwitchTrack:
+        return WebCore::SwitchTrackPart::create();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3216,7 +3216,8 @@ enum class WebCore::StyleAppearance : uint8_t {
     SearchFieldCancelButton,
     SliderThumbHorizontal,
     SliderThumbVertical,
-    Switch
+    SwitchThumb,
+    SwitchTrack
 };
 
 #if ENABLE(APPLE_PAY)


### PR DESCRIPTION
#### 97661e2a2d6838b9b044ac95164e8e20980c618a
<pre>
Add &lt;input type=checkbox switch&gt; macOS implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=263372">https://bugs.webkit.org/show_bug.cgi?id=263372</a>
rdar://117199685

Reviewed by NOBODY (OOPS!).

Add a shadow root for &lt;input type=checkbox switch&gt; in a matter
consistent with the CSS WG plan for a track and thumb pseudo-element.

Add a macOS implementation that has these known shortcomings:

- There&apos;s no animation support.
- There&apos;s no support for dragging the thumb.
- Toggling &quot;Increase contrast&quot; or &quot;Differentiate without color&quot; doesn&apos;t
  update the look of the control dynamically.

This builds on excellent prototyping work done by Lily Spiniolas.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/PlatformMac.cmake:
* Source/WebCore/PAL/pal/spi/mac/CoreUISPI.h:
* Source/WebCore/PAL/pal/spi/mac/NSSwitchSPI.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
* Source/WebCore/css/html.css:
(input[type=&quot;checkbox&quot;][switch]):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::createShadowSubtree):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::needsShadowSubtree const):
(WebCore::CheckboxInputType::createShadowSubtree):
(WebCore::CheckboxInputType::attributeChanged):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::createShadowSubtree):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::createShadowSubtree):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::destroyShadowSubtree):
* Source/WebCore/html/InputType.h:
(WebCore::InputType::needsShadowSubtree const):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::createShadowSubtree):
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::createShadowSubtree):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createShadowSubtree):
* Source/WebCore/html/shadow/SwitchThumbElement.cpp: Added.
(WebCore::SwitchThumbElement::create):
(WebCore::SwitchThumbElement::SwitchThumbElement):
(WebCore::SwitchThumbElement::resolveCustomStyle):
* Source/WebCore/html/shadow/SwitchThumbElement.h: Added.
* Source/WebCore/html/shadow/SwitchTrackElement.cpp: Added.
(WebCore::SwitchTrackElement::create):
(WebCore::SwitchTrackElement::SwitchTrackElement):
(WebCore::SwitchTrackElement::resolveCustomStyle):
* Source/WebCore/html/shadow/SwitchTrackElement.h: Added.
* Source/WebCore/platform/graphics/controls/ControlFactory.h:
* Source/WebCore/platform/graphics/controls/SwitchThumbPart.h: Added.
* Source/WebCore/platform/graphics/controls/SwitchTrackPart.h: Added.
* Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.h:
* Source/WebCore/platform/graphics/ios/controls/ControlFactoryIOS.mm:
(WebCore::ControlFactoryIOS::createPlatformSwitchThumb):
(WebCore::ControlFactoryIOS::createPlatformSwitchTrack):
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.h:
* Source/WebCore/platform/graphics/mac/controls/ControlFactoryMac.mm:
(WebCore::ControlFactoryMac::switchControl const):
(WebCore::ControlFactoryMac::createPlatformSwitchThumb):
(WebCore::ControlFactoryMac::createPlatformSwitchTrack):
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.h: Added.
* Source/WebCore/platform/graphics/mac/controls/SwitchThumbMac.mm: Added.
(WebCore::SwitchThumbMac::SwitchThumbMac):
(WebCore::SwitchThumbMac::draw):
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.h: Added.
* Source/WebCore/platform/graphics/mac/controls/SwitchTrackMac.mm: Added.
(WebCore::SwitchTrackMac::SwitchTrackMac):
(WebCore::SwitchTrackMac::draw):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):
(WebCore::RenderTheme::createControlPart const):
(WebCore::RenderTheme::isChecked const):
(WebCore::RenderTheme::isEnabled const):
(WebCore::RenderTheme::isPressed const):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canPaint const):
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
* Source/WebCore/style/StyleAppearance.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleAppearance.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::encode):
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97661e2a2d6838b9b044ac95164e8e20980c618a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22115 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25697 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23115 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26970 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19961 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24829 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22292 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18273 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/29715 "Built successfully") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22754 "Failed resultsdbpy unit tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20556 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6152 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/875 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/28113 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/631 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6016 "Passed tests") | 
<!--EWS-Status-Bubble-End-->