### PR TITLE
[WGSL] Add support for derivative functions

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -1352,7 +1352,15 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
         }
 
         static constexpr std::pair<ComparableASCIILiteral, ASCIILiteral> baseTypesMappings[] {
+            { "dpdx", "dfdx"_s },
+            { "dpdxCoarse", "dfdx"_s },
+            { "dpdxFine", "dfdx"_s },
+            { "dpdy", "dfdy"_s },
+            { "dpdyCoarse", "dfdy"_s },
+            { "dpdyFine", "dfdy"_s },
             { "f32", "float"_s },
+            { "fwidthCoarse", "fwidth"_s },
+            { "fwidthFine", "fwidth"_s },
             { "i32", "int"_s },
             { "mat2x2f", "float2x2"_s },
             { "mat2x3f", "float2x3"_s },

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -582,6 +582,33 @@ operator :trunc, {
     [T < Float, N].(vec[N][T]) => vec[N][T],
 }
 
+# 16.6. Derivative Built-in Functions (https://www.w3.org/TR/WGSL/#derivative-builtin-functions)
+[
+    # 16.6.1
+    :dpdx,
+    # 16.6.2
+    :dpdxCoarse,
+    # 16.6.3
+    :dpdxFine,
+    # 16.6.4
+    :dpdy,
+    # 16.6.5
+    :dpdyCoarse,
+    # 16.6.6
+    :dpdyFine,
+    # 16.6.7
+    :fwidth,
+    # 16.6.8
+    :fwidthCoarse,
+    # 16.6.9
+    :fwidthFine,
+]. each do |op|
+    operator op, {
+        [].(f32) => f32,
+        [N].(vec[N][f32]) => vec[N][f32],
+    }
+end
+
 # 16.7. Texture Built-in Functions (https://gpuweb.github.io/gpuweb/wgsl/#texture-builtin-functions)
 
 # 16.7.1

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -2088,6 +2088,70 @@ fn testTrunc()
     }
 }
 
+// 16.6. Derivative Built-in Functions (https://www.w3.org/TR/WGSL/#derivative-builtin-functions)
+// RUN: %metal-compile testDerivativeFunctions
+@fragment
+fn testDerivativeFunctions()
+{
+    // All have the same signatures:
+    //   [].(f32) => f32,
+    //   [N].(vec[N][f32]) => vec[N][f32],
+
+    // 16.6.1 dpdx
+    _ = dpdx(2.0);
+    _ = dpdx(vec2(2.0));
+    _ = dpdx(vec3(2.0));
+    _ = dpdx(vec4(2.0));
+
+    // 16.6.2 dpdxCoarse
+    _ = dpdxCoarse(2.0);
+    _ = dpdxCoarse(vec2(2.0));
+    _ = dpdxCoarse(vec3(2.0));
+    _ = dpdxCoarse(vec4(2.0));
+
+    // 16.6.3 dpdxFine
+    _ = dpdxFine(2.0);
+    _ = dpdxFine(vec2(2.0));
+    _ = dpdxFine(vec3(2.0));
+    _ = dpdxFine(vec4(2.0));
+
+    // 16.6.4 dpdy
+    _ = dpdy(2.0);
+    _ = dpdy(vec2(2.0));
+    _ = dpdy(vec3(2.0));
+    _ = dpdy(vec4(2.0));
+
+    // 16.6.5 dpdyCoarse
+    _ = dpdyCoarse(2.0);
+    _ = dpdyCoarse(vec2(2.0));
+    _ = dpdyCoarse(vec3(2.0));
+    _ = dpdyCoarse(vec4(2.0));
+
+    // 16.6.6 dpdyFine
+    _ = dpdyFine(2.0);
+    _ = dpdyFine(vec2(2.0));
+    _ = dpdyFine(vec3(2.0));
+    _ = dpdyFine(vec4(2.0));
+
+    // 16.6.7 fwidth
+    _ = fwidth(2.0);
+    _ = fwidth(vec2(2.0));
+    _ = fwidth(vec3(2.0));
+    _ = fwidth(vec4(2.0));
+
+    // 16.6.8 fwidthCoarse
+    _ = fwidthCoarse(2.0);
+    _ = fwidthCoarse(vec2(2.0));
+    _ = fwidthCoarse(vec3(2.0));
+    _ = fwidthCoarse(vec4(2.0));
+
+    // 16.6.9 fwidthFine
+    _ = fwidthFine(2.0);
+    _ = fwidthFine(vec2(2.0));
+    _ = fwidthFine(vec3(2.0));
+    _ = fwidthFine(vec4(2.0));
+}
+
 // 16.7. Texture Built-in Functions (https://gpuweb.github.io/gpuweb/wgsl/#texture-builtin-functions)
 
 @group(0) @binding( 0) var s: sampler;


### PR DESCRIPTION
#### 6a9bd6f73f12e257aeb25f3b2b424c1ff4fde865
<pre>
[WGSL] Add support for derivative functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=263397">https://bugs.webkit.org/show_bug.cgi?id=263397</a>
rdar://117222152

Reviewed by Dan Glastonbury.

Implement all the functions from the &quot;Derivative Built-in Functions&quot; section
of the spec[1].

[1]: <a href="https://www.w3.org/TR/WGSL/#derivative-builtin-functions">https://www.w3.org/TR/WGSL/#derivative-builtin-functions</a>

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/269607@main">https://commits.webkit.org/269607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f918d32a2953d24a66601ea07cdaf7eb2b9dc090

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5499 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->