### PR TITLE
Ensure that CachedFontLoadRequest::fontLoaded longs Font before font is released

### DIFF
--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -82,13 +82,12 @@ private:
     void fontLoaded(CachedFont& font) final
     {
         ASSERT_UNUSED(font, &font == m_font.get());
-        if (m_fontLoadRequestClient)
-            m_fontLoadRequestClient->fontLoaded(*this);
-
         if (m_font->didRefuseToLoadCustomFont() && m_context) {
             auto message = makeString("[Lockdown Mode] This font has been blocked: ", m_font->url().string());
             m_context->addConsoleMessage(MessageSource::Security, MessageLevel::Info, message);
         }
+        if (m_fontLoadRequestClient)
+            m_fontLoadRequestClient->fontLoaded(*this); // fontLoaded() might destroy this object. Don't deref its members after it.
     }
 
     CachedResourceHandle<CachedFont> m_font;


### PR DESCRIPTION
#### 0b63ffe87813e5068683d0b5b86bfccb364bffad
<pre>
Ensure that CachedFontLoadRequest::fontLoaded longs Font before font is released
<a href="https://bugs.webkit.org/show_bug.cgi?id=263400">https://bugs.webkit.org/show_bug.cgi?id=263400</a>
rdar://117077759

Reviewed by Chris Dumez.

The problem happens because CachedFontLoadRequest::fontLoaded calls
m_fontLoadRequestClient-&gt;fontLoaded(*this) which will end up destroying CachedFontLoadRequest itself.

We use a local Ref object to try to guarantee the ownership of the object&apos;s CSSFontFace&amp; m_face.

We end up calling the destructor of  CSSFontFace once we leave the function&apos;s scope. This means that this Ref was the only one to the FontFace, but there was no way for us to know that, since we have a l-value ref to it here.

The CSSFontFace will destroy its unique_ptr to CSSFontFaceSource which will destroy its FontLoadRequest (actually a CachedFontLoadRequest) that will finally destroy its CachedResourceHandle&lt;CachedFont&gt; m_font;

The caller of CSSFontFaceSource::fontLoaded is CachedFontLoadRequest::fontLoaded.  CachedFontLoadRequest has a CachedResourceHandle&lt;CachedFont&gt; m_font that is accessed in fontLoaded, causing the bug.

Proposed solution:
CachedFontLoadRequest::fontLoaded is the function that does the actual use after free by using the object&apos;s m_font member after this pointer is deleted. We can simply do the logging before m_fontLoadRequestClient-&gt;fontLoaded starts the deallocation cycle.

This will work to avoid this specific use, but we should strengthen, but
we should consider using a WeakPtr to CSSFontFace at CSSFontFaceSource
instead of a l-value reference so we can check if the FontFace that owns this CSSFontFaceSource is no longer existent.

* Source/WebCore/loader/cache/CachedFontLoadRequest.h:

Canonical link: <a href="https://commits.webkit.org/269562@main">https://commits.webkit.org/269562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/517ceecb4cc25494170aecd0d6b56c48720590db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/22934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24845 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/23199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/23175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/19897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/25702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/25702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/21037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/25702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5474 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->