### PR TITLE
[cssom-view] Add option to check for content-visibility: auto to element.checkVisibility()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html
@@ -81,12 +81,23 @@ test(() => {
   assert_false(slottedincvhidden.checkVisibility());
 }, 'checkVisibility on element slotted in content-visibility: hidden shadow host.');
 
-test(() => {
-  assert_true(cvauto.checkVisibility());
+promise_test(async () => {
+  await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+  assert_true(cvauto.checkVisibility({
+    checkContentVisibilityAuto: false
+  }), 'checkContentVisibilityAuto: false');
+  assert_true(cvauto.checkVisibility({
+    checkContentVisibilityAuto: true
+  }), 'checkContentVisibilityAuto: true');
 }, 'checkVisibility on content-visibility:auto element.');
 
 test(() => {
-  assert_true(cvautooffscreen.checkVisibility());
+  assert_true(cvautooffscreen.checkVisibility({
+    checkContentVisibilityAuto: false
+  }), 'checkContentVisibilityAuto: false');
+  assert_false(cvautooffscreen.checkVisibility({
+    checkContentVisibilityAuto: true
+  }), 'checkContentVisibilityAuto: true');
 }, 'checkVisibility on content-visibility:auto element which is outside the viewport.');
 
 test(() => {
@@ -124,8 +135,12 @@ test(() => {
   cvautocontainer.style.contentVisibility = 'auto';
   cvautochild.style.visibility = 'hidden';
   assert_false(cvautochild.checkVisibility({checkVisibilityCSS: true}));
+  assert_false(cvautochild.checkVisibility({checkContentVisibilityAuto: true}));
+  assert_true(cvautochild.checkVisibility());
   cvautochild.style.visibility = 'visible';
   assert_true(cvautochild.checkVisibility({checkVisibilityCSS: true}));
+  assert_false(cvautochild.checkVisibility({checkContentVisibilityAuto: true}));
+  assert_true(cvautochild.checkVisibility());
 }, 'checkVisibility on content-visibility:auto with visibility:hidden inside.');
 
 test(() => {

--- a/Source/WebCore/dom/CheckVisibilityOptions.h
+++ b/Source/WebCore/dom/CheckVisibilityOptions.h
@@ -30,6 +30,7 @@ namespace WebCore {
 struct CheckVisibilityOptions {
     bool checkOpacity { false };
     bool checkVisibilityCSS { false };
+    bool checkContentVisibilityAuto { false };
 };
 
 }

--- a/Source/WebCore/dom/CheckVisibilityOptions.idl
+++ b/Source/WebCore/dom/CheckVisibilityOptions.idl
@@ -27,4 +27,5 @@
 dictionary CheckVisibilityOptions {
     boolean checkOpacity = false;
     boolean checkVisibilityCSS = false;
+    boolean checkContentVisibilityAuto = false;
 };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5491,6 +5491,9 @@ bool Element::checkVisibility(const CheckVisibilityOptions& options)
     if (isSkippedContentWithReason(ContentVisibility::Hidden))
         return false;
 
+    if (options.checkContentVisibilityAuto && isSkippedContentWithReason(ContentVisibility::Auto))
+        return false;
+
     for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
         auto* ancestorStyle = ancestor->computedStyle();
         if (ancestorStyle->display() == DisplayType::None)


### PR DESCRIPTION
#### 5014c3a97ffa1b72e3fff85b70a69407a5529400
<pre>
[cssom-view] Add option to check for content-visibility: auto to element.checkVisibility()
<a href="https://bugs.webkit.org/show_bug.cgi?id=263352">https://bugs.webkit.org/show_bug.cgi?id=263352</a>
rdar://117177342

Reviewed by Simon Fraser.

As resolved in <a href="https://github.com/w3c/csswg-drafts/issues/9474#issuecomment-1768906480">https://github.com/w3c/csswg-drafts/issues/9474#issuecomment-1768906480</a>

Add a checkContentVisibilityAuto option to element.checkVisibility().

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/checkVisibility.html:
* Source/WebCore/dom/CheckVisibilityOptions.h:
* Source/WebCore/dom/CheckVisibilityOptions.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::checkVisibility):

Canonical link: <a href="https://commits.webkit.org/269903@main">https://commits.webkit.org/269903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de869bd79e38b426317a9a858ad32529d3b7984e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26021 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22007 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22560 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26612 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27789 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18927 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21319 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5738 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->