### PR TITLE
[web-animations] linear() probably does not work with transform and other accelerated properties

### DIFF
--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6-expected.txt
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6-expected.txt
@@ -1,0 +1,7 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS internals.acceleratedAnimationsForElement(element).length became 1
+PASS internals.acceleratedAnimationsForElement(element).length became 2
+PASS internals.acceleratedAnimationsForElement(element).length became 0
+

--- a/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html
+++ b/LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html
@@ -1,0 +1,35 @@
+<div id="target" style="width: 100px; height: 100px; background-color: black;"></div>
+<script src="../resources/js-test.js"></script>
+<script>
+
+const element = document.getElementById("target");
+const timing = { duration: 1000, iterations: Infinity };
+
+const shouldBecomeEqualAsync = async (actual, expected) => new Promise(resolve => shouldBecomeEqual(actual, expected, resolve));
+
+(async () => {
+    if (!window.testRunner || !window.internals) {
+        debug("This test should be run in a test runner.");
+        return;
+    }
+
+    testRunner.waitUntilDone();
+
+    // First, start a transform-related animation that can be accelerated.
+    element.animate({ scale: [1, 2] }, timing);
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "1");
+
+    // Now, start another transform-related animation that can also be accelerated.
+    const rotationAnimation = element.animate({ rotate: ["30deg", "60deg"] }, timing);
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "2");
+
+    // Now, update the last transform-related animation to a state that cannot be accelerated anymore
+    // due to using a linear() timing function. This should not only prevent this animation from
+    // running accelerated, but also make the first animation revert to a non-accelerated state.
+    rotationAnimation.effect.updateTiming({ easing: "linear(0 0%, 0.2 50%, 1 100%)" });
+    await shouldBecomeEqualAsync("internals.acceleratedAnimationsForElement(element).length", "0");
+
+    testRunner.notifyDone();
+})();
+    
+</script>

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -216,7 +216,7 @@ private:
     Ref<const Animation> backingAnimationForCompositedRenderer() const;
     void computedNeedsForcedLayout();
     void computeStackingContextImpact();
-    void computeSomeKeyframesUseStepsTimingFunction();
+    void computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoints();
     void clearBlendingKeyframes();
     void updateBlendingKeyframes(RenderStyle& elementStyle, const Style::ResolutionContext&);
     void computeCSSAnimationBlendingKeyframes(const RenderStyle& unanimatedStyle, const Style::ResolutionContext&);
@@ -285,6 +285,7 @@ private:
     bool m_triggersStackingContext { false };
     size_t m_transformFunctionListsMatchPrefix { 0 };
     bool m_inTargetEffectStack { false };
+    bool m_someKeyframesUseLinearTimingFunctionWithPoints { false };
     bool m_someKeyframesUseStepsTimingFunction { false };
     bool m_hasImplicitKeyframeForAcceleratedProperty { false };
     bool m_hasKeyframeComposingAcceleratedProperty { false };


### PR DESCRIPTION
#### 07b0116f3ef9d91fa6828fe1dd52fe77c8108c04
<pre>
[web-animations] linear() probably does not work with transform and other accelerated properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=260136">https://bugs.webkit.org/show_bug.cgi?id=260136</a>
rdar://114084978

Reviewed by Dean Jackson.

Devin Rousso added support for the `linear()` timing function in 266195@main. That initial patch
did not account for the lack of a Core Animation equivalent for this timing function, which meant
that accelerated properties would fail to respect this timing function.

We now use the same mechanism we use for the `steps()` timing function for `linear()`.

* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6-expected.txt: Added.
* LayoutTests/webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::isLinearTimingFunctionWithPoints):
(WebCore::KeyframeEffect::computeSomeKeyframesUseStepsOrLinearTimingFunctionWithPoints):
(WebCore::KeyframeEffect::canBeAccelerated const):
(WebCore::KeyframeEffect::animationDidChangeTimingProperties):
(WebCore::KeyframeEffect::computeSomeKeyframesUseStepsTimingFunction): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/269594@main">https://commits.webkit.org/269594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c951eeb3c9d33461df89538ddbec2030d92f07ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21246 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23495 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23196 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/497 "Found 38 new test failures: accessibility/ios-simulator/inline-prediction-attributed-string.html, editing/caret/ios/absolute-caret-position-after-scroll.html, editing/caret/ios/caret-color-after-refocusing-input.html, editing/caret/ios/caret-color-auto.html, editing/caret/ios/caret-color-currentcolor.html, editing/caret/ios/caret-color-in-nested-editable-containers.html, editing/caret/ios/caret-in-overflow-area.html, editing/selection/character-granularity-rect.html, editing/selection/ios/absolute-selection-after-scroll.html, editing/selection/ios/become-first-responder-after-relinquishing-focus.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25724 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20791 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/26989 "Found 1 new test failure: webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html (failure)") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/24844 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20576 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/892 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2918 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/658 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->