### PR TITLE
[run-api-tests] Limit log lines for tests

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -33,12 +33,12 @@ from webkitpy.port.server_process import ServerProcess, _log as server_process_l
 _log = logging.getLogger(__name__)
 
 
-def setup_shard(port=None, devices=None):
+def setup_shard(port=None, devices=None, log_limit=None):
     if devices and getattr(port, 'DEVICE_MANAGER', None):
         port.DEVICE_MANAGER.AVAILABLE_DEVICES = devices.get('available_devices', [])
         port.DEVICE_MANAGER.INITIALIZED_DEVICES = devices.get('initialized_devices', None)
 
-    return _Worker.setup(port=port)
+    return _Worker.setup(port=port, log_limit=log_limit)
 
 
 def run_shard(name, *tests):
@@ -78,11 +78,12 @@ class Runner(object):
 
     instance = None
 
-    def __init__(self, port, printer):
+    def __init__(self, port, printer, log_limit=250):
         self.port = port
         self.printer = printer
         self.tests_run = 0
         self._num_workers = 1
+        self.log_limit = log_limit
         self._has_logged_for_test = True  # Suppress an empty line between "Running tests" and the first test's output.
         self.results = {}
 
@@ -143,7 +144,7 @@ class Runner(object):
 
             with TaskPool(
                 workers=self._num_workers,
-                setup=setup_shard, setupkwargs=dict(port=self.port, devices=devices), teardown=teardown_shard,
+                setup=setup_shard, setupkwargs=dict(port=self.port, devices=devices, log_limit=self.log_limit), teardown=teardown_shard,
             ) as pool:
                 for name, tests in iteritems(shards):
                     pool.do(run_shard, name, *tests)
@@ -163,18 +164,20 @@ class Runner(object):
 
 class _Worker(object):
     instance = None
+    EXCEEDED_LOG_LINE_MESSAGE = 'EXCEEDED LOG LINE THRESHOLD OF {}\n'
 
     @classmethod
-    def setup(cls, port=None):
-        cls.instance = cls(port)
+    def setup(cls, port=None, log_limit=None):
+        cls.instance = cls(port, log_limit)
 
     @classmethod
     def teardown(cls):
         cls.instance = None
 
-    def __init__(self, port):
+    def __init__(self, port, log_limit):
         self._port = port
         self.host = port.host
+        self.log_limit = log_limit
 
         # ServerProcess doesn't allow for a timeout of 'None,' this uses a week instead of None.
         self._timeout = int(self._port.get_option('timeout')) if self._port.get_option('timeout') else 60 * 24 * 7
@@ -200,6 +203,7 @@ class _Worker(object):
 
         stdout_buffer = ''
         stderr_buffer = ''
+        line_count = 0
 
         try:
             started = time.time()
@@ -209,6 +213,17 @@ class _Worker(object):
             while status == Runner.STATUS_RUNNING:
                 stdout_line, stderr_line = server_process.read_either_stdout_or_stderr_line(started + self._timeout)
                 if not stderr_line and not stdout_line:
+                    break
+                if stdout_line:
+                    line_count += 1
+                if stderr_line:
+                    line_count += 1
+                if line_count > self.log_limit:
+                    stderr_line = self.EXCEEDED_LOG_LINE_MESSAGE.format(self.log_limit)
+                    stderr_buffer += stderr_line
+                    _log.error(stderr_line[:-1])
+                    server_process.stop()
+                    status = Runner.STATUS_FAILED
                     break
 
                 if stderr_line:
@@ -235,11 +250,21 @@ class _Worker(object):
                 status = Runner.STATUS_FAILED
 
         finally:
+            output_buffer = stderr_buffer + stdout_buffer
             remaining_stderr = string_utils.decode(server_process.pop_all_buffered_stderr(), target_type=str)
             remaining_stdout = string_utils.decode(server_process.pop_all_buffered_stdout(), target_type=str)
             for line in (remaining_stdout + remaining_stderr).splitlines(False):
+                line_count += 1
+                if line_count > self.log_limit:
+                    status = Runner.STATUS_FAILED
+                    line = self.EXCEEDED_LOG_LINE_MESSAGE.format(self.log_limit)
+
                 _log.error(line)
-            output_buffer = stderr_buffer + stdout_buffer + remaining_stderr + remaining_stdout
+                output_buffer += line
+
+                if line_count > self.log_limit:
+                    break
+
             server_process.stop()
 
         TaskPool.Process.queue.send(TaskPool.Task(
@@ -267,7 +292,8 @@ class _Worker(object):
                 started = time.time()
                 last_test = None
                 last_status = None
-                stdout_buffer = ''
+                buffer = ''
+                line_count = 0
 
                 server_process.start()
                 while remaining_tests:
@@ -287,22 +313,28 @@ class _Worker(object):
 
                     assert stdout is not None
                     stdout_split = stdout.rstrip().split(' ')
+
+                    line_count += len(stdout_split)
+                    if line_count > self.log_limit:
+                        break
+
                     if len(stdout_split) != 2 or not (stdout_split[0].startswith('**') and stdout_split[0].endswith('**')):
-                        stdout_buffer += stdout
+                        buffer += stdout
                         continue
                     if last_test is not None:
                         remaining_tests.remove(last_test)
 
-                        for line in stdout_buffer.splitlines(False):
+                        for line in buffer.splitlines(False):
                             _log.error(line)
+                        line_count = 0
                         TaskPool.Process.queue.send(TaskPool.Task(
                             report_result, None, TaskPool.Process.name,
                             '{}.{}'.format(binary_name, last_test),
-                            last_status, stdout_buffer,
+                            last_status, buffer,
                             elapsed=time.time() - started,
                         ))
                         started = time.time()
-                        stdout_buffer = ''
+                        buffer = ''
 
                     if '**PASS**' == stdout_split[0]:
                         last_status = Runner.STATUS_PASSED
@@ -313,16 +345,26 @@ class _Worker(object):
                 # We assume that stderr is only relevant if there is a crash (meaning we triggered an assert)
                 if last_test:
                     remaining_tests.remove(last_test)
-                    stdout_buffer += string_utils.decode(server_process.pop_all_buffered_stdout(), target_type=str)
+                    stdout_buffer = string_utils.decode(server_process.pop_all_buffered_stdout(), target_type=str)
                     stderr_buffer = string_utils.decode(server_process.pop_all_buffered_stderr(), target_type=str) if last_status == Runner.STATUS_CRASHED else ''
-                    for line in (stdout_buffer + stderr_buffer).splitlines(keepends=False):
-                        _log.error(line)
+                    for line in (stdout_buffer + stderr_buffer).splitlines():
+                        line_count += 1
+                        if line_count > self.log_limit:
+                            break
+                        buffer += line
+                        _log.error(line[:-1])
+
+                    if line_count > self.log_limit:
+                        last_status = Runner.STATUS_FAILED
+                        line = self.EXCEEDED_LOG_LINE_MESSAGE.format(self.log_limit)
+                        buffer += line
+                        _log.error(line[:-1])
 
                     TaskPool.Process.queue.send(TaskPool.Task(
                         report_result, None, TaskPool.Process.name,
                         '{}.{}'.format(binary_name, last_test),
                         last_status,
-                        self._filter_noisy_output(stdout_buffer + stderr_buffer),
+                        self._filter_noisy_output(buffer),
                         elapsed=time.time() - started,
                     ))
 


### PR DESCRIPTION
#### 0df1e37069766b6f679f83adafcedba26481c255
<pre>
[run-api-tests] Limit log lines for tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=263446">https://bugs.webkit.org/show_bug.cgi?id=263446</a>
rdar://117265047

Reviewed by Aakash Jain.

Limit the number of logging lines a single API test can
output. By default, limit a given test to 250 lines.

* Tools/Scripts/webkitpy/api_tests/runner.py:
(setup_shard): Pass log_limit.
(Runner.__init__): Ditto.
(Runner.run): Ditto.
(_Worker): Ditto.
(_Worker.setup): Ditto.
(_Worker.__init__): Ditto.
(_Worker._run_single_test): Count number of log lines, and
fail test if we exceed the log limit.
(_Worker.run): Ditto.

Canonical link: <a href="https://commits.webkit.org/269576@main">https://commits.webkit.org/269576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acb8b5ee29740f69356c30af31054699ec29fb46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/22967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/1042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/24075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/24881 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/21257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/23231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/2274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/23508 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/23209 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/19920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/25738 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/23154 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/20801 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/27002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/20778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/21060 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/24861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/18297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/902 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/2908 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->