### PR TITLE
Disabled inputs should not get Interaction Regions

### DIFF
--- a/LayoutTests/interaction-region/disabled-controls-expected.txt
+++ b/LayoutTests/interaction-region/disabled-controls-expected.txt
@@ -1,0 +1,17 @@
+      off
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/disabled-controls.html
+++ b/LayoutTests/interaction-region/disabled-controls.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<style>
+</style>
+<body>
+
+<input type="text" disabled />
+<input type="checkbox" disabled />
+<input type="radio" checked disabled />
+
+<textarea disabled>text</textarea>
+<select disabled>
+   <option>Choose</option>
+   <option>From</option>
+   <option>The List</option>
+</select>
+<button disabled>off</button>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>

--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -118,6 +118,18 @@
                       (layer position [x: 48 y: 48])
                       (layer cornerRadius 6))
                     (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48])
                       (layer opacity 0)
@@ -231,6 +243,18 @@
                       (layer position [x: 6 y: 6])
                       (layer cornerRadius 6))
                     (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
                       (layer bounds [x: 0 y: 0 width: 6 height: 90])
                       (layer position [x: 6 y: 6])
                       (layer opacity 0)
@@ -309,7 +333,7 @@
                               (layer position [x: 3 y: 3])
                               (layer cornerRadius 1))))))
                     (
-                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
                       (layer position [x: 6 y: 6])
                       (layer opacity 0.15)
                       (layer cornerRadius 3))))))))))))

--- a/LayoutTests/interaction-region/labels-expected.txt
+++ b/LayoutTests/interaction-region/labels-expected.txt
@@ -1,5 +1,7 @@
 Inactive label Do you like coffee?
 And checkboxes?
+Disabled checkbox
+Disabled input
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)

--- a/LayoutTests/interaction-region/labels.html
+++ b/LayoutTests/interaction-region/labels.html
@@ -22,6 +22,11 @@
 <label class="container">
     And checkboxes? <input type="checkbox">
 </label>
+<label class="container">
+    Disabled checkbox <input type="checkbox" disabled>
+</label>
+<label for="disabled-input">Disabled input</label>
+<input type="text" name="disabled-input" id="disabled-input" disabled>
 
 <pre id="results"></pre>
 <script>

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -141,6 +141,18 @@
                       (layer position [x: 48 y: 48])
                       (layer cornerRadius 6))
                     (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                      (layer position [x: 48 y: 48])
+                      (layer cornerRadius 6))
+                    (
                       (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
                       (layer position [x: 48 y: 48])
                       (layer opacity 0)
@@ -241,6 +253,18 @@
                   (layer position [x: 6 y: 6])
                   (layer cornerRadius 6)
                   (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                      (layer position [x: 6 y: 6])
+                      (layer cornerRadius 6))
                     (
                       (layer bounds [x: 0 y: 0 width: 12 height: 96])
                       (layer position [x: 6 y: 6])

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -77,6 +77,9 @@ static bool shouldAllowElement(const Element& element)
         return false;
 
     if (auto* input = dynamicDowncast<HTMLInputElement>(element)) {
+        if (input->isDisabledFormControl())
+            return false;
+
         // Do not allow regions for the <input type='range'>, because we make one for the thumb.
         if (input->isRangeControl())
             return false;
@@ -251,7 +254,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         // Could be a `<label for="...">` or a label with a descendant.
         // In cases where both elements get a region we want to group them by the same `elementIdentifier`.
         auto associatedElement = downcast<HTMLLabelElement>(matchedElement)->control();
-        if (associatedElement) {
+        if (associatedElement && !associatedElement->isDisabledFormControl()) {
             hasPointer = true;
             elementIdentifier = associatedElement->identifier();
         }


### PR DESCRIPTION
#### 0031075b36df98b33c4fe43e8188a64f1f94965d
<pre>
Disabled inputs should not get Interaction Regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=263379">https://bugs.webkit.org/show_bug.cgi?id=263379</a>
&lt;rdar://116931433&gt;

Reviewed by Wenson Hsieh and Aditya Keerthi.

Before generating an Interaction Region for an input, or a label
associated with an input, make sure the label is enabled.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowElement):
Disallow disabled inputs.
(WebCore::interactionRegionForRenderedRegion):
Check if the label&apos;s associated element is enabled.

* LayoutTests/interaction-region/labels.html:
* LayoutTests/interaction-region/labels-expected.txt:
Update the labels test to cover this case. No new region in the
expectation since we&apos;re not generating extra regions.
* LayoutTests/interaction-region/disabled-controls-expected.txt: Added.
* LayoutTests/interaction-region/disabled-controls.html: Added.
Add a new test covering disabled controls.

* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
Re-baseline of layer based tests.

Canonical link: <a href="https://commits.webkit.org/269625@main">https://commits.webkit.org/269625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/596c1987b47b5205d9b33b1d790c35106af538e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21222 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22106 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25691 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23108 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26962 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19956 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24822 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22286 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18270 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/29712 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22793 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20548 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6150 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5510 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/870 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/28078 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/625 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6013 "Passed tests") | 
<!--EWS-Status-Bubble-End-->