### PR TITLE
Add <input type=checkbox switch> shadow tree

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1609,6 +1609,8 @@ html/shadow/ProgressShadowElement.cpp
 html/shadow/ShadowPseudoIds.cpp
 html/shadow/SliderThumbElement.cpp
 html/shadow/SpinButtonElement.cpp
+html/shadow/SwitchThumbElement.cpp
+html/shadow/SwitchTrackElement.cpp
 html/shadow/TextControlInnerElements.cpp
 html/shadow/TextPlaceholderElement.cpp
 html/track/AudioTrack.cpp

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -383,7 +383,8 @@ constexpr CSSValueID toCSSValueID(StyleAppearance e)
     case StyleAppearance::SearchFieldCancelButton:
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderThumbVertical:
-    case StyleAppearance::Switch:
+    case StyleAppearance::SwitchThumb:
+    case StyleAppearance::SwitchTrack:
         ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
         return CSSValueNone;
     }

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -51,7 +51,7 @@ private:
 
     const AtomString& formControlType() const final;
     String valueMissingText() const final;
-    void attributeChanged(const QualifiedName&) final;
+    void createShadowSubtree() final;
     void handleKeyupEvent(KeyboardEvent&) final;
     void willDispatchClick(InputElementClickState&) final;
     void didDispatchClick(Event&, const InputElementClickState&) final;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -848,6 +848,20 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         }
         break;
 #endif
+    case AttributeNames::switchAttr:
+        if (document().settings().switchControlEnabled()) {
+            auto hasSwitchAttribute = !newValue.isNull();
+            if (hasSwitchAttribute == isSwitch())
+                return;
+            m_hasSwitchAttribute = hasSwitchAttribute;
+            if (isSwitch())
+                m_inputType->createShadowSubtreeIfNeeded();
+            else if (isCheckbox())
+                m_inputType->removeShadowSubtree();
+            if (renderer())
+                invalidateStyleAndRenderersForSubtree();
+        }
+        break;
     default:
         break;
     }
@@ -1855,7 +1869,7 @@ bool HTMLInputElement::isCheckbox() const
 
 bool HTMLInputElement::isSwitch() const
 {
-    return document().settings().switchControlEnabled() && isCheckbox() && hasAttributeWithoutSynchronization(switchAttr);
+    return m_inputType->isSwitch();
 }
 
 bool HTMLInputElement::isRangeControl() const

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -92,6 +92,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<void> stepDown(int = 1);
     WEBCORE_EXPORT unsigned width() const;
     WEBCORE_EXPORT void setWidth(unsigned);
+    bool hasSwitchAttribute() const { return m_hasSwitchAttribute; }
     WEBCORE_EXPORT String validationMessage() const final;
     std::optional<unsigned> selectionStartForBindings() const;
     ExceptionOr<void> setSelectionStartForBindings(std::optional<unsigned>);
@@ -481,6 +482,7 @@ private:
 #endif
     bool m_isSpellcheckDisabledExceptTextReplacement : 1 { false };
     bool m_hasPendingUserAgentShadowTreeUpdate : 1 { false };
+    bool m_hasSwitchAttribute : 1 { false };
     RefPtr<InputType> m_inputType;
     // The ImageLoader must be owned by this element because the loader code assumes
     // that it lives as long as its owning element lives. If we move the loader into

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -677,6 +677,7 @@ void InputType::removeShadowSubtree()
         return;
 
     root->removeChildren();
+    m_hasCreatedShadowSubtree = false;
 }
 
 Decimal InputType::parseToNumber(const String&, const Decimal& defaultValue) const

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -176,6 +176,7 @@ public:
     // scattered code with special cases for various types.
 
     bool isCheckbox() const { return m_type == Type::Checkbox; }
+    bool isSwitch() const { return isCheckbox() && m_element && m_element->hasSwitchAttribute(); }
     bool isColorControl() const { return m_type == Type::Color; }
     bool isDateField() const { return m_type == Type::Date; }
     bool isDateTimeLocalField() const { return m_type == Type::DateTimeLocal; }
@@ -208,7 +209,7 @@ public:
     bool isInteractiveContent() const;
     bool isLabelable() const;
     bool isEnumeratable() const;
-    bool needsShadowSubtree() const { return !nonShadowRootTypes.contains(m_type); }
+    bool needsShadowSubtree() const { return !nonShadowRootTypes.contains(m_type) || isSwitch(); }
     bool hasCreatedShadowSubtree() const { return m_hasCreatedShadowSubtree; }
 
     // Form value functions.

--- a/Source/WebCore/html/shadow/SwitchThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SwitchThumbElement.h"
+
+#include "ResolvedStyle.h"
+
+namespace WebCore {
+
+using namespace HTMLNames;
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SwitchThumbElement);
+
+Ref<SwitchThumbElement> SwitchThumbElement::create(Document& document)
+{
+    return adoptRef(*new SwitchThumbElement(document));
+}
+
+SwitchThumbElement::SwitchThumbElement(Document& document)
+    : HTMLDivElement(HTMLNames::divTag, document, CreateSwitchThumbElement)
+{
+}
+
+std::optional<Style::ResolvedStyle> SwitchThumbElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* hostStyle)
+{
+    if (!hostStyle)
+        return std::nullopt;
+
+    auto elementStyle = resolveStyle(resolutionContext);
+    if (hostStyle->effectiveAppearance() == StyleAppearance::Auto)
+        elementStyle.style->setEffectiveAppearance(StyleAppearance::SwitchThumb);
+
+    return elementStyle;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchThumbElement.h
+++ b/Source/WebCore/html/shadow/SwitchThumbElement.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "HTMLDivElement.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class HTMLInputElement;
+
+class SwitchThumbElement final : public HTMLDivElement {
+    WTF_MAKE_ISO_ALLOCATED(SwitchThumbElement);
+public:
+    static Ref<SwitchThumbElement> create(Document&);
+private:
+    static constexpr auto CreateSwitchThumbElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit SwitchThumbElement(Document&);
+
+    std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle*) final;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchTrackElement.cpp
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SwitchTrackElement.h"
+
+#include "ResolvedStyle.h"
+
+namespace WebCore {
+
+using namespace HTMLNames;
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(SwitchTrackElement);
+
+Ref<SwitchTrackElement> SwitchTrackElement::create(Document& document)
+{
+    return adoptRef(*new SwitchTrackElement(document));
+}
+
+SwitchTrackElement::SwitchTrackElement(Document& document)
+    : HTMLDivElement(HTMLNames::divTag, document, CreateSwitchTrackElement)
+{
+}
+
+std::optional<Style::ResolvedStyle> SwitchTrackElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* hostStyle)
+{
+    if (!hostStyle)
+        return std::nullopt;
+
+    auto elementStyle = resolveStyle(resolutionContext);
+    if (hostStyle->effectiveAppearance() == StyleAppearance::Auto)
+        elementStyle.style->setEffectiveAppearance(StyleAppearance::SwitchTrack);
+
+    return elementStyle;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/shadow/SwitchTrackElement.h
+++ b/Source/WebCore/html/shadow/SwitchTrackElement.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "HTMLDivElement.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class HTMLInputElement;
+
+class SwitchTrackElement final : public HTMLDivElement {
+    WTF_MAKE_ISO_ALLOCATED(SwitchTrackElement);
+public:
+    static Ref<SwitchTrackElement> create(Document&);
+private:
+    static constexpr auto CreateSwitchTrackElement = CreateHTMLDivElement | NodeFlag::HasCustomStyleResolveCallbacks;
+    explicit SwitchTrackElement(Document&);
+
+    std::optional<Style::ResolvedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle*) final;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/style/StyleAppearance.cpp
+++ b/Source/WebCore/style/StyleAppearance.cpp
@@ -139,8 +139,11 @@ TextStream& operator<<(TextStream& ts, StyleAppearance appearance)
     case StyleAppearance::SliderThumbVertical:
         ts << "sliderthumb-vertical";
         break;
-    case StyleAppearance::Switch:
-        ts << "switch";
+    case StyleAppearance::SwitchThumb:
+        ts << "switch-thumb";
+        break;
+    case StyleAppearance::SwitchTrack:
+        ts << "switch-track";
         break;
     }
     return ts;

--- a/Source/WebCore/style/StyleAppearance.h
+++ b/Source/WebCore/style/StyleAppearance.h
@@ -78,7 +78,8 @@ enum class StyleAppearance : uint8_t {
     SearchFieldCancelButton,
     SliderThumbHorizontal,
     SliderThumbVertical,
-    Switch
+    SwitchThumb,
+    SwitchTrack
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, StyleAppearance);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1259,7 +1259,8 @@ void ArgumentCoder<ControlPart>::encode(Encoder& encoder, const ControlPart& par
     case WebCore::StyleAppearance::SearchFieldCancelButton:
     case WebCore::StyleAppearance::SliderThumbHorizontal:
     case WebCore::StyleAppearance::SliderThumbVertical:
-    case WebCore::StyleAppearance::Switch:
+    case WebCore::StyleAppearance::SwitchThumb:
+    case WebCore::StyleAppearance::SwitchTrack:
         break;
     }
 }
@@ -1382,7 +1383,8 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     case WebCore::StyleAppearance::SliderThumbVertical:
         return WebCore::SliderThumbPart::create(*type);
 
-    case WebCore::StyleAppearance::Switch:
+    case WebCore::StyleAppearance::SwitchThumb:
+    case WebCore::StyleAppearance::SwitchTrack:
         break;
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3215,7 +3215,8 @@ enum class WebCore::StyleAppearance : uint8_t {
     SearchFieldCancelButton,
     SliderThumbHorizontal,
     SliderThumbVertical,
-    Switch
+    SwitchThumb,
+    SwitchTrack
 };
 
 #if ENABLE(APPLE_PAY)


### PR DESCRIPTION
#### 26e165bb2d52c3cd874938c8767c6b703b9ff949
<pre>
Add &lt;input type=checkbox switch&gt; shadow tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=263435">https://bugs.webkit.org/show_bug.cgi?id=263435</a>
rdar://117254677

Reviewed by Chris Dumez.

This conditionally adds a shadow tree with two elements when a checkbox
becomes a switch control. It also gives these two elements distinct
appearance values that depend on the shadow host&apos;s appearance value
being auto.

As checkboxes have been made performance-critical by forces outside of
my control, we add a bit to HTMLInputElement to track the presence of a
switch attribute, which needsShadowSubtree() can then rely on.

As we call removeShadowSubtree() while the InputType class stays alive,
we need to reset m_hasCreatedShadowSubtree to false as otherwise a
subsequent createShadowSubtreeIfNeeded() returns too early.

In preparation for future work we also ensure that RenderTheme does the
correct thing for isChecked, isEnabled, and isPressed, when it comes to
the new elements in the shadow tree.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::createShadowSubtree):
(WebCore::CheckboxInputType::shouldAppearIndeterminate const):
(WebCore::CheckboxInputType::attributeChanged): Deleted.
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::attributeChanged):
(WebCore::HTMLInputElement::isSwitch const):
* Source/WebCore/html/HTMLInputElement.h:
(WebCore::HTMLInputElement::hasSwitchAttribute const):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::removeShadowSubtree):
* Source/WebCore/html/InputType.h:
(WebCore::InputType::isSwitch const):
(WebCore::InputType::needsShadowSubtree const):
* Source/WebCore/html/shadow/SwitchThumbElement.cpp: Added.
(WebCore::SwitchThumbElement::create):
(WebCore::SwitchThumbElement::SwitchThumbElement):
(WebCore::SwitchThumbElement::resolveCustomStyle):
* Source/WebCore/html/shadow/SwitchThumbElement.h: Added.
* Source/WebCore/html/shadow/SwitchTrackElement.cpp: Added.
(WebCore::SwitchTrackElement::create):
(WebCore::SwitchTrackElement::SwitchTrackElement):
(WebCore::SwitchTrackElement::resolveCustomStyle):
* Source/WebCore/html/shadow/SwitchTrackElement.h: Added.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):
(WebCore::RenderTheme::createControlPart const):
(WebCore::RenderTheme::isChecked const):
(WebCore::RenderTheme::isEnabled const):
(WebCore::RenderTheme::isPressed const):
* Source/WebCore/style/StyleAppearance.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/style/StyleAppearance.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ControlPart&gt;::encode):
(IPC::ArgumentCoder&lt;ControlPart&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/269869@main">https://commits.webkit.org/269869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fba5d7ec834879977853a9a534330b76a644527

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26029 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/22014 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/24157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24379 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26620 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21551 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/21771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25581 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/1256 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5707 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->