### PR TITLE
object-fit:fill doesn't work for a video element using a canvas stream srcObject

### DIFF
--- a/LayoutTests/fast/mediastream/video-srcObject-fit-fill-expected.txt
+++ b/LayoutTests/fast/mediastream/video-srcObject-fit-fill-expected.txt
@@ -1,0 +1,5 @@
+
+
+
+PASS Validate video element is filled
+

--- a/LayoutTests/fast/mediastream/video-srcObject-fit-fill.html
+++ b/LayoutTests/fast/mediastream/video-srcObject-fit-fill.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div>
+<video muted style="object-fit: fill" id="video" width=300 height=100 autoplay playsinline></video>
+<br>
+<canvas id="canvas" width=100 height=100></canvas>
+<br>
+<image id='image'></image>
+<script>
+function getPixel(x, y, canvas, data)
+{
+    const position = 4 * (x * canvas.width + y);
+    return {r: data[position], g: data[position+1], b: data[position+2]};
+}
+
+function isPixelGreen(x, y, canvas, data)
+{
+   const pixel = getPixel(x, y, canvas, data);
+   return pixel.r === 0 && pixel.g === 128 && pixel.b === 0;
+}
+
+function isPixelWhite(x, y, canvas, data)
+{
+   const pixel = getPixel(x, y, canvas, data);
+   return pixel.r === 255 && pixel.g === 255 && pixel.b === 255;
+}
+
+async function validateSnapshot()
+{
+    if (!window.testRunner)
+        return 300;
+    const dataURL = await new Promise(resolve => testRunner.takeViewPortSnapshot(resolve));
+
+    const loadPromise = new Promise((resolve, reject) => {
+        image.onload = resolve;
+        image.onerror = reject;
+        setTimeout(() => reject("image load timed out"), 2000);
+    });
+    image.src = dataURL;
+    await loadPromise;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = image.width;
+    canvas.height = image.height;
+    canvas.getContext('2d').drawImage(image, 0, 0);
+    const data = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height).data;
+
+    // We inspect the horizontal line at pixel 50. We should get white, then green, then white.
+    // Green block width should be 300.
+
+    const horizontalLine = 50;
+    let j = 0;
+
+    if (!isPixelWhite(horizontalLine, j, canvas, data))
+        return -1;
+    while (isPixelWhite(horizontalLine, ++j, canvas, data)) { };
+
+    if (!isPixelGreen(horizontalLine, j, canvas, data))
+        return -2;
+
+    const startGreen = j;
+    while (isPixelGreen(horizontalLine, ++j, canvas, data)) { };
+    const endGreen = j;
+
+    if (!isPixelWhite(horizontalLine, j, canvas, data))
+        return -3;
+
+    return endGreen - startGreen;
+}
+
+promise_test(async () => {
+     const context = canvas.getContext('2d');
+     setInterval(() => {
+        context.fillStyle = "green";
+        context.fillRect(0, 0, 100, 100);
+    }, 100);
+    video.srcObject = canvas.captureStream();
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    let counter = 0;
+    let result =  0;
+    while (counter++ < 150 && result !== 300) {
+        await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+        try {
+            result = await validateSnapshot();
+        } catch (e) {
+            console.log(e);
+        }
+    }
+    assert_equals(result, 300);
+    image.parentNode.removeChild(image);
+}, "Validate video element is filled")
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -167,6 +167,7 @@ LocalSampleBufferDisplayLayer::LocalSampleBufferDisplayLayer(RetainPtr<AVSampleB
 void LocalSampleBufferDisplayLayer::initialize(bool hideRootLayer, IntSize size, CompletionHandler<void(bool didSucceed)>&& callback)
 {
     m_sampleBufferDisplayLayer.get().anchorPoint = { .5, .5 };
+    m_sampleBufferDisplayLayer.get().videoGravity = AVLayerVideoGravityResizeAspectFill;
 
     m_processingQueue->dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, layer = RetainPtr { m_sampleBufferDisplayLayer }]() mutable {
         auto protectedThis = weakThis.get();
@@ -288,6 +289,7 @@ void LocalSampleBufferDisplayLayer::updateSampleLayerBoundsAndPosition(std::opti
 
         m_sampleBufferDisplayLayer = adoptNS([PAL::allocAVSampleBufferDisplayLayerInstance() init]);
         m_sampleBufferDisplayLayer.get().anchorPoint = { .5, .5 };
+        m_sampleBufferDisplayLayer.get().videoGravity = AVLayerVideoGravityResizeAspectFill;
         [m_sampleBufferDisplayLayer setName:@"LocalSampleBufferDisplayLayer AVSampleBufferDisplayLayer"];
 
         auto layerBounds = bounds.value_or(m_rootLayer.get().bounds);


### PR DESCRIPTION
#### 45f8986d119655e76b33627c7bd36191b69b1cce
<pre>
object-fit:fill doesn&apos;t work for a video element using a canvas stream srcObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=263036">https://bugs.webkit.org/show_bug.cgi?id=263036</a>
rdar://116832514

Reviewed by Eric Carlson.

We mistakenly removed setting videoGravity in rdar://109257177.
Add it back to get back to past behavior.

* LayoutTests/fast/mediastream/video-srcObject-fit-fill-expected.txt: Added.
* LayoutTests/fast/mediastream/video-srcObject-fit-fill.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::initialize):
(WebCore::LocalSampleBufferDisplayLayer::updateSampleLayerBoundsAndPosition):

Canonical link: <a href="https://commits.webkit.org/269568@main">https://commits.webkit.org/269568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2e47bcbc46e2ea2acf04d5fa9046aa5b8ed508e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24856 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23184 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25713 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20781 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/26976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21042 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/478 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5479 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/646 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->