### PR TITLE
Postpone initialization of StructureAlignedMemoryAllocator.

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -164,6 +164,10 @@ void StructureAlignedMemoryAllocator::initializeStructureAddressSpace()
 
 void* StructureAlignedMemoryAllocator::tryMallocBlock()
 {
+    static std::once_flag s_onceFlag;
+    std::call_once(s_onceFlag, [] {
+        initializeStructureAddressSpace();
+    });
     return s_structureMemoryManager->tryMallocStructureBlock();
 }
 

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -38,7 +38,6 @@
 #include "LLIntData.h"
 #include "NativeCalleeRegistry.h"
 #include "Options.h"
-#include "StructureAlignedMemoryAllocator.h"
 #include "SuperSampler.h"
 #include "VMTraps.h"
 #include "WasmCapabilities.h"
@@ -92,7 +91,6 @@ void initialize()
                 isARM64E_FPAC(); // Call this to initialize g_jscConfig.canUseFPAC.
 #endif
             }
-            StructureAlignedMemoryAllocator::initializeStructureAddressSpace();
         }
         Options::finalize();
 


### PR DESCRIPTION
#### 91adc5e2412ce1d92a3271e5bc983618cb2aabba
<pre>
Postpone initialization of StructureAlignedMemoryAllocator.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263380">https://bugs.webkit.org/show_bug.cgi?id=263380</a>

Reviewed by Keith Miller.

StructureAlignedMemoryAllocator reserves a large amount of pages at startup
even on UIProcess and NetworkProcess because the initialization is called from
JSC::initialize().

In this patch, we postpone the initialization of StructureAlignedMemoryAllocator
until the first time it is used. Because permanentlyFreeze() will be called
at the end of construction of VM, it is safe to postpone the initialization.

* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
(JSC::StructureAlignedMemoryAllocator::tryMallocBlock):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):

Canonical link: <a href="https://commits.webkit.org/269633@main">https://commits.webkit.org/269633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79a56510f6efb32ad9ea8ed09b4fdd166b1ec7c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22183 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25825 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27052 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/20060 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21145 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24920 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22424 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18348 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/29798 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/490 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6157 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5515 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/972 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/29446 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/764 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6048 "Passed tests") | 
<!--EWS-Status-Bubble-End-->