### PR TITLE
[cairo] When creating a native image from pixel buffer the buffer should be owned by the cairo surface

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -33,10 +33,6 @@
 #include "PlatformImage.h"
 #include "RenderingResource.h"
 
-#if USE(CAIRO)
-#include "PixelBuffer.h"
-#endif
-
 namespace WebCore {
 
 class GraphicsContext;
@@ -47,9 +43,6 @@ public:
     static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
     // Creates a NativeImage that is intended to be drawn once or only few times. Signals the platform to avoid generating any caches for the image.
     static WEBCORE_EXPORT RefPtr<NativeImage> createTransient(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
-#if USE(CAIRO)
-    static RefPtr<NativeImage> create(Ref<PixelBuffer>&&, bool premultipliedAlpha);
-#endif
 
     WEBCORE_EXPORT void setPlatformImage(PlatformImagePtr&&);
     const PlatformImagePtr& platformImage() const { return m_platformImage; }
@@ -64,16 +57,10 @@ public:
 
 private:
     NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier);
-#if USE(CAIRO)
-    NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier, Ref<PixelBuffer>&&);
-#endif
 
     bool isNativeImage() const final { return true; }
 
     PlatformImagePtr m_platformImage;
-#if USE(CAIRO)
-    RefPtr<PixelBuffer> m_pixelBuffer;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
@@ -108,7 +108,31 @@ bool GraphicsContextGLImageExtractor::extractImage(bool premultiplyAlpha, bool i
 
 RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const GraphicsContextGLAttributes& sourceContextAttributes, Ref<PixelBuffer>&& pixelBuffer)
 {
-    return NativeImage::create(WTFMove(pixelBuffer), sourceContextAttributes.premultipliedAlpha);
+    ASSERT(!pixelBuffer->size().isEmpty());
+
+    // Convert RGBA to BGRA. BGRA is CAIRO_FORMAT_ARGB32 on little-endian architectures.
+    Ref protectedPixelBuffer = pixelBuffer;
+    size_t totalBytes = pixelBuffer->sizeInBytes();
+    uint8_t* pixels = pixelBuffer->bytes();
+    for (size_t i = 0; i < totalBytes; i += 4)
+        std::swap(pixels[i], pixels[i + 2]);
+
+    if (!sourceContextAttributes.premultipliedAlpha) {
+        for (size_t i = 0; i < totalBytes; i += 4) {
+            pixels[i + 0] = std::min(255, pixels[i + 0] * pixels[i + 3] / 255);
+            pixels[i + 1] = std::min(255, pixels[i + 1] * pixels[i + 3] / 255);
+            pixels[i + 2] = std::min(255, pixels[i + 2] * pixels[i + 3] / 255);
+        }
+    }
+
+    auto imageSize = pixelBuffer->size();
+    RefPtr<cairo_surface_t> imageSurface = adoptRef(cairo_image_surface_create_for_data(
+        pixelBuffer->bytes(), CAIRO_FORMAT_ARGB32, imageSize.width(), imageSize.height(), imageSize.width() * 4));
+    static cairo_user_data_key_t dataKey;
+    cairo_surface_set_user_data(imageSurface.get(), &dataKey, &protectedPixelBuffer.leakRef(), [](void* buffer) {
+        static_cast<PixelBuffer*>(buffer)->deref();
+    });
+    return NativeImage::create(WTFMove(imageSurface));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -35,38 +35,6 @@
 
 namespace WebCore {
 
-RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer, bool premultipliedAlpha)
-{
-    ASSERT(!pixelBuffer->size().isEmpty());
-
-    // Convert RGBA to BGRA. BGRA is CAIRO_FORMAT_ARGB32 on little-endian architectures.
-    size_t totalBytes = pixelBuffer->sizeInBytes();
-    uint8_t* pixels = pixelBuffer->bytes();
-    for (size_t i = 0; i < totalBytes; i += 4)
-        std::swap(pixels[i], pixels[i + 2]);
-
-    if (!premultipliedAlpha) {
-        for (size_t i = 0; i < totalBytes; i += 4) {
-            pixels[i + 0] = std::min(255, pixels[i + 0] * pixels[i + 3] / 255);
-            pixels[i + 1] = std::min(255, pixels[i + 1] * pixels[i + 3] / 255);
-            pixels[i + 2] = std::min(255, pixels[i + 2] * pixels[i + 3] / 255);
-        }
-    }
-
-    auto imageSize = pixelBuffer->size();
-    RefPtr<cairo_surface_t> imageSurface = adoptRef(cairo_image_surface_create_for_data(
-        pixelBuffer->bytes(), CAIRO_FORMAT_ARGB32, imageSize.width(), imageSize.height(), imageSize.width() * 4));
-
-    return adoptRef(*new NativeImage(WTFMove(imageSurface), RenderingResourceIdentifier::generate(), WTFMove(pixelBuffer)));
-}
-
-NativeImage::NativeImage(PlatformImagePtr&& platformImage, RenderingResourceIdentifier renderingResourceIdentifier, Ref<PixelBuffer>&& pixelBuffer)
-    : RenderingResource(renderingResourceIdentifier)
-    , m_platformImage(WTFMove(platformImage))
-    , m_pixelBuffer(WTFMove(pixelBuffer))
-{
-}
-
 IntSize NativeImage::size() const
 {
     return cairoSurfaceSize(m_platformImage.get());


### PR DESCRIPTION
#### 504426c318618e8a85c33c0d843d84898bb9137c
<pre>
[cairo] When creating a native image from pixel buffer the buffer should be owned by the cairo surface
<a href="https://bugs.webkit.org/show_bug.cgi?id=263440">https://bugs.webkit.org/show_bug.cgi?id=263440</a>

Reviewed by Alejandro G. Castro.

It&apos;s currently owned by the NativeImage container, but the surface can
be alive after the container destruction. This patch reverts 262575@main
and uses cairo_surface_set_user_data() instead.

* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):
* Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp:
(WebCore::NativeImage::create): Deleted.
(WebCore::NativeImage::NativeImage): Deleted.

Canonical link: <a href="https://commits.webkit.org/269618@main">https://commits.webkit.org/269618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b35e1bcaf159525edffca593a18bf4ceaba1ea52

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22118 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25710 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26986 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20834 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.WindowClientNavigate (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24839 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18282 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/385 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/881 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2931 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->