### PR TITLE
[popover] @supports selector(:popover-open) does not reflect disabled preference

### DIFF
--- a/LayoutTests/fast/selectors/popover-open-disabled-expected.html
+++ b/LayoutTests/fast/selectors/popover-open-disabled-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 100px;
+            height: 100px;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <p>Test passes if you see a green square</p>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/fast/selectors/popover-open-disabled.html
+++ b/LayoutTests/fast/selectors/popover-open-disabled.html
@@ -1,0 +1,21 @@
+<!-- webkit-test-runner [ PopoverAttributeEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that :popover-open selector is not supported when popover attribute is disabled</title>
+    <style>
+        div {
+            width: 100px;
+            height: 100px;
+            background-color: red;
+            @supports not selector(:popover-open) {
+                background-color: green;
+            }
+        }
+    </style>
+</head>
+<body>
+    <p>Test passes if you see a green square</p>
+    <div></div>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -57,6 +57,7 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
     if (mode == UASheetMode) {
         colorMixEnabled = true;
         focusVisibleEnabled = true;
+        popoverAttributeEnabled = true;
         propertySettings.cssContainmentEnabled = true;
         propertySettings.cssIndividualTransformPropertiesEnabled = true;
         propertySettings.cssInputSecurityEnabled = true;
@@ -104,6 +105,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
     , cssTextWrapNewValuesEnabled { document.settings().cssTextWrapNewValuesEnabled() }
     , cssWordBreakAutoEnabled { document.settings().cssWordBreakAutoEnabled() }
+    , popoverAttributeEnabled { document.settings().popoverAttributeEnabled() }
     , sidewaysWritingModesEnabled { document.settings().sidewaysWritingModesEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
@@ -138,8 +140,9 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssTextUnderlinePositionLeftRightEnabled  << 22
         | context.cssTextWrapNewValuesEnabled               << 23
         | context.cssWordBreakAutoEnabled                   << 24
-        | context.sidewaysWritingModesEnabled               << 25
-        | (uint64_t)context.mode                            << 26; // This is multiple bits, so keep it last.
+        | context.popoverAttributeEnabled                   << 25
+        | context.sidewaysWritingModesEnabled               << 26
+        | (uint64_t)context.mode                            << 27; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -96,6 +96,7 @@ struct CSSParserContext {
     bool cssTextUnderlinePositionLeftRightEnabled { false };
     bool cssTextWrapNewValuesEnabled { false };
     bool cssWordBreakAutoEnabled { false };
+    bool popoverAttributeEnabled { false };
     bool sidewaysWritingModesEnabled { false };
 
     // Settings, those affecting properties.

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -52,6 +52,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , cssNestingEnabled(context.cssNestingEnabled)
     , focusVisibleEnabled(context.focusVisibleEnabled)
     , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
+    , popoverAttributeEnabled(context.popoverAttributeEnabled)
 {
 }
 
@@ -60,6 +61,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , cssNestingEnabled(document.settings().cssNestingEnabled())
     , focusVisibleEnabled(document.settings().focusVisibleEnabled())
     , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
+    , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
 {
 }
 
@@ -798,6 +800,8 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             if (!m_context.focusVisibleEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::FocusVisible)
                 return nullptr;
             if (!m_context.hasPseudoClassEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::Has)
+                return nullptr;
+            if (!m_context.popoverAttributeEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::PopoverOpen)
                 return nullptr;
             if (m_context.mode != UASheetMode && selector->pseudoClassType() == CSSSelector::PseudoClassType::HtmlDocument)
                 return nullptr;

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -50,6 +50,7 @@ struct CSSSelectorParserContext {
     bool cssNestingEnabled { false };
     bool focusVisibleEnabled { false };
     bool hasPseudoClassEnabled { false };
+    bool popoverAttributeEnabled { false };
 
     bool isHashTableDeletedValue { false };
 


### PR DESCRIPTION
#### d544e51a1947e66d0f8e259b4697c25850260231
<pre>
[popover] @supports selector(:popover-open) does not reflect disabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=263405">https://bugs.webkit.org/show_bug.cgi?id=263405</a>
rdar://117226626

Reviewed by Simon Fraser.

* LayoutTests/fast/selectors/popover-open-disabled-expected.html: Added.
* LayoutTests/fast/selectors/popover-open-disabled.html: Added.
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::CSSSelectorParser::consumePseudo):
* Source/WebCore/css/parser/CSSSelectorParser.h:

Canonical link: <a href="https://commits.webkit.org/269565@main">https://commits.webkit.org/269565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4865113518d0acc9a30455c9091bc05a4a1dc022

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23454 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23160 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25687 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23103 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/20774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21019 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22282 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/22713 "Failed resultsdbpy unit tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20552 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/864 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/28101 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/2899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/621 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6015 "Passed tests") | 
<!--EWS-Status-Bubble-End-->