### PR TITLE
Don't emit shifts in macro assembler when shift amount is zero

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -878,6 +878,8 @@ public:
 
     void lshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.lsl<32>(dest, src, imm.m_value & 0x1f);
     }
 
@@ -904,6 +906,8 @@ public:
 
     void lshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.lsl<64>(dest, src, imm.m_value & 0x3f);
     }
 
@@ -1214,6 +1218,8 @@ public:
 
     void rotateRight32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.ror<32>(dest, src, imm.m_value & 31);
     }
 
@@ -1229,6 +1235,8 @@ public:
 
     void rotateRight64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.ror<64>(dest, src, imm.m_value & 63);
     }
 
@@ -1249,6 +1257,8 @@ public:
 
     void rshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.asr<32>(dest, src, imm.m_value & 0x1f);
     }
 
@@ -1269,6 +1279,8 @@ public:
     
     void rshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.asr<64>(dest, src, imm.m_value & 0x3f);
     }
     
@@ -1411,6 +1423,8 @@ public:
     
     void urshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.lsr<32>(dest, src, imm.m_value & 0x1f);
     }
 
@@ -1431,6 +1445,8 @@ public:
     
     void urshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.lsr<64>(dest, src, imm.m_value & 0x3f);
     }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
@@ -433,11 +433,15 @@ public:
 
     void lshift32(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.sll(dest, dest, imm.m_value);
     }
 
     void lshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.sll(dest, src, imm.m_value);
     }
 
@@ -664,11 +668,15 @@ public:
 
     void rshift32(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.sra(dest, dest, imm.m_value);
     }
 
     void rshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.sra(dest, src, imm.m_value);
     }
 
@@ -684,11 +692,15 @@ public:
 
     void urshift32(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.srl(dest, dest, imm.m_value);
     }
 
     void urshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.srl(dest, src, imm.m_value);
     }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -649,6 +649,8 @@ public:
 
     void lshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.slliwInsn(dest, src, uint32_t(imm.m_value & ((1 << 5) - 1)));
         m_assembler.maskRegister<32>(dest);
     }
@@ -677,6 +679,8 @@ public:
 
     void lshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.slliInsn(dest, src, uint32_t(imm.m_value & ((1 << 6) - 1)));
     }
 
@@ -705,6 +709,8 @@ public:
 
     void rshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.sraiwInsn(dest, src, uint32_t(imm.m_value & ((1 << 5) - 1)));
         m_assembler.maskRegister<32>(dest);
     }
@@ -726,6 +732,8 @@ public:
 
     void rshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.sraiInsn(dest, src, uint32_t(imm.m_value & ((1 << 6) - 1)));
     }
 
@@ -747,6 +755,8 @@ public:
 
     void urshift32(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.srliwInsn(dest, src, uint32_t(imm.m_value & ((1 << 5) - 1)));
         m_assembler.maskRegister<32>(dest);
     }
@@ -775,6 +785,8 @@ public:
 
     void urshift64(RegisterID src, TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return move(src, dest);
         m_assembler.srliInsn(dest, src, uint32_t(imm.m_value & ((1 << 6) - 1)));
     }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -470,6 +470,8 @@ public:
 
     void lshift32(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.shll_i8r(imm.m_value, dest);
     }
     
@@ -765,6 +767,8 @@ public:
 
     void rshift32(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.sarl_i8r(imm.m_value, dest);
     }
     
@@ -800,6 +804,8 @@ public:
 
     void urshift32(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.shrl_i8r(imm.m_value, dest);
     }
     
@@ -811,6 +817,8 @@ public:
 
     void rotateRight32(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.rorl_i8r(imm.m_value, dest);
     }
 
@@ -844,6 +852,8 @@ public:
 
     void rotateLeft32(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.roll_i8r(imm.m_value, dest);
     }
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -586,6 +586,8 @@ public:
 
     void lshift64(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.shlq_i8r(imm.m_value, dest);
     }
     
@@ -639,6 +641,8 @@ public:
 
     void rshift64(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.sarq_i8r(imm.m_value, dest);
     }
 
@@ -676,6 +680,8 @@ public:
 
     void urshift64(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.shrq_i8r(imm.m_value, dest);
     }
 
@@ -713,6 +719,8 @@ public:
 
     void rotateRight64(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.rorq_i8r(imm.m_value, dest);
     }
 
@@ -750,6 +758,8 @@ public:
 
     void rotateLeft64(TrustedImm32 imm, RegisterID dest)
     {
+        if (UNLIKELY(!imm.m_value))
+            return;
         m_assembler.rolq_i8r(imm.m_value, dest);
     }
 


### PR DESCRIPTION
#### 003f045ae01b34bcac128c57c5cfeb6e37534728
<pre>
Don&apos;t emit shifts in macro assembler when shift amount is zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=263390">https://bugs.webkit.org/show_bug.cgi?id=263390</a>
rdar://117220277

Reviewed by Yusuke Suzuki.

Adds checks for zero shift or rotate amount to each macro assembler,
and skips generating a shift or rotate instruction if this is the case.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::lshift32):
(JSC::MacroAssemblerARM64::lshift64):
(JSC::MacroAssemblerARM64::rotateRight32):
(JSC::MacroAssemblerARM64::rotateRight64):
(JSC::MacroAssemblerARM64::rshift32):
(JSC::MacroAssemblerARM64::rshift64):
(JSC::MacroAssemblerARM64::urshift32):
(JSC::MacroAssemblerARM64::urshift64):
* Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h:
(JSC::MacroAssemblerMIPS::lshift32):
(JSC::MacroAssemblerMIPS::rshift32):
(JSC::MacroAssemblerMIPS::urshift32):
* Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h:
(JSC::MacroAssemblerRISCV64::lshift32):
(JSC::MacroAssemblerRISCV64::lshift64):
(JSC::MacroAssemblerRISCV64::rshift32):
(JSC::MacroAssemblerRISCV64::rshift64):
(JSC::MacroAssemblerRISCV64::urshift32):
(JSC::MacroAssemblerRISCV64::urshift64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::lshift32):
(JSC::MacroAssemblerX86Common::rshift32):
(JSC::MacroAssemblerX86Common::urshift32):
(JSC::MacroAssemblerX86Common::rotateRight32):
(JSC::MacroAssemblerX86Common::rotateLeft32):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::lshift64):
(JSC::MacroAssemblerX86_64::rshift64):
(JSC::MacroAssemblerX86_64::urshift64):
(JSC::MacroAssemblerX86_64::rotateRight64):
(JSC::MacroAssemblerX86_64::rotateLeft64):

Canonical link: <a href="https://commits.webkit.org/269608@main">https://commits.webkit.org/269608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40be91919144cba5d8823744533ea8f8c26c9cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22860 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/1037 "Build was cancelled. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23953 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24769 "Build is in progress. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21160 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23391 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22062 "Build is in progress. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 13 flakes 199 failures; Uploaded test results; Running layout-tests-repeat-failures; Compiled WebKit (warnings); Running layout-tests-repeat-failures-without-change") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25626 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26921 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19909 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20777 "Found 2 new API test failures: TestWebKitAPI.ServiceWorker.WindowClientNavigate, TestWebKitAPI.ServiceWorker.WindowClientNavigateCrossOrigin (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/20987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24774 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22222 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18223 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/26280 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/323 "Build is in progress. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6146 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running jscore-test") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5500 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/818 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/27563 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/553 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5996 "Passed tests") | 
<!--EWS-Status-Bubble-End-->