### PR TITLE
Follow-up: [WebRTC] Add target for sdp_integration_fuzzer

### DIFF
--- a/Source/ThirdParty/libwebrtc/WebKit/sdp_integration_fuzzer-libwebrtc.diff
+++ b/Source/ThirdParty/libwebrtc/WebKit/sdp_integration_fuzzer-libwebrtc.diff
@@ -1,8 +1,39 @@
 diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc
-index ece4b50505d8..e39e89f6c616 100644
+index ece4b50505d8..f66ed04a792f 100644
 --- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc
 +++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc
-@@ -44,8 +44,10 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
+@@ -10,8 +10,10 @@
+ 
+ #include <stddef.h>
+ #include <stdint.h>
++#include <stdlib.h>
+ 
+ #include "absl/strings/string_view.h"
++#include "api/jsep.h"
+ #include "pc/test/integration_test_helpers.h"
+ 
+ namespace webrtc {
+@@ -21,7 +23,7 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
+   FuzzerTest()
+       : PeerConnectionIntegrationBaseTest(SdpSemantics::kUnifiedPlan) {}
+ 
+-  void RunNegotiateCycle(absl::string_view message) {
++  void RunNegotiateCycle(SdpType sdpType, absl::string_view message) {
+     CreatePeerConnectionWrappers();
+     // Note - we do not do test.ConnectFakeSignaling(); all signals
+     // generated are discarded.
+@@ -29,9 +31,8 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
+     auto srd_observer =
+         rtc::make_ref_counted<FakeSetRemoteDescriptionObserver>();
+ 
+-    SdpParseError error;
+     std::unique_ptr<SessionDescriptionInterface> sdp(
+-        CreateSessionDescription("offer", std::string(message), &error));
++        CreateSessionDescription(sdpType, std::string(message)));
+     caller()->pc()->SetRemoteDescription(std::move(sdp), srd_observer);
+     // Wait a short time for observer to be called. Timeout is short
+     // because the fuzzer should be trying many branches.
+@@ -44,8 +45,10 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
        caller()->pc()->SetLocalDescription(sld_observer);
        EXPECT_TRUE_WAIT(sld_observer->called(), 100);
      }
@@ -13,6 +44,52 @@ index ece4b50505d8..e39e89f6c616 100644
    }
  
    // This test isn't using the test definition macros, so we have to
+@@ -54,13 +57,42 @@ class FuzzerTest : public PeerConnectionIntegrationBaseTest {
+ };
+ 
+ void FuzzOneInput(const uint8_t* data, size_t size) {
+-  if (size > 16384) {
+-    return;
++  uint8_t* newData = const_cast<uint8_t*>(data);
++  size_t newSize = size;
++  uint8_t type = 0;
++
++  if (const char* var = getenv("SDP_TYPE")) {
++    if (size > 16384) {
++      return;
++    }
++    type = atoi(var);
++  } else {
++    if (size < 1 || size > 16385) {
++      return;
++    }
++    type = data[0];
++    newSize = size - 1;
++    newData = reinterpret_cast<uint8_t*>(malloc(newSize));
++    if (!newData)
++      return;
++    memcpy(newData, &data[1], newSize);
++  }
++
++  SdpType sdpType = SdpType::kOffer;
++  switch (type % 4) {
++    case 0: sdpType = SdpType::kOffer; break;
++    case 1: sdpType = SdpType::kPrAnswer; break;
++    case 2: sdpType = SdpType::kAnswer; break;
++    case 3: sdpType = SdpType::kRollback; break;
+   }
+ 
+   FuzzerTest test;
+   test.RunNegotiateCycle(
+-      absl::string_view(reinterpret_cast<const char*>(data), size));
++      sdpType,
++      absl::string_view(reinterpret_cast<const char*>(newData), newSize));
++
++  if (newData != data)
++      free(newData);
+ }
+ 
+ }  // namespace webrtc
 diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/test/gmock.h b/Source/ThirdParty/libwebrtc/Source/webrtc/test/gmock.h
 index f137d080a4b3..2d4e26eb9738 100644
 --- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/gmock.h


### PR DESCRIPTION
#### c0e58a114febdf366376fd27a6f0af8579c3cd26
<pre>
Follow-up: [WebRTC] Add target for sdp_integration_fuzzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=263225">https://bugs.webkit.org/show_bug.cgi?id=263225</a>
&lt;rdar://117044163&gt;

Unreviewed fuzzer coverage improvement.

* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/sdp_integration_fuzzer.cc:
(webrtc::FuzzerTest::RunNegotiateCycle):
- Add SdpType enum method argument instead of hard-coding a string.
- Remove unused SdpParseError stack variable.
- Call overload of CreateSessionDescription() that takes an SdpType enum
  value to avoid creating a std::string just to have it converted back
  to an SdpType enum later.
(webrtc::FuzzOneInput):
- If SDP_TYPE environment variable is set, run the fuzzer in
  single-SdpType mode based on the integer value of the variable, else
  use the first byte of input to determine the SdpType of the input.

* Source/ThirdParty/libwebrtc/WebKit/sdp_integration_fuzzer-libwebrtc.diff:
- Update patch to include changes to sdp_integration_fuzzer.cc.

Canonical link: <a href="https://commits.webkit.org/269551@main">https://commits.webkit.org/269551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c2c8fcd124cedfd20610cbd2dc7bbefa198e3a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2889 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->