### PR TITLE
Implement UIAsyncTextInput methods to request word rects for and apply autocorrections

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1661,6 +1661,10 @@
 #define HAVE_UI_ASYNC_DRAG_INTERACTION 1
 #endif
 
+#if __has_include(<UIKit/UIAsyncTextInput.h>) && __has_include(<UIKit/UIKeyEventContext.h>)
+#define HAVE_UI_ASYNC_TEXT_INPUT 1
+#endif
+
 #if !PLATFORM(WATCHOS) && __has_include(<UIKit/_UIContextMenuAsyncConfiguration.h>)
 #define HAVE_UI_CONTEXT_MENU_ASYNC_CONFIGURATION 1
 #endif

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -118,6 +118,11 @@
 #import <UIKit/_UITextDragCaretView.h>
 #endif
 
+#if HAVE(UI_ASYNC_TEXT_INPUT)
+#import <UIKit/UIAsyncTextInput.h>
+#import <UIKit/UIKeyEventContext.h>
+#endif
+
 #if HAVE(UI_ASYNC_DRAG_INTERACTION)
 #import <UIKit/UIDragInteraction_AsyncSupport.h>
 #import <UIKit/_UIAsyncDragInteraction.h>


### PR DESCRIPTION
#### 309970939cb08c60f9ed724eddd2410e2053b55f
<pre>
Implement UIAsyncTextInput methods to request word rects for and apply autocorrections
<a href="https://bugs.webkit.org/show_bug.cgi?id=263388">https://bugs.webkit.org/show_bug.cgi?id=263388</a>
rdar://117219847

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Adopt several new `UIAsyncTextInput` (and adjacent) methods and classes:

```
UIKeyEventContext
-requestTextRectsForString:withCompletionHandler:
-replaceText:withText:options:withCompletionHandler:
-deferEventHandlingToSystemWithContext:
```

See below for more details.

* Source/WTF/wtf/PlatformHave.h:

Add a compile-time flag to guard the availability of these new APIs.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Import some of these new private headers.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(+[WKUITextSelectionRect selectionRectWithCGRect:]):
(-[WKUITextSelectionRect initWithCGRect:]):
(-[WKUITextSelectionRect rect]):

Add a custom `UITextSelectionRect` subclass that we can initialize with a `CGRect`.

(-[WKContentView _ensureBinaryCompatibilityWithAsyncInteractionsIfNeeded]):

To make debugging and bincompat sanity-checking a bit more convenient, dump all optional methods on
`UIAsyncTextInput` that are unimplemented on the content view.

(-[WKContentView requestAutocorrectionRectsForString:withCompletionHandler:]):
(-[WKContentView _internalRequestTextRectsForString:completion:]):

Refactor these two legacy `UIWKInteractionViewProtocol` methods to use the same internal helper
method as the new `UIAsyncTextInput` methods. Note that these internal helper methods don&apos;t use any
of the legacy `UIWK*` classes; this will make it easier to cleanly excise these deprecated codepaths
after the minimum supported iOS version has system support for `UIAsyncTextInput`.

(-[WKContentView applyAutocorrection:toString:isCandidate:withCompletionHandler:]):
(-[WKContentView _internalReplaceText:withText:isCandidate:completion:]):
(-[WKContentView _interpretKeyEvent:isCharEvent:]):

Set up a key event context object when deferring key event handling to the system; this allows
only `keypress` events to trigger text editing, while still allowing `keydown` events to trigger
other actions, like menu commands.

(-[WKContentView replaceText:withText:options:withCompletionHandler:]):
(-[WKContentView requestTextRectsForString:withCompletionHandler:]):

Canonical link: <a href="https://commits.webkit.org/269593@main">https://commits.webkit.org/269593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e8c802e053461af87eda371c09e13e98ef9e804

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21260 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23511 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25741 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20813 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19992 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20765 "Build is in progress. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21075 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22335 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/29737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/414 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/29737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5493 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/905 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/28762 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/674 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6027 "Found 2 new JSC stress test failures: microbenchmarks/array-from-object-func.js.lockdown, microbenchmarks/array-from-object.js.lockdown (failure)") | 
<!--EWS-Status-Bubble-End-->