### PR TITLE
Rewrite Python CGI under http/tests/multipart for Windows Python

### DIFF
--- a/LayoutTests/http/tests/multipart/load-last-non-html-frame.py
+++ b/LayoutTests/http/tests/multipart/load-last-non-html-frame.py
@@ -2,7 +2,7 @@
 
 import sys
 
-sys.stdout.write(
+sys.stdout.buffer.write(
     'Content-type: multipart/x-mixed-replace;boundary=asdf\r\n\r\n'
     '--asdf\n'
     'Content-type: text/plain\n'
@@ -17,5 +17,5 @@ sys.stdout.write(
     'This test passes if the last multipart frame is displayed.\n'
     'PASS\n'
     '{padding}\r\n'
-    '--asdf--\n'.format(padding=' ' * 5000)
+    '--asdf--\n'.format(padding=' ' * 5000).encode()
 )

--- a/LayoutTests/http/tests/multipart/multipart-html.py
+++ b/LayoutTests/http/tests/multipart/multipart-html.py
@@ -5,7 +5,7 @@ import time
 
 padding = ' ' * 5000
 
-sys.stdout.write(
+sys.stdout.buffer.write(
     'Connection: keep-alive\r\n'
     'Content-type: multipart/x-mixed-replace; boundary=boundary\r\n\r\n'
     '--boundary\r\n'
@@ -18,23 +18,23 @@ sys.stdout.write(
     '    if (testRunner.setShouldDecideResponsePolicyAfterDelay)\n'
     '        testRunner.setShouldDecideResponsePolicyAfterDelay(true);\n'
     '}\n'
-    '</script>\n\n'
+    '</script>\n\n'.encode()
 )
 
 for i in range(0, 11):
-    sys.stdout.write(
-        '--boundary\r\n'
-        'Content-Type: text/html\r\n\r\n'
+    sys.stdout.buffer.write(
+        b'--boundary\r\n'
+        b'Content-Type: text/html\r\n\r\n'
     )
     
     if i < 10:
-        sys.stdout.write(
+        sys.stdout.buffer.write(
             'This is message {}.<br>'
-            'FAIL: The message number should be 10.'.format(i)
+            'FAIL: The message number should be 10.'.format(i).encode()
         )
     else:
-        sys.stdout.write('PASS: This is message {}.'.format(i))
+        sys.stdout.buffer.write('PASS: This is message {}.'.format(i).encode())
 
-    sys.stdout.write('{}\r\n\r\n'.format(padding))
+    sys.stdout.buffer.write('{}\r\n\r\n'.format(padding).encode())
     sys.stdout.flush()
     time.sleep(0.1)

--- a/LayoutTests/http/tests/multipart/multipart-replace-non-html-content.py
+++ b/LayoutTests/http/tests/multipart/multipart-replace-non-html-content.py
@@ -5,7 +5,7 @@ import time
 
 padding = ' ' * 5000
 
-sys.stdout.write(
+sys.stdout.buffer.write(
     'Connection: keep-alive\r\n'
     'Content-type: multipart/x-mixed-replace; boundary=boundary\r\n\r\n'
     '--boundary\r\n'
@@ -15,17 +15,17 @@ sys.stdout.write(
     '<script>\n'
     'if (window.testRunner)\n'
     '    testRunner.dumpAsText();\n'
-    '</script>\n\n'
+    '</script>\n\n'.encode()
 )
 
 for i in range(0, 11):
-    sys.stdout.write(
+    sys.stdout.buffer.write(
         '\r\n--boundary\r\n'
         'Content-Type: text/plain\r\n\r\n'
         'This text should only appear once {}'
-        '{}'.format(i, padding)
+        '{}'.format(i, padding).encode()
     )
     sys.stdout.flush()
     time.sleep(0.1)
 
-sys.stdout.write('\r\n\r\n\r\n--boundary--\r\n')
+sys.stdout.buffer.write(b'\r\n\r\n\r\n--boundary--\r\n')

--- a/LayoutTests/http/tests/multipart/policy-ignore-crash.py
+++ b/LayoutTests/http/tests/multipart/policy-ignore-crash.py
@@ -2,7 +2,7 @@
 
 import sys
 
-sys.stdout.write(
+sys.stdout.buffer.write(
     'Content-Type: multipart/x-mixed-replace;boundary=asdf\r\n\r\n'
     '--asdf\n'
     'Content-type: text/html\n'
@@ -12,12 +12,12 @@ sys.stdout.write(
     'if (window.testRunner)\n'
     '    testRunner.dumpAsText();\n'
     '</script>\n'
-    '{}\r\n'.format(' ' * 5000)
+    '{}\r\n'.format(' ' * 5000).encode()
 )
 
 sys.stdout.flush()
 
-sys.stdout.write(
+sys.stdout.buffer.write(
     '--asdf\n'
     'Content-type: text/rtf\n'
     '\n'
@@ -25,5 +25,5 @@ sys.stdout.write(
     'for this load to be ignored. This causes the request to be canceled.\n'
     '\n'
     '{}\r\n'
-    '--asdf--\n'.format(' ' * 5000)
+    '--asdf--\n'.format(' ' * 5000).encode()
 )

--- a/LayoutTests/http/tests/multipart/resources/multipart-nodashes.py
+++ b/LayoutTests/http/tests/multipart/resources/multipart-nodashes.py
@@ -7,10 +7,10 @@ import os
 import sys
 
 boundary = 'cutHere'
-sys.stdout.write(
+sys.stdout.buffer.write(
     'Content-Type: multipart/x-mixed-replace; boundary={boundary}\r\n\r\n'
     '{boundary}\r\n'
-    'Content-Type: image/png\r\n\r\n'.format(boundary=boundary)
+    'Content-Type: image/png\r\n\r\n'.format(boundary=boundary).encode()
 )
 
 sys.stdout.flush()

--- a/LayoutTests/http/tests/multipart/resources/multipart-wait-before-boundary.py
+++ b/LayoutTests/http/tests/multipart/resources/multipart-wait-before-boundary.py
@@ -8,42 +8,43 @@ from urllib.parse import parse_qs
 done = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True).get('done', [None])[0]
 
 if done is not None:
-    sys.stdout.write(
-        'Content-Type: text/html\r\n\r\n'
-        '<script>parent.success()</script>'
+    sys.stdout.buffer.write(
+        b'Content-Type: text/html\r\n\r\n'
+        b'<script>parent.success()</script>'
     )
     sys.exit(0)
 
 boundary = 'cutHere'
 padding = 'a' * 2048
 def sendHeader():
-    sys.stdout.write(
+    sys.stdout.buffer.write(
         '--{}\r\n'
-        'Content-Type: text/html\r\n\r\n'.format(boundary)
+        'Content-Type: text/html\r\n\r\n'.format(boundary).encode()
     )
     sys.stdout.flush()
 
-sys.stdout.write('Content-Type: multipart/x-mixed-replace; boundary={}\r\n\r\n'.format(boundary))
+
+sys.stdout.buffer.write('Content-Type: multipart/x-mixed-replace; boundary={}\r\n\r\n'.format(boundary).encode())
 
 sendHeader()
-sys.stdout.write(
+sys.stdout.buffer.write(
     'test html\n'
-    '<!-- {} -->'.format(padding)
+    '<!-- {} -->'.format(padding).encode()
 )
 sys.stdout.flush()
 
 sendHeader()
-sys.stdout.write(
+sys.stdout.buffer.write(
     'second html\n'
     '<script>parent.childLoaded()</script>'
-    '<!-- {} -->'.format(padding)
+    '<!-- {} -->'.format(padding).encode()
 )
 sys.stdout.flush()
 
 sendHeader()
-sys.stdout.write(
+sys.stdout.buffer.write(
     'third html\n'
-    '<!-- {} -->'.format(padding)
+    '<!-- {} -->'.format(padding).encode()
 )
 sys.stdout.flush()
 

--- a/LayoutTests/http/tests/multipart/resources/multipart.py
+++ b/LayoutTests/http/tests/multipart/resources/multipart.py
@@ -7,10 +7,9 @@ from urllib.parse import parse_qs
 
 boundary = 'cutHere'
 def send_part(data):
-    sys.stdout.write('Content-Type: image/png\r\n\r\n')
-    sys.stdout.flush()
+    sys.stdout.buffer.write(b'Content-Type: image/png\r\n\r\n')
     sys.stdout.buffer.write(data)
-    sys.stdout.write('\r\n--{}\r\n'.format(boundary))
+    sys.stdout.buffer.write('\r\n--{}\r\n'.format(boundary).encode())
     sys.stdout.flush()
 
 query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
@@ -34,9 +33,9 @@ if interval is not None:
 else:
     interval = 1
 
-sys.stdout.write(
+sys.stdout.buffer.write(
     'Content-Type: multipart/x-mixed-replace; boundary={boundary}\r\n\r\n'
-    '--{boundary}\r\n'.format(boundary=boundary)
+    '--{boundary}\r\n'.format(boundary=boundary).encode()
 )
 sys.stdout.flush()
 

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -976,7 +976,9 @@ http/tests/site-isolation [ Skip ]
 
 webkit.org/b/123431 http/tests/css/link-css-disabled-value-with-slow-loading-sheet.html [ Pass Failure ]
 
-
+webkit.org/b/263423 http/tests/multipart/invalid-image-data.html [ Skip ]
+webkit.org/b/263423 http/tests/multipart/multipart-async-image.html [ Skip ]
+  
 #///////////////////////////////////////////////////////////////////////////////
 # Issue categories below are shared with other platforms (primarily AppleWin)
 #///////////////////////////////////////////////////////////////////////////////
@@ -1091,8 +1093,6 @@ css-dark-mode [ Pass ]
 css-dark-mode/older-systems [ Skip ]
 
 webkit.org/b/142260 fast/css/has-attachment.html [ Skip ]
-
-http/tests/multipart [ Skip ]
 
 ################################################################################
 ##############################   End CSS Issues   ##############################

--- a/LayoutTests/platform/wincairo/http/tests/multipart/invalid-image-data-standalone-expected.txt
+++ b/LayoutTests/platform/wincairo/http/tests/multipart/invalid-image-data-standalone-expected.txt
@@ -3,23 +3,23 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {P} at (0,0) size 784x40
-        RenderText {#text} at (0,0) size 51x19
-          text run at (0,0) width 51: "Test for "
-        RenderInline {I} at (0,0) size 779x39
-          RenderInline {A} at (0,0) size 305x19 [color=#0000EE]
-            RenderText {#text} at (51,0) size 305x19
-              text run at (51,0) width 305: "http://bugs.webkit.org/show_bug.cgi?id=13759"
-          RenderText {#text} at (356,0) size 779x39
-            text run at (356,0) width 4: " "
-            text run at (360,0) width 419: "REGRESSION (r20182-r20184): Incorrect rendering of multipart"
-            text run at (0,20) width 45: "images"
-        RenderText {#text} at (45,20) size 4x19
-          text run at (45,20) width 4: "."
-      RenderBlock {P} at (0,56) size 784x20
-        RenderText {#text} at (0,0) size 234x19
-          text run at (0,0) width 234: "There should be a green square below."
-      RenderBlock (anonymous) at (0,92) size 784x124
+      RenderBlock {P} at (0,0) size 784x36
+        RenderText {#text} at (0,0) size 52x17
+          text run at (0,0) width 52: "Test for "
+        RenderInline {I} at (0,0) size 775x35
+          RenderInline {A} at (0,0) size 301x17 [color=#0000EE]
+            RenderText {#text} at (52,0) size 301x17
+              text run at (52,0) width 301: "http://bugs.webkit.org/show_bug.cgi?id=13759"
+          RenderText {#text} at (353,0) size 775x35
+            text run at (353,0) width 4: " "
+            text run at (357,0) width 418: "REGRESSION (r20182-r20184): Incorrect rendering of multipart"
+            text run at (0,18) width 45: "images"
+        RenderText {#text} at (45,18) size 4x17
+          text run at (45,18) width 4: "."
+      RenderBlock {P} at (0,52) size 784x18
+        RenderText {#text} at (0,0) size 243x17
+          text run at (0,0) width 243: "There should be a green square below."
+      RenderBlock (anonymous) at (0,86) size 784x124
         RenderIFrame {IFRAME} at (0,0) size 124x124 [border: (2px inset #000000)]
           layer at (0,0) size 120x120
             RenderView at (0,0) size 120x120


### PR DESCRIPTION
#### 903c53aa4abcd48c2108c02ab063043c746cd91c
<pre>
Rewrite Python CGI under http/tests/multipart for Windows Python
<a href="https://bugs.webkit.org/show_bug.cgi?id=263425">https://bugs.webkit.org/show_bug.cgi?id=263425</a>

Reviewed by Ross Kirsling.

Windows Python replaces &apos;\n&apos; to &apos;\r\n&apos; for sys.stdout. Use
sys.stdout.buffer.write instead of sys.stdout.write.

* LayoutTests/http/tests/multipart/load-last-non-html-frame.py:
* LayoutTests/http/tests/multipart/multipart-html.py:
* LayoutTests/http/tests/multipart/multipart-replace-non-html-content.py:
* LayoutTests/http/tests/multipart/policy-ignore-crash.py:
* LayoutTests/http/tests/multipart/resources/multipart-nodashes.py:
* LayoutTests/http/tests/multipart/resources/multipart-wait-before-boundary.py:
* LayoutTests/http/tests/multipart/resources/multipart.py:
* LayoutTests/platform/wincairo/TestExpectations:
* LayoutTests/platform/wincairo/http/tests/multipart/invalid-image-data-standalone-expected.txt:

Canonical link: <a href="https://commits.webkit.org/269589@main">https://commits.webkit.org/269589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2ef68e61ebfb24b9afb4ed34a1a3200ef2c02e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/23999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24812 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21202 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/2318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22096 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23143 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/453 "Found 39 new test failures: accessibility/ios-simulator/inline-prediction-attributed-string.html, editing/caret/ios/absolute-caret-position-after-scroll.html, editing/caret/ios/caret-color-after-refocusing-input.html, editing/caret/ios/caret-color-auto.html, editing/caret/ios/caret-color-currentcolor.html, editing/caret/ios/caret-color-in-nested-editable-containers.html, editing/caret/ios/caret-in-overflow-area.html, editing/selection/character-granularity-rect.html, editing/selection/ios/absolute-selection-after-scroll.html, editing/selection/ios/become-first-responder-after-relinquishing-focus.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25670 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/358 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26946 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20744 "Build is in progress. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24802 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/354 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/848 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2913 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/605 "Build is in progress. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
<!--EWS-Status-Bubble-End-->