### PR TITLE
[WGSL] Implement bitcast

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -248,6 +248,13 @@ operator :vec4, {
     [].() => vec4[abstract_int],
 }
 
+# 16.2. Bit Reinterpretation Built-in Functions (https://www.w3.org/TR/WGSL/#bitcast-builtin)
+
+# NOTE: Our overload resolution/constraints aren't expressive enough to support
+# some of the bitcast overloads. They require a constraint on the type variable
+# to constrain it to a vector type, which we cannot express here, so it's implemented
+# inline in the type checker
+
 # 17.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)
 
 # 17.3.1 & 17.3.2

--- a/Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl
@@ -1,0 +1,28 @@
+// RUN: %not %wgslc | %check
+
+fn testWrongNumberOfArguments()
+{
+    // CHECK: bitcast expects a single argument, found 2
+    _ = bitcast<i32>(0, 0);
+
+    // CHECK: bitcast expects a single argument, found 0
+    _ = bitcast<i32>();
+}
+
+fn testWrongNumberOfTemplateArguments()
+{
+    // CHECK: bitcast expects a single template argument, found 2
+    _ = bitcast<i32, i32>(0);
+
+    // CHECK: bitcast expects a single template argument, found 0
+    _ = bitcast(0);
+}
+
+fn testInvalidConversion()
+{
+    // CHECK: cannot bitcast from 'i32' to 'vec2<i32>'
+    _ = bitcast<vec2<i32>>(0);
+
+    // CHECK: cannot bitcast from 'vec2<i32>' to 'i32'
+    _ = bitcast<i32>(vec2(0));
+}

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -518,6 +518,71 @@ fn testVec4() {
   _ = vec4(0, vec3(0, 0, 0));
 }
 
+// 16.2. Bit Reinterpretation Built-in Functions (https://www.w3.org/TR/WGSL/#bitcast-builtin)
+// RUN: %metal-compile testBitcast
+@compute @workgroup_size(1)
+fn testBitcast()
+{
+    let u = 0u;
+    let i = 0i;
+    let f = 0f;
+
+    // [T < Concrete32BitNumber, S < Concrete32BitNumber].(S) => T
+    { let x: u32 = bitcast<u32>(u); }
+    { let x: u32 = bitcast<u32>(i); }
+    { let x: u32 = bitcast<u32>(f); }
+
+    { let x: i32 = bitcast<i32>(u); }
+    { let x: i32 = bitcast<i32>(i); }
+    { let x: i32 = bitcast<i32>(f); }
+
+    { let x: f32 = bitcast<f32>(u); }
+    { let x: f32 = bitcast<f32>(i); }
+    { let x: f32 = bitcast<f32>(f); }
+
+    // [T < Concrete32BitNumber, S < Concrete32BitNumber, N].(vec[N][S]) => vec[N][T]
+    // vec2
+    { let x: vec2<u32> = bitcast<vec2<u32>>(vec2(u)); }
+    { let x: vec2<u32> = bitcast<vec2<u32>>(vec2(i)); }
+    { let x: vec2<u32> = bitcast<vec2<u32>>(vec2(f)); }
+
+    { let x: vec2<i32> = bitcast<vec2<i32>>(vec2(u)); }
+    { let x: vec2<i32> = bitcast<vec2<i32>>(vec2(i)); }
+    { let x: vec2<i32> = bitcast<vec2<i32>>(vec2(f)); }
+
+    { let x: vec2<f32> = bitcast<vec2<f32>>(vec2(u)); }
+    { let x: vec2<f32> = bitcast<vec2<f32>>(vec2(i)); }
+    { let x: vec2<f32> = bitcast<vec2<f32>>(vec2(f)); }
+
+    // vec3
+    { let x: vec3<u32> = bitcast<vec3<u32>>(vec3(u)); }
+    { let x: vec3<u32> = bitcast<vec3<u32>>(vec3(i)); }
+    { let x: vec3<u32> = bitcast<vec3<u32>>(vec3(f)); }
+
+    { let x: vec3<i32> = bitcast<vec3<i32>>(vec3(u)); }
+    { let x: vec3<i32> = bitcast<vec3<i32>>(vec3(i)); }
+    { let x: vec3<i32> = bitcast<vec3<i32>>(vec3(f)); }
+
+    { let x: vec3<f32> = bitcast<vec3<f32>>(vec3(u)); }
+    { let x: vec3<f32> = bitcast<vec3<f32>>(vec3(i)); }
+    { let x: vec3<f32> = bitcast<vec3<f32>>(vec3(f)); }
+
+    // vec4
+    { let x: vec4<u32> = bitcast<vec4<u32>>(vec4(u)); }
+    { let x: vec4<u32> = bitcast<vec4<u32>>(vec4(i)); }
+    { let x: vec4<u32> = bitcast<vec4<u32>>(vec4(f)); }
+
+    { let x: vec4<i32> = bitcast<vec4<i32>>(vec4(u)); }
+    { let x: vec4<i32> = bitcast<vec4<i32>>(vec4(i)); }
+    { let x: vec4<i32> = bitcast<vec4<i32>>(vec4(f)); }
+
+    { let x: vec4<f32> = bitcast<vec4<f32>>(vec4(u)); }
+    { let x: vec4<f32> = bitcast<vec4<f32>>(vec4(i)); }
+    { let x: vec4<f32> = bitcast<vec4<f32>>(vec4(f)); }
+
+    // FIXME: add f16 overloads
+}
+
 // 17.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)
 
 // 17.3.1


### PR DESCRIPTION
#### 6bee9173fc860b6cf3d950c8fb7c4e51d31aadfa
<pre>
[WGSL] Implement bitcast
<a href="https://bugs.webkit.org/show_bug.cgi?id=263398">https://bugs.webkit.org/show_bug.cgi?id=263398</a>
rdar://117222621

Reviewed by Dan Glastonbury.

Implement bitcast according to the spec[1]. Unfortunately, as mentioned in the comment
I added in TypeDeclarations.rb, our constraint system isn&apos;t flexible enough to express
all the bitcast overloads, so the checking is done manually in the type checker.

[1]: <a href="https://www.w3.org/TR/WGSL/#bitcast-builtin">https://www.w3.org/TR/WGSL/#bitcast-builtin</a>

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::emitBitcast):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::bitcast):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/269586@main">https://commits.webkit.org/269586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cba228fb4783b3e6c801424c1b2acdc56e28b322

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5488 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->