### PR TITLE
Regression(269372@main) Crash under SVGPathElement::attributeChanged() after memory pressure

### DIFF
--- a/LayoutTests/fast/svg/path-element-d-attribute-crash-memory-pressure-expected.txt
+++ b/LayoutTests/fast/svg/path-element-d-attribute-crash-memory-pressure-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/svg/path-element-d-attribute-crash-memory-pressure.html
+++ b/LayoutTests/fast/svg/path-element-d-attribute-crash-memory-pressure.html
@@ -1,0 +1,20 @@
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function simulateMemoryPressure()
+{
+    if (window.internals) {
+        internals.beginSimulatedMemoryWarning();
+        internals.endSimulatedMemoryWarning();
+    }
+}
+
+for (let i = 0; i < 2000; ++i) {
+    let path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', 'M10,' + i + ' A20,20 0,0,1 50,30 A20,20 0,0,1 90,30 Q90,60 50,90 Q10,60 10,30 z M5,5 L90,90');
+    simulateMemoryPressure();
+}
+
+</script>


### PR DESCRIPTION
#### ec2d23a0902a7c2e65afbd221a275ce3040b9e1c
<pre>
Regression(269372@main) Crash under SVGPathElement::attributeChanged() after memory pressure
<a href="https://bugs.webkit.org/show_bug.cgi?id=263381">https://bugs.webkit.org/show_bug.cgi?id=263381</a>
rdar://117176058

Reviewed by Said Abou-Hallawa.

We were failing to reset pathSegListCacheSize to 0 after clearing the cache. As a result,
SVGPathElement::attributeChanged() could get in a state where pathSegListCacheSize becomes
greater than maxPathSegListCacheSize even though the cache map is empty. As a result, we
would try to remove `cache.random()` which returns `cache.end()` when the cache is empty.

I also moved the caching logic to a new class for better insulation / clarity.

* LayoutTests/fast/svg/path-element-d-attribute-crash-memory-pressure-expected.txt: Added.
* LayoutTests/fast/svg/path-element-d-attribute-crash-memory-pressure.html: Added.
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::attributeChanged):
(WebCore::SVGPathElement::clearCache):

Canonical link: <a href="https://commits.webkit.org/269547@main">https://commits.webkit.org/269547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73cea1a69a523c4204e920567dc69e2ef0430b04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23095 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19817 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25617 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26906 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24755 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/392 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20501 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5456 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->