### PR TITLE
REGRESSION: WebKit provides rectilinear selection rects for rotated text in images

### DIFF
--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -164,14 +164,6 @@ void EditorState::clipOwnedRectExtentsToNumericLimits()
         visualData.caretRectAtEnd = visualData.caretRectAtEnd.toRectWithExtentsClippedToNumericLimits();
         visualData.markedTextCaretRectAtStart = visualData.markedTextCaretRectAtStart.toRectWithExtentsClippedToNumericLimits();
         visualData.markedTextCaretRectAtEnd = visualData.markedTextCaretRectAtEnd.toRectWithExtentsClippedToNumericLimits();
-
-        auto sanitizeSelectionGeometryVector = [](auto& selectionGeometries) {
-            forEach(selectionGeometries, [](auto& selectionGeometry) {
-                selectionGeometry.setRect(selectionGeometry.rect().toRectWithExtentsClippedToNumericLimits());
-            });
-        };
-        sanitizeSelectionGeometryVector(visualData.selectionGeometries);
-        sanitizeSelectionGeometryVector(visualData.markedTextRects);
 #endif
 #if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
         visualData.caretRectAtStart = visualData.caretRectAtStart.toRectWithExtentsClippedToNumericLimits();


### PR DESCRIPTION
#### 89775b5ff064e50f6a1177def010eca32b2cbea3
<pre>
REGRESSION: WebKit provides rectilinear selection rects for rotated text in images
<a href="https://bugs.webkit.org/show_bug.cgi?id=259888">https://bugs.webkit.org/show_bug.cgi?id=259888</a>
rdar://113287677

Reviewed by Wenson Hsieh.

`EditorState::clipOwnedRectExtentsToNumericLimits` was erroneously converting some selection
geometries from quads to rects.

Fix by removing these conversions. Since `FloatQuad`s have no notion of validity, there is no
need to clip them to numeric limits.

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::EditorState::clipOwnedRectExtentsToNumericLimits):

Canonical link: <a href="https://commits.webkit.org/265870.235@safari-7616-branch">https://commits.webkit.org/265870.235@safari-7616-branch</a>

Canonical link: <a href="https://commits.webkit.org/269572@main">https://commits.webkit.org/269572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91e9a7013cb804d7ccd66fa5618d2ed27b375ec6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24752 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21143 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/1894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22049 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25606 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/327 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26892 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20702 "Build is in progress. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24749 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/381 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18210 "Found 1 new test failure: media/video-remove-insert-repaints.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/710 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2904 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->