### PR TITLE
[WGSL] Unary expression serialization breaks precedence

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1403,6 +1403,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
 
 void FunctionDefinitionWriter::visit(AST::UnaryExpression& unary)
 {
+    m_stringBuilder.append("(");
     switch (unary.operation()) {
     case AST::UnaryOperation::Complement:
         m_stringBuilder.append("~");
@@ -1421,6 +1422,7 @@ void FunctionDefinitionWriter::visit(AST::UnaryExpression& unary)
         break;
     }
     visit(unary.expression());
+    m_stringBuilder.append(")");
 }
 
 void FunctionDefinitionWriter::visit(AST::BinaryExpression& binary)

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -267,13 +267,13 @@ fn testBinaryOperations() -> i32
 
 fn testUnaryOperations() -> i32
 {
-    // CHECK: global\d+\.v2f\.x = -global\d+\.v2f\.x;
-    // CHECK-NEXT: global\d+\.v3f\.x = -global\d+\.v3f\.x;
-    // CHECK-NEXT: global\d+\.v4f\.x = -global\d+\.v4f\.x;
-    // CHECK-NEXT: global\d+\.v2f = -global\d+\.v2f;
-    // CHECK-NEXT: global\d+\.v3f = -float3\(global\d+\.v3f\);
-    // CHECK-NEXT: global\d+\.v4f = -global\d+\.v4f;
-    // CHECK-NEXT: global\d+\.f = -global\d+\.f;
+    // CHECK: global\d+\.v2f\.x = \(-global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = \(-global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = \(-global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2f = \(-global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = \(-float3\(global\d+\.v3f\)\);
+    // CHECK-NEXT: global\d+\.v4f = \(-global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.f = \(-global\d+\.f\);
     t.v2f.x = -t1.v2f.x;
     t.v3f.x = -t1.v3f.x;
     t.v4f.x = -t1.v4f.x;
@@ -282,13 +282,13 @@ fn testUnaryOperations() -> i32
     t.v4f   = -t1.v4f;
     t.f     = -t1.f;
 
-    // CHECK-NEXT: global\d+\.v2f\.x = -global\d+\.v2f\.x;
-    // CHECK-NEXT: global\d+\.v3f\.x = -global\d+\.v3f\.x;
-    // CHECK-NEXT: global\d+\.v4f\.x = -global\d+\.v4f\.x;
-    // CHECK-NEXT: global\d+\.v2f = -global\d+\.v2f;
-    // CHECK-NEXT: global\d+\.v3f = packed_float3\(-float3\(global\d+\.v3f\)\);
-    // CHECK-NEXT: global\d+\.v4f = -global\d+\.v4f;
-    // CHECK-NEXT: global\d+\.f = -global\d+\.f;
+    // CHECK-NEXT: global\d+\.v2f\.x = \(-global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = \(-global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = \(-global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2f = \(-global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(\(-float3\(global\d+\.v3f\)\)\);
+    // CHECK-NEXT: global\d+\.v4f = \(-global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.f = \(-global\d+\.f\);
     t1.v2f.x = -t2.v2f.x;
     t1.v3f.x = -t2.v3f.x;
     t1.v4f.x = -t2.v4f.x;
@@ -297,13 +297,13 @@ fn testUnaryOperations() -> i32
     t1.v4f   = -t2.v4f;
     t1.f     = -t2.f;
 
-    // CHECK-NEXT: global\d+\.v2f\.x = -global\d+\.v2f\.x;
-    // CHECK-NEXT: global\d+\.v3f\.x = -global\d+\.v3f\.x;
-    // CHECK-NEXT: global\d+\.v4f\.x = -global\d+\.v4f\.x;
-    // CHECK-NEXT: global\d+\.v2f = -global\d+\.v2f;
-    // CHECK-NEXT: global\d+\.v3f = packed_float3\(-global\d+\.v3f\);
-    // CHECK-NEXT: global\d+\.v4f = -global\d+\.v4f;
-    // CHECK-NEXT: global\d+\.f = -global\d+\.f;
+    // CHECK-NEXT: global\d+\.v2f\.x = \(-global\d+\.v2f\.x\);
+    // CHECK-NEXT: global\d+\.v3f\.x = \(-global\d+\.v3f\.x\);
+    // CHECK-NEXT: global\d+\.v4f\.x = \(-global\d+\.v4f\.x\);
+    // CHECK-NEXT: global\d+\.v2f = \(-global\d+\.v2f\);
+    // CHECK-NEXT: global\d+\.v3f = packed_float3\(\(-global\d+\.v3f\)\);
+    // CHECK-NEXT: global\d+\.v4f = \(-global\d+\.v4f\);
+    // CHECK-NEXT: global\d+\.f = \(-global\d+\.f\);
     t2.v2f.x = -t.v2f.x;
     t2.v3f.x = -t.v3f.x;
     t2.v4f.x = -t.v4f.x;

--- a/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/pointers.wgsl
@@ -12,6 +12,10 @@ fn f2(x: ptr<private, i32>) -> i32
 
 fn f3(x: vec3<f32>) { }
 
+fn f4(p: ptr<function, vec2<i32>>) -> i32 {
+    return (*p).x;
+}
+
 var<private> global: i32;
 
 struct S { x: vec3<f32> }
@@ -53,6 +57,13 @@ fn testShadowedLocalRewriting()
     }
 }
 
+fn testVectorAccessPrecedence()
+{
+    var v = vec2(0);
+    let p = &v;
+    let x = f4(p);
+}
+
 @compute @workgroup_size(1)
 fn main()
 {
@@ -71,4 +82,5 @@ fn main()
     testPhonyPointerElimination();
     testShadowedGlobalRewriting();
     testShadowedLocalRewriting();
+    testVectorAccessPrecedence();
 }


### PR DESCRIPTION
#### 5b1b2fbebfb0ab22215a0b9dfdf4a41ca10ca827
<pre>
[WGSL] Unary expression serialization breaks precedence
<a href="https://bugs.webkit.org/show_bug.cgi?id=263394">https://bugs.webkit.org/show_bug.cgi?id=263394</a>
rdar://117221664

Reviewed by Dan Glastonbury.

When serializing unary expressions, we need to add parentheses around the result,
as otherwise the precedence of the result might be wrong. This is easily noticeable
with pointers, as `(*p).x` from WGSL was being serialized as `*p.x` in MSL.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:
* Source/WebGPU/WGSL/tests/valid/pointers.wgsl:

Canonical link: <a href="https://commits.webkit.org/269582@main">https://commits.webkit.org/269582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19fd6493de33b50d597d8f32f9fb15a50e8f5ae3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5484 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->