### PR TITLE
import invokers wpt tests

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -302,6 +302,7 @@
     "web-platform-tests/html/semantics/interactive-elements/the-details-element": "import",
     "web-platform-tests/html/semantics/interactive-elements/the-dialog-element": "import",
     "web-platform-tests/html/semantics/interactive-elements/the-summary-element": "skip",
+    "web-platform-tests/html/semantics/invokers": "import",
     "web-platform-tests/html/semantics/links/downloading-resources": "import",
     "web-platform-tests/html/semantics/links/following-hyperlinks": "skip",
     "web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL idl_test setup promise_test: Unhandled rejection with value: object "Error fetching /interfaces/invokers.tentative.idl."
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+
+<script>
+  idl_test(["invokers.tentative"], ["html", "dom"], (idl_array) => {
+    idl_array.add_objects({
+      InvokeEvent: ['new InvokeEvent("invoke")'],
+    });
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt
@@ -1,0 +1,17 @@
+
+
+FAIL invokeTargetElement reflects invokee HTML element assert_equals: expected (object) Element node <div id="invokee"></div> but got (undefined) undefined
+FAIL invokeTargetElement reflects set value assert_equals: expected "" but got "invokee"
+FAIL invokeTargetElement reflects set value across shadow root into light dom assert_equals: expected "" but got "invokee"
+FAIL invokeTargetElement does not reflect set value inside shadowroot assert_equals: expected null but got Element node <div></div>
+FAIL invokeTargetElement throws error on assignment of non Element assert_throws_js: invokeTargetElement attribute must be an instance of Element function "function () {
+        invoker.invokeTargetElement = {};
+      }" did not throw
+FAIL invokeAction reflects 'auto' when attribute not present assert_equals: expected (string) "auto" but got (undefined) undefined
+FAIL invokeAction reflects 'auto' when attribute empty assert_equals: expected (string) "auto" but got (undefined) undefined
+PASS invokeAction reflects same casing
+FAIL invokeAction reflects 'auto' when attribute empty 2 assert_equals: expected "auto" but got ""
+FAIL invokeAction reflects tostring value assert_equals: expected "1,2,3" but got ""
+FAIL invokeAction reflects 'auto' when attribute set to [] assert_equals: expected (string) "auto" but got (object) []
+FAIL invokeAction reflects tostring value 2 assert_equals: expected (string) "[object Object]" but got (object) object "[object Object]"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<button id="invoker" invoketarget="invokee"></button>
+<div id="invokee"></div>
+
+<script>
+  test(function () {
+    assert_equals(invoker.invokeTargetElement, invokee);
+  }, "invokeTargetElement reflects invokee HTML element");
+
+  test(function () {
+    const div = document.body.appendChild(document.createElement("div"));
+    invoker.invokeTargetElement = div;
+    assert_equals(invoker.invokeTargetElement, div);
+    assert_equals(invoker.getAttribute('invoketarget'), '');
+    assert_false(invoker.hasAttribute('invokeaction'));
+  }, "invokeTargetElement reflects set value");
+
+  test(function () {
+    const host = document.body.appendChild(document.createElement("div"));
+    const shadow = host.attachShadow({ mode: "open" });
+    const button = shadow.appendChild(document.createElement("button"));
+    button.invokeTargetElement = invokee;
+    assert_equals(button.invokeTargetElement, invokee);
+    assert_equals(invoker.getAttribute('invoketarget'), '');
+    assert_false(invoker.hasAttribute('invokeaction'));
+  }, "invokeTargetElement reflects set value across shadow root into light dom");
+
+  test(function () {
+    const host = document.body.appendChild(document.createElement("div"));
+    const shadow = host.attachShadow({ mode: "open" });
+    const div = shadow.appendChild(document.createElement("div"));
+    invoker.invokeTargetElement = div;
+    assert_equals(invoker.invokeTargetElement, null);
+    assert_equals(invoker.getAttribute('invoketarget'), '');
+    assert_false(invoker.hasAttribute('invokeaction'));
+  }, "invokeTargetElement does not reflect set value inside shadowroot");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        invoker.invokeTargetElement = {};
+      },
+      "invokeTargetElement attribute must be an instance of Element",
+    );
+  }, "invokeTargetElement throws error on assignment of non Element");
+
+  test(function () {
+    assert_false(invoker.hasAttribute('invokeaction'));
+    assert_equals(invoker.invokeAction, "auto");
+  }, "invokeAction reflects 'auto' when attribute not present");
+
+  test(function () {
+    invoker.setAttribute("invokeaction", "");
+    assert_equals(invoker.getAttribute("invokeaction"), "");
+    assert_equals(invoker.invokeAction, "auto");
+  }, "invokeAction reflects 'auto' when attribute empty");
+
+  test(function () {
+    invoker.invokeAction = "fooBarBaz";
+    assert_equals(invoker.invokeAction, "fooBarBaz");
+  }, "invokeAction reflects same casing");
+
+  test(function () {
+    invoker.invokeAction = "";
+    assert_equals(invoker.getAttribute("invokeaction"), "");
+    assert_equals(invoker.invokeAction, "auto");
+  }, "invokeAction reflects 'auto' when attribute empty 2");
+
+  test(function () {
+    invoker.invokeAction = [1, 2, 3];
+    assert_equals(invoker.getAttribute("invokeaction"), "1,2,3");
+    assert_equals(invoker.invokeAction, "1,2,3");
+  }, "invokeAction reflects tostring value");
+
+  test(function () {
+    invoker.invokeAction = [];
+    assert_equals(invoker.getAttribute("invokeaction"), "");
+    assert_equals(invoker.invokeAction, "auto");
+  }, "invokeAction reflects 'auto' when attribute set to []");
+
+  test(function () {
+    invoker.invokeAction = {};
+    assert_equals(invoker.invokeAction, "[object Object]");
+  }, "invokeAction reflects tostring value 2");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL InvokeEvent propagates across shadow boundaries retargeting invoker Can't find variable: InvokeEvent
+FAIL cross shadow InvokeEvent retargets invoker to host element Can't find variable: InvokeEvent
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="div"></div>
+<button id="button"></button>
+
+<script>
+  test(function () {
+    const host = document.createElement("div");
+    const child = host.appendChild(document.createElement("p"));
+    const shadow = host.attachShadow({ mode: "closed" });
+    const slot = shadow.appendChild(document.createElement("slot"));
+    let childEvent = null;
+    let childEventTarget = null;
+    let childEventInvoker = null;
+    let hostEvent = null;
+    let hostEventTarget = null;
+    let hostEventInvoker = null;
+    slot.addEventListener(
+      "invoke",
+      (e) => {
+        childEvent = e;
+        childEventTarget = e.target;
+        childEventInvoker = e.invoker;
+      },
+      { once: true },
+    );
+    host.addEventListener(
+      "invoke",
+      (e) => {
+        hostEvent = e;
+        hostEventTarget = e.target;
+        hostEventInvoker = e.invoker;
+      },
+      { once: true },
+    );
+    const event = new InvokeEvent("invoke", {
+      bubbles: true,
+      invoker: slot,
+      composed: true,
+    });
+    slot.dispatchEvent(event);
+    assert_true(childEvent instanceof InvokeEvent, "slot saw invoke event");
+    assert_equals(
+      childEventTarget,
+      slot,
+      "target is child inside shadow boundary",
+    );
+    assert_equals(
+      childEventInvoker,
+      slot,
+      "invoker is child inside shadow boundary",
+    );
+    assert_equals(
+      hostEvent,
+      childEvent,
+      "event dispatch propagates across shadow boundary",
+    );
+    assert_equals(
+      hostEventTarget,
+      host,
+      "target is retargeted to shadowroot host",
+    );
+    assert_equals(
+      hostEventInvoker,
+      host,
+      "invoker is retargeted to shadowroot host",
+    );
+  }, "InvokeEvent propagates across shadow boundaries retargeting invoker");
+
+  test(function (t) {
+    const host = document.createElement("div");
+    document.body.append(host);
+    t.add_cleanup(() => host.remove());
+    const shadow = host.attachShadow({ mode: "open" });
+    const button = shadow.appendChild(document.createElement("button"));
+    const invokee = host.appendChild(document.createElement("div"));
+    button.invokeTargetElement = invokee;
+    let event = null;
+    let eventTarget = null;
+    let eventInvoker = null;
+    invokee.addEventListener(
+      "invoke",
+      (e) => {
+        event = e;
+        eventTarget = e.target;
+        eventInvoker = e.invoker;
+      },
+      { once: true },
+    );
+    button.click();
+    assert_true(event instanceof InvokeEvent);
+    assert_equals(eventTarget, invokee, "target is invokee");
+    assert_equals(eventInvoker, host, "invoker is host");
+  }, "cross shadow InvokeEvent retargets invoker to host element");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt
@@ -1,0 +1,41 @@
+
+
+FAIL action is a readonly defaulting to 'auto' Can't find variable: InvokeEvent
+FAIL invoker is readonly defaulting to null Can't find variable: InvokeEvent
+FAIL action reflects initialized attribute Can't find variable: InvokeEvent
+FAIL action set to undefined Can't find variable: InvokeEvent
+FAIL action set to null Can't find variable: InvokeEvent
+FAIL action set to false Can't find variable: InvokeEvent
+FAIL action set to true Can't find variable: InvokeEvent
+FAIL action set to a number Can't find variable: InvokeEvent
+FAIL action set to [] Can't find variable: InvokeEvent
+FAIL action set to [1, 2, 3] Can't find variable: InvokeEvent
+FAIL action set to an object Can't find variable: InvokeEvent
+FAIL action set to an object with a valueOf function Can't find variable: InvokeEvent
+FAIL InvokeEventInit properties set value Can't find variable: InvokeEvent
+FAIL InvokeEventInit properties set value 2 Can't find variable: InvokeEvent
+FAIL InvokeEventInit properties set value 3 Can't find variable: InvokeEvent
+FAIL invoker set to undefined Can't find variable: InvokeEvent
+FAIL invoker set to null Can't find variable: InvokeEvent
+FAIL invoker set to false assert_throws_js: invoker is not an object function "function () {
+        new InvokeEvent("test", { invoker: false });
+      }" threw object "ReferenceError: Can't find variable: InvokeEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL invoker set to true assert_throws_js: invoker is not an object function "function () {
+        const event = new InvokeEvent("test", { invoker: true });
+      }" threw object "ReferenceError: Can't find variable: InvokeEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL invoker set to {} assert_throws_js: invoker is not an object function "function () {
+        const event = new InvokeEvent("test", { invoker: {} });
+      }" threw object "ReferenceError: Can't find variable: InvokeEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL invoker set to non-Element EventTarget assert_throws_js: invoker is not an Element function "function () {
+        const eventInit = { action: "closed", invoker: new XMLHttpRequest() };
+        const event = new InvokeEvent("toggle", eventInit);
+      }" threw object "ReferenceError: Can't find variable: InvokeEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="div"></div>
+<button id="button"></button>
+
+<script>
+  test(function () {
+    const event = new InvokeEvent("test");
+    assert_equals(event.action, "auto");
+    assert_readonly(event, "action", "readonly attribute value");
+  }, "action is a readonly defaulting to 'auto'");
+
+  test(function () {
+    const event = new InvokeEvent("test");
+    assert_equals(event.invoker, null);
+    assert_readonly(event, "invoker", "readonly attribute value");
+  }, "invoker is readonly defaulting to null");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: "sAmPle" });
+    assert_equals(event.action, "sAmPle");
+  }, "action reflects initialized attribute");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: undefined });
+    assert_equals(event.action, "auto");
+  }, "action set to undefined");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: null });
+    assert_equals(event.action, "null");
+  }, "action set to null");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: false });
+    assert_equals(event.action, "false");
+  }, "action set to false");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: true });
+    assert_equals(event.action, "true");
+  }, "action set to true");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: 0.5 });
+    assert_equals(event.action, "0.5");
+  }, "action set to a number");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: [] });
+    assert_equals(event.action, "auto");
+  }, "action set to []");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: [1, 2, 3] });
+    assert_equals(event.action, "1,2,3");
+  }, "action set to [1, 2, 3]");
+
+  test(function () {
+    const event = new InvokeEvent("test", { action: { sample: 0.5 } });
+    assert_equals(event.action, "[object Object]");
+  }, "action set to an object");
+
+  test(function () {
+    const event = new InvokeEvent("test", {
+      action: {
+        valueOf: function () {
+          return "sample";
+        },
+      },
+    });
+    assert_equals(event.action, "[object Object]");
+  }, "action set to an object with a valueOf function");
+
+  test(function () {
+    const eventInit = { action: "sample", invoker: document.body };
+    const event = new InvokeEvent("test", eventInit);
+    assert_equals(event.action, "sample");
+    assert_equals(event.invoker, document.body);
+  }, "InvokeEventInit properties set value");
+
+  test(function () {
+    const eventInit = {
+      action: "open",
+      invoker: document.getElementById("div"),
+    };
+    const event = new InvokeEvent("beforetoggle", eventInit);
+    assert_equals(event.action, "open");
+    assert_equals(event.invoker, document.getElementById("div"));
+  }, "InvokeEventInit properties set value 2");
+
+  test(function () {
+    const eventInit = {
+      action: "closed",
+      invoker: document.getElementById("button"),
+    };
+    const event = new InvokeEvent("toggle", eventInit);
+    assert_equals(event.action, "closed");
+    assert_equals(event.invoker, document.getElementById("button"));
+  }, "InvokeEventInit properties set value 3");
+
+  test(function () {
+    const event = new InvokeEvent("test", { invoker: undefined });
+    assert_equals(event.invoker, null);
+  }, "invoker set to undefined");
+
+  test(function () {
+    const event = new InvokeEvent("test", { invoker: null });
+    assert_equals(event.invoker, null);
+  }, "invoker set to null");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        new InvokeEvent("test", { invoker: false });
+      },
+      "invoker is not an object",
+    );
+  }, "invoker set to false");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        const event = new InvokeEvent("test", { invoker: true });
+      },
+      "invoker is not an object",
+    );
+  }, "invoker set to true");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        const event = new InvokeEvent("test", { invoker: {} });
+      },
+      "invoker is not an object",
+    );
+  }, "invoker set to {}");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        const eventInit = { action: "closed", invoker: new XMLHttpRequest() };
+        const event = new InvokeEvent("toggle", eventInit);
+      },
+      "invoker is not an Element",
+    );
+  }, "invoker set to non-Element EventTarget");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
@@ -1,0 +1,8 @@
+
+
+FAIL event dispatches on click promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: InvokeEvent"
+FAIL event action is set to invokeAction promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: InvokeEvent"
+FAIL event action is set to invokeaction attribute promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: InvokeEvent"
+PASS event does not dispatch if click:preventDefault is called
+PASS event does not dispatch if invoker is disabled
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="invokee"></div>
+<button id="invokerbutton" invoketarget="invokee"></button>
+
+<script>
+  promise_test(async function (t) {
+    let event = null;
+    invokee.addEventListener("invoke", (e) => (event = e), { once: true });
+    await clickOn(invokerbutton);
+    assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
+    assert_equals(event.type, "invoke", "type");
+    assert_equals(event.bubbles, false, "bubbles");
+    assert_equals(event.composed, false, "composed");
+    assert_equals(event.isTrusted, true, "isTrusted");
+    assert_equals(event.action, "auto", "action");
+    assert_equals(event.target, invokee, "target");
+    assert_equals(event.invoker, invokerbutton, "invoker");
+  }, "event dispatches on click");
+
+  promise_test(async function (t) {
+    let event = null;
+    invokee.addEventListener("invoke", (e) => (event = e), { once: true });
+    invokerbutton.invokeAction = "fooBar";
+    await clickOn(invokerbutton);
+    assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
+    assert_equals(event.type, "invoke", "type");
+    assert_equals(event.bubbles, false, "bubbles");
+    assert_equals(event.composed, false, "composed");
+    assert_equals(event.isTrusted, true, "isTrusted");
+    assert_equals(event.action, "fooBar", "action");
+    assert_equals(event.target, invokee, "target");
+    assert_equals(event.invoker, invokerbutton, "invoker");
+  }, "event action is set to invokeAction");
+
+  promise_test(async function (t) {
+    let event = null;
+    invokee.addEventListener("invoke", (e) => (event = e), { once: true });
+    invokerbutton.setAttribute("invokeaction", "BaRbAz");
+    await clickOn(invokerbutton);
+    assert_true(event instanceof InvokeEvent, "event is InvokeEvent");
+    assert_equals(event.type, "invoke", "type");
+    assert_equals(event.bubbles, false, "bubbles");
+    assert_equals(event.composed, false, "composed");
+    assert_equals(event.isTrusted, true, "isTrusted");
+    assert_equals(event.action, "BaRbAz", "action");
+    assert_equals(event.target, invokee, "target");
+    assert_equals(event.invoker, invokerbutton, "invoker");
+  }, "event action is set to invokeaction attribute");
+
+  promise_test(async function (t) {
+    let called = false;
+    invokerbutton.addEventListener(
+      "click",
+      (event) => {
+        event.preventDefault();
+      },
+      { once: true },
+    );
+    invokee.addEventListener(
+      "invoke",
+      (event) => {
+        called = true;
+      },
+      { once: true },
+    );
+    await clickOn(invokerbutton);
+    assert_false(called, "event was not called");
+  }, "event does not dispatch if click:preventDefault is called");
+
+  promise_test(async function (t) {
+    let called = false;
+    invokee.addEventListener(
+      "invoke",
+      (event) => {
+        called = true;
+      },
+      { once: true },
+    );
+    invokerbutton.setAttribute("disabled", "");
+    await clickOn(invokerbutton);
+    assert_false(called, "event was not called");
+  }, "event does not dispatch if invoker is disabled");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/invoker-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/invoker-utils.js
@@ -1,0 +1,12 @@
+function waitForRender() {
+  return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+async function clickOn(element) {
+  const actions = new test_driver.Actions();
+  await waitForRender();
+  await actions.pointerMove(0, 0, {origin: element})
+      .pointerDown({button: actions.ButtonType.LEFT})
+      .pointerUp({button: actions.ButtonType.LEFT})
+      .send();
+  await waitForRender();
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/invoker-utils.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log
@@ -1,0 +1,21 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html


### PR DESCRIPTION
#### bb7f62f1e69f9411526191c4b5fb0659bd58fcf4
<pre>
import invokers wpt tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=263443">https://bugs.webkit.org/show_bug.cgi?id=263443</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/0d569c25cc1d7265e8eb92ead6049600edef4a1b">https://github.com/web-platform-tests/wpt/commit/0d569c25cc1d7265e8eb92ead6049600edef4a1b</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/idlharness.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeelement-interface.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-dispatch-shadow.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invokeevent-interface.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/invoker-utils.js: Added.
(waitForRender):
(async clickOn):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/resources/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/w3c-import.log: Added.

Canonical link: <a href="https://commits.webkit.org/269715@main">https://commits.webkit.org/269715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/391c3b0f1aa10cb71988dc4b70b28a0908769270

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/23183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/25104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/21430 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/22281 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25946 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/27147 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/21144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/25018 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/18452 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/616 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/20757 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5570 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/1093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->