### PR TITLE
PerformanceTests/IndexedDB/stress tests use one database for all iterations unexpectedly

### DIFF
--- a/PerformanceTests/IndexedDB/stress/large-array-keys.html
+++ b/PerformanceTests/IndexedDB/stress/large-array-keys.html
@@ -23,18 +23,21 @@ var currentIteration = 0;
 PerfTestRunner.prepareToMeasureValuesAsync({
     customIterationCount: iterationCount,
     unit: 'ms',
-    done: function () {
-        db = null;
-        testGenerator = null;
-        PerfTestRunner.gc();
-        ++currentIteration;
-    }
 });
 
 function startIteration()
 {
     testGenerator = runIteration();
     nextStep();
+}
+
+function iterationCleanup()
+{
+    if (db)
+        db.close();
+    db = null;
+    testGenerator = null;
+    ++currentIteration;
 }
 
 function nextStep()
@@ -78,6 +81,8 @@ function *runIteration()
     }
 
     yield;
+
+    iterationCleanup();
 
     if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime))
         return;

--- a/PerformanceTests/IndexedDB/stress/large-binary-keys.html
+++ b/PerformanceTests/IndexedDB/stress/large-binary-keys.html
@@ -23,18 +23,21 @@ var currentIteration = 0;
 PerfTestRunner.prepareToMeasureValuesAsync({
     customIterationCount: iterationCount,
     unit: 'ms',
-    done: function () {
-        db = null;
-        testGenerator = null;
-        PerfTestRunner.gc();
-        ++currentIteration;
-    }
 });
 
 function startIteration()
 {
     testGenerator = runIteration();
     nextStep();
+}
+
+function iterationCleanup()
+{
+    if (db)
+        db.close();
+    db = null;
+    testGenerator = null;
+    ++currentIteration;
 }
 
 function nextStep()
@@ -74,6 +77,8 @@ function *runIteration()
         objectStore.put("Some value!!!", array[i]);
 
     yield;
+
+    iterationCleanup();
 
     if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime))
         return;

--- a/PerformanceTests/IndexedDB/stress/large-number-of-inserts-responsiveness.html
+++ b/PerformanceTests/IndexedDB/stress/large-number-of-inserts-responsiveness.html
@@ -23,19 +23,21 @@ var currentIteration = 0;
 PerfTestRunner.prepareToMeasureValuesAsync({
     customIterationCount: iterationCount,
     unit: 'ms',
-    done: function () {
-        db = null;
-        largestDelay = 0;
-        testGenerator = null;
-        PerfTestRunner.gc();
-        ++currentIteration;
-    }
 });
 
 function startIteration()
 {
     testGenerator = runIteration();
     nextStep();
+}
+
+function iterationCleanup()
+{
+    if (db)
+        db.close();
+    db = null;
+    testGenerator = null;
+    ++currentIteration;
 }
 
 function nextStep()
@@ -71,6 +73,8 @@ function *runIteration()
     yield;
 
     PerfTestRunner.stopCheckingResponsiveness();
+
+    iterationCleanup();
     
     if (!PerfTestRunner.measureValueAsync(PerfTestRunner.longestResponsivenessDelay()))
         return;

--- a/PerformanceTests/IndexedDB/stress/large-number-of-inserts.html
+++ b/PerformanceTests/IndexedDB/stress/large-number-of-inserts.html
@@ -23,18 +23,21 @@ var currentIteration = 0;
 PerfTestRunner.prepareToMeasureValuesAsync({
     customIterationCount: iterationCount,
     unit: 'ms',
-    done: function () {
-        db = null;
-        testGenerator = null;
-        PerfTestRunner.gc();
-        ++currentIteration;
-    }
 });
 
 function startIteration()
 {
     testGenerator = runIteration();
     nextStep();
+}
+
+function iterationCleanup()
+{
+    if (db)
+        db.close();
+    db = null;
+    testGenerator = null;
+    ++currentIteration;
 }
 
 function nextStep()
@@ -68,6 +71,8 @@ function *runIteration()
         objectStore.put(objectsToInsert[i]);
 
     yield;
+
+    iterationCleanup();
 
     if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime))
         return;

--- a/PerformanceTests/IndexedDB/stress/large-string-keys.html
+++ b/PerformanceTests/IndexedDB/stress/large-string-keys.html
@@ -23,18 +23,21 @@ var currentIteration = 0;
 PerfTestRunner.prepareToMeasureValuesAsync({
     customIterationCount: iterationCount,
     unit: 'ms',
-    done: function () {
-        db = null;
-        testGenerator = null;
-        PerfTestRunner.gc();
-        ++currentIteration;
-    }
 });
 
 function startIteration()
 {
     testGenerator = runIteration();
     nextStep();
+}
+
+function iterationCleanup()
+{
+    if (db)
+        db.close();
+    db = null;
+    testGenerator = null;
+    ++currentIteration;
 }
 
 function nextStep()
@@ -71,6 +74,8 @@ function *runIteration()
         objectStore.put("Some value!!!", array[i]);
 
     yield;
+
+    iterationCleanup();
 
     if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime))
         return;


### PR DESCRIPTION
#### 3144f3ca572e6621959e68562e2569ff3cbd3ded
<pre>
PerformanceTests/IndexedDB/stress tests use one database for all iterations unexpectedly
<a href="https://bugs.webkit.org/show_bug.cgi?id=263437">https://bugs.webkit.org/show_bug.cgi?id=263437</a>
rdar://117257501

Reviewed by Youenn Fablet and Brady Eidson.

The done function passed to PerfTestRunner is invoked at the end of all test iterations, not at the end of each
iteration. That means, currentIteration is not updated between iterations and all iterations use the same database (as
database name is created based on currentIteration value). This can lead to misleading results. For example, only the
first iteration spends time in opening the database and the other iterations don&apos;t; only the first iteration is adding
items to database, and the other iterations are updating items (since we use put() function in tests).

To fix this, ensure the clean up tasks happen after each test iteration, and tests use different database for different
iterations.

* PerformanceTests/IndexedDB/stress/large-array-keys.html:
* PerformanceTests/IndexedDB/stress/large-binary-keys.html:
* PerformanceTests/IndexedDB/stress/large-number-of-inserts-responsiveness.html:
* PerformanceTests/IndexedDB/stress/large-number-of-inserts.html:
* PerformanceTests/IndexedDB/stress/large-string-keys.html:

Canonical link: <a href="https://commits.webkit.org/269584@main">https://commits.webkit.org/269584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23503e03745b5d93160f3f4f32962e0cee5920cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21237 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23473 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25705 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26982 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24832 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/473 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/29721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/386 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/29721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5492 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/882 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->