### PR TITLE
Adopt more smart pointers in RenderObject

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -76,7 +76,7 @@ public:
     { }
 
     template<typename OtherType, typename OtherPtrTraits> CheckedPtr(CheckedPtr<OtherType, OtherPtrTraits>&& other)
-        : m_ptr { PtrTraits::exchange(other.m_ptr, nullptr) }
+        : m_ptr { OtherPtrTraits::exchange(other.m_ptr, nullptr) }
     { }
 
     CheckedPtr(CheckedRef<T, PtrTraits>& other)

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3815,6 +3815,16 @@ void LocalFrameView::flushAnyPendingPostLayoutTasks()
         updateEmbeddedObjectsTimerFired();
 }
 
+CheckedRef<const LocalFrameViewLayoutContext> LocalFrameView::checkedLayoutContext() const
+{
+    return m_layoutContext;
+}
+
+CheckedRef<LocalFrameViewLayoutContext> LocalFrameView::checkedLayoutContext()
+{
+    return m_layoutContext;
+}
+
 void LocalFrameView::performPostLayoutTasks()
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -132,6 +132,8 @@ public:
 
     const LocalFrameViewLayoutContext& layoutContext() const { return m_layoutContext; }
     LocalFrameViewLayoutContext& layoutContext() { return m_layoutContext; }
+    CheckedRef<const LocalFrameViewLayoutContext> checkedLayoutContext() const;
+    CheckedRef<LocalFrameViewLayoutContext> checkedLayoutContext();
 
     WEBCORE_EXPORT bool didFirstLayout() const;
 

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -28,6 +28,7 @@
 #include "LayoutUnit.h"
 #include "RenderLayerModelObject.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
@@ -60,7 +61,7 @@ struct UpdateScrollInfoAfterLayoutTransaction {
     WeakHashSet<RenderBlock> blocks;
 };
 
-class LocalFrameViewLayoutContext {
+class LocalFrameViewLayoutContext : public CanMakeCheckedPtr {
 public:
     LocalFrameViewLayoutContext(LocalFrameView&);
     ~LocalFrameViewLayoutContext();

--- a/Source/WebCore/rendering/LayoutRepainter.cpp
+++ b/Source/WebCore/rendering/LayoutRepainter.cpp
@@ -38,7 +38,7 @@ LayoutRepainter::LayoutRepainter(RenderElement& renderer, bool checkForRepaint, 
     if (!m_checkForRepaint)
         return;
 
-    m_repaintContainer = m_renderer.containerForRepaint().renderer;
+    m_repaintContainer = m_renderer.containerForRepaint().renderer.get();
     m_oldBounds = m_renderer.clippedOverflowRectForRepaint(m_repaintContainer);
 
     if (m_repaintOutlineBounds)

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -1338,7 +1338,7 @@ void LegacyLineLayout::layoutRunsAndFloats(LineLayoutState& layoutState, bool ha
             // that the block really needed a full layout, we missed our chance to repaint the layer
             // before layout started. Luckily the layer has cached the repaint rect for its original
             // position and size, and so we can use that to make a repaint happen now.
-            m_flow.repaintUsingContainer(m_flow.containerForRepaint().renderer, m_flow.layerRepaintRects()->clippedOverflowRect);
+            m_flow.repaintUsingContainer(m_flow.containerForRepaint().renderer.get(), m_flow.layerRepaintRects()->clippedOverflowRect);
         }
     }
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1908,7 +1908,7 @@ void RenderElement::issueRepaintForOutlineAuto(float outlineSize)
 {
     LayoutRect repaintRect;
     Vector<LayoutRect> focusRingRects;
-    addFocusRingRects(focusRingRects, LayoutPoint(), containerForRepaint().renderer);
+    addFocusRingRects(focusRingRects, LayoutPoint(), containerForRepaint().renderer.get());
     for (auto rect : focusRingRects) {
         rect.inflate(outlineSize);
         repaintRect.unite(rect);

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -592,6 +592,16 @@ inline bool RenderObject::isSkippedContentRoot() const
     return downcast<RenderElement>(*this).isSkippedContentRoot();
 }
 
+inline RenderElement* RenderObject::parent() const
+{
+    return m_parent.get();
+}
+
+inline CheckedPtr<RenderElement> RenderObject::checkedParent() const
+{
+    return m_parent;
+}
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderElement, isRenderElement())

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -956,7 +956,7 @@ void RenderFragmentedFlow::mapLocalToContainer(const RenderLayerModelObject* anc
 
         // If the repaint container is nullptr, we have to climb up to the RenderView, otherwise swap
         // it with the fragment's repaint container.
-        ancestorContainer = ancestorContainer ? fragment->containerForRepaint().renderer : nullptr;
+        ancestorContainer = ancestorContainer ? fragment->containerForRepaint().renderer.get() : nullptr;
 
         if (RenderFragmentedFlow* fragmentFragmentedFlow = fragment->enclosingFragmentedFlow()) {
             RenderFragmentContainer* startFragment = nullptr;

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -437,10 +437,10 @@ void RenderFrameSet::layout()
 
     bool doFullRepaint = selfNeedsLayout() && checkForRepaintDuringLayout();
     LayoutRect oldBounds;
-    const RenderLayerModelObject* repaintContainer = nullptr;
+    CheckedPtr<const RenderLayerModelObject> repaintContainer;
     if (doFullRepaint) {
         repaintContainer = containerForRepaint().renderer;
-        oldBounds = clippedOverflowRectForRepaint(repaintContainer);
+        oldBounds = clippedOverflowRectForRepaint(repaintContainer.get());
     }
 
     if (!parent()->isFrameSet() && !document().printing()) {
@@ -469,10 +469,10 @@ void RenderFrameSet::layout()
     updateLayerTransform();
 
     if (doFullRepaint) {
-        repaintUsingContainer(repaintContainer, snappedIntRect(oldBounds));
-        LayoutRect newBounds = clippedOverflowRectForRepaint(repaintContainer);
+        repaintUsingContainer(repaintContainer.get(), snappedIntRect(oldBounds));
+        LayoutRect newBounds = clippedOverflowRectForRepaint(repaintContainer.get());
         if (newBounds != oldBounds)
-            repaintUsingContainer(repaintContainer, snappedIntRect(newBounds));
+            repaintUsingContainer(repaintContainer.get(), snappedIntRect(newBounds));
     }
 
     clearNeedsLayout();

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -55,6 +55,7 @@
 #include "RenderSVGModelObject.h"
 #include "ScrollBehavior.h"
 #include <memory>
+#include <wtf/CheckedRef.h>
 #include <wtf/Markable.h>
 #include <wtf/WeakPtr.h>
 
@@ -149,7 +150,7 @@ struct ScrollRectToVisibleOptions {
 
 using ScrollingScope = uint64_t;
 
-class RenderLayer : public CanMakeWeakPtr<RenderLayer> {
+class RenderLayer : public CanMakeWeakPtr<RenderLayer>, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(RenderLayer);
 public:
     friend class RenderReplica;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2107,11 +2107,11 @@ void RenderLayerCompositor::repaintOnCompositingChange(RenderLayer& layer)
     if (&layer.renderer() != &m_renderView && !layer.renderer().parent())
         return;
 
-    auto* repaintContainer = layer.renderer().containerForRepaint().renderer;
+    CheckedPtr repaintContainer = layer.renderer().containerForRepaint().renderer;
     if (!repaintContainer)
         repaintContainer = &m_renderView;
 
-    layer.repaintIncludingNonCompositingDescendants(repaintContainer);
+    layer.repaintIncludingNonCompositingDescendants(repaintContainer.get());
     if (repaintContainer == &m_renderView) {
         // The contents of this layer may be moving between the window
         // and a GraphicsLayer, so we need to make sure the window system

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -176,7 +176,7 @@ void RenderLayerModelObject::styleDidChange(StyleDifference diff, const RenderSt
 
         // Repaint the about to be destroyed self-painting layer when style change also triggers repaint.
         if (layer()->isSelfPaintingLayer() && layer()->repaintStatus() == NeedsFullRepaint && layer()->repaintRects())
-            repaintUsingContainer(containerForRepaint().renderer, layer()->repaintRects()->clippedOverflowRect);
+            repaintUsingContainer(containerForRepaint().renderer.get(), layer()->repaintRects()->clippedOverflowRect);
 
         layer()->removeOnlyThisLayer(RenderLayer::LayerChangeTiming::StyleChange); // calls destroyLayer() which clears m_layer
         if (s_wasFloating && isFloating())
@@ -460,6 +460,11 @@ void RenderLayerModelObject::updateHasSVGTransformFlags()
     bool hasSVGTransform = needsHasSVGTransformFlags();
     setHasTransformRelatedProperty(hasSVGTransform || style().hasTransformRelatedProperty());
     setHasSVGTransform(hasSVGTransform);
+}
+
+CheckedPtr<RenderLayer> RenderLayerModelObject::checkedLayer() const
+{
+    return m_layer.get();
 }
 
 void RenderLayerModelObject::repaintOrRelayoutAfterSVGTransformChange()

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -46,6 +46,7 @@ public:
 
     bool hasSelfPaintingLayer() const;
     RenderLayer* layer() const { return m_layer.get(); }
+    CheckedPtr<RenderLayer> checkedLayer() const;
 
     void styleWillChange(StyleDifference, const RenderStyle& newStyle) override;
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -384,11 +384,11 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     }
 
     LocalFrame& frame = renderer.frame();
-    auto* repaintContainer = renderer.containerForRepaint().renderer;
+    CheckedPtr repaintContainer = renderer.containerForRepaint().renderer;
     // The caret rect needs to be invalidated after scrolling
     frame.selection().setCaretRectNeedsUpdate();
 
-    LayoutRect rectForRepaint = layer().repaintRects() ? layer().repaintRects()->clippedOverflowRect : renderer.clippedOverflowRectForRepaint(repaintContainer);
+    LayoutRect rectForRepaint = layer().repaintRects() ? layer().repaintRects()->clippedOverflowRect : renderer.clippedOverflowRectForRepaint(repaintContainer.get());
 
     FloatQuad quadForFakeMouseMoveEvent = FloatQuad(rectForRepaint);
     if (repaintContainer)
@@ -409,7 +409,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
 
     // Just schedule a full repaint of our object.
     if (requiresRepaint) {
-        renderer.repaintUsingContainer(repaintContainer, rectForRepaint);
+        renderer.repaintUsingContainer(repaintContainer.get(), rectForRepaint);
 
         // We also have to repaint any descendant composited layers that have fixed backgrounds.
         if (auto slowRepaintObjects = view.frameView().slowRepaintObjects()) {

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -233,10 +233,11 @@ public:
 
     virtual ASCIILiteral renderName() const = 0;
 
-    RenderElement* parent() const { return m_parent; }
+    inline RenderElement* parent() const; // Defined in RenderElement.h.
+    inline CheckedPtr<RenderElement> checkedParent() const; // Defined in RenderElement.h.
     bool isDescendantOf(const RenderObject*) const;
 
-    RenderObject* previousSibling() const { return m_previous; }
+    RenderObject* previousSibling() const { return m_previous.get(); }
     RenderObject* nextSibling() const { return m_next.get(); }
     RenderObject* previousInFlowSibling() const;
     RenderObject* nextInFlowSibling() const;
@@ -602,7 +603,9 @@ public:
 
     inline bool preservesNewline() const;
 
-    RenderView& view() const { return *document().renderView(); };
+    RenderView& view() const { return *document().renderView(); }
+    CheckedRef<RenderView> checkedView() const;
+
     HostWindow* hostWindow() const;
 
     // Returns true if this renderer is rooted.
@@ -694,6 +697,7 @@ public:
 
     // Returns the containing block level element for this element.
     WEBCORE_EXPORT RenderBlock* containingBlock() const;
+    CheckedPtr<RenderBlock> checkedContainingBlock() const;
     static RenderBlock* containingBlockForPositionType(PositionType, const RenderObject&);
 
     // Convert the given local point to absolute coordinates. If OptionSet<MapCoordinatesMode> includes UseTransforms, take transforms into account.
@@ -762,8 +766,8 @@ public:
     // Return the RenderLayerModelObject in the container chain which is responsible for painting this object, or nullptr
     // if painting is root-relative. This is the container that should be passed to the 'forRepaint' functions.
     struct RepaintContainerStatus {
-        bool fullRepaintIsScheduled { false }; // Either the repaint container or a layer in-between has aleady been scheduled for full repaint.
-        const RenderLayerModelObject* renderer { nullptr };
+        bool fullRepaintIsScheduled { false }; // Either the repaint container or a layer in-between has already been scheduled for full repaint.
+        CheckedPtr<const RenderLayerModelObject> renderer { nullptr };
     };
     RepaintContainerStatus containerForRepaint() const;
     // Actually do the repaint of rect r for this object which has been computed in the coordinate space
@@ -1109,9 +1113,9 @@ private:
 
     CheckedRef<Node> m_node;
 
-    RenderElement* m_parent;
-    RenderObject* m_previous;
-    PackedPtr<RenderObject> m_next;
+    CheckedPtr<RenderElement> m_parent;
+    CheckedPtr<RenderObject> m_previous;
+    PackedPtr<RenderObject> m_next; // FIXME: This should use a CheckedPtr.
     Type m_type;
 
     CheckedPtr<Layout::Box> m_layoutBox;
@@ -1157,7 +1161,7 @@ public:
 #if ASSERT_ENABLED
     ~SetLayoutNeededForbiddenScope();
 private:
-    const RenderObject& m_renderObject;
+    CheckedRef<const RenderObject> m_renderObject;
     bool m_preexistingForbidden;
 #endif
 };

--- a/Source/WebCore/rendering/RenderSelectionGeometry.cpp
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 
 RenderSelectionGeometryBase::RenderSelectionGeometryBase(RenderObject& renderer)
     : m_renderer(renderer)
-    , m_repaintContainer(renderer.containerForRepaint().renderer)
+    , m_repaintContainer(renderer.containerForRepaint().renderer.get())
     , m_state(renderer.selectionState())
 {
 }

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -502,8 +502,8 @@ void RenderView::repaintRootContents()
 
     // Always use layoutOverflowRect() to fix rdar://problem/27182267.
     // This should be cleaned up via webkit.org/b/159913 and webkit.org/b/159914.
-    auto* repaintContainer = containerForRepaint().renderer;
-    repaintUsingContainer(repaintContainer, computeRectForRepaint(layoutOverflowRect(), repaintContainer));
+    CheckedPtr repaintContainer = containerForRepaint().renderer;
+    repaintUsingContainer(repaintContainer.get(), computeRectForRepaint(layoutOverflowRect(), repaintContainer.get()));
 }
 
 void RenderView::repaintViewRectangle(const LayoutRect& repaintRect) const


### PR DESCRIPTION
#### 64b1214b0d438f905ddd349da7639c50e5d69558
<pre>
Adopt more smart pointers in RenderObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=263418">https://bugs.webkit.org/show_bug.cgi?id=263418</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::checkedLayoutContext const):
(WebCore::LocalFrameView::checkedLayoutContext):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/LayoutRepainter.cpp:
(WebCore::LayoutRepainter::LayoutRepainter):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::layoutRunsAndFloats):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::issueRepaintForOutlineAuto):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::mapLocalToContainer const):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::layout):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::computeRepaintRectsIncludingDescendants):
(WebCore::RenderLayer::recursiveUpdateLayerPositionsAfterScroll):
(WebCore::RenderLayer::setHasVisibleContent):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::repaintOnCompositingChange):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::styleDidChange):
(WebCore::RenderLayerModelObject::checkedLayer const):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollTo):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::SetLayoutNeededForbiddenScope::SetLayoutNeededForbiddenScope):
(WebCore::RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope):
(WebCore::RenderObject::RenderObject):
(WebCore::RenderObject::~RenderObject):
(WebCore::RenderObject::checkedView const):
(WebCore::RenderObject::setFragmentedFlowStateIncludingDescendants):
(WebCore::RenderObject::computedFragmentedFlowState):
(WebCore::RenderObject::traverseNext const):
(WebCore::scheduleRelayoutForSubtree):
(WebCore::RenderObject::markContainingBlocksForLayout):
(WebCore::RenderObject::invalidateContainerPreferredLogicalWidths):
(WebCore::RenderObject::setLayerNeedsFullRepaint):
(WebCore::RenderObject::setLayerNeedsFullRepaintForPositionedMovementLayout):
(WebCore::RenderObject::containingBlockForPositionType):
(WebCore::RenderObject::containingBlock const):
(WebCore::RenderObject::checkedContainingBlock const):
(WebCore::RenderObject::addPDFURLRect const):
(WebCore::RenderObject::collectSelectionGeometries):
(WebCore::RenderObject::addAbsoluteRectForLayer):
(WebCore::RenderObject::paintingRootRect):
(WebCore::RenderObject::containerForRepaint const):
(WebCore::RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded const):
(WebCore::RenderObject::repaintUsingContainer const):
(WebCore::fullRepaintIsScheduled):
(WebCore::RenderObject::issueRepaint const):
(WebCore::RenderObject::repaintSlowRepaintObject const):
(WebCore::RenderObject::computeVisibleRectInContainer const):
(WebCore::RenderObject::showNodeTreeForThis const):
(WebCore::RenderObject::showRenderTreeForThis const):
(WebCore::RenderObject::outputRegionsInformation const):
(WebCore::RenderObject::outputRenderSubTreeAndMark const):
(WebCore::RenderObject::mapLocalToContainer const):
(WebCore::RenderObject::pushMappingToContainer const):
(WebCore::RenderObject::mapAbsoluteToLocalPoint const):
(WebCore::RenderObject::getTransformFromContainer const):
(WebCore::RenderObject::offsetFromAncestorContainer const):
(WebCore::containerForElement):
(WebCore::RenderObject::willBeDestroyed):
(WebCore::invalidateLineLayoutAfterTreeMutationIfNeeded):
(WebCore::RenderObject::checkedParent const):
(WebCore::RenderObject::insertedIntoTree):
(WebCore::RenderObject::willBeRemovedFromTree):
(WebCore::RenderObject::updateHitTestResult):
(WebCore::RenderObject::offsetParent const):
(WebCore::RenderObject::createVisiblePosition const):
(WebCore::RenderObject::canUpdateSelectionOnRootLineBoxes):
(WebCore::RenderObject::setNeedsBoundariesUpdate):
(WebCore::RenderObject::locateEnclosingFragmentedFlow const):
(WebCore::RenderObject::hasNonEmptyVisibleRectRespectingParentFrames const):
(WebCore::RenderObject::absoluteTextQuads):
(WebCore::absoluteRectsForRangeInText):
(WebCore::RenderObject::absoluteTextRects):
(WebCore::nodeAfter):
(WebCore::borderAndTextRects):
(WebCore::RenderObject::collectSelectionGeometriesInternal):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::view const):
* Source/WebCore/rendering/RenderSelectionGeometry.cpp:
(WebCore::RenderSelectionGeometryBase::RenderSelectionGeometryBase):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::repaintRootContents):
(WebCore::RenderView::protectedFrameView const):
* Source/WebCore/rendering/RenderView.h:

Canonical link: <a href="https://commits.webkit.org/269603@main">https://commits.webkit.org/269603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc89c726cbde6e0e7cdde11e2d7c64e2da473196

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23501 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25729 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26994 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/19983 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24849 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/22326 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18291 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/29729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/403 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/29729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/896 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/28938 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2925 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/664 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6030 "Passed tests") | 
<!--EWS-Status-Bubble-End-->