### PR TITLE
[ANGLE] Clear pending program linking in Context::onDestroy

### DIFF
--- a/Source/ThirdParty/ANGLE/changes.diff
+++ b/Source/ThirdParty/ANGLE/changes.diff
@@ -67,6 +67,19 @@ index d5a48edd40f382359db76acf1a1ce75b6a6dc6d5..907c62e0bb659292b391270790498186
  /* Bison interface for Yacc-like parsers in C
  
     Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+diff --git a/src/libANGLE/Context.cpp b/src/libANGLE/Context.cpp
+index 8e52937f55bcd77be026e2d99bead9ac4db2c2b9..f956247eaf93806b62d84d15b65f1ab2f59479bc 100644
+--- a/src/libANGLE/Context.cpp
++++ b/src/libANGLE/Context.cpp
+@@ -828,6 +828,8 @@ egl::Error Context::onDestroy(const egl::Display *display)
+         return egl::NoError();
+     }
+ 
++    mState.ensureNoPendingLink(this);
++
+     // eglDestoryContext() must have been called for this Context and there must not be any Threads
+     // that still have it current.
+     ASSERT(mIsDestroyed == true && mRefCount == 0);
 diff --git a/src/libANGLE/State.cpp b/src/libANGLE/State.cpp
 index 68e94d1594a4c2b0d11b9ae2a87a38db88c8fde8..dcfdbf60ae37d2b3f461df8e65e8965909c1c679 100644
 --- a/src/libANGLE/State.cpp

--- a/Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp
@@ -828,6 +828,8 @@ egl::Error Context::onDestroy(const egl::Display *display)
         return egl::NoError();
     }
 
+    mState.ensureNoPendingLink(this);
+
     // eglDestoryContext() must have been called for this Context and there must not be any Threads
     // that still have it current.
     ASSERT(mIsDestroyed == true && mRefCount == 0);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -300,6 +300,27 @@ TEST_F(GraphicsContextGLCocoaTest, MultipleGPUsDifferentGPUIDsMetal)
 }
 #endif
 
+TEST_F(GraphicsContextGLCocoaTest, TwoLinks)
+{
+    WebCore::GraphicsContextGLAttributes attributes;
+    attributes.useMetal = true;
+    auto gl = TestedGraphicsContextGLCocoa::create(WTFMove(attributes));
+    auto vs = gl->createShader(WebCore::GraphicsContextGL::VERTEX_SHADER);
+    gl->shaderSource(vs, "void main() { }"_s);
+    gl->compileShader(vs);
+    auto fs = gl->createShader(WebCore::GraphicsContextGL::FRAGMENT_SHADER);
+    gl->shaderSource(fs, "void main() { }"_s);
+    gl->compileShader(fs);
+    auto program = gl->createProgram();
+    gl->attachShader(program, vs);
+    gl->attachShader(program, fs);
+    gl->linkProgram(program);
+    gl->useProgram(program);
+    gl->linkProgram(program);
+    EXPECT_TRUE(gl->getErrors().isEmpty());
+    gl = nullptr;
+}
+
 TEST_P(AnyContextAttributeTest, DisplayBuffersAreRecycled)
 {
     auto context = createTestContext({ 20, 20 });


### PR DESCRIPTION
#### 15b02a1209b1a129490ed9e0b587aeed29ff1c68
<pre>
[ANGLE] Clear pending program linking in Context::onDestroy
<a href="https://bugs.webkit.org/show_bug.cgi?id=263429">https://bugs.webkit.org/show_bug.cgi?id=263429</a>
rdar://117242201

Reviewed by Kimmo Kinnunen.

When destroying Context, ANGLE resets any internal state before releasing
allocated objects, such as Programs and Shaders. When destroying a program, any
pending program linking is resolved via Program::resolveLink. This results in
trying to access the Context state that’s just been reset.

To work around this, we ensure there are no pending links before resetting the
Context state.

* Source/ThirdParty/ANGLE/changes.diff:
* Source/ThirdParty/ANGLE/src/libANGLE/Context.cpp:
(gl::Context::onDestroy):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/269693@main">https://commits.webkit.org/269693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03d3dd5f12acb792647f4c502fbec7aad576da4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24431 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23864 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/980 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/20186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26078 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21073 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21338 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/740 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5555 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->