### PR TITLE
[SVG] Add strokeContains fast path

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -60,8 +60,6 @@ void RenderSVGRect::updateShapeFromElement()
     m_fillBoundingBox = FloatRect();
     m_strokeBoundingBox = std::nullopt;
     m_approximateStrokeBoundingBox = std::nullopt;
-    m_innerStrokeRect = FloatRect();
-    m_outerStrokeRect = FloatRect();
 
     SVGLengthContext lengthContext(&rectElement());
     FloatSize boundingBoxSize(lengthContext.valueForLength(style().width(), SVGLengthMode::Width), lengthContext.valueForLength(style().height(), SVGLengthMode::Height));
@@ -85,24 +83,17 @@ void RenderSVGRect::updateShapeFromElement()
         lengthContext.valueForLength(style().svgStyle().y(), SVGLengthMode::Height)),
         boundingBoxSize);
 
-    // To decide if the stroke contains a point we create two rects which represent the inner and
-    // the outer stroke borders. A stroke contains the point, if the point is between them.
-    m_innerStrokeRect = m_fillBoundingBox;
-    m_outerStrokeRect = m_fillBoundingBox;
-
-    if (style().svgStyle().hasStroke()) {
-        float strokeWidth = this->strokeWidth();
-        m_innerStrokeRect.inflate(-strokeWidth / 2);
-        m_outerStrokeRect.inflate(strokeWidth / 2);
-    }
-
-    m_strokeBoundingBox = m_outerStrokeRect;
+    auto strokeBoundingBox = m_fillBoundingBox;
+    if (style().svgStyle().hasStroke())
+        strokeBoundingBox.inflate(this->strokeWidth() / 2);
 
 #if USE(CG)
     // CoreGraphics can inflate the stroke by 1px when drawing a rectangle with antialiasing disabled at non-integer coordinates, we need to compensate.
     if (style().svgStyle().shapeRendering() == ShapeRendering::CrispEdges)
-        m_strokeBoundingBox->inflate(1);
+        strokeBoundingBox.inflate(1);
 #endif
+
+    m_strokeBoundingBox = strokeBoundingBox;
 }
 
 void RenderSVGRect::fillShape(GraphicsContext& context) const
@@ -128,6 +119,39 @@ void RenderSVGRect::fillShape(GraphicsContext& context) const
     context.fillRect(m_fillBoundingBox);
 }
 
+bool RenderSVGRect::canUseStrokeHitTestFastPath() const
+{
+    // Non-scaling-stroke needs special handling.
+    if (hasNonScalingStroke())
+        return false;
+
+    // We can compute intersections with simple, continuous strokes on
+    // regular rectangles without using a Path.
+    return m_shapeType == ShapeType::Rectangle && definitelyHasSimpleStroke();
+}
+
+// Returns true if the stroke is continuous and definitely uses miter joins.
+bool RenderSVGRect::definitelyHasSimpleStroke() const
+{
+    // The four angles of a rect are 90 degrees. Using the formula at:
+    // http://www.w3.org/TR/SVG/painting.html#StrokeMiterlimitProperty
+    // when the join style of the rect is "miter", the ratio of the miterLength
+    // to the stroke-width is found to be
+    // miterLength / stroke-width = 1 / sin(45 degrees)
+    //                            = 1 / (1 / sqrt(2))
+    //                            = sqrt(2)
+    //                            = 1.414213562373095...
+    // When sqrt(2) exceeds the miterlimit, then the join style switches to
+    // "bevel". When the miterlimit is greater than or equal to sqrt(2) then
+    // the join style remains "miter".
+    //
+    // An approximation of sqrt(2) is used here because at certain precise
+    // miterlimits, the join style used might not be correct (e.g. a miterlimit
+    // of 1.4142135 should result in bevel joins, but may be drawn using miter
+    // joins).
+    return style().svgStyle().strokeDashArray().isEmpty() && style().joinStyle() == LineJoin::Miter && style().strokeMiterLimit() >= 1.5;
+}
+
 void RenderSVGRect::strokeShape(GraphicsContext& context) const
 {
     if (!style().hasVisibleStroke())
@@ -143,20 +167,28 @@ void RenderSVGRect::strokeShape(GraphicsContext& context) const
 
 bool RenderSVGRect::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)
 {
-    // The optimized code below does not support non-smooth strokes so we need
-    // to fall back to RenderSVGShape::shapeDependentStrokeContains in these cases.
-    if (!hasSmoothStroke())
+    if (!canUseStrokeHitTestFastPath()) {
         ensurePath();
-
-    if (hasPath())
         return RenderSVGShape::shapeDependentStrokeContains(point, pointCoordinateSpace);
+    }
 
-    return m_outerStrokeRect.contains(point, FloatRect::InsideOrOnStroke) && !m_innerStrokeRect.contains(point, FloatRect::InsideButNotOnStroke);
+    auto halfStrokeWidth = strokeWidth() / 2;
+    auto halfWidth = m_fillBoundingBox.width() / 2;
+    auto halfHeight = m_fillBoundingBox.height() / 2;
+
+    auto fillBoundingBoxCenter = FloatPoint(m_fillBoundingBox.x() + halfWidth, m_fillBoundingBox.y() + halfHeight);
+    auto absDeltaX = std::abs(point.x() - fillBoundingBoxCenter.x());
+    auto absDeltaY = std::abs(point.y() - fillBoundingBoxCenter.y());
+
+    if (!(absDeltaX <= halfWidth + halfStrokeWidth && absDeltaY <= halfHeight + halfStrokeWidth))
+        return false;
+
+    return (halfWidth - halfStrokeWidth <= absDeltaX) || (halfHeight - halfStrokeWidth <= absDeltaY);
 }
 
 bool RenderSVGRect::shapeDependentFillContains(const FloatPoint& point, const WindRule fillRule) const
 {
-    if (hasPath())
+    if (m_shapeType != ShapeType::Rectangle)
         return RenderSVGShape::shapeDependentFillContains(point, fillRule);
     return m_fillBoundingBox.contains(point.x(), point.y());
 }

--- a/Source/WebCore/rendering/svg/RenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.h
@@ -57,8 +57,8 @@ private:
     bool shapeDependentFillContains(const FloatPoint&, const WindRule) const override;
 
 private:
-    FloatRect m_innerStrokeRect;
-    FloatRect m_outerStrokeRect;
+    bool definitelyHasSimpleStroke() const;
+    bool canUseStrokeHitTestFastPath() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -109,7 +109,6 @@ protected:
     virtual bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace);
     virtual bool shapeDependentFillContains(const FloatPoint&, const WindRule) const;
     float strokeWidth() const;
-    bool hasSmoothStroke() const;
 
     inline bool hasNonScalingStroke() const;
     AffineTransform nonScalingStrokeTransform() const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -53,6 +53,7 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
     m_strokeBoundingBox = std::nullopt;
+    m_approximateStrokeBoundingBox = std::nullopt;
     m_center = FloatPoint();
     m_radii = FloatSize();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -55,6 +55,7 @@ void LegacyRenderSVGPath::updateShapeFromElement()
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = ensurePath().boundingRect();
     m_strokeBoundingBox = std::nullopt;
+    m_approximateStrokeBoundingBox = std::nullopt;
     processMarkerPositions();
     updateZeroLengthSubpaths();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -56,8 +56,7 @@ void LegacyRenderSVGRect::updateShapeFromElement()
     m_shapeType = ShapeType::Empty;
     m_fillBoundingBox = FloatRect();
     m_strokeBoundingBox = std::nullopt;
-    m_innerStrokeRect = FloatRect();
-    m_outerStrokeRect = FloatRect();
+    m_approximateStrokeBoundingBox = std::nullopt;
 
     SVGLengthContext lengthContext(&rectElement());
     FloatSize boundingBoxSize(lengthContext.valueForLength(style().width(), SVGLengthMode::Width), lengthContext.valueForLength(style().height(), SVGLengthMode::Height));
@@ -81,24 +80,17 @@ void LegacyRenderSVGRect::updateShapeFromElement()
         lengthContext.valueForLength(style().svgStyle().y(), SVGLengthMode::Height)),
         boundingBoxSize);
 
-    // To decide if the stroke contains a point we create two rects which represent the inner and
-    // the outer stroke borders. A stroke contains the point, if the point is between them.
-    m_innerStrokeRect = m_fillBoundingBox;
-    m_outerStrokeRect = m_fillBoundingBox;
-
-    if (style().svgStyle().hasStroke()) {
-        float strokeWidth = this->strokeWidth();
-        m_innerStrokeRect.inflate(-strokeWidth / 2);
-        m_outerStrokeRect.inflate(strokeWidth / 2);
-    }
-
-    m_strokeBoundingBox = m_outerStrokeRect;
+    auto strokeBoundingBox = m_fillBoundingBox;
+    if (style().svgStyle().hasStroke())
+        strokeBoundingBox.inflate(this->strokeWidth() / 2);
 
 #if USE(CG)
     // CoreGraphics can inflate the stroke by 1px when drawing a rectangle with antialiasing disabled at non-integer coordinates, we need to compensate.
     if (style().svgStyle().shapeRendering() == ShapeRendering::CrispEdges)
-        m_strokeBoundingBox->inflate(1);
+        strokeBoundingBox.inflate(1);
 #endif
+
+    m_strokeBoundingBox = strokeBoundingBox;
 }
 
 void LegacyRenderSVGRect::fillShape(GraphicsContext& context) const
@@ -137,22 +129,63 @@ void LegacyRenderSVGRect::strokeShape(GraphicsContext& context) const
     context.strokeRect(m_fillBoundingBox, strokeWidth());
 }
 
+bool LegacyRenderSVGRect::canUseStrokeHitTestFastPath() const
+{
+    // Non-scaling-stroke needs special handling.
+    if (hasNonScalingStroke())
+        return false;
+
+    // We can compute intersections with simple, continuous strokes on
+    // regular rectangles without using a Path.
+    return m_shapeType == ShapeType::Rectangle && definitelyHasSimpleStroke();
+}
+
+// Returns true if the stroke is continuous and definitely uses miter joins.
+bool LegacyRenderSVGRect::definitelyHasSimpleStroke() const
+{
+    // The four angles of a rect are 90 degrees. Using the formula at:
+    // http://www.w3.org/TR/SVG/painting.html#StrokeMiterlimitProperty
+    // when the join style of the rect is "miter", the ratio of the miterLength
+    // to the stroke-width is found to be
+    // miterLength / stroke-width = 1 / sin(45 degrees)
+    //                            = 1 / (1 / sqrt(2))
+    //                            = sqrt(2)
+    //                            = 1.414213562373095...
+    // When sqrt(2) exceeds the miterlimit, then the join style switches to
+    // "bevel". When the miterlimit is greater than or equal to sqrt(2) then
+    // the join style remains "miter".
+    //
+    // An approximation of sqrt(2) is used here because at certain precise
+    // miterlimits, the join style used might not be correct (e.g. a miterlimit
+    // of 1.4142135 should result in bevel joins, but may be drawn using miter
+    // joins).
+    return style().svgStyle().strokeDashArray().isEmpty() && style().joinStyle() == LineJoin::Miter && style().strokeMiterLimit() >= 1.5;
+}
+
 bool LegacyRenderSVGRect::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)
 {
-    // The optimized code below does not support non-smooth strokes so we need to
-    // fall back to LegacyRenderSVGShape::shapeDependentStrokeContains in these cases.
-    if (!hasSmoothStroke())
+    if (!canUseStrokeHitTestFastPath()) {
         ensurePath();
-
-    if (hasPath())
         return LegacyRenderSVGShape::shapeDependentStrokeContains(point, pointCoordinateSpace);
+    }
 
-    return m_outerStrokeRect.contains(point, FloatRect::InsideOrOnStroke) && !m_innerStrokeRect.contains(point, FloatRect::InsideButNotOnStroke);
+    auto halfStrokeWidth = strokeWidth() / 2;
+    auto halfWidth = m_fillBoundingBox.width() / 2;
+    auto halfHeight = m_fillBoundingBox.height() / 2;
+
+    auto fillBoundingBoxCenter = FloatPoint(m_fillBoundingBox.x() + halfWidth, m_fillBoundingBox.y() + halfHeight);
+    auto absDeltaX = std::abs(point.x() - fillBoundingBoxCenter.x());
+    auto absDeltaY = std::abs(point.y() - fillBoundingBoxCenter.y());
+
+    if (!(absDeltaX <= halfWidth + halfStrokeWidth && absDeltaY <= halfHeight + halfStrokeWidth))
+        return false;
+
+    return (halfWidth - halfStrokeWidth <= absDeltaX) || (halfHeight - halfStrokeWidth <= absDeltaY);
 }
 
 bool LegacyRenderSVGRect::shapeDependentFillContains(const FloatPoint& point, const WindRule fillRule) const
 {
-    if (hasPath())
+    if (m_shapeType != ShapeType::Rectangle)
         return LegacyRenderSVGShape::shapeDependentFillContains(point, fillRule);
     return m_fillBoundingBox.contains(point.x(), point.y());
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h
@@ -54,8 +54,8 @@ private:
     bool shapeDependentFillContains(const FloatPoint&, const WindRule) const override;
 
 private:
-    FloatRect m_innerStrokeRect;
-    FloatRect m_outerStrokeRect;
+    bool definitelyHasSimpleStroke() const;
+    bool canUseStrokeHitTestFastPath() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -97,7 +97,6 @@ protected:
     virtual bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace);
     virtual bool shapeDependentFillContains(const FloatPoint&, const WindRule) const;
     float strokeWidth() const;
-    bool hasSmoothStroke() const;
 
     inline bool hasNonScalingStroke() const;
     AffineTransform nonScalingStrokeTransform() const;
@@ -106,6 +105,7 @@ protected:
     virtual FloatRect adjustStrokeBoundingBoxForMarkersAndZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const { return strokeBoundingBox; }
 
     FloatRect strokeBoundingBox() const final;
+    FloatRect approximateStrokeBoundingBox() const;
 
 private:
     // Hit-detection separated for the fill and the stroke
@@ -146,6 +146,7 @@ private:
 protected:
     FloatRect m_fillBoundingBox;
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
+    mutable Markable<FloatRect, FloatRect::MarkableTraits> m_approximateStrokeBoundingBox;
 private:
     FloatRect m_repaintBoundingBox;
 


### PR DESCRIPTION
#### 95809c73c52a490f49049917d6b4ccd7e59be56b
<pre>
[SVG] Add strokeContains fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=263430">https://bugs.webkit.org/show_bug.cgi?id=263430</a>
rdar://problem/117439322

Reviewed by Cameron McCormack.

This is one step of the patch series implementing approximate repainting rect for SVG path, derived from blink&apos;s work[1].

This patch adds strokeContains optimization. The key is that we can use approximateStrokeBoundingBox to filter out the candidates
Instead of strokeBoundingBox since approximateStrokeBoundingBox is always larger than strokeBoundingBox. And approximateStrokeBoundingBox
is incredibly faster than strokeBoundingBox. We also extend our fast path handling for SVG Rect.

[1]: <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=435097">https://bugs.chromium.org/p/chromium/issues/detail?id=435097</a>

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
(WebCore::LegacyRenderSVGEllipse::updateShapeFromElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::updateShapeFromElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
(WebCore::LegacyRenderSVGRect::updateShapeFromElement):
(WebCore::LegacyRenderSVGRect::canUseStrokeHitTestFastPath const):
(WebCore::LegacyRenderSVGRect::definitelyHasSimpleStroke const):
(WebCore::LegacyRenderSVGRect::shapeDependentStrokeContains):
(WebCore::LegacyRenderSVGRect::shapeDependentFillContains const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::strokeContains):
(WebCore::LegacyRenderSVGShape::approximateStrokeBoundingBox const):
(WebCore::LegacyRenderSVGShape::updateRepaintBoundingBox):
(WebCore::LegacyRenderSVGShape::hasSmoothStroke const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:

Canonical link: <a href="https://commits.webkit.org/269745@main">https://commits.webkit.org/269745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d468c64333678dab933b849f6429a27357ccbef9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24584 "Built successfully") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24002 "Built successfully") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26218 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21198 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21452 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/876 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1320 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/3004 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->