### PR TITLE
Deploy smart pointers in Position.cpp

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1599,15 +1599,14 @@ int AccessibilityRenderObject::indexForVisiblePosition(const VisiblePosition& po
     return AccessibilityNodeObject::indexForVisiblePosition(position);
 }
 
-Element* AccessibilityRenderObject::rootEditableElementForPosition(const Position& position) const
+RefPtr<Element> AccessibilityRenderObject::rootEditableElementForPosition(const Position& position) const
 {
     // Find the root editable or pseudo-editable (i.e. having an editable ARIA role) element.
-    Element* result = nullptr;
-    
-    Element* rootEditableElement = position.rootEditableElement();
+    RefPtr<Element> result;
+    RefPtr rootEditableElement = position.rootEditableElement();
 
-    for (Element* e = position.element(); e && e != rootEditableElement; e = e->parentElement()) {
-        if (nodeIsTextControl(e))
+    for (RefPtr e = position.anchorElementAncestor(); e && e != rootEditableElement; e = e->parentElement()) {
+        if (nodeIsTextControl(e.get()))
             result = e;
         if (e->hasTagName(bodyTag))
             break;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -153,7 +153,7 @@ private:
     bool isAccessibilityRenderObject() const final { return true; }
     bool isAllowedChildOfTree() const;
     CharacterRange documentBasedSelectedTextRange() const;
-    Element* rootEditableElementForPosition(const Position&) const;
+    RefPtr<Element> rootEditableElementForPosition(const Position&) const;
     bool nodeIsTextControl(const Node*) const;
     Path elementPath() const override;
     

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -124,7 +124,7 @@ public:
     TreeScope* treeScope() const { return m_anchorNode ? &m_anchorNode->treeScope() : nullptr; }
     Element* rootEditableElement() const
     {
-        Node* container = containerNode();
+        RefPtr container = containerNode();
         return container ? container->rootEditableElement() : nullptr;
     }
 
@@ -137,7 +137,7 @@ public:
     bool isNotNull() const { return m_anchorNode; }
     bool isOrphan() const { return m_anchorNode && !m_anchorNode->isConnected(); }
 
-    Element* element() const;
+    RefPtr<Element> anchorElementAncestor() const;
 
     // Move up or down the DOM by one position.
     // Offsets are computed using render text for nodes that have renderers - but note that even when
@@ -156,7 +156,7 @@ public:
 
     // Returns true if the visually equivalent positions around have different editability
     bool atEditingBoundary() const;
-    Node* parentEditingBoundary() const;
+    RefPtr<Node> parentEditingBoundary() const;
     
     bool atStartOfTree() const;
     bool atEndOfTree() const;
@@ -185,7 +185,7 @@ public:
     static bool hasRenderedNonAnonymousDescendantsWithHeight(const RenderElement&);
     static bool nodeIsUserSelectNone(Node*);
     static bool nodeIsUserSelectAll(const Node*);
-    static Node* rootUserSelectAllForNode(Node*);
+    static RefPtr<Node> rootUserSelectAllForNode(Node*);
 
     void debugPosition(const char* msg = "") const;
 

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1575,7 +1575,7 @@ RefPtr<EditingStyle> EditingStyle::styleAtSelectionStart(const VisibleSelection&
     if (selection.isRange() && is<Text>(positionNode) && static_cast<unsigned>(position.computeOffsetInContainerNode()) == downcast<Text>(*positionNode).length())
         position = nextVisuallyDistinctCandidate(position);
 
-    RefPtr element = position.element();
+    RefPtr element = position.anchorElementAncestor();
     if (!element)
         return nullptr;
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -979,7 +979,7 @@ void Editor::clearLastEditCommand()
 
 RefPtr<Element> Editor::findEventTargetFrom(const VisibleSelection& selection) const
 {
-    RefPtr target { selection.start().element() };
+    RefPtr target { selection.start().anchorElementAncestor() };
     if (!target)
         target = document().bodyOrFrameset();
     if (!target)

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2515,7 +2515,7 @@ RefPtr<HTMLFormElement> FrameSelection::currentForm() const
     // Start looking either at the active (first responder) node, or where the selection is.
     RefPtr start = m_document->focusedElement();
     if (!start)
-        start = m_selection.start().element();
+        start = m_selection.start().anchorElementAncestor();
     if (!start)
         return nullptr;
 


### PR DESCRIPTION
#### 3660d70f9f4973c61dccfc581fd5ae6967a48546
<pre>
Deploy smart pointers in Position.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=263426">https://bugs.webkit.org/show_bug.cgi?id=263426</a>

Reviewed by Chris Dumez.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::rootEditableElementForPosition const):
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::containerOrParentElement const):
(WebCore::Position::anchorElementAncestor const):
(WebCore::Position::previous const):
(WebCore::Position::atFirstEditingPositionForNode const):
(WebCore::Position::atLastEditingPositionForNode const):
(WebCore::Position::parentEditingBoundary const):
(WebCore::Position::atStartOfTree const):
(WebCore::Position::atEndOfTree const):
(WebCore::Position::previousCharacterPosition const):
(WebCore::Position::nextCharacterPosition const):
(WebCore::isStreamer):
(WebCore::Position::upstream const):
(WebCore::Position::downstream const):
(WebCore::Position::nodeIsUserSelectAll):
(WebCore::Position::rootUserSelectAllForNode):
(WebCore::Position::isCandidate const):
(WebCore::Position::isRenderedCharacter const):
(WebCore::Position::rendersInDifferentPosition const):
(WebCore::Position::leadingWhitespacePosition const):
(WebCore::searchAheadForBetterMatch):
(WebCore::Position::inlineBoxAndOffset const):
(WebCore::commonInclusiveAncestor):
(WebCore::positionInParentBeforeNode):
(WebCore::positionInParentAfterNode):
(WebCore::Position::element const): Deleted.
* Source/WebCore/dom/Position.h:
(WebCore::Position::rootEditableElement const):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::styleAtSelectionStart):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::findEventTargetFrom const):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::currentForm const):

Canonical link: <a href="https://commits.webkit.org/269571@main">https://commits.webkit.org/269571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b8fca15048816a699fec07edfa995de7ac78c98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23460 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25692 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26963 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24817 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18261 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/375 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/871 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2903 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->