### PR TITLE
Use C++ serializers for NSString and NSURL

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -782,30 +782,32 @@ static std::optional<RetainPtr<id>> decodeSecureCodingInternal(Decoder& decoder,
 
 static inline void encodeStringInternal(Encoder& encoder, NSString *string)
 {
-    encoder << bridge_cast(string);
+    encoder << String { string };
 }
 
 static inline std::optional<RetainPtr<id>> decodeStringInternal(Decoder& decoder)
 {
-    RetainPtr<CFStringRef> string;
-    if (!decoder.decode(string))
+    std::optional<String> string;
+    decoder >> string;
+    if (!string)
         return std::nullopt;
-    return { bridge_cast(WTFMove(string)) };
+    return { (NSString *)(*string) };
 }
 
 #pragma mark - NSURL
 
-static inline void encodeURLInternal(Encoder& encoder, NSURL *URL)
+static inline void encodeURLInternal(Encoder& encoder, NSURL *url)
 {
-    encoder << bridge_cast(URL);
+    encoder << URL { url };
 }
 
 static inline std::optional<RetainPtr<id>> decodeURLInternal(Decoder& decoder)
 {
-    RetainPtr<CFURLRef> URL;
-    if (!decoder.decode(URL))
+    std::optional<URL> url;
+    decoder >> url;
+    if (!url)
         return std::nullopt;
-    return { bridge_cast(WTFMove(URL)) };
+    return { (NSURL *)(*url) };
 }
 
 #pragma mark - CF


### PR DESCRIPTION
#### 1e851ff01daba9c70bbabe570f0772902c581f92
<pre>
Use C++ serializers for NSString and NSURL
<a href="https://bugs.webkit.org/show_bug.cgi?id=263389">https://bugs.webkit.org/show_bug.cgi?id=263389</a>

Reviewed by Alex Christensen.

We auto generate our WTF::String and WTF::URL serializers.
So leverage them when encoding/decoding NSString or NSURL.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::encodeStringInternal):
(IPC::decodeStringInternal):
(IPC::encodeURLInternal):
(IPC::decodeURLInternal):

Canonical link: <a href="https://commits.webkit.org/269599@main">https://commits.webkit.org/269599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4742108e1ee5e48a4ae889ca0df074f0bc2c0b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24896 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23523 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23223 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25750 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23168 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20824 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20000 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21085 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22348 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22781 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20603 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5497 "Built successfully and passed tests") | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/913 "Failed to checkout and rebase branch from PR 19290") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29053 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/688 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6032 "Passed tests") | 
<!--EWS-Status-Bubble-End-->