### PR TITLE
[WGSL] Add support for switch statements

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -96,6 +96,8 @@ class ReferenceTypeExpression;
 class Variable;
 class VariableQualifier;
 
+struct SwitchClause;
+
 enum class BinaryOperation : uint8_t;
 enum class ParameterRole : uint8_t;
 enum class StructureRole : uint8_t;

--- a/Source/WebGPU/WGSL/AST/ASTSwitchStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTSwitchStatement.h
@@ -29,15 +29,33 @@
 
 namespace WGSL::AST {
 
+struct SwitchClause {
+    AST::Expression::List selectors;
+    AST::CompoundStatement::Ref body;
+};
+
 class SwitchStatement final : public Statement {
     WGSL_AST_BUILDER_NODE(SwitchStatement);
 public:
     NodeKind kind() const final;
+    Expression& value() { return m_value.get(); }
+    Attribute::List& valueAttributes() { return m_valueAttributes; }
+    Vector<SwitchClause>& clauses() { return m_clauses; }
+    SwitchClause& defaultClause() { return m_defaultClause; }
 
 private:
-    SwitchStatement(SourceSpan span)
+    SwitchStatement(SourceSpan span, AST::Expression::Ref&& value, AST::Attribute::List&& valueAttributes, Vector<SwitchClause>&& clauses, SwitchClause&& defaultClause)
         : Statement(span)
+        , m_value(WTFMove(value))
+        , m_valueAttributes(WTFMove(valueAttributes))
+        , m_clauses(WTFMove(clauses))
+        , m_defaultClause(WTFMove(defaultClause))
     { }
+
+    Expression::Ref m_value;
+    Attribute::List m_valueAttributes;
+    Vector<SwitchClause> m_clauses;
+    SwitchClause m_defaultClause;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -462,8 +462,21 @@ void Visitor::visit(AST::StaticAssertStatement& staticAssertStatement)
     checkErrorAndVisit(staticAssertStatement.expression());
 }
 
-void Visitor::visit(AST::SwitchStatement&)
+void Visitor::visit(AST::SwitchStatement& statement)
 {
+    checkErrorAndVisit(statement.value());
+    for (auto& attribute : statement.valueAttributes())
+        checkErrorAndVisit(attribute);
+    for (auto& clause : statement.clauses())
+        checkErrorAndVisit(clause);
+    checkErrorAndVisit(statement.defaultClause());
+}
+
+void Visitor::visit(AST::SwitchClause& clause)
+{
+    for (auto& selector : clause.selectors)
+        checkErrorAndVisit(selector);
+    checkErrorAndVisit(clause.body);
 }
 
 void Visitor::visit(AST::VariableStatement& varStatement)

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -114,6 +114,7 @@ public:
     virtual void visit(AST::VariableQualifier&);
 
     virtual void visit(AST::InterpolateAttribute::Type, std::optional<AST::InterpolateAttribute::Sampling>) { }
+    virtual void visit(AST::SwitchClause&);
 
     bool hasError() const;
     Result<void> result();

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -81,6 +81,7 @@ public:
     Result<AST::Statement::Ref> parseIfStatement();
     Result<AST::Statement::Ref> parseIfStatementWithAttributes(AST::Attribute::List&&, SourcePosition _startOfElementPosition);
     Result<AST::Statement::Ref> parseForStatement();
+    Result<AST::Statement::Ref> parseSwitchStatement();
     Result<AST::Statement::Ref> parseWhileStatement();
     Result<AST::Statement::Ref> parseReturnStatement();
     Result<AST::Statement::Ref> parseVariableUpdatingStatement();

--- a/Source/WebGPU/WGSL/tests/invalid/switch.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/switch.wgsl
@@ -1,0 +1,15 @@
+// RUN: %not %wgslc | %check
+
+fn main() {
+    let x: u32 = 42;
+    switch 1u {
+        // CHECK-L: the case selector values must have the same type as the selector expression: the selector expression has type 'u32' and case selector has type 'i32'
+        case 1i, default,: { }
+    }
+
+    // CHECK-L: switch selector must be of type i32 or u32
+    switch false {
+        // CHECK-NOT-L: the case selector values must have the same type as the selector expression: the selector expression has type 'u32' and case selector has type 'i32'
+        case 1i, default,: { }
+    }
+}

--- a/Source/WebGPU/WGSL/tests/valid/switch.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/switch.wgsl
@@ -1,0 +1,63 @@
+// RUN: %metal-compile main
+
+@compute @workgroup_size(1)
+fn main() {
+    switch 1 {
+        case 1,: { }
+        case 2 { }
+        case 4, 5, 6 { }
+        case 7, 8, 9, { }
+        case 10, 11, 12: { }
+        case 13, 14, 15: { }
+        default { }
+    }
+
+    switch 1 {
+        default { }
+        case 1,: { }
+        case 2 { }
+        case 4, 5, 6 { }
+        case 7, 8, 9, { }
+        case 10, 11, 12: { }
+        case 13, 14, 15: { }
+    }
+
+    switch 1 {
+        case 1,: { }
+        case 2 { }
+        default { }
+        case 4, 5, 6 { }
+        case 7, 8, 9, { }
+    }
+
+    switch 1 {
+        case 1,: { }
+        case 2 { }
+        case 4, 5, 6 { }
+        case 7, default, 8, 9, { }
+    }
+
+    switch 1 {
+        case default { }
+    }
+
+    switch 1 {
+        case default,: { }
+    }
+
+    switch 1 {
+        case default: { }
+    }
+
+    switch 1 {
+        case default,: { }
+    }
+
+    switch 1 {
+        case default, 1, 2, 3,: { }
+    }
+
+    switch 1 {
+        case 1, 2, 3, default,: { }
+    }
+}


### PR DESCRIPTION
#### afec2be5706616f59530963bbf45cf0332c7f801
<pre>
[WGSL] Add support for switch statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=263404">https://bugs.webkit.org/show_bug.cgi?id=263404</a>
rdar://117224289

Reviewed by Dan Glastonbury.

Add parsing, type checking and code generation for switch statements.

* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTSwitchStatement.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseSwitchStatement):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/switch.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/switch.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/269580@main">https://commits.webkit.org/269580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f22d75ab91cb36939a39c851118ccc65916fade6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5485 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->