### PR TITLE
Stop failing muted audio capture when AirPods are taken out of ears

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -250,6 +250,9 @@ imported/w3c/web-platform-tests/video-rvfc [ Skip ]
 fast/mediastream/getUserMedia-rvfc.html [ Skip ]
 webrtc/peerConnection-rvfc.html [ Skip ]
 
+# Only Mac has a way to fail mock capture on device removal
+fast/mediastream/microphone-change-while-muted.html [ Skip ]
+
 # This test only makes sense on Mac
 fast/attachment/attachment-subtitle-resize.html [ Skip ]
 

--- a/LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt
+++ b/LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt
@@ -1,5 +1,6 @@
 CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
 
 
-PASS Detection of missing capturing device should trigger capture to fail even if track is muted
+PASS Detection of missing capturing device should not trigger capture to fail if device disappears when track is muted
+PASS Detection of missing capturing device should trigger capture to fail even if device disappears when track is muted and track gets later on unmuted
 

--- a/LayoutTests/fast/mediastream/microphone-change-while-muted.html
+++ b/LayoutTests/fast/mediastream/microphone-change-while-muted.html
@@ -46,11 +46,50 @@
         await new Promise(resolve => video.srcObject.getAudioTracks()[0].onmute = resolve);
 
         testRunner.removeMockMediaDevice("usbmic");
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        assert_true(video.srcObject.getAudioTracks()[0].muted);
+        assert_equals(video.srcObject.getAudioTracks()[0].readyState, "live");
+
+        testRunner.addMockMicrophoneDevice("usbmic", "my USB microphone");
+
+        if (window.internals)
+            internals.setPageMuted("");
+
+        await new Promise(resolve => video.srcObject.getAudioTracks()[0].onunmute = resolve);
+        await new Promise(resolve => setTimeout(resolve, 500));
+        assert_false(video.srcObject.getAudioTracks()[0].muted);
+        assert_equals(video.srcObject.getAudioTracks()[0].readyState, "live");
+    }, "Detection of missing capturing device should not trigger capture to fail if device disappears when track is muted");
+
+    promise_test(async (test) => {
+        await setup(test);
+
+        testRunner.addMockMicrophoneDevice("usbmic", "my USB microphone");
+
+        const deviceId = await getDeviceId("my USB microphone");
+        video.srcObject = await navigator.mediaDevices.getUserMedia({ audio: { deviceId } });
+        await video.play();
+
+        if (window.internals)
+            internals.setPageMuted("capturedevices");
+
+        await new Promise(resolve => video.srcObject.getAudioTracks()[0].onmute = resolve);
+
+        testRunner.removeMockMediaDevice("usbmic");
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        assert_true(video.srcObject.getAudioTracks()[0].muted);
+        assert_equals(video.srcObject.getAudioTracks()[0].readyState, "live");
+
+        if (window.internals)
+            internals.setPageMuted("");
+
         return new Promise((resolve, reject) => {
             video.srcObject.getAudioTracks()[0].onended = resolve;
             setTimeout(() => reject("track did not end"), 2000);
         });
-    }, "Detection of missing capturing device should trigger capture to fail even if track is muted");
+    }, "Detection of missing capturing device should trigger capture to fail even if device disappears when track is muted and track gets later on unmuted");
     </script>
 </body>
 </html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -192,6 +192,9 @@ editing/pasteboard/file-drag-to-editable.html [ Skip ]
 # EventSender::dumpFilenameBeingDragged not implemented.
 webkit.org/b/61827 fast/events/drag-image-filename.html
 
+# Only Mac has a way to fail mock capture on device removal
+fast/mediastream/microphone-change-while-muted.html [ Pass ]
+
 # Media Stream API is not fully supported.
 fast/mediastream/MediaStream-add-ended-tracks.html
 

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp
@@ -169,6 +169,11 @@ void BaseAudioSharedUnit::devicesChanged()
         return;
     }
 
+    if (!m_producingCount) {
+        RELEASE_LOG_ERROR(WebRTC, "BaseAudioSharedUnit::devicesChanged - returning early as not capturing");
+        return;
+    }
+
     RELEASE_LOG_ERROR(WebRTC, "BaseAudioSharedUnit::devicesChanged - failing capture, capturing device is missing");
     captureFailed();
 }

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -397,8 +397,11 @@ OSStatus MockAudioSharedInternalUnit::set(AudioUnitPropertyID property, AudioUni
     }
     if (property == kAudioOutputUnitProperty_CurrentDevice) {
         ASSERT(!*static_cast<const uint32_t*>(value));
-        if (auto device = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(MockAudioSharedUnit::singleton().persistentIDForTesting()))
-            m_streamFormat.mSampleRate = m_outputStreamFormat.mSampleRate = std::get<MockMicrophoneProperties>(device->properties).defaultSampleRate;
+        auto device = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(MockAudioSharedUnit::singleton().persistentIDForTesting());
+        if (!device)
+            return -1;
+
+        m_streamFormat.mSampleRate = m_outputStreamFormat.mSampleRate = std::get<MockMicrophoneProperties>(device->properties).defaultSampleRate;
         return 0;
     }
     


### PR DESCRIPTION
#### 5a41af799e85572c94a2b25581e967e6d871e699
<pre>
Stop failing muted audio capture when AirPods are taken out of ears
<a href="https://bugs.webkit.org/show_bug.cgi?id=263433">https://bugs.webkit.org/show_bug.cgi?id=263433</a>
rdar://117252822

Reviewed by Eric Carlson.

When taking AirPods out of ears, the AirPod devices are disappearing and we were failing capture right away.
Given we are muting capture in that case, it is best to wait to fail capture when unmuted instead.

This allows to put AirPods in and out without having the website dealing with restarting capture.
We modify LayoutTests/fast/mediastream/microphone-change-while-muted.html accordingly and mock capture to validate device is available when starting capturing, like done by CoreAudio.

The test is only enabled in MacOS since other ports do not have a way to handle mock capture failure in case of missing device.

* LayoutTests/TestExpectations:
* LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt:
* LayoutTests/fast/mediastream/microphone-change-while-muted.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::devicesChanged):
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedInternalUnit::set):

Canonical link: <a href="https://commits.webkit.org/269807@main">https://commits.webkit.org/269807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cb0c517fcaded320a0f5fe9b18009bc767f0fed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24173 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26392 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/1096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27631 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25394 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/1065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18768 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/21130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5650 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->