### PR TITLE
[ iOS17 ] TestWebKitAPI.AutocorrectionTests.FontAtCaretWhenUsingUICTFontTextStyle is constantly failing.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
@@ -24,6 +24,7 @@
  */
 
 #import "config.h"
+#import "Test.h"
 
 #if PLATFORM(IOS_FAMILY)
 
@@ -69,12 +70,12 @@
 
 @end
 
-static void checkCGRectIsEqualToCGRectWithLogging(CGRect expected, CGRect observed)
+static void checkCGRectIsNotEmpty(CGRect rect)
 {
-    BOOL isEqual = CGRectEqualToRect(expected, observed);
-    EXPECT_TRUE(isEqual);
-    if (!isEqual)
-        NSLog(@"Expected: %@ but observed: %@", NSStringFromCGRect(expected), NSStringFromCGRect(observed));
+    BOOL isEmpty = CGRectIsEmpty(rect);
+    EXPECT_FALSE(isEmpty);
+    if (isEmpty)
+        NSLog(@"Expected %@ to be non-empty", NSStringFromCGRect(rect));
 }
 
 TEST(AutocorrectionTests, FontAtCaretWhenUsingUICTFontTextStyle)
@@ -91,9 +92,9 @@ TEST(AutocorrectionTests, FontAtCaretWhenUsingUICTFontTextStyle)
     [webView evaluateJavaScriptAndWaitForInputSessionToChange:@"document.body.focus()"];
     [webView _executeEditCommand:@"MoveToEndOfLine" argument:nil completion:nil];
 
-    auto autocorrectionRects = retainPtr([webView autocorrectionRectsForString:@"Wulk"]);
-    checkCGRectIsEqualToCGRectWithLogging(CGRectMake(8, 9, 36, 20), [autocorrectionRects firstRect]);
-    checkCGRectIsEqualToCGRectWithLogging(CGRectMake(8, 9, 36, 20), [autocorrectionRects lastRect]);
+    RetainPtr autocorrectionRects = [webView autocorrectionRectsForString:@"Wulk"];
+    checkCGRectIsNotEmpty([autocorrectionRects firstRect]);
+    checkCGRectIsNotEmpty([autocorrectionRects lastRect]);
 
     auto contentView = [webView textInputContentView];
     UIFont *fontBeforeScaling = [contentView fontForCaretSelection];


### PR DESCRIPTION
#### fcbf065e192954578678887bf38fd0175140f2b8
<pre>
[ iOS17 ] TestWebKitAPI.AutocorrectionTests.FontAtCaretWhenUsingUICTFontTextStyle is constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263125">https://bugs.webkit.org/show_bug.cgi?id=263125</a>
rdar://116924205

Reviewed by Richard Robinson.

Make this test robust against minor differences in the size of text rects used for autocorrection when using
`UICTFontTextStyle`. This test appears to fail with an autocorrection bubble width of 24 instead of 20 after recent EWS
updates to iOS 17, though it still seems to pass (i.e. rect width = 20) when running locally. It&apos;s unclear what&apos;s
causing this disparity.

The purpose of this test isn&apos;t to check the specific autocorrection rect geometry in the first place, so we should just
make this more robust and check that non-empty autocorrection rects appear.

* Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm:
(checkCGRectIsNotEmpty):
(checkCGRectIsEqualToCGRectWithLogging): Deleted.

Canonical link: <a href="https://commits.webkit.org/269533@main">https://commits.webkit.org/269533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25bcdf37fa6a6a3d31f28c559f39e1209d21002c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23354 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25590 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26877 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/20668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18180 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/291 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5442 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->